### PR TITLE
mem usage in MVCC: pack timestamp begin/end in RowVersion

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1,7 +1,7 @@
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
-    DeleteRowStateMachine, MVTableId, MvStore, Row, RowID, RowKey, RowVersion, SortableIndexKey,
-    TxTimestampOrID, WriteRowStateMachine, MVCC_META_KEY_PERSISTENT_TX_TS_MAX,
+    DeleteRowStateMachine, MVTableId, MvStore, Row, RowID, RowKey, RowVersion,
+    SortableIndexKey, TxTimestampOrID, WriteRowStateMachine, MVCC_META_KEY_PERSISTENT_TX_TS_MAX,
     MVCC_META_TABLE_NAME, SQLITE_SCHEMA_MVCC_TABLE_ID,
 };
 #[cfg(any(test, injected_yields))]
@@ -386,7 +386,7 @@ fn sqlite_schema_versions_refer_to_btree(lhs: &RowVersion, rhs: &RowVersion) -> 
 /// `ALTER TABLE ... RENAME COLUMN`, must collapse to the latest version; otherwise checkpoint
 /// treats one schema row chain as a DROP+CREATE pair and emits duplicate work for the same rowid.
 fn is_schema_metadata_only_rewrite(current: &RowVersion, next: Option<&RowVersion>) -> bool {
-    if current.end.is_none() {
+    if current.end().is_none() {
         return false;
     }
 
@@ -740,11 +740,11 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             // There is a version whose begin timestamp is <= than the last checkpoint timestamp, AND
             // There is NO version whose END timestamp is <= than the last checkpoint timestamp.
             let mut begin_ts = None;
-            if let Some(TxTimestampOrID::Timestamp(b)) = version.begin {
+            if let Some(TxTimestampOrID::Timestamp(b)) = version.begin() {
                 begin_ts = Some(b);
             }
             let mut end_ts = None;
-            if let Some(TxTimestampOrID::Timestamp(e)) = version.end {
+            if let Some(TxTimestampOrID::Timestamp(e)) = version.end() {
                 end_ts = Some(e);
             }
             if begin_ts.is_none() && end_ts.is_none() {
@@ -809,7 +809,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 }
 
                 if let Some(previous_version) = versions_to_checkpoint.last() {
-                    let should_drop_previous = previous_version.end.is_some()
+                    let should_drop_previous = previous_version.end().is_some()
                         && !is_schema_metadata_only_rewrite(previous_version, Some(version));
                     if should_drop_previous {
                         versions_to_checkpoint.pop();
@@ -857,7 +857,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             let row_versions = entry.value().read();
 
             for version in self.maybe_get_checkpointable_versions(&row_versions, key.table_id) {
-                let is_delete = version.end.is_some();
+                let is_delete = version.end().is_some();
 
                 let mut special_write = None;
                 // Set to true for schema deletes of never-checkpointed tables/indexes.
@@ -977,7 +977,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     // Schema row without a B-tree identity (e.g. sequence, trigger, view).
                     // If it was never checkpointed to the B-tree, skip the delete — there
                     // is nothing to remove from the pager.
-                    let begin_ts = match &version.begin {
+                    let begin_ts = match &version.begin() {
                         Some(TxTimestampOrID::Timestamp(ts)) => Some(*ts),
                         _ => None,
                     };
@@ -1050,7 +1050,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 self.collect_index_key_cursor = Some(entry.key().clone());
 
                 for version in self.maybe_get_checkpointable_versions(&versions, index_id) {
-                    let is_delete = version.end.is_some();
+                    let is_delete = version.end().is_some();
 
                     // Only write the row to the B-tree if it is not a delete, or if it is a delete and it exists in
                     // the database file.
@@ -1070,7 +1070,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
     #[cfg(any(test, debug_assertions))]
     fn max_collected_version_timestamp(&self) -> u64 {
         fn max_version_timestamp(version: &RowVersion) -> u64 {
-            [version.begin.as_ref(), version.end.as_ref()]
+            [version.begin().as_ref(), version.end().as_ref()]
                 .into_iter()
                 .filter_map(|ts| match ts {
                     Some(TxTimestampOrID::Timestamp(ts)) => Some(*ts),
@@ -1429,8 +1429,8 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         self.write_set.push((
             RowVersion {
                 id: 0,
-                begin: Some(TxTimestampOrID::Timestamp(new)),
-                end: None,
+                begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(new))),
+                end: crate::mvcc::database::PackedTs::pack(None),
                 row,
                 btree_resident: true,
             },
@@ -1804,7 +1804,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                         })?;
 
                 // Check if this is an insert or delete
-                if row_version.end.is_some() {
+                if row_version.end().is_some() {
                     // This is a delete operation.
                     // Don't write the deletion record to the b-tree if the b-tree was just created; we can no-op in this case,
                     // since there is no existing row to delete.
@@ -2330,8 +2330,8 @@ mod tests {
         .unwrap();
         RowVersion {
             id: 1,
-            begin: begin.map(TxTimestampOrID::Timestamp),
-            end: end.map(TxTimestampOrID::Timestamp),
+            begin: crate::mvcc::database::PackedTs::pack(begin.map(TxTimestampOrID::Timestamp)),
+            end: crate::mvcc::database::PackedTs::pack(end.map(TxTimestampOrID::Timestamp)),
             row: Row::new_table_row(
                 RowID::new(SQLITE_SCHEMA_MVCC_TABLE_ID, RowKey::Int(rowid)),
                 record.as_blob().to_vec(),
@@ -2403,8 +2403,8 @@ mod tests {
     fn sqlite_schema_identity_ignores_payloadless_tombstones() {
         let tombstone = RowVersion {
             id: 1,
-            begin: None,
-            end: Some(TxTimestampOrID::Timestamp(2)),
+            begin: crate::mvcc::database::PackedTs::pack(None),
+            end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(2))),
             row: Row::new_table_row(
                 RowID::new(SQLITE_SCHEMA_MVCC_TABLE_ID, RowKey::Int(9)),
                 Vec::new(),
@@ -2459,8 +2459,8 @@ mod tests {
         );
         let row_version = RowVersion {
             id: version_id,
-            begin: begin.map(TxTimestampOrID::Timestamp),
-            end: end.map(TxTimestampOrID::Timestamp),
+            begin: crate::mvcc::database::PackedTs::pack(begin.map(TxTimestampOrID::Timestamp)),
+            end: crate::mvcc::database::PackedTs::pack(end.map(TxTimestampOrID::Timestamp)),
             row,
             btree_resident,
         };
@@ -2515,8 +2515,8 @@ mod tests {
         let record = ImmutableRecord::from_values(&[Value::from_i64(rowid)], 1).unwrap();
         RowVersion {
             id: 1,
-            begin: Some(TxTimestampOrID::Timestamp(5)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(5))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row: Row::new_table_row(
                 RowID::new(table_id, RowKey::Int(rowid)),
                 record.as_blob().to_vec(),

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1,7 +1,7 @@
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
-    DeleteRowStateMachine, MVTableId, MvStore, Row, RowID, RowKey, RowVersion,
-    SortableIndexKey, TxTimestampOrID, WriteRowStateMachine, MVCC_META_KEY_PERSISTENT_TX_TS_MAX,
+    DeleteRowStateMachine, MVTableId, MvStore, Row, RowID, RowKey, RowVersion, SortableIndexKey,
+    TxTimestampOrID, WriteRowStateMachine, MVCC_META_KEY_PERSISTENT_TX_TS_MAX,
     MVCC_META_TABLE_NAME, SQLITE_SCHEMA_MVCC_TABLE_ID,
 };
 #[cfg(any(test, injected_yields))]

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -329,15 +329,74 @@ impl Row {
     }
 }
 
+/// Packed representation of `Option<TxTimestampOrID>` in a single `u64`,
+/// halving the size of the `begin`/`end` fields (16 bytes each → 8).
+///
+/// Layout (top two bits are the tag):
+/// * `0`                  → `None`
+/// * `(1 << 62) | value`  → `Some(Timestamp(value))`
+/// * `(1 << 63) | value`  → `Some(TxID(value))`
+///
+/// `value` occupies the low 62 bits. Timestamps and transaction IDs are
+/// monotonic counters that start near zero, so 62 bits (~4.6e18) is never
+/// exhausted; `pack` asserts this invariant. The two distinct tag bits (rather
+/// than a zero sentinel) are required because `Timestamp(0)` is a real value —
+/// the logical clock hands out timestamp 0 to the first transaction.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PackedTs(u64);
+
+impl PackedTs {
+    const TIMESTAMP_TAG: u64 = 1 << 62;
+    const TXID_TAG: u64 = 1 << 63;
+    const VALUE_MASK: u64 = (1 << 62) - 1;
+    const NONE: PackedTs = PackedTs(0);
+
+    #[inline]
+    pub(crate) fn pack(value: Option<TxTimestampOrID>) -> Self {
+        match value {
+            None => Self::NONE,
+            Some(TxTimestampOrID::Timestamp(ts)) => {
+                turso_assert!(ts <= Self::VALUE_MASK, "timestamp exceeds 62-bit range");
+                PackedTs(Self::TIMESTAMP_TAG | ts)
+            }
+            Some(TxTimestampOrID::TxID(id)) => {
+                turso_assert!(id <= Self::VALUE_MASK, "tx id exceeds 62-bit range");
+                PackedTs(Self::TXID_TAG | id)
+            }
+        }
+    }
+
+    #[inline]
+    fn unpack(self) -> Option<TxTimestampOrID> {
+        if self.0 == 0 {
+            None
+        } else if self.0 & Self::TXID_TAG != 0 {
+            Some(TxTimestampOrID::TxID(self.0 & Self::VALUE_MASK))
+        } else {
+            Some(TxTimestampOrID::Timestamp(self.0 & Self::VALUE_MASK))
+        }
+    }
+}
+
+impl std::fmt::Debug for PackedTs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.unpack(), f)
+    }
+}
+
 /// A row version.
-/// TODO: we can optimize this by using bitpacking for the begin and end fields.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RowVersion {
     /// Unique identifier for this version within the MvStore.
     /// Used for savepoint tracking to identify specific versions to rollback.
     pub id: u64,
-    pub begin: Option<TxTimestampOrID>,
-    pub end: Option<TxTimestampOrID>,
+    /// `begin`/`end` timestamps are bit-packed. Read them through the
+    /// [`RowVersion::begin`]/[`RowVersion::end`] accessors and write them with
+    /// [`RowVersion::set_begin`]/[`RowVersion::set_end`]; the raw `PackedTs`
+    /// fields are `pub(crate)` only so they can be set in struct literals (via
+    /// `PackedTs::pack`).
+    pub(crate) begin: PackedTs,
+    pub(crate) end: PackedTs,
     pub row: Row,
     /// Indicates this version was created for a row that existed in B-tree before
     /// MVCC was enabled (e.g., after switching from WAL to MVCC journal mode).
@@ -518,7 +577,7 @@ fn portable_delete_op_extension_for_row_version<Clock: LogicalClock>(
     if !connection.portable_logical_changes_enabled() {
         return Ok(None);
     }
-    if !matches!(row_version.end, Some(TxTimestampOrID::Timestamp(_))) {
+    if !matches!(row_version.end(), Some(TxTimestampOrID::Timestamp(_))) {
         return Ok(None);
     }
     let RowKey::Int(rowid) = row_version.row.id.row_id else {
@@ -588,7 +647,7 @@ fn portable_delete_op_extension_for_row_version<Clock: LogicalClock>(
 /// phase of the transaction. During the active phase, new versions track the
 /// transaction ID in the `begin` and `end` fields. After a transaction commits,
 /// versions switch to tracking timestamps.
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub enum TxTimestampOrID {
     /// A committed transaction's timestamp.
     Timestamp(u64),
@@ -1599,7 +1658,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             // A row that we are trying to commit was deleted/updated by another
             // committed transaction after our begin timestamp. Even if that
             // version is now "ended", this is still a write-write conflict.
-            if let Some(TxTimestampOrID::Timestamp(end_ts)) = version.end {
+            if let Some(TxTimestampOrID::Timestamp(end_ts)) = version.end() {
                 turso_assert!(
                     end_ts != tx.begin_ts,
                     "committed end_ts and begin_ts cannot be equal: txn timestamps are strictly monotonic"
@@ -1615,11 +1674,11 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             // on the row — same as Hekaton's End field. We must detect this
             // as a write-write conflict using the same state-based logic used
             // for begin: TxID checks below.
-            if version.begin.is_none() {
+            if version.begin().is_none() {
                 // Committed tombstones (end: Timestamp) are already handled by
                 // the check above at lines 1070-1074. Here we only need to check
                 // in-flight tombstones (end: TxID) from other transactions.
-                if let Some(TxTimestampOrID::TxID(other_tx_id)) = version.end {
+                if let Some(TxTimestampOrID::TxID(other_tx_id)) = version.end() {
                     if other_tx_id != self.tx_id {
                         let other_tx = mvcc_store.txs.get(&other_tx_id).expect(
                             "check_version_conflicts: tombstone end TxID not found in txn map",
@@ -1643,7 +1702,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 continue;
             }
 
-            match version.end {
+            match version.end() {
                 Some(TxTimestampOrID::Timestamp(end_ts)) => {
                     // Committed deletion. If end_ts > our begin_ts, the conflict
                     // would have been already caught earlier when we iterate through
@@ -1689,7 +1748,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 }
             }
 
-            match version.begin {
+            match version.begin() {
                 Some(TxTimestampOrID::TxID(other_tx_id)) => {
                     // Skip our own version
                     if other_tx_id == self.tx_id {
@@ -1799,13 +1858,13 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
 
         let is_our_begin = |row_version: &RowVersion| {
             matches!(
-                row_version.begin,
+                row_version.begin(),
                 Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
             )
         };
         let is_our_end = |row_version: &RowVersion| {
             matches!(
-                row_version.end,
+                row_version.end(),
                 Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
             )
         };
@@ -2013,13 +2072,13 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 if our_begin {
                     // New version is valid STARTING FROM the committing
                     // transaction's end timestamp. See Hekaton page 299.
-                    committed.begin = Some(TxTimestampOrID::Timestamp(end_ts));
+                    committed.set_begin(Some(TxTimestampOrID::Timestamp(end_ts)));
 
                     if !our_end {
-                        // A version row_version we inserted may have row_version.end == tx_b.tx_id,
+                        // A version row_version we inserted may have row_version.end() == tx_b.tx_id,
                         // where tx_b is a concurrent tx. This is because when a tx transitions to
                         // Preparing, its row_version becomes *speculatively updatable*, and a tx tx_b
-                        // is allowed to change row_version.end from None to tx_b.tx_id to delete it
+                        // is allowed to change row_version.end() from None to tx_b.tx_id to delete it
                         // (see the Hekaton paper, §3.1, heading "check updatability").
                         //
                         // That deletion is tx_b's contribution, and tx_b will log it on its own commit.
@@ -2027,13 +2086,13 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                         // set, it will be serialized as a OP_DELETE_* in the logical log, so we unset
                         // it so that it will be serialized as an OP_UPSERT_*. tx_b will take care of
                         // logging the deletion.
-                        committed.end = None;
+                        committed.set_end(None);
                     }
                 }
                 if our_end {
                     // Old version is valid UNTIL the committing
                     // transaction's end timestamp. See Hekaton page 299.
-                    committed.end = Some(TxTimestampOrID::Timestamp(end_ts));
+                    committed.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
                 }
                 Some(committed)
             };
@@ -2046,7 +2105,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 let replaces_last = entry_versions.last().is_some_and(|last| {
                     last.row.id == committed_version.row.id
                         && matches!(
-                            (&last.begin, &committed_version.begin),
+                            (&last.begin(), &committed_version.begin()),
                             (
                                 Some(TxTimestampOrID::Timestamp(existing)),
                                 Some(TxTimestampOrID::Timestamp(new))
@@ -2064,7 +2123,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                     let same_row_and_begin = |existing: &RowVersion| {
                         existing.row.id == committed_version.row.id
                             && matches!(
-                                (&existing.begin, &committed_version.begin),
+                                (&existing.begin(), &committed_version.begin()),
                                 (
                                     Some(TxTimestampOrID::Timestamp(existing)),
                                     Some(TxTimestampOrID::Timestamp(new))
@@ -2444,14 +2503,14 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             let (_id, row_versions) = &write_set.entries[ctx.cursor];
             let mut row_versions = row_versions.write();
             for row_version in row_versions.iter_mut() {
-                if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.begin {
+                if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.begin() {
                     if rv_id == tx_id {
-                        row_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
+                        row_version.set_begin(Some(TxTimestampOrID::Timestamp(end_ts)));
                     }
                 }
-                if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.end {
+                if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.end() {
                     if rv_id == tx_id {
-                        row_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
+                        row_version.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
                     }
                 }
             }
@@ -4313,8 +4372,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let version_id = self.get_version_id();
                 let row_version = RowVersion {
                     id: version_id,
-                    begin: Some(TxTimestampOrID::TxID(tx.tx_id)),
-                    end: None,
+                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(tx.tx_id))),
+                    end: crate::mvcc::database::PackedTs::pack(None),
                     row: row.clone(),
                     btree_resident: false,
                 };
@@ -4341,8 +4400,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let version_id = self.get_version_id();
                 let row_version = RowVersion {
                     id: version_id,
-                    begin: Some(TxTimestampOrID::TxID(tx.tx_id)),
-                    end: None,
+                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(tx.tx_id))),
+                    end: crate::mvcc::database::PackedTs::pack(None),
                     row,
                     btree_resident: false,
                 };
@@ -4370,8 +4429,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             id: version_id,
             // Tombstones over B-tree-resident rows have no MVCC creator begin.
             // They invalidate B-tree visibility via end timestamp only.
-            begin: None,
-            end: Some(TxTimestampOrID::TxID(tx_id)),
+            begin: crate::mvcc::database::PackedTs::pack(None),
+            end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(tx_id))),
             row: row.clone(),
             btree_resident: true,
         };
@@ -4429,8 +4488,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let version_id = self.get_version_id();
                 let row_version = RowVersion {
                     id: version_id,
-                    begin: Some(TxTimestampOrID::TxID(tx.tx_id)),
-                    end: None,
+                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(tx.tx_id))),
+                    end: crate::mvcc::database::PackedTs::pack(None),
                     row: row.clone(),
                     btree_resident: true,
                 };
@@ -4449,8 +4508,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let version_id = self.get_version_id();
                 let row_version = RowVersion {
                     id: version_id,
-                    begin: Some(TxTimestampOrID::TxID(tx.tx_id)),
-                    end: None,
+                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(tx.tx_id))),
+                    end: crate::mvcc::database::PackedTs::pack(None),
                     row,
                     btree_resident: true,
                 };
@@ -4573,7 +4632,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         }
 
                         let version_id = rv.id;
-                        rv.end = Some(TxTimestampOrID::TxID(tx.tx_id));
+                        rv.set_end(Some(TxTimestampOrID::TxID(tx.tx_id)));
                         let tx = self
                             .txs
                             .get(&tx_id)
@@ -4609,7 +4668,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         }
 
                         let version_id = rv.id;
-                        rv.end = Some(TxTimestampOrID::TxID(tx.tx_id));
+                        rv.set_end(Some(TxTimestampOrID::TxID(tx.tx_id)));
                         drop(locked_row_versions);
                         drop(row_versions_opt);
                         let tx = self
@@ -5624,7 +5683,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let mut versions = entry.value().write();
                 for rv in versions.iter_mut() {
                     if rv.id == version_id {
-                        rv.end = None;
+                        rv.set_end(None);
                         tracing::debug!(
                             "rollback_savepoint: restored table version(table_id={}, row_id={}, version_id={})",
                             rowid.table_id,
@@ -5643,7 +5702,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     let mut versions = entry.value().write();
                     for rv in versions.iter_mut() {
                         if rv.id == version_id {
-                            rv.end = None;
+                            rv.set_end(None);
                             tracing::debug!(
                                 "rollback_savepoint: restored index version(table_id={}, version_id={})",
                                 table_id,
@@ -5675,8 +5734,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             };
             let versions = entry.value().read();
             return versions.iter().any(|rv| {
-                rv.begin == Some(TxTimestampOrID::TxID(tx_id))
-                    || rv.end == Some(TxTimestampOrID::TxID(tx_id))
+                rv.begin() == Some(TxTimestampOrID::TxID(tx_id))
+                    || rv.end() == Some(TxTimestampOrID::TxID(tx_id))
             });
         }
 
@@ -5691,8 +5750,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         };
         let versions = entry.value().read();
         versions.iter().any(|rv| {
-            rv.begin == Some(TxTimestampOrID::TxID(tx_id))
-                || rv.end == Some(TxTimestampOrID::TxID(tx_id))
+            rv.begin() == Some(TxTimestampOrID::TxID(tx_id))
+                || rv.end() == Some(TxTimestampOrID::TxID(tx_id))
         })
     }
 
@@ -5975,10 +6034,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
     fn collect_referenced_txids(versions: &[RowVersion], referenced_tx_ids: &mut HashSet<TxID>) {
         for version in versions {
-            if let Some(TxTimestampOrID::TxID(tx_id)) = version.begin {
+            if let Some(TxTimestampOrID::TxID(tx_id)) = version.begin() {
                 referenced_tx_ids.insert(tx_id);
             }
-            if let Some(TxTimestampOrID::TxID(tx_id)) = version.end {
+            if let Some(TxTimestampOrID::TxID(tx_id)) = version.end() {
                 referenced_tx_ids.insert(tx_id);
             }
         }
@@ -6018,7 +6077,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let before = versions.len();
 
         // Rule 1: aborted garbage
-        versions.retain(|rv| !matches!((&rv.begin, &rv.end), (None, None)));
+        versions.retain(|rv| !matches!((&rv.begin(), &rv.end()), (None, None)));
 
         // Rule 2: superseded versions below LWM, with tombstone guard.
         // A superseded version with e <= lwm is invisible to all readers and
@@ -6032,8 +6091,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // which would resurrect the B-tree row if the tombstone was removed.
         let has_current = versions
             .iter()
-            .any(|rv| rv.end.is_none() && matches!(&rv.begin, Some(TxTimestampOrID::Timestamp(_))));
-        versions.retain(|rv| match &rv.end {
+            .any(|rv| rv.end().is_none() && matches!(&rv.begin(), Some(TxTimestampOrID::Timestamp(_))));
+        versions.retain(|rv| match &rv.end() {
             Some(TxTimestampOrID::Timestamp(e)) if *e <= lwm => {
                 // Retain only if this is a tombstone AND not yet checkpointed.
                 !has_current && *e > ckpt_max
@@ -6047,7 +6106,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // remain that would poison is_btree_invalidating_version.
         if versions.len() == 1 {
             if let (Some(TxTimestampOrID::Timestamp(b)), None) =
-                (&versions[0].begin, &versions[0].end)
+                (&versions[0].begin(), &versions[0].end())
             {
                 if *b <= ckpt_max && *b < lwm {
                     versions.clear();
@@ -6158,8 +6217,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // which performs a binary search for the insertion point.
         let mut position = 0_usize;
         for (i, v) in versions.iter().enumerate().rev() {
-            let existing_begin = self.resolve_begin_timestamp(&v.begin);
-            let new_begin = self.resolve_begin_timestamp(&row_version.begin);
+            let existing_begin = self.resolve_begin_timestamp(&v.begin());
+            let new_begin = self.resolve_begin_timestamp(&row_version.begin());
             if existing_begin <= new_begin {
                 // Recovery can replay multiple operations for the same row from one transaction
                 // (e.g. insert then delete), which share the same begin timestamp.
@@ -6170,7 +6229,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 // must never be conflated with a later statement's transient tombstone.
                 if versions[i].row.id == row_version.row.id
                     && matches!(
-                        (&versions[i].begin, &row_version.begin),
+                        (&versions[i].begin(), &row_version.begin()),
                         (
                             Some(TxTimestampOrID::Timestamp(existing)),
                             Some(TxTimestampOrID::Timestamp(new))
@@ -7082,8 +7141,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let version_id = self.get_version_id();
                         let row_version = RowVersion {
                             id: version_id,
-                            begin: Some(TxTimestampOrID::Timestamp(commit_ts)),
-                            end: None,
+                            begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
+                            end: crate::mvcc::database::PackedTs::pack(None),
                             row: row.clone(),
                             btree_resident,
                         };
@@ -7134,16 +7193,16 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             // resident row not yet in memory), insert a tombstone instead.
                             let mut versions = versions.value().write();
                             if let Some(existing) = versions.iter_mut().rev().find(|rv| {
-                        rv.end.is_none()
-                            && matches!(rv.begin, Some(TxTimestampOrID::Timestamp(b)) if b < commit_ts)
+                        rv.end().is_none()
+                            && matches!(rv.begin(), Some(TxTimestampOrID::Timestamp(b)) if b < commit_ts)
                     }) {
-                        existing.end = Some(TxTimestampOrID::Timestamp(commit_ts));
+                        existing.set_end(Some(TxTimestampOrID::Timestamp(commit_ts)));
                     } else {
                         let version_id = self.get_version_id();
                         let row_version = RowVersion {
                             id: version_id,
-                            begin: None,
-                            end: Some(TxTimestampOrID::Timestamp(commit_ts)),
+                            begin: crate::mvcc::database::PackedTs::pack(None),
+                            end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
                             row: tombstone_row.clone(),
                             btree_resident,
                         };
@@ -7153,8 +7212,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             let version_id = self.get_version_id();
                             let row_version = RowVersion {
                                 id: version_id,
-                                begin: None,
-                                end: Some(TxTimestampOrID::Timestamp(commit_ts)),
+                                begin: crate::mvcc::database::PackedTs::pack(None),
+                                end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
                                 row: tombstone_row,
                                 btree_resident,
                             };
@@ -7207,8 +7266,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let version_id = self.get_version_id();
                         let row_version = RowVersion {
                             id: version_id,
-                            begin: Some(TxTimestampOrID::Timestamp(commit_ts)),
-                            end: None,
+                            begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
+                            end: crate::mvcc::database::PackedTs::pack(None),
                             row: row.clone(),
                             btree_resident,
                         };
@@ -7236,10 +7295,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             if let Some(versions) = index_map.value().get(&sortable_key) {
                                 let mut versions = versions.value().write();
                                 if let Some(existing) = versions.iter_mut().rev().find(|rv| {
-                            rv.end.is_none()
-                                && matches!(rv.begin, Some(TxTimestampOrID::Timestamp(b)) if b < commit_ts)
+                            rv.end().is_none()
+                                && matches!(rv.begin(), Some(TxTimestampOrID::Timestamp(b)) if b < commit_ts)
                         }) {
-                            existing.end = Some(TxTimestampOrID::Timestamp(commit_ts));
+                            existing.set_end(Some(TxTimestampOrID::Timestamp(commit_ts)));
                             continue;
                         }
                             }
@@ -7247,8 +7306,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let version_id = self.get_version_id();
                         let row_version = RowVersion {
                             id: version_id,
-                            begin: None,
-                            end: Some(TxTimestampOrID::Timestamp(commit_ts)),
+                            begin: crate::mvcc::database::PackedTs::pack(None),
+                            end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
                             row: row.clone(),
                             btree_resident,
                         };
@@ -7451,16 +7510,16 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 }
 
 fn rollback_row_version(tx_id: u64, rv: &mut RowVersion) {
-    if rv.begin == Some(TxTimestampOrID::TxID(tx_id)) {
+    if rv.begin() == Some(TxTimestampOrID::TxID(tx_id)) {
         // If the transaction has aborted,
         // it marks all its new versions as garbage and sets their Begin
         // and End timestamps to infinity to make them invisible
         // See section 2.4: https://www.cs.cmu.edu/~15721-f24/papers/Hekaton.pdf
-        rv.begin = None;
-        rv.end = None;
-    } else if rv.end == Some(TxTimestampOrID::TxID(tx_id)) {
+        rv.set_begin(None);
+        rv.set_end(None);
+    } else if rv.end() == Some(TxTimestampOrID::TxID(tx_id)) {
         // undo deletions by this transaction
-        rv.end = None;
+        rv.set_end(None);
     }
 }
 
@@ -7566,7 +7625,7 @@ fn is_write_write_conflict(
     tx: &Transaction,
     rv: &RowVersion,
 ) -> bool {
-    match rv.end {
+    match rv.end() {
         Some(TxTimestampOrID::TxID(rv_end)) => {
             if rv_end == tx.tx_id {
                 return false;
@@ -7596,6 +7655,45 @@ fn is_write_write_conflict(
 }
 
 impl RowVersion {
+    /// Construct a row version. `begin`/`end` are bit-packed internally.
+    pub fn new(
+        id: u64,
+        begin: Option<TxTimestampOrID>,
+        end: Option<TxTimestampOrID>,
+        row: Row,
+        btree_resident: bool,
+    ) -> Self {
+        Self {
+            id,
+            begin: crate::mvcc::database::PackedTs::pack(begin),
+            end: crate::mvcc::database::PackedTs::pack(end),
+            row,
+            btree_resident,
+        }
+    }
+
+    /// The begin timestamp/tx-id, or `None`.
+    #[inline]
+    pub fn begin(&self) -> Option<TxTimestampOrID> {
+        self.begin.unpack()
+    }
+
+    /// The end timestamp/tx-id, or `None`.
+    #[inline]
+    pub fn end(&self) -> Option<TxTimestampOrID> {
+        self.end.unpack()
+    }
+
+    #[inline]
+    pub fn set_begin(&mut self, value: Option<TxTimestampOrID>) {
+        self.begin = crate::mvcc::database::PackedTs::pack(value);
+    }
+
+    #[inline]
+    pub fn set_end(&mut self, value: Option<TxTimestampOrID>) {
+        self.end = crate::mvcc::database::PackedTs::pack(value);
+    }
+
     /// A row is visible to a transaction if:
     /// * Begin is visible to the transaction
     /// * End timestamp is not applicable yet, meaning deletion of row is not visible to this transaction
@@ -7629,7 +7727,7 @@ impl RowVersion {
         }
 
         // Check if this version represents a deletion/update that affects us
-        match self.end {
+        match self.end() {
             Some(TxTimestampOrID::Timestamp(end_ts)) => {
                 // Row was deleted at end_ts. If we started after end_ts, we shouldn't see it
                 turso_assert!(
@@ -7772,7 +7870,7 @@ fn is_begin_visible(
     tx: &Transaction,
     rv: &RowVersion,
 ) -> bool {
-    match rv.begin {
+    match rv.begin() {
         Some(TxTimestampOrID::Timestamp(rv_begin_ts)) => {
             turso_assert!(
                 tx.begin_ts != rv_begin_ts,
@@ -7785,7 +7883,7 @@ fn is_begin_visible(
                 Some(tb_entry) => {
                     let tb = tb_entry.value();
                     let visible = match tb.state.load() {
-                        TransactionState::Active => tx.tx_id == tb.tx_id && rv.end.is_none(),
+                        TransactionState::Active => tx.tx_id == tb.tx_id && rv.end().is_none(),
                         TransactionState::Preparing(end_ts) => {
                             // Hekaton Table 1 / Section 2.5: speculative read of TB.
                             // If begin_ts > end_ts, the version would be visible once TB
@@ -7823,8 +7921,8 @@ fn is_begin_visible(
                     };
                     tracing::trace!(
                         "is_begin_visible: tx={tx}, tb={tb} rv = {:?}-{:?} visible = {visible}",
-                        rv.begin,
-                        rv.end
+                        rv.begin(),
+                        rv.end()
                     );
                     visible
                 }
@@ -7863,7 +7961,7 @@ fn is_end_visible(
     current_tx: &Transaction,
     row_version: &RowVersion,
 ) -> bool {
-    match row_version.end {
+    match row_version.end() {
         Some(TxTimestampOrID::Timestamp(rv_end_ts)) => current_tx.begin_ts < rv_end_ts,
         Some(TxTimestampOrID::TxID(rv_end)) => {
             let visible = match txs.get(&rv_end) {
@@ -7898,8 +7996,8 @@ fn is_end_visible(
                     };
                     tracing::trace!(
                         "is_end_visible: tx={current_tx}, te={other_tx} rv = {:?}-{:?}  visible = {visible}",
-                        row_version.begin,
-                        row_version.end
+                        row_version.begin(),
+                        row_version.end()
                     );
                     visible
                 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4372,7 +4372,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let version_id = self.get_version_id();
                 let row_version = RowVersion {
                     id: version_id,
-                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(tx.tx_id))),
+                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(
+                        tx.tx_id,
+                    ))),
                     end: crate::mvcc::database::PackedTs::pack(None),
                     row: row.clone(),
                     btree_resident: false,
@@ -4400,7 +4402,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let version_id = self.get_version_id();
                 let row_version = RowVersion {
                     id: version_id,
-                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(tx.tx_id))),
+                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(
+                        tx.tx_id,
+                    ))),
                     end: crate::mvcc::database::PackedTs::pack(None),
                     row,
                     btree_resident: false,
@@ -4488,7 +4492,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let version_id = self.get_version_id();
                 let row_version = RowVersion {
                     id: version_id,
-                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(tx.tx_id))),
+                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(
+                        tx.tx_id,
+                    ))),
                     end: crate::mvcc::database::PackedTs::pack(None),
                     row: row.clone(),
                     btree_resident: true,
@@ -4508,7 +4514,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let version_id = self.get_version_id();
                 let row_version = RowVersion {
                     id: version_id,
-                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(tx.tx_id))),
+                    begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(
+                        tx.tx_id,
+                    ))),
                     end: crate::mvcc::database::PackedTs::pack(None),
                     row,
                     btree_resident: true,
@@ -6089,9 +6097,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // has_current only counts committed current versions (begin=Timestamp).
         // Pending inserts (begin=TxID) don't count — they might roll back,
         // which would resurrect the B-tree row if the tombstone was removed.
-        let has_current = versions
-            .iter()
-            .any(|rv| rv.end().is_none() && matches!(&rv.begin(), Some(TxTimestampOrID::Timestamp(_))));
+        let has_current = versions.iter().any(|rv| {
+            rv.end().is_none() && matches!(&rv.begin(), Some(TxTimestampOrID::Timestamp(_)))
+        });
         versions.retain(|rv| match &rv.end() {
             Some(TxTimestampOrID::Timestamp(e)) if *e <= lwm => {
                 // Retain only if this is a tombstone AND not yet checkpointed.
@@ -7141,7 +7149,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let version_id = self.get_version_id();
                         let row_version = RowVersion {
                             id: version_id,
-                            begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
+                            begin: crate::mvcc::database::PackedTs::pack(Some(
+                                TxTimestampOrID::Timestamp(commit_ts),
+                            )),
                             end: crate::mvcc::database::PackedTs::pack(None),
                             row: row.clone(),
                             btree_resident,
@@ -7213,7 +7223,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             let row_version = RowVersion {
                                 id: version_id,
                                 begin: crate::mvcc::database::PackedTs::pack(None),
-                                end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
+                                end: crate::mvcc::database::PackedTs::pack(Some(
+                                    TxTimestampOrID::Timestamp(commit_ts),
+                                )),
                                 row: tombstone_row,
                                 btree_resident,
                             };
@@ -7266,7 +7278,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let version_id = self.get_version_id();
                         let row_version = RowVersion {
                             id: version_id,
-                            begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
+                            begin: crate::mvcc::database::PackedTs::pack(Some(
+                                TxTimestampOrID::Timestamp(commit_ts),
+                            )),
                             end: crate::mvcc::database::PackedTs::pack(None),
                             row: row.clone(),
                             btree_resident,
@@ -7307,7 +7321,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let row_version = RowVersion {
                             id: version_id,
                             begin: crate::mvcc::database::PackedTs::pack(None),
-                            end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
+                            end: crate::mvcc::database::PackedTs::pack(Some(
+                                TxTimestampOrID::Timestamp(commit_ts),
+                            )),
                             row: row.clone(),
                             btree_resident,
                         };

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7566,8 +7566,8 @@ fn test_gc_integration_rollback_creates_aborted_garbage() {
 fn test_gc_shrinks_version_chain_capacity() {
     let make_version = |begin, end| RowVersion {
         id: 0,
-        begin,
-        end,
+        begin: crate::mvcc::database::PackedTs::pack(begin),
+        end: crate::mvcc::database::PackedTs::pack(end),
         row: generate_simple_string_row((-2).into(), 1, "shrink"),
         btree_resident: false,
     };
@@ -7930,8 +7930,9 @@ fn prop_gc_retains_txid_begins(chain: ArbitraryVersionChain) -> bool {
 fn prop_gc_retains_txid_ends(chain: ArbitraryVersionChain) -> bool {
     // Versions with end=TxID and non-None begin are not matched by any removal
     // rule (rule 1 requires (None,None), rule 2 requires end=Timestamp).
-    let filter =
-        |rv: &&RowVersion| matches!(&rv.end(), Some(TxTimestampOrID::TxID(_))) && rv.begin().is_some();
+    let filter = |rv: &&RowVersion| {
+        matches!(&rv.end(), Some(TxTimestampOrID::TxID(_))) && rv.begin().is_some()
+    };
     let txid_ends_before: usize = chain.versions.iter().filter(filter).count();
     let mut versions = chain.versions;
     MvStore::<MvccClock>::gc_version_chain(&mut versions, chain.lwm, chain.ckpt_max);

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1213,15 +1213,15 @@ fn test_recovery_rejects_schema_op_after_data_op_in_frame() {
     let commit_ts = 1u64 << 40;
     let data_version = RowVersion {
         id: 1,
-        begin: Some(TxTimestampOrID::Timestamp(commit_ts)),
-        end: None,
+        begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
+        end: crate::mvcc::database::PackedTs::pack(None),
         row: generate_simple_string_row(MVTableId::from(-999), 1, "data"),
         btree_resident: false,
     };
     let schema_version = RowVersion {
         id: 2,
-        begin: Some(TxTimestampOrID::Timestamp(commit_ts)),
-        end: None,
+        begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
+        end: crate::mvcc::database::PackedTs::pack(None),
         row: generate_simple_string_row(SQLITE_SCHEMA_MVCC_TABLE_ID, 1, "schema"),
         btree_resident: false,
     };
@@ -4440,8 +4440,8 @@ fn test_snapshot_isolation_tx_visible1() {
     let rv_visible = |begin: Option<TxTimestampOrID>, end: Option<TxTimestampOrID>| {
         let row_version = RowVersion {
             id: 0, // Dummy ID for visibility tests
-            begin,
-            end,
+            begin: crate::mvcc::database::PackedTs::pack(begin),
+            end: crate::mvcc::database::PackedTs::pack(end),
             row: generate_simple_string_row((-2).into(), 1, "testme"),
             btree_resident: false,
         };
@@ -4540,8 +4540,8 @@ fn test_visibility_uses_finalized_state_for_removed_committed_tx() {
 
     let inserted_row = RowVersion {
         id: 1,
-        begin: Some(TxTimestampOrID::TxID(42)),
-        end: None,
+        begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(42))),
+        end: crate::mvcc::database::PackedTs::pack(None),
         row: generate_simple_string_row((-2).into(), 1, "x"),
         btree_resident: false,
     };
@@ -4552,8 +4552,8 @@ fn test_visibility_uses_finalized_state_for_removed_committed_tx() {
 
     let deleted_row = RowVersion {
         id: 2,
-        begin: Some(TxTimestampOrID::Timestamp(1)),
-        end: Some(TxTimestampOrID::TxID(42)),
+        begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(1))),
+        end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(42))),
         row: generate_simple_string_row((-2).into(), 2, "y"),
         btree_resident: false,
     };
@@ -4627,8 +4627,8 @@ fn test_commit_dependency_speculative_read() {
 
     let rv = RowVersion {
         id: 0,
-        begin: Some(TxTimestampOrID::TxID(1)),
-        end: None,
+        begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(1))),
+        end: crate::mvcc::database::PackedTs::pack(None),
         row: generate_simple_string_row((-2).into(), 1, "test"),
         btree_resident: false,
     };
@@ -4659,8 +4659,8 @@ fn test_commit_dependency_cascade_abort() {
 
     let rv = RowVersion {
         id: 0,
-        begin: Some(TxTimestampOrID::TxID(1)),
-        end: None,
+        begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(1))),
+        end: crate::mvcc::database::PackedTs::pack(None),
         row: generate_simple_string_row((-2).into(), 1, "test"),
         btree_resident: false,
     };
@@ -4734,8 +4734,8 @@ fn test_commit_dependency_speculative_ignore() {
 
     let rv = RowVersion {
         id: 0,
-        begin: Some(TxTimestampOrID::Timestamp(2)),
-        end: Some(TxTimestampOrID::TxID(3)),
+        begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(2))),
+        end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(3))),
         row: generate_simple_string_row((-2).into(), 1, "test"),
         btree_resident: false,
     };
@@ -4763,8 +4763,8 @@ fn test_commit_dependency_multiple_reads_dedup() {
 
     let make_rv = |row_id: i64| RowVersion {
         id: row_id as u64,
-        begin: Some(TxTimestampOrID::TxID(1)),
-        end: None,
+        begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(1))),
+        end: crate::mvcc::database::PackedTs::pack(None),
         row: generate_simple_string_row((-2).into(), row_id, "test"),
         btree_resident: false,
     };
@@ -5068,11 +5068,11 @@ fn test_commit_dep_threaded_commit_resolves() {
         for entry in mvcc_store.rows.iter() {
             let mut rvs = entry.value().write();
             for rv in rvs.iter_mut() {
-                if rv.begin == Some(TxTimestampOrID::TxID(writer_tx_id)) {
-                    rv.begin = Some(TxTimestampOrID::Timestamp(end_ts));
+                if rv.begin() == Some(TxTimestampOrID::TxID(writer_tx_id)) {
+                    rv.set_begin(Some(TxTimestampOrID::Timestamp(end_ts)));
                 }
-                if rv.end == Some(TxTimestampOrID::TxID(writer_tx_id)) {
-                    rv.end = Some(TxTimestampOrID::Timestamp(end_ts));
+                if rv.end() == Some(TxTimestampOrID::TxID(writer_tx_id)) {
+                    rv.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
                 }
             }
         }
@@ -5320,11 +5320,11 @@ fn test_commit_dep_readonly_does_not_advance_timestamp() {
         for entry in mvcc_store.rows.iter() {
             let mut rvs = entry.value().write();
             for rv in rvs.iter_mut() {
-                if rv.begin == Some(TxTimestampOrID::TxID(writer_tx_id)) {
-                    rv.begin = Some(TxTimestampOrID::Timestamp(end_ts));
+                if rv.begin() == Some(TxTimestampOrID::TxID(writer_tx_id)) {
+                    rv.set_begin(Some(TxTimestampOrID::Timestamp(end_ts)));
                 }
-                if rv.end == Some(TxTimestampOrID::TxID(writer_tx_id)) {
-                    rv.end = Some(TxTimestampOrID::Timestamp(end_ts));
+                if rv.end() == Some(TxTimestampOrID::TxID(writer_tx_id)) {
+                    rv.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
                 }
             }
         }
@@ -5482,11 +5482,11 @@ fn test_commit_dep_readonly_does_not_cause_spurious_busy() {
         for entry in mvcc_store.rows.iter() {
             let mut rvs = entry.value().write();
             for rv in rvs.iter_mut() {
-                if rv.begin == Some(TxTimestampOrID::TxID(writer_tx_id)) {
-                    rv.begin = Some(TxTimestampOrID::Timestamp(end_ts));
+                if rv.begin() == Some(TxTimestampOrID::TxID(writer_tx_id)) {
+                    rv.set_begin(Some(TxTimestampOrID::Timestamp(end_ts)));
                 }
-                if rv.end == Some(TxTimestampOrID::TxID(writer_tx_id)) {
-                    rv.end = Some(TxTimestampOrID::Timestamp(end_ts));
+                if rv.end() == Some(TxTimestampOrID::TxID(writer_tx_id)) {
+                    rv.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
                 }
             }
         }
@@ -7153,8 +7153,8 @@ fn test_update_multiple_unique_columns_partial_rollback() {
 fn make_rv(begin: Option<TxTimestampOrID>, end: Option<TxTimestampOrID>) -> RowVersion {
     RowVersion {
         id: 0,
-        begin,
-        end,
+        begin: crate::mvcc::database::PackedTs::pack(begin),
+        end: crate::mvcc::database::PackedTs::pack(end),
         row: generate_simple_string_row((-2).into(), 1, "gc_test"),
         btree_resident: false,
     }
@@ -7196,7 +7196,7 @@ fn test_gc_rule1_aborted_among_live_versions() {
     assert_eq!(versions.len(), 2);
     assert!(versions
         .iter()
-        .all(|rv| rv.begin.is_some() || rv.end.is_some()));
+        .all(|rv| rv.begin().is_some() || rv.end().is_some()));
 }
 
 /// What this test checks: Garbage collection removes only versions that are provably unreachable and keeps versions still required for visibility and safety.
@@ -7214,7 +7214,7 @@ fn test_gc_rule2_superseded_below_lwm_with_current() {
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 0);
     assert_eq!(dropped, 1);
     assert_eq!(versions.len(), 1);
-    assert!(versions[0].end.is_none()); // only current remains
+    assert!(versions[0].end().is_none()); // only current remains
 }
 
 /// What this test checks: Garbage collection removes only versions that are provably unreachable and keeps versions still required for visibility and safety.
@@ -7406,7 +7406,7 @@ fn test_gc_rule2_committed_current_disables_tombstone_guard() {
     // Superseded removed (has_current=true for committed version), current remains.
     assert_eq!(dropped, 1);
     assert_eq!(versions.len(), 1);
-    assert!(versions[0].end.is_none());
+    assert!(versions[0].end().is_none());
 }
 
 /// What this test checks: Garbage collection removes only versions that are provably unreachable and keeps versions still required for visibility and safety.
@@ -7539,8 +7539,8 @@ fn test_gc_integration_rollback_creates_aborted_garbage() {
     {
         let versions = entry.as_ref().unwrap().value().read();
         assert_eq!(versions.len(), 1);
-        assert!(versions[0].begin.is_none());
-        assert!(versions[0].end.is_none());
+        assert!(versions[0].begin().is_none());
+        assert!(versions[0].end().is_none());
     }
 
     // GC should clean up the version. The SkipMap entry stays (lazy removal
@@ -7831,8 +7831,8 @@ fn arbitrary_row_version(g: &mut Gen) -> RowVersion {
 
     RowVersion {
         id: 0,
-        begin,
-        end,
+        begin: crate::mvcc::database::PackedTs::pack(begin),
+        end: crate::mvcc::database::PackedTs::pack(end),
         row: generate_simple_string_row((-2).into(), 1, "qc"),
         btree_resident: bool::arbitrary(g),
     }
@@ -7887,7 +7887,7 @@ fn prop_gc_is_idempotent(chain: ArbitraryVersionChain) -> bool {
         && v1
             .iter()
             .zip(snapshot.iter())
-            .all(|(a, b)| a.begin == b.begin && a.end == b.end)
+            .all(|(a, b)| a.begin() == b.begin() && a.end() == b.end())
 }
 
 /// Aborted garbage (begin=None, end=None) is invisible to every transaction and
@@ -7899,7 +7899,7 @@ fn prop_gc_removes_all_aborted_garbage(chain: ArbitraryVersionChain) -> bool {
     MvStore::<MvccClock>::gc_version_chain(&mut versions, chain.lwm, chain.ckpt_max);
     versions
         .iter()
-        .all(|rv| !matches!((&rv.begin, &rv.end), (None, None)))
+        .all(|rv| !matches!((&rv.begin(), &rv.end()), (None, None)))
 }
 
 /// Uncommitted inserts (begin=TxID, end=None) belong to an in-flight transaction.
@@ -7910,13 +7910,13 @@ fn prop_gc_retains_txid_begins(chain: ArbitraryVersionChain) -> bool {
     let txid_begins_before: usize = chain
         .versions
         .iter()
-        .filter(|rv| matches!(&rv.begin, Some(TxTimestampOrID::TxID(_))) && rv.end.is_none())
+        .filter(|rv| matches!(&rv.begin(), Some(TxTimestampOrID::TxID(_))) && rv.end().is_none())
         .count();
     let mut versions = chain.versions;
     MvStore::<MvccClock>::gc_version_chain(&mut versions, chain.lwm, chain.ckpt_max);
     let txid_begins_after: usize = versions
         .iter()
-        .filter(|rv| matches!(&rv.begin, Some(TxTimestampOrID::TxID(_))) && rv.end.is_none())
+        .filter(|rv| matches!(&rv.begin(), Some(TxTimestampOrID::TxID(_))) && rv.end().is_none())
         .count();
     // Active uncommitted versions (begin=TxID, end=None) are never aborted garbage
     // and don't match rule 2 or 3, so they should be retained.
@@ -7931,7 +7931,7 @@ fn prop_gc_retains_txid_ends(chain: ArbitraryVersionChain) -> bool {
     // Versions with end=TxID and non-None begin are not matched by any removal
     // rule (rule 1 requires (None,None), rule 2 requires end=Timestamp).
     let filter =
-        |rv: &&RowVersion| matches!(&rv.end, Some(TxTimestampOrID::TxID(_))) && rv.begin.is_some();
+        |rv: &&RowVersion| matches!(&rv.end(), Some(TxTimestampOrID::TxID(_))) && rv.begin().is_some();
     let txid_ends_before: usize = chain.versions.iter().filter(filter).count();
     let mut versions = chain.versions;
     MvStore::<MvccClock>::gc_version_chain(&mut versions, chain.lwm, chain.ckpt_max);
@@ -7949,7 +7949,7 @@ fn prop_gc_current_versions_protected_before_checkpoint(chain: ArbitraryVersionC
         .iter()
         .filter(|rv| {
             matches!(
-                (&rv.begin, &rv.end),
+                (&rv.begin(), &rv.end()),
                 (Some(TxTimestampOrID::Timestamp(_)), None)
             )
         })
@@ -7960,7 +7960,7 @@ fn prop_gc_current_versions_protected_before_checkpoint(chain: ArbitraryVersionC
         .iter()
         .filter(|rv| {
             matches!(
-                (&rv.begin, &rv.end),
+                (&rv.begin(), &rv.end()),
                 (Some(TxTimestampOrID::Timestamp(_)), None)
             )
         })
@@ -7986,16 +7986,16 @@ fn prop_gc_tombstone_guard_preserves_btree_safety(chain: ArbitraryVersionChain) 
     let had_committed_current = chain
         .versions
         .iter()
-        .any(|rv| rv.end.is_none() && matches!(&rv.begin, Some(TxTimestampOrID::Timestamp(_))));
+        .any(|rv| rv.end().is_none() && matches!(&rv.begin(), Some(TxTimestampOrID::Timestamp(_))));
     let had_uncheckpointed_tombstone = chain
         .versions
         .iter()
-        .any(|rv| matches!(&rv.end, Some(TxTimestampOrID::Timestamp(e)) if *e > chain.ckpt_max));
+        .any(|rv| matches!(&rv.end(), Some(TxTimestampOrID::Timestamp(e)) if *e > chain.ckpt_max));
     // Only non-garbage versions matter (aborted garbage is always removed first)
     let had_non_garbage = chain
         .versions
         .iter()
-        .any(|rv| !matches!((&rv.begin, &rv.end), (None, None)));
+        .any(|rv| !matches!((&rv.begin(), &rv.end()), (None, None)));
 
     if !had_committed_current && had_uncheckpointed_tombstone && had_non_garbage {
         !versions.is_empty()
@@ -8020,10 +8020,10 @@ fn prop_gc_no_orphaned_superseded_versions(chain: ArbitraryVersionChain) -> bool
 
     let has_committed_current = versions
         .iter()
-        .any(|rv| rv.end.is_none() && matches!(&rv.begin, Some(TxTimestampOrID::Timestamp(_))));
+        .any(|rv| rv.end().is_none() && matches!(&rv.begin(), Some(TxTimestampOrID::Timestamp(_))));
     let has_superseded = versions.iter().any(|rv| {
         matches!(
-            (&rv.begin, &rv.end),
+            (&rv.begin(), &rv.end()),
             (
                 Some(TxTimestampOrID::Timestamp(_)),
                 Some(TxTimestampOrID::Timestamp(_))
@@ -8036,7 +8036,7 @@ fn prop_gc_no_orphaned_superseded_versions(chain: ArbitraryVersionChain) -> bool
             .iter()
             .filter(|rv| {
                 matches!(
-                    (&rv.begin, &rv.end),
+                    (&rv.begin(), &rv.end()),
                     (
                         Some(TxTimestampOrID::Timestamp(_)),
                         Some(TxTimestampOrID::Timestamp(_))
@@ -8044,7 +8044,7 @@ fn prop_gc_no_orphaned_superseded_versions(chain: ArbitraryVersionChain) -> bool
                 )
             })
             .all(|rv| {
-                if let Some(TxTimestampOrID::Timestamp(e)) = &rv.end {
+                if let Some(TxTimestampOrID::Timestamp(e)) = &rv.end() {
                     *e > chain.lwm || *e > chain.ckpt_max
                 } else {
                     false

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -238,9 +238,7 @@ use crate::turso_assert;
 use crate::{
     io::{CompletionGroup, ReadComplete},
     io_yield_one,
-    mvcc::database::{
-        LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey,
-    },
+    mvcc::database::{LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey},
     return_if_io,
     storage::sqlite3_ondisk::{
         read_varint, read_varint_partial, varint_len, write_varint_to_vec, DatabaseHeader,
@@ -3963,7 +3961,9 @@ mod tests {
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row: row.clone(),
             btree_resident: false,
@@ -4048,7 +4048,9 @@ mod tests {
         let row = generate_simple_string_row(table_id, rowid, payload_text);
         let row_version = crate::mvcc::database::RowVersion {
             id: commit_ts,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts),
+            )),
             end: crate::mvcc::database::PackedTs::pack(if is_delete {
                 Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))
             } else {
@@ -4175,7 +4177,9 @@ mod tests {
     ) -> crate::mvcc::database::RowVersion {
         crate::mvcc::database::RowVersion {
             id: commit_ts,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row: generate_simple_string_row(table_id, rowid, data),
             btree_resident: false,
@@ -4782,7 +4786,9 @@ mod tests {
         let mut tx1 = crate::mvcc::database::LogRecord::new(10);
         tx1.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(10))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(10),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row: row.clone(),
             btree_resident: false,
@@ -4793,7 +4799,9 @@ mod tests {
         let mut tx2 = crate::mvcc::database::LogRecord::new(20);
         tx2.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 2,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(20))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(20),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,
@@ -4946,7 +4954,9 @@ mod tests {
             3,
             &[crate::mvcc::database::RowVersion {
                 id: 3,
-                begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(3))),
+                begin: crate::mvcc::database::PackedTs::pack(Some(
+                    crate::mvcc::database::TxTimestampOrID::Timestamp(3),
+                )),
                 end: crate::mvcc::database::PackedTs::pack(None),
                 row: row3,
                 btree_resident: false,
@@ -4998,7 +5008,9 @@ mod tests {
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(123))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(123),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,
@@ -5470,7 +5482,9 @@ mod tests {
         let mut tx = crate::mvcc::database::LogRecord::new(300);
         tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(300))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(300),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row: generate_simple_string_row((-2).into(), 42, "flip"),
             btree_resident: false,
@@ -5546,9 +5560,9 @@ mod tests {
                     tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
                         id: 0,
                         begin: crate::mvcc::database::PackedTs::pack(None),
-                        end: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
-                            tx.tx_timestamp,
-                        ))),
+                        end: crate::mvcc::database::PackedTs::pack(Some(
+                            crate::mvcc::database::TxTimestampOrID::Timestamp(tx.tx_timestamp),
+                        )),
                         row: Row::new_table_row(
                             RowID::new((-2).into(), RowKey::Int(rowid)),
                             Vec::new(),
@@ -5566,9 +5580,9 @@ mod tests {
                     let row = generate_simple_string_row((-2).into(), rowid, &payload);
                     tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
                         id: 0,
-                        begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
-                            tx.tx_timestamp,
-                        ))),
+                        begin: crate::mvcc::database::PackedTs::pack(Some(
+                            crate::mvcc::database::TxTimestampOrID::Timestamp(tx.tx_timestamp),
+                        )),
                         end: crate::mvcc::database::PackedTs::pack(None),
                         row: row.clone(),
                         btree_resident,
@@ -5601,9 +5615,9 @@ mod tests {
             });
             large_tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
                 id: rowid as u64,
-                begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
-                    large_commit_ts,
-                ))),
+                begin: crate::mvcc::database::PackedTs::pack(Some(
+                    crate::mvcc::database::TxTimestampOrID::Timestamp(large_commit_ts),
+                )),
                 end: crate::mvcc::database::PackedTs::pack(None),
                 row,
                 btree_resident: false,
@@ -5638,7 +5652,9 @@ mod tests {
             let row = generate_simple_string_row((-2).into(), rowid, &payload_text);
             let row_version = crate::mvcc::database::RowVersion {
                 id: commit_ts,
-                begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+                begin: crate::mvcc::database::PackedTs::pack(Some(
+                    crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts),
+                )),
                 end: crate::mvcc::database::PackedTs::pack(if is_delete {
                     Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))
                 } else {
@@ -5745,7 +5761,9 @@ mod tests {
         row.id.table_id = (-2).into();
         let version = crate::mvcc::database::RowVersion {
             id: 1,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(55))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(55),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: true,
@@ -5804,7 +5822,9 @@ mod tests {
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(10))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(10),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,
@@ -6096,7 +6116,9 @@ mod tests {
         let row = generate_simple_string_row(table_id, rowid, value);
         crate::mvcc::database::RowVersion {
             id: rowid as u64,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,
@@ -6130,7 +6152,9 @@ mod tests {
         let row = Row::new_index_row(row_id, 2);
         crate::mvcc::database::RowVersion {
             id: rowid as u64,
-            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            begin: crate::mvcc::database::PackedTs::pack(Some(
+                crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts),
+            )),
             end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -238,7 +238,9 @@ use crate::turso_assert;
 use crate::{
     io::{CompletionGroup, ReadComplete},
     io_yield_one,
-    mvcc::database::{LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey},
+    mvcc::database::{
+        LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey,
+    },
     return_if_io,
     storage::sqlite3_ondisk::{
         read_varint, read_varint_partial, varint_len, write_varint_to_vec, DatabaseHeader,
@@ -1036,7 +1038,7 @@ pub(crate) fn serialize_op_entry(
     row_version: &RowVersion,
     portable_extension: Option<&[u8]>,
 ) -> Result<()> {
-    let is_delete = row_version.end.is_some();
+    let is_delete = row_version.end().is_some();
 
     let mut flags = 0u8;
     if row_version.btree_resident {
@@ -3961,8 +3963,8 @@ mod tests {
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row: row.clone(),
             btree_resident: false,
         };
@@ -4046,12 +4048,12 @@ mod tests {
         let row = generate_simple_string_row(table_id, rowid, payload_text);
         let row_version = crate::mvcc::database::RowVersion {
             id: commit_ts,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts)),
-            end: if is_delete {
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            end: crate::mvcc::database::PackedTs::pack(if is_delete {
                 Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))
             } else {
                 None
-            },
+            }),
             row,
             btree_resident,
         };
@@ -4173,8 +4175,8 @@ mod tests {
     ) -> crate::mvcc::database::RowVersion {
         crate::mvcc::database::RowVersion {
             id: commit_ts,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row: generate_simple_string_row(table_id, rowid, data),
             btree_resident: false,
         }
@@ -4780,8 +4782,8 @@ mod tests {
         let mut tx1 = crate::mvcc::database::LogRecord::new(10);
         tx1.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(10)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(10))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row: row.clone(),
             btree_resident: false,
         });
@@ -4791,8 +4793,8 @@ mod tests {
         let mut tx2 = crate::mvcc::database::LogRecord::new(20);
         tx2.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 2,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(20)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(20))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,
         });
@@ -4944,8 +4946,8 @@ mod tests {
             3,
             &[crate::mvcc::database::RowVersion {
                 id: 3,
-                begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(3)),
-                end: None,
+                begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(3))),
+                end: crate::mvcc::database::PackedTs::pack(None),
                 row: row3,
                 btree_resident: false,
             }],
@@ -4996,8 +4998,8 @@ mod tests {
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(123)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(123))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,
         };
@@ -5468,8 +5470,8 @@ mod tests {
         let mut tx = crate::mvcc::database::LogRecord::new(300);
         tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(300)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(300))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row: generate_simple_string_row((-2).into(), 42, "flip"),
             btree_resident: false,
         });
@@ -5543,10 +5545,10 @@ mod tests {
                 if is_delete {
                     tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
                         id: 0,
-                        begin: None,
-                        end: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
+                        begin: crate::mvcc::database::PackedTs::pack(None),
+                        end: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
                             tx.tx_timestamp,
-                        )),
+                        ))),
                         row: Row::new_table_row(
                             RowID::new((-2).into(), RowKey::Int(rowid)),
                             Vec::new(),
@@ -5564,10 +5566,10 @@ mod tests {
                     let row = generate_simple_string_row((-2).into(), rowid, &payload);
                     tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
                         id: 0,
-                        begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
+                        begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
                             tx.tx_timestamp,
-                        )),
-                        end: None,
+                        ))),
+                        end: crate::mvcc::database::PackedTs::pack(None),
                         row: row.clone(),
                         btree_resident,
                     });
@@ -5599,10 +5601,10 @@ mod tests {
             });
             large_tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
                 id: rowid as u64,
-                begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
+                begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
                     large_commit_ts,
-                )),
-                end: None,
+                ))),
+                end: crate::mvcc::database::PackedTs::pack(None),
                 row,
                 btree_resident: false,
             });
@@ -5636,12 +5638,12 @@ mod tests {
             let row = generate_simple_string_row((-2).into(), rowid, &payload_text);
             let row_version = crate::mvcc::database::RowVersion {
                 id: commit_ts,
-                begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts)),
-                end: if is_delete {
+                begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+                end: crate::mvcc::database::PackedTs::pack(if is_delete {
                     Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))
                 } else {
                     None
-                },
+                }),
                 row: row.clone(),
                 btree_resident,
             };
@@ -5743,8 +5745,8 @@ mod tests {
         row.id.table_id = (-2).into();
         let version = crate::mvcc::database::RowVersion {
             id: 1,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(55)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(55))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: true,
         };
@@ -5802,8 +5804,8 @@ mod tests {
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(10)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(10))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,
         };
@@ -6094,8 +6096,8 @@ mod tests {
         let row = generate_simple_string_row(table_id, rowid, value);
         crate::mvcc::database::RowVersion {
             id: rowid as u64,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,
         }
@@ -6128,8 +6130,8 @@ mod tests {
         let row = Row::new_index_row(row_id, 2);
         crate::mvcc::database::RowVersion {
             id: rowid as u64,
-            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts)),
-            end: None,
+            begin: crate::mvcc::database::PackedTs::pack(Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))),
+            end: crate::mvcc::database::PackedTs::pack(None),
             row,
             btree_resident: false,
         }
@@ -6154,16 +6156,16 @@ mod tests {
         let row = Row::new_table_row(RowID::new(table_id, RowKey::Int(rowid)), record_bytes, 1);
         crate::mvcc::database::RowVersion {
             id: rowid as u64,
-            begin: if is_delete {
+            begin: crate::mvcc::database::PackedTs::pack(if is_delete {
                 None
             } else {
                 Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))
-            },
-            end: if is_delete {
+            }),
+            end: crate::mvcc::database::PackedTs::pack(if is_delete {
                 Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))
             } else {
                 None
-            },
+            }),
             row,
             btree_resident: false,
         }
@@ -6181,16 +6183,16 @@ mod tests {
         let row = Row::new_index_row(row_id, 2);
         crate::mvcc::database::RowVersion {
             id: rowid as u64,
-            begin: if is_delete {
+            begin: crate::mvcc::database::PackedTs::pack(if is_delete {
                 None
             } else {
                 Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))
-            },
-            end: if is_delete {
+            }),
+            end: crate::mvcc::database::PackedTs::pack(if is_delete {
                 Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts))
             } else {
                 None
-            },
+            }),
             row,
             btree_resident: false,
         }


### PR DESCRIPTION
This is meant to be stacked on top of #7464 

This packs the begin + end timestamps in RowVersion, bringing each field from 16B to 8B
<img width="795" height="283" alt="image" src="https://github.com/user-attachments/assets/a94e8b2a-8b0b-4126-b9f7-5c02029d7952" />
