### PR TITLE
core/translate: Fix NULL parent-key semantics in FK parent checks

### DIFF
--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -446,8 +446,22 @@ where
     Ok(())
 }
 
-/// Iterate a table and call `on_match` when all child columns equal the key at
-/// `parent_key_start`.
+fn emit_skip_if_any_null(
+    program: &mut ProgramBuilder,
+    reg_start: usize,
+    nregs: usize,
+    target_pc: BranchOffset,
+) {
+    for i in 0..nregs {
+        program.emit_insn(Insn::IsNull {
+            reg: reg_start + i,
+            target_pc,
+        });
+    }
+}
+
+/// Iterate a table and call `on_match` when all child columns equal the
+/// non-NULL key at `parent_key_start`.
 ///
 /// Rows with any NULL FK column do not reference a parent and are ignored. For
 /// self-referential UPDATEs, `self_exclude_rowid` skips the current row when
@@ -497,7 +511,7 @@ where
             lhs: tmp,
             rhs: parent_key_start + i,
             target_pc: cont,
-            flags: CmpInsFlags::default().jump_if_null(),
+            flags: CmpInsFlags::default(),
             collation: Some(CollationSeq::Binary),
         });
         program.emit_insn(Insn::Goto {
@@ -886,6 +900,8 @@ fn emit_fk_parent_key_probe(
     let child_cols = &fk_ref.fk.child_columns;
     let is_deferred = fk_ref.fk.deferred;
     let is_restrict = matches!(fk_ref.fk.on_update, RefAct::Restrict);
+    let skip_probe = program.allocate_label();
+    emit_skip_if_any_null(program, parent_key_start, n_cols, skip_probe);
 
     let on_match = |p: &mut ProgramBuilder| -> Result<()> {
         match (is_deferred, pass) {
@@ -954,6 +970,7 @@ fn emit_fk_parent_key_probe(
         )?;
     }
 
+    program.preassign_label_to_next_insn(skip_probe);
     Ok(())
 }
 
@@ -1380,6 +1397,9 @@ fn emit_fk_delete_parent_existence_check_single(
         resolver,
     )?;
 
+    let skip_check = program.allocate_label();
+    emit_skip_if_any_null(program, parent_key_start, ncols, skip_check);
+
     let child_cols = &fk_ref.fk.child_columns;
     let child_idx = if !is_self_ref {
         let indices: Vec<_> = resolver.with_schema(database_id, |s| {
@@ -1439,6 +1459,7 @@ fn emit_fk_delete_parent_existence_check_single(
             },
         )?;
     }
+    program.preassign_label_to_next_insn(skip_check);
     Ok(())
 }
 

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -221,24 +221,7 @@ fn emit_parent_key_change_probes(
             None
         };
 
-    for i in 0..n_cols {
-        let next = if i + 1 == n_cols {
-            skip
-        } else {
-            program.allocate_label()
-        };
-        program.emit_insn(Insn::Eq {
-            lhs: old_key_start + i,
-            rhs: new_key_start + i,
-            target_pc: next,
-            flags: CmpInsFlags::default(),
-            collation: None,
-        });
-        program.emit_insn(Insn::Goto { target_pc: changed });
-        if i + 1 != n_cols {
-            program.preassign_label_to_next_insn(next);
-        }
-    }
+    emit_key_change_check(program, old_key_start, new_key_start, n_cols, skip, changed);
 
     program.preassign_label_to_next_insn(changed);
     if let Some(ref plan) = deferred_new_key_probe {
@@ -1674,6 +1657,7 @@ fn copy_key_from_values(
 }
 
 /// Emit instructions to detect if key values have changed between old and new registers.
+/// NULL values compare equal here, matching SQLite's FK action WHEN guard.
 /// Jumps to `skip_label` if all values are equal, falls through to `changed_label` if any differ.
 fn emit_key_change_check(
     program: &mut ProgramBuilder,
@@ -1693,7 +1677,7 @@ fn emit_key_change_check(
             lhs: old_key_start + i,
             rhs: new_key_start + i,
             target_pc: next.unwrap_or(skip_label),
-            flags: CmpInsFlags::default(),
+            flags: CmpInsFlags::default().null_eq(),
             collation: None,
         });
         program.emit_insn(Insn::Goto {
@@ -2647,4 +2631,32 @@ pub fn emit_fk_drop_table_check(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_change_check_treats_nulls_as_equal() {
+        let mut program =
+            ProgramBuilder::new(QueryMode::Normal, None, ProgramBuilderOpts::new(0, 4, 2));
+        let skip = program.allocate_label();
+        let changed = program.allocate_label();
+
+        emit_key_change_check(&mut program, 1, 2, 1, skip, changed);
+
+        assert!(
+            program.insns.iter().any(|(insn, _)| matches!(
+                insn,
+                Insn::Eq {
+                    lhs: 1,
+                    rhs: 2,
+                    flags,
+                    ..
+                } if flags.has_nulleq()
+            )),
+            "FK UPDATE action guard must use IS semantics for OLD/NEW key comparison"
+        );
+    }
 }

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -3089,6 +3089,157 @@ expect {
     0
 }
 
+# ON UPDATE RESTRICT should ignore parent keys containing NULL (SQLite `=` semantics).
+@cross-check-integrity
+test fk-update-restrict-null-parent-key-noop {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(k INT UNIQUE);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        pkey INT REFERENCES parent(k) ON UPDATE RESTRICT
+    );
+    CREATE INDEX child_pkey_idx ON child(pkey);
+    INSERT INTO parent VALUES(NULL), (1);
+    INSERT INTO child VALUES(10, NULL), (20, 1);
+    UPDATE parent SET k = k WHERE k IS NULL;
+    SELECT ifnull(pkey, 'NULL') FROM child ORDER BY id;
+}
+expect {
+    NULL
+    1
+}
+
+# ON UPDATE RESTRICT should also ignore NULL parent keys without a child index.
+@cross-check-integrity
+test fk-update-restrict-null-parent-key-noop-scan {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(k INT UNIQUE);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        pkey INT REFERENCES parent(k) ON UPDATE RESTRICT
+    );
+    INSERT INTO parent VALUES(NULL), (1);
+    INSERT INTO child VALUES(10, NULL), (20, 1);
+    UPDATE parent SET k = k WHERE k IS NULL;
+    SELECT ifnull(pkey, 'NULL') FROM child ORDER BY id;
+}
+expect {
+    NULL
+    1
+}
+
+# ON UPDATE NO ACTION should also ignore parent keys containing NULL.
+@cross-check-integrity
+test fk-update-noaction-null-parent-key-noop {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(k INT UNIQUE);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        pkey INT REFERENCES parent(k) ON UPDATE NO ACTION
+    );
+    CREATE INDEX child_pkey_idx ON child(pkey);
+    INSERT INTO parent VALUES(NULL), (1);
+    INSERT INTO child VALUES(10, NULL), (20, 1);
+    UPDATE parent SET k = 2 WHERE k IS NULL;
+    SELECT ifnull(pkey, 'NULL') FROM child ORDER BY id;
+}
+expect {
+    NULL
+    1
+}
+
+# ON DELETE RESTRICT should ignore NULL parent keys without a child index.
+@cross-check-integrity
+test fk-delete-restrict-null-parent-key-noop-scan {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(k INT UNIQUE);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        pkey INT REFERENCES parent(k) ON DELETE RESTRICT
+    );
+    INSERT INTO parent VALUES(NULL), (1);
+    INSERT INTO child VALUES(10, NULL), (20, 1);
+    DELETE FROM parent WHERE k IS NULL;
+    SELECT count(*) FROM parent WHERE k IS NULL;
+    SELECT k FROM parent;
+    SELECT ifnull(pkey, 'NULL') FROM child ORDER BY id;
+}
+expect {
+    0
+    1
+    NULL
+    1
+}
+
+# ON DELETE RESTRICT should ignore NULL parent keys when the child lookup uses an index.
+@cross-check-integrity
+test fk-delete-restrict-null-parent-key-noop-index {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(k INT UNIQUE);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        pkey INT REFERENCES parent(k) ON DELETE RESTRICT
+    );
+    CREATE INDEX child_pkey_idx ON child(pkey);
+    INSERT INTO parent VALUES(NULL), (1);
+    INSERT INTO child VALUES(10, NULL), (20, 1);
+    DELETE FROM parent WHERE k IS NULL;
+    SELECT count(*) FROM parent WHERE k IS NULL;
+    SELECT k FROM parent;
+    SELECT ifnull(pkey, 'NULL') FROM child ORDER BY id;
+}
+expect {
+    0
+    1
+    NULL
+    1
+}
+
+# Composite parent key: a partial-NULL key cannot be referenced, so ON UPDATE
+# RESTRICT must ignore it even when other components match a child row.
+@cross-check-integrity
+test fk-update-restrict-partial-null-composite-parent-key-noop {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(a INT, b INT, UNIQUE(a, b));
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        x INT,
+        y INT,
+        FOREIGN KEY(x, y) REFERENCES parent(a, b) ON UPDATE RESTRICT
+    );
+    INSERT INTO parent VALUES(1, NULL), (1, 2);
+    INSERT INTO child VALUES(10, 1, 2);
+    UPDATE parent SET b = b WHERE b IS NULL;
+    SELECT a, ifnull(b, 'NULL') FROM parent ORDER BY a, b;
+}
+expect {
+    1|NULL
+    1|2
+}
+
+# Composite parent key: deleting a partial-NULL parent row must not trip
+# ON DELETE RESTRICT for children matching the non-NULL components.
+@cross-check-integrity
+test fk-delete-restrict-partial-null-composite-parent-key {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(a INT, b INT, UNIQUE(a, b));
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        x INT,
+        y INT,
+        FOREIGN KEY(x, y) REFERENCES parent(a, b) ON DELETE RESTRICT
+    );
+    INSERT INTO parent VALUES(1, NULL), (1, 2);
+    INSERT INTO child VALUES(10, 1, 2);
+    DELETE FROM parent WHERE b IS NULL;
+    SELECT count(*) FROM parent;
+    SELECT a, b FROM parent;
+}
+expect {
+    1
+    1|2
+}
+
 # DROP parent table should fail when child rows reference it
 @cross-check-integrity
 test fk-drop-parent-with-child-references {


### PR DESCRIPTION
The FK parent-side checks could search for child rows using parent keys that contained NULL, which is wrong for SQLite FK semantics. since a  parent key containing NULL cannot be referenced by a child row, because FK matching uses = semantics, and NULL = value never matches.(eg: NULL =1 or say NULL = NULL too)

  For example:
```sql
  CREATE TABLE parent(a INT, b INT, UNIQUE(a, b));
  CREATE TABLE child(x INT, y INT,
    FOREIGN KEY(x, y) REFERENCES parent(a, b) ON DELETE RESTRICT
  );

  INSERT INTO parent VALUES(1, NULL), (1, 2);
  INSERT INTO child VALUES(1, 2);
```
  Deleting (1, NULL) must not treat (1, 2) as a referencing child.

  There was a second related UPDATE bug: the FK action guard used ordinary equality to decide whether OLD and NEW parent keys changed. For FK actions, SQLite uses OLD.col IS NEW.col semantics, so NULL -> NULL is not a key change.

  The fix skips parent-side FK probes when any parent-key register is NULL, and makes the FK UPDATE key-change guard compare with NULL equality