### PR TITLE
Add SQL-standard scalar functions and PG-compatible aliases

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -1803,7 +1803,7 @@ impl Func {
             "array_element" => Ok(Some(Self::Scalar(ScalarFunc::ArrayElement))),
             "array_set_element" => Ok(Some(Self::Scalar(ScalarFunc::ArraySetElement))),
             // Array functions
-            "array_length" => Ok(Some(Self::Scalar(ScalarFunc::ArrayLength))),
+            "array_length" | "array_upper" => Ok(Some(Self::Scalar(ScalarFunc::ArrayLength))),
             "array_append" => Ok(Some(Self::Scalar(ScalarFunc::ArrayAppend))),
             "array_prepend" => Ok(Some(Self::Scalar(ScalarFunc::ArrayPrepend))),
             "array_cat" => Ok(Some(Self::Scalar(ScalarFunc::ArrayCat))),

--- a/core/function.rs
+++ b/core/function.rs
@@ -800,6 +800,12 @@ pub enum ScalarFunc {
     #[cfg(feature = "test_helper")]
     TestNondetCounter,
     StringReverse,
+    // SQL-standard string and math extensions (PG/MySQL/Oracle compatible)
+    Gcd,
+    Lcm,
+    Repeat,
+    Lpad,
+    Rpad,
     // Built-in type support functions
     BooleanToInt,
     IntToBoolean,
@@ -921,6 +927,11 @@ impl Deterministic for ScalarFunc {
             | ScalarFunc::TestUintLt
             | ScalarFunc::TestUintEq
             | ScalarFunc::StringReverse => true,
+            ScalarFunc::Gcd
+            | ScalarFunc::Lcm
+            | ScalarFunc::Repeat
+            | ScalarFunc::Lpad
+            | ScalarFunc::Rpad => true,
             #[cfg(feature = "test_helper")]
             ScalarFunc::TestNondetCounter => false,
             ScalarFunc::BooleanToInt
@@ -1063,6 +1074,11 @@ impl Display for ScalarFunc {
             #[cfg(feature = "test_helper")]
             Self::TestNondetCounter => "test_nondet_counter",
             Self::StringReverse => "string_reverse",
+            Self::Gcd => "gcd",
+            Self::Lcm => "lcm",
+            Self::Repeat => "repeat",
+            Self::Lpad => "lpad",
+            Self::Rpad => "rpad",
             Self::BooleanToInt => "boolean_to_int",
             Self::IntToBoolean => "int_to_boolean",
             Self::ValidateIpAddr => "validate_ipaddr",
@@ -1198,6 +1214,9 @@ impl ScalarFunc {
             | Self::IsAutocommit => &[0],
             // Scalar max/min (multi-arg)
             Self::Max | Self::Min => &[-1],
+            // SQL-standard string and math extensions
+            Self::Gcd | Self::Lcm | Self::Repeat => &[2],
+            Self::Lpad | Self::Rpad => &[2, 3],
             // Test functions for custom types (1-arg encode/decode, 2-arg operators)
             Self::TestUintEncode | Self::TestUintDecode | Self::StringReverse => &[1],
             Self::TestUintAdd
@@ -1786,6 +1805,11 @@ impl Func {
             #[cfg(feature = "test_helper")]
             "test_nondet_counter" => Ok(Some(Self::Scalar(ScalarFunc::TestNondetCounter))),
             "string_reverse" | "reverse" => Ok(Some(Self::Scalar(ScalarFunc::StringReverse))),
+            "gcd" => Ok(Some(Self::Scalar(ScalarFunc::Gcd))),
+            "lcm" => Ok(Some(Self::Scalar(ScalarFunc::Lcm))),
+            "repeat" => Ok(Some(Self::Scalar(ScalarFunc::Repeat))),
+            "lpad" => Ok(Some(Self::Scalar(ScalarFunc::Lpad))),
+            "rpad" => Ok(Some(Self::Scalar(ScalarFunc::Rpad))),
             // Built-in type support functions
             "boolean_to_int" => Ok(Some(Self::Scalar(ScalarFunc::BooleanToInt))),
             "int_to_boolean" => Ok(Some(Self::Scalar(ScalarFunc::IntToBoolean))),

--- a/core/function.rs
+++ b/core/function.rs
@@ -1598,7 +1598,7 @@ impl Func {
             "jsonb_group_object" => Ok(Some(Self::Agg(AggFunc::JsonbGroupObject))),
             #[cfg(feature = "json")]
             "json_group_object" => Ok(Some(Self::Agg(AggFunc::JsonGroupObject))),
-            "char" => Ok(Some(Self::Scalar(ScalarFunc::Char))),
+            "char" | "chr" => Ok(Some(Self::Scalar(ScalarFunc::Char))),
             "coalesce" => Ok(Some(Self::Scalar(ScalarFunc::Coalesce))),
             "concat" => {
                 if arg_count == 0 {
@@ -1617,18 +1617,20 @@ impl Func {
             "glob" => Ok(Some(Self::Scalar(ScalarFunc::Glob))),
             "ifnull" => Ok(Some(Self::Scalar(ScalarFunc::IfNull))),
             "if" | "iif" => Ok(Some(Self::Scalar(ScalarFunc::Iif))),
-            "instr" => Ok(Some(Self::Scalar(ScalarFunc::Instr))),
+            "instr" | "strpos" => Ok(Some(Self::Scalar(ScalarFunc::Instr))),
             "like" => Ok(Some(Self::Scalar(ScalarFunc::Like))),
             "abs" => Ok(Some(Self::Scalar(ScalarFunc::Abs))),
             "upper" => Ok(Some(Self::Scalar(ScalarFunc::Upper))),
             "lower" => Ok(Some(Self::Scalar(ScalarFunc::Lower))),
             "random" => Ok(Some(Self::Scalar(ScalarFunc::Random))),
             "randomblob" => Ok(Some(Self::Scalar(ScalarFunc::RandomBlob))),
-            "trim" => Ok(Some(Self::Scalar(ScalarFunc::Trim))),
+            "trim" | "btrim" => Ok(Some(Self::Scalar(ScalarFunc::Trim))),
             "ltrim" => Ok(Some(Self::Scalar(ScalarFunc::LTrim))),
             "rtrim" => Ok(Some(Self::Scalar(ScalarFunc::RTrim))),
             "round" => Ok(Some(Self::Scalar(ScalarFunc::Round))),
-            "length" => Ok(Some(Self::Scalar(ScalarFunc::Length))),
+            "length" | "char_length" | "character_length" => {
+                Ok(Some(Self::Scalar(ScalarFunc::Length)))
+            }
             "octet_length" => Ok(Some(Self::Scalar(ScalarFunc::OctetLength))),
             "sign" => Ok(Some(Self::Scalar(ScalarFunc::Sign))),
             "substr" => {
@@ -1783,7 +1785,7 @@ impl Func {
             "test_uint_eq" => Ok(Some(Self::Scalar(ScalarFunc::TestUintEq))),
             #[cfg(feature = "test_helper")]
             "test_nondet_counter" => Ok(Some(Self::Scalar(ScalarFunc::TestNondetCounter))),
-            "string_reverse" => Ok(Some(Self::Scalar(ScalarFunc::StringReverse))),
+            "string_reverse" | "reverse" => Ok(Some(Self::Scalar(ScalarFunc::StringReverse))),
             // Built-in type support functions
             "boolean_to_int" => Ok(Some(Self::Scalar(ScalarFunc::BooleanToInt))),
             "int_to_boolean" => Ok(Some(Self::Scalar(ScalarFunc::IntToBoolean))),

--- a/core/functions/math.rs
+++ b/core/functions/math.rs
@@ -1,0 +1,169 @@
+//! Common SQL math functions not in SQLite's built-in set.
+//!
+//! `gcd(a, b)` and `lcm(a, b)` are present in PostgreSQL, MySQL 8 and Oracle.
+//! Both operate on signed 64-bit integers and propagate `LimboError::IntegerOverflow`
+//! on values that can't be represented — matching PG's `ERROR: bigint out of range`
+//! contract rather than silently wrapping.
+
+use crate::types::Value;
+use crate::{LimboError, Result};
+
+/// Internal Euclidean GCD. Always returns a non-negative value.
+fn gcd_inner(mut a: i64, mut b: i64) -> Option<i64> {
+    // GCD is defined as positive; `wrapping_abs(i64::MIN)` is still `i64::MIN`,
+    // so flag that case explicitly rather than returning a negative result.
+    if a == i64::MIN || b == i64::MIN {
+        // Special case: gcd(i64::MIN, 0) = |i64::MIN|, which doesn't fit in i64.
+        // gcd(i64::MIN, i64::MIN) = |i64::MIN|, same problem.
+        if a == 0 || b == 0 || a == b {
+            return None;
+        }
+        // Recover: reduce the MIN-valued operand once via the modulo loop body.
+        // a = a % b is safe because b != 0 and b != i64::MIN here.
+        if a == i64::MIN {
+            a %= b;
+        } else {
+            b %= a;
+        }
+    }
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    Some(a.abs())
+}
+
+/// `gcd(a, b)` — greatest common divisor of two integers. Returns NULL when
+/// either argument is NULL. Errors with [`LimboError::IntegerOverflow`] when
+/// the result would not fit in `i64` (only happens with `i64::MIN`).
+pub fn exec_gcd(a: &Value, b: &Value) -> Result<Value> {
+    let (Some(a), Some(b)) = (value_as_i64(a), value_as_i64(b)) else {
+        return Ok(Value::Null);
+    };
+    match gcd_inner(a, b) {
+        Some(g) => Ok(Value::from_i64(g)),
+        None => Err(LimboError::IntegerOverflow),
+    }
+}
+
+/// `lcm(a, b)` — least common multiple of two integers. Returns 0 when either
+/// argument is 0 (matches PG), NULL when either is NULL. Errors with
+/// [`LimboError::IntegerOverflow`] when the result doesn't fit in `i64`.
+pub fn exec_lcm(a: &Value, b: &Value) -> Result<Value> {
+    let (Some(a), Some(b)) = (value_as_i64(a), value_as_i64(b)) else {
+        return Ok(Value::Null);
+    };
+    if a == 0 || b == 0 {
+        return Ok(Value::from_i64(0));
+    }
+    let g = gcd_inner(a, b).ok_or(LimboError::IntegerOverflow)?;
+    // (a / g) * |b| — checked to surface overflow. PG returns a non-negative
+    // LCM; we mirror that with `abs` after the multiplication so the sign of
+    // the inputs doesn't leak into the result.
+    let lcm = (a / g)
+        .checked_mul(b.checked_abs().ok_or(LimboError::IntegerOverflow)?)
+        .and_then(i64::checked_abs)
+        .ok_or(LimboError::IntegerOverflow)?;
+    Ok(Value::from_i64(lcm))
+}
+
+/// Coerce a Value to i64 for the math-function entry points. Text inputs are
+/// parsed in the same way SQLite's arithmetic operators would. NULL passes
+/// through as `None`; anything that can't be parsed also returns `None` (the
+/// caller surfaces that as SQL NULL).
+fn value_as_i64(v: &Value) -> Option<i64> {
+    match v {
+        Value::Null => None,
+        Value::Numeric(crate::Numeric::Integer(i)) => Some(*i),
+        Value::Numeric(crate::Numeric::Float(f)) => {
+            let f: f64 = (*f).into();
+            if f.is_finite() {
+                Some(f as i64)
+            } else {
+                None
+            }
+        }
+        Value::Text(t) => t.as_str().parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Value;
+
+    fn v(i: i64) -> Value {
+        Value::from_i64(i)
+    }
+
+    #[test]
+    fn gcd_basic() {
+        assert_eq!(exec_gcd(&v(12), &v(8)).unwrap(), v(4));
+        assert_eq!(exec_gcd(&v(0), &v(7)).unwrap(), v(7));
+        assert_eq!(exec_gcd(&v(7), &v(0)).unwrap(), v(7));
+        assert_eq!(exec_gcd(&v(0), &v(0)).unwrap(), v(0));
+        // GCD is always non-negative regardless of operand signs.
+        assert_eq!(exec_gcd(&v(-12), &v(8)).unwrap(), v(4));
+        assert_eq!(exec_gcd(&v(-12), &v(-8)).unwrap(), v(4));
+    }
+
+    #[test]
+    fn gcd_null_propagates() {
+        assert!(matches!(
+            exec_gcd(&Value::Null, &v(7)).unwrap(),
+            Value::Null
+        ));
+        assert!(matches!(
+            exec_gcd(&v(7), &Value::Null).unwrap(),
+            Value::Null
+        ));
+    }
+
+    #[test]
+    fn gcd_overflow() {
+        // i64::MIN doesn't have a representable absolute value in i64.
+        assert!(matches!(
+            exec_gcd(&v(i64::MIN), &v(0)),
+            Err(LimboError::IntegerOverflow)
+        ));
+        assert!(matches!(
+            exec_gcd(&v(i64::MIN), &v(i64::MIN)),
+            Err(LimboError::IntegerOverflow)
+        ));
+        // gcd(i64::MIN, x) for x != 0, i64::MIN works because we reduce first.
+        assert_eq!(exec_gcd(&v(i64::MIN), &v(2)).unwrap(), v(2));
+    }
+
+    #[test]
+    fn lcm_basic() {
+        assert_eq!(exec_lcm(&v(4), &v(6)).unwrap(), v(12));
+        assert_eq!(exec_lcm(&v(0), &v(5)).unwrap(), v(0));
+        assert_eq!(exec_lcm(&v(5), &v(0)).unwrap(), v(0));
+        // PG returns the non-negative LCM regardless of operand signs.
+        assert_eq!(exec_lcm(&v(-4), &v(6)).unwrap(), v(12));
+        assert_eq!(exec_lcm(&v(-4), &v(-6)).unwrap(), v(12));
+    }
+
+    #[test]
+    fn lcm_null_propagates() {
+        assert!(matches!(
+            exec_lcm(&Value::Null, &v(7)).unwrap(),
+            Value::Null
+        ));
+        assert!(matches!(
+            exec_lcm(&v(7), &Value::Null).unwrap(),
+            Value::Null
+        ));
+    }
+
+    #[test]
+    fn lcm_overflow() {
+        // Two large coprime values can't multiply within i64 range.
+        assert!(matches!(
+            exec_lcm(&v(i64::MAX), &v(3)),
+            Err(LimboError::IntegerOverflow)
+        ));
+    }
+}

--- a/core/functions/mod.rs
+++ b/core/functions/mod.rs
@@ -1,2 +1,4 @@
 pub mod datetime;
+pub mod math;
 pub mod printf;
+pub mod string;

--- a/core/functions/string.rs
+++ b/core/functions/string.rs
@@ -1,0 +1,169 @@
+//! Common SQL string functions not in SQLite's built-in set.
+//!
+//! `repeat`, `lpad`, `rpad` are present in PostgreSQL, MySQL and Oracle. All
+//! three operate on the character count of the input string (not byte length),
+//! matching the PG contract.
+
+use crate::types::Value;
+
+/// `repeat(string, n)` — return `string` concatenated `n` times. Returns NULL
+/// for NULL input or NULL count. `n <= 0` produces an empty string (matches
+/// PG; SQLite's analogue isn't built-in).
+pub fn exec_repeat(input: &Value, count: &Value) -> Value {
+    let s = match input {
+        Value::Null => return Value::Null,
+        Value::Text(t) => t.as_str().to_owned(),
+        v => v.to_string(),
+    };
+    let n = match count {
+        Value::Null => return Value::Null,
+        Value::Numeric(crate::Numeric::Integer(i)) => *i,
+        Value::Numeric(crate::Numeric::Float(f)) => {
+            let f: f64 = (*f).into();
+            f as i64
+        }
+        Value::Text(t) => t.as_str().parse::<i64>().unwrap_or(0),
+        _ => return Value::Null,
+    };
+    if n <= 0 {
+        return Value::build_text(String::new());
+    }
+    Value::build_text(s.repeat(n as usize))
+}
+
+/// `lpad(string, length [, fill])` — left-pad `string` with `fill` (default
+/// space) so the result is exactly `length` characters. If `string` already
+/// has `length` or more characters, it is truncated from the right.
+pub fn exec_lpad(input: &Value, length: &Value, fill: Option<&Value>) -> Value {
+    pad(input, length, fill, /* on_left */ true)
+}
+
+/// `rpad(string, length [, fill])` — right-pad `string` with `fill` (default
+/// space) to exactly `length` characters. Same truncation behaviour as
+/// [`exec_lpad`].
+pub fn exec_rpad(input: &Value, length: &Value, fill: Option<&Value>) -> Value {
+    pad(input, length, fill, /* on_left */ false)
+}
+
+/// Shared body for [`exec_lpad`] / [`exec_rpad`]. The only difference between
+/// the two is which side the padding goes on, so we route by a boolean to
+/// avoid duplicating the truncation, count, and fill-cycling logic.
+fn pad(input: &Value, length: &Value, fill: Option<&Value>, on_left: bool) -> Value {
+    let s = match input {
+        Value::Null => return Value::Null,
+        Value::Text(t) => t.as_str().to_owned(),
+        v => v.to_string(),
+    };
+    let target_len = match length {
+        Value::Null => return Value::Null,
+        Value::Numeric(crate::Numeric::Integer(i)) => *i,
+        Value::Numeric(crate::Numeric::Float(f)) => {
+            let f: f64 = (*f).into();
+            f as i64
+        }
+        Value::Text(t) => t.as_str().parse::<i64>().unwrap_or(0),
+        _ => return Value::Null,
+    };
+    if target_len <= 0 {
+        return Value::build_text(String::new());
+    }
+    let target_len = target_len as usize;
+    let char_count = s.chars().count();
+    if char_count >= target_len {
+        // Truncate. lpad/rpad both trim from the right when over-length, per PG.
+        return Value::build_text(s.chars().take(target_len).collect::<String>());
+    }
+    // Pull the fill string (default space) and bail if it's empty: there's
+    // nothing to repeat, so just return the input as-is.
+    let fill_str = match fill {
+        None => " ".to_string(),
+        Some(Value::Null) => return Value::Null,
+        Some(Value::Text(t)) => t.as_str().to_owned(),
+        Some(v) => v.to_string(),
+    };
+    let fill_chars: Vec<char> = fill_str.chars().collect();
+    if fill_chars.is_empty() {
+        return Value::build_text(s);
+    }
+    let pad: String = fill_chars
+        .iter()
+        .cycle()
+        .take(target_len - char_count)
+        .collect();
+    Value::build_text(if on_left {
+        format!("{pad}{s}")
+    } else {
+        format!("{s}{pad}")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(s: &str) -> Value {
+        Value::build_text(s.to_string())
+    }
+    fn i(n: i64) -> Value {
+        Value::from_i64(n)
+    }
+
+    #[test]
+    fn repeat_basic() {
+        assert_eq!(exec_repeat(&t("ab"), &i(3)), t("ababab"));
+        assert_eq!(exec_repeat(&t("x"), &i(0)), t(""));
+        assert_eq!(exec_repeat(&t("x"), &i(-1)), t(""));
+        assert_eq!(exec_repeat(&t(""), &i(5)), t(""));
+    }
+
+    #[test]
+    fn repeat_null() {
+        assert!(matches!(exec_repeat(&Value::Null, &i(3)), Value::Null));
+        assert!(matches!(exec_repeat(&t("x"), &Value::Null), Value::Null));
+    }
+
+    #[test]
+    fn lpad_basic() {
+        assert_eq!(exec_lpad(&t("abc"), &i(6), None), t("   abc"));
+        assert_eq!(exec_lpad(&t("abc"), &i(6), Some(&t("xy"))), t("xyxabc"));
+        // Already long enough — truncate from the right.
+        assert_eq!(exec_lpad(&t("abcdef"), &i(3), None), t("abc"));
+        // Equal length — pass through.
+        assert_eq!(exec_lpad(&t("abc"), &i(3), Some(&t("x"))), t("abc"));
+    }
+
+    #[test]
+    fn rpad_basic() {
+        assert_eq!(exec_rpad(&t("abc"), &i(6), None), t("abc   "));
+        assert_eq!(exec_rpad(&t("abc"), &i(6), Some(&t("xy"))), t("abcxyx"));
+        assert_eq!(exec_rpad(&t("abcdef"), &i(3), None), t("abc"));
+    }
+
+    #[test]
+    fn pad_null() {
+        assert!(matches!(exec_lpad(&Value::Null, &i(3), None), Value::Null));
+        assert!(matches!(
+            exec_lpad(&t("x"), &Value::Null, None),
+            Value::Null
+        ));
+        assert!(matches!(
+            exec_lpad(&t("x"), &i(3), Some(&Value::Null)),
+            Value::Null
+        ));
+    }
+
+    #[test]
+    fn pad_empty_fill_returns_input() {
+        // PG: if fill is empty the result is the input unchanged.
+        assert_eq!(exec_lpad(&t("abc"), &i(10), Some(&t(""))), t("abc"));
+        assert_eq!(exec_rpad(&t("abc"), &i(10), Some(&t(""))), t("abc"));
+    }
+
+    #[test]
+    fn pad_unicode_counts_characters_not_bytes() {
+        // 'é' is 2 bytes in UTF-8 but one char. lpad/rpad pad to character
+        // count, so a 3-char input needs 1 more char to reach length 4.
+        assert_eq!(exec_lpad(&t("aéc"), &i(4), None), t(" aéc"));
+        assert_eq!(exec_rpad(&t("aéc"), &i(4), None), t("aéc "));
+    }
+}

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -829,8 +829,16 @@ fn bootstrap_builtin_types(registry: &mut HashMap<String, Arc<TypeDef>>) -> crat
         "CREATE TYPE jsonb(value text) BASE blob ENCODE jsonb(value) DECODE json(value)",
         "CREATE TYPE varchar(value text, maxlen integer) BASE text ENCODE CASE WHEN length(value) <= maxlen THEN value ELSE RAISE(ABORT, 'value too long for varchar') END DECODE value OPERATOR '<'",
         "CREATE TYPE date(value text) BASE text ENCODE CASE WHEN value IS NULL THEN NULL WHEN date(value) IS NULL THEN RAISE(ABORT, 'invalid date value') ELSE date(value) END DECODE value OPERATOR '<'",
-        "CREATE TYPE time(value text) BASE text ENCODE CASE WHEN value IS NULL THEN NULL WHEN time(value) IS NULL THEN RAISE(ABORT, 'invalid time value') ELSE time(value) END DECODE value OPERATOR '<'",
-        "CREATE TYPE timestamp(value text) BASE text ENCODE CASE WHEN value IS NULL THEN NULL WHEN datetime(value) IS NULL THEN RAISE(ABORT, 'invalid timestamp value') ELSE datetime(value) END DECODE value OPERATOR '<'",
+        // ENCODE preserves sub-second precision through strftime + a rtrim pair
+        // that strips trailing zeros and the dangling dot, matching PostgreSQL's
+        // text format: whole seconds render as `HH:MM:SS` (no .000), trailing
+        // zeros are dropped (`.500` -> `.5`), and the dot is removed when no
+        // fractional digits remain. `time(...)` / `datetime(...)` would truncate
+        // the fraction outright, silently dropping precision on insert.
+        // Caveat: Turso's `%f` directive is millisecond resolution, so PG's
+        // microsecond inputs are clamped to 3 digits (`.123456` -> `.123`).
+        "CREATE TYPE time(value text) BASE text ENCODE CASE WHEN value IS NULL THEN NULL WHEN time(value) IS NULL THEN RAISE(ABORT, 'invalid time value') ELSE rtrim(rtrim(strftime('%H:%M:%f', value), '0'), '.') END DECODE value OPERATOR '<'",
+        "CREATE TYPE timestamp(value text) BASE text ENCODE CASE WHEN value IS NULL THEN NULL WHEN datetime(value) IS NULL THEN RAISE(ABORT, 'invalid timestamp value') ELSE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', value), '0'), '.') END DECODE value OPERATOR '<'",
         "CREATE TYPE smallint(value integer) BASE integer ENCODE CASE WHEN value BETWEEN -32768 AND 32767 THEN value ELSE RAISE(ABORT, 'integer out of range for smallint') END DECODE value OPERATOR '<'",
         "CREATE TYPE bigint(value integer) BASE integer",
         "CREATE TYPE inet(value text) BASE text ENCODE validate_ipaddr(value) DECODE value",

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -1822,6 +1822,11 @@ pub fn translate_expr(
                         | ScalarFunc::TestUintLt
                         | ScalarFunc::TestUintEq
                         | ScalarFunc::StringReverse
+                        | ScalarFunc::Gcd
+                        | ScalarFunc::Lcm
+                        | ScalarFunc::Repeat
+                        | ScalarFunc::Lpad
+                        | ScalarFunc::Rpad
                         | ScalarFunc::BooleanToInt
                         | ScalarFunc::IntToBoolean
                         | ScalarFunc::ValidateIpAddr

--- a/core/vdbe/array.rs
+++ b/core/vdbe/array.rs
@@ -250,6 +250,31 @@ pub(crate) fn compute_array_length(val: &Value) -> Option<i64> {
     }
 }
 
+/// Compute the element count at array dimension `dim` (1-based). For `dim == 1`,
+/// returns the same value as [`compute_array_length`]. For `dim > 1`, the array
+/// is assumed to be uniform — each outer element is itself an array — and the
+/// walker recurses into element zero `dim - 1` times.
+///
+/// Returns `None` for NULL or non-array input, for `dim < 1`, for an empty
+/// array when `dim > 1` (no element zero to peek into), and for `dim` deeper
+/// than the array's actual nesting. Matches PostgreSQL's
+/// `array_length(arr, dim)` contract — except Turso doesn't track per-
+/// dimension lower bounds, so `array_upper(arr, dim)` equals this function
+/// for all valid `dim`.
+pub(crate) fn compute_array_length_at_dim(val: &Value, dim: i64) -> Option<i64> {
+    if dim < 1 {
+        return None;
+    }
+    if dim == 1 {
+        return compute_array_length(val);
+    }
+    // dim > 1: peek into element zero and recurse. Uniform-shape arrays let
+    // us answer "length at depth N" by looking at any element at depth 1;
+    // element zero is the cheapest to extract.
+    let first = array_values_from_any(val)?.into_iter().next()?;
+    compute_array_length_at_dim(&first, dim - 1)
+}
+
 pub(crate) fn exec_array_append(arr: &Value, elem: &Value) -> Result<Value> {
     let Some(mut elements) = array_values_from_any(arr) else {
         return Ok(Value::Null);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -102,12 +102,11 @@ use crate::storage::btree::{BTreeCursor, BTreeKey};
 
 use super::{
     array::{
-        array_values_from_blob, compare_arrays, compute_array_length,
-        compute_array_length_at_dim, exec_array_append, exec_array_cat, exec_array_contains,
-        exec_array_contains_all, exec_array_overlap, exec_array_position, exec_array_prepend,
-        exec_array_remove, exec_array_slice, exec_array_to_string, exec_string_to_array,
-        make_array_from_registers, parse_text_array, serialize_array_from_blob,
-        values_to_record_blob,
+        array_values_from_blob, compare_arrays, compute_array_length, compute_array_length_at_dim,
+        exec_array_append, exec_array_cat, exec_array_contains, exec_array_contains_all,
+        exec_array_overlap, exec_array_position, exec_array_prepend, exec_array_remove,
+        exec_array_slice, exec_array_to_string, exec_string_to_array, make_array_from_registers,
+        parse_text_array, serialize_array_from_blob, values_to_record_blob,
     },
     insn::{Cookie, RegisterOrLiteral, SortComparatorType},
     CommitState,
@@ -8349,6 +8348,47 @@ pub fn op_function(
                     }
                 };
                 state.registers[*dest].set_value(result);
+            }
+            ScalarFunc::Gcd => {
+                check_arg_count!(arg_count, 2);
+                let a = state.registers[*start_reg].get_value();
+                let b = state.registers[*start_reg + 1].get_value();
+                state.registers[*dest].set_value(crate::functions::math::exec_gcd(a, b)?);
+            }
+            ScalarFunc::Lcm => {
+                check_arg_count!(arg_count, 2);
+                let a = state.registers[*start_reg].get_value();
+                let b = state.registers[*start_reg + 1].get_value();
+                state.registers[*dest].set_value(crate::functions::math::exec_lcm(a, b)?);
+            }
+            ScalarFunc::Repeat => {
+                check_arg_count!(arg_count, 2);
+                let input = state.registers[*start_reg].get_value();
+                let count = state.registers[*start_reg + 1].get_value();
+                state.registers[*dest]
+                    .set_value(crate::functions::string::exec_repeat(input, count));
+            }
+            ScalarFunc::Lpad => {
+                let input = state.registers[*start_reg].get_value();
+                let length = state.registers[*start_reg + 1].get_value();
+                let fill = if arg_count >= 3 {
+                    Some(state.registers[*start_reg + 2].get_value())
+                } else {
+                    None
+                };
+                state.registers[*dest]
+                    .set_value(crate::functions::string::exec_lpad(input, length, fill));
+            }
+            ScalarFunc::Rpad => {
+                let input = state.registers[*start_reg].get_value();
+                let length = state.registers[*start_reg + 1].get_value();
+                let fill = if arg_count >= 3 {
+                    Some(state.registers[*start_reg + 2].get_value())
+                } else {
+                    None
+                };
+                state.registers[*dest]
+                    .set_value(crate::functions::string::exec_rpad(input, length, fill));
             }
             ScalarFunc::BooleanToInt => {
                 check_arg_count!(arg_count, 1);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -102,11 +102,12 @@ use crate::storage::btree::{BTreeCursor, BTreeKey};
 
 use super::{
     array::{
-        array_values_from_blob, compare_arrays, compute_array_length, exec_array_append,
-        exec_array_cat, exec_array_contains, exec_array_contains_all, exec_array_overlap,
-        exec_array_position, exec_array_prepend, exec_array_remove, exec_array_slice,
-        exec_array_to_string, exec_string_to_array, make_array_from_registers, parse_text_array,
-        serialize_array_from_blob, values_to_record_blob,
+        array_values_from_blob, compare_arrays, compute_array_length,
+        compute_array_length_at_dim, exec_array_append, exec_array_cat, exec_array_contains,
+        exec_array_contains_all, exec_array_overlap, exec_array_position, exec_array_prepend,
+        exec_array_remove, exec_array_slice, exec_array_to_string, exec_string_to_array,
+        make_array_from_registers, parse_text_array, serialize_array_from_blob,
+        values_to_record_blob,
     },
     insn::{Cookie, RegisterOrLiteral, SortComparatorType},
     CommitState,
@@ -8568,9 +8569,20 @@ pub fn op_function(
                 state.registers[*dest].set_value(exec_array_position(&arr_val, &target));
             }
             ScalarFunc::ArrayLength => {
-                // Accept 1 or 2 args; dimension arg (PG compat) ignored for 1D arrays
+                // 1-arg form: equivalent to `array_length(arr, 1)`. 2-arg form
+                // honors the dimension and walks into nested arrays for dim > 1
+                // (Turso arrays are 1-indexed, so `array_upper(arr, dim)` shares
+                // this code path via its alias and produces the same result).
                 let arr_val = state.registers[*start_reg].get_value();
-                match compute_array_length(arr_val) {
+                let dim = if arg_count >= 2 {
+                    state.registers[*start_reg + 1]
+                        .get_value()
+                        .as_int()
+                        .unwrap_or(0)
+                } else {
+                    1
+                };
+                match compute_array_length_at_dim(arr_val, dim) {
                     Some(count) => state.registers[*dest].set_int(count),
                     None => state.registers[*dest].set_null(),
                 };

--- a/docs/sql-reference/functions/array.mdx
+++ b/docs/sql-reference/functions/array.mdx
@@ -137,7 +137,7 @@ SELECT tags[1:3] FROM t;
 
 ### array_length
 
-Returns the number of elements in an array.
+Returns the number of elements along a given dimension of an array.
 
 ```sql
 array_length(array)
@@ -147,9 +147,11 @@ array_length(array, dimension)
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `array` | BLOB/TEXT | The array to measure |
-| `dimension` | INTEGER | Optional. Currently only dimension 1 is supported |
+| `dimension` | INTEGER | Optional. 1-based dimension index. Defaults to `1` (the outermost dimension) |
 
-**Returns:** INTEGER -- the number of elements. NULL if the input is NULL.
+**Returns:** INTEGER -- the number of elements along `dimension`. NULL if the input is NULL, if `dimension < 1`, or if `dimension` exceeds the array's nesting depth.
+
+For multi-dimensional arrays the walker peeks into element zero at each level, so values are reported as if every inner array at a given depth has the same length (the layout Turso materialises).
 
 ```sql
 SELECT array_length(ARRAY[10, 20, 30]);
@@ -159,6 +161,46 @@ SELECT array_length('[]');
 -- 0
 
 SELECT array_length(NULL);
+-- NULL
+
+SELECT array_length(ARRAY[ARRAY[1,2,3], ARRAY[4,5,6]], 1);
+-- 2 (outer dimension)
+
+SELECT array_length(ARRAY[ARRAY[1,2,3], ARRAY[4,5,6]], 2);
+-- 3 (inner dimension)
+
+SELECT array_length(ARRAY[1, 2, 3], 2);
+-- NULL (dimension beyond the array's depth)
+
+SELECT array_length(ARRAY[1, 2, 3], 0);
+-- NULL (dimension < 1)
+```
+
+### array_upper
+
+Returns the upper bound (inclusive) of a given dimension of an array.
+
+```sql
+array_upper(array, dimension)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array` | BLOB/TEXT | The array to measure |
+| `dimension` | INTEGER | 1-based dimension index |
+
+**Returns:** INTEGER -- the upper bound of `dimension`. NULL with the same conditions as `array_length`.
+
+Turso arrays are always 1-indexed, so `array_upper(arr, dim)` is equivalent to `array_length(arr, dim)` for every valid input. The function is provided for PostgreSQL compatibility.
+
+```sql
+SELECT array_upper(ARRAY[10, 20, 30], 1);
+-- 3
+
+SELECT array_upper(ARRAY[ARRAY[1,2,3], ARRAY[4,5,6]], 2);
+-- 3
+
+SELECT array_upper(ARRAY[1, 2, 3], 2);
 -- NULL
 ```
 

--- a/docs/sql-reference/functions/math.mdx
+++ b/docs/sql-reference/functions/math.mdx
@@ -73,6 +73,8 @@ The single-argument `log(X)` returns the natural logarithm (base e), matching SQ
 | `power(X, Y)` | Alias for `pow(X, Y)` | REAL |
 | `sqrt(X)` | Square root of X. X must be >= 0 | REAL |
 | `sign(X)` | Returns -1, 0, or +1 for negative, zero, or positive X | INTEGER |
+| `gcd(A, B)` | Greatest common divisor of two integers | INTEGER |
+| `lcm(A, B)` | Least common multiple of two integers | INTEGER |
 
 ### Constants
 
@@ -264,6 +266,55 @@ exp(X)
 ```sql
 SELECT exp(0);   -- 1.0
 SELECT exp(1);   -- 2.718281828459045
+```
+
+---
+
+### gcd()
+
+```sql
+gcd(A, B)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `A` | INTEGER | First operand |
+| `B` | INTEGER | Second operand |
+
+**Returns:** INTEGER. The greatest common divisor of A and B. The result is always non-negative regardless of the signs of the inputs. `gcd(0, 0)` returns `0`. Returns NULL if either argument is NULL. Raises an integer-overflow error when the result is not representable as a signed 64-bit integer (the only such case involves `-9223372036854775808`).
+
+```sql
+SELECT gcd(12, 8);     -- 4
+SELECT gcd(-12, 8);    -- 4
+SELECT gcd(0, 7);      -- 7
+SELECT gcd(0, 0);      -- 0
+SELECT gcd(NULL, 7);   -- NULL
+```
+
+<Info>
+`gcd` and `lcm` are PostgreSQL/MySQL/Oracle-compatible additions that SQLite does not ship. They operate on signed 64-bit integers; non-integer text inputs that cannot be parsed return NULL.
+</Info>
+
+---
+
+### lcm()
+
+```sql
+lcm(A, B)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `A` | INTEGER | First operand |
+| `B` | INTEGER | Second operand |
+
+**Returns:** INTEGER. The least common multiple of A and B. The result is always non-negative regardless of the signs of the inputs. `lcm(_, 0)` and `lcm(0, _)` return `0`. Returns NULL if either argument is NULL. Raises an integer-overflow error when the multiplication does not fit in a signed 64-bit integer.
+
+```sql
+SELECT lcm(4, 6);      -- 12
+SELECT lcm(-4, 6);     -- 12
+SELECT lcm(5, 0);      -- 0
+SELECT lcm(NULL, 7);   -- NULL
 ```
 
 ---

--- a/docs/sql-reference/functions/scalar.mdx
+++ b/docs/sql-reference/functions/scalar.mdx
@@ -27,28 +27,38 @@ Scalar functions accept one or more arguments and return a single value. They ca
 | Function | Description |
 |----------|-------------|
 | `char(X1, X2, ..., XN)` | Returns a string composed of characters with Unicode code points X1 through XN |
+| `chr(X)` | Alias for `char(X)`. PostgreSQL/SQL-standard spelling |
 | `concat(X, ...)` | Concatenates all arguments as strings. NULL arguments are skipped |
 | `concat_ws(SEP, X, ...)` | Concatenates arguments with separator SEP. NULL arguments are skipped |
 | `format(FORMAT, ...)` | Returns a formatted string using printf-style format specifiers |
 | `hex(X)` | Returns the uppercase hexadecimal representation of X |
 | `instr(X, Y)` | Returns the 1-based position of the first occurrence of Y in X, or 0 if not found |
+| `strpos(X, Y)` | Alias for `instr(X, Y)`. PostgreSQL spelling, identical argument order |
 | `length(X)` | Returns the string length in characters, or blob length in bytes |
+| `char_length(X)` | Alias for `length(X)`. SQL-standard short form |
+| `character_length(X)` | Alias for `length(X)`. SQL-standard long form |
 | `lower(X)` | Returns a lowercase copy of string X |
+| `lpad(X, N)` / `lpad(X, N, F)` | Pads X on the left to length N using F (defaults to a single space) |
 | `ltrim(X)` | Removes leading whitespace from X |
 | `ltrim(X, Y)` | Removes leading characters found in Y from X |
 | `octet_length(X)` | Returns the length of X in bytes |
 | `printf(FORMAT, ...)` | Alias for `format()`. Returns a formatted string |
 | `quote(X)` | Returns the SQL literal representation of X |
+| `repeat(X, N)` | Returns X concatenated N times. `N <= 0` produces an empty string |
 | `replace(X, Y, Z)` | Returns X with every occurrence of Y replaced by Z |
+| `reverse(X)` | Returns the characters of string X in reverse order. Alias for `string_reverse(X)` |
+| `rpad(X, N)` / `rpad(X, N, F)` | Pads X on the right to length N using F (defaults to a single space) |
 | `rtrim(X)` | Removes trailing whitespace from X |
 | `rtrim(X, Y)` | Removes trailing characters found in Y from X |
 | `soundex(X)` | Returns the Soundex encoding of string X |
+| `string_reverse(X)` | Returns the characters of string X in reverse order |
 | `substr(X, Y)` | Returns the substring of X starting at position Y (1-based) |
 | `substr(X, Y, Z)` | Returns Z characters from X starting at position Y |
 | `substring(X, Y)` | Alias for `substr(X, Y)` |
 | `substring(X, Y, Z)` | Alias for `substr(X, Y, Z)` |
 | `trim(X)` | Removes leading and trailing whitespace from X |
 | `trim(X, Y)` | Removes leading and trailing characters found in Y from X |
+| `btrim(X)` / `btrim(X, Y)` | Alias for `trim(X)` / `trim(X, Y)`. PostgreSQL/Oracle spelling |
 | `unhex(X)` | Converts hexadecimal string X to a blob. Returns NULL if X contains non-hex characters |
 | `unhex(X, Y)` | Like `unhex(X)`, but characters in Y are silently ignored in X |
 | `unicode(X)` | Returns the Unicode code point of the first character of string X |
@@ -120,14 +130,17 @@ SELECT abs(0);         -- 0
 SELECT abs(NULL);      -- NULL
 ```
 
-### char(X1, X2, ..., XN)
+### char(X1, X2, ..., XN) and chr(X)
 
-Returns a string composed of characters having the Unicode code points X1 through XN. Arguments that are not valid code points are replaced with the Unicode replacement character (U+FFFD).
+`char` returns a string composed of characters having the Unicode code points X1 through XN. Arguments that are not valid code points are replaced with the Unicode replacement character (U+FFFD).
+
+`chr` is a single-argument alias provided for PostgreSQL and SQL-standard compatibility. It is identical to `char(X)`.
 
 ```sql
 SELECT char(72, 101, 108, 108, 111);   -- 'Hello'
 SELECT char(9731);                       -- snowman character
 SELECT hex(char(0));                     -- '00'
+SELECT chr(65);                          -- 'A'
 ```
 
 ### coalesce(X, Y, ...)
@@ -218,27 +231,35 @@ SELECT iif(NULL, 'yes', 'no');         -- 'no'
 SELECT if(10 > 5, 'big', 'small');     -- 'big'
 ```
 
-### instr(X, Y)
+### instr(X, Y) and strpos(X, Y)
 
 Returns the 1-based position of the first occurrence of string Y in string X. Returns 0 if Y is not found in X. If either argument is NULL, returns NULL.
+
+`strpos` is a PostgreSQL-compatible alias with the same argument order.
 
 ```sql
 SELECT instr('Hello World', 'World');   -- 7
 SELECT instr('Hello World', 'xyz');     -- 0
 SELECT instr('abcabc', 'bc');           -- 2
+SELECT strpos('Hello World', 'World');  -- 7
 ```
 
-### length(X) and octet_length(X)
+### length(X), char_length(X), character_length(X), and octet_length(X)
 
 `length` returns the number of characters in a text value, or the number of bytes in a blob value. For NULL, returns NULL. For numeric values, returns the length of the text representation.
+
+`char_length` and `character_length` are SQL-standard aliases for `length`, accepted for compatibility with PostgreSQL and other engines.
 
 `octet_length` always returns the length in bytes, regardless of type.
 
 ```sql
-SELECT length('Hello');          -- 5
-SELECT length(x'AABBCC');        -- 3 (bytes for blob)
-SELECT length(12345);            -- 5 (text representation)
-SELECT octet_length('Hello');    -- 5 (ASCII, 1 byte per char)
+SELECT length('Hello');             -- 5
+SELECT length(x'AABBCC');           -- 3 (bytes for blob)
+SELECT length(12345);               -- 5 (text representation)
+SELECT char_length('café');         -- 4 (counts characters, not bytes)
+SELECT character_length('café');    -- 4
+SELECT octet_length('Hello');       -- 5 (ASCII, 1 byte per char)
+SELECT octet_length('café');        -- 5 (é is 2 bytes in UTF-8)
 ```
 
 ### like(X, Y) and like(X, Y, Z)
@@ -264,21 +285,25 @@ SELECT lower('Hello World');   -- 'hello world'
 SELECT upper('Hello World');   -- 'HELLO WORLD'
 ```
 
-### ltrim(X), rtrim(X), trim(X)
+### ltrim(X), rtrim(X), trim(X), btrim(X)
 
 These functions remove characters from the ends of a string. Without a second argument, they remove whitespace. With a second argument Y, they remove any characters present in the string Y.
+
+`btrim` is a PostgreSQL/Oracle-compatible alias for `trim` (both the one- and two-argument forms).
 
 ```sql
 -- Whitespace trimming
 SELECT ltrim('   Hello');          -- 'Hello'
 SELECT rtrim('Hello   ');          -- 'Hello'
 SELECT trim('   Hello   ');        -- 'Hello'
+SELECT btrim('   Hello   ');       -- 'Hello'
 
 -- Character trimming
-SELECT ltrim('xxxHello', 'x');     -- 'Hello'
-SELECT rtrim('Helloyyy', 'y');     -- 'Hello'
-SELECT trim('***Hello***', '*');   -- 'Hello'
-SELECT trim('abcHelloabc', 'abc'); -- 'Hello' (removes any of a, b, or c)
+SELECT ltrim('xxxHello', 'x');       -- 'Hello'
+SELECT rtrim('Helloyyy', 'y');       -- 'Hello'
+SELECT trim('***Hello***', '*');     -- 'Hello'
+SELECT trim('abcHelloabc', 'abc');   -- 'Hello' (removes any of a, b, or c)
+SELECT btrim('xyzHelloxyz', 'xyz');  -- 'Hello'
 ```
 
 ### max(X, Y, ...) and min(X, Y, ...)
@@ -328,6 +353,44 @@ SELECT hex(randomblob(4)); -- e.g., 'A1B2C3D4' (4 random bytes)
 SELECT abs(random()) % 100; -- random number between 0 and 99
 ```
 
+### lpad(X, N) and lpad(X, N, F)
+
+Left-pads the string X with the fill string F until the result has exactly N characters. F defaults to a single space. If X is already at least N characters long, it is truncated from the right to length N. F is cycled when it is more than one character long. Returns NULL if any argument is NULL. If F is an empty string, the input is returned unchanged.
+
+Lengths are counted in Unicode characters, not bytes, so multi-byte input is padded correctly.
+
+```sql
+SELECT lpad('abc', 6);              -- '   abc'
+SELECT lpad('abc', 6, 'xy');        -- 'xyxabc'
+SELECT lpad('abcdef', 3);           -- 'abc'   (truncated from the right)
+SELECT lpad('aéc', 4);              -- ' aéc'  (character count, not bytes)
+SELECT lpad('abc', 10, '');         -- 'abc'   (empty fill)
+SELECT lpad(NULL, 5);               -- NULL
+```
+
+### rpad(X, N) and rpad(X, N, F)
+
+Right-pads the string X with the fill string F until the result has exactly N characters. F defaults to a single space. Truncation, fill cycling, NULL propagation, and empty-fill handling are identical to `lpad` (see the section above).
+
+```sql
+SELECT rpad('abc', 6);              -- 'abc   '
+SELECT rpad('abc', 6, 'xy');        -- 'abcxyx'
+SELECT rpad('abcdef', 3);           -- 'abc'   (truncated from the right)
+SELECT rpad('aéc', 4);              -- 'aéc '
+```
+
+### repeat(X, N)
+
+Returns the string X concatenated with itself N times. Returns an empty string when `N <= 0`. Returns NULL if either argument is NULL. Non-text inputs are converted to their text representation first.
+
+```sql
+SELECT repeat('ab', 3);      -- 'ababab'
+SELECT repeat('x', 0);       -- ''
+SELECT repeat('x', -1);      -- ''
+SELECT repeat('', 5);        -- ''
+SELECT repeat(NULL, 3);      -- NULL
+```
+
 ### replace(X, Y, Z)
 
 Returns a copy of string X with every occurrence of string Y replaced by string Z. If Y is empty, X is returned unchanged.
@@ -336,6 +399,20 @@ Returns a copy of string X with every occurrence of string Y replaced by string 
 SELECT replace('Hello World', 'World', 'Turso');   -- 'Hello Turso'
 SELECT replace('aabbcc', 'bb', 'XX');               -- 'aaXXcc'
 SELECT replace('2024-01-15', '-', '/');              -- '2024/01/15'
+```
+
+### reverse(X) and string_reverse(X)
+
+Returns string X with its characters in reverse order. Reversal is done on Unicode characters, so multi-byte characters are preserved intact. Returns NULL if X is NULL. Non-text inputs are converted to their text representation first.
+
+`reverse` is the PostgreSQL (since version 17), MySQL, and Oracle spelling; `string_reverse` is the canonical Turso name. The two are interchangeable.
+
+```sql
+SELECT reverse('hello');         -- 'olleh'
+SELECT reverse('');              -- ''
+SELECT reverse('café');          -- 'éfac'
+SELECT string_reverse('abc');    -- 'cba'
+SELECT reverse(NULL);            -- NULL
 ```
 
 ### round(X) and round(X, Y)

--- a/testing/sqltests/turso-tests/array.sqltest
+++ b/testing/sqltests/turso-tests/array.sqltest
@@ -1234,6 +1234,90 @@ expect {
     c
 }
 
+# array_length(arr, dim) honors the dimension argument. PostgreSQL contract:
+# dim=1 is the outermost length, dim=2 is the next level, etc.
+test array-length-2d-dim {
+    CREATE TABLE md_dim (id INTEGER PRIMARY KEY, matrix INTEGER[][]) STRICT;
+    INSERT INTO md_dim VALUES (1, ARRAY[ARRAY[1,2,3], ARRAY[4,5,6]]);
+    SELECT array_length(matrix, 1) FROM md_dim WHERE id = 1;
+    SELECT array_length(matrix, 2) FROM md_dim WHERE id = 1;
+}
+expect {
+    2
+    3
+}
+
+# 3-D array_length: each dimension reports the count at that depth.
+test array-length-3d-dim {
+    CREATE TABLE md_3d (id INTEGER PRIMARY KEY, cube INTEGER[][][]) STRICT;
+    INSERT INTO md_3d VALUES (1, ARRAY[ARRAY[ARRAY[1,2], ARRAY[3,4]], ARRAY[ARRAY[5,6], ARRAY[7,8]]]);
+    SELECT array_length(cube, 1) FROM md_3d WHERE id = 1;
+    SELECT array_length(cube, 2) FROM md_3d WHERE id = 1;
+    SELECT array_length(cube, 3) FROM md_3d WHERE id = 1;
+}
+expect {
+    2
+    2
+    2
+}
+
+# array_length(arr) without a dim defaults to dim=1, matching PG.
+test array-length-default-dim {
+    CREATE TABLE md_def (id INTEGER PRIMARY KEY, matrix INTEGER[][]) STRICT;
+    INSERT INTO md_def VALUES (1, ARRAY[ARRAY[1,2,3], ARRAY[4,5,6]]);
+    SELECT array_length(matrix) FROM md_def WHERE id = 1;
+    SELECT array_length(matrix, 1) FROM md_def WHERE id = 1;
+}
+expect {
+    2
+    2
+}
+
+# Dimension beyond the actual depth → NULL.
+test array-length-dim-out-of-range {
+    SELECT array_length(ARRAY[ARRAY[1,2], ARRAY[3,4]], 3) IS NULL;
+    SELECT array_length(ARRAY[1,2,3], 2) IS NULL;
+}
+expect {
+    1
+    1
+}
+
+# Invalid dim (zero, negative) → NULL.
+test array-length-invalid-dim {
+    SELECT array_length(ARRAY[1,2,3], 0) IS NULL;
+    SELECT array_length(ARRAY[1,2,3], -1) IS NULL;
+}
+expect {
+    1
+    1
+}
+
+# array_upper(arr, dim) is the PostgreSQL spelling. Turso arrays are
+# always 1-indexed, so the upper bound equals array_length at that dim.
+test array-upper-matches-array-length {
+    CREATE TABLE md_up (id INTEGER PRIMARY KEY, matrix INTEGER[][]) STRICT;
+    INSERT INTO md_up VALUES (1, ARRAY[ARRAY[1,2,3], ARRAY[4,5,6]]);
+    SELECT array_upper(matrix, 1) FROM md_up WHERE id = 1;
+    SELECT array_upper(matrix, 2) FROM md_up WHERE id = 1;
+    SELECT array_upper(ARRAY[10,20,30], 1);
+}
+expect {
+    2
+    3
+    3
+}
+
+# array_upper out-of-range / invalid dim behaves the same as array_length.
+test array-upper-out-of-range {
+    SELECT array_upper(ARRAY[1,2,3], 2) IS NULL;
+    SELECT array_upper(ARRAY[1,2,3], 0) IS NULL;
+}
+expect {
+    1
+    1
+}
+
 test array-compare-equal {
     SELECT ARRAY[1,2,3] = ARRAY[1,2,3];
 }

--- a/testing/sqltests/turso-tests/custom_type_datetime_validation.sqltest
+++ b/testing/sqltests/turso-tests/custom_type_datetime_validation.sqltest
@@ -53,6 +53,31 @@ expect {
 }
 
 @requires strict "uses STRICT tables"
+test valid-time-preserves-fraction {
+    -- Sub-second input round-trips at millisecond resolution; the previous
+    -- ENCODE (`time(value)`) silently truncated to whole seconds.
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, t time) STRICT;
+    INSERT INTO t1 VALUES (1, '14:30:00.789');
+    SELECT id, t FROM t1;
+}
+expect {
+    1|14:30:00.789
+}
+
+@requires strict "uses STRICT tables"
+test valid-time-trims-trailing-zeros {
+    -- Matches PostgreSQL: '14:30:00.500' renders as '14:30:00.5'.
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, t time) STRICT;
+    INSERT INTO t1 VALUES (1, '14:30:00.500');
+    INSERT INTO t1 VALUES (2, '14:30:00.000');
+    SELECT id, t FROM t1 ORDER BY id;
+}
+expect {
+    1|14:30:00.5
+    2|14:30:00
+}
+
+@requires strict "uses STRICT tables"
 test invalid-time-rejected {
     CREATE TABLE t1(id INTEGER PRIMARY KEY, t time) STRICT;
     INSERT INTO t1 VALUES (1, 'not-a-time');
@@ -69,6 +94,18 @@ test valid-timestamp-accepted {
 }
 expect {
     1|2024-01-15 14:30:00
+}
+
+@requires strict "uses STRICT tables"
+test valid-timestamp-preserves-fraction {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, ts timestamp) STRICT;
+    INSERT INTO t1 VALUES (1, '2024-01-15 14:30:00.789');
+    INSERT INTO t1 VALUES (2, '2024-01-15 14:30:00.500');
+    SELECT id, ts FROM t1 ORDER BY id;
+}
+expect {
+    1|2024-01-15 14:30:00.789
+    2|2024-01-15 14:30:00.5
 }
 
 @requires strict "uses STRICT tables"

--- a/testing/sqltests/turso-tests/custom_types.sqltest
+++ b/testing/sqltests/turso-tests/custom_types.sqltest
@@ -312,8 +312,8 @@ expect {
     jsonb(value text)|blob|jsonb (value)|json (value)||
     numeric(value any, precision integer, scale integer)|blob|numeric_encode (value, precision, scale)|numeric_decode (value)||'+' numeric_add, '-' numeric_sub, '*' numeric_mul, '/' numeric_div, '<' numeric_lt, '=' numeric_eq
     smallint(value integer)|integer|CASE WHEN value BETWEEN - 32768 AND 32767 THEN value ELSE RAISE (ABORT, 'integer out of range for smallint') END|value||'<'
-    time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE time (value) END|value||'<'
-    timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE datetime (value) END|value||'<'
+    time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE rtrim (rtrim (strftime ('%H:%M:%f', value), '0'), '.') END|value||'<'
+    timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
     uuid(value text)|blob|uuid_blob (value)|uuid_str (value)|uuid4_str ()|'<'
     varchar(value text, maxlen integer)|text|CASE WHEN length (value) <= maxlen THEN value ELSE RAISE (ABORT, 'value too long for varchar') END|value||'<'
 }
@@ -343,8 +343,8 @@ expect {
     numeric(value any, precision integer, scale integer)|blob|numeric_encode (value, precision, scale)|numeric_decode (value)||'+' numeric_add, '-' numeric_sub, '*' numeric_mul, '/' numeric_div, '<' numeric_lt, '=' numeric_eq
     smallint(value integer)|integer|CASE WHEN value BETWEEN - 32768 AND 32767 THEN value ELSE RAISE (ABORT, 'integer out of range for smallint') END|value||'<'
     test_uint(value any)|text|test_uint_encode (value)|test_uint_decode (value)|0|'+' test_uint_add
-    time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE time (value) END|value||'<'
-    timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE datetime (value) END|value||'<'
+    time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE rtrim (rtrim (strftime ('%H:%M:%f', value), '0'), '.') END|value||'<'
+    timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
     uuid(value text)|blob|uuid_blob (value)|uuid_str (value)|uuid4_str ()|'<'
     varchar(value text, maxlen integer)|text|CASE WHEN length (value) <= maxlen THEN value ELSE RAISE (ABORT, 'value too long for varchar') END|value||'<'
 }

--- a/testing/sqltests/turso-tests/gcd_lcm_repeat_pad.sqltest
+++ b/testing/sqltests/turso-tests/gcd_lcm_repeat_pad.sqltest
@@ -1,0 +1,164 @@
+@database :memory:
+
+# SQL-standard math and string functions present in PG, MySQL, Oracle but
+# not in SQLite. Each test pins one canonical behavior; overflow/NULL paths
+# are covered in the Rust unit tests next to each function.
+
+# -----------------------------------------------------------------------------
+# gcd(a, b)
+# -----------------------------------------------------------------------------
+
+test gcd-basic {
+    SELECT gcd(12, 8);
+    SELECT gcd(0, 7);
+    SELECT gcd(7, 0);
+    SELECT gcd(0, 0);
+}
+expect {
+    4
+    7
+    7
+    0
+}
+
+test gcd-negative-operands {
+    SELECT gcd(-12, 8);
+    SELECT gcd(-12, -8);
+    SELECT gcd(12, -8);
+}
+expect {
+    4
+    4
+    4
+}
+
+test gcd-null {
+    SELECT gcd(NULL, 5) IS NULL;
+    SELECT gcd(5, NULL) IS NULL;
+    SELECT gcd(NULL, NULL) IS NULL;
+}
+expect {
+    1
+    1
+    1
+}
+
+# -----------------------------------------------------------------------------
+# lcm(a, b)
+# -----------------------------------------------------------------------------
+
+test lcm-basic {
+    SELECT lcm(4, 6);
+    SELECT lcm(2, 3);
+    SELECT lcm(0, 5);
+    SELECT lcm(5, 0);
+}
+expect {
+    12
+    6
+    0
+    0
+}
+
+test lcm-negative-operands {
+    SELECT lcm(-4, 6);
+    SELECT lcm(-4, -6);
+}
+expect {
+    12
+    12
+}
+
+test lcm-null {
+    SELECT lcm(NULL, 5) IS NULL;
+    SELECT lcm(5, NULL) IS NULL;
+}
+expect {
+    1
+    1
+}
+
+# -----------------------------------------------------------------------------
+# repeat(string, n)
+# -----------------------------------------------------------------------------
+
+test repeat-basic {
+    SELECT repeat('ab', 3);
+    SELECT repeat('x', 0);
+    SELECT repeat('x', -1);
+    SELECT repeat('', 5);
+}
+expect {
+    ababab
+
+
+
+}
+
+test repeat-null {
+    SELECT repeat(NULL, 3) IS NULL;
+    SELECT repeat('x', NULL) IS NULL;
+}
+expect {
+    1
+    1
+}
+
+# -----------------------------------------------------------------------------
+# lpad / rpad
+# -----------------------------------------------------------------------------
+
+test lpad-default-fill {
+    SELECT '|' || lpad('abc', 6) || '|';
+}
+expect {
+    |   abc|
+}
+
+test lpad-custom-fill {
+    SELECT '|' || lpad('abc', 6, 'xy') || '|';
+}
+expect {
+    |xyxabc|
+}
+
+test rpad-default-fill {
+    SELECT '|' || rpad('abc', 6) || '|';
+}
+expect {
+    |abc   |
+}
+
+test rpad-custom-fill {
+    SELECT '|' || rpad('abc', 6, 'xy') || '|';
+}
+expect {
+    |abcxyx|
+}
+
+test pad-truncates-when-too-long {
+    SELECT lpad('abcdef', 3);
+    SELECT rpad('abcdef', 3);
+}
+expect {
+    abc
+    abc
+}
+
+test pad-empty-fill-returns-input {
+    SELECT lpad('abc', 10, '');
+    SELECT rpad('abc', 10, '');
+}
+expect {
+    abc
+    abc
+}
+
+test pad-zero-length-returns-empty {
+    SELECT lpad('abc', 0);
+    SELECT rpad('abc', 0);
+}
+expect {
+
+
+}

--- a/tests/integration/statement_metadata.rs
+++ b/tests/integration/statement_metadata.rs
@@ -1,14 +1,21 @@
-//! Tests for Turso-specific statement result-column metadata APIs.
+//! Tests for Turso-specific statement result-column metadata APIs and
+//! function-name aliases.
 //!
-//! `Statement::get_column_type_info` is one entry point for "what is the type
-//! of this column?", covering both direct table-column references (declared
-//! name, array depth, custom-type kind, resolved primitive) and computed
-//! expressions (inferred affinity primitive). Gated behind the experimental
-//! custom-types feature.
+//! Two pieces of public surface bundled because they share the same testing
+//! pattern: prepare a statement, inspect column metadata or invoke aliased
+//! functions, assert the result.
+//!
+//! - `Statement::get_column_type_info`: one entry point for "what is the type
+//!   of this column?", covering both direct table-column references (declared
+//!   name, array depth, custom-type kind, resolved primitive) and computed
+//!   expressions (inferred affinity primitive). Gated behind the experimental
+//!   custom-types feature.
+//! - Function-name aliases: `chr` resolves to the same scalar function as
+//!   `char`, and `strpos` resolves to the same scalar function as `instr`.
 
 #[cfg(test)]
 mod tests {
-    use crate::common::TempDatabase;
+    use crate::common::{ExecRows, TempDatabase};
     use tempfile::TempDir;
     use turso_core::{ColumnTypeInfo, ColumnTypeKind, Statement};
 
@@ -361,5 +368,98 @@ mod tests {
         assert_eq!(b_info.declared_name, "INTEGER");
         assert_eq!(b_info.array_dimensions, 0);
         assert_eq!(b_info.kind, ColumnTypeKind::Builtin);
+    }
+
+    /// `chr(n)` is the SQL standard / PostgreSQL spelling of SQLite's
+    /// `char(n)`. Both must produce identical results.
+    #[test]
+    fn chr_alias_matches_char() {
+        let db = TempDatabase::new_empty();
+        let conn = db.connect_limbo();
+
+        let via_char: Vec<(String,)> = conn.exec_rows("SELECT char(65, 66, 67)");
+        let via_chr: Vec<(String,)> = conn.exec_rows("SELECT chr(65, 66, 67)");
+
+        assert_eq!(via_char, vec![("ABC".to_string(),)]);
+        assert_eq!(via_chr, vec![("ABC".to_string(),)]);
+    }
+
+    /// `strpos(haystack, needle)` is the PostgreSQL spelling of SQLite's
+    /// `instr(haystack, needle)`. Argument order is identical, so the alias
+    /// is unambiguous.
+    #[test]
+    fn strpos_alias_matches_instr() {
+        let db = TempDatabase::new_empty();
+        let conn = db.connect_limbo();
+
+        let via_instr: Vec<(i64,)> = conn.exec_rows("SELECT instr('hello world', 'world')");
+        let via_strpos: Vec<(i64,)> = conn.exec_rows("SELECT strpos('hello world', 'world')");
+        assert_eq!(via_instr, vec![(7,)]);
+        assert_eq!(via_strpos, vec![(7,)]);
+
+        // Needle not found → 0 from both spellings.
+        let miss_instr: Vec<(i64,)> = conn.exec_rows("SELECT instr('hello', 'xyz')");
+        let miss_strpos: Vec<(i64,)> = conn.exec_rows("SELECT strpos('hello', 'xyz')");
+        assert_eq!(miss_instr, vec![(0,)]);
+        assert_eq!(miss_strpos, vec![(0,)]);
+    }
+
+    /// `btrim(X[, chars])` is the PG/Oracle spelling of SQLite's
+    /// `trim(X[, chars])`. Both trim the listed characters (or whitespace by
+    /// default) from both sides of the string with identical semantics.
+    #[test]
+    fn btrim_alias_matches_trim() {
+        let db = TempDatabase::new_empty();
+        let conn = db.connect_limbo();
+
+        // Default: trim whitespace.
+        let trim_ws: Vec<(String,)> = conn.exec_rows("SELECT trim('  hello  ')");
+        let btrim_ws: Vec<(String,)> = conn.exec_rows("SELECT btrim('  hello  ')");
+        assert_eq!(trim_ws, vec![("hello".to_string(),)]);
+        assert_eq!(btrim_ws, vec![("hello".to_string(),)]);
+
+        // Explicit character set.
+        let trim_x: Vec<(String,)> = conn.exec_rows("SELECT trim('xxhelloxx', 'x')");
+        let btrim_x: Vec<(String,)> = conn.exec_rows("SELECT btrim('xxhelloxx', 'x')");
+        assert_eq!(trim_x, vec![("hello".to_string(),)]);
+        assert_eq!(btrim_x, vec![("hello".to_string(),)]);
+    }
+
+    /// `char_length(X)` and `character_length(X)` are the SQL standard
+    /// spellings of SQLite's `length(X)`. All three return the character
+    /// count for TEXT input.
+    #[test]
+    fn char_length_aliases_match_length() {
+        let db = TempDatabase::new_empty();
+        let conn = db.connect_limbo();
+
+        let via_length: Vec<(i64,)> = conn.exec_rows("SELECT length('hello world')");
+        let via_char_length: Vec<(i64,)> = conn.exec_rows("SELECT char_length('hello world')");
+        let via_character_length: Vec<(i64,)> =
+            conn.exec_rows("SELECT character_length('hello world')");
+
+        assert_eq!(via_length, vec![(11,)]);
+        assert_eq!(via_char_length, vec![(11,)]);
+        assert_eq!(via_character_length, vec![(11,)]);
+
+        // Multi-byte input: SQLite reports character count, not byte count.
+        let via_length_unicode: Vec<(i64,)> = conn.exec_rows("SELECT length('héllo')");
+        let via_char_length_unicode: Vec<(i64,)> = conn.exec_rows("SELECT char_length('héllo')");
+        assert_eq!(via_length_unicode, vec![(5,)]);
+        assert_eq!(via_char_length_unicode, vec![(5,)]);
+    }
+
+    /// `reverse(X)` is the spelling PG, MySQL, and Oracle all use; upstream
+    /// Turso registered the function under the more explicit `string_reverse`
+    /// name. Both must produce identical results.
+    #[test]
+    fn reverse_alias_matches_string_reverse() {
+        let db = TempDatabase::new_empty();
+        let conn = db.connect_limbo();
+
+        let via_string_reverse: Vec<(String,)> = conn.exec_rows("SELECT string_reverse('hello')");
+        let via_reverse: Vec<(String,)> = conn.exec_rows("SELECT reverse('hello')");
+        assert_eq!(via_string_reverse, vec![("olleh".to_string(),)]);
+        assert_eq!(via_reverse, vec![("olleh".to_string(),)]);
     }
 }


### PR DESCRIPTION
## Summary

Five commits adding scalar functions and PostgreSQL-compatible parity that SQLite does not ship with, plus one fix to an existing `array_length` corner case and one to the built-in `time`/`timestamp` ENCODE expressions.

- **core/function: expose SQLite functions under PG-compatible names** — `chr`, `strpos`, `btrim`, `char_length`, `character_length`, `reverse` resolve to existing Turso scalar implementations. Pure resolver-level name routing; no new `ScalarFunc` variants. `position(... IN ...)` and `array_upper(arr, dim)` are deliberately left out (would need parser support / would silently misbehave for multi-dim arrays respectively).
- **core/vdbe/array: honor dimension argument in array_length, add array_upper** — `array_length(arr, dim)` parsed-accepted the 2-arg form but the exec arm ignored `dim` and always returned the outermost element count, so `array_length(matrix, 2)` was indistinguishable from `array_length(matrix, 1)`. Adds a `compute_array_length_at_dim` walker over the uniform-shape nested layout and wires up `array_upper` (Turso arrays are always 1-indexed, so equal to `array_length` for valid dims).
- **core/functions: add gcd, lcm, repeat, lpad, rpad** — Five new first-class `ScalarFunc` variants in two new modules (`core/functions/math.rs` and `core/functions/string.rs`). PG semantics: i64 overflow propagates `LimboError::IntegerOverflow`, `gcd` is always non-negative, `repeat` with `count <= 0` returns empty string, `lpad`/`rpad` target length is in characters (multibyte-safe) and over-length input is right-truncated.
- **schema: canonicalise time/timestamp sub-second to PG text format** — The built-in `time` / `timestamp` custom types' ENCODE expressions used `time(value)` / `datetime(value)`, which strip fractional seconds outright. Inserting `'14:30:00.789'` into a `time`-typed STRICT column silently stored `'14:30:00'`. Switches ENCODE to `rtrim(rtrim(strftime('%H:%M:%f', value), '0'), '.')` (and the same for timestamp), matching PostgreSQL's text format for 1-3 fractional digits and trailing-zero handling. Turso's `%f` directive caps at milliseconds, so PG's microsecond inputs are clamped (`'14:30:00.123456'` stores as `'14:30:00.123'`) — documented as a known divergence; lifting it requires widening internal `i_jd` from ms to µs, separate change.
- **docs/sql-reference: document new functions and PG aliases** — Adds reference entries to `math.mdx`, `array.mdx`, `scalar.mdx` for the new functions, the now-honored `array_length` dim argument, and the aliases above.

## Test plan

- [ ] `cargo test -p turso_core` passes
- [ ] `cargo test --test integration` passes (covers the new `statement_metadata.rs` cases that lock in the aliases side-by-side with their canonical forms)
- [ ] `make -C testing/sqltests run-rust ARGS='--snapshot-filter array'` passes (new array_length / array_upper cases)
- [ ] `make -C testing/sqltests run-rust ARGS='--snapshot-filter gcd_lcm_repeat_pad'` passes
- [ ] `make -C testing/sqltests run-rust ARGS='--snapshot-filter custom_type_datetime_validation'` passes (time/timestamp ENCODE)
- [ ] `cargo clippy --workspace --all-features --all-targets -- --deny=warnings` clean
- [ ] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)