### PR TITLE
cli: fix CSV import and dot-command SQLite compatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -331,6 +331,8 @@ jobs:
 
       - uses: "./.github/shared/install_sqlite"
       - name: Test
+        env:
+          SQLITE3_EXEC: sqlite3
         run: make test
 
   concurrent-simulator:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6590,7 +6590,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
- "csv",
  "ctrlc",
  "dirs 5.0.1",
  "env_logger",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,6 @@ cfg-if = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { version = "=4.5.47", features = ["unstable-dynamic"] }
 comfy-table = "7.1.4"
-csv = "1.3.1"
 ctrlc = "3.4.4"
 dirs = "5.0.1"
 env_logger = { workspace = true }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -29,7 +29,7 @@ use std::{
     str::Chars,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, RwLock,
     },
     time::{Duration, Instant},
 };
@@ -121,6 +121,7 @@ pub struct Limbo {
     io: Arc<dyn turso_core::IO>,
     writer: Option<Box<dyn Write>>,
     conn: Arc<turso_core::Connection>,
+    interrupt_conn: Arc<RwLock<Arc<turso_core::Connection>>>,
     pub interrupt_count: Arc<AtomicUsize>,
     input_buff: ManuallyDrop<String>,
     pub(crate) opts: Settings,
@@ -279,11 +280,18 @@ impl Limbo {
             conn._free_extension_ctx(ext_api);
         }
         let interrupt_count = Arc::new(AtomicUsize::new(0));
+        let interrupt_conn = Arc::new(RwLock::new(conn.clone()));
         {
             let interrupt_count: Arc<AtomicUsize> = Arc::clone(&interrupt_count);
+            let interrupt_conn = interrupt_conn.clone();
             ctrlc::set_handler(move || {
-                // Increment the interrupt count on Ctrl-C
+                // Keep both import CSV reads and the current database connection interruptible.
                 interrupt_count.fetch_add(1, Ordering::Release);
+                let conn = interrupt_conn
+                    .read()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .clone();
+                conn.interrupt();
             })
             .expect("Error setting Ctrl-C handler");
         }
@@ -296,6 +304,7 @@ impl Limbo {
             io,
             writer: Some(get_writer(&opts.output)),
             conn,
+            interrupt_conn,
             interrupt_count,
             input_buff: ManuallyDrop::new(sql.unwrap_or_default()),
             read_state: ReadState::default(),
@@ -457,6 +466,13 @@ impl Limbo {
         self.had_query_error
     }
 
+    fn set_interrupt_connection(&self, conn: Arc<turso_core::Connection>) {
+        *self
+            .interrupt_conn
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = conn;
+    }
+
     fn dot_command_error(&mut self, message: impl std::fmt::Display) {
         self.had_query_error = true;
         let _ = writeln!(io::stderr(), "{message}");
@@ -492,7 +508,9 @@ impl Limbo {
             )
         };
         self.io = io;
-        self.conn = db.connect()?;
+        let conn = db.connect()?;
+        self.conn = conn.clone();
+        self.set_interrupt_connection(conn);
         self.opts.db_file = path.to_string();
         Ok(())
     }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -23,8 +23,10 @@ use std::num::NonZeroUsize;
 use std::{
     fs::File,
     io::{self, BufRead, BufReader, IsTerminal, Write},
+    iter::Peekable,
     mem::{forget, ManuallyDrop},
     path::PathBuf,
+    str::Chars,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -779,26 +781,26 @@ impl Limbo {
     }
 
     pub fn handle_dot_command(&mut self, line: &str) {
-        let first = line.split_whitespace().next();
-        let parse = match first {
-            Some("parameter") | Some("param") => {
-                let args = shlex::split(line).unwrap_or_else(|| {
-                    line.split_whitespace()
-                        .map(str::to_owned)
-                        .collect::<Vec<_>>()
-                });
-                if args.is_empty() {
-                    return;
-                }
-                CommandParser::try_parse_from(args)
-            }
-            _ => {
-                let args = line.split_whitespace();
-                CommandParser::try_parse_from(args)
+        let args = match split_dot_command_args(line) {
+            Ok(args) => args,
+            Err(e) => {
+                self.had_query_error = true;
+                let _ = writeln!(io::stderr(), "Error: {e}");
+                return;
             }
         };
+        if args.is_empty() {
+            return;
+        }
+        let parse = CommandParser::try_parse_from(args);
         match parse {
             Err(err) => {
+                if !matches!(
+                    err.kind(),
+                    clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
+                ) {
+                    self.had_query_error = true;
+                }
                 // Let clap print with Styled Colors instead
                 let _ = err.print();
             }
@@ -2258,30 +2260,30 @@ fn parameter_name_to_index(name: &str) -> Option<NonZeroUsize> {
 }
 
 fn parse_parameter_value(value: &str) -> Result<Value, String> {
-    let value = value.trim();
-    if value.eq_ignore_ascii_case("null") {
+    let literal = value.trim();
+    if literal.eq_ignore_ascii_case("null") {
         return Ok(Value::Null);
     }
 
-    if let Ok(integer) = value.parse::<i64>() {
+    if let Ok(integer) = literal.parse::<i64>() {
         return Ok(Value::from_i64(integer));
     }
 
-    if value.contains(['.', 'e', 'E']) {
-        if let Ok(float) = value.parse::<f64>() {
+    if literal.contains(['.', 'e', 'E']) {
+        if let Ok(float) = literal.parse::<f64>() {
             return Ok(Value::from_f64(float));
         }
     }
 
-    if let Some(hex) = value
+    if let Some(hex) = literal
         .strip_prefix("x'")
-        .or_else(|| value.strip_prefix("X'"))
+        .or_else(|| literal.strip_prefix("X'"))
         .and_then(|stripped| stripped.strip_suffix('\''))
     {
         return parse_hex_blob(hex).map(Value::from_blob);
     }
 
-    if let Some(inner) = value
+    if let Some(inner) = literal
         .strip_prefix('\'')
         .and_then(|stripped| stripped.strip_suffix('\''))
     {
@@ -2371,9 +2373,269 @@ fn normalize_db_path(db_file: String) -> String {
     db_file
 }
 
+// Mirrors SQLite shell's parseDotCmdArgs for dot-command argument splitting.
+// Backslash escapes are resolved only inside double-quoted arguments.
+fn split_dot_command_args(line: &str) -> Result<Vec<String>, String> {
+    DotCommandArgParser::new(line).parse()
+}
+
+struct DotCommandArgParser<'a> {
+    chars: Peekable<Chars<'a>>,
+}
+
+impl<'a> DotCommandArgParser<'a> {
+    fn new(line: &'a str) -> Self {
+        Self {
+            chars: trim_dot_command_tail(line).chars().peekable(),
+        }
+    }
+
+    fn parse(mut self) -> Result<Vec<String>, String> {
+        let mut args = Vec::new();
+        loop {
+            self.skip_space();
+            let Some(c) = self.peek() else {
+                break;
+            };
+
+            let arg = match c {
+                '\'' | '"' => self.parse_quoted_arg(c)?,
+                _ => self.parse_unquoted_arg(),
+            };
+            args.push(arg);
+        }
+        Ok(args)
+    }
+
+    fn parse_quoted_arg(&mut self, delimiter: char) -> Result<String, String> {
+        let _ = self.chars.next();
+        let mut arg = String::new();
+        while let Some(c) = self.chars.next() {
+            if c == delimiter {
+                break;
+            }
+            if c == '\\' && delimiter == '"' {
+                arg.push(c);
+                let Some(next) = self.chars.next() else {
+                    break;
+                };
+                arg.push(next);
+                continue;
+            }
+            arg.push(c);
+        }
+        if delimiter == '"' {
+            resolve_dot_backslashes(&arg)
+        } else {
+            Ok(arg)
+        }
+    }
+
+    fn parse_unquoted_arg(&mut self) -> String {
+        let mut arg = String::new();
+        while let Some(c) = self.peek() {
+            if is_dot_command_space(c) {
+                break;
+            }
+            let _ = self.chars.next();
+            arg.push(c);
+        }
+        arg
+    }
+
+    fn skip_space(&mut self) {
+        while self.peek().is_some_and(is_dot_command_space) {
+            let _ = self.chars.next();
+        }
+    }
+
+    fn peek(&mut self) -> Option<char> {
+        self.chars.peek().copied()
+    }
+}
+
+fn trim_dot_command_tail(line: &str) -> &str {
+    let mut line = line.trim_end_matches(is_dot_command_space);
+    if let Some(without_semicolon) = line.strip_suffix(';') {
+        line = without_semicolon.trim_end_matches(is_dot_command_space);
+    }
+    line
+}
+
+fn is_dot_command_space(c: char) -> bool {
+    matches!(c, '\t' | '\n' | '\x0b' | '\x0c' | '\r' | ' ')
+}
+
+// Mirrors SQLite shell's resolve_backslashes for double-quoted dot-command args.
+// Turso stores command arguments as UTF-8 Strings, so raw non-UTF-8 escape output
+// is rejected even though SQLite can carry those bytes through C strings.
+fn resolve_dot_backslashes(input: &str) -> Result<String, String> {
+    let bytes = input.as_bytes();
+    let mut output = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'\\' || i + 1 == bytes.len() {
+            output.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+
+        i += 1;
+        match bytes[i] {
+            b'a' => output.push(b'\x07'),
+            b'b' => output.push(b'\x08'),
+            b't' => output.push(b'\t'),
+            b'n' => output.push(b'\n'),
+            b'v' => output.push(b'\x0b'),
+            b'f' => output.push(b'\x0c'),
+            b'r' => output.push(b'\r'),
+            b'"' => output.push(b'"'),
+            b'\'' => output.push(b'\''),
+            b'\\' => output.push(b'\\'),
+            b'x' => {
+                let mut value = 0u8;
+                let mut digits = 0;
+                while digits < 2 && i + 1 < bytes.len() {
+                    let Some(digit) = hex_digit_value(bytes[i + 1]) else {
+                        break;
+                    };
+                    value = (value << 4) | digit;
+                    i += 1;
+                    digits += 1;
+                }
+                output.push(value);
+            }
+            c @ b'0'..=b'7' => {
+                let mut value = u16::from(c - b'0');
+                let mut digits = 1;
+                while digits < 3 && i + 1 < bytes.len() {
+                    let next = bytes[i + 1];
+                    if !(b'0'..=b'7').contains(&next) {
+                        break;
+                    }
+                    value = (value << 3) + u16::from(next - b'0');
+                    i += 1;
+                    digits += 1;
+                }
+                output.push(value as u8);
+            }
+            c => output.push(c),
+        }
+        i += 1;
+    }
+    // SQLite observes the resolved argument through C-string APIs after this
+    // point, so an escaped NUL truncates the visible argument.
+    if let Some(nul) = output.iter().position(|byte| *byte == 0) {
+        output.truncate(nul);
+    }
+    String::from_utf8(output).map_err(|_| "dot-command escape produced invalid UTF-8".to_string())
+}
+
+fn hex_digit_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_split_dot_command_args_preserves_unquoted_windows_paths() {
+        assert_eq!(
+            split_dot_command_args(r#"open C:\Users\me\db.sqlite"#).unwrap(),
+            vec!["open", r#"C:\Users\me\db.sqlite"#]
+        );
+    }
+
+    #[test]
+    fn test_split_dot_command_args_strips_quotes_and_keeps_empty_arg() {
+        assert_eq!(
+            split_dot_command_args(r#"import "data file.csv" "weird table" "";"#).unwrap(),
+            vec!["import", "data file.csv", "weird table", ""]
+        );
+    }
+
+    #[test]
+    fn test_split_dot_command_args_double_quote_backslash_escapes() {
+        assert_eq!(
+            split_dot_command_args(r#"parameter set @x "two\nwords\"""#).unwrap(),
+            vec!["parameter", "set", "@x", "two\nwords\""]
+        );
+    }
+
+    #[test]
+    fn test_split_dot_command_args_single_quotes_do_not_resolve_backslashes() {
+        assert_eq!(
+            split_dot_command_args(r#"parameter set @x 'two\nwords'"#).unwrap(),
+            vec!["parameter", "set", "@x", r#"two\nwords"#]
+        );
+    }
+
+    #[test]
+    fn test_split_dot_command_args_uses_ascii_whitespace_only() {
+        assert_eq!(
+            split_dot_command_args("tables\u{00a0}x").unwrap(),
+            vec!["tables\u{00a0}x"]
+        );
+    }
+
+    #[test]
+    fn test_split_dot_command_args_treats_vertical_tab_as_space() {
+        assert_eq!(
+            split_dot_command_args("tables\x0bfoo").unwrap(),
+            vec!["tables", "foo"]
+        );
+    }
+
+    #[test]
+    fn test_split_dot_command_args_unterminated_quote() {
+        assert_eq!(
+            split_dot_command_args(r#"open "unterminated path"#).unwrap(),
+            vec!["open", "unterminated path"]
+        );
+    }
+
+    #[test]
+    fn test_resolve_dot_backslashes_zero_digit_hex_truncates_at_nul() {
+        assert_eq!(
+            split_dot_command_args(r#"parameter set @x "\xZZ""#).unwrap()[3],
+            ""
+        );
+    }
+
+    #[test]
+    fn test_resolve_dot_backslashes_truncates_at_nul_like_sqlite() {
+        assert_eq!(
+            split_dot_command_args(r#"parameter set @x "A\0B""#).unwrap()[3],
+            "A"
+        );
+    }
+
+    #[test]
+    fn test_resolve_dot_backslashes_decodes_hex_utf8_bytes() {
+        assert_eq!(
+            split_dot_command_args(r#"parameter set @x "\xC3\xA9""#).unwrap()[3],
+            "\u{00e9}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_dot_backslashes_decodes_octal_utf8_bytes() {
+        assert_eq!(
+            split_dot_command_args(r#"parameter set @x "\303\251""#).unwrap()[3],
+            "\u{00e9}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_dot_backslashes_rejects_invalid_utf8_bytes_current_turso_policy() {
+        assert!(split_dot_command_args(r#"parameter set @x "\xFF""#).is_err());
+    }
 
     #[test]
     fn test_normalize_db_path_adds_file_prefix_for_query_params() {

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -457,6 +457,11 @@ impl Limbo {
         self.had_query_error
     }
 
+    fn dot_command_error(&mut self, message: impl std::fmt::Display) {
+        self.had_query_error = true;
+        let _ = writeln!(io::stderr(), "{message}");
+    }
+
     fn toggle_echo(&mut self, arg: EchoMode) {
         match arg {
             EchoMode::On => self.opts.echo = true,
@@ -817,22 +822,22 @@ impl Limbo {
                 }
                 Command::Open(args) => {
                     if let Err(e) = self.open_db(&args.path, args.vfs_name.as_deref()) {
-                        let _ = self.writeln(e.to_string());
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Schema(args) => {
                     if let Err(e) = self.display_schema(args.table_name.as_deref()) {
-                        let _ = self.writeln(e.to_string());
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Tables(args) => {
                     if let Err(e) = self.display_tables(args.pattern.as_deref()) {
-                        let _ = self.writeln(e.to_string());
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Databases => {
                     if let Err(e) = self.display_databases() {
-                        let _ = self.writeln(e.to_string());
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Opcodes(args) => {
@@ -853,13 +858,13 @@ impl Limbo {
                 }
                 Command::OutputMode(args) => {
                     if let Err(e) = self.set_mode(args.mode) {
-                        let _ = self.writeln_fmt(format_args!("Error: {e}"));
+                        self.dot_command_error(format!("Error: {e}"));
                     }
                 }
                 Command::SetOutput(args) => {
                     if let Some(path) = args.path {
                         if let Err(e) = self.set_output_file(&path) {
-                            let _ = self.writeln_fmt(format_args!("Error: {e}"));
+                            self.dot_command_error(format!("Error: {e}"));
                         }
                     } else {
                         self.set_output_stdout();
@@ -869,14 +874,16 @@ impl Limbo {
                     self.toggle_echo(args.mode);
                 }
                 Command::Cwd(args) => {
-                    let _ = std::env::set_current_dir(args.directory);
+                    if let Err(e) = std::env::set_current_dir(args.directory) {
+                        self.dot_command_error(format!("Error: {e}"));
+                    }
                 }
                 Command::ShowInfo => {
                     let _ = self.show_info();
                 }
                 Command::Stats(args) => {
                     if let Err(e) = self.display_stats(args) {
-                        let _ = self.writeln(e.to_string());
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Import(args) => {
@@ -887,12 +894,12 @@ impl Limbo {
                 Command::LoadExtension(args) => {
                     #[cfg(not(target_family = "wasm"))]
                     if let Err(e) = self.handle_load_extension(&args.path) {
-                        let _ = self.writeln(&e);
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Dump => {
                     if let Err(e) = self.dump_database() {
-                        let _ = self.writeln_fmt(format_args!("/****** ERROR: {e} ******/"));
+                        self.dot_command_error(format!("/****** ERROR: {e} ******/"));
                     }
                 }
                 Command::DbConfig(args) => match (args.config.as_deref(), args.mode) {
@@ -907,7 +914,7 @@ impl Limbo {
                         let _ = self.writeln(format!("dqs_dml {val}"));
                     }
                     (Some(name), _) => {
-                        let _ = self.writeln(format!("unknown dbconfig: {name}"));
+                        self.dot_command_error(format!("unknown dbconfig: {name}"));
                     }
                     (None, _) => {
                         let dqs = if self.conn.get_dqs_dml() { "on" } else { "off" };
@@ -922,7 +929,7 @@ impl Limbo {
                 }
                 Command::ListIndexes(args) => {
                     if let Err(e) = self.display_indexes(args.tbl_name) {
-                        let _ = self.writeln(e.to_string());
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Timer(timer_mode) => {
@@ -939,28 +946,31 @@ impl Limbo {
                 }
                 Command::Clone(args) => {
                     if let Err(e) = self.clone_database(&args.output_file) {
-                        let _ = self.writeln(e.to_string());
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Manual(args) => {
-                    let w = self.writer.as_mut().unwrap();
-                    if let Err(e) = manual::display_manual(args.page.as_deref(), w) {
-                        let _ = self.writeln(e.to_string());
+                    let result = {
+                        let w = self.writer.as_mut().unwrap();
+                        manual::display_manual(args.page.as_deref(), w)
+                    };
+                    if let Err(e) = result {
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Read(args) => {
                     if let Err(e) = self.read_sql_file(&args.path) {
-                        let _ = self.writeln(e.to_string());
+                        self.dot_command_error(e);
                     }
                 }
                 Command::Parameter(args) => {
                     if let Err(e) = self.handle_parameter_command(args) {
-                        let _ = self.writeln_fmt(format_args!("Error: {e}"));
+                        self.dot_command_error(format!("Error: {e}"));
                     }
                 }
                 Command::Dbtotxt(args) => {
                     if let Err(e) = self.dump_database_as_text(args.page_no) {
-                        let _ = self.writeln_fmt(format_args!("ERROR:{e}"));
+                        self.dot_command_error(format!("ERROR:{e}"));
                     }
                 }
             },

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -887,9 +887,17 @@ impl Limbo {
                     }
                 }
                 Command::Import(args) => {
-                    let w = self.writer.as_mut().unwrap();
-                    let mut import_file = ImportFile::new(self.conn.clone(), w);
-                    import_file.import(args)
+                    let import_failed = {
+                        let interrupt_count = self.interrupt_count.clone();
+                        let w = self.writer.as_mut().unwrap();
+                        let mut err = io::stderr();
+                        let mut import_file = ImportFile::new(self.conn.clone(), w, &mut err)
+                            .with_interrupt_count(interrupt_count);
+                        import_file.import(args)
+                    };
+                    if import_failed {
+                        self.had_query_error = true;
+                    }
                 }
                 Command::LoadExtension(args) => {
                     #[cfg(not(target_family = "wasm"))]

--- a/cli/commands/import.rs
+++ b/cli/commands/import.rs
@@ -1,13 +1,28 @@
 use clap::Args;
 use clap_complete::{ArgValueCompleter, PathCompleter};
-use std::{fs::File, io::Write, path::PathBuf, sync::Arc};
-use turso_core::{Connection, LimboError};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    fs::File,
+    io::{self, Read, Write},
+    num::NonZero,
+    path::{Path, PathBuf},
+    string::FromUtf8Error,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use turso_core::{Connection, LimboError, Statement, Value};
 
 #[derive(Debug, Clone, Args)]
 pub struct ImportArgs {
     /// Use , and \n as column and row separators
     #[arg(long, default_value = "true")]
     csv: bool,
+    /// Roll back this import if any row fails
+    #[arg(long, default_value = "false")]
+    atomic: bool,
     /// "Verbose" - increase auxiliary output
     #[arg(short, default_value = "false")]
     verbose: bool,
@@ -21,257 +36,1538 @@ pub struct ImportArgs {
 
 pub struct ImportFile<'a> {
     conn: Arc<Connection>,
-    writer: &'a mut dyn Write,
+    out: &'a mut dyn Write,
+    err: &'a mut dyn Write,
+    interrupt_count: Option<Arc<AtomicUsize>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ImportTransaction {
+    Unmanaged,
+    Managed,
+    AtomicSavepoint,
+}
+
+enum RelationKind {
+    Table,
+    View,
+}
+
+impl RelationKind {
+    fn from_sqlite_master_type(value: &str) -> Result<Self, LimboError> {
+        match value {
+            "table" => Ok(Self::Table),
+            "view" => Ok(Self::View),
+            _ => Err(LimboError::InternalError(format!(
+                "unexpected sqlite_master.type for import target: {value}"
+            ))),
+        }
+    }
+}
+
+/// `.import` emits its own diagnostics as it runs; `failed` only tells the
+/// shell whether the command should count as a query error.
+#[derive(Debug, Default)]
+struct ImportProgress {
+    failed: bool,
+    success_rows: u64,
+    failed_rows: u64,
+}
+
+impl ImportProgress {
+    fn record_failure(&mut self) {
+        self.failed_rows += 1;
+        self.failed = true;
+    }
+}
+
+#[derive(Debug)]
+enum ImportAbort {
+    Message(String),
+    RowError(String),
+    Interrupted,
+}
+
+impl ImportAbort {
+    fn message(message: impl Into<String>) -> Self {
+        Self::Message(message.into())
+    }
+
+    fn read_row(error: CsvReadError) -> Self {
+        match error {
+            CsvReadError::Interrupted => Self::Interrupted,
+            CsvReadError::InvalidUtf8 { .. } => {
+                Self::RowError(format!("Error reading row: {error}"))
+            }
+            CsvReadError::Io(_) => Self::Message(format!("Error reading row: {error}")),
+        }
+    }
 }
 
 impl<'a> ImportFile<'a> {
-    pub fn new(conn: Arc<Connection>, writer: &'a mut dyn Write) -> Self {
-        Self { conn, writer }
+    pub fn new(conn: Arc<Connection>, out: &'a mut dyn Write, err: &'a mut dyn Write) -> Self {
+        Self {
+            conn,
+            out,
+            err,
+            interrupt_count: None,
+        }
     }
 
-    pub fn import(&mut self, args: ImportArgs) {
-        self.import_csv(args);
+    pub fn with_interrupt_count(mut self, interrupt_count: Arc<AtomicUsize>) -> Self {
+        self.interrupt_count = Some(interrupt_count);
+        self
     }
 
-    pub fn import_csv(&mut self, args: ImportArgs) {
-        // Check if the target table exists
-        let table_check_query = format!(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='{}';",
-            args.table
-        );
+    /// Runs `.import`, emitting its own diagnostics. Returns true when the
+    /// command should count as a query error.
+    pub(crate) fn import(&mut self, args: ImportArgs) -> bool {
+        self.import_csv(args)
+    }
 
-        let mut table_exists = false;
-
-        match self.conn.query(table_check_query) {
-            Ok(rows) => {
-                if let Some(mut rows) = rows {
-                    let res = rows.run_with_row_callback(|_| {
-                        table_exists = true;
-                        Ok(())
-                    });
-                    if let Err(e) = res {
-                        let _ = self.writer.write_all(
-                            format!("Error checking table existence: {e:?}\n").as_bytes(),
-                        );
-                        return;
-                    }
-                }
-            }
-            Err(e) => {
-                let _ = self
-                    .writer
-                    .write_all(format!("Error checking table existence: {e:?}\n").as_bytes());
-                return;
+    pub(crate) fn import_csv(&mut self, args: ImportArgs) -> bool {
+        match self.import_csv_inner(args) {
+            Ok(failed) => failed,
+            Err(abort) => {
+                self.emit_abort(abort);
+                true
             }
         }
+    }
 
-        let file = match File::open(args.file) {
-            Ok(file) => file,
+    fn import_csv_inner(&mut self, args: ImportArgs) -> Result<bool, ImportAbort> {
+        let relation_kind = match self.relation_kind(&args.table) {
+            Ok(kind) => kind,
             Err(e) => {
-                let _ = self.writer.write_all(format!("{e:?}\n").as_bytes());
-                return;
+                return Err(ImportAbort::message(format!(
+                    "Error checking table existence: {e}"
+                )));
             }
         };
 
-        let mut rdr = csv::ReaderBuilder::new()
-            .has_headers(false)
-            .from_reader(file);
+        let mut csv_reader = self.open_csv_reader(&args)?;
+        self.skip_import_records(&args, &mut csv_reader)?;
 
-        let mut success_rows = 0u64;
-        let mut failed_rows = 0u64;
+        let mut transaction = ImportTransaction::Unmanaged;
+        match relation_kind {
+            None => {
+                let header = self.read_import_header(&args, &mut csv_reader)?;
+                let auto_columns = auto_column_names_with_renames(&header);
+                self.emit_column_rename_notice(&args.file, &auto_columns.renames);
 
-        let mut records = rdr.records().skip(args.skip as usize).peekable();
-
-        // If table doesn't exist, use first row as header to create table
-        if !table_exists {
-            if let Some(Ok(header)) = records.next() {
-                let columns = header
-                    .iter()
-                    .map(normalize_ident)
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let create_table = format!("CREATE TABLE {} ({});", args.table, columns);
-
-                let rows = match self.conn.query(create_table) {
-                    Ok(rows) => rows,
-                    Err(e) => {
-                        let _ = self
-                            .writer
-                            .write_all(format!("Error creating table: {e:?}\n").as_bytes());
-                        return;
-                    }
-                };
-                let Some(mut rows) = rows else {
-                    let _ = self.writer.write_all(b"Error creating table\n");
-                    return;
-                };
-
-                let res = rows.run_with_row_callback(|_| {
-                    // Not expected for CREATE TABLE
-                    panic!("Unexpected row for CREATE TABLE");
-                });
-                match res {
-                    Ok(_) => {}
-                    Err(LimboError::Busy | LimboError::Interrupt) => {
-                        let _ = self
-                            .writer
-                            .write_all("Error creating table: interrupted / busy\n".as_bytes());
-                        return;
-                    }
-                    Err(e) => {
-                        let _ = self.writer.write_all(
-                            format!("Error checking table existence: {e:?}\n").as_bytes(),
-                        );
-                        return;
-                    }
+                if args.atomic {
+                    transaction = self.begin_import_transaction(true).map_err(|e| {
+                        ImportAbort::message(format!("Error beginning import transaction: {e}"))
+                    })?;
                 }
-            } else {
-                let _ = self.writer.write_all(b"Error: Empty input file\n");
-                return;
+
+                if let Err(abort) = self.create_import_table(&args, &auto_columns.columns) {
+                    self.rollback_atomic_import(transaction);
+                    return Err(abort);
+                }
             }
+            Some(RelationKind::Table) => {}
+            Some(RelationKind::View) => {
+                return Err(ImportAbort::message(format!(
+                    "Error: cannot modify {} because it is a view",
+                    args.table
+                )));
+            }
+        };
+
+        let column_count = match self.table_column_count(&args.table) {
+            Ok(column_count) => column_count,
+            Err(e) => {
+                self.rollback_atomic_import(transaction);
+                return Err(ImportAbort::message(format!(
+                    "Error reading table columns: {e}"
+                )));
+            }
+        };
+        if column_count == 0 {
+            let mut progress = ImportProgress::default();
+            self.complete_import_transaction(transaction, args.atomic, &mut progress);
+            return Ok(progress.failed);
         }
 
-        /// TODO: should this be in a single transaction (i.e. all or nothing)?
-        const CSV_INSERT_BATCH_SIZE: usize = 1000;
-        let mut batch = Vec::with_capacity(CSV_INSERT_BATCH_SIZE);
-        for result in records {
-            let record = match result {
-                Ok(r) => r,
-                Err(e) => {
-                    failed_rows += 1;
-                    let _ = self
-                        .writer
-                        .write_all(format!("Error reading row: {e:?}\n").as_bytes());
+        let insert_sql = insert_statement_sql(&args.table, column_count);
+        let mut insert_stmt = match self.conn.prepare(&insert_sql) {
+            Ok(stmt) => stmt,
+            Err(e) => {
+                self.rollback_atomic_import(transaction);
+                return Err(ImportAbort::message(format!("Error preparing insert: {e}")));
+            }
+        };
+        transaction = self.ensure_import_transaction_started(args.atomic, transaction)?;
+
+        let mut progress =
+            self.import_records(&args, &mut csv_reader, &mut insert_stmt, column_count);
+
+        drop(insert_stmt);
+        self.complete_import_transaction(transaction, args.atomic, &mut progress);
+        self.emit_verbose_summary(&args, &csv_reader, &progress);
+        Ok(progress.failed)
+    }
+
+    fn open_csv_reader(&self, args: &ImportArgs) -> Result<CsvImportReader<File>, ImportAbort> {
+        let file = File::open(&args.file).map_err(|_| {
+            ImportAbort::message(format!("Error: cannot open \"{}\"", args.file.display()))
+        })?;
+        let mut csv_reader = CsvImportReader::new(file);
+        if let Some(interrupt_count) = &self.interrupt_count {
+            csv_reader = csv_reader.with_interrupt_count(interrupt_count.clone());
+        }
+        Ok(csv_reader)
+    }
+
+    fn skip_import_records<R: Read>(
+        &mut self,
+        args: &ImportArgs,
+        csv_reader: &mut CsvImportReader<R>,
+    ) -> Result<(), ImportAbort> {
+        for _ in 0..args.skip {
+            if self
+                .read_raw_import_record(csv_reader, &args.file)?
+                .is_none()
+            {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_import_header<R: Read>(
+        &mut self,
+        args: &ImportArgs,
+        csv_reader: &mut CsvImportReader<R>,
+    ) -> Result<Vec<String>, ImportAbort> {
+        match self.read_import_record(csv_reader, &args.file)? {
+            Some(record) => Ok(record.fields),
+            None => Err(ImportAbort::message(format!(
+                "{}: empty file",
+                args.file.display()
+            ))),
+        }
+    }
+
+    fn create_import_table(
+        &mut self,
+        args: &ImportArgs,
+        columns: &[String],
+    ) -> Result<(), ImportAbort> {
+        let column_defs = columns
+            .iter()
+            .map(|column| format!("{} ANY", quote_ident(column)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let create_table = format!(
+            "CREATE TABLE {} ({});",
+            quote_ident(&args.table),
+            column_defs
+        );
+        self.run_statement(&create_table)
+            .map_err(|e| ImportAbort::message(format!("Error creating table: {e}")))
+    }
+
+    fn ensure_import_transaction_started(
+        &mut self,
+        atomic: bool,
+        transaction: ImportTransaction,
+    ) -> Result<ImportTransaction, ImportAbort> {
+        match transaction {
+            ImportTransaction::Unmanaged => self.begin_import_transaction(atomic).map_err(|e| {
+                ImportAbort::message(format!("Error beginning import transaction: {e}"))
+            }),
+            _ => Ok(transaction),
+        }
+    }
+
+    fn import_records<R: Read>(
+        &mut self,
+        args: &ImportArgs,
+        csv_reader: &mut CsvImportReader<R>,
+        insert_stmt: &mut Statement,
+        column_count: usize,
+    ) -> ImportProgress {
+        let mut progress = ImportProgress::default();
+        loop {
+            let record = match self.read_import_record(csv_reader, &args.file) {
+                Ok(Some(record)) => record,
+                Ok(None) => break,
+                Err(ImportAbort::Interrupted) => {
+                    progress.failed = true;
+                    self.emit_interrupt();
+                    break;
+                }
+                Err(ImportAbort::RowError(message)) => {
+                    progress.record_failure();
+                    let _ = writeln!(self.err, "{message}");
                     continue;
+                }
+                Err(ImportAbort::Message(message)) => {
+                    progress.failed = true;
+                    let _ = writeln!(self.err, "{message}");
+                    break;
                 }
             };
 
-            if !record.is_empty() {
-                let values: Vec<String> = record
-                    .iter()
-                    .map(|r| format!("'{}'", r.replace("'", "''")))
-                    .collect();
-                batch.push(values.join(","));
+            let start_line = record.start_line;
+            let trailing_empty_field_at_eof = record.trailing_empty_field_at_eof;
+            let field_count = record.fields.len() + usize::from(trailing_empty_field_at_eof);
+            self.emit_column_count_warning(args, start_line, column_count, field_count);
 
-                if batch.len() >= CSV_INSERT_BATCH_SIZE {
-                    println!("Inserting batch of {} rows", batch.len());
-                    let insert_string =
-                        format!("INSERT INTO {} VALUES ({});", args.table, batch.join("),("));
-
-                    match self.conn.query(insert_string) {
-                        Ok(rows) => {
-                            if let Some(mut rows) = rows {
-                                let res = rows.run_with_row_callback(|_| {
-                                    panic!("Unexpected row for INSERT");
-                                });
-                                match res {
-                                    Ok(_) => {
-                                        success_rows += batch.len() as u64;
-                                    }
-                                    Err(LimboError::Interrupt) => {
-                                        let _ = self.writer.write_all(b"interrupt\n");
-
-                                        failed_rows += batch.len() as u64;
-                                    }
-                                    Err(LimboError::Busy) => {
-                                        let _ = self.writer.write_all(b"database is busy\n");
-
-                                        failed_rows += batch.len() as u64;
-                                    }
-                                    Err(e) => {
-                                        let _ = self.writer.write_all(
-                                            format!("Error executing query: {e:?}\n").as_bytes(),
-                                        );
-                                        failed_rows += batch.len() as u64;
-                                    }
-                                }
-                            } else {
-                                success_rows += batch.len() as u64;
-                            }
-                        }
-                        Err(e) => {
-                            let _ = self
-                                .writer
-                                .write_all(format!("Error executing query: {e:?}\n").as_bytes());
-                            failed_rows += batch.len() as u64;
-                        }
-                    }
-                    batch.clear();
-                }
+            if let Err(e) = bind_import_row(
+                insert_stmt,
+                record.fields,
+                column_count,
+                trailing_empty_field_at_eof,
+            ) {
+                progress.record_failure();
+                insert_stmt.clear_bindings();
+                insert_stmt.reset_best_effort();
+                let message = import_insert_error_message(&e);
+                self.emit_insert_error(&args.file, start_line, &message);
+                continue;
             }
-        }
 
-        // Insert remaining records
-        if !batch.is_empty() {
-            let insert_string =
-                format!("INSERT INTO {} VALUES ({});", args.table, batch.join("),("));
-
-            match self.conn.query(insert_string) {
-                Ok(rows) => {
-                    if let Some(mut rows) = rows {
-                        let res = rows.run_with_row_callback(|_| {
-                            panic!("Unexpected row for INSERT");
-                        });
-                        match res {
-                            Ok(_) => {
-                                success_rows += batch.len() as u64;
-                            }
-                            Err(LimboError::Interrupt) => {
-                                let _ = self.writer.write_all(b"interrupt\n");
-
-                                failed_rows += batch.len() as u64;
-                            }
-                            Err(LimboError::Busy) => {
-                                let _ = self.writer.write_all(b"database is busy\n");
-
-                                failed_rows += batch.len() as u64;
-                            }
-                            Err(e) => {
-                                let _ = self.writer.write_all(
-                                    format!("Error executing query: {e:?}\n").as_bytes(),
-                                );
-                                failed_rows += batch.len() as u64;
-                            }
-                        }
-                    } else {
-                        success_rows += batch.len() as u64;
-                    }
+            match run_import_insert(insert_stmt) {
+                Ok(()) => {
+                    progress.success_rows += 1;
+                }
+                Err(LimboError::Interrupt) => {
+                    self.emit_interrupt();
+                    progress.failed = true;
+                    break;
                 }
                 Err(e) => {
-                    let _ = self
-                        .writer
-                        .write_all(format!("Error executing query: {e:?}\n").as_bytes());
-                    failed_rows += batch.len() as u64;
+                    progress.record_failure();
+                    let message = import_insert_error_message(&e);
+                    self.emit_insert_error(&args.file, start_line, &message);
                 }
             }
         }
+        progress
+    }
 
-        if args.verbose {
-            let _ = self.writer.write_all(
-                format!(
-                    "Added {} rows with {} errors using {} lines of input",
-                    success_rows,
-                    failed_rows,
-                    success_rows + failed_rows,
-                )
-                .as_bytes(),
+    fn emit_column_count_warning(
+        &mut self,
+        args: &ImportArgs,
+        line: u64,
+        column_count: usize,
+        field_count: usize,
+    ) {
+        if field_count < column_count {
+            let _ = writeln!(
+                self.err,
+                "{}:{}: expected {} columns but found {} - filling the rest with NULL",
+                args.file.display(),
+                line,
+                column_count,
+                field_count
             );
+        } else if field_count > column_count {
+            let _ = writeln!(
+                self.err,
+                "{}:{}: expected {} columns but found {} - extras ignored",
+                args.file.display(),
+                line,
+                column_count,
+                field_count
+            );
+        }
+    }
+
+    fn complete_import_transaction(
+        &mut self,
+        transaction: ImportTransaction,
+        atomic: bool,
+        progress: &mut ImportProgress,
+    ) {
+        // SQLite commits the successful prefix after row errors or Ctrl-C.
+        // --atomic is the explicit opt-in to rollback instead.
+        if progress.failed && atomic {
+            self.rollback_atomic_import(transaction);
+        } else if let Err(e) = self.finish_import_transaction(transaction) {
+            let _ = writeln!(self.err, "Error committing import transaction: {e}");
+            if atomic {
+                self.rollback_atomic_import(transaction);
+            }
+            progress.failed = true;
+        }
+    }
+
+    fn emit_verbose_summary<R: Read>(
+        &mut self,
+        args: &ImportArgs,
+        csv_reader: &CsvImportReader<R>,
+        progress: &ImportProgress,
+    ) {
+        if args.verbose {
+            let _ = writeln!(self.out, "Column separator \",\", row separator \"\\n\"");
+            let input_lines = csv_reader.lines_read_for_summary();
+            let _ = writeln!(
+                self.out,
+                "Added {} rows with {} errors using {input_lines} lines of input",
+                progress.success_rows, progress.failed_rows
+            );
+        }
+    }
+
+    fn emit_csv_warnings(&mut self, file: &Path, warnings: &[CsvWarning]) {
+        for warning in warnings {
+            let message = match warning.kind {
+                CsvWarningKind::UnescapedQuote => "unescaped \" character",
+                CsvWarningKind::UnterminatedQuote => "unterminated \"-quoted field",
+            };
+            let _ = writeln!(self.err, "{}:{}: {message}", file.display(), warning.line);
+        }
+    }
+
+    fn emit_abort(&mut self, abort: ImportAbort) {
+        match abort {
+            ImportAbort::Message(message) | ImportAbort::RowError(message) => {
+                let _ = writeln!(self.err, "{message}");
+            }
+            ImportAbort::Interrupted => self.emit_interrupt(),
+        }
+    }
+
+    fn read_import_record<R: Read>(
+        &mut self,
+        csv_reader: &mut CsvImportReader<R>,
+        file: &Path,
+    ) -> Result<Option<CsvRecord>, ImportAbort> {
+        self.read_raw_import_record(csv_reader, file)?
+            .map(|record| record.into_record().map_err(ImportAbort::read_row))
+            .transpose()
+    }
+
+    fn read_raw_import_record<R: Read>(
+        &mut self,
+        csv_reader: &mut CsvImportReader<R>,
+        file: &Path,
+    ) -> Result<Option<CsvRawRecord>, ImportAbort> {
+        let record = csv_reader
+            .read_raw_record()
+            .map_err(ImportAbort::read_row)?;
+        if let Some(record) = &record {
+            self.emit_csv_warnings(file, &record.warnings);
+        }
+        Ok(record)
+    }
+
+    fn emit_interrupt(&mut self) {
+        let _ = writeln!(self.err, "interrupt");
+    }
+
+    fn rollback_managed_import(&mut self, context: &str) {
+        if let Err(e) = self.run_statement("ROLLBACK") {
+            let _ = writeln!(
+                self.err,
+                "Error rolling back import transaction {context}: {e}"
+            );
+        }
+    }
+
+    fn begin_import_transaction(&mut self, atomic: bool) -> Result<ImportTransaction, LimboError> {
+        if self.conn.get_auto_commit() {
+            self.run_statement("BEGIN")?;
+            Ok(ImportTransaction::Managed)
+        } else if atomic {
+            // A savepoint keeps --atomic scoped to this import when the caller
+            // already owns the surrounding transaction.
+            self.run_statement("SAVEPOINT \"__turso_import_atomic\"")?;
+            Ok(ImportTransaction::AtomicSavepoint)
+        } else {
+            Ok(ImportTransaction::Unmanaged)
+        }
+    }
+
+    fn finish_import_transaction(
+        &mut self,
+        transaction: ImportTransaction,
+    ) -> Result<(), LimboError> {
+        match transaction {
+            ImportTransaction::Unmanaged => Ok(()),
+            ImportTransaction::Managed => self.run_statement("COMMIT"),
+            ImportTransaction::AtomicSavepoint => {
+                self.run_statement("RELEASE \"__turso_import_atomic\"")
+            }
+        }
+    }
+
+    fn rollback_atomic_import(&mut self, transaction: ImportTransaction) {
+        match transaction {
+            ImportTransaction::Unmanaged => {}
+            ImportTransaction::Managed => {
+                self.rollback_managed_import("after failed atomic import")
+            }
+            ImportTransaction::AtomicSavepoint => {
+                if let Err(e) = self.run_statement("ROLLBACK TO \"__turso_import_atomic\"") {
+                    let _ = writeln!(
+                        self.err,
+                        "Error rolling back import transaction after failed atomic import: {e}"
+                    );
+                }
+                if let Err(e) = self.run_statement("RELEASE \"__turso_import_atomic\"") {
+                    let _ = writeln!(
+                        self.err,
+                        "Error releasing import savepoint after failed atomic import: {e}"
+                    );
+                }
+            }
+        }
+    }
+
+    fn emit_insert_error(&mut self, file: &Path, line: u64, message: &str) {
+        let _ = writeln!(
+            self.err,
+            "{}:{line}: INSERT failed: {message}",
+            file.display()
+        );
+    }
+
+    fn emit_column_rename_notice(&mut self, file: &Path, renamed_columns: &[(String, String)]) {
+        if renamed_columns.is_empty() {
+            return;
+        }
+
+        let renames = renamed_columns
+            .iter()
+            .map(|(from, to)| format!("{} to {}", quote_ident(from), quote_ident(to)))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        let _ = writeln!(
+            self.err,
+            "Columns renamed during .import {} due to duplicates:\n{renames}",
+            file.display()
+        );
+    }
+
+    fn relation_kind(&mut self, table: &str) -> Result<Option<RelationKind>, LimboError> {
+        let sql = format!(
+            "SELECT type FROM sqlite_master WHERE name={} COLLATE NOCASE AND type IN ('table','view') LIMIT 1",
+            sql_quote_string_literal(table)
+        );
+        let mut kind = None;
+        if let Some(mut rows) = self.conn.query(sql)? {
+            rows.run_with_row_callback(|row| {
+                let value = row.get::<&Value>(0)?;
+                let Value::Text(text) = value else {
+                    return Err(LimboError::InternalError(
+                        "sqlite_master.type must be text".to_string(),
+                    ));
+                };
+                kind = Some(RelationKind::from_sqlite_master_type(text.as_str())?);
+                Ok(())
+            })?;
+        }
+        Ok(kind)
+    }
+
+    fn table_column_count(&mut self, table: &str) -> Result<usize, LimboError> {
+        let sql = format!("PRAGMA table_info({})", quote_ident(table));
+        let mut count = 0usize;
+        if let Some(mut rows) = self.conn.query(sql)? {
+            rows.run_with_row_callback(|_| {
+                count += 1;
+                Ok(())
+            })?;
+        }
+        Ok(count)
+    }
+
+    fn run_statement(&mut self, sql: &str) -> Result<(), LimboError> {
+        let mut stmt = self.conn.prepare(sql)?;
+        let result = stmt.run_with_row_callback(|_| {
+            Err(LimboError::InternalError(format!(
+                "unexpected row from statement: {sql}"
+            )))
+        });
+        match result {
+            Ok(()) => stmt.reset(),
+            Err(e) => {
+                stmt.reset_best_effort();
+                Err(e)
+            }
         }
     }
 }
 
-// https://sqlite.org/lang_keywords.html
-const QUOTE_PAIRS: &[(char, char)] = &[('"', '"'), ('[', ']'), ('`', '`')];
+#[derive(Debug)]
+struct CsvRecord {
+    fields: Vec<String>,
+    start_line: u64,
+    trailing_empty_field_at_eof: bool,
+}
 
-pub fn normalize_ident(identifier: &str) -> String {
-    let quote_pair = QUOTE_PAIRS
-        .iter()
-        .find(|&(start, end)| identifier.starts_with(*start) && identifier.ends_with(*end));
+#[derive(Debug)]
+struct CsvRawRecord {
+    fields: Vec<Vec<u8>>,
+    start_line: u64,
+    warnings: Vec<CsvWarning>,
+    trailing_empty_field_at_eof: bool,
+}
 
-    if let Some(&(_, _)) = quote_pair {
-        &identifier[1..identifier.len() - 1]
-    } else {
-        identifier
+impl CsvRawRecord {
+    fn into_record(self) -> Result<CsvRecord, CsvReadError> {
+        let start_line = self.start_line;
+        let fields = self
+            .fields
+            .into_iter()
+            .map(String::from_utf8)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|source| CsvReadError::InvalidUtf8 {
+                line: start_line,
+                source,
+            })?;
+        Ok(CsvRecord {
+            fields,
+            start_line,
+            trailing_empty_field_at_eof: self.trailing_empty_field_at_eof,
+        })
     }
-    .to_lowercase()
+}
+
+/// Errors produced while reading one CSV record.
+///
+/// `InvalidUtf8` is recoverable per row: the raw record was fully consumed, so
+/// the reader is already positioned at the next record. Turso values require
+/// valid UTF-8 text while SQLite's shell can bind arbitrary bytes, making this
+/// a deliberate CLI compatibility gap rather than a parser synchronization
+/// error.
+#[derive(Debug)]
+enum CsvReadError {
+    Interrupted,
+    InvalidUtf8 { line: u64, source: FromUtf8Error },
+    Io(io::Error),
+}
+
+impl fmt::Display for CsvReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Interrupted => write!(f, "interrupt"),
+            Self::InvalidUtf8 { line, source } => {
+                write!(f, "line {line}: invalid UTF-8: {source}")
+            }
+            Self::Io(error) => error.fmt(f),
+        }
+    }
+}
+
+impl From<io::Error> for CsvReadError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CsvWarning {
+    line: u64,
+    kind: CsvWarningKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CsvWarningKind {
+    UnescapedQuote,
+    UnterminatedQuote,
+}
+
+#[derive(Debug)]
+struct CsvField {
+    bytes: Vec<u8>,
+    terminator: FieldTerminator,
+    warnings: Vec<CsvWarning>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldTerminator {
+    Column,
+    Row,
+    Eof,
+}
+
+const CSV_IMPORT_BUFFER_SIZE: usize = 8 * 1024;
+
+/// CSV reader for `.import --csv`.
+///
+/// This intentionally follows SQLite shell import behavior instead of RFC 4180:
+/// physical blank rows are one empty field, EOF can terminate a final record,
+/// trailing column separators add an empty field, and line counts are physical
+/// input lines used for diagnostics and the verbose summary.
+struct CsvImportReader<R> {
+    reader: R,
+    buffer: [u8; CSV_IMPORT_BUFFER_SIZE],
+    buffer_pos: usize,
+    buffer_len: usize,
+    pushed_byte: Option<u8>,
+    line: u64,
+    seen_any: bool,
+    interrupt_count: Option<Arc<AtomicUsize>>,
+}
+
+impl<R: Read> CsvImportReader<R> {
+    fn new(reader: R) -> Self {
+        Self {
+            reader,
+            buffer: [0; CSV_IMPORT_BUFFER_SIZE],
+            buffer_pos: 0,
+            buffer_len: 0,
+            pushed_byte: None,
+            line: 1,
+            seen_any: false,
+            interrupt_count: None,
+        }
+    }
+
+    fn with_interrupt_count(mut self, interrupt_count: Arc<AtomicUsize>) -> Self {
+        self.interrupt_count = Some(interrupt_count);
+        self
+    }
+
+    fn read_raw_record(&mut self) -> Result<Option<CsvRawRecord>, CsvReadError> {
+        let start_line = self.line;
+        let mut fields = Vec::new();
+        let mut warnings = Vec::new();
+        let mut needs_trailing_empty_field = false;
+        loop {
+            let Some(field) = self.read_field()? else {
+                if fields.is_empty() {
+                    return Ok(None);
+                }
+                return Ok(Some(CsvRawRecord {
+                    fields,
+                    start_line,
+                    warnings,
+                    trailing_empty_field_at_eof: needs_trailing_empty_field,
+                }));
+            };
+            warnings.extend(field.warnings);
+            fields.push(field.bytes);
+            match field.terminator {
+                FieldTerminator::Column => {
+                    needs_trailing_empty_field = true;
+                }
+                FieldTerminator::Row | FieldTerminator::Eof => {
+                    return Ok(Some(CsvRawRecord {
+                        fields,
+                        start_line,
+                        warnings,
+                        trailing_empty_field_at_eof: false,
+                    }));
+                }
+            }
+        }
+    }
+
+    fn read_field(&mut self) -> Result<Option<CsvField>, CsvReadError> {
+        if self.is_interrupted() {
+            return Err(CsvReadError::Interrupted);
+        }
+        let Some(mut c) = self.next_byte()? else {
+            return Ok(None);
+        };
+        let mut field_prefix = Vec::new();
+
+        if !self.seen_any && c == 0xef {
+            let Some(second) = self.next_byte()? else {
+                self.seen_any = true;
+                return Ok(Some(CsvField {
+                    bytes: vec![c],
+                    terminator: FieldTerminator::Eof,
+                    warnings: Vec::new(),
+                }));
+            };
+            field_prefix.push(c);
+            if second == 0xbb {
+                let Some(third) = self.next_byte()? else {
+                    self.seen_any = true;
+                    field_prefix.push(second);
+                    return Ok(Some(CsvField {
+                        bytes: field_prefix,
+                        terminator: FieldTerminator::Eof,
+                        warnings: Vec::new(),
+                    }));
+                };
+                if third == 0xbf {
+                    self.seen_any = true;
+                    return self.read_field();
+                }
+                field_prefix.push(second);
+                c = third;
+            } else {
+                c = second;
+            }
+        }
+
+        self.seen_any = true;
+        if field_prefix.is_empty() && c == b'"' {
+            return self.read_quoted_field(self.line).map(Some);
+        }
+
+        let mut field = field_prefix;
+        loop {
+            match c {
+                b',' => {
+                    return Ok(Some(CsvField {
+                        bytes: field,
+                        terminator: FieldTerminator::Column,
+                        warnings: Vec::new(),
+                    }));
+                }
+                b'\n' => {
+                    self.line += 1;
+                    if field.last() == Some(&b'\r') {
+                        field.pop();
+                    }
+                    return Ok(Some(CsvField {
+                        bytes: field,
+                        terminator: FieldTerminator::Row,
+                        warnings: Vec::new(),
+                    }));
+                }
+                _ => field.push(c),
+            }
+
+            let Some(next) = self.next_byte()? else {
+                return Ok(Some(CsvField {
+                    bytes: field,
+                    terminator: FieldTerminator::Eof,
+                    warnings: Vec::new(),
+                }));
+            };
+            c = next;
+        }
+    }
+
+    fn read_quoted_field(&mut self, start_line: u64) -> Result<CsvField, CsvReadError> {
+        let mut field = Vec::new();
+        let mut warnings = Vec::new();
+        loop {
+            let Some(c) = self.next_byte()? else {
+                warnings.push(CsvWarning {
+                    line: start_line,
+                    kind: CsvWarningKind::UnterminatedQuote,
+                });
+                return Ok(CsvField {
+                    bytes: field,
+                    terminator: FieldTerminator::Eof,
+                    warnings,
+                });
+            };
+            match c {
+                b'"' => {
+                    let Some(next) = self.next_byte()? else {
+                        return Ok(CsvField {
+                            bytes: field,
+                            terminator: FieldTerminator::Eof,
+                            warnings,
+                        });
+                    };
+                    match next {
+                        b'"' => field.push(b'"'),
+                        b',' => {
+                            return Ok(CsvField {
+                                bytes: field,
+                                terminator: FieldTerminator::Column,
+                                warnings,
+                            });
+                        }
+                        b'\n' => {
+                            self.line += 1;
+                            return Ok(CsvField {
+                                bytes: field,
+                                terminator: FieldTerminator::Row,
+                                warnings,
+                            });
+                        }
+                        b'\r' => {
+                            let following = self.next_byte()?;
+                            if following == Some(b'\n') {
+                                self.line += 1;
+                                return Ok(CsvField {
+                                    bytes: field,
+                                    terminator: FieldTerminator::Row,
+                                    warnings,
+                                });
+                            }
+                            if let Some(following) = following {
+                                self.push_byte(following);
+                            }
+                            field.push(b'"');
+                            field.push(b'\r');
+                        }
+                        other => {
+                            warnings.push(CsvWarning {
+                                line: self.line,
+                                kind: CsvWarningKind::UnescapedQuote,
+                            });
+                            field.push(b'"');
+                            field.push(other);
+                        }
+                    }
+                }
+                b'\n' => {
+                    self.line += 1;
+                    field.push(c);
+                }
+                _ => field.push(c),
+            }
+        }
+    }
+
+    fn next_byte(&mut self) -> io::Result<Option<u8>> {
+        if let Some(byte) = self.pushed_byte.take() {
+            return Ok(Some(byte));
+        }
+
+        if self.buffer_pos == self.buffer_len {
+            self.refill_buffer()?;
+        }
+        if self.buffer_pos == self.buffer_len {
+            Ok(None)
+        } else {
+            let byte = self.buffer[self.buffer_pos];
+            self.buffer_pos += 1;
+            Ok(Some(byte))
+        }
+    }
+
+    fn refill_buffer(&mut self) -> io::Result<()> {
+        self.buffer_pos = 0;
+        match self.reader.read(&mut self.buffer) {
+            Ok(bytes_read) => {
+                self.buffer_len = bytes_read;
+                Ok(())
+            }
+            Err(error) => {
+                self.buffer_len = 0;
+                Err(error)
+            }
+        }
+    }
+
+    fn push_byte(&mut self, byte: u8) {
+        assert!(
+            self.pushed_byte.replace(byte).is_none(),
+            "CsvImportReader supports one byte of lookahead"
+        );
+    }
+
+    fn lines_read_for_summary(&self) -> u64 {
+        self.line.saturating_sub(1)
+    }
+
+    fn is_interrupted(&self) -> bool {
+        self.interrupt_count
+            .as_ref()
+            .is_some_and(|count| count.load(Ordering::Acquire) > 0)
+    }
+}
+
+fn bind_import_row(
+    stmt: &mut Statement,
+    fields: Vec<String>,
+    column_count: usize,
+    trailing_empty_field_at_eof: bool,
+) -> Result<(), LimboError> {
+    let field_count = fields.len();
+    let mut fields = fields.into_iter();
+    for i in 0..column_count {
+        let value = fields.next().map_or_else(
+            || {
+                if trailing_empty_field_at_eof
+                    && field_count + 1 == column_count
+                    && i + 1 == column_count
+                {
+                    Value::from_text("")
+                } else {
+                    Value::Null
+                }
+            },
+            Value::from_text,
+        );
+        let index = NonZero::new(i + 1).expect("bind indexes are 1-based");
+        stmt.bind_at(index, value)?;
+    }
+    Ok(())
+}
+
+fn run_import_insert(stmt: &mut Statement) -> Result<(), LimboError> {
+    let result = stmt.run_with_row_callback(|_| {
+        Err(LimboError::InternalError(
+            "unexpected row from import INSERT".to_string(),
+        ))
+    });
+    let reset = stmt.reset();
+    match (result, reset) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(e), Ok(())) | (Ok(()), Err(e)) => Err(e),
+        (Err(e), Err(_)) => Err(e),
+    }
+}
+
+fn import_insert_error_message(error: &LimboError) -> String {
+    match error {
+        LimboError::Constraint(message)
+        | LimboError::ForeignKeyConstraint(message)
+        | LimboError::Raise(_, message) => message.to_string(),
+        LimboError::Busy => "database is busy".to_string(),
+        _ => error.to_string(),
+    }
+}
+
+fn insert_statement_sql(table: &str, column_count: usize) -> String {
+    format!(
+        "INSERT INTO {} VALUES({})",
+        quote_ident(table),
+        vec!["?"; column_count].join(",")
+    )
+}
+
+#[cfg(test)]
+fn auto_column_names(headers: &[String]) -> Vec<String> {
+    auto_column_names_with_renames(headers).columns
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AutoColumnNames {
+    columns: Vec<String>,
+    renames: Vec<(String, String)>,
+}
+
+fn auto_column_names_with_renames(headers: &[String]) -> AutoColumnNames {
+    let base_names = headers
+        .iter()
+        .map(|name| {
+            if name.is_empty() {
+                "?".to_string()
+            } else {
+                name.to_string()
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut counts = HashMap::<String, usize>::new();
+    for name in &base_names {
+        *counts.entry(name.to_ascii_lowercase()).or_default() += 1;
+    }
+    let repeated = counts
+        .into_iter()
+        .filter_map(|(name, count)| (count > 1).then_some(name))
+        .collect::<HashSet<_>>();
+    if repeated.is_empty() {
+        return AutoColumnNames {
+            columns: base_names,
+            renames: Vec::new(),
+        };
+    }
+
+    // IMPORTANT: SQLite checks for collisions using candidates padded to
+    // the digit count of the column total, but emits names that start
+    // unpadded, so past 9 columns the name it checks is not the name it
+    // creates and CREATE TABLE can fail on a clash its check never saw:
+    //
+    //   printf 'X,X,c3,c4,c5,c6,c7,c8,c9,c10,c11,x_1\n' > /tmp/dup12.csv
+    //   sqlite3 :memory: '.import --csv /tmp/dup12.csv t'
+    //   => duplicate column name: x_1   (checked "X_01" but emitted "X_1")
+    //
+    // To avoid this we test the exact names we will emit, widening until
+    // they are unique.
+    let max_width = base_names
+        .iter()
+        .map(String::len)
+        .max()
+        .unwrap_or(0)
+        .saturating_add(headers.len().to_string().len())
+        .saturating_add(1);
+    for width in 1..=max_width {
+        let candidate_names = base_names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                if repeated.contains(&name.to_ascii_lowercase()) {
+                    format!("{name}_{:0width$}", i + 1)
+                } else {
+                    name.to_string()
+                }
+            })
+            .collect::<Vec<_>>();
+        let mut seen = HashSet::with_capacity(candidate_names.len());
+        if candidate_names
+            .iter()
+            .all(|name| seen.insert(name.to_ascii_lowercase()))
+        {
+            let renames = base_names
+                .iter()
+                .zip(candidate_names.iter())
+                .filter(|(from, to)| from != to)
+                .map(|(from, to)| (from.clone(), to.clone()))
+                .collect();
+            return AutoColumnNames {
+                columns: candidate_names,
+                renames,
+            };
+        }
+    }
+
+    unreachable!(
+        "suffix width exceeds every literal header length, so generated import column names cannot collide"
+    )
+}
+
+fn quote_ident(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn sql_quote_string_literal(literal: &str) -> String {
+    format!("'{}'", literal.replace('\'', "''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+    use turso_core::{Database, MemoryIO, Numeric};
+
+    impl<R: Read> CsvImportReader<R> {
+        fn read_record(&mut self) -> Result<Option<CsvRecord>, CsvReadError> {
+            self.read_raw_record()?
+                .map(CsvRawRecord::into_record)
+                .transpose()
+        }
+    }
+
+    #[test]
+    fn auto_column_names_grows_suffix_width_on_collision() {
+        let headers = vec!["X".to_string(), "X".to_string(), "x_1".to_string()];
+        assert_eq!(auto_column_names(&headers), vec!["X_01", "X_02", "x_1"]);
+    }
+
+    #[test]
+    fn auto_column_names_does_not_panic_when_width_exceeds_usize_digits() {
+        let mut headers = Vec::new();
+        headers.push("X_22".to_string());
+        for width in 3..=20 {
+            headers.push(format!("X_{:0width$}", 22));
+        }
+        headers.push("Y".to_string());
+        headers.push("X".to_string());
+        headers.push("X".to_string());
+
+        let columns = auto_column_names(&headers);
+        assert_eq!(columns[20], format!("X_{:021}", 21));
+        assert_eq!(columns[21], format!("X_{:021}", 22));
+    }
+
+    #[test]
+    fn auto_column_names_reports_renamed_columns() {
+        let headers = vec!["id".to_string(), "id".to_string(), "x_1".to_string()];
+        let auto_columns = auto_column_names_with_renames(&headers);
+        assert_eq!(auto_columns.columns, vec!["id_1", "id_2", "x_1"]);
+        assert_eq!(
+            auto_columns.renames,
+            vec![
+                ("id".to_string(), "id_1".to_string()),
+                ("id".to_string(), "id_2".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn auto_column_names_uses_question_mark_for_empty_header() {
+        let headers = vec!["".to_string(), "".to_string()];
+        assert_eq!(auto_column_names(&headers), vec!["?_1", "?_2"]);
+    }
+
+    #[test]
+    fn csv_import_reader_preserves_blank_lines_as_empty_field_records() {
+        let mut reader = CsvImportReader::new("a,b\n\n1,2\n".as_bytes());
+        assert_eq!(
+            reader.read_record().unwrap().unwrap().fields,
+            vec!["a", "b"]
+        );
+        assert_eq!(reader.read_record().unwrap().unwrap().fields, vec![""]);
+        assert_eq!(
+            reader.read_record().unwrap().unwrap().fields,
+            vec!["1", "2"]
+        );
+        assert!(reader.read_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn csv_import_reader_handles_multiline_quoted_fields() {
+        let mut reader = CsvImportReader::new("\"a\nb\",c\n".as_bytes());
+        let record = reader.read_record().unwrap().unwrap();
+        assert_eq!(record.start_line, 1);
+        assert_eq!(record.fields, vec!["a\nb", "c"]);
+        assert_eq!(reader.line, 3);
+    }
+
+    #[test]
+    fn csv_import_reader_reports_unescaped_and_unterminated_quotes() {
+        let mut reader = CsvImportReader::new("a,\"b\"c\n".as_bytes());
+        let record = reader.read_raw_record().unwrap().unwrap();
+        assert_eq!(record.fields, vec![b"a".to_vec(), b"b\"c\n".to_vec()]);
+        assert_eq!(
+            record.warnings,
+            vec![
+                CsvWarning {
+                    line: 1,
+                    kind: CsvWarningKind::UnescapedQuote,
+                },
+                CsvWarning {
+                    line: 1,
+                    kind: CsvWarningKind::UnterminatedQuote,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn csv_import_reader_reports_unescaped_quote_on_current_line() {
+        let mut reader = CsvImportReader::new("\"a\nb\"c".as_bytes());
+        let record = reader.read_raw_record().unwrap().unwrap();
+        assert_eq!(
+            record.warnings,
+            vec![
+                CsvWarning {
+                    line: 2,
+                    kind: CsvWarningKind::UnescapedQuote,
+                },
+                CsvWarning {
+                    line: 1,
+                    kind: CsvWarningKind::UnterminatedQuote,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn csv_import_reader_refills_before_pushed_byte() {
+        let field = "a".repeat(CSV_IMPORT_BUFFER_SIZE - 3);
+        let input = format!("\"{field}\"\rb\",c\n");
+        let mut reader = CsvImportReader::new(input.as_bytes());
+
+        let record = reader.read_record().unwrap().unwrap();
+        assert_eq!(
+            record.fields,
+            vec![format!("{field}\"\rb"), "c".to_string()]
+        );
+        assert!(reader.read_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn csv_import_reader_consumes_record_before_utf8_error() {
+        let cases: &[(&[u8], u64)] = &[
+            (b"\xff,a\nb,c\n", 2),
+            (b"\xef\nb,c\n", 2),
+            (b"a,\xff\nb,c\n", 2),
+            (b"\"a\n\xff\",z\nb,c\n", 3),
+        ];
+
+        for (input, next_record_line) in cases {
+            let mut reader = CsvImportReader::new(*input);
+            let err = reader.read_record().unwrap_err();
+            assert!(err.to_string().contains("line 1: invalid UTF-8"));
+
+            let record = reader.read_record().unwrap().unwrap();
+            assert_eq!(record.start_line, *next_record_line);
+            assert_eq!(record.fields, vec!["b", "c"]);
+        }
+    }
+
+    #[test]
+    fn csv_import_reader_checks_separator_after_partial_bom_prefix() {
+        let mut reader = CsvImportReader::new(b"\xef,a\nb,c\n".as_slice());
+        let record = reader.read_raw_record().unwrap().unwrap();
+        assert_eq!(record.fields, vec![vec![0xef], b"a".to_vec()]);
+
+        let record = reader.read_record().unwrap().unwrap();
+        assert_eq!(record.start_line, 2);
+        assert_eq!(record.fields, vec!["b", "c"]);
+    }
+
+    #[test]
+    fn csv_import_reader_skips_utf8_bom() {
+        let mut reader = CsvImportReader::new(b"\xef\xbb\xbfa,b\n".as_slice());
+        let record = reader.read_record().unwrap().unwrap();
+        assert_eq!(record.start_line, 1);
+        assert_eq!(record.fields, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn csv_import_reader_observes_interrupt_before_next_field() {
+        let interrupt_count = Arc::new(AtomicUsize::new(1));
+        let mut reader =
+            CsvImportReader::new("a,b\n".as_bytes()).with_interrupt_count(interrupt_count);
+
+        let err = reader.read_record().unwrap_err();
+        assert!(matches!(err, CsvReadError::Interrupted));
+    }
+
+    #[test]
+    fn import_read_row_keeps_only_decode_errors_recoverable() {
+        let invalid_utf8 = ImportAbort::read_row(CsvReadError::InvalidUtf8 {
+            line: 1,
+            source: String::from_utf8(vec![0xff]).unwrap_err(),
+        });
+        assert!(matches!(invalid_utf8, ImportAbort::RowError(_)));
+
+        let source_error = ImportAbort::read_row(CsvReadError::Io(io::Error::other(
+            "persistent read failure",
+        )));
+        assert!(matches!(source_error, ImportAbort::Message(_)));
+    }
+
+    #[test]
+    fn import_insert_error_message_uses_raw_constraint_message() {
+        let error = LimboError::Constraint("UNIQUE constraint failed: t.x (19)".to_string());
+        assert_eq!(
+            import_insert_error_message(&error),
+            "UNIQUE constraint failed: t.x (19)"
+        );
+    }
+
+    #[test]
+    fn import_connection_interrupt_handles_default_and_atomic_modes() {
+        let (failed, error, auto_commit, count) = run_progress_interrupted_import(false);
+
+        assert!(failed);
+        assert!(error.contains("interrupt"));
+        assert!(auto_commit);
+        assert!(
+            count > 0,
+            "default import should preserve rows inserted before interrupt"
+        );
+        assert!(count < 200, "interrupt should stop before all rows import");
+
+        let (failed, error, auto_commit, count) = run_progress_interrupted_import(true);
+
+        assert!(failed);
+        assert!(error.contains("interrupt"));
+        assert!(auto_commit);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn import_atomic_auto_create_rolls_back_created_table_on_read_error() {
+        let io: Arc<dyn turso_core::IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, ":memory:import-atomic-auto-create").unwrap();
+        let conn = db.connect().unwrap();
+
+        let path = std::env::temp_dir().join(format!(
+            "turso-import-atomic-auto-create-{}-{}.csv",
+            std::process::id(),
+            unique_test_id()
+        ));
+        fs::write(&path, b"x\n\xff\n").unwrap();
+
+        let mut output = Vec::new();
+        let mut error = Vec::new();
+        let mut importer = ImportFile::new(conn.clone(), &mut output, &mut error);
+        let failed = importer.import_csv(ImportArgs {
+            csv: true,
+            atomic: true,
+            verbose: false,
+            skip: 0,
+            file: path.clone(),
+            table: "auto_atomic".to_string(),
+        });
+        let _ = fs::remove_file(path);
+
+        assert!(failed);
+        assert!(conn.get_auto_commit());
+        assert_eq!(
+            select_count(
+                &conn,
+                "SELECT count(*) FROM sqlite_master WHERE name='auto_atomic'"
+            ),
+            0
+        );
+        assert!(String::from_utf8(error)
+            .unwrap()
+            .contains("Error reading row: line 2: invalid UTF-8"));
+    }
+
+    fn run_progress_interrupted_import(atomic: bool) -> (bool, String, bool, i64) {
+        let io: Arc<dyn turso_core::IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, ":memory:import-interrupt").unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(x)").unwrap();
+
+        let path = std::env::temp_dir().join(format!(
+            "turso-import-interrupt-{}-{}.csv",
+            std::process::id(),
+            unique_test_id()
+        ));
+        let mut contents = String::new();
+        for i in 0..200 {
+            contents.push_str(&format!("{i}\n"));
+        }
+        fs::write(&path, contents).unwrap();
+
+        let fired = Arc::new(AtomicBool::new(false));
+        let fired_for_handler = fired.clone();
+        let steps = Arc::new(AtomicUsize::new(0));
+        let steps_for_handler = steps.clone();
+        let conn_for_handler = conn.clone();
+        conn.set_progress_handler(
+            1,
+            Some(Box::new(move || {
+                if steps_for_handler.fetch_add(1, Ordering::SeqCst) > 100
+                    && !fired_for_handler.swap(true, Ordering::SeqCst)
+                {
+                    conn_for_handler.interrupt();
+                }
+                false
+            })),
+        );
+
+        let mut output = Vec::new();
+        let mut error = Vec::new();
+        let mut importer = ImportFile::new(conn.clone(), &mut output, &mut error);
+        let failed = importer.import_csv(ImportArgs {
+            csv: true,
+            atomic,
+            verbose: false,
+            skip: 0,
+            file: path.clone(),
+            table: "t".to_string(),
+        });
+        conn.set_progress_handler(0, None);
+        let _ = fs::remove_file(path);
+
+        let auto_commit = conn.get_auto_commit();
+        let count = select_count(&conn, "SELECT count(*) FROM t");
+        (
+            failed,
+            String::from_utf8(error).unwrap(),
+            auto_commit,
+            count,
+        )
+    }
+
+    #[test]
+    fn import_commit_failure_handles_default_and_atomic_modes() {
+        let (conn, failed, error) = run_deferred_fk_import(false);
+
+        assert!(failed);
+        assert!(error.contains("Error committing import transaction"));
+        assert!(!conn.get_auto_commit());
+        assert_eq!(select_count(&conn, "SELECT count(*) FROM child"), 1);
+        conn.execute("ROLLBACK").unwrap();
+        assert!(conn.get_auto_commit());
+
+        let (conn, failed, error) = run_deferred_fk_import(true);
+
+        assert!(failed);
+        assert!(error.contains("Error committing import transaction"));
+        assert!(conn.get_auto_commit());
+        assert_eq!(select_count(&conn, "SELECT count(*) FROM child"), 0);
+    }
+
+    #[test]
+    fn import_atomic_inside_existing_transaction_rolls_back_to_savepoint() {
+        let io: Arc<dyn turso_core::IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, ":memory:import-savepoint").unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(x UNIQUE)").unwrap();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("INSERT INTO t VALUES('outer')").unwrap();
+
+        let path = std::env::temp_dir().join(format!(
+            "turso-import-savepoint-{}-{}.csv",
+            std::process::id(),
+            unique_test_id()
+        ));
+        fs::write(&path, "a\na\nb\n").unwrap();
+
+        let mut output = Vec::new();
+        let mut error = Vec::new();
+        let mut importer = ImportFile::new(conn.clone(), &mut output, &mut error);
+        let failed = importer.import_csv(ImportArgs {
+            csv: true,
+            atomic: true,
+            verbose: false,
+            skip: 0,
+            file: path.clone(),
+            table: "t".to_string(),
+        });
+        let _ = fs::remove_file(path);
+
+        assert!(failed);
+        assert!(!conn.get_auto_commit());
+        assert_eq!(select_count(&conn, "SELECT count(*) FROM t"), 1);
+        conn.execute("COMMIT").unwrap();
+        assert_eq!(select_count(&conn, "SELECT count(*) FROM t"), 1);
+        assert!(String::from_utf8(error)
+            .unwrap()
+            .contains("UNIQUE constraint failed: t.x"));
+    }
+
+    fn run_deferred_fk_import(atomic: bool) -> (Arc<Connection>, bool, String) {
+        let io: Arc<dyn turso_core::IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, ":memory:import-commit-failure").unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("PRAGMA foreign_keys = ON").unwrap();
+        conn.execute("CREATE TABLE parent(id INTEGER PRIMARY KEY)")
+            .unwrap();
+        conn.execute(
+            "CREATE TABLE child(parent_id INTEGER REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED)",
+        )
+        .unwrap();
+
+        let path = std::env::temp_dir().join(format!(
+            "turso-import-deferred-fk-{}-{}.csv",
+            std::process::id(),
+            unique_test_id()
+        ));
+        fs::write(&path, "1\n").unwrap();
+
+        let mut output = Vec::new();
+        let mut error = Vec::new();
+        let mut importer = ImportFile::new(conn.clone(), &mut output, &mut error);
+        let failed = importer.import_csv(ImportArgs {
+            csv: true,
+            atomic,
+            verbose: false,
+            skip: 0,
+            file: path.clone(),
+            table: "child".to_string(),
+        });
+        let _ = fs::remove_file(path);
+
+        (conn, failed, String::from_utf8(error).unwrap())
+    }
+
+    fn select_count(conn: &Arc<Connection>, sql: &str) -> i64 {
+        let mut count = None;
+        let mut stmt = conn.query(sql).unwrap().unwrap();
+        stmt.run_with_row_callback(|row| {
+            let value = row.get::<&Value>(0)?;
+            count = numeric_integer(value);
+            Ok(())
+        })
+        .unwrap();
+        count.unwrap()
+    }
+
+    fn numeric_integer(value: &Value) -> Option<i64> {
+        match value {
+            Value::Numeric(Numeric::Integer(i)) => Some(*i),
+            _ => None,
+        }
+    }
+
+    fn unique_test_id() -> usize {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+        NEXT_ID.fetch_add(1, Ordering::SeqCst)
+    }
 }

--- a/cli/tests/non_interactive_exit_code.rs
+++ b/cli/tests/non_interactive_exit_code.rs
@@ -1,5 +1,29 @@
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn temp_test_path(name: &str) -> PathBuf {
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+    let unique = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir().join(format!("turso-{name}-{}-{unique}", std::process::id()))
+}
+
+fn run_piped_script(script: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to run tursodb");
+
+    let mut stdin = child.stdin.take().unwrap();
+    stdin.write_all(script.as_bytes()).unwrap();
+    drop(stdin);
+
+    child.wait_with_output().expect("failed to wait")
+}
 
 // ---------------------------------------------------------------------------
 // A. SQL argument mode
@@ -152,59 +176,21 @@ fn sqlite_dbpage_update_allows_unsafe_testing() {
 /// B8: Success path returns 0
 #[test]
 fn piped_stdin_returns_exit_code_zero_on_success() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_tursodb"))
-        .arg(":memory:")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("failed to run tursodb");
-
-    let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all(b"select 1;\n").unwrap();
-    drop(stdin);
-
-    let status = child.wait().expect("failed to wait");
-    assert_eq!(status.code(), Some(0));
+    let output = run_piped_script("select 1;\n");
+    assert_eq!(output.status.code(), Some(0));
 }
 
 /// B9: Parse/prepare failure returns non-zero
 #[test]
 fn piped_stdin_returns_exit_code_one_on_query_failure() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_tursodb"))
-        .arg(":memory:")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("failed to run tursodb");
-
-    let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all(b"select * from nonexistent;\n").unwrap();
-    drop(stdin);
-
-    let status = child.wait().expect("failed to wait");
-    assert_eq!(status.code(), Some(1));
+    let output = run_piped_script("select * from nonexistent;\n");
+    assert_eq!(output.status.code(), Some(1));
 }
 
 /// B10: Fail-fast in piped multi-statement failure
 #[test]
 fn piped_stdin_stops_execution_after_first_error() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_tursodb"))
-        .arg(":memory:")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("failed to run tursodb");
-
-    let mut stdin = child.stdin.take().unwrap();
-    stdin
-        .write_all(b"select 'one'; select * from missing; select 'two';\n")
-        .unwrap();
-    drop(stdin);
-
-    let output = child.wait_with_output().expect("failed to wait");
+    let output = run_piped_script("select 'one'; select * from missing; select 'two';\n");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("one"), "first query should execute");
     assert!(
@@ -217,26 +203,91 @@ fn piped_stdin_stops_execution_after_first_error() {
 /// B11: Runtime/step failure in piped mode returns non-zero
 #[test]
 fn piped_stdin_runtime_error_returns_nonzero() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_tursodb"))
-        .arg(":memory:")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
+    let output = run_piped_script(
+        "create table t(x integer primary key);\n\
+         insert into t values(1);\n\
+         insert into t values(1);\n",
+    );
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
+fn piped_stdin_dot_command_parse_error_returns_nonzero_and_continues() {
+    let csv_path = temp_test_path("bad-import-option.csv");
+    std::fs::write(&csv_path, "1\n").expect("failed to write csv");
+    let script = format!(
+        ".mode list\n.import --badopt \"{}\" t\nSELECT 1;\n",
+        csv_path.display()
+    );
+    let output = run_piped_script(&script);
+    let _ = std::fs::remove_file(&csv_path);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stdout, "1\n");
+    assert!(
+        stderr.contains("unexpected argument '--badopt'"),
+        "expected clap parse error, got: {stderr}"
+    );
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
+fn piped_stdin_dot_command_help_returns_zero() {
+    let output = run_piped_script(".schema --help\n");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Display schema for a table"),
+        "expected .schema help, got: {stdout}"
+    );
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
+fn top_level_help_returns_zero() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg("--help")
+        .output()
         .expect("failed to run tursodb");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("The Turso interactive SQL shell"),
+        "expected top-level help, got: {stdout}"
+    );
+    assert_eq!(output.status.code(), Some(0));
+}
 
-    let mut stdin = child.stdin.take().unwrap();
-    stdin
-        .write_all(
-            b"create table t(x integer primary key);\n\
-              insert into t values(1);\n\
-              insert into t values(1);\n",
-        )
-        .unwrap();
-    drop(stdin);
+#[test]
+fn piped_stdin_parameter_error_returns_nonzero_and_continues() {
+    let output = run_piped_script(".mode list\n.parameter set x 41\nSELECT 1;\n");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("parameter name must start with one of"));
+    assert!(
+        stdout.ends_with("1\n"),
+        "SELECT after dot error should run: {stdout}"
+    );
+    assert_eq!(output.status.code(), Some(1));
+}
 
-    let status = child.wait().expect("failed to wait");
-    assert_eq!(status.code(), Some(1));
+#[test]
+fn piped_stdin_read_missing_file_reports_stderr_and_continues() {
+    let missing_path = temp_test_path("missing-read.sql");
+    let script = format!(
+        ".mode list\n.read \"{}\"\nSELECT 1;\n",
+        missing_path.display()
+    );
+    let output = run_piped_script(&script);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stdout, "1\n");
+    assert!(
+        stderr.contains(&format!(
+            "Error: cannot open \"{}\"",
+            missing_path.display()
+        )),
+        "expected .read error on stderr, got: {stderr:?}"
+    );
+    assert_eq!(output.status.code(), Some(1));
 }
 
 /// C1: .read handles multi-line CREATE TRIGGER correctly
@@ -251,7 +302,7 @@ END;\n\
 INSERT INTO t VALUES (1, 'hello');\n\
 SELECT msg FROM log;\n";
 
-    let sql_path = std::env::temp_dir().join("limbo_test_dot_read_trigger.sql");
+    let sql_path = temp_test_path("dot-read-trigger.sql");
     std::fs::write(&sql_path, sql).expect("failed to write sql file");
 
     let dot_read = format!(".read {}", sql_path.display());

--- a/cli/tests/non_interactive_exit_code.rs
+++ b/cli/tests/non_interactive_exit_code.rs
@@ -1,5 +1,5 @@
 use std::io::{BufRead, BufReader, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
@@ -9,6 +9,20 @@ fn temp_test_path(name: &str) -> PathBuf {
     static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
     let unique = NEXT_ID.fetch_add(1, Ordering::SeqCst);
     std::env::temp_dir().join(format!("turso-{name}-{}-{unique}", std::process::id()))
+}
+
+fn dot_command_path_arg(path: &Path) -> String {
+    let path = path.display().to_string();
+    let mut arg = String::with_capacity(path.len() + 2);
+    arg.push('"');
+    for c in path.chars() {
+        if matches!(c, '\\' | '"') {
+            arg.push('\\');
+        }
+        arg.push(c);
+    }
+    arg.push('"');
+    arg
 }
 
 fn run_piped_script(script: &str) -> Output {
@@ -218,8 +232,8 @@ fn piped_stdin_import_row_error_returns_nonzero_and_keeps_successful_rows() {
     let csv_path = temp_test_path("unique-import.csv");
     std::fs::write(&csv_path, "a\na\nb\n").expect("failed to write csv");
     let script = format!(
-        ".mode list\nCREATE TABLE t(x UNIQUE);\n.import --csv \"{}\" t\nSELECT count(*) FROM t;\n",
-        csv_path.display()
+        ".mode list\nCREATE TABLE t(x UNIQUE);\n.import --csv {} t\nSELECT count(*) FROM t;\n",
+        dot_command_path_arg(&csv_path)
     );
     let output = run_piped_script(&script);
     let _ = std::fs::remove_file(&csv_path);
@@ -241,8 +255,8 @@ fn piped_stdin_dot_command_parse_error_returns_nonzero_and_continues() {
     let csv_path = temp_test_path("bad-import-option.csv");
     std::fs::write(&csv_path, "1\n").expect("failed to write csv");
     let script = format!(
-        ".mode list\n.import --badopt \"{}\" t\nSELECT 1;\n",
-        csv_path.display()
+        ".mode list\n.import --badopt {} t\nSELECT 1;\n",
+        dot_command_path_arg(&csv_path)
     );
     let output = run_piped_script(&script);
     let _ = std::fs::remove_file(&csv_path);
@@ -298,8 +312,8 @@ fn piped_stdin_parameter_error_returns_nonzero_and_continues() {
 fn piped_stdin_read_missing_file_reports_stderr_and_continues() {
     let missing_path = temp_test_path("missing-read.sql");
     let script = format!(
-        ".mode list\n.read \"{}\"\nSELECT 1;\n",
-        missing_path.display()
+        ".mode list\n.read {}\nSELECT 1;\n",
+        dot_command_path_arg(&missing_path)
     );
     let output = run_piped_script(&script);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -431,7 +445,7 @@ SELECT msg FROM log;\n";
     let sql_path = temp_test_path("dot-read-trigger.sql");
     std::fs::write(&sql_path, sql).expect("failed to write sql file");
 
-    let dot_read = format!(".read {}", sql_path.display());
+    let dot_read = format!(".read {}", dot_command_path_arg(&sql_path));
     let mut child = Command::new(env!("CARGO_BIN_EXE_tursodb"))
         .arg(":memory:")
         .stdin(Stdio::piped())

--- a/cli/tests/non_interactive_exit_code.rs
+++ b/cli/tests/non_interactive_exit_code.rs
@@ -1,7 +1,9 @@
-use std::io::Write;
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 fn temp_test_path(name: &str) -> PathBuf {
     static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
@@ -311,6 +313,107 @@ fn piped_stdin_read_missing_file_reports_stderr_and_continues() {
         "expected .read error on stderr, got: {stderr:?}"
     );
     assert_eq!(output.status.code(), Some(1));
+}
+
+#[cfg(unix)]
+#[test]
+fn ctrl_c_interrupts_query_after_dot_open() {
+    let db_path = temp_test_path("interrupt-after-open.db");
+    let script = format!(
+        ".mode list\n.open {}\nSELECT * FROM generate_series(1, 1000000000);\n",
+        db_path.display()
+    );
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to run tursodb");
+
+    let mut stdin = child.stdin.take().unwrap();
+    stdin.write_all(script.as_bytes()).unwrap();
+    drop(stdin);
+
+    let stdout = child.stdout.take().unwrap();
+    let (query_started_tx, query_started_rx) = mpsc::channel();
+    let stdout_reader = std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut stdout = String::new();
+        let mut line = String::new();
+        while reader.read_line(&mut line)? != 0 {
+            if line.trim_end() == "1" {
+                let _ = query_started_tx.send(());
+            }
+            stdout.push_str(&line);
+            line.clear();
+        }
+        Ok::<_, std::io::Error>(stdout)
+    });
+
+    if let Err(e) = query_started_rx.recv_timeout(Duration::from_secs(3)) {
+        let _ = child.kill();
+        let _ = child.wait();
+        let stdout = stdout_reader
+            .join()
+            .expect("stdout reader thread panicked")
+            .expect("failed to read stdout");
+        let mut stderr = String::new();
+        child
+            .stderr
+            .take()
+            .unwrap()
+            .read_to_string(&mut stderr)
+            .expect("failed to read stderr");
+        panic!("query did not start before SIGINT: {e}; stdout={stdout:?}, stderr={stderr:?}");
+    }
+
+    unsafe {
+        libc::kill(child.id() as libc::pid_t, libc::SIGINT);
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("failed to poll child") {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            let stdout = stdout_reader
+                .join()
+                .expect("stdout reader thread panicked")
+                .expect("failed to read stdout");
+            let mut stderr = String::new();
+            child
+                .stderr
+                .take()
+                .unwrap()
+                .read_to_string(&mut stderr)
+                .expect("failed to read stderr");
+            panic!("query did not exit after SIGINT; stdout={stdout:?}, stderr={stderr:?}");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
+
+    let stdout = stdout_reader
+        .join()
+        .expect("stdout reader thread panicked")
+        .expect("failed to read stdout");
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .expect("failed to read stderr");
+    let _ = std::fs::remove_file(db_path);
+    let combined = format!("{stdout}{stderr}");
+    assert_eq!(status.code(), Some(1));
+    assert!(
+        combined.to_ascii_lowercase().contains("interrupt"),
+        "expected interrupt diagnostic, got: {combined:?}"
+    );
 }
 
 /// C1: .read handles multi-line CREATE TRIGGER correctly

--- a/cli/tests/non_interactive_exit_code.rs
+++ b/cli/tests/non_interactive_exit_code.rs
@@ -212,6 +212,29 @@ fn piped_stdin_runtime_error_returns_nonzero() {
 }
 
 #[test]
+fn piped_stdin_import_row_error_returns_nonzero_and_keeps_successful_rows() {
+    let csv_path = temp_test_path("unique-import.csv");
+    std::fs::write(&csv_path, "a\na\nb\n").expect("failed to write csv");
+    let script = format!(
+        ".mode list\nCREATE TABLE t(x UNIQUE);\n.import --csv \"{}\" t\nSELECT count(*) FROM t;\n",
+        csv_path.display()
+    );
+    let output = run_piped_script(&script);
+    let _ = std::fs::remove_file(&csv_path);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stdout, "2\n");
+    assert_eq!(
+        stderr,
+        format!(
+            "{}:2: INSERT failed: UNIQUE constraint failed: t.x (19)\n",
+            csv_path.display()
+        )
+    );
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
 fn piped_stdin_dot_command_parse_error_returns_nonzero_and_continues() {
     let csv_path = temp_test_path("bad-import-option.csv");
     std::fs::write(&csv_path, "1\n").expect("failed to write csv");

--- a/cli/tests/parameter_bindings.rs
+++ b/cli/tests/parameter_bindings.rs
@@ -6,7 +6,7 @@ fn run_cli(input: &[u8]) -> Output {
         .arg(":memory:")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("failed to run tursodb");
 
@@ -20,6 +20,10 @@ fn run_cli(input: &[u8]) -> Output {
 fn stdout_lines(output: &Output) -> Vec<&str> {
     let s = std::str::from_utf8(&output.stdout).expect("non-utf8 stdout");
     s.lines().collect()
+}
+
+fn stderr_text(output: &Output) -> &str {
+    std::str::from_utf8(&output.stderr).expect("non-utf8 stderr")
 }
 
 #[test]
@@ -50,13 +54,11 @@ fn parameter_clear_removes_binding() {
 fn parameter_set_rejects_bare_name() {
     let output = run_cli(b".mode list\n.parameter set x 41\nselect :x;\n");
 
-    assert_eq!(output.status.code(), Some(0));
-    let lines = stdout_lines(&output);
+    assert_eq!(output.status.code(), Some(1));
     assert!(
-        lines
-            .iter()
-            .any(|l| l.contains("Error: parameter name must start with one of")),
-        "expected bare-name validation error, got: {lines:?}"
+        stderr_text(&output).contains("Error: parameter name must start with one of"),
+        "expected bare-name validation error, got: {:?}",
+        stderr_text(&output)
     );
 }
 
@@ -66,6 +68,44 @@ fn parameter_set_supports_quoted_multi_word_text() {
 
     assert_eq!(output.status.code(), Some(0));
     assert_eq!(stdout_lines(&output), vec!["hello world"]);
+}
+
+#[test]
+fn parameter_set_preserves_escaped_newline_text() {
+    let output = run_cli(b".mode list\n.parameter set @x \"\\xA\"\nselect hex(@x), length(@x);\n");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_lines(&output), vec!["0A|1"]);
+}
+
+#[test]
+fn parameter_set_preserves_fallback_text_spaces() {
+    let output =
+        run_cli(b".mode list\n.parameter set @x \"  a  \"\nselect quote(@x), length(@x);\n");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_lines(&output), vec!["'  a  '|5"]);
+}
+
+#[test]
+fn parameter_set_truncates_nul_escape_like_sqlite_shell() {
+    let output = run_cli(b".mode list\n.parameter set @x \"\\xZZ\"\nselect hex(@x), quote(@x);\n");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_lines(&output), vec!["|''"]);
+}
+
+#[test]
+fn parameter_set_rejects_invalid_utf8_escape_current_turso_policy() {
+    let output = run_cli(b".mode list\n.parameter set @x \"\\xFF\"\nselect hex(@x);\n");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stdout_lines(&output), vec![""]);
+    assert!(
+        stderr_text(&output).contains("dot-command escape produced invalid UTF-8"),
+        "expected invalid UTF-8 escape error, got: {:?}",
+        stderr_text(&output)
+    );
 }
 
 #[test]
@@ -82,13 +122,11 @@ fn parameter_clear_only_removes_requested_name() {
 fn parameter_set_rejects_zero_positional_index() {
     let output = run_cli(b".mode list\n.parameter set ?0 41\n");
 
-    assert_eq!(output.status.code(), Some(0));
-    let lines = stdout_lines(&output);
+    assert_eq!(output.status.code(), Some(1));
     assert!(
-        lines
-            .iter()
-            .any(|l| l.contains("?N' must use an index >= 1")),
-        "expected positional index bounds validation error, got: {lines:?}"
+        stderr_text(&output).contains("?N' must use an index >= 1"),
+        "expected positional index bounds validation error, got: {:?}",
+        stderr_text(&output)
     );
 }
 

--- a/testing/cli_tests/cli_test_cases.py
+++ b/testing/cli_tests/cli_test_cases.py
@@ -140,10 +140,14 @@ def test_output_file():
     with open(output_file, "r") as f:
         contents = f.read()
 
+    # Dot-command diagnostics go to stderr, never into the redirected output file.
+    assert "Error: pretty output can only be written to a tty" not in contents, (
+        "Error message for pretty mode must not leak into the output file"
+    )
+
     expected_lines = {
         f"Output: {output_filename}": "Can direct output to a file",
         "Output mode: list": "Output mode remains list when output is redirected",
-        "Error: pretty output can only be written to a tty": "Error message for pretty mode",
         "SELECT 'TEST_ECHO'": "Echoed command",
         "TEST_ECHO": "Echoed result",
         "Null value: turso": "Null value setting",

--- a/testing/cli_tests/cli_test_cases.py
+++ b/testing/cli_tests/cli_test_cases.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import os
+import subprocess
+import tempfile
 import time
 from pathlib import Path
 
@@ -117,6 +119,78 @@ def verify_output_file(filepath: Path, expected_lines: dict) -> None:
         assert line in contents, f"Missing: {description}"
 
 
+def run_turso_script(script: str, extra_args=None) -> subprocess.CompletedProcess:
+    exec_name = os.environ.get("SQLITE_EXEC", "./scripts/limbo-sqlite3")
+    args = [exec_name]
+    if extra_args:
+        args.extend(extra_args)
+    return subprocess.run(
+        args,
+        input=script,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def sqlite3_baseline_exec() -> str | None:
+    configured = os.environ.get("SQLITE3_EXEC")
+    if configured:
+        return configured
+    return None
+
+
+def run_sqlite_script(script: str, sqlite3_exec: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sqlite3_exec],
+        input=script,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def normalize_shell_stdout(stdout: str) -> str:
+    lines = [
+        line
+        for line in stdout.splitlines()
+        if line != "Exiting Turso SQL Shell."
+    ]
+    return "\n".join(lines).rstrip()
+
+
+def assert_import_matches_sqlite(name: str, script: str, turso_args=None) -> None:
+    sqlite3_exec = sqlite3_baseline_exec()
+    if sqlite3_exec is None:
+        console.info(
+            f"Skipping SQLite differential import test {name}: SQLITE3_EXEC is not set",
+            _stack_offset=2,
+        )
+        return
+
+    console.test(f"Running SQLite differential import test: {name}", _stack_offset=2)
+    sqlite_result = run_sqlite_script(script, sqlite3_exec)
+    turso_result = run_turso_script(script, turso_args)
+    if sqlite_result.returncode == 0:
+        assert turso_result.returncode == 0, (
+            f"{name}: Turso failed when SQLite succeeded\n"
+            f"Turso return code: {turso_result.returncode}\n"
+            f"Turso stderr:\n{turso_result.stderr!r}"
+        )
+    assert normalize_shell_stdout(turso_result.stdout) == normalize_shell_stdout(
+        sqlite_result.stdout
+    ), (
+        f"{name}: stdout mismatch\n"
+        f"SQLite:\n{sqlite_result.stdout!r}\n"
+        f"Turso:\n{turso_result.stdout!r}"
+    )
+    assert turso_result.stderr == sqlite_result.stderr, (
+        f"{name}: stderr mismatch\n"
+        f"SQLite:\n{sqlite_result.stderr!r}\n"
+        f"Turso:\n{turso_result.stderr!r}"
+    )
+
+
 def test_output_file():
     shell = TestTursoShell()
     output_filename = "turso_output.txt"
@@ -197,7 +271,7 @@ def test_import_csv():
     )
     shell.run_test(
         "verify-csv-no-options",
-        "select * from csv_table;",
+        "select * from csv_table ORDER BY rowid;",
         "1|2.0|String'1\n3|4.0|String2",
     )
     shell.quit()
@@ -210,11 +284,12 @@ def test_import_csv_verbose():
     shell.run_test(
         "import-csv-verbose",
         ".import --csv -v ./testing/cli_tests/test_files/test.csv csv_table",
-        "Added 2 rows with 0 errors using 2 lines of input",
+        'Column separator ",", row separator "\\n"\n'
+        "Added 2 rows with 0 errors using 1 lines of input",
     )
     shell.run_test(
         "verify-csv-verbose",
-        "select * from csv_table;",
+        "select * from csv_table ORDER BY rowid;",
         "1|2.0|String'1\n3|4.0|String2",
     )
     shell.quit()
@@ -229,7 +304,11 @@ def test_import_csv_skip():
         ".import --csv --skip 1 ./testing/cli_tests/test_files/test.csv csv_table",
         "",
     )
-    shell.run_test("verify-csv-skip", "select * from csv_table;", "3|4.0|String2")
+    shell.run_test(
+        "verify-csv-skip",
+        "select * from csv_table ORDER BY rowid;",
+        "3|4.0|String2",
+    )
     shell.quit()
 
 
@@ -246,15 +325,233 @@ def test_import_csv_create_table_from_header():
     shell.run_test(
         "verify-auto-table-schema",
         ".schema auto_table",
-        "CREATE TABLE auto_table (id, interesting_number, interesting_string);",
+        'CREATE TABLE "auto_table" ("id" ANY, "interesting_number" ANY, "interesting_string" ANY);',
     )
     # Verify data was imported correctly (header row excluded)
     shell.run_test(
         "verify-auto-table-data",
-        "select * from auto_table;",
-        "1|2.0|String'1\n3|4.0|String2",
+        "select * from auto_table ORDER BY rowid;",
+        "1|2|String'1\n3|4|String2",
     )
     shell.quit()
+
+
+def test_import_csv_quotes_generated_identifiers():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "import_identifiers.csv"
+        path.write_text('"User Name","select","he""llo"\nAlice,1,x\n', encoding="utf-8")
+        shell = TestTursoShell()
+        try:
+            shell.run_test("open-memory", ".open :memory:", "")
+            shell.run_test(
+                "import-identifiers",
+                f'.import --csv "{path}" "weird table"',
+                "",
+            )
+            shell.run_test(
+                "verify-identifier-data",
+                'SELECT "User Name","select","he""llo" FROM "weird table";',
+                "Alice|1|x",
+            )
+        finally:
+            shell.quit()
+
+
+def test_import_csv_view_target_does_not_create_table():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "import_view.csv"
+        path.write_text("1\n", encoding="utf-8")
+        shell = TestTursoShell()
+        try:
+            shell.run_test("open-memory", ".open :memory:", "")
+            shell.run_test("create-view-base", "CREATE TABLE base(a);", "")
+            shell.run_test("create-view", "CREATE VIEW v AS SELECT a FROM base;", "")
+            shell.run_test(
+                "import-view",
+                f'.import --csv "{path}" v',
+                "Error: cannot modify v because it is a view",
+            )
+            shell.run_test(
+                "verify-view-still-exists",
+                "SELECT type FROM sqlite_master WHERE name='v';",
+                "view",
+            )
+        finally:
+            shell.quit()
+
+
+def test_import_csv_diagnostics_go_to_stderr_not_output_file():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "import_ragged.csv"
+        capture_path = Path(tmpdir) / "captured.txt"
+        path.write_text("x,y\n", encoding="utf-8")
+        result = run_turso_script(
+            f""".open :memory:
+CREATE TABLE t(a,b,c);
+.output "{capture_path}"
+.import --csv "{path}" t
+.output stdout
+.quit
+"""
+        )
+        expected = f"{path}:1: expected 3 columns but found 2 - filling the rest with NULL\n"
+        assert result.returncode == 0, result.stderr
+        assert result.stderr == expected
+        assert expected not in result.stdout
+        assert capture_path.read_text(encoding="utf-8") == ""
+
+
+def test_import_csv_reports_malformed_csv_warnings():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "malformed.csv"
+        path.write_text('a,"b"c\n', encoding="utf-8")
+        result = run_turso_script(
+            f""".open :memory:
+CREATE TABLE t(a,b);
+.import --csv "{path}" t
+.quit
+"""
+        )
+        expected = (
+            f'{path}:1: unescaped " character\n'
+            f'{path}:1: unterminated "-quoted field\n'
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stderr == expected
+
+
+def test_import_csv_reports_warnings_for_skip_and_header_rows():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        skip_path = Path(tmpdir) / "skip_warning.csv"
+        header_path = Path(tmpdir) / "header_warning.csv"
+        skip_path.write_text('"bad"x",c\n1,2\n', encoding="utf-8")
+        header_path.write_text('"bad"x",c\n1,2\n', encoding="utf-8")
+        result = run_turso_script(
+            f""".open :memory:
+CREATE TABLE skip_warn(a,b);
+.import --csv --skip 1 "{skip_path}" skip_warn
+.import --csv "{header_path}" header_warn
+SELECT * FROM skip_warn ORDER BY rowid;
+.quit
+"""
+        )
+        expected = (
+            f'{skip_path}:1: unescaped " character\n'
+            f'{header_path}:1: unescaped " character\n'
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stderr == expected
+        assert "1|2" in result.stdout
+
+
+def test_import_csv_duplicate_header_rename_notice():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "duplicate_header.csv"
+        path.write_text("id,id,x_1\n1,2,3\n", encoding="utf-8")
+        result = run_turso_script(
+            f""".open :memory:
+.import --csv "{path}" auto_dupe
+.schema auto_dupe
+.quit
+"""
+        )
+        expected_stderr = (
+            f"Columns renamed during .import {path} due to duplicates:\n"
+            '"id" to "id_1",\n'
+            '"id" to "id_2"\n'
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stderr == expected_stderr
+        assert '"id_1" ANY, "id_2" ANY, "x_1" ANY' in result.stdout
+
+
+def test_import_csv_matches_sqlite_quoted_fields():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "quoted_fields.csv"
+        path.write_bytes(
+            b'1,"",11\n'
+            b'2,"x",22\n'
+            b'3,"""",33\n'
+            b'4,"hello",44\n'
+            b'5,55,""\r\n'
+            b'6,66,"x"\n'
+            b'7,77,""""\n'
+            b'8,88,"hello"\n'
+            b'"",9,99\n'
+            b'"x",10,110\n'
+            b'"""",11,121\n'
+            b'"hello",12,132\n'
+        )
+        assert_import_matches_sqlite(
+            "quoted-fields",
+            f""".open :memory:
+.mode list
+.headers off
+CREATE TABLE t(a,b,c);
+.import --csv "{path}" t
+SELECT quote(a), quote(b), quote(c), typeof(a), typeof(b), typeof(c) FROM t ORDER BY rowid;
+""",
+        )
+
+
+def test_import_csv_matches_sqlite_multiline_quoted_fields():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "multiline.csv"
+        path.write_bytes(
+            b"column1,column2,column3,column4\n"
+            b'field1,field2,"x3 ""\r\ndata"" 3",field4\n'
+            b'x1,x2,"x3 ""\ndata"" 3",x4\n'
+        )
+        assert_import_matches_sqlite(
+            "multiline-quoted-fields",
+            f""".open :memory:
+.mode list
+.headers off
+CREATE TABLE t(a,b,c,d);
+.import --csv "{path}" t
+SELECT hex(a), hex(b), hex(c), hex(d) FROM t ORDER BY rowid;
+""",
+        )
+
+
+def test_import_csv_matches_sqlite_ragged_blank_rows_and_skip():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ragged_path = Path(tmpdir) / "ragged.csv"
+        skip_path = Path(tmpdir) / "skip.csv"
+        ragged_path.write_text("a,b\n\n1,2,3,4\n,,\n", encoding="utf-8")
+        skip_path.write_text("x,y,z\n1,2,3\n", encoding="utf-8")
+        assert_import_matches_sqlite(
+            "ragged-blank-rows-and-skip",
+            f""".open :memory:
+.mode list
+.headers off
+CREATE TABLE ragged(a,b,c);
+.import --csv "{ragged_path}" ragged
+CREATE TABLE skipped(a,b,c);
+.import --csv --skip 1 "{skip_path}" skipped
+SELECT quote(a), quote(b), quote(c), typeof(a), typeof(b), typeof(c) FROM ragged ORDER BY rowid;
+SELECT quote(a), quote(b), quote(c), typeof(a), typeof(b), typeof(c) FROM skipped ORDER BY rowid;
+""",
+        )
+
+
+def test_import_csv_matches_sqlite_generated_columns():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "generated.csv"
+        path.write_text("a,b\nx,y\n", encoding="utf-8")
+        assert_import_matches_sqlite(
+            "generated-columns",
+            f""".open :memory:
+.mode list
+.headers off
+CREATE TABLE t(a,b,c AS (a||b));
+.import --csv --skip 1 "{path}" t
+SELECT a,b,c FROM t ORDER BY rowid;
+SELECT count(*) FROM pragma_table_info('t');
+SELECT count(*) FROM pragma_table_xinfo('t');
+""",
+            ["--experimental-generated-columns"],
+        )
 
 
 def test_table_patterns():
@@ -500,6 +797,16 @@ def main():
     test_import_csv_verbose()
     test_import_csv_skip()
     test_import_csv_create_table_from_header()
+    test_import_csv_quotes_generated_identifiers()
+    test_import_csv_view_target_does_not_create_table()
+    test_import_csv_diagnostics_go_to_stderr_not_output_file()
+    test_import_csv_reports_malformed_csv_warnings()
+    test_import_csv_reports_warnings_for_skip_and_header_rows()
+    test_import_csv_duplicate_header_rename_notice()
+    test_import_csv_matches_sqlite_quoted_fields()
+    test_import_csv_matches_sqlite_multiline_quoted_fields()
+    test_import_csv_matches_sqlite_ragged_blank_rows_and_skip()
+    test_import_csv_matches_sqlite_generated_columns()
     test_table_patterns()
     test_update_with_limit()
     test_update_with_limit_and_offset()


### PR DESCRIPTION


This pr  removes `csv` crate and adds a custom csv reader - there were quite a few incompatibilities with sqlite which cannot be addressed if we use a outside crate.

  we have been doing a multi-row INSERT per 1000-row batch, so one bad row could fail and discard the entire batch. new we prepare one INSERT statement .
  if we fail in middle of .import - sqlite's behaviour is leaving partial inserts as-is, we follow this behaviour but we also add a  --atomic which will rollback entire .import on any error.


Dot commands now use SQLite-style parsing, fixing quoted/escaped args, spaces, semicolons, empty args, and escape 0-byte handling

Failures now go to stderr, fail noninteractive runs, and don’t leak into .output; 
