### PR TITLE
Force MVCC recovery in turso-stress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6832,6 +6832,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "turso",
+ "turso_core",
  "turso_macros",
 ]
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -6891,6 +6891,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         ctx: &mut RecoverCtx,
         frame: Vec<ParsedOp>,
     ) -> Result<()> {
+        turso_assert_reachable!("Recovering MVCC frame");
         let mut max_commit_ts_seen = ctx.max_commit_ts_seen;
         let replay_cutoff_ts = ctx.replay_cutoff_ts;
         let cookie = ctx.cookie;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1172,22 +1172,19 @@ pub fn turso_assert_all(input: TokenStream) -> TokenStream {
     emit_boolean_guidance(&file_path, input, BooleanCombinator::All).into()
 }
 
-/// Asserts that a code path is reached **at least once** during Antithesis testing.
-///
-/// # Behavior
-///
-/// **Currently a no-op in all builds.** This macro is disabled pending better SQL
-/// generation in `turso-stress`. When enabled, it will tell Antithesis that this code
-/// path should be exercised at least once across the entire test campaign.
+/// Asserts that a code path is reached **at least once** during Antithesis testing. No-op in
+/// non-antithesis builds.
 ///
 /// # Parameters
 ///
-/// - `"message"` — human-readable description of the code path.
+/// - `"message"` — human-readable description of the code path (required).
+/// - `{ "key": value, ... }` *(optional)* — structured details for Antithesis.
 ///
 /// # Usage
 ///
 /// ```ignore
 /// turso_assert_reachable!("opcode: Init");
+/// turso_assert_reachable!("checkpoint", { "frames": frame_count });
 /// ```
 ///
 /// # Examples
@@ -1200,11 +1197,26 @@ pub fn turso_assert_all(input: TokenStream) -> TokenStream {
 /// # When to use
 ///
 /// Place at code paths that should be exercised by the fuzzer.
-//TODO enable this when turso-stress has better SQL generation
 #[proc_macro]
-pub fn turso_assert_reachable(_input: TokenStream) -> TokenStream {
+pub fn turso_assert_reachable(input: TokenStream) -> TokenStream {
+    let file_path = get_caller_file(&input);
+    let input = parse_macro_input!(input as MessageAssertInput);
+    let prefixed = prefix_message(&file_path, &input.message);
+    let details = details_json(&input.details);
+    let debug_check = details_debug_check(&input.details);
+
+    let env_check = antithesis_env_check();
     quote! {
         {
+            #[cfg(antithesis)]
+            {
+                #env_check
+                antithesis_sdk::assert_reachable!(#prefixed, #details);
+            }
+            #[cfg(not(antithesis))]
+            {
+                #debug_check
+            }
         }
     }
     .into()

--- a/testing/stress/Cargo.toml
+++ b/testing/stress/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 turso = { workspace = true, features = ["io_memory_yield"] }
+turso_core = { workspace = true, features = ["simulator"] }
 turso_macros = { workspace = true }
 rusqlite = { workspace = true }
 

--- a/testing/stress/barrier.rs
+++ b/testing/stress/barrier.rs
@@ -1,0 +1,274 @@
+#[cfg(shuttle)]
+use shuttle::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(shuttle)]
+use shuttle::sync::{Condvar, Mutex};
+use std::future::Future;
+use std::sync::Arc;
+
+#[cfg(not(shuttle))]
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(not(shuttle))]
+use std::sync::Mutex;
+#[cfg(not(shuttle))]
+use tokio::sync::Notify;
+
+/// A barrier that starts in the down position, comes up when synchronization is requested,
+/// and then goes back down until the next synchronization request.
+#[derive(Debug)]
+pub struct RequestableSync {
+    closed: AtomicBool,
+
+    requested: AtomicU64,
+    completed: AtomicU64,
+
+    arrive: CloseableBarrier,
+    done: CloseableBarrier,
+    leave: CloseableBarrier,
+}
+
+impl RequestableSync {
+    pub fn new(participants: usize) -> Self {
+        Self {
+            closed: AtomicBool::new(false),
+            requested: AtomicU64::new(0),
+            completed: AtomicU64::new(0),
+            arrive: CloseableBarrier::new(participants),
+            done: CloseableBarrier::new(participants),
+            leave: CloseableBarrier::new(participants),
+        }
+    }
+
+    /// Returns `true` if the synchronization could be requested.
+    pub fn request_synchronization(&self) -> Result<bool, Closed> {
+        loop {
+            if self.closed.load(Ordering::Acquire) {
+                return Err(Closed);
+            }
+
+            let requested = self.requested.load(Ordering::Acquire);
+            let completed = self.completed.load(Ordering::Acquire);
+
+            if requested != completed {
+                return Ok(false);
+            }
+
+            let next = requested.checked_add(1).unwrap();
+
+            match self.requested.compare_exchange(
+                requested,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Ok(true),
+                Err(_) => continue,
+            }
+        }
+    }
+
+    /// Synchronizes with other threads if synchronization was requested via
+    /// `request_synchronization`, in which case the following steps happen in sequence:
+    ///
+    /// 1. Wait on a barrier
+    /// 2. Execute `action`
+    /// 3. Wait on a second barrier
+    ///
+    /// This ensures that
+    ///
+    /// 1. No thread starts executing `action` before all participating threads have entered
+    ///    `maybe_rendezvous_and_run`, and
+    /// 2. No thread exits `maybe_rendezvous_and_run` before all participating threads have
+    ///    finished executing `action`.
+    pub async fn maybe_rendezvous_and_run<F, Fut>(&self, action: F) -> Result<(), Closed>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = ()>,
+    {
+        let target = self.requested.load(Ordering::Acquire);
+
+        if target == self.completed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
+        self.arrive.wait().await?;
+
+        action().await;
+
+        let done = self.done.wait().await?;
+        if done.is_leader() {
+            self.completed.store(target, Ordering::Release);
+        }
+
+        self.leave.wait().await?;
+
+        Ok(())
+    }
+
+    /// Signal all waiters to stop waiting on the barrier.
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+
+        self.arrive.close();
+        self.done.close();
+        self.leave.close();
+    }
+
+    /// Returns a guard than, when dropped, will signal all waiters to stop waiting on the barrier.
+    #[must_use]
+    pub fn close_guard(self: Arc<Self>) -> impl Drop {
+        CloseGuard(self)
+    }
+}
+
+struct CloseGuard(Arc<RequestableSync>);
+
+impl Drop for CloseGuard {
+    fn drop(&mut self) {
+        self.0.close();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Closed;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BarrierWaitResult {
+    leader: bool,
+}
+
+impl BarrierWaitResult {
+    fn is_leader(&self) -> bool {
+        self.leader
+    }
+}
+
+#[derive(Debug)]
+struct BarrierState {
+    generation: u64,
+    arrived: usize,
+    closed: bool,
+}
+
+#[derive(Debug)]
+struct CloseableBarrier {
+    participants: usize,
+    state: Mutex<BarrierState>,
+    #[cfg(shuttle)]
+    condvar: Condvar,
+    #[cfg(not(shuttle))]
+    notify: Notify,
+}
+
+impl CloseableBarrier {
+    fn new(participants: usize) -> Self {
+        assert!(participants > 0);
+
+        Self {
+            participants,
+            state: Mutex::new(BarrierState {
+                generation: 0,
+                arrived: 0,
+                closed: false,
+            }),
+            #[cfg(shuttle)]
+            condvar: Condvar::new(),
+            #[cfg(not(shuttle))]
+            notify: Notify::new(),
+        }
+    }
+
+    fn close(&self) {
+        let mut state = self.state.lock().unwrap();
+
+        if state.closed {
+            return;
+        }
+
+        state.closed = true;
+        state.arrived = 0;
+        state.generation = state.generation.wrapping_add(1);
+
+        #[cfg(shuttle)]
+        self.condvar.notify_all();
+        #[cfg(not(shuttle))]
+        self.notify.notify_waiters();
+    }
+
+    #[cfg(shuttle)]
+    async fn wait(&self) -> Result<BarrierWaitResult, Closed> {
+        let mut state = self.state.lock().unwrap();
+
+        if state.closed {
+            return Err(Closed);
+        }
+
+        let my_generation = state.generation;
+
+        state.arrived += 1;
+
+        if state.arrived == self.participants {
+            state.arrived = 0;
+            state.generation = state.generation.wrapping_add(1);
+            self.condvar.notify_all();
+
+            return Ok(BarrierWaitResult { leader: true });
+        }
+
+        loop {
+            state = self.condvar.wait(state).unwrap();
+
+            if state.closed {
+                return Err(Closed);
+            }
+
+            if state.generation != my_generation {
+                return Ok(BarrierWaitResult { leader: false });
+            }
+        }
+    }
+
+    #[cfg(not(shuttle))]
+    async fn wait(&self) -> Result<BarrierWaitResult, Closed> {
+        let my_generation = {
+            let mut state = self.state.lock().unwrap();
+
+            if state.closed {
+                return Err(Closed);
+            }
+
+            let generation = state.generation;
+
+            state.arrived += 1;
+
+            if state.arrived == self.participants {
+                state.arrived = 0;
+                state.generation = state.generation.wrapping_add(1);
+                self.notify.notify_waiters();
+
+                return Ok(BarrierWaitResult { leader: true });
+            }
+
+            generation
+        };
+
+        loop {
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            {
+                let state = self.state.lock().unwrap();
+
+                if state.closed {
+                    return Err(Closed);
+                }
+
+                if state.generation != my_generation {
+                    return Ok(BarrierWaitResult { leader: false });
+                }
+            }
+
+            notified.await;
+        }
+    }
+}

--- a/testing/stress/lib.rs
+++ b/testing/stress/lib.rs
@@ -1,3 +1,5 @@
+pub mod barrier;
+
 #[cfg(shuttle)]
 pub mod sync {
     pub use shuttle::sync::atomic;

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -32,6 +32,52 @@ use tracing_subscriber::reload;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 use turso::Builder;
+use turso_stress::barrier::RequestableSync;
+
+/// A wrapper around `Database` that simplifies dropping the db.
+struct SharedDb {
+    db: Option<turso::Database>,
+    db_file: String,
+    vfs: Option<String>,
+}
+
+impl SharedDb {
+    fn new(db_file: String, vfs: Option<String>) -> Self {
+        Self {
+            db: None,
+            db_file,
+            vfs,
+        }
+    }
+
+    async fn get_or_init(&mut self) -> turso::Result<&turso::Database> {
+        if self.db.is_none() {
+            let mut builder = Builder::new_local(&self.db_file);
+            if let Some(ref vfs) = self.vfs {
+                builder = builder.with_io(vfs.clone());
+            }
+            self.db = Some(builder.build().await?);
+        }
+        Ok(self.db.as_ref().unwrap())
+    }
+
+    fn reset(&mut self) {
+        self.db = None;
+    }
+
+    async fn connect(
+        this: &Arc<Mutex<Self>>,
+        busy_timeout: u64,
+    ) -> turso::Result<turso::Connection> {
+        let conn = {
+            let mut guard = this.lock().await;
+            guard.get_or_init().await?.connect()?
+        };
+        conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
+        conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
+        Ok(conn)
+    }
+}
 
 /// Represents a column in a SQLite table
 #[derive(Debug, Clone)]
@@ -691,30 +737,22 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
 
     let vfs_option = opts.vfs.clone();
 
-    let mut builder = Builder::new_local(&db_file);
-    if let Some(ref vfs) = vfs_option {
-        builder = builder.with_io(vfs.clone());
-    }
-    let db = Arc::new(Mutex::new(builder.build().await?));
+    let db = Arc::new(Mutex::new(SharedDb::new(
+        db_file.clone(),
+        vfs_option.clone(),
+    )));
+    let reopen_sync = Arc::new(RequestableSync::new(opts.nr_threads));
 
     for thread in 0..opts.nr_threads {
         if stop {
             break;
         }
-        let db_file = db_file.clone();
-        let conn = db.lock().await.connect()?;
-
-        match opts.tx_mode {
-            TxMode::SQLite => {
-                conn.pragma_update("journal_mode", "WAL").await?;
-                conn.busy_timeout(std::time::Duration::from_millis(opts.busy_timeout))?;
-            }
-            TxMode::Concurrent => {
-                conn.pragma_update("journal_mode", "mvcc").await?;
-            }
+        let conn = SharedDb::connect(&db, opts.busy_timeout).await?;
+        let journal_mode = match opts.tx_mode {
+            TxMode::SQLite => "WAL",
+            TxMode::Concurrent => "mvcc",
         };
-
-        conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
+        conn.pragma_update("journal_mode", journal_mode).await?;
 
         for stmt in &ddl_statements {
             let mut retry_counter = 0;
@@ -785,22 +823,19 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
 
         let nr_iterations = opts.nr_iterations;
         let db = db.clone();
-        let vfs_for_task = vfs_option.clone();
         let schema_for_task = schema.clone();
         let busy_timeout = opts.busy_timeout;
         let tx_mode = opts.tx_mode;
         let sql_log = sql_log.clone();
+        let reopen_sync = reopen_sync.clone();
 
         let progress_bar = multi_progress.add(ProgressBar::new(nr_iterations as u64));
         progress_bar.set_style(progress_style.clone());
         progress_bar.set_prefix(format!("Thread {thread}"));
 
         let handle = turso_stress::future::spawn(async move {
-            let mut conn = db.lock().await.connect()?;
-
-            conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
-
-            conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
+            let mut conn: Option<turso::Connection> = None;
+            let _close_guard = reopen_sync.clone().close_guard();
 
             progress_bar.set_message("executing queries...");
 
@@ -808,21 +843,27 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
 
             for i in 0..nr_iterations {
                 if gen_bool(&mut rng, 0.01) {
-                    // Reopen the database
-                    let mut db_guard = db.lock().await;
-                    let mut builder = Builder::new_local(&db_file);
-                    if let Some(ref vfs) = vfs_for_task {
-                        builder = builder.with_io(vfs.clone());
-                    }
-                    *db_guard = builder.build().await?;
-                    conn = db_guard.connect()?;
-                    conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
-                } else if gen_bool(&mut rng, 0.02) {
-                    // Reconnect to the database
-                    let db_guard = db.lock().await;
-                    conn = db_guard.connect()?;
-                    conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
+                    // force a reopen to exercise MVCC recovery
+                    let _ = reopen_sync.request_synchronization();
                 }
+
+                let _ = reopen_sync
+                    .maybe_rendezvous_and_run(async || {
+                        conn = None;
+                        db.lock().await.reset();
+                        turso_core::clear_database_registry();
+                    })
+                    .await;
+
+                if gen_bool(&mut rng, 0.02) {
+                    // force a reconnect
+                    conn = None;
+                }
+
+                if conn.is_none() {
+                    conn = Some(SharedDb::connect(&db, busy_timeout).await?);
+                }
+                let conn = conn.as_ref().unwrap();
 
                 let tx = if rng.get_random() % 2 == 0 {
                     match tx_mode {
@@ -991,12 +1032,16 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                     }
                 }
             }
+
             // In case this thread is running an exclusive transaction, commit it so that it doesn't block other threads.
-            match conn.execute("COMMIT", ()).await {
-                Ok(_) => log_sql(&sql_log, thread, "COMMIT", "OK"),
-                Err(e) => log_sql(&sql_log, thread, "COMMIT", &format!("ERROR: {e}")),
+            if let Some(conn) = conn.as_ref() {
+                match conn.execute("COMMIT", ()).await {
+                    Ok(_) => log_sql(&sql_log, thread, "COMMIT", "OK"),
+                    Err(e) => log_sql(&sql_log, thread, "COMMIT", &format!("ERROR: {e}")),
+                }
             }
             progress_bar.finish_with_message("done");
+
             Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
         });
         handles.push(handle);


### PR DESCRIPTION
## Description

We were never exercising MVCC recovery in stress because Turso has a cache of databases, and forcing recovery requires clearing the cache, or else new DBs are simply served from the cache.

For this, I had to add a custom synchronization mechanism. Vibe-coding a synchronization mechanism is not very safe, but the worst that can happen is that (1) it will deadlock, or (2) it won't work and recovery will happen. In either case, we'll know soon enough.

With Antithesis, the idiomatic way to do all the stress interactions in `parallel` drivers and then force recovery would have been with a `singleton` driver, but this requires multi-process support, so we can't use it yet.

Confirmed by adding a panic in the recovery path, it triggers with the fix, but doesn't trigger without the fix.

I also enabled `turso_assert_reachable`, since it can catch regressions. I look at the few other invocation sites, and they should pass in Antithesis. Even if they don't, I'd rather know about it.

## Description of AI Usage

This was found by Fable while investigating something else, but it was not flagged! I only found out about it when reading through its output.

The synchronization mechanism was devised by ChatGPT, the `SharedDb` wrapper by Claude, and I did a lot of manual tweaking.