### PR TITLE
Fix attached-database schema resolution

### DIFF
--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -526,7 +526,10 @@ pub fn bind_and_rewrite_expr<'a>(
                                 let is_rowid_alias = col.is_rowid_alias();
                                 let normalized_tbl_name = normalize_ident(&tbl_name_str);
                                 let matching_tbl = referenced_tables
-                                    .find_table_and_internal_id_by_identifier(&normalized_tbl_name);
+                                    .find_table_and_internal_id_by_identifier(
+                                        &normalized_tbl_name,
+                                        Some(database_id),
+                                    );
 
                                 if let Some((tbl_id, _)) = matching_tbl {
                                     *expr = Expr::Column {
@@ -553,7 +556,7 @@ pub fn bind_and_rewrite_expr<'a>(
                         let normalized_col = normalize_ident(&tbl_name_str);
                         let field_name = normalize_ident(&col_name_str);
                         let matching_tbl = referenced_tables
-                            .find_table_and_internal_id_by_identifier(&normalized_tbl_name);
+                            .find_table_and_internal_id_by_identifier(&normalized_tbl_name, None);
                         if let Some((tbl_id, tbl)) = matching_tbl {
                             let col_idx = tbl.columns().iter().position(|c| {
                                 c.name

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -191,7 +191,13 @@ fn translate_integrity_check_impl(
         target_pc: no_structural_error_label,
     });
 
-    program.emit_string8("*** in database main ***\n".to_string(), scratch_reg);
+    let database_name = resolver
+        .get_database_name_by_index(database_id)
+        .unwrap_or_else(|| "main".to_string());
+    program.emit_string8(
+        format!("*** in database {database_name} ***\n"),
+        scratch_reg,
+    );
     program.emit_insn(Insn::Concat {
         lhs: scratch_reg,
         rhs: message_reg,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1440,13 +1440,21 @@ impl TableReferences {
     /// Returns `(internal_id, &Table)` for the table with the given identifier.
     /// Searches `joined_tables` first, then visible `outer_query_refs`
     /// (excluding CTE-definition-only entries).
+    ///
+    /// If `database_id` is `Some`, a `joined_tables` entry only matches when its
+    /// `database_id` also matches. This disambiguates references like `aux.t1.id`
+    /// from an identically-named `main.t1` in `joined_tables`, allowing the lookup
+    /// to fall through to `outer_query_refs` where `aux.t1` lives.
     pub fn find_table_and_internal_id_by_identifier(
         &self,
         identifier: &str,
+        database_id: Option<usize>,
     ) -> Option<(TableInternalId, &Table)> {
         self.joined_tables
             .iter()
-            .find(|t| t.identifier == identifier)
+            .find(|t| {
+                t.identifier == identifier && database_id.is_none_or(|db_id| t.database_id == db_id)
+            })
             .map(|t| (t.internal_id, &t.table))
             .or_else(|| {
                 self.outer_query_refs

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1389,12 +1389,16 @@ fn query_pragma(
         }
         PragmaName::IntegrityCheck => {
             let max_errors = parse_max_errors_from_value(&value);
-            translate_integrity_check(schema, program, resolver, database_id, max_errors)?;
+            resolver.with_schema(database_id, |schema| {
+                translate_integrity_check(schema, program, resolver, database_id, max_errors)
+            })?;
             Ok(TransactionMode::Read)
         }
         PragmaName::QuickCheck => {
             let max_errors = parse_max_errors_from_value(&value);
-            translate_quick_check(schema, program, resolver, database_id, max_errors)?;
+            resolver.with_schema(database_id, |schema| {
+                translate_quick_check(schema, program, resolver, database_id, max_errors)
+            })?;
             Ok(TransactionMode::Read)
         }
         PragmaName::CaptureDataChangesConn | PragmaName::UnstableCaptureDataChangesConn => {

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -568,3 +568,171 @@ fn test_begin_deferred_emits_no_transaction_opcodes(_tmp_db: TempDatabase) -> an
     );
     Ok(())
 }
+
+/// Regression test for https://github.com/tursodatabase/turso/issues/6279
+///
+/// A `DoublyQualified` reference like `aux.t1.id` inside a correlated subquery
+/// must bind to `aux.t1` (an outer query reference), not to an identically-named
+/// `main.t1` in the subquery's own FROM clause.
+#[turso_macros::test]
+fn test_correlated_subquery_cross_database_same_table_name(
+    _tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let db = attach_enabled_db(DatabaseOpts::new());
+    let turso = db.connect_limbo();
+
+    turso.execute("ATTACH ':memory:' AS aux")?;
+    turso.execute("CREATE TABLE aux.t1 (id INTEGER PRIMARY KEY, val TEXT)")?;
+    turso.execute("INSERT INTO aux.t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")?;
+    turso.execute("CREATE TABLE main.t1 (id INTEGER PRIMARY KEY, val TEXT)")?;
+    turso.execute("INSERT INTO main.t1 VALUES (2, 'x')")?;
+
+    // EXISTS must correlate per-row, not always evaluate true.
+    let rows = limbo_exec_rows(
+        &turso,
+        "SELECT id, val FROM aux.t1 WHERE EXISTS (
+            SELECT 1 FROM main.t1 WHERE main.t1.id = aux.t1.id
+        )",
+    );
+    assert_eq!(
+        rows,
+        vec![vec![
+            rusqlite::types::Value::Integer(2),
+            rusqlite::types::Value::Text("b".to_string())
+        ]],
+        "EXISTS should only match aux.t1 rows whose id exists in main.t1"
+    );
+
+    // NOT EXISTS must be the complement of the above.
+    let rows = limbo_exec_rows(
+        &turso,
+        "SELECT id, val FROM aux.t1 WHERE NOT EXISTS (
+            SELECT 1 FROM main.t1 WHERE main.t1.id = aux.t1.id
+        )",
+    );
+    assert_eq!(
+        rows,
+        vec![
+            vec![
+                rusqlite::types::Value::Integer(1),
+                rusqlite::types::Value::Text("a".to_string())
+            ],
+            vec![
+                rusqlite::types::Value::Integer(3),
+                rusqlite::types::Value::Text("c".to_string())
+            ],
+        ]
+    );
+
+    // Correlated scalar subquery must be evaluated per-row, returning NULL
+    // when there is no matching row in main.t1.
+    let rows = limbo_exec_rows(
+        &turso,
+        "SELECT id, val, (
+            SELECT val FROM main.t1 WHERE main.t1.id = aux.t1.id
+        ) AS main_val FROM aux.t1 ORDER BY id",
+    );
+    assert_eq!(
+        rows,
+        vec![
+            vec![
+                rusqlite::types::Value::Integer(1),
+                rusqlite::types::Value::Text("a".to_string()),
+                rusqlite::types::Value::Null,
+            ],
+            vec![
+                rusqlite::types::Value::Integer(2),
+                rusqlite::types::Value::Text("b".to_string()),
+                rusqlite::types::Value::Text("x".to_string()),
+            ],
+            vec![
+                rusqlite::types::Value::Integer(3),
+                rusqlite::types::Value::Text("c".to_string()),
+                rusqlite::types::Value::Null,
+            ],
+        ]
+    );
+
+    Ok(())
+}
+
+/// Regression test for https://github.com/tursodatabase/turso/issues/6278
+///
+/// `PRAGMA aux.integrity_check` / `PRAGMA aux.quick_check` must enumerate the
+/// attached database's own tables/indexes, not main's. Previously this crashed
+/// with an I/O error when main had more pages than aux, and falsely reported
+/// "never used" pages when main had none.
+#[turso_macros::test]
+fn test_integrity_check_on_attached_database(_tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let db = attach_enabled_db(DatabaseOpts::new());
+    let turso = db.connect_limbo();
+
+    turso.execute("ATTACH ':memory:' AS aux")?;
+
+    // main has more tables/indexes (and thus more pages) than aux.
+    turso.execute("CREATE TABLE main.m1 (id INTEGER PRIMARY KEY)")?;
+    turso.execute("CREATE TABLE main.m2 (id INTEGER PRIMARY KEY)")?;
+    turso.execute("CREATE TABLE main.m3 (id INTEGER PRIMARY KEY)")?;
+    turso.execute("CREATE TABLE main.m4 (id INTEGER PRIMARY KEY)")?;
+    turso.execute("CREATE INDEX main.idx_m1 ON m1(id)")?;
+    turso.execute("CREATE INDEX main.idx_m2 ON m2(id)")?;
+    turso.execute("INSERT INTO main.m1 VALUES (1)")?;
+    turso.execute("INSERT INTO main.m2 VALUES (1)")?;
+    turso.execute("INSERT INTO main.m3 VALUES (1)")?;
+    turso.execute("INSERT INTO main.m4 VALUES (1)")?;
+
+    turso.execute("CREATE TABLE aux.a1 (id INTEGER PRIMARY KEY, val TEXT)")?;
+    turso.execute("INSERT INTO aux.a1 VALUES (1, 'hello')")?;
+
+    let rows = limbo_exec_rows(&turso, "PRAGMA aux.integrity_check");
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Text("ok".to_string())]],
+        "integrity_check on an attached db with fewer pages than main must not crash"
+    );
+
+    let rows = limbo_exec_rows(&turso, "PRAGMA aux.quick_check");
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Text("ok".to_string())]]
+    );
+
+    // main.integrity_check / unqualified integrity_check must still check main.
+    let rows = limbo_exec_rows(&turso, "PRAGMA main.integrity_check");
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Text("ok".to_string())]]
+    );
+    let rows = limbo_exec_rows(&turso, "PRAGMA integrity_check");
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Text("ok".to_string())]]
+    );
+
+    Ok(())
+}
+
+/// Regression test for https://github.com/tursodatabase/turso/issues/6278
+///
+/// When main has no user tables, `PRAGMA aux.integrity_check` must not treat
+/// aux's pages as "never used" pages of an empty main schema.
+#[turso_macros::test]
+fn test_integrity_check_on_attached_database_when_main_is_empty(
+    _tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let db = attach_enabled_db(DatabaseOpts::new());
+    let turso = db.connect_limbo();
+
+    turso.execute("ATTACH ':memory:' AS aux")?;
+    turso.execute("CREATE TABLE aux.a1 (id INTEGER PRIMARY KEY, val TEXT NOT NULL)")?;
+    turso.execute("INSERT INTO aux.a1 VALUES (1, 'hello')")?;
+
+    let rows = limbo_exec_rows(&turso, "PRAGMA aux.integrity_check");
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Text("ok".to_string())]],
+        "integrity_check on an attached db must not report main's empty schema as corruption"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #6278 and #6279, both caused by code paths that always resolved against main's schema instead of the target attached database's. 
PRAGMA  <db>.integrity_check/quick_check now use the correct database's schema (was crashing/false-erroring), and correlated subqueries referencing <db>.table no longer get shadowed by a same-named table in main. 
Added 3 regression tests covering both cases; full attach/pragma/integrity_check/subquery suite (95 tests) and clippy pass clean.