### PR TITLE
core/mvcc: parameterize MvStore over the skiplist allocator with fallible inserts

### DIFF
--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -160,5 +160,37 @@ pub type Rc<T> = std::rc::Rc<T>;
 
 pub type RcWeak<T> = std::rc::Weak<T>;
 
+/// An allocator that fails every allocation while its flag is set.
+///
+/// Delegates to [`TursoAllocator`] otherwise, so memory is still backed by
+/// the regular Turso heap. Shared test utility for exercising fallible
+/// allocation paths (skiplists, MvStore).
+#[cfg(test)]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct FailOnDemandAlloc {
+    fail: crate::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[cfg(test)]
+impl FailOnDemandAlloc {
+    pub(crate) fn fail_allocations(&self, fail: bool) {
+        self.fail.store(fail, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+unsafe impl ApiAllocator for FailOnDemandAlloc {
+    fn allocate(&self, layout: Layout) -> Result<std::ptr::NonNull<[u8]>, AllocError> {
+        if self.fail.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(AllocError);
+        }
+        TursoAllocator.allocate(layout)
+    }
+
+    unsafe fn deallocate(&self, ptr: std::ptr::NonNull<u8>, layout: Layout) {
+        unsafe { TursoAllocator.deallocate(ptr, layout) }
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1366,7 +1366,7 @@ impl Connection {
                             *watermark_row,
                         )?;
                         if let Some(mv_store) = self.db.get_mv_store().as_ref() {
-                            mv_store.set_sequence_watermark(&normalized, watermark);
+                            mv_store.set_sequence_watermark(&normalized, watermark)?;
                         }
                         let sequence = seq.take().expect("sequence set above");
                         inner.fresh.sequences.insert(normalized, Arc::new(sequence));
@@ -3512,7 +3512,7 @@ impl Connection {
                         *watermark_row,
                     )?;
                     if let Some(mv_store) = self.db.get_mv_store().as_ref() {
-                        mv_store.set_sequence_watermark(&normalized, watermark);
+                        mv_store.set_sequence_watermark(&normalized, watermark)?;
                     }
                     let sequence = seq.take().expect("sequence set above");
                     self.with_database_schema_mut(MAIN_DB_ID, |schema| {
@@ -3820,7 +3820,7 @@ impl Connection {
                                 mv_store.set_sequence_watermark(
                                     &autoincrement_sequence_name(&rows[*idx].0),
                                     first_unsafe,
-                                );
+                                )?;
                             }
                             *idx += 1;
                             *sub = SyncRowStep::Start;

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -692,7 +692,7 @@ impl HybridBTreeDirectory {
         cursor.index_info = Some(Arc::new(IndexInfo {
             has_rowid: false,
             num_cols: Self::CHUNK_LEN,
-            key_info: vec![key_info(), key_info(), key_info()],
+            key_info: crate::alloc::vec![key_info(), key_info(), key_info()],
             is_unique: false,
         }));
 
@@ -1871,7 +1871,7 @@ impl FtsCursor {
         cursor.index_info = Some(Arc::new(IndexInfo {
             has_rowid: false,
             num_cols: 3,
-            key_info: vec![key_info(), key_info(), key_info()],
+            key_info: crate::alloc::vec![key_info(), key_info(), key_info()],
             is_unique: false,
         }));
         self.fts_dir_cursor = Some(cursor);

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,5 +1,4 @@
 use crate::skiplist::map::Entry;
-use crate::skiplist::SkipMap;
 use crate::turso_assert;
 
 use crate::mvcc::clock::LogicalClock;
@@ -301,8 +300,11 @@ pub enum MvccCursorType {
     Index(Arc<IndexInfo>),
 }
 
-pub(crate) type MvccIterator<'l, T> =
-    Box<dyn Iterator<Item = Entry<'l, T, RowVersions>> + Send + Sync>;
+pub(crate) type MvccIterator<'l, T, A = crate::alloc::TursoAllocator> = Box<
+    dyn Iterator<Item = Entry<'l, T, RowVersions, crate::skiplist::comparator::BasicComparator, A>>
+        + Send
+        + Sync,
+>;
 
 /// Extends the lifetime of a SkipMap iterator to `'static`.
 ///
@@ -326,11 +328,36 @@ pub(crate) type MvccIterator<'l, T> =
 ///   that outlives the cursor.
 macro_rules! static_iterator_hack {
     ($iter:expr, $key_type:ty) => {
+        static_iterator_hack!($iter, $key_type, crate::alloc::TursoAllocator)
+    };
+    ($iter:expr, $key_type:ty, $alloc:ty) => {
         // SAFETY: See macro documentation above.
         unsafe {
             std::mem::transmute::<
-                Box<dyn Iterator<Item = Entry<'_, $key_type, RowVersions>> + Send + Sync>,
-                Box<dyn Iterator<Item = Entry<'static, $key_type, RowVersions>> + Send + Sync>,
+                Box<
+                    dyn Iterator<
+                            Item = Entry<
+                                '_,
+                                $key_type,
+                                RowVersions,
+                                crate::skiplist::comparator::BasicComparator,
+                                $alloc,
+                            >,
+                        > + Send
+                        + Sync,
+                >,
+                Box<
+                    dyn Iterator<
+                            Item = Entry<
+                                'static,
+                                $key_type,
+                                RowVersions,
+                                crate::skiplist::comparator::BasicComparator,
+                                $alloc,
+                            >,
+                        > + Send
+                        + Sync,
+                >,
             >($iter)
         }
     };
@@ -904,9 +931,9 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
     }
 
     /// Initialize MVCC iterator for forward iteration (used when next() is called without rewind())
-    fn init_mvcc_iterator_forward(&mut self) {
+    fn init_mvcc_iterator_forward(&mut self) -> Result<()> {
         if self.table_iterator.is_some() || self.index_iterator.is_some() {
-            return; // Already initialized
+            return Ok(()); // Already initialized
         }
         match &self.mv_cursor_type {
             MvccCursorType::Table => {
@@ -920,15 +947,13 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                 self.table_iterator = Some(static_iterator_hack!(iter_box, RowID));
             }
             MvccCursorType::Index(_) => {
-                let index_rows = self
-                    .db
-                    .index_rows
-                    .get_or_insert_with(self.table_id, SkipMap::new);
+                let index_rows = self.db.index_rows_map(self.table_id)?;
                 let index_rows = index_rows.value();
                 let iter_box = Box::new(index_rows.iter());
                 self.index_iterator = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));
             }
         }
+        Ok(())
     }
 }
 
@@ -994,7 +1019,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                 self.table_id,
                 self.tx_id,
                 &mut self.index_iterator,
-            ) {
+            )? {
                 Some(k) => {
                     self.dual_peek.mvcc_peek = CursorPeek::Row {
                         key: k,
@@ -1025,7 +1050,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                 let uninitialized = self.dual_peek.both_uninitialized();
                 if uninitialized {
                     // Initialize MVCC iterator and get first peek
-                    self.init_mvcc_iterator_forward();
+                    self.init_mvcc_iterator_forward()?;
                     self.advance_mvcc_iterator();
                     self.state
                         .replace(MvccLazyCursorState::Next(NextState::AdvanceUnitialized));
@@ -1353,7 +1378,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                                 direction,
                                 self.tx_id,
                                 &mut self.index_iterator,
-                            );
+                            )?;
 
                             // Set MVCC peek
                             {
@@ -1856,10 +1881,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
             }
             MvccCursorType::Index(_) => {
                 // For index cursors, initialize the iterator to the beginning
-                let index_rows = self
-                    .db
-                    .index_rows
-                    .get_or_insert_with(self.table_id, SkipMap::new);
+                let index_rows = self.db.index_rows_map(self.table_id)?;
                 let index_rows = index_rows.value();
                 let iter_box = Box::new(index_rows.iter());
                 self.index_iterator = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1,3 +1,4 @@
+use crate::alloc::TursoAllocator;
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
     DeleteRowStateMachine, MVTableId, MvStore, Row, RowID, RowKey, RowVersion, SortableIndexKey,
@@ -8,6 +9,7 @@ use crate::mvcc::database::{
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
 use crate::mvcc::yield_points::{inject_transition_failure, inject_transition_yield};
 use crate::schema::Index;
+use crate::skiplist::SkiplistAllocator;
 use crate::state_machine::{StateMachine, StateTransition, TransitionResult};
 use crate::storage::btree::{BTreeCursor, CursorTrait};
 use crate::storage::pager::CreateBTreeFlags;
@@ -130,7 +132,7 @@ pub struct LockStates {
 /// 7. Fsync the DB file
 /// 8. Truncate logical log to 0 (salt regenerated in memory), fsync, then truncate WAL
 /// 9. Releases the blocking_checkpoint_lock
-pub struct CheckpointStateMachine<Clock: LogicalClock> {
+pub struct CheckpointStateMachine<Clock: LogicalClock, A: SkiplistAllocator = TursoAllocator> {
     /// The current state of the state machine
     state: CheckpointState,
     /// The states of the locks held by the state machine - these are tracked for error handling so that they are
@@ -143,7 +145,7 @@ pub struct CheckpointStateMachine<Clock: LogicalClock> {
     /// Pager used for writing to the B-tree
     pager: Arc<Pager>,
     /// MVCC store containing the row versions.
-    mvstore: Arc<MvStore<Clock>>,
+    mvstore: Arc<MvStore<Clock, A>>,
     /// Connection to the database
     connection: Arc<Connection>,
     #[cfg(any(test, injected_yields))]
@@ -192,7 +194,7 @@ pub struct CheckpointStateMachine<Clock: LogicalClock> {
     collect_index_key_cursor: Option<Arc<SortableIndexKey>>,
     /// Async driver for `CheckpointState::CompactSequences`. Lazily set
     /// on first entry to that state; cleared when the driver completes.
-    seq_compact: Option<SeqCompactDriver<Clock>>,
+    seq_compact: Option<SeqCompactDriver<Clock, A>>,
 }
 
 /// One pending compaction job in the per-checkpoint sequence sweep.
@@ -255,7 +257,7 @@ enum SeqCompactPhase {
 /// would leave entries with `btree_resident: true` pointing at B-tree
 /// rows that no longer exist, surviving until `drop_unused_row_versions`
 /// Rule 3 catches up.
-struct SeqCompactDriver<Clock: LogicalClock> {
+struct SeqCompactDriver<Clock: LogicalClock, A: SkiplistAllocator = TursoAllocator> {
     /// Remaining backing tables to compact, in arbitrary order.
     pending: Vec<SeqCompaction>,
     /// Index of the in-flight compaction within `pending`.
@@ -280,11 +282,13 @@ struct SeqCompactDriver<Clock: LogicalClock> {
     pager: Arc<Pager>,
     /// MVCC store used to purge version-chain entries paired with each
     /// B-tree delete. See the struct-level comment for the invariant.
-    mvstore: Arc<MvStore<Clock>>,
+    mvstore: Arc<MvStore<Clock, A>>,
 }
 
 #[cfg(any(test, injected_yields))]
-impl<Clock: LogicalClock> ProvidesYieldContext for CheckpointStateMachine<Clock> {
+impl<Clock: LogicalClock, A: SkiplistAllocator> ProvidesYieldContext
+    for CheckpointStateMachine<Clock, A>
+{
     fn yield_context(&self) -> YieldContext {
         YieldContext::new(
             self.connection.yield_injector(),
@@ -400,7 +404,7 @@ fn is_schema_metadata_only_rewrite(current: &RowVersion, next: Option<&RowVersio
     }
 }
 
-impl<Clock: LogicalClock> SeqCompactDriver<Clock> {
+impl<Clock: LogicalClock, A: SkiplistAllocator> SeqCompactDriver<Clock, A> {
     /// Drive one step of the compaction sweep. Returns `IOResult::IO` on
     /// any cursor page IO so the caller can yield up; returns
     /// `IOResult::Done(())` when every pending backing table has been
@@ -537,7 +541,7 @@ impl<Clock: LogicalClock> SeqCompactDriver<Clock> {
     }
 }
 
-impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
+impl<Clock: LogicalClock, A: SkiplistAllocator> CheckpointStateMachine<Clock, A> {
     /// Build the per-checkpoint list of non-CYCLE sequence backing tables
     /// to compact. CYCLE seqs are skipped — they keep themselves at one
     /// row via inline compaction in the nextval bytecode and using
@@ -597,7 +601,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
     pub fn new(
         pager: Arc<Pager>,
-        mvstore: Arc<MvStore<Clock>>,
+        mvstore: Arc<MvStore<Clock, A>>,
         connection: Arc<Connection>,
         update_transaction_state: bool,
         sync_mode: SyncMode,
@@ -1577,7 +1581,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             self.mvstore.insert_table_id_to_rootpage(
                                 table_id,
                                 Some(created_root_page as u64),
-                            );
+                            )?;
                         }
                         SpecialWrite::BTreeDestroy {
                             table_id,
@@ -1623,7 +1627,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             self.mvstore.insert_table_id_to_rootpage(
                                 index_id,
                                 Some(created_root_page as u64),
-                            );
+                            )?;
                             // Index struct should already be stored in index_id_to_index from collect_committed_versions
                             turso_assert!(
                                 self.index_id_to_index.contains_key(&index_id),
@@ -2266,7 +2270,9 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
     }
 }
 
-impl<Clock: LogicalClock> StateTransition for CheckpointStateMachine<Clock> {
+impl<Clock: LogicalClock, A: SkiplistAllocator> StateTransition
+    for CheckpointStateMachine<Clock, A>
+{
     type Context = ();
     type SMResult = CheckpointResult;
 
@@ -2490,7 +2496,9 @@ mod tests {
         let (_, tombstone_version) =
             index_row_version(index_id, "blue_river_906", 75, 2, None, Some(10), true);
 
-        mvstore.insert_index_version(index_id, garbage_key, garbage_version);
+        mvstore
+            .insert_index_version(index_id, garbage_key, garbage_version)
+            .unwrap();
         let entry = mvstore
             .index_rows
             .get(&index_id)
@@ -2501,7 +2509,9 @@ mod tests {
             .expect("key bucket should exist after first insert")
             .key()
             .clone();
-        mvstore.insert_index_version(index_id, tombstone_key, tombstone_version);
+        mvstore
+            .insert_index_version(index_id, tombstone_key, tombstone_version)
+            .unwrap();
 
         while checkpoint.collect_index_rows().is_some() {}
 
@@ -2584,7 +2594,9 @@ mod tests {
         let row_count = COLLECT_PREEMPTION_THRESHOLD + 10;
         for i in 0..row_count as i64 {
             let (key, version) = index_row_version(index_id, "k", i, 1, Some(5), None, false);
-            mvstore.insert_index_version(index_id, key, version);
+            mvstore
+                .insert_index_version(index_id, key, version)
+                .unwrap();
         }
 
         let first = checkpoint.collect_index_rows();
@@ -2665,7 +2677,9 @@ mod tests {
         let row_count = COLLECT_PREEMPTION_THRESHOLD + 10;
         for i in 0..row_count as i64 {
             let (key, version) = index_row_version(index_id, "k", i, 1, Some(5), None, false);
-            mvstore.insert_index_version(index_id, key, version.clone());
+            mvstore
+                .insert_index_version(index_id, key, version.clone())
+                .unwrap();
             checkpoint.index_write_set.push((index_id, version, false));
         }
         checkpoint.state = CheckpointState::GcIndexRows {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2790,14 +2790,7 @@ impl<Clock: LogicalClock, A: SkiplistAllocator> StateTransition for CommitStateM
                         mvcc_store.release_exclusive_tx(&self.tx_id);
                     }
                     mvcc_store.unlock_commit_lock_if_held(tx);
-                    if let Err(e) =
-                        mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)
-                    {
-                        // The tx is already committed, so this must not fail
-                        // the commit; the tx lingers in `txs` (still fully
-                        // resolvable) until a later cleanup retires it.
-                        tracing::error!("failed to retire committed tx {}: {e}", self.tx_id);
-                    }
+                    mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)?;
                     inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;
                     return Ok(TransitionResult::Done(()));
@@ -2877,14 +2870,7 @@ impl<Clock: LogicalClock, A: SkiplistAllocator> StateTransition for CommitStateM
                         mvcc_store.release_exclusive_tx(&self.tx_id);
                         self.commit_coordinator.pager_commit_lock.unlock();
                     }
-                    if let Err(e) =
-                        mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)
-                    {
-                        // Read-only tx: remove_tx caches no finalized state,
-                        // so this is unreachable in practice; never fail a
-                        // committed tx regardless.
-                        tracing::error!("failed to retire committed tx {}: {e}", self.tx_id);
-                    }
+                    mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)?;
                     inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;
                     return Ok(TransitionResult::Done(()));
@@ -3154,14 +3140,7 @@ impl<Clock: LogicalClock, A: SkiplistAllocator> StateTransition for CommitStateM
                     mvcc_store.release_exclusive_tx(&self.tx_id);
                 }
                 inject_transition_yield!(self, CommitYieldPoint::BeforeFinishCommittedTx);
-                if let Err(e) =
-                    mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)
-                {
-                    // The tx is already committed, so this must not fail the
-                    // commit; the tx lingers in `txs` (still fully resolvable)
-                    // until a later cleanup retires it.
-                    tracing::error!("failed to retire committed tx {}: {e}", self.tx_id);
-                }
+                mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)?;
                 inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                 if mvcc_store.storage.should_checkpoint() {
                     let state_machine = StateMachine::new(CheckpointStateMachine::new(
@@ -5348,7 +5327,9 @@ impl<Clock: LogicalClock, A: SkiplistAllocator> MvStore<Clock, A> {
         if let Err(e) = self.txs.try_insert(tx_id, tx) {
             // Release everything acquired above, mirroring the vanished-tx
             // bail-out: the transaction was never published.
-            self.commit_coordinator.pager_commit_lock.unlock();
+            if !already_holds_commit_lock {
+                self.commit_coordinator.pager_commit_lock.unlock();
+            }
             if !already_exclusive {
                 self.release_exclusive_tx(&tx_id);
             }
@@ -5442,7 +5423,13 @@ impl<Clock: LogicalClock, A: SkiplistAllocator> MvStore<Clock, A> {
 
         let sequence_name = crate::util::normalize_ident(sequence_name);
         let mut allocations = self.sequence_allocations.lock();
+        if !allocations.contains_key(&sequence_name) {
+            allocations.try_reserve(1)?;
+        }
         let tx_allocations = allocations.entry(sequence_name).or_default();
+        if !tx_allocations.contains_key(&tx_id) {
+            tx_allocations.try_reserve(1)?;
+        }
         tx_allocations
             .entry(tx_id)
             .and_modify(|value| *value = (*value).min(sequence_value))
@@ -5450,11 +5437,14 @@ impl<Clock: LogicalClock, A: SkiplistAllocator> MvStore<Clock, A> {
         Ok(())
     }
 
-    pub fn set_sequence_watermark(&self, sequence_name: &str, watermark: i64) {
+    pub fn set_sequence_watermark(&self, sequence_name: &str, watermark: i64) -> Result<()> {
         let sequence_name = crate::util::normalize_ident(sequence_name);
-        self.sequence_watermarks
-            .lock()
-            .insert(sequence_name, watermark);
+        let mut watermarks = self.sequence_watermarks.lock();
+        if !watermarks.contains_key(&sequence_name) {
+            watermarks.try_reserve(1)?;
+        }
+        watermarks.insert(sequence_name, watermark);
+        Ok(())
     }
 
     /// Returns the first sequence value that is not safe for cursor scans to pass.
@@ -5462,7 +5452,7 @@ impl<Clock: LogicalClock, A: SkiplistAllocator> MvStore<Clock, A> {
     /// Readers can safely consume rows with sequence values less than this
     /// watermark. The value is the minimum of the current sequence boundary and
     /// any lower value already allocated by an active transaction.
-    pub fn sequence_watermark(&self, sequence_name: &str) -> Option<i64> {
+    pub fn sequence_watermark(&self, sequence_name: &str) -> Result<Option<i64>> {
         let sequence_name = crate::util::normalize_ident(sequence_name);
         let mut allocations = self.sequence_allocations.lock();
         let mut remove_allocations = false;
@@ -5490,9 +5480,9 @@ impl<Clock: LogicalClock, A: SkiplistAllocator> MvStore<Clock, A> {
         }
         let current_watermark = self.sequence_watermarks.lock().get(&sequence_name).copied();
         match (current_watermark, active_watermark) {
-            (Some(current), Some(active)) => Some(current.min(active)),
-            (Some(current), None) => Some(current),
-            (None, active) => active,
+            (Some(current), Some(active)) => Ok(Some(current.min(active))),
+            (Some(current), None) => Ok(Some(current)),
+            (None, active) => Ok(active),
         }
     }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1,12 +1,13 @@
-use crate::alloc::TursoTryWithCapacityExt;
+use crate::alloc::{TursoAllocator, TursoTryWithCapacityExt};
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::cursor::{static_iterator_hack, MvccIterator};
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
 use crate::mvcc::yield_points::{inject_transition_failure, inject_transition_yield};
 use crate::schema::{Schema, Sequence, Table};
+use crate::skiplist::comparator::BasicComparator;
 use crate::skiplist::map::Entry;
-use crate::skiplist::SkipMap;
+use crate::skiplist::{SkipMap, SkiplistAllocator};
 use crate::state_machine::StateMachine;
 use crate::state_machine::StateTransition;
 use crate::state_machine::TransitionResult;
@@ -109,6 +110,11 @@ pub struct MVTableId(i64);
 
 /// The versions of a single row
 pub type RowVersions = Arc<RwLock<Vec<RowVersion>>>;
+
+/// Per-index map of sortable keys to their version chains, stored as the
+/// values of [`MvStore::index_rows`].
+pub type IndexRowsMap<A = TursoAllocator> =
+    SkipMap<Arc<SortableIndexKey>, RowVersions, BasicComparator, A>;
 
 impl MVTableId {
     pub fn new(value: i64) -> Self {
@@ -547,8 +553,8 @@ struct PortableTableRef {
 }
 
 #[cfg(feature = "conn_raw_api")]
-fn rootpage_for_mv_table_id<Clock: LogicalClock>(
-    mvcc_store: &MvStore<Clock>,
+fn rootpage_for_mv_table_id<Clock: LogicalClock, A: SkiplistAllocator>(
+    mvcc_store: &MvStore<Clock, A>,
     table_id: MVTableId,
 ) -> i64 {
     mvcc_store
@@ -560,9 +566,9 @@ fn rootpage_for_mv_table_id<Clock: LogicalClock>(
 }
 
 #[cfg(feature = "conn_raw_api")]
-fn portable_table_name_for_mv_table_id<Clock: LogicalClock>(
+fn portable_table_name_for_mv_table_id<Clock: LogicalClock, A: SkiplistAllocator>(
     connection: &Connection,
-    mvcc_store: &MvStore<Clock>,
+    mvcc_store: &MvStore<Clock, A>,
     table_id: MVTableId,
 ) -> Option<String> {
     let rootpage = rootpage_for_mv_table_id(mvcc_store, table_id);
@@ -583,9 +589,9 @@ fn portable_table_name_for_mv_table_id<Clock: LogicalClock>(
 }
 
 #[cfg(feature = "conn_raw_api")]
-fn portable_delete_op_extension_for_row_version<Clock: LogicalClock>(
+fn portable_delete_op_extension_for_row_version<Clock: LogicalClock, A: SkiplistAllocator>(
     connection: &Connection,
-    mvcc_store: &MvStore<Clock>,
+    mvcc_store: &MvStore<Clock, A>,
     row_version: &RowVersion,
 ) -> Result<Option<Vec<u8>>> {
     if !connection.portable_logical_changes_enabled() {
@@ -1223,7 +1229,7 @@ impl AtomicTransactionState {
 }
 
 #[allow(clippy::large_enum_variant)]
-pub enum CommitState<Clock: LogicalClock> {
+pub enum CommitState<Clock: LogicalClock, A: SkiplistAllocator = TursoAllocator> {
     Initial,
     Commit {
         end_ts: u64,
@@ -1261,7 +1267,7 @@ pub enum CommitState<Clock: LogicalClock> {
     Checkpoint {
         // TODO: if and when we transform this code to async we won't be needing this explicit state machine nor
         // the mutex
-        state_machine: Mutex<StateMachine<CheckpointStateMachine<Clock>>>,
+        state_machine: Mutex<StateMachine<CheckpointStateMachine<Clock, A>>>,
     },
     CommitEnd {
         end_ts: u64,
@@ -1391,7 +1397,9 @@ fn commit_yield_key(tx_id: u64) -> u64 {
 }
 
 #[cfg(any(test, injected_yields))]
-impl<Clock: LogicalClock> ProvidesYieldContext for CommitStateMachine<Clock> {
+impl<Clock: LogicalClock, A: SkiplistAllocator> ProvidesYieldContext
+    for CommitStateMachine<Clock, A>
+{
     fn yield_context(&self) -> YieldContext {
         YieldContext::new(
             self.connection.yield_injector(),
@@ -1402,14 +1410,14 @@ impl<Clock: LogicalClock> ProvidesYieldContext for CommitStateMachine<Clock> {
     }
 }
 
-pub struct CommitStateMachine<Clock: LogicalClock> {
-    state: CommitState<Clock>,
+pub struct CommitStateMachine<Clock: LogicalClock, A: SkiplistAllocator = TursoAllocator> {
+    state: CommitState<Clock, A>,
     is_finalized: bool,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
     did_commit_schema_change: bool,
     tx_id: TxID,
-    mvcc_store: Arc<MvStore<Clock>>,
+    mvcc_store: Arc<MvStore<Clock, A>>,
     connection: Arc<Connection>,
     /// Database index this commit is for (`MAIN_DB_ID` or an attached-db id).
     /// Threaded through so that `finish_committed_tx` can clear the matching
@@ -1425,7 +1433,7 @@ pub struct CommitStateMachine<Clock: LogicalClock> {
     _phantom: PhantomData<Clock>,
 }
 
-impl<Clock: LogicalClock> Debug for CommitStateMachine<Clock> {
+impl<Clock: LogicalClock, A: SkiplistAllocator> Debug for CommitStateMachine<Clock, A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CommitStateMachine")
             .field("state", &self.state)
@@ -1434,7 +1442,7 @@ impl<Clock: LogicalClock> Debug for CommitStateMachine<Clock> {
     }
 }
 
-impl<Clock: LogicalClock> Drop for CommitStateMachine<Clock> {
+impl<Clock: LogicalClock, A: SkiplistAllocator> Drop for CommitStateMachine<Clock, A> {
     fn drop(&mut self) {
         self.cleanup_unfinished_commit();
     }
@@ -1466,7 +1474,7 @@ pub struct DeleteRowStateMachine {
     cursor: Arc<RwLock<BTreeCursor>>,
 }
 
-impl<Clock: LogicalClock> CommitStateMachine<Clock> {
+impl<Clock: LogicalClock, A: SkiplistAllocator> CommitStateMachine<Clock, A> {
     pub(crate) fn cleanup_mvcc_checkpoint_state(&mut self) {
         if let CommitState::Checkpoint { state_machine } = &mut self.state {
             let _ = state_machine
@@ -1481,9 +1489,9 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
 
     #[allow(clippy::too_many_arguments)]
     fn new(
-        state: CommitState<Clock>,
+        state: CommitState<Clock, A>,
         tx_id: TxID,
-        mvcc_store: Arc<MvStore<Clock>>,
+        mvcc_store: Arc<MvStore<Clock, A>>,
         connection: Arc<Connection>,
         db_id: usize,
         commit_coordinator: Arc<CommitCoordinator>,
@@ -1579,7 +1587,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         rowid: &RowID,
         end_ts: u64,
         tx: &Transaction,
-        mvcc_store: &Arc<MvStore<Clock>>,
+        mvcc_store: &Arc<MvStore<Clock, A>>,
     ) -> Result<()> {
         let row_versions = mvcc_store.rows.get(rowid);
         if row_versions.is_none() {
@@ -1603,7 +1611,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         rowid: &RowID,
         end_ts: u64,
         tx: &Transaction,
-        mvcc_store: &Arc<MvStore<Clock>>,
+        mvcc_store: &Arc<MvStore<Clock, A>>,
     ) -> Result<()> {
         let RowKey::Record(record) = &rowid.row_id else {
             panic!("invalid index row_id type, should be Record")
@@ -1664,7 +1672,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         &self,
         end_ts: u64,
         tx: &Transaction,
-        mvcc_store: &Arc<MvStore<Clock>>,
+        mvcc_store: &Arc<MvStore<Clock, A>>,
         row_versions: &[RowVersion],
     ) -> Result<()> {
         // Check for conflicts - iterate in reverse for faster early termination
@@ -1827,7 +1835,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
     /// in two passes so that log replay sees CREATE TABLE before INSERTs.
     fn step_build_log_record(
         &mut self,
-        mvcc_store: &Arc<MvStore<Clock>>,
+        mvcc_store: &Arc<MvStore<Clock, A>>,
     ) -> Result<TransitionResult<()>> {
         // First entry into BuildLogRecord (no chunk processed yet): a yield-
         // point to bracket the chunked yields so tests can count them exactly.
@@ -2237,7 +2245,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
 
     fn populate_portable_changes(
         &self,
-        mvcc_store: &Arc<MvStore<Clock>>,
+        mvcc_store: &Arc<MvStore<Clock, A>>,
         log_record: &mut LogRecord,
     ) -> Result<()> {
         #[cfg(not(feature = "conn_raw_api"))]
@@ -2484,7 +2492,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
     /// references resolve via `txs[tx_id]` for visibility/conflict checks.
     fn step_rewrite_live_versions(
         &mut self,
-        mvcc_store: &Arc<MvStore<Clock>>,
+        mvcc_store: &Arc<MvStore<Clock, A>>,
     ) -> Result<TransitionResult<()>> {
         let tx_id = self.tx_id;
         let tx_entry = mvcc_store.txs.get(&tx_id);
@@ -2554,8 +2562,8 @@ impl WriteRowStateMachine {
     }
 }
 
-impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
-    type Context = Arc<MvStore<Clock>>;
+impl<Clock: LogicalClock, A: SkiplistAllocator> StateTransition for CommitStateMachine<Clock, A> {
+    type Context = Arc<MvStore<Clock, A>>;
     type SMResult = ();
 
     #[tracing::instrument(fields(state = ?self.state), skip(self, mvcc_store), level = Level::DEBUG)]
@@ -2782,7 +2790,14 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         mvcc_store.release_exclusive_tx(&self.tx_id);
                     }
                     mvcc_store.unlock_commit_lock_if_held(tx);
-                    mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id);
+                    if let Err(e) =
+                        mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)
+                    {
+                        // The tx is already committed, so this must not fail
+                        // the commit; the tx lingers in `txs` (still fully
+                        // resolvable) until a later cleanup retires it.
+                        tracing::error!("failed to retire committed tx {}: {e}", self.tx_id);
+                    }
                     inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;
                     return Ok(TransitionResult::Done(()));
@@ -2862,7 +2877,14 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         mvcc_store.release_exclusive_tx(&self.tx_id);
                         self.commit_coordinator.pager_commit_lock.unlock();
                     }
-                    mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id);
+                    if let Err(e) =
+                        mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)
+                    {
+                        // Read-only tx: remove_tx caches no finalized state,
+                        // so this is unreachable in practice; never fail a
+                        // committed tx regardless.
+                        tracing::error!("failed to retire committed tx {}: {e}", self.tx_id);
+                    }
                     inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;
                     return Ok(TransitionResult::Done(()));
@@ -3132,7 +3154,14 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     mvcc_store.release_exclusive_tx(&self.tx_id);
                 }
                 inject_transition_yield!(self, CommitYieldPoint::BeforeFinishCommittedTx);
-                mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id);
+                if let Err(e) =
+                    mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)
+                {
+                    // The tx is already committed, so this must not fail the
+                    // commit; the tx lingers in `txs` (still fully resolvable)
+                    // until a later cleanup retires it.
+                    tracing::error!("failed to retire committed tx {}: {e}", self.tx_id);
+                }
                 inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                 if mvcc_store.storage.should_checkpoint() {
                     let state_machine = StateMachine::new(CheckpointStateMachine::new(
@@ -3667,9 +3696,13 @@ pub struct RecoverCtx {
 }
 
 /// A multi-version concurrency control database.
+///
+/// Generic over the skiplist allocator so tests can inject a failing
+/// allocator and exercise allocation-failure paths; production code uses
+/// the default [`TursoAllocator`].
 #[derive(Debug)]
-pub struct MvStore<Clock: LogicalClock> {
-    pub rows: SkipMap<RowID, Arc<RwLock<Vec<RowVersion>>>>,
+pub struct MvStore<Clock: LogicalClock, A: SkiplistAllocator = TursoAllocator> {
+    pub rows: SkipMap<RowID, Arc<RwLock<Vec<RowVersion>>>, BasicComparator, A>,
     /// Table ID is an opaque identifier that is only meaningful to the MV store.
     /// Each checkpointed MVCC table corresponds to a single B-tree on the pager,
     /// which naturally has a root page.
@@ -3681,15 +3714,18 @@ pub struct MvStore<Clock: LogicalClock> {
     /// Hence, we store the mapping here.
     /// The value is Option because tables created in an MVCC commit that have not
     /// been checkpointed yet have no real root page assigned yet.
-    pub table_id_to_rootpage: SkipMap<MVTableId, Option<u64>>,
+    pub table_id_to_rootpage: SkipMap<MVTableId, Option<u64>, BasicComparator, A>,
     /// Unlike table rows which are stored in a single map, we have a separate map for every index
     /// because operations like last() on an index are much easier when we don't have to take the
     /// table identifier into account.
-    pub index_rows: SkipMap<MVTableId, SkipMap<Arc<SortableIndexKey>, RowVersions>>,
-    txs: SkipMap<TxID, Transaction>,
+    pub index_rows: SkipMap<MVTableId, IndexRowsMap<A>, BasicComparator, A>,
+    txs: SkipMap<TxID, Transaction, BasicComparator, A>,
     /// Final state for removed transactions. Readers may still race with stale TxID
     /// references in row versions after a transaction is removed from `txs`.
-    finalized_tx_states: SkipMap<TxID, TransactionState>,
+    finalized_tx_states: SkipMap<TxID, TransactionState, BasicComparator, A>,
+    /// Allocator backing every skiplist in this store, including lazily
+    /// created per-index maps in `index_rows`.
+    alloc: A,
     tx_ids: AtomicU64,
     version_id_counter: AtomicU64,
     next_rowid: AtomicU64,
@@ -3752,6 +3788,16 @@ pub struct MvStore<Clock: LogicalClock> {
 }
 
 impl<Clock: LogicalClock> MvStore<Clock> {
+    /// Creates a new database backed by the default [`TursoAllocator`].
+    pub fn new(
+        clock: Clock,
+        storage: Arc<dyn crate::mvcc::persistent_storage::DurableStorage>,
+    ) -> Result<Self> {
+        Self::new_in(clock, storage, TursoAllocator)
+    }
+}
+
+impl<Clock: LogicalClock, A: SkiplistAllocator> MvStore<Clock, A> {
     fn uses_durable_mvcc_metadata(&self, connection: &Arc<Connection>) -> bool {
         !connection.db.is_in_memory_db()
     }
@@ -3798,17 +3844,22 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         *connection.db.schema.lock() = connection.schema.read().clone();
     }
 
-    /// Creates a new database.
-    pub fn new(
+    /// Creates a new database whose skiplists allocate through `alloc`.
+    pub fn new_in(
         clock: Clock,
         storage: Arc<dyn crate::mvcc::persistent_storage::DurableStorage>,
-    ) -> Self {
-        Self {
-            rows: SkipMap::new(),
-            table_id_to_rootpage: SkipMap::from_iter(vec![(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1))]), // table id 1 / root page 1 is always sqlite_schema.
-            index_rows: SkipMap::new(),
-            txs: SkipMap::new(),
-            finalized_tx_states: SkipMap::new(),
+        alloc: A,
+    ) -> Result<Self> {
+        let table_id_to_rootpage = SkipMap::new_in(alloc.clone());
+        // table id 1 / root page 1 is always sqlite_schema.
+        table_id_to_rootpage.try_insert(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1))?;
+        Ok(Self {
+            rows: SkipMap::new_in(alloc.clone()),
+            table_id_to_rootpage,
+            index_rows: SkipMap::new_in(alloc.clone()),
+            txs: SkipMap::new_in(alloc.clone()),
+            finalized_tx_states: SkipMap::new_in(alloc.clone()),
+            alloc,
             tx_ids: AtomicU64::new(1), // let's reserve transaction 0 for special purposes
             version_id_counter: AtomicU64::new(1), // Reserve 0 for special purposes
             next_rowid: AtomicU64::new(0), // TODO: determine this from B-Tree
@@ -3826,7 +3877,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             table_id_to_last_rowid: RwLock::new(HashMap::default()),
             sequence_watermarks: Mutex::new(HashMap::default()),
             sequence_allocations: Mutex::new(HashMap::default()),
-        }
+        })
     }
 
     /// Get the table ID from the root page.
@@ -3853,8 +3904,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
     /// Insert a table ID and root page mapping.
     /// Root page must be positive here, because we only invoke this method with Some() for checkpointed tables.
-    pub fn insert_table_id_to_rootpage(&self, table_id: MVTableId, root_page: Option<u64>) {
-        self.table_id_to_rootpage.insert(table_id, root_page);
+    pub fn insert_table_id_to_rootpage(
+        &self,
+        table_id: MVTableId,
+        root_page: Option<u64>,
+    ) -> Result<()> {
+        self.table_id_to_rootpage.try_insert(table_id, root_page)?;
         let minimum: i64 = if let Some(root_page) = root_page {
             // On recovery, we assign table_id = -root_page. Let's make sure we don't get any clashes between checkpointed and non-checkpointed tables
             // E.g. if we checkpoint a table that has physical root page 7, let's require the next table_id to be less than -7 (or if table_id is already smaller, then smaller than that.)
@@ -3866,6 +3921,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         if minimum <= self.next_table_id.load(Ordering::SeqCst) {
             self.next_table_id.store(minimum - 1, Ordering::SeqCst);
         }
+        Ok(())
     }
 
     pub fn remove_table_id_to_rootpage(&self, table_id: &MVTableId) {
@@ -3965,10 +4021,14 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
         self.table_id_to_rootpage.clear();
         self.table_id_to_last_rowid.write().clear();
-        self.insert_table_id_to_rootpage(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1));
+        // This runs after the VACUUM image is committed, where failure cannot
+        // be rolled back; a lost mapping would corrupt every later lookup.
+        self.insert_table_id_to_rootpage(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1))
+            .expect("post-VACUUM rootpage mapping rebuild must not fail");
         for root_page in root_pages {
             let table_id = MVTableId::from(-root_page);
-            self.insert_table_id_to_rootpage(table_id, Some(root_page as u64));
+            self.insert_table_id_to_rootpage(table_id, Some(root_page as u64))
+                .expect("post-VACUUM rootpage mapping rebuild must not fail");
         }
         self.global_header.write().replace(header);
     }
@@ -4360,7 +4420,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         for root_page in sqlite_schema_root_pages {
             turso_assert!(root_page > 0, "root_page={root_page} must be positive");
             let root_page_as_table_id = MVTableId::from(-(root_page));
-            self.insert_table_id_to_rootpage(root_page_as_table_id, Some(root_page as u64));
+            self.insert_table_id_to_rootpage(root_page_as_table_id, Some(root_page as u64))?;
         }
         Ok(())
     }
@@ -4426,7 +4486,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 // returns the canonical Arc (ours on miss, an existing one
                 // on hit), which we hand to savepoint tracking.
                 let (canonical_key, row_versions) =
-                    self.insert_index_version(index_id, sortable_key, row_version);
+                    self.insert_index_version(index_id, sortable_key, row_version)?;
                 tx.insert_to_write_set(
                     RowID::new(id.table_id, RowKey::Record(canonical_key.clone())),
                     row_versions,
@@ -4449,10 +4509,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     row,
                     btree_resident: false,
                 };
+                // The fallible chain insert goes first: if it fails, no
+                // savepoint tracking, rowid-allocator, or write-set state may
+                // reference a version that never landed.
+                let row_versions = self.insert_version(id.clone(), row_version)?;
                 tx.record_created_table_version(id.clone(), version_id);
                 let allocator = self.get_rowid_allocator(&id.table_id);
                 allocator.insert_row_id_maybe_update(id.row_id.to_int_or_panic());
-                let row_versions = self.insert_version(id.clone(), row_version);
                 tx.insert_to_write_set(id, row_versions);
             }
         }
@@ -4489,7 +4552,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     panic!("Index writes must be to a record");
                 };
                 let (canonical_key, row_versions) =
-                    self.insert_index_version(index_id, sortable_key, row_version);
+                    self.insert_index_version(index_id, sortable_key, row_version)?;
                 tx.insert_to_write_set(
                     RowID::new(id.table_id, RowKey::Record(canonical_key.clone())),
                     row_versions,
@@ -4497,8 +4560,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 tx.record_created_index_version((index_id, canonical_key), version_id);
             }
             None => {
+                let row_versions = self.insert_version(id.clone(), row_version)?;
                 tx.record_created_table_version(id.clone(), version_id);
-                let row_versions = self.insert_version(id.clone(), row_version);
                 tx.insert_to_write_set(id, row_versions);
             }
         }
@@ -4543,7 +4606,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     panic!("Index writes must be to a record");
                 };
                 let (canonical_key, row_versions) =
-                    self.insert_index_version(index_id, sortable_key, row_version);
+                    self.insert_index_version(index_id, sortable_key, row_version)?;
                 tx.insert_to_write_set(
                     RowID::new(id.table_id, RowKey::Record(canonical_key.clone())),
                     row_versions,
@@ -4561,8 +4624,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     row,
                     btree_resident: true,
                 };
+                let row_versions = self.insert_version(id.clone(), row_version)?;
                 tx.record_created_table_version(id.clone(), version_id);
-                let row_versions = self.insert_version(id.clone(), row_version);
                 tx.insert_to_write_set(id, row_versions);
             }
         }
@@ -4653,7 +4716,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         tracing::trace!("delete(tx_id={}, id={:?})", tx_id, id);
         match maybe_index_id {
             Some(index_id) => {
-                let rows = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
+                let rows = self.index_rows_map(index_id)?;
                 let rows = rows.value();
                 let RowKey::Record(sortable_key) = id.row_id.clone() else {
                     panic!("Index deletes must have a record row_id");
@@ -4769,7 +4832,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         turso_assert_eq!(tx.state, TransactionState::Active);
         match maybe_index_id {
             Some(index_id) => {
-                let rows = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
+                let rows = self.index_rows_map(index_id)?;
                 let rows = rows.value();
                 let RowKey::Record(sortable_key) = &id.row_id else {
                     panic!("Index reads must have a record row_id");
@@ -4869,7 +4932,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     pub(crate) fn advance_cursor_and_get_row_id_for_table(
         &self,
         table_id: MVTableId,
-        mv_store_iterator: &mut Option<MvccIterator<'static, RowID>>,
+        mv_store_iterator: &mut Option<MvccIterator<'static, RowID, A>>,
         tx_id: TxID,
     ) -> Option<(RowID, RowVersions)> {
         let mv_store_iterator = mv_store_iterator.as_mut().expect(
@@ -4904,7 +4967,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
     pub(crate) fn advance_cursor_and_get_row_id_for_index(
         &self,
-        mv_store_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
+        mv_store_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>, A>>,
         tx_id: TxID,
     ) -> Option<RowID> {
         let mv_store_iterator = mv_store_iterator.as_mut().expect(
@@ -4956,7 +5019,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 !btree_is_invalid
             }
             RowKey::Record(record) => {
-                let index_rows = self.index_rows.get_or_insert_with(table_id, SkipMap::new);
+                // Pure read: an absent per-index map means no MVCC versions.
+                let Some(index_rows) = self.index_rows.get(&table_id) else {
+                    return true;
+                };
                 let index_rows = index_rows.value();
                 let Some(versions) = index_rows.get(record.as_ref()) else {
                     // No MVCC version -> B-tree is valid
@@ -4977,7 +5043,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     fn find_last_visible_version(
         &self,
         tx: &Transaction,
-        row: &Entry<'_, RowID, Arc<RwLock<Vec<RowVersion>>>>,
+        row: &Entry<'_, RowID, Arc<RwLock<Vec<RowVersion>>>, BasicComparator, A>,
     ) -> Option<(RowID, RowVersions)> {
         row.value()
             .read()
@@ -4990,7 +5056,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     fn find_last_visible_index_version(
         &self,
         tx: &Transaction,
-        row: Entry<'_, Arc<SortableIndexKey>, Arc<RwLock<Vec<RowVersion>>>>,
+        row: Entry<'_, Arc<SortableIndexKey>, Arc<RwLock<Vec<RowVersion>>>, BasicComparator, A>,
     ) -> Option<RowID> {
         row.value()
             .read()
@@ -5007,6 +5073,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 'a,
                 Arc<SortableIndexKey>,
                 Arc<RwLock<Vec<RowVersion>>>,
+                BasicComparator,
+                A,
             >,
         >,
     {
@@ -5025,7 +5093,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         table_id: MVTableId,
     ) -> Option<(RowID, RowVersions)>
     where
-        I: Iterator<Item = Entry<'a, RowID, Arc<RwLock<Vec<RowVersion>>>>>,
+        I: Iterator<Item = Entry<'a, RowID, Arc<RwLock<Vec<RowVersion>>>, BasicComparator, A>>,
     {
         loop {
             let row = rows.next()?;
@@ -5044,7 +5112,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         inclusive: bool,
         direction: IterationDirection,
         tx_id: TxID,
-        table_iterator: &mut Option<MvccIterator<'static, RowID>>,
+        table_iterator: &mut Option<MvccIterator<'static, RowID, A>>,
     ) -> Option<RowID> {
         let table_id = start.table_id;
         let iter_box = {
@@ -5057,19 +5125,33 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             match direction {
                 IterationDirection::Forwards => Box::new(self.rows.range(range))
                     as Box<
-                        dyn Iterator<Item = Entry<'_, RowID, Arc<RwLock<Vec<RowVersion>>>>>
-                            + Send
+                        dyn Iterator<
+                                Item = Entry<
+                                    '_,
+                                    RowID,
+                                    Arc<RwLock<Vec<RowVersion>>>,
+                                    BasicComparator,
+                                    A,
+                                >,
+                            > + Send
                             + Sync,
                     >,
                 IterationDirection::Backwards => Box::new(self.rows.range(range).rev())
                     as Box<
-                        dyn Iterator<Item = Entry<'_, RowID, Arc<RwLock<Vec<RowVersion>>>>>
-                            + Send
+                        dyn Iterator<
+                                Item = Entry<
+                                    '_,
+                                    RowID,
+                                    Arc<RwLock<Vec<RowVersion>>>,
+                                    BasicComparator,
+                                    A,
+                                >,
+                            > + Send
                             + Sync,
                     >,
             }
         };
-        *table_iterator = Some(static_iterator_hack!(iter_box, RowID));
+        *table_iterator = Some(static_iterator_hack!(iter_box, RowID, A));
 
         let mv_store_iterator = table_iterator
             .as_mut()
@@ -5092,9 +5174,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         inclusive: bool,
         direction: IterationDirection,
         tx_id: TxID,
-        index_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
-    ) -> Option<RowID> {
-        let index_rows = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
+        index_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>, A>>,
+    ) -> Result<Option<RowID>> {
+        // The iterator handed back to the cursor borrows the per-index map
+        // entry, so an absent map must still be created here (lazily) to keep
+        // iterator state consistent with later inserts.
+        let index_rows = self.index_rows_map(index_id)?;
         let index_rows = index_rows.value();
         let start = if inclusive {
             Bound::Included(start)
@@ -5106,19 +5191,31 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             IterationDirection::Forwards => Box::new(index_rows.range(range))
                 as Box<
                     dyn Iterator<
-                            Item = Entry<'_, Arc<SortableIndexKey>, Arc<RwLock<Vec<RowVersion>>>>,
+                            Item = Entry<
+                                '_,
+                                Arc<SortableIndexKey>,
+                                Arc<RwLock<Vec<RowVersion>>>,
+                                BasicComparator,
+                                A,
+                            >,
                         > + Send
                         + Sync,
                 >,
             IterationDirection::Backwards => Box::new(index_rows.range(range).rev())
                 as Box<
                     dyn Iterator<
-                            Item = Entry<'_, Arc<SortableIndexKey>, Arc<RwLock<Vec<RowVersion>>>>,
+                            Item = Entry<
+                                '_,
+                                Arc<SortableIndexKey>,
+                                Arc<RwLock<Vec<RowVersion>>>,
+                                BasicComparator,
+                                A,
+                            >,
                         > + Send
                         + Sync,
                 >,
         };
-        *index_iterator = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));
+        *index_iterator = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>, A));
         let mv_store_iterator = index_iterator
             .as_mut()
             .expect("index_iterator was assigned above if it was None");
@@ -5128,7 +5225,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             .get(&tx_id)
             .expect("transaction should exist in txs map");
         let tx = tx.value();
-        self.find_next_visible_index_row(tx, mv_store_iterator)
+        Ok(self.find_next_visible_index_row(tx, mv_store_iterator))
     }
 
     /// Begins an exclusive write transaction that prevents concurrent writes.
@@ -5248,13 +5345,22 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
         let tx = Transaction::new(tx_id, begin_ts, header);
         tx.pager_commit_lock_held.store(true, Ordering::Release);
+        if let Err(e) = self.txs.try_insert(tx_id, tx) {
+            // Release everything acquired above, mirroring the vanished-tx
+            // bail-out: the transaction was never published.
+            self.commit_coordinator.pager_commit_lock.unlock();
+            if !already_exclusive {
+                self.release_exclusive_tx(&tx_id);
+            }
+            unlock_checkpoint_guard();
+            return Err(e.into());
+        }
         tracing::trace!(
             "begin_exclusive_tx(tx_id={}, begin_ts={}) - exclusive write logical log transaction",
             tx_id,
             begin_ts
         );
         tracing::debug!("begin_exclusive_tx: tx_id={} succeeded", tx_id);
-        self.txs.insert(tx_id, tx);
         Ok(tx_id)
     }
 
@@ -5275,21 +5381,30 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let header = self.get_new_transaction_database_header(&pager);
         let tx = Transaction::new(tx_id, begin_ts, header);
         tracing::trace!("begin_tx(tx_id={}, begin_ts={})", tx_id, begin_ts);
-        self.txs.insert(tx_id, tx);
+        if let Err(e) = self.txs.try_insert(tx_id, tx) {
+            // The transaction was never published, so release the
+            // blocking-checkpoint read guard acquired above (normally
+            // released by `remove_tx`).
+            self.blocking_checkpoint_lock.unlock();
+            return Err(e.into());
+        }
 
         Ok(tx_id)
     }
 
-    pub fn remove_tx(&self, tx_id: TxID) {
-        self.remove_sequence_allocations(tx_id);
+    pub fn remove_tx(&self, tx_id: TxID) -> Result<()> {
         if let Some(entry) = self.txs.get(&tx_id) {
             let tx = entry.value();
             if let TransactionState::Committed(commit_ts) = tx.state.load() {
                 // Read-only transactions cannot leave row versions with stale TxID
                 // references, so they do not need finalized-state caching.
                 if !tx.write_set.lock().is_empty() {
+                    // Must land before the tx leaves `txs`: bailing out here
+                    // keeps the tx (and its checkpoint guard) alive, whereas
+                    // removing it anyway would strand stale TxID references
+                    // with no resolvable state.
                     self.finalized_tx_states
-                        .insert(tx_id, TransactionState::Committed(commit_ts));
+                        .try_insert(tx_id, TransactionState::Committed(commit_ts))?;
                 }
             }
             let dep_set = std::mem::take(&mut *tx.commit_dep_set.lock());
@@ -5302,8 +5417,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 "remove_tx({tx_id}): commit_dep_set is not empty"
             );
         }
+        self.remove_sequence_allocations(tx_id);
         self.txs.remove(&tx_id);
         self.blocking_checkpoint_lock.unlock();
+        Ok(())
     }
 
     pub fn register_sequence_allocation(
@@ -5399,9 +5516,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// Use this anywhere the commit state machine would otherwise call
     /// `remove_tx` directly. Other call sites that don't have a connection
     /// context (e.g. tests poking internal state) keep using `remove_tx`.
-    pub fn finish_committed_tx(&self, tx_id: TxID, conn: &Connection, db_id: usize) {
+    pub fn finish_committed_tx(&self, tx_id: TxID, conn: &Connection, db_id: usize) -> Result<()> {
         conn.set_mv_tx_for_db(db_id, None);
-        self.remove_tx(tx_id);
+        self.remove_tx(tx_id)
     }
 
     fn get_new_transaction_database_header(&self, pager: &Arc<Pager>) -> DatabaseHeader {
@@ -5525,7 +5642,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         tx_id: TxID,
         connection: &Arc<Connection>,
         db_id: usize,
-    ) -> Result<StateMachine<Box<CommitStateMachine<Clock>>>> {
+    ) -> Result<StateMachine<Box<CommitStateMachine<Clock, A>>>> {
         let state = Box::new(CommitStateMachine::new(
             CommitState::Initial,
             tx_id,
@@ -5626,7 +5743,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // already completed its register_commit_dependency call (it runs under the
         // read lock), so no future txs.get() for this tx_id can come from a
         // speculative read path.
-        self.remove_tx(tx_id);
+        self.remove_tx(tx_id)
+            .expect("removing a Terminated tx caches no finalized state and cannot allocate");
     }
 
     fn cleanup_dropped_commit(&self, tx_id: TxID, connection: &Connection, db_id: usize) {
@@ -5642,7 +5760,14 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 if self.is_exclusive_tx(&tx_id) {
                     self.release_exclusive_tx(&tx_id);
                 }
-                self.finish_committed_tx(tx_id, connection, db_id);
+                if let Err(e) = self.finish_committed_tx(tx_id, connection, db_id) {
+                    // Drop-path cleanup cannot propagate. Leaving the
+                    // committed tx in `txs` is safe (readers still resolve
+                    // its state); it only delays garbage collection.
+                    tracing::error!(
+                        "cleanup_dropped_commit: failed to retire committed tx {tx_id}: {e}"
+                    );
+                }
             }
             Some(TransactionState::Aborted | TransactionState::Terminated) | None => {
                 if connection.get_mv_tx_id_for_db(db_id) == Some(tx_id) {
@@ -6293,13 +6418,30 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
     /// Inserts a new row version into the database, while making sure that the row version
     /// is inserted in the correct order. Returns a reference to the modified version chain.
-    fn insert_version(&self, id: RowID, row_version: RowVersion) -> Arc<RwLock<Vec<RowVersion>>> {
+    ///
+    /// On allocation failure the chain is untouched: the fallible skiplist
+    /// insert happens before any version is appended.
+    fn insert_version(&self, id: RowID, row_version: RowVersion) -> Result<RowVersions> {
         let versions = self
             .rows
-            .get_or_insert_with(id, || Arc::new(RwLock::new(Vec::new())));
+            .try_get_or_insert_with(id, || Arc::new(RwLock::new(Vec::new())))?;
         let row_versions = versions.value().clone();
         self.insert_version_raw(&mut row_versions.write(), row_version);
-        row_versions
+        Ok(row_versions)
+    }
+
+    /// Returns the per-index map for `index_id`, lazily creating an empty one.
+    ///
+    /// Use this only when the entry must exist afterwards (e.g. an iterator
+    /// borrows it); pure reads should use `self.index_rows.get` and treat an
+    /// absent map as empty instead of allocating.
+    pub(crate) fn index_rows_map(
+        &self,
+        index_id: MVTableId,
+    ) -> Result<Entry<'_, MVTableId, IndexRowsMap<A>, BasicComparator, A>> {
+        Ok(self
+            .index_rows
+            .try_get_or_insert_with(index_id, || SkipMap::new_in(self.alloc.clone()))?)
     }
 
     /// Gets an existing Arc<SortableIndexKey> from the index if the key exists,
@@ -6309,7 +6451,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         index_id: MVTableId,
         key: Arc<SortableIndexKey>,
     ) -> Arc<SortableIndexKey> {
-        let index = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
+        // Pure read: an absent per-index map cannot hold an existing Arc.
+        let Some(index) = self.index_rows.get(&index_id) else {
+            return key;
+        };
         let index = index.value();
         let existing = index.get(&*key).map(|entry| entry.key().clone());
         existing.unwrap_or(key)
@@ -6322,10 +6467,15 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         index_id: MVTableId,
         key: Arc<SortableIndexKey>,
         mut row_version: RowVersion,
-    ) -> (Arc<SortableIndexKey>, RowVersions) {
-        let index = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
+    ) -> Result<(Arc<SortableIndexKey>, RowVersions)> {
+        // Both fallible skiplist inserts happen before the version is
+        // appended, so an allocation failure leaves every chain untouched.
+        // (A per-index map created by the first insert may be left behind
+        // empty if the second fails; empty slots are valid — lazy removal
+        // already leaves them around.)
+        let index = self.index_rows_map(index_id)?;
         let index = index.value();
-        let entry = index.get_or_insert_with(key, || Arc::new(RwLock::new(Vec::new())));
+        let entry = index.try_get_or_insert_with(key, || Arc::new(RwLock::new(Vec::new())))?;
         // The Arc that's actually stored in the SkipMap may be the one we
         // passed in (on miss) or a pre-existing one (on hit). Return that
         // canonical Arc so savepoint tracking and the SkipMap stay in sync.
@@ -6333,7 +6483,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         row_version.row.id.row_id = RowKey::Record(canonical_key.clone());
         let row_versions = entry.value().clone();
         self.insert_version_raw(&mut row_versions.write(), row_version);
-        (canonical_key, row_versions)
+        Ok((canonical_key, row_versions))
     }
 
     /// Inserts a new row version into the internal data structure for versions,
@@ -6434,7 +6584,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     pub fn get_last_table_rowid(
         &self,
         table_id: MVTableId,
-        table_iterator: &mut Option<MvccIterator<'static, RowID>>,
+        table_iterator: &mut Option<MvccIterator<'static, RowID, A>>,
         tx_id: TxID,
     ) -> Option<RowKey> {
         let tx = self
@@ -6448,7 +6598,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         };
         let range = create_seek_range(Bound::Included(max_rowid), IterationDirection::Backwards);
         let iter_box = Box::new(self.rows.range(range).rev());
-        *table_iterator = Some(static_iterator_hack!(iter_box, RowID));
+        *table_iterator = Some(static_iterator_hack!(iter_box, RowID, A));
         let iter = table_iterator
             .as_mut()
             .expect("table_iterator was assigned above");
@@ -6501,12 +6651,14 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         &self,
         index_id: MVTableId,
         tx_id: TxID,
-        index_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
-    ) -> Option<RowKey> {
-        let index = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
+        index_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>, A>>,
+    ) -> Result<Option<RowKey>> {
+        // Like `seek_index`, the escaping iterator borrows the per-index map
+        // entry, so an absent map is created lazily here.
+        let index = self.index_rows_map(index_id)?;
         let index = index.value();
         let iter_box = Box::new(index.iter().rev());
-        *index_iterator = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));
+        *index_iterator = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>, A));
         let iter = index_iterator
             .as_mut()
             .expect("index_iterator was assigned above");
@@ -6515,8 +6667,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             .get(&tx_id)
             .expect("transaction should exist in txs map");
         let tx = tx.value();
-        self.find_next_visible_index_row(tx, iter)
-            .map(|row| row.row_id)
+        Ok(self
+            .find_next_visible_index_row(tx, iter)
+            .map(|row| row.row_id))
     }
 
     pub fn get_logical_log_file(&self) -> Arc<dyn File> {
@@ -7246,7 +7399,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                             panic!("Logical log contains an insertion of a sqlite_schema record that has both a negative root page and a positive root page: {root_page} & {value}");
                                         }
                                     }
-                                    self.insert_table_id_to_rootpage(table_id, None);
+                                    self.insert_table_id_to_rootpage(table_id, None)?;
                                 } else {
                                     dropped_root_pages.remove(&root_page);
                                     let table_id = self.get_table_id_from_root_page(root_page);
@@ -7279,9 +7432,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             btree_resident,
                         };
                         {
-                            let versions = self.rows.get_or_insert_with(rowid.clone(), || {
-                                Arc::new(RwLock::new(Vec::new()))
-                            });
+                            let versions =
+                                self.rows.try_get_or_insert_with(rowid.clone(), || {
+                                    Arc::new(RwLock::new(Vec::new()))
+                                })?;
                             let mut versions = versions.value().write();
                             self.insert_version_raw(&mut versions, row_version);
                         }
@@ -7300,7 +7454,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
                             // See comment in UpsertTableRow: old logs may have data rows
                             // serialized before the schema INSERT that registers the table_id.
-                            self.insert_table_id_to_rootpage(rowid.table_id, None);
+                            self.insert_table_id_to_rootpage(rowid.table_id, None)?;
                         }
                         let tombstone_row = if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
                             let rowid_int = rowid.row_id.to_int_or_panic();
@@ -7351,9 +7505,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                 row: tombstone_row,
                                 btree_resident,
                             };
-                            let versions = self.rows.get_or_insert_with(rowid.clone(), || {
-                                Arc::new(RwLock::new(Vec::new()))
-                            });
+                            let versions =
+                                self.rows.try_get_or_insert_with(rowid.clone(), || {
+                                    Arc::new(RwLock::new(Vec::new()))
+                                })?;
                             let mut versions = versions.value().write();
                             self.insert_version_raw(&mut versions, row_version);
                         }
@@ -7410,7 +7565,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let RowKey::Record(sortable_key) = rowid.row_id.clone() else {
                             panic!("Index writes must be to a record");
                         };
-                        self.insert_index_version(rowid.table_id, sortable_key, row_version);
+                        self.insert_index_version(rowid.table_id, sortable_key, row_version)?;
                     }
                     StreamingResult::DeleteIndexRow {
                         row,
@@ -7449,7 +7604,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             row: row.clone(),
                             btree_resident,
                         };
-                        self.insert_index_version(rowid.table_id, sortable_key, row_version);
+                        self.insert_index_version(rowid.table_id, sortable_key, row_version)?;
                     }
                     StreamingResult::UpdateHeader { header, commit_ts } => {
                         max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
@@ -7757,9 +7912,9 @@ pub fn create_seek_range<K: Ord>(
 /// TE’s state is Aborted"
 /// Ref: https://www.cs.cmu.edu/~15721-f24/papers/Hekaton.pdf , page 301,
 /// 2.6. Updating a Version.
-fn is_write_write_conflict(
-    txs: &SkipMap<TxID, Transaction>,
-    finalized_tx_states: &SkipMap<TxID, TransactionState>,
+fn is_write_write_conflict<A: SkiplistAllocator>(
+    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+    finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     tx: &Transaction,
     rv: &RowVersion,
 ) -> bool {
@@ -7835,11 +7990,11 @@ impl RowVersion {
     /// A row is visible to a transaction if:
     /// * Begin is visible to the transaction
     /// * End timestamp is not applicable yet, meaning deletion of row is not visible to this transaction
-    fn is_visible_to(
+    fn is_visible_to<A: SkiplistAllocator>(
         &self,
         tx: &Transaction,
-        txs: &SkipMap<TxID, Transaction>,
-        finalized_tx_states: &SkipMap<TxID, TransactionState>,
+        txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+        finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     ) -> bool {
         is_begin_visible(txs, finalized_tx_states, tx, self)
             && is_end_visible(txs, finalized_tx_states, tx, self)
@@ -7853,11 +8008,11 @@ impl RowVersion {
     /// 3. The current transaction itself has deleted/updated this row (end = current tx_id)
     ///
     /// This is used by dual-cursor to determine if a B-tree row should be shown or hidden.
-    fn is_btree_invalidating_version(
+    fn is_btree_invalidating_version<A: SkiplistAllocator>(
         &self,
         tx: &Transaction,
-        txs: &SkipMap<TxID, Transaction>,
-        finalized_tx_states: &SkipMap<TxID, TransactionState>,
+        txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+        finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     ) -> bool {
         // If the version is fully visible, it invalidates the B-tree
         if self.is_visible_to(tx, txs, finalized_tx_states) {
@@ -7917,8 +8072,8 @@ impl RowVersion {
 ///
 /// The lock on `commit_dep_set` serializes with the drain in commit/abort
 /// resolution, preventing the race where we push an entry after the drain.
-fn register_commit_dependency(
-    txs: &SkipMap<TxID, Transaction>,
+fn register_commit_dependency<A: SkiplistAllocator>(
+    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
     dependent_tx: &Transaction,
     depended_on_tx_id: TxID,
 ) {
@@ -7975,9 +8130,9 @@ fn register_commit_dependency(
     }
 }
 
-fn lookup_tx_state(
-    txs: &SkipMap<TxID, Transaction>,
-    finalized_tx_states: &SkipMap<TxID, TransactionState>,
+fn lookup_tx_state<A: SkiplistAllocator>(
+    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+    finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     tx_id: TxID,
 ) -> Option<TransactionState> {
     txs.get(&tx_id)
@@ -7985,8 +8140,8 @@ fn lookup_tx_state(
         .or_else(|| finalized_tx_states.get(&tx_id).map(|entry| *entry.value()))
 }
 
-fn lookup_finalized_tx_state(
-    finalized_tx_states: &SkipMap<TxID, TransactionState>,
+fn lookup_finalized_tx_state<A: SkiplistAllocator>(
+    finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     tx_id: TxID,
 ) -> Option<TransactionState> {
     finalized_tx_states.get(&tx_id).map(|entry| {
@@ -8002,9 +8157,9 @@ fn lookup_finalized_tx_state(
     })
 }
 
-fn is_begin_visible(
-    txs: &SkipMap<TxID, Transaction>,
-    finalized_tx_states: &SkipMap<TxID, TransactionState>,
+fn is_begin_visible<A: SkiplistAllocator>(
+    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+    finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     tx: &Transaction,
     rv: &RowVersion,
 ) -> bool {
@@ -8093,9 +8248,9 @@ fn is_begin_visible(
     }
 }
 
-fn is_end_visible(
-    txs: &SkipMap<TxID, Transaction>,
-    finalized_tx_states: &SkipMap<TxID, TransactionState>,
+fn is_end_visible<A: SkiplistAllocator>(
+    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+    finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     current_tx: &Transaction,
     row_version: &RowVersion,
 ) -> bool {
@@ -8162,7 +8317,7 @@ fn is_end_visible(
     }
 }
 
-impl<Clock: LogicalClock> Debug for CommitState<Clock> {
+impl<Clock: LogicalClock, A: SkiplistAllocator> Debug for CommitState<Clock, A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Initial => write!(f, "Initial"),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -181,7 +181,7 @@ fn mvcc_active_read_tx_blocks_vacuum_gate() {
         Err(LimboError::Busy)
     ));
 
-    db.mvcc_store.remove_tx(tx_id);
+    db.mvcc_store.remove_tx(tx_id).unwrap();
     db.mvcc_store.try_begin_vacuum_gate().unwrap();
     db.mvcc_store.release_vacuum_gate();
 }
@@ -287,7 +287,8 @@ fn mvcc_reset_after_vacuum_installs_header_and_rootpages() {
         .write()
         .replace(DatabaseHeader::default());
     db.mvcc_store
-        .insert_table_id_to_rootpage(MVTableId::from(-999_i64), Some(999));
+        .insert_table_id_to_rootpage(MVTableId::from(-999_i64), Some(999))
+        .unwrap();
 
     db.mvcc_store.try_begin_vacuum_gate().unwrap();
     db.mvcc_store.reset_after_vacuum(header, schema.as_ref());
@@ -7992,7 +7993,7 @@ fn test_gc_active_reader_pins_lwm() {
     );
 
     // Close the reader transaction.
-    db.mvcc_store.remove_tx(tx2);
+    db.mvcc_store.remove_tx(tx2).unwrap();
 
     // LWM should now be u64::MAX.
     assert_eq!(db.mvcc_store.compute_lwm(), u64::MAX);

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -4104,7 +4104,9 @@ fn test_sequence_watermark_tracks_lowest_active_allocation() {
     let mv_store = db.get_mvcc_store();
     let pager = conn.pager.load().clone();
 
-    mv_store.set_sequence_watermark("turso_cdc_pk_autoincrement", 13);
+    mv_store
+        .set_sequence_watermark("turso_cdc_pk_autoincrement", 13)
+        .unwrap();
     let tx1 = mv_store.begin_tx(pager.clone()).unwrap();
     let tx2 = mv_store.begin_tx(pager.clone()).unwrap();
     mv_store
@@ -4118,19 +4120,25 @@ fn test_sequence_watermark_tracks_lowest_active_allocation() {
         .unwrap();
 
     assert_eq!(
-        mv_store.sequence_watermark("turso_cdc_pk_autoincrement"),
+        mv_store
+            .sequence_watermark("turso_cdc_pk_autoincrement")
+            .unwrap(),
         Some(10)
     );
 
     commit_tx(mv_store.clone(), &conn, tx1).unwrap();
     assert_eq!(
-        mv_store.sequence_watermark("turso_cdc_pk_autoincrement"),
+        mv_store
+            .sequence_watermark("turso_cdc_pk_autoincrement")
+            .unwrap(),
         Some(12)
     );
 
     mv_store.rollback_tx(tx2, pager, conn.as_ref(), crate::MAIN_DB_ID);
     assert_eq!(
-        mv_store.sequence_watermark("turso_cdc_pk_autoincrement"),
+        mv_store
+            .sequence_watermark("turso_cdc_pk_autoincrement")
+            .unwrap(),
         Some(13)
     );
 }
@@ -4143,7 +4151,7 @@ fn test_sequence_watermark_function_returns_current_watermark_without_active_all
     let pager = conn.pager.load().clone();
 
     conn.execute("CREATE SEQUENCE s").unwrap();
-    mv_store.set_sequence_watermark("s", 42);
+    mv_store.set_sequence_watermark("s", 42).unwrap();
     let rows = get_rows(&conn, "SELECT sequence_watermark_experimental('s')");
 
     assert_eq!(rows.len(), 1);
@@ -15586,7 +15594,6 @@ fn injected_yield_surfaces_as_step_result_yield() {
     let rows = get_rows(&conn, "SELECT id, v FROM t");
     assert_eq!(rows.len(), 1);
 }
-
 #[test]
 fn test_checkpoint_seek_skip_divider_reinsert_loses_row() {
     let _ = tracing_subscriber::fmt::try_init();
@@ -15629,5 +15636,176 @@ fn test_checkpoint_seek_skip_divider_reinsert_loses_row() {
             "rowid {g} vanished from point lookup after re-insert \
              (checkpoint seek-skip wrote it on the wrong side of the divider)"
         );
+    }
+}
+
+/// Allocation-failure coverage: every fallible MvStore skiplist path must
+/// surface `OutOfMemory` without mutating state, and succeed once the
+/// allocator recovers.
+mod allocation_failure {
+    use super::*;
+    use crate::alloc::FailOnDemandAlloc;
+    use crate::mvcc::persistent_storage::Storage;
+
+    type FailingMvStore = MvStore<MvccClock, FailOnDemandAlloc>;
+
+    fn failing_storage() -> Arc<Storage> {
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file("mvstore-oom.log", OpenFlags::Create, false)
+            .unwrap();
+        Arc::new(Storage::new(file, io, None))
+    }
+
+    fn failing_store() -> (Arc<FailingMvStore>, FailOnDemandAlloc) {
+        let alloc = FailOnDemandAlloc::default();
+        let store = MvStore::new_in(MvccClock::new(), failing_storage(), alloc.clone()).unwrap();
+        (Arc::new(store), alloc)
+    }
+
+    /// A pager for `begin_tx`; comes from a throwaway default-allocator
+    /// database, which is fine because the pager is independent of the
+    /// MvStore allocator under test.
+    fn helper_pager() -> (MvccTestDb, Arc<Pager>) {
+        let db = MvccTestDb::new();
+        let pager = db.conn.pager.load().clone();
+        (db, pager)
+    }
+
+    #[test]
+    fn new_in_surfaces_allocation_failure() {
+        let alloc = FailOnDemandAlloc::default();
+        alloc.fail_allocations(true);
+        // The constructor seeds the sqlite_schema rootpage mapping, which
+        // needs a node allocation.
+        assert!(MvStore::new_in(MvccClock::new(), failing_storage(), alloc.clone()).is_err());
+
+        alloc.fail_allocations(false);
+        MvStore::new_in(MvccClock::new(), failing_storage(), alloc).unwrap();
+    }
+
+    #[test]
+    fn begin_tx_failure_releases_checkpoint_guard() {
+        let (store, alloc) = failing_store();
+        let (_db, pager) = helper_pager();
+
+        alloc.fail_allocations(true);
+        assert!(matches!(
+            store.begin_tx(pager.clone()),
+            Err(LimboError::OutOfMemory)
+        ));
+
+        // The blocking-checkpoint read guard must have been released: the
+        // stop-the-world vacuum gate (a write acquisition of the same lock)
+        // would stay Busy forever if begin_tx leaked its guard.
+        store.try_begin_vacuum_gate().unwrap();
+        store.release_vacuum_gate();
+
+        alloc.fail_allocations(false);
+        let tx_id = store.begin_tx(pager).unwrap();
+        assert!(store.txs.get(&tx_id).is_some());
+    }
+
+    #[test]
+    fn insert_failure_leaves_store_and_tx_untouched() {
+        let (store, alloc) = failing_store();
+        let (_db, pager) = helper_pager();
+        let tx_id = store.begin_tx(pager).unwrap();
+
+        let table_id = MVTableId::from(-2);
+        let row = generate_simple_string_row(table_id, 1, "payload");
+
+        alloc.fail_allocations(true);
+        assert!(matches!(
+            store.insert(tx_id, row.clone()),
+            Err(LimboError::OutOfMemory)
+        ));
+        // No version chain, no write-set entry, no savepoint tracking may
+        // reference the version that never landed.
+        assert!(store.rows.is_empty());
+        let tx = store.txs.get(&tx_id).unwrap();
+        assert!(tx.value().write_set.lock().is_empty());
+        drop(tx);
+
+        alloc.fail_allocations(false);
+        store.insert(tx_id, row.clone()).unwrap();
+        let read_back = store.read(tx_id, &row.id).unwrap().unwrap();
+        assert_eq!(read_back.payload(), row.payload());
+    }
+
+    #[test]
+    fn index_rows_map_failure_does_not_create_empty_map() {
+        let (store, alloc) = failing_store();
+        let index_id = MVTableId::from(-5);
+
+        alloc.fail_allocations(true);
+        assert!(store.index_rows_map(index_id).is_err());
+        assert!(store.index_rows.get(&index_id).is_none());
+
+        alloc.fail_allocations(false);
+        store.index_rows_map(index_id).unwrap();
+        assert!(store.index_rows.get(&index_id).is_some());
+    }
+
+    #[test]
+    fn remove_tx_failure_keeps_committed_tx_resolvable() {
+        let (store, alloc) = failing_store();
+        let (_db, pager) = helper_pager();
+        let tx_id = store.begin_tx(pager).unwrap();
+        let row = generate_simple_string_row(MVTableId::from(-2), 1, "payload");
+        store.insert(tx_id, row).unwrap();
+
+        // Simulate the commit state machine having committed the tx; with a
+        // non-empty write set, remove_tx must cache the finalized state.
+        store
+            .txs
+            .get(&tx_id)
+            .unwrap()
+            .value()
+            .state
+            .store(TransactionState::Committed(42));
+
+        alloc.fail_allocations(true);
+        assert!(matches!(
+            store.remove_tx(tx_id),
+            Err(LimboError::OutOfMemory)
+        ));
+        // The tx must remain resolvable: still in txs, and never half-moved
+        // into finalized_tx_states.
+        assert!(store.txs.get(&tx_id).is_some());
+        assert!(store.finalized_tx_states.get(&tx_id).is_none());
+
+        alloc.fail_allocations(false);
+        store.remove_tx(tx_id).unwrap();
+        assert!(store.txs.get(&tx_id).is_none());
+        assert_eq!(
+            *store.finalized_tx_states.get(&tx_id).unwrap().value(),
+            TransactionState::Committed(42)
+        );
+    }
+
+    #[test]
+    fn rootpage_mapping_failure_does_not_advance_table_id_counter() {
+        let (store, alloc) = failing_store();
+        let table_id = MVTableId::from(-77);
+        let counter_before = store.next_table_id.load(Ordering::SeqCst);
+
+        alloc.fail_allocations(true);
+        assert!(matches!(
+            store.insert_table_id_to_rootpage(table_id, Some(7)),
+            Err(LimboError::OutOfMemory)
+        ));
+        assert!(store.table_id_to_rootpage.get(&table_id).is_none());
+        assert_eq!(store.next_table_id.load(Ordering::SeqCst), counter_before);
+
+        alloc.fail_allocations(false);
+        store
+            .insert_table_id_to_rootpage(table_id, Some(7))
+            .unwrap();
+        assert_eq!(
+            *store.table_id_to_rootpage.get(&table_id).unwrap().value(),
+            Some(7)
+        );
+        assert!(store.next_table_id.load(Ordering::SeqCst) < counter_before);
     }
 }

--- a/core/skiplist/base_tests.rs
+++ b/core/skiplist/base_tests.rs
@@ -1024,7 +1024,7 @@ fn remove_race() {
 
 #[test]
 fn try_insert_family_surfaces_allocation_failure() {
-    let alloc = super::map_tests::FailOnDemandAlloc::default();
+    let alloc = crate::alloc::FailOnDemandAlloc::default();
     let guard = &epoch::pin();
     let s = SkipList::new_in(epoch::default_collector().clone(), alloc.clone());
 

--- a/core/skiplist/map_tests.rs
+++ b/core/skiplist/map_tests.rs
@@ -1027,36 +1027,7 @@ fn comparator() {
     assert!(s.is_empty());
 }
 
-/// An allocator that fails every allocation while its flag is set.
-///
-/// Delegates to [`TursoAllocator`] otherwise, so nodes are still backed by the
-/// regular Turso heap.
-#[derive(Clone, Default)]
-pub(crate) struct FailOnDemandAlloc {
-    fail: Arc<std::sync::atomic::AtomicBool>,
-}
-
-impl FailOnDemandAlloc {
-    pub(crate) fn fail_allocations(&self, fail: bool) {
-        self.fail.store(fail, std::sync::atomic::Ordering::Relaxed);
-    }
-}
-
-unsafe impl crate::alloc::ApiAllocator for FailOnDemandAlloc {
-    fn allocate(
-        &self,
-        layout: crate::alloc::Layout,
-    ) -> Result<std::ptr::NonNull<[u8]>, crate::alloc::AllocError> {
-        if self.fail.load(std::sync::atomic::Ordering::Relaxed) {
-            return Err(crate::alloc::AllocError);
-        }
-        crate::alloc::TursoAllocator.allocate(layout)
-    }
-
-    unsafe fn deallocate(&self, ptr: std::ptr::NonNull<u8>, layout: crate::alloc::Layout) {
-        unsafe { crate::alloc::TursoAllocator.deallocate(ptr, layout) }
-    }
-}
+use crate::alloc::FailOnDemandAlloc;
 
 #[test]
 fn try_insert_surfaces_allocation_failure() {

--- a/core/skiplist/set_tests.rs
+++ b/core/skiplist/set_tests.rs
@@ -819,7 +819,7 @@ fn comparator() {
 
 #[test]
 fn try_insert_surfaces_allocation_failure() {
-    let alloc = super::map_tests::FailOnDemandAlloc::default();
+    let alloc = crate::alloc::FailOnDemandAlloc::default();
     let set: SkipSet<i32, _, _> = SkipSet::new_in(alloc.clone());
     set.try_insert(7).unwrap();
 

--- a/core/storage/journal_mode.rs
+++ b/core/storage/journal_mode.rs
@@ -98,5 +98,5 @@ pub fn open_mv_store(
             ))
         };
 
-    Ok(Arc::new(MvStore::new(mvcc::MvccClock::new(), storage)))
+    Ok(Arc::new(MvStore::new(mvcc::MvccClock::new(), storage)?))
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8224,10 +8224,11 @@ pub fn op_function(
                         (MAIN_DB_ID, crate::util::normalize_ident(sequence_name))
                     };
                 program.connection.find_sequence(sequence_name)?;
-                let watermark = program
-                    .connection
-                    .mv_store_for_db(db_id)
-                    .and_then(|mv_store| mv_store.sequence_watermark(&sequence_key));
+                let watermark = if let Some(mv_store) = program.connection.mv_store_for_db(db_id) {
+                    mv_store.sequence_watermark(&sequence_key)?
+                } else {
+                    None
+                };
                 match watermark {
                     Some(watermark) => state.registers[*dest].set_int(watermark),
                     None => state.registers[*dest].set_value(Value::Null),
@@ -11806,7 +11807,7 @@ pub fn op_sequence_track_allocation(
             })?;
         let current_watermark =
             crate::mvcc::database::first_unsafe_sequence_watermark(&seq, value, true);
-        mv_store.set_sequence_watermark(&normalized_seq_name, current_watermark);
+        mv_store.set_sequence_watermark(&normalized_seq_name, current_watermark)?;
 
         if let Some((tx_id, _)) = program.connection.get_mv_tx_for_db(*db) {
             if mv_store.is_tx_rollbackable(tx_id) {

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -1,0 +1,96 @@
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::alloc::{alloc, dealloc};
+use std::ptr::NonNull;
+use std::sync::Mutex;
+use turso_core::alloc::{AllocError, Layout, SetAllocatorError, TursoAllocBackend, set_allocator};
+
+pub(crate) struct AllocationFaultAllocator {
+    probability: f64,
+    rng: Mutex<ChaCha8Rng>,
+}
+
+impl AllocationFaultAllocator {
+    pub(crate) fn new(seed: u64, probability: f64) -> Self {
+        Self {
+            probability,
+            rng: Mutex::new(ChaCha8Rng::seed_from_u64(seed)),
+        }
+    }
+
+    fn should_fail(&self) -> bool {
+        let mut rng = self.rng.lock().unwrap();
+        rng.random_bool(self.probability)
+    }
+}
+
+unsafe impl TursoAllocBackend for AllocationFaultAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        if self.should_fail() {
+            return Err(AllocError);
+        }
+        if layout.size() == 0 {
+            return Ok(NonNull::slice_from_raw_parts(NonNull::<u8>::dangling(), 0));
+        }
+        let ptr = unsafe { alloc(layout) };
+        NonNull::new(ptr)
+            .map(|ptr| NonNull::slice_from_raw_parts(ptr, layout.size()))
+            .ok_or(AllocError)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        if layout.size() != 0 {
+            unsafe {
+                dealloc(ptr.as_ptr(), layout);
+            }
+        }
+    }
+}
+
+pub(crate) fn validate_probability(probability: f64) -> anyhow::Result<bool> {
+    if probability == 0.0 {
+        return Ok(false);
+    }
+    if !probability.is_finite() || !(0.0..=1.0).contains(&probability) {
+        anyhow::bail!("allocation fault probability must be between 0.0 and 1.0");
+    }
+    Ok(true)
+}
+
+pub(crate) fn install(seed: u64, probability: f64) -> anyhow::Result<bool> {
+    if !validate_probability(probability)? {
+        return Ok(false);
+    }
+
+    let allocator = Box::leak(Box::new(AllocationFaultAllocator::new(seed, probability)));
+    unsafe {
+        set_allocator(allocator).map_err(|err| match err {
+            SetAllocatorError::AlreadyInitialized => anyhow::anyhow!(
+                "Turso allocator was already initialized before Whopper installed allocation faults"
+            ),
+        })?;
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocator_fails_when_probability_is_one() {
+        let allocator = AllocationFaultAllocator::new(1, 1.0);
+        let layout = Layout::from_size_align(8, 8).unwrap();
+        assert!(allocator.allocate(layout).is_err());
+    }
+
+    #[test]
+    fn allocator_delegates_when_probability_is_zero() {
+        let allocator = AllocationFaultAllocator::new(1, 0.0);
+        let layout = Layout::from_size_align(8, 8).unwrap();
+        let ptr = allocator.allocate(layout).expect("allocation succeeds");
+        unsafe {
+            allocator.deallocate(ptr.cast(), layout);
+        }
+    }
+}

--- a/testing/concurrent-simulator/error_handling.rs
+++ b/testing/concurrent-simulator/error_handling.rs
@@ -34,7 +34,11 @@ pub enum ErrorAction {
 /// transaction that needs rolling back (i.e. not autocommit). The
 /// drivers compute this from their own fiber-state tracking before
 /// calling in.
-pub fn classify_op_error(err: &LimboError, in_tx: bool) -> ErrorAction {
+pub fn classify_op_error(
+    err: &LimboError,
+    in_tx: bool,
+    allocation_faults_enabled: bool,
+) -> ErrorAction {
     // DatabaseFull is overloaded — it is raised for both real storage
     // exhaustion (pager.rs) and autoincrement max-rowid overflow
     // (translate/insert.rs). Only swallow the well-defined "non-
@@ -75,6 +79,13 @@ pub fn classify_op_error(err: &LimboError, in_tx: bool) -> ErrorAction {
                 ErrorAction::ClearTxn
             }
         }
+        LimboError::OutOfMemory if allocation_faults_enabled => {
+            if in_tx {
+                ErrorAction::Rollback
+            } else {
+                ErrorAction::ClearTxn
+            }
+        }
         LimboError::Corrupt(_) | LimboError::CheckpointFailed(_) => ErrorAction::Respawn,
         _ => ErrorAction::Fatal,
     }
@@ -87,38 +98,46 @@ mod tests {
     #[test]
     fn parse_error_in_tx_queues_rollback() {
         let err = LimboError::ParseError("nope".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Rollback);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Rollback);
     }
 
     #[test]
     fn parse_error_autocommit_clears_txn() {
         let err = LimboError::ParseError("nope".into());
-        assert_eq!(classify_op_error(&err, false), ErrorAction::ClearTxn);
+        assert_eq!(classify_op_error(&err, false, false), ErrorAction::ClearTxn);
     }
 
     #[test]
     fn sequence_exhaustion_is_swallowed() {
         let err = LimboError::DatabaseFull("nextval: reached minimum value of \"s\"".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Rollback);
-        assert_eq!(classify_op_error(&err, false), ErrorAction::ClearTxn);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Rollback);
+        assert_eq!(classify_op_error(&err, false, false), ErrorAction::ClearTxn);
     }
 
     #[test]
     fn generic_database_full_is_fatal() {
         let err = LimboError::DatabaseFull("disk image is full".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Fatal);
-        assert_eq!(classify_op_error(&err, false), ErrorAction::Fatal);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Fatal);
+        assert_eq!(classify_op_error(&err, false, false), ErrorAction::Fatal);
     }
 
     #[test]
     fn corrupt_respawns() {
         let err = LimboError::Corrupt("bad page".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Respawn);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Respawn);
+    }
+
+    #[test]
+    fn out_of_memory_is_recoverable_only_when_faults_are_enabled() {
+        let err = LimboError::OutOfMemory;
+        assert_eq!(classify_op_error(&err, true, true), ErrorAction::Rollback);
+        assert_eq!(classify_op_error(&err, false, true), ErrorAction::ClearTxn);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Fatal);
     }
 
     #[test]
     fn unknown_error_is_fatal() {
         let err = LimboError::InternalError("unexpected".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Fatal);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Fatal);
     }
 }

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -22,6 +22,7 @@ use turso_core::{
 };
 use turso_parser::ast::{ColumnConstraint, SortOrder};
 
+mod allocation_fault;
 pub mod chaotic_elle;
 pub mod elle;
 pub mod error_handling;
@@ -278,6 +279,8 @@ pub struct WhopperOpts {
     pub close_connections_gracefully: bool,
     /// Probabilty of a reopen fault.
     pub reopen_probability: f64,
+    /// Probability that a Turso fallible allocation fails.
+    pub allocation_fault_probability: f64,
 }
 
 /// Schema-generation bias
@@ -324,6 +327,7 @@ impl Default for WhopperOpts {
             disable_mvcc_auto_checkpoint: false,
             close_connections_gracefully: true,
             reopen_probability: 0.0,
+            allocation_fault_probability: 0.05,
         }
     }
 }
@@ -430,6 +434,11 @@ impl WhopperOpts {
         profiles: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)>,
     ) -> Self {
         self.chaotic_profiles = profiles;
+        self
+    }
+
+    pub fn with_allocation_fault_probability(mut self, probability: f64) -> Self {
+        self.allocation_fault_probability = probability;
         self
     }
 }
@@ -585,6 +594,7 @@ pub struct Whopper {
     disable_mvcc_auto_checkpoint: bool,
     /// If false, drop fiber connections without first closing them.
     close_connections_gracefully: bool,
+    allocation_faults_enabled: bool,
 }
 
 impl Whopper {
@@ -596,6 +606,7 @@ impl Whopper {
         });
 
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        allocation_fault::validate_probability(opts.allocation_fault_probability)?;
 
         // Create a separate RNG for IO operations with a derived seed
         let io_rng = ChaCha8Rng::seed_from_u64(seed.wrapping_add(1));
@@ -730,9 +741,12 @@ impl Whopper {
             chaotic_profiles: opts.chaotic_profiles,
             disable_mvcc_auto_checkpoint: opts.disable_mvcc_auto_checkpoint,
             close_connections_gracefully: opts.close_connections_gracefully,
+            allocation_faults_enabled: false,
         };
 
         whopper.open_connections()?;
+        whopper.allocation_faults_enabled =
+            allocation_fault::install(seed, opts.allocation_fault_probability)?;
 
         Ok(whopper)
     }
@@ -904,7 +918,11 @@ impl Whopper {
 
             if let Err(error) = op_result {
                 let in_tx = ctx.fiber.state.is_in_tx() && !ctx.fiber.connection.get_auto_commit();
-                match crate::error_handling::classify_op_error(&error, in_tx) {
+                match crate::error_handling::classify_op_error(
+                    &error,
+                    in_tx,
+                    self.allocation_faults_enabled,
+                ) {
                     crate::error_handling::ErrorAction::Rollback => {
                         ctx.fiber.current_op = Some(Operation::Rollback);
                     }
@@ -992,6 +1010,11 @@ impl Whopper {
                 self.seed, fiber_idx,
             )));
             if let Err(e) = op.init_op(&mut ctx) {
+                if self.allocation_faults_enabled
+                    && matches!(e, turso_core::LimboError::OutOfMemory)
+                {
+                    return Ok(());
+                }
                 let err = e.to_string().to_lowercase();
                 // Allow "no such table/index" and "already exists" errors
                 if err.contains("no such")

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -81,6 +81,9 @@ struct Args {
     /// Probability of restarting the full worker cohort per step (multiprocess mode only)
     #[arg(long, default_value_t = 0.0)]
     restart_probability: f64,
+    /// Probability that a Turso fallible allocation fails.
+    #[arg(long, default_value_t = 0.05)]
+    allocation_fault_probability: f64,
     /// Stream multiprocess operation/lifecycle history as JSONL for deterministic debugging
     #[arg(long)]
     history_output: Option<PathBuf>,
@@ -99,6 +102,11 @@ enum SubCmd {
         /// Number of connections to open inside this worker process
         #[arg(long, default_value_t = 1)]
         connections_per_process: usize,
+        /// Probability that a Turso fallible allocation fails.
+        #[arg(long, default_value_t = 0.0)]
+        allocation_fault_probability: f64,
+        #[arg(long, default_value_t = 0, hide = true)]
+        allocation_fault_seed: u64,
     },
 }
 
@@ -111,6 +119,8 @@ fn main() -> anyhow::Result<()> {
         db_path,
         enable_mvcc,
         connections_per_process,
+        allocation_fault_probability,
+        allocation_fault_seed,
     }) = &args.subcommand
     {
         #[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]
@@ -119,6 +129,8 @@ fn main() -> anyhow::Result<()> {
                 db_path,
                 *enable_mvcc,
                 *connections_per_process,
+                *allocation_fault_probability,
+                *allocation_fault_seed,
             );
         }
         #[cfg(not(all(any(unix, target_os = "windows"), target_pointer_width = "64")))]
@@ -182,6 +194,7 @@ fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
         restart_probability: args.restart_probability,
         history_output: args.history_output.clone(),
         keep_files: args.keep,
+        allocation_fault_probability: args.allocation_fault_probability,
     };
 
     println!(
@@ -198,6 +211,12 @@ fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
     }
     if let Some(path) = &args.history_output {
         println!("history_output = {}", path.display());
+    }
+    if args.allocation_fault_probability > 0.0 {
+        println!(
+            "allocation_fault_probability = {}",
+            args.allocation_fault_probability
+        );
     }
 
     let mut whopper = MultiprocessWhopper::new(opts)?;
@@ -248,6 +267,12 @@ fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
 
     if opts.cosmic_ray_probability > 0.0 {
         println!("cosmic ray probability = {}", opts.cosmic_ray_probability);
+    }
+    if opts.allocation_fault_probability > 0.0 {
+        println!(
+            "allocation_fault_probability = {}",
+            opts.allocation_fault_probability
+        );
     }
 
     let reopen_probability = args.reopen_probability.unwrap_or(opts.reopen_probability);
@@ -436,7 +461,8 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         .with_elle_tables(elle_tables)
         .with_workloads(workloads)
         .with_properties(properties)
-        .with_chaotic_profiles(chaotic_profiles);
+        .with_chaotic_profiles(chaotic_profiles)
+        .with_allocation_fault_probability(args.allocation_fault_probability);
 
     Ok(opts)
 }

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -49,6 +49,7 @@ pub struct MultiprocessOpts {
     pub restart_probability: f64,
     pub history_output: Option<PathBuf>,
     pub keep_files: bool,
+    pub allocation_fault_probability: f64,
 }
 
 struct OperationHistoryWriter {
@@ -223,6 +224,8 @@ pub struct MultiprocessWhopper {
     kill_probability: f64,
     restart_probability: f64,
     keep_files: bool,
+    allocation_faults_enabled: bool,
+    allocation_fault_probability: f64,
 }
 
 impl MultiprocessWhopper {
@@ -242,6 +245,8 @@ impl MultiprocessWhopper {
             rng.next_u64()
         });
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let allocation_faults_enabled =
+            crate::allocation_fault::validate_probability(opts.allocation_fault_probability)?;
 
         // Create database file on disk.
         // Use an atomic counter alongside the timestamp to guarantee uniqueness
@@ -339,6 +344,8 @@ impl MultiprocessWhopper {
                 &db_path,
                 opts.enable_mvcc,
                 opts.connections_per_process,
+                opts.allocation_fault_probability,
+                allocation_fault_worker_seed(seed, process_idx),
             )?;
             debug!("process {} ready: {:?}", handle.process_idx, telemetry);
             history.record(&HistoryEvent::WorkerSpawned {
@@ -387,6 +394,8 @@ impl MultiprocessWhopper {
             kill_probability: opts.kill_probability,
             restart_probability: opts.restart_probability,
             keep_files: opts.keep_files,
+            allocation_faults_enabled,
+            allocation_fault_probability: opts.allocation_fault_probability,
         })
     }
 
@@ -585,8 +594,14 @@ impl MultiprocessWhopper {
     ) -> anyhow::Result<(WorkerStartupTelemetry, OpResult)> {
         let sql = sql.into();
         let probe_worker_id = self.processes.len();
-        let (mut worker, telemetry) =
-            spawn_ready_worker(probe_worker_id, &self.db_path, self.enable_mvcc, 1)?;
+        let (mut worker, telemetry) = spawn_ready_worker(
+            probe_worker_id,
+            &self.db_path,
+            self.enable_mvcc,
+            1,
+            self.allocation_fault_probability,
+            allocation_fault_worker_seed(self.seed, probe_worker_id),
+        )?;
 
         let result = (|| -> anyhow::Result<OpResult> {
             for _ in 0..8 {
@@ -679,6 +694,8 @@ impl MultiprocessWhopper {
                 &self.db_path,
                 self.enable_mvcc,
                 self.connections_per_process,
+                self.allocation_fault_probability,
+                allocation_fault_worker_seed(self.seed, process_idx),
             )?;
             self.history.record(&HistoryEvent::WorkerSpawned {
                 step: Some(self.current_step),
@@ -973,7 +990,11 @@ impl MultiprocessWhopper {
             let in_tx = self.connection_states[connection_idx]
                 .fiber_state
                 .is_in_tx();
-            match crate::error_handling::classify_op_error(error, in_tx) {
+            match crate::error_handling::classify_op_error(
+                error,
+                in_tx,
+                self.allocation_faults_enabled,
+            ) {
                 crate::error_handling::ErrorAction::Rollback => {
                     debug!(
                         "connection {}: auto-rollback after {:?}",
@@ -1137,6 +1158,8 @@ impl MultiprocessWhopper {
             &self.db_path,
             self.enable_mvcc,
             self.connections_per_process,
+            self.allocation_fault_probability,
+            allocation_fault_worker_seed(self.seed, location.process_idx),
         )?;
         self.history.record(&HistoryEvent::WorkerSpawned {
             step: Some(self.current_step),
@@ -1205,8 +1228,17 @@ fn spawn_ready_worker(
     db_path: &Path,
     enable_mvcc: bool,
     connections_per_process: usize,
+    allocation_fault_probability: f64,
+    allocation_fault_seed: u64,
 ) -> anyhow::Result<(WorkerProcessHandle, WorkerStartupTelemetry)> {
-    let mut handle = spawn_worker(process_idx, db_path, enable_mvcc, connections_per_process)?;
+    let mut handle = spawn_worker(
+        process_idx,
+        db_path,
+        enable_mvcc,
+        connections_per_process,
+        allocation_fault_probability,
+        allocation_fault_seed,
+    )?;
     let response = recv_response(&mut handle)?;
     match response {
         WorkerResponse::Ready { telemetry } => Ok((handle, telemetry)),
@@ -1224,6 +1256,8 @@ fn spawn_worker(
     db_path: &Path,
     enable_mvcc: bool,
     connections_per_process: usize,
+    allocation_fault_probability: f64,
+    allocation_fault_seed: u64,
 ) -> anyhow::Result<WorkerProcessHandle> {
     let exe = worker_executable()?;
     let mut cmd = Command::new(&exe);
@@ -1232,6 +1266,10 @@ fn spawn_worker(
         .arg(db_path)
         .arg("--connections-per-process")
         .arg(connections_per_process.to_string())
+        .arg("--allocation-fault-probability")
+        .arg(allocation_fault_probability.to_string())
+        .arg("--allocation-fault-seed")
+        .arg(allocation_fault_seed.to_string())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit());
@@ -1254,6 +1292,10 @@ fn spawn_worker(
         responses,
         process_idx,
     })
+}
+
+fn allocation_fault_worker_seed(seed: u64, process_idx: usize) -> u64 {
+    seed ^ ((process_idx as u64).wrapping_add(1)).wrapping_mul(0x9e37_79b9_7f4a_7c15)
 }
 
 fn worker_executable() -> anyhow::Result<PathBuf> {

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -259,6 +259,7 @@ impl Property for IntegrityCheckProperty {
                         | LimboError::CommitDependencyAborted
                         | LimboError::SchemaUpdated
                         | LimboError::SchemaConflict
+                        | LimboError::OutOfMemory
                 ) {
                     return Ok(());
                 }
@@ -1169,6 +1170,7 @@ impl Property for SequenceCorrectnessProperty {
                     || err_msg.contains("Write-write conflict")
                     || err_msg.contains("Commit dependency aborted")
                     || err_msg.contains("Database schema conflict")
+                    || err_msg.contains("Out of memory")
                     || err_msg.contains("setval requires an exclusive transaction")
                 {
                     self.fiber_last_nextval

--- a/testing/concurrent-simulator/protocol.rs
+++ b/testing/concurrent-simulator/protocol.rs
@@ -143,6 +143,7 @@ pub fn limbo_error_to_kind(err: &LimboError) -> &'static str {
         LimboError::InternalError(_) => "InternalError",
         LimboError::Conflict(_) => "Conflict",
         LimboError::CheckpointFailed(_) => "CheckpointFailed",
+        LimboError::OutOfMemory => "OutOfMemory",
         LimboError::ParseError(_) => "ParseError",
         LimboError::TxError(_) => "TxError",
         LimboError::DatabaseFull(_) => "DatabaseFull",
@@ -168,6 +169,7 @@ fn error_kind_to_limbo_error(kind: &str, message: &str) -> LimboError {
         "InternalError" => LimboError::InternalError(message.to_string()),
         "Conflict" => LimboError::Conflict(message.to_string()),
         "CheckpointFailed" => LimboError::CheckpointFailed(message.to_string()),
+        "OutOfMemory" => LimboError::OutOfMemory,
         "ParseError" => LimboError::ParseError(message.to_string()),
         "TxError" => LimboError::TxError(message.to_string()),
         "DatabaseFull" => LimboError::DatabaseFull(message.to_string()),
@@ -204,6 +206,9 @@ mod tests {
                 LimboError::DatabaseFull("nextval: reached minimum value of sequence \"s\"".into()),
                 |e| matches!(e, LimboError::DatabaseFull(m) if m.starts_with("nextval: reached ")),
             ),
+            (LimboError::OutOfMemory, |e| {
+                matches!(e, LimboError::OutOfMemory)
+            }),
             (LimboError::Busy, |e| matches!(e, LimboError::Busy)),
             (LimboError::WriteWriteConflict, |e| {
                 matches!(e, LimboError::WriteWriteConflict)

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -114,6 +114,7 @@ fn create_multiprocess_whopper_with_shape_and_keep(
         restart_probability: 0.0,
         history_output: None,
         keep_files,
+        allocation_fault_probability: 0.0,
     })
     .expect("create multiprocess whopper")
 }

--- a/testing/concurrent-simulator/worker.rs
+++ b/testing/concurrent-simulator/worker.rs
@@ -29,6 +29,8 @@ pub fn run_worker(
     db_path: &str,
     enable_mvcc: bool,
     connections_per_process: usize,
+    allocation_fault_probability: f64,
+    allocation_fault_seed: u64,
 ) -> anyhow::Result<()> {
     // Install a panic hook that writes to stderr so panics don't pollute stdout JSON protocol.
     std::panic::set_hook(Box::new(|info| {
@@ -76,6 +78,7 @@ pub fn run_worker(
     }
 
     let telemetry = worker_startup_telemetry(&db)?;
+    crate::allocation_fault::install(allocation_fault_seed, allocation_fault_probability)?;
 
     // Signal ready
     send_response(&WorkerResponse::Ready { telemetry })?;


### PR DESCRIPTION
## What

`MvStore` gains an `A: SkiplistAllocator = TursoAllocator` type parameter and an `alloc: A` field, threaded into every `SkipMap` it owns — including the lazily created per-index maps in `index_rows`. The commit/checkpoint state machines (`CommitStateMachine`, `CommitState`, `CheckpointStateMachine`, `SeqCompactDriver`), `MvccIterator`, and `static_iterator_hack!` carry the same defaulted parameter, so all existing call sites (`lib.rs` alias, vdbe, cursor) compile unchanged.

All skiplist mutations now go through the fallible `try_` variants from #7482 and surface `LimboError::OutOfMemory` instead of aborting the process.

The generic exists so tests can inject a failing allocator and exercise the allocation-failure paths directly; production always uses the default `TursoAllocator`.

## Failure-ordering guarantees

Allocation failure must never leave the store in an inconsistent state:

- **Insert paths reordered**: the fallible version-chain insert now happens *before* savepoint tracking (`record_created_*`), the rowid-allocator bump, and the write-set insert. Previously a mid-path failure would have left tx-local tracking referencing a version that never landed.
- **`begin_tx` / `begin_exclusive_tx`**: if publishing the tx into `txs` fails, they release everything acquired up to that point (blocking-checkpoint read guard, pager commit lock, exclusive marker), mirroring the existing vanished-tx bail-outs.
- **`remove_tx`** caches the finalized state *before* removing a committed tx and refuses to remove it if that insert fails — the tx stays fully resolvable instead of stranding stale `TxID` references. On commit-completion and `Drop` cleanup paths, where the tx is already durably committed, the error is logged and the tx left in `txs` (safe; only delays GC) rather than failing an already-durable commit.
- **Pure read paths** (`read`, `delete` lookups, `is_btree_row_valid_for_tx`, `get_or_create_index_key_arc`) no longer allocate empty per-index maps; an absent map is treated as empty. Iterator-returning paths (`seek_index`, `get_last_index_rowid`, cursor init) keep lazy creation through a new fallible `MvStore::index_rows_map`, since the escaping iterator must borrow a live entry.
- **`reset_after_vacuum`** keeps `expect()`: it runs after the VACUUM image is committed, inside a documented must-be-infallible install path where a lost mapping cannot be rolled back.

## Tests

`FailOnDemandAlloc` is promoted from a skiplist-test-local type to a shared `cfg(test)` utility in `core::alloc`. Six new tests instantiate `MvStore<MvccClock, FailOnDemandAlloc>` and, for each path, assert the operation fails with `OutOfMemory` while leaving state untouched, then succeeds once allocations recover:

- `new_in` fails cleanly while seeding the sqlite_schema rootpage mapping
- `begin_tx` releases the blocking-checkpoint read guard (proven via the vacuum gate staying acquirable)
- `insert` leaves `rows`, the write set, and savepoint tracking untouched
- per-index map creation leaves no half-created entry
- `remove_tx` keeps a committed tx resolvable in `txs`
- a failed rootpage mapping does not advance `next_table_id`

Verified with `cargo clippy --all-features --all-targets -- --deny=warnings`, the nightly-cfg check, and the full MVCC suite (377 passed) plus skiplist suite (90 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
