### PR TITLE
mvcc: decouple GC from checkpointing and make configurable

### DIFF
--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -112,7 +112,6 @@ cargo run --release -p memory-benchmark -- \
   -b <batch-size> \
   --connections <N> \
   --checkpoint \
-  --mvcc-checkpoint-threshold <bytes> \
   --timeout <ms> \
   --cache-size <pages> \
   --mvcc-checkpoint-threshold <bytes>   # MVCC only; -1 disables auto-checkpoint

--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -107,7 +107,7 @@ cargo run --release -p memory-benchmark -- --mode mvcc --workload insert-heavy -
 # All CLI options
 cargo run --release -p memory-benchmark -- \
   --mode wal|mvcc \
-  --workload insert-heavy|read-heavy|mixed|scan-heavy|series-blob \
+  --workload insert-heavy|read-heavy|mixed|scan-heavy|series-blob|update-churn \
   -i <iterations> \
   -b <batch-size> \
   --connections <N> \
@@ -115,8 +115,16 @@ cargo run --release -p memory-benchmark -- \
   --mvcc-checkpoint-threshold <bytes> \
   --timeout <ms> \
   --cache-size <pages> \
+  --mvcc-checkpoint-threshold <bytes>   # MVCC only; -1 disables auto-checkpoint
+  --mvcc-gc-threshold <versions>        # MVCC only; -1 disables inline GC
   --format human|json|csv
 ```
+
+The two `--mvcc-*-threshold` flags set the corresponding PRAGMAs on the shared
+mv_store before the run. They are the knobs for isolating MVCC GC behavior:
+disable the checkpoint (`--mvcc-checkpoint-threshold=-1`) so the only
+reclamation is inline GC, then A/B the GC threshold (e.g. `-1` off vs `16384`
+default vs a smaller, more aggressive value) on the `update-churn` workload.
 
 Every run produces a `dhat-heap.json` in the current directory. This file contains per-allocation-site data for the entire run.
 
@@ -129,6 +137,7 @@ Every run produces a `dhat-heap.json` in the current directory. This file contai
 | `mixed` | 50% SELECT / 50% INSERT | Seeds 10k rows |
 | `scan-heavy` | Full table scans with LIKE | Seeds 10k rows |
 | `series-blob` | `INSERT INTO bench(data) SELECT zeroblob(2048) FROM generate_series(1, ?)` | Creates `bench`; `batch-size` is the series length |
+| `update-churn` | Repeated UPDATEs to a fixed 10k-row set (key space partitioned per connection to avoid write-write conflicts) | Seeds 10k rows. Generates superseded versions — the MVCC GC accumulation case. |
 
 Profiles implement the `Profile` trait in `perf/memory/src/profile/`. To add a new workload, create a new file implementing the trait and wire it into the `WorkloadProfile` enum in `main.rs`.
 

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -4456,6 +4456,24 @@ impl Connection {
             None => Err(LimboError::InternalError("MVCC not enabled".into())),
         }
     }
+
+    pub(crate) fn set_mvcc_gc_threshold(&self, threshold: i64) -> Result<()> {
+        match self.db.get_mv_store().as_ref() {
+            Some(mv_store) => {
+                mv_store.set_gc_threshold(threshold);
+                self.bump_prepare_context_generation();
+                Ok(())
+            }
+            None => Err(LimboError::InternalError("MVCC not enabled".into())),
+        }
+    }
+
+    pub(crate) fn mvcc_gc_threshold(&self) -> Result<i64> {
+        match self.db.get_mv_store().as_ref() {
+            Some(mv_store) => Ok(mv_store.gc_threshold()),
+            None => Err(LimboError::InternalError("MVCC not enabled".into())),
+        }
+    }
 }
 
 pub type Row = vdbe::Row;

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3796,14 +3796,14 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// purge). This is a *heuristic* used only to decide when to run an
     /// incremental GC pass (`should_gc`) — never a correctness input. Aborted
     /// versions are left counted until GC reclaims them (they still occupy
-    /// memory). See [`Self::live_version_count`].
-    live_version_count: AtomicUsize,
-    /// Snapshot of `live_version_count` taken at the end of the last
+    /// memory). See [`Self::live_version_count_approx`].
+    live_version_count_approx: AtomicUsize,
+    /// Snapshot of `live_version_count_approx` taken at the end of the last
     /// `gc_incremental` pass. `should_gc` fires once growth since this snapshot
     /// crosses `gc_version_threshold`, giving a roughly fixed GC cadence per N
     /// new versions regardless of how many a single pass reclaims.
     live_versions_at_last_gc: AtomicUsize,
-    /// Growth in `live_version_count` (number of newly inserted versions since
+    /// Growth in `live_version_count_approx` (number of newly inserted versions since
     /// the last GC pass) that triggers an incremental GC pass on the commit
     /// path. Negative disables inline GC entirely. Configurable via the
     /// `mvcc_gc_threshold` PRAGMA; mirrors `checkpoint_threshold`.
@@ -3828,6 +3828,17 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// inline pass runs at a time; a committer that loses the race simply skips
     /// GC for that commit.
     gc_in_progress: AtomicBool,
+    /// LWM observed by the last inline GC pass that actually ran. When a
+    /// long-running transaction pins the LWM, re-scanning at the same LWM
+    /// reclaims nothing new — any version superseded since then has
+    /// `end_ts > LWM` (the pinning txn is older) and stays visible. So an inline
+    /// pass short-circuits when the LWM hasn't advanced, avoiding wasted scans
+    /// while a long txn is open. `u64::MAX` means "no pass has run yet" and also
+    /// the no-active-txn state, which never short-circuits (there is always
+    /// potential garbage to reclaim then). Aborted garbage and post-checkpoint
+    /// sole-survivors that a skipped pass leaves behind are still collected by
+    /// the checkpoint's full sweep.
+    gc_last_lwm: AtomicU64,
 }
 
 impl<Clock: LogicalClock> MvStore<Clock> {
@@ -3920,12 +3931,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             table_id_to_last_rowid: RwLock::new(HashMap::default()),
             sequence_watermarks: Mutex::new(HashMap::default()),
             sequence_allocations: Mutex::new(HashMap::default()),
-            live_version_count: AtomicUsize::new(0),
+            live_version_count_approx: AtomicUsize::new(0),
             live_versions_at_last_gc: AtomicUsize::new(0),
             gc_version_threshold: AtomicI64::new(Self::DEFAULT_GC_VERSION_THRESHOLD),
             gc_table_cursor: Mutex::new(None),
             gc_index_cursor: Mutex::new(None),
             gc_in_progress: AtomicBool::new(false),
+            gc_last_lwm: AtomicU64::new(u64::MAX),
         }
     }
 
@@ -5326,13 +5338,26 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         };
         let tx_id = maybe_existing_tx_id.unwrap_or_else(|| self.get_tx_id());
         let begin_ts = if let Some(tx_id) = maybe_existing_tx_id {
+            // Upgrade path: the transaction is already published in `txs`
+            // (from begin_tx), so it is already visible to compute_lwm().
             self.txs
                 .get(&tx_id)
                 .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?
                 .value()
                 .begin_ts
         } else {
-            self.get_begin_timestamp()
+            // Fresh path: publish the transaction into `txs` atomically with
+            // begin_ts allocation, under the clock lock — same begin-publish
+            // window fix as begin_tx(). Without this, inline GC on a concurrent
+            // committer's commit path could compute an LWM above our begin_ts
+            // and reclaim a version this snapshot still needs. The header read
+            // (possibly blocking I/O) happens before the clock lock is taken;
+            // the error paths below remove this tx if begin fails. The real
+            // header is set here, so the tail only flips `pager_commit_lock_held`.
+            let header = self.get_new_transaction_database_header(&pager);
+            self.clock.get_timestamp(|ts| {
+                self.txs.insert(tx_id, Transaction::new(tx_id, ts, header));
+            })
         };
         #[cfg(any(test, injected_yields))]
         let exclusive_yield_context = YieldContext::new(
@@ -5349,7 +5374,15 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         let already_exclusive = self.is_exclusive_tx(&tx_id);
         if !already_exclusive {
             self.acquire_exclusive_tx(&tx_id, exclusive_yield_context)
-                .inspect_err(|_| unlock_checkpoint_guard())?;
+                .inspect_err(|_| {
+                    // Fresh txns were already published into `txs` above; undo
+                    // that so a failed begin doesn't leave a phantom Active txn
+                    // pinning the LWM forever.
+                    if maybe_existing_tx_id.is_none() {
+                        self.txs.remove(&tx_id);
+                    }
+                    unlock_checkpoint_guard();
+                })?;
         }
 
         // Hoist: validate the existing tx still exists and snapshot the
@@ -5376,6 +5409,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     "begin_exclusive_tx: tx_id={} failed with Busy on pager_commit_lock",
                     tx_id
                 );
+                if maybe_existing_tx_id.is_none() {
+                    self.txs.remove(&tx_id);
+                }
                 if !already_exclusive {
                     self.release_exclusive_tx(&tx_id);
                 }
@@ -5384,9 +5420,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             }
         }
 
-        let header = self.get_new_transaction_database_header(&pager);
-
         if let Some(existing_tx_id) = maybe_existing_tx_id {
+            // Upgrade path: read the (possibly blocking) header now that all
+            // locks are held, then apply it to the already-published txn.
+            let header = self.get_new_transaction_database_header(&pager);
             // Re-fetch the Ref now that all blocking I/O is done. If the tx
             // vanished between the earlier validation and now (extraordinarily
             // narrow window — only checkpoint can remove a tx and it cannot
@@ -5414,15 +5451,22 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             return Ok(tx_id);
         }
 
-        let tx = Transaction::new(tx_id, begin_ts, header);
-        tx.pager_commit_lock_held.store(true, Ordering::Release);
+        // Fresh path: the transaction (with its header) was already published
+        // into `txs` under the clock lock during begin_ts allocation. Now that
+        // we hold the commit lock, just record that.
+        let tx = self
+            .txs
+            .get(&tx_id)
+            .expect("fresh exclusive tx was published during begin_ts allocation");
+        tx.value()
+            .pager_commit_lock_held
+            .store(true, Ordering::Release);
         tracing::trace!(
             "begin_exclusive_tx(tx_id={}, begin_ts={}) - exclusive write logical log transaction",
             tx_id,
             begin_ts
         );
         tracing::debug!("begin_exclusive_tx: tx_id={} succeeded", tx_id);
-        self.txs.insert(tx_id, tx);
         Ok(tx_id)
     }
 
@@ -5437,13 +5481,25 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             return Err(LimboError::Busy);
         }
         let tx_id = self.get_tx_id();
-        let begin_ts = self.get_begin_timestamp();
 
-        // Set txn's header to the global header
+        // Set txn's header to the global header. Do the (possibly blocking)
+        // header read BEFORE taking the clock lock below.
         let header = self.get_new_transaction_database_header(&pager);
-        let tx = Transaction::new(tx_id, begin_ts, header);
+
+        // Allocate begin_ts and publish the transaction into `txs` atomically
+        // under the clock lock. This closes the "begin-publish window": between
+        // allocating a snapshot timestamp and inserting into `txs`, the txn is
+        // invisible to `compute_lwm`. Inline GC runs on the commit path holding
+        // only `blocking_checkpoint_lock.read()` (same as us), so a writer that
+        // commits in that window could compute an LWM above our begin_ts and
+        // reclaim a version this snapshot still needs — a snapshot-isolation
+        // violation. Publishing under the clock lock orders us strictly before
+        // or after any commit timestamp (commits also take the clock lock), so
+        // any GC that runs after a later commit already sees our begin_ts.
+        let begin_ts = self.clock.get_timestamp(|ts| {
+            self.txs.insert(tx_id, Transaction::new(tx_id, ts, header));
+        });
         tracing::trace!("begin_tx(tx_id={}, begin_ts={})", tx_id, begin_ts);
-        self.txs.insert(tx_id, tx);
 
         Ok(tx_id)
     }
@@ -5953,7 +6009,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 let mut versions = entry.value().write();
                 let before = versions.len();
                 versions.retain(|rv| rv.id != version_id);
-                self.dec_live_version_count(before - versions.len());
+                self.dec_live_version_count_approx(before - versions.len());
                 tracing::debug!(
                     "rollback_savepoint: removed table version(table_id={}, row_id={}, version_id={})",
                     rowid.table_id,
@@ -5969,7 +6025,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     let mut versions = entry.value().write();
                     let before = versions.len();
                     versions.retain(|rv| rv.id != version_id);
-                    self.dec_live_version_count(before - versions.len());
+                    self.dec_live_version_count_approx(before - versions.len());
                     tracing::debug!(
                         "rollback_savepoint: removed index version(table_id={}, version_id={})",
                         table_id,
@@ -6244,22 +6300,22 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     pub const MAX_CHAINS_PER_GC: usize = 4096;
 
     /// Current approximate live row-version count. Heuristic only (see the
-    /// `live_version_count` field) — never use for correctness decisions.
-    pub fn live_version_count(&self) -> usize {
-        self.live_version_count.load(Ordering::Relaxed)
+    /// `live_version_count_approx` field) — never use for correctness decisions.
+    pub fn live_version_count_approx(&self) -> usize {
+        self.live_version_count_approx.load(Ordering::Relaxed)
     }
 
     /// Saturating decrement of the live-version heuristic. The counter is
     /// approximate, so clamp at zero rather than risk an underflow wrap that
     /// would make `should_gc` fire on every commit.
-    fn dec_live_version_count(&self, n: usize) {
+    fn dec_live_version_count_approx(&self, n: usize) {
         if n == 0 {
             return;
         }
-        let mut current = self.live_version_count.load(Ordering::Relaxed);
+        let mut current = self.live_version_count_approx.load(Ordering::Relaxed);
         loop {
             let next = current.saturating_sub(n);
-            match self.live_version_count.compare_exchange_weak(
+            match self.live_version_count_approx.compare_exchange_weak(
                 current,
                 next,
                 Ordering::Relaxed,
@@ -6284,14 +6340,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     }
 
     /// Whether an incremental GC pass should run now: inline GC is enabled
-    /// (threshold >= 0) and `live_version_count` has grown past the threshold
+    /// (threshold >= 0) and `live_version_count_approx` has grown past the threshold
     /// since the last pass. Heuristic — drift only changes GC frequency.
     pub fn should_gc(&self) -> bool {
         let threshold = self.gc_version_threshold.load(Ordering::Relaxed);
         if threshold < 0 {
             return false;
         }
-        let current = self.live_version_count.load(Ordering::Relaxed);
+        let current = self.live_version_count_approx.load(Ordering::Relaxed);
         let at_last = self.live_versions_at_last_gc.load(Ordering::Relaxed);
         current.saturating_sub(at_last) >= threshold as usize
     }
@@ -6322,8 +6378,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Reclaims invisible versions (same rules as `gc_version_chain`) from up
     /// to `max_chains` table-row chains, resuming from where the previous pass
     /// stopped (`gc_table_cursor`) so repeated calls eventually cover the whole
-    /// `rows` map without scanning it all at once. Returns the number of
-    /// versions reclaimed.
+    /// `rows` map without scanning it all at once.
     ///
     /// Safety / design notes:
     /// - **Lazy mode only.** Empty SkipMap slots are left in place (no
@@ -6357,6 +6412,22 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         let _gate = GcGate(&self.gc_in_progress);
 
         let lwm = self.compute_lwm();
+
+        // Short-circuit when a long-running transaction has pinned the LWM at
+        // the same value since the last pass: nothing newly reclaimable can
+        // exist below it (any version superseded since then ends above the
+        // pinning txn's begin_ts). `u64::MAX` (no active txns) never
+        // short-circuits — that is exactly when the most is reclaimable. Reset
+        // the trigger baseline so `should_gc` doesn't spin on every commit
+        // while the LWM is stuck.
+        if lwm != u64::MAX && lwm == self.gc_last_lwm.load(Ordering::Relaxed) {
+            self.live_versions_at_last_gc.store(
+                self.live_version_count_approx.load(Ordering::Relaxed),
+                Ordering::Relaxed,
+            );
+            return 0;
+        }
+
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
 
         let mut dropped = 0;
@@ -6390,17 +6461,28 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         // single huge index can't force an unbounded pass.
         dropped += self.gc_index_incremental(lwm, ckpt_max, max_chains);
 
-        self.dec_live_version_count(dropped);
+        self.dec_live_version_count_approx(dropped);
         // Reset the trigger baseline so `should_gc` measures growth from here.
         self.live_versions_at_last_gc.store(
-            self.live_version_count.load(Ordering::Relaxed),
+            self.live_version_count_approx.load(Ordering::Relaxed),
             Ordering::Relaxed,
         );
+
+        // Record the LWM only once a full cycle (both cursors wrapped back to
+        // the start) has completed at this LWM, so the short-circuit above
+        // never skips chains we haven't yet swept at the current LWM. Until the
+        // cycle finishes, leave `gc_last_lwm` unchanged so subsequent passes
+        // keep scanning.
+        let full_cycle =
+            self.gc_table_cursor.lock().is_none() && self.gc_index_cursor.lock().is_none();
+        if full_cycle {
+            self.gc_last_lwm.store(lwm, Ordering::Relaxed);
+        }
 
         if dropped > 0 {
             tracing::trace!(
                 "gc_incremental: reclaimed {dropped} versions ({processed} table chains, table_wrapped={table_wrapped}), live~{}",
-                self.live_version_count.load(Ordering::Relaxed)
+                self.live_version_count_approx.load(Ordering::Relaxed)
             );
         }
         dropped
@@ -6472,7 +6554,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     &mut referenced_tx_ids,
                     remove_empty_slots,
                 );
-        self.dec_live_version_count(dropped);
+        self.dec_live_version_count_approx(dropped);
         let pruned_finalized = self.prune_finalized_tx_states(&referenced_tx_ids);
 
         tracing::trace!(
@@ -6763,7 +6845,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         versions.insert(position, row_version);
         // A genuine insert (the collapse branch above `return`s without
         // reaching here). Track it for the GC trigger heuristic.
-        self.live_version_count.fetch_add(1, Ordering::Relaxed);
+        self.live_version_count_approx
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn write_row_to_pager(
@@ -6816,7 +6899,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     pub fn purge_row_versions_during_checkpoint(&self, rowid: RowID) {
         if let Some(entry) = self.rows.get(&rowid) {
             let mut versions = entry.value().write();
-            self.dec_live_version_count(versions.len());
+            self.dec_live_version_count_approx(versions.len());
             versions.clear();
             Self::shrink_version_chain_allocation(&mut versions);
         }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -6390,6 +6390,19 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     ///   the *complete* referenced-txid set across all chains, which a partial
     ///   sweep cannot produce. The checkpoint path still prunes it.
     pub fn gc_incremental(&self, max_chains: usize) -> usize {
+        // Hold the checkpoint read lock for the whole pass so a stop-the-world
+        // checkpoint cannot run concurrently.
+        if !self.blocking_checkpoint_lock.read() {
+            return 0;
+        }
+        struct CheckpointReadGuard<'a>(&'a TursoRwLock);
+        impl Drop for CheckpointReadGuard<'_> {
+            fn drop(&mut self) {
+                self.0.unlock();
+            }
+        }
+        let _ckpt_guard = CheckpointReadGuard(&self.blocking_checkpoint_lock);
+
         // Single-flight: only one inline GC pass runs at a time across all
         // connections (see `gc_in_progress`). Losing the race is a no-op — the
         // growth that triggered this commit's `should_gc` will retrigger soon,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3813,6 +3813,21 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// sweep from the beginning of `rows` (and marks the point where index
     /// chains are swept — see `gc_incremental`).
     gc_table_cursor: Mutex<Option<RowID>>,
+    /// Resume cursor for the incremental index-row GC sweep: the last
+    /// `(index id, key)` processed by the previous `gc_incremental` pass.
+    /// `None` restarts from the beginning of `index_rows`. Mirrors
+    /// `gc_table_cursor` but over the nested `index_rows` maps, so a single
+    /// huge index can't force an unbounded pass.
+    gc_index_cursor: Mutex<Option<(MVTableId, Arc<SortableIndexKey>)>>,
+    /// Single-flight gate for inline GC. Many connections commit concurrently
+    /// (each shares this `MvStore`), and the commit path calls
+    /// `gc_incremental` without holding any global lock — so without this gate
+    /// several threads would run overlapping GC passes at once. That is *safe*
+    /// (per-chain write locks + idempotent reclamation) but wasteful: redundant
+    /// scans plus thrashing of `gc_table_cursor`. This flag ensures at most one
+    /// inline pass runs at a time; a committer that loses the race simply skips
+    /// GC for that commit.
+    gc_in_progress: AtomicBool,
 }
 
 impl<Clock: LogicalClock> MvStore<Clock> {
@@ -3909,6 +3924,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             live_versions_at_last_gc: AtomicUsize::new(0),
             gc_version_threshold: AtomicI64::new(Self::DEFAULT_GC_VERSION_THRESHOLD),
             gc_table_cursor: Mutex::new(None),
+            gc_index_cursor: Mutex::new(None),
+            gc_in_progress: AtomicBool::new(false),
         }
     }
 
@@ -6314,17 +6331,31 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     ///   races no concurrent `get_or_insert_with` (see the TOCTOU note in
     ///   `gc_table_row_versions`). Physical slot removal stays exclusive to the
     ///   checkpoint's `_and_slots` sweep.
-    /// - **No I/O.** Pure in-memory chain reclamation under each chain's write
-    ///   lock; no `Completion`/yield machinery needed.
-    /// - **Index chains** are swept in full once per *full table-cursor cycle*
-    ///   (when the table sweep wraps back to the start). They are typically far
-    ///   fewer than table-row chains, so a periodic full sweep keeps per-pass
-    ///   cost bounded in the common case. This can be made incrementally
-    ///   resumable later if index counts grow large.
     /// - `finalized_tx_states` pruning is intentionally skipped here: it needs
     ///   the *complete* referenced-txid set across all chains, which a partial
     ///   sweep cannot produce. The checkpoint path still prunes it.
     pub fn gc_incremental(&self, max_chains: usize) -> usize {
+        // Single-flight: only one inline GC pass runs at a time across all
+        // connections (see `gc_in_progress`). Losing the race is a no-op — the
+        // growth that triggered this commit's `should_gc` will retrigger soon,
+        // or the in-flight pass already covers the same chains. The RAII guard
+        // releases the gate even if the body panics, so a stuck flag can never
+        // wedge GC for the lifetime of the store.
+        if self
+            .gc_in_progress
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return 0;
+        }
+        struct GcGate<'a>(&'a AtomicBool);
+        impl Drop for GcGate<'_> {
+            fn drop(&mut self) {
+                self.0.store(false, Ordering::Release);
+            }
+        }
+        let _gate = GcGate(&self.gc_in_progress);
+
         let lwm = self.compute_lwm();
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
 
@@ -6351,16 +6382,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
         // If we processed fewer chains than the budget, the range was
         // exhausted — wrap the cursor to the start for the next pass.
-        let wrapped = processed < max_chains;
-        *self.gc_table_cursor.lock() = if wrapped { None } else { last_key };
+        let table_wrapped = processed < max_chains;
+        *self.gc_table_cursor.lock() = if table_wrapped { None } else { last_key };
 
-        // Sweep index chains once per full table-cursor cycle to bound the
-        // per-pass cost (see the doc comment). A throwaway referenced-txid set
-        // is collected and discarded — we do not prune finalized states here.
-        if wrapped {
-            let mut referenced_tx_ids = HashSet::default();
-            dropped += self.gc_index_row_versions(lwm, ckpt_max, &mut referenced_tx_ids, false);
-        }
+        // Sweep index chains with their own bounded, resumable budget (see
+        // `gc_index_incremental`). Each map has an independent cursor so a
+        // single huge index can't force an unbounded pass.
+        dropped += self.gc_index_incremental(lwm, ckpt_max, max_chains);
 
         self.dec_live_version_count(dropped);
         // Reset the trigger baseline so `should_gc` measures growth from here.
@@ -6371,10 +6399,63 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
         if dropped > 0 {
             tracing::trace!(
-                "gc_incremental: reclaimed {dropped} versions across {processed} chains (wrapped={wrapped}), live~{}",
+                "gc_incremental: reclaimed {dropped} versions ({processed} table chains, table_wrapped={table_wrapped}), live~{}",
                 self.live_version_count.load(Ordering::Relaxed)
             );
         }
+        dropped
+    }
+
+    /// Resumable index-chain GC: the index-map counterpart to the table sweep
+    /// in [`Self::gc_incremental`]. Applies `gc_version_chain` to up to
+    /// `max_chains` index version chains, resuming strictly after the
+    /// `(index id, key)` the previous pass stopped at (`gc_index_cursor`) and
+    /// wrapping to the start when the nested maps are exhausted. Lazy mode: it
+    /// never removes empty slots (no blocking lock), exactly like the table
+    /// sweep. Returns the number of versions reclaimed.
+    ///
+    /// `index_rows` is nested (`MVTableId -> key -> chain`), so the cursor is a
+    /// `(MVTableId, key)` pair: the outer scan resumes at the saved index id
+    /// (inclusive, to finish its remaining keys) and the inner scan resumes
+    /// after the saved key; later indexes start from their first key.
+    fn gc_index_incremental(&self, lwm: u64, ckpt_max: u64, max_chains: usize) -> usize {
+        let mut dropped = 0;
+        let mut processed = 0;
+        let mut last: Option<(MVTableId, Arc<SortableIndexKey>)> = None;
+
+        let cursor = self.gc_index_cursor.lock().clone();
+        let outer_start = match &cursor {
+            Some((index_id, _)) => Bound::Included(*index_id),
+            None => Bound::Unbounded,
+        };
+        'outer: for outer in self.index_rows.range((outer_start, Bound::Unbounded)) {
+            if processed >= max_chains {
+                break;
+            }
+            let index_id = *outer.key();
+            let inner = outer.value();
+            // Resume after the saved key only within the index that the cursor
+            // pointed into; every later index starts from its first key.
+            let inner_start = match &cursor {
+                Some((cursor_id, key)) if *cursor_id == index_id => Bound::Excluded(key.clone()),
+                _ => Bound::Unbounded,
+            };
+            for inner_entry in inner.range((inner_start, Bound::Unbounded)) {
+                if processed >= max_chains {
+                    break 'outer;
+                }
+                {
+                    let mut versions = inner_entry.value().write();
+                    dropped += Self::gc_version_chain(&mut versions, lwm, ckpt_max);
+                }
+                last = Some((index_id, inner_entry.key().clone()));
+                processed += 1;
+            }
+        }
+
+        // Fewer chains than the budget => nested maps exhausted; wrap to start.
+        let wrapped = processed < max_chains;
+        *self.gc_index_cursor.lock() = if wrapped { None } else { last };
         dropped
     }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -19,7 +19,7 @@ use crate::storage::pager::SavepointResult;
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
 use crate::storage::wal::{CheckpointMode, CheckpointResult, TursoRwLock};
 use crate::sync::atomic::{AtomicBool, AtomicI64};
-use crate::sync::atomic::{AtomicU64, Ordering};
+use crate::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use crate::sync::Arc;
 use crate::sync::{Mutex, RwLock};
 use crate::translate::plan::IterationDirection;
@@ -3174,6 +3174,16 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                     self.state = CommitState::Checkpoint { state_machine };
                     return Ok(TransitionResult::Continue);
                 }
+                // Not checkpointing this commit. Reclaim invisible versions
+                // inline with a bounded, non-blocking GC pass so steady-state
+                // memory stays flat between checkpoints (which only fire on
+                // logical-log byte growth, not version accumulation). The pass
+                // does no I/O and is capped at MAX_CHAINS_PER_GC chains, so it
+                // doesn't meaningfully slow this committing connection. See
+                // `gc_incremental`.
+                if mvcc_store.should_gc() {
+                    mvcc_store.gc_incremental(MvStore::<Clock>::MAX_CHAINS_PER_GC);
+                }
                 tracing::trace!("logged(tx_id={}, end_ts={})", self.tx_id, *end_ts);
                 self.finalize(mvcc_store)?;
                 Ok(TransitionResult::Done(()))
@@ -3779,6 +3789,30 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// database live in one process. Multi-process MVCC will need a shared
     /// coordination mechanism before sync can rely on this watermark.
     sequence_allocations: Mutex<HashMap<String, StdHashMap<TxID, i64>>>,
+
+    /// Approximate count of live row versions across `rows` + `index_rows`.
+    /// Incremented on every inserted version, decremented when versions are
+    /// reclaimed (GC) or physically removed (savepoint rollback, checkpoint
+    /// purge). This is a *heuristic* used only to decide when to run an
+    /// incremental GC pass (`should_gc`) — never a correctness input. Aborted
+    /// versions are left counted until GC reclaims them (they still occupy
+    /// memory). See [`Self::live_version_count`].
+    live_version_count: AtomicUsize,
+    /// Snapshot of `live_version_count` taken at the end of the last
+    /// `gc_incremental` pass. `should_gc` fires once growth since this snapshot
+    /// crosses `gc_version_threshold`, giving a roughly fixed GC cadence per N
+    /// new versions regardless of how many a single pass reclaims.
+    live_versions_at_last_gc: AtomicUsize,
+    /// Growth in `live_version_count` (number of newly inserted versions since
+    /// the last GC pass) that triggers an incremental GC pass on the commit
+    /// path. Negative disables inline GC entirely. Configurable via the
+    /// `mvcc_gc_threshold` PRAGMA; mirrors `checkpoint_threshold`.
+    gc_version_threshold: AtomicI64,
+    /// Resume cursor for the incremental table-row GC sweep: the last `RowID`
+    /// processed by the previous `gc_incremental` pass. `None` restarts the
+    /// sweep from the beginning of `rows` (and marks the point where index
+    /// chains are swept — see `gc_incremental`).
+    gc_table_cursor: Mutex<Option<RowID>>,
 }
 
 impl<Clock: LogicalClock> MvStore<Clock> {
@@ -3871,6 +3905,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             table_id_to_last_rowid: RwLock::new(HashMap::default()),
             sequence_watermarks: Mutex::new(HashMap::default()),
             sequence_allocations: Mutex::new(HashMap::default()),
+            live_version_count: AtomicUsize::new(0),
+            live_versions_at_last_gc: AtomicUsize::new(0),
+            gc_version_threshold: AtomicI64::new(Self::DEFAULT_GC_VERSION_THRESHOLD),
+            gc_table_cursor: Mutex::new(None),
         }
     }
 
@@ -5896,7 +5934,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             touched_rowids.insert(rowid.clone());
             if let Some(entry) = self.rows.get(&rowid) {
                 let mut versions = entry.value().write();
+                let before = versions.len();
                 versions.retain(|rv| rv.id != version_id);
+                self.dec_live_version_count(before - versions.len());
                 tracing::debug!(
                     "rollback_savepoint: removed table version(table_id={}, row_id={}, version_id={})",
                     rowid.table_id,
@@ -5910,7 +5950,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             if let Some(index) = self.index_rows.get(&table_id) {
                 if let Some(entry) = index.value().get(&key) {
                     let mut versions = entry.value().write();
+                    let before = versions.len();
                     versions.retain(|rv| rv.id != version_id);
+                    self.dec_live_version_count(before - versions.len());
                     tracing::debug!(
                         "rollback_savepoint: removed index version(table_id={}, version_id={})",
                         table_id,
@@ -6172,6 +6214,71 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             .unwrap_or(u64::MAX)
     }
 
+    /// Default `mvcc_gc_threshold`: run an incremental GC pass roughly every
+    /// this many newly inserted versions. Small enough that steady-state
+    /// memory stays bounded under heavy short-txn concurrency, large enough
+    /// that small workloads (and most unit tests) never trigger a pass.
+    pub const DEFAULT_GC_VERSION_THRESHOLD: i64 = 16 * 1024;
+
+    /// Upper bound on table-row chains scanned by one inline `gc_incremental`
+    /// pass on the commit path. Keeps a pass cheap (sub-millisecond) so it
+    /// doesn't noticeably slow the committing connection; steady state relies
+    /// on frequent passes resuming via `gc_table_cursor`.
+    pub const MAX_CHAINS_PER_GC: usize = 4096;
+
+    /// Current approximate live row-version count. Heuristic only (see the
+    /// `live_version_count` field) — never use for correctness decisions.
+    pub fn live_version_count(&self) -> usize {
+        self.live_version_count.load(Ordering::Relaxed)
+    }
+
+    /// Saturating decrement of the live-version heuristic. The counter is
+    /// approximate, so clamp at zero rather than risk an underflow wrap that
+    /// would make `should_gc` fire on every commit.
+    fn dec_live_version_count(&self, n: usize) {
+        if n == 0 {
+            return;
+        }
+        let mut current = self.live_version_count.load(Ordering::Relaxed);
+        loop {
+            let next = current.saturating_sub(n);
+            match self.live_version_count.compare_exchange_weak(
+                current,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    /// Set the inline-GC trigger threshold (growth in live versions since the
+    /// last GC pass). Negative disables inline GC. Mirrors
+    /// `set_checkpoint_threshold`; wired to the `mvcc_gc_threshold` PRAGMA.
+    pub fn set_gc_threshold(&self, threshold: i64) {
+        self.gc_version_threshold
+            .store(threshold, Ordering::Relaxed);
+    }
+
+    pub fn gc_threshold(&self) -> i64 {
+        self.gc_version_threshold.load(Ordering::Relaxed)
+    }
+
+    /// Whether an incremental GC pass should run now: inline GC is enabled
+    /// (threshold >= 0) and `live_version_count` has grown past the threshold
+    /// since the last pass. Heuristic — drift only changes GC frequency.
+    pub fn should_gc(&self) -> bool {
+        let threshold = self.gc_version_threshold.load(Ordering::Relaxed);
+        if threshold < 0 {
+            return false;
+        }
+        let current = self.live_version_count.load(Ordering::Relaxed);
+        let at_last = self.live_versions_at_last_gc.load(Ordering::Relaxed);
+        current.saturating_sub(at_last) >= threshold as usize
+    }
+
     /// Garbage-collects row versions that are invisible to all active transactions.
     /// Uses the low-water mark (LWM) to determine reclaimability in O(1) per version.
     /// Covers both table rows (`self.rows`) and index rows (`self.index_rows`).
@@ -6192,6 +6299,85 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         self.drop_unused_row_versions_inner(true)
     }
 
+    /// Incremental, non-blocking GC pass — the inline counterpart to
+    /// [`Self::drop_unused_row_versions`], driven from the commit path.
+    ///
+    /// Reclaims invisible versions (same rules as `gc_version_chain`) from up
+    /// to `max_chains` table-row chains, resuming from where the previous pass
+    /// stopped (`gc_table_cursor`) so repeated calls eventually cover the whole
+    /// `rows` map without scanning it all at once. Returns the number of
+    /// versions reclaimed.
+    ///
+    /// Safety / design notes:
+    /// - **Lazy mode only.** Empty SkipMap slots are left in place (no
+    ///   `entry.remove()`), so the pass needs no blocking checkpoint lock — it
+    ///   races no concurrent `get_or_insert_with` (see the TOCTOU note in
+    ///   `gc_table_row_versions`). Physical slot removal stays exclusive to the
+    ///   checkpoint's `_and_slots` sweep.
+    /// - **No I/O.** Pure in-memory chain reclamation under each chain's write
+    ///   lock; no `Completion`/yield machinery needed.
+    /// - **Index chains** are swept in full once per *full table-cursor cycle*
+    ///   (when the table sweep wraps back to the start). They are typically far
+    ///   fewer than table-row chains, so a periodic full sweep keeps per-pass
+    ///   cost bounded in the common case. This can be made incrementally
+    ///   resumable later if index counts grow large.
+    /// - `finalized_tx_states` pruning is intentionally skipped here: it needs
+    ///   the *complete* referenced-txid set across all chains, which a partial
+    ///   sweep cannot produce. The checkpoint path still prunes it.
+    pub fn gc_incremental(&self, max_chains: usize) -> usize {
+        let lwm = self.compute_lwm();
+        let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
+
+        let mut dropped = 0;
+        let mut processed = 0;
+        let mut last_key: Option<RowID> = None;
+
+        // Resume strictly after the last key processed by the previous pass.
+        let start_bound = match self.gc_table_cursor.lock().clone() {
+            Some(k) => Bound::Excluded(k),
+            None => Bound::Unbounded,
+        };
+        for entry in self.rows.range((start_bound, Bound::Unbounded)) {
+            if processed >= max_chains {
+                break;
+            }
+            {
+                let mut versions = entry.value().write();
+                dropped += Self::gc_version_chain(&mut versions, lwm, ckpt_max);
+            }
+            last_key = Some(entry.key().clone());
+            processed += 1;
+        }
+
+        // If we processed fewer chains than the budget, the range was
+        // exhausted — wrap the cursor to the start for the next pass.
+        let wrapped = processed < max_chains;
+        *self.gc_table_cursor.lock() = if wrapped { None } else { last_key };
+
+        // Sweep index chains once per full table-cursor cycle to bound the
+        // per-pass cost (see the doc comment). A throwaway referenced-txid set
+        // is collected and discarded — we do not prune finalized states here.
+        if wrapped {
+            let mut referenced_tx_ids = HashSet::default();
+            dropped += self.gc_index_row_versions(lwm, ckpt_max, &mut referenced_tx_ids, false);
+        }
+
+        self.dec_live_version_count(dropped);
+        // Reset the trigger baseline so `should_gc` measures growth from here.
+        self.live_versions_at_last_gc.store(
+            self.live_version_count.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+
+        if dropped > 0 {
+            tracing::trace!(
+                "gc_incremental: reclaimed {dropped} versions across {processed} chains (wrapped={wrapped}), live~{}",
+                self.live_version_count.load(Ordering::Relaxed)
+            );
+        }
+        dropped
+    }
+
     fn drop_unused_row_versions_inner(&self, remove_empty_slots: bool) -> usize {
         let lwm = self.compute_lwm();
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
@@ -6205,6 +6391,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     &mut referenced_tx_ids,
                     remove_empty_slots,
                 );
+        self.dec_live_version_count(dropped);
         let pruned_finalized = self.prune_finalized_tx_states(&referenced_tx_ids);
 
         tracing::trace!(
@@ -6493,6 +6680,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             }
         }
         versions.insert(position, row_version);
+        // A genuine insert (the collapse branch above `return`s without
+        // reaching here). Track it for the GC trigger heuristic.
+        self.live_version_count.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn write_row_to_pager(
@@ -6545,6 +6735,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     pub fn purge_row_versions_during_checkpoint(&self, rowid: RowID) {
         if let Some(entry) = self.rows.get(&rowid) {
             let mut versions = entry.value().write();
+            self.dec_live_version_count(versions.len());
             versions.clear();
             Self::shrink_version_chain_allocation(&mut versions);
         }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8125,10 +8125,10 @@ fn test_gc_active_reader_pins_lwm() {
 /// version. Exactness here is convenient for the test but only approximate
 /// accuracy is required by the engine.
 #[test]
-fn test_live_version_count_tracks_inserts_and_gc() {
+fn test_live_version_count_approx_tracks_inserts_and_gc() {
     let db = MvccTestDb::new();
     let table_id: MVTableId = (-2).into();
-    let start = db.mvcc_store.live_version_count();
+    let start = db.mvcc_store.live_version_count_approx();
 
     // Insert a row + commit -> one live version.
     let tx = db
@@ -8139,7 +8139,7 @@ fn test_live_version_count_tracks_inserts_and_gc() {
         .insert(tx, generate_simple_string_row(table_id, 1, "v1"))
         .unwrap();
     commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
-    assert_eq!(db.mvcc_store.live_version_count(), start + 1);
+    assert_eq!(db.mvcc_store.live_version_count_approx(), start + 1);
 
     // Update the row + commit -> a second version (old one superseded, not
     // removed, so the count grows to two).
@@ -8151,13 +8151,13 @@ fn test_live_version_count_tracks_inserts_and_gc() {
         .update(tx, generate_simple_string_row(table_id, 1, "v2"))
         .unwrap();
     commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
-    assert_eq!(db.mvcc_store.live_version_count(), start + 2);
+    assert_eq!(db.mvcc_store.live_version_count_approx(), start + 2);
 
     // No active readers -> the superseded version is reclaimable. GC drops it
     // and the counter follows.
     let dropped = db.mvcc_store.drop_unused_row_versions();
     assert_eq!(dropped, 1);
-    assert_eq!(db.mvcc_store.live_version_count(), start + 1);
+    assert_eq!(db.mvcc_store.live_version_count_approx(), start + 1);
 }
 
 /// `should_gc` fires once live-version growth since the last pass crosses the
@@ -8399,7 +8399,7 @@ fn test_gc_incremental_concurrent_is_safe() {
         })
         .sum();
     assert_eq!(
-        db.mvcc_store.live_version_count(),
+        db.mvcc_store.live_version_count_approx(),
         table_live + index_live,
         "live-version counter drifted from actual chain contents"
     );

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8309,6 +8309,187 @@ fn test_gc_incremental_reclaims_like_full_sweep() {
     }
 }
 
+/// Concurrency safety. Many connections share one `MvStore` and each commit
+/// calls `gc_incremental` with no global lock held, so several threads can run
+/// GC at once. The single-flight gate keeps only one pass active, but the
+/// stronger guarantee is that concurrent passes can never corrupt a chain or
+/// the live-version counter. Hammer GC from many threads, then assert the
+/// outcome equals a single full sweep and that the (heuristic) counter still
+/// exactly matches the live versions — proving no double/missed decrement.
+#[test]
+fn test_gc_incremental_concurrent_is_safe() {
+    let db = MvccTestDb::new();
+    let table_id: MVTableId = (-2).into();
+
+    // Each row: insert+commit (v1) then update+commit (v2) -> one reclaimable
+    // superseded version per chain. No readers stay open, so LWM = MAX.
+    let n: i64 = 200;
+    for i in 1..=n {
+        let tx = db
+            .mvcc_store
+            .begin_tx(db.conn.pager.load().clone())
+            .unwrap();
+        db.mvcc_store
+            .insert(tx, generate_simple_string_row(table_id, i, "v1"))
+            .unwrap();
+        commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
+
+        let tx = db
+            .mvcc_store
+            .begin_tx(db.conn.pager.load().clone())
+            .unwrap();
+        db.mvcc_store
+            .update(tx, generate_simple_string_row(table_id, i, "v2"))
+            .unwrap();
+        commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
+    }
+    assert_eq!(db.mvcc_store.compute_lwm(), u64::MAX);
+
+    // 8 threads each run many small bounded passes concurrently.
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let store = db.mvcc_store.clone();
+        handles.push(std::thread::spawn(move || {
+            for _ in 0..500 {
+                store.gc_incremental(8);
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Drain anything the bounded passes didn't reach (single-threaded now).
+    while db
+        .mvcc_store
+        .gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC)
+        > 0
+    {}
+
+    // A full sweep finds nothing left, and each chain kept exactly its current
+    // version — concurrent GC reclaimed precisely what one sweep would.
+    assert_eq!(db.mvcc_store.drop_unused_row_versions(), 0);
+    for i in 1..=n {
+        let entry = db
+            .mvcc_store
+            .rows
+            .get(&RowID::new(table_id, RowKey::Int(i)))
+            .unwrap();
+        assert_eq!(entry.value().read().len(), 1);
+    }
+
+    // The heuristic counter exactly matches the live versions still in memory:
+    // no decrement was lost or double-applied under concurrency.
+    let table_live: usize = db
+        .mvcc_store
+        .rows
+        .iter()
+        .map(|e| e.value().read().len())
+        .sum();
+    let index_live: usize = db
+        .mvcc_store
+        .index_rows
+        .iter()
+        .map(|outer| {
+            outer
+                .value()
+                .iter()
+                .map(|inner| inner.value().read().len())
+                .sum::<usize>()
+        })
+        .sum();
+    assert_eq!(
+        db.mvcc_store.live_version_count(),
+        table_live + index_live,
+        "live-version counter drifted from actual chain contents"
+    );
+}
+
+/// Index chains are swept by their own bounded, resumable cursor
+/// (`gc_index_cursor`), just like table rows — a single huge index can't force
+/// an unbounded pass. Aborted index garbage (Rule 1) is reclaimable
+/// unconditionally, so it lets us exercise the index sweep without depending on
+/// checkpoint timing. This asserts the sweep is resumable mid-pass and that
+/// driving it in tiny chunks reclaims exactly what a full sweep would.
+#[test]
+fn test_gc_incremental_reclaims_index_chains_resumably() {
+    let db = MvccTestDb::new();
+    let conn = &db.conn;
+    // Drive GC manually: disable both the checkpoint and the inline-GC trigger.
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    conn.execute("PRAGMA mvcc_gc_threshold = -1").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX idx_v ON t(v)").unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 'keep')").unwrap();
+
+    // Insert many indexed rows in one transaction, then roll back: each leaves
+    // aborted garbage in its own index chain.
+    conn.execute("BEGIN").unwrap();
+    for i in 100..200 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, 'g{i}')"))
+            .unwrap();
+    }
+    conn.execute("ROLLBACK").unwrap();
+
+    let count_index_versions = || -> usize {
+        db.mvcc_store
+            .index_rows
+            .iter()
+            .map(|outer| {
+                outer
+                    .value()
+                    .iter()
+                    .map(|inner| inner.value().read().len())
+                    .sum::<usize>()
+            })
+            .sum()
+    };
+    let before = count_index_versions();
+    assert!(
+        before > 8,
+        "expected accumulated index garbage chains, got {before}"
+    );
+    assert_eq!(db.mvcc_store.compute_lwm(), u64::MAX);
+
+    // A single tiny pass is bounded and leaves the index sweep mid-flight —
+    // the cursor is parked partway through (there are far more than 4 chains).
+    db.mvcc_store.gc_incremental(4);
+    assert!(
+        db.mvcc_store.gc_index_cursor.lock().is_some(),
+        "index sweep should resume from a saved cursor, not restart each pass"
+    );
+
+    // Drive to convergence in 4-chain chunks: done when a pass reclaims nothing
+    // and both cursors have wrapped back to the start.
+    let mut passes = 0;
+    loop {
+        let dropped = db.mvcc_store.gc_incremental(4);
+        passes += 1;
+        if dropped == 0
+            && db.mvcc_store.gc_table_cursor.lock().is_none()
+            && db.mvcc_store.gc_index_cursor.lock().is_none()
+        {
+            break;
+        }
+        assert!(passes < 100_000, "incremental GC failed to converge");
+    }
+
+    // Everything the full sweep would reclaim is already gone (table + index).
+    assert_eq!(db.mvcc_store.drop_unused_row_versions(), 0);
+    let after = count_index_versions();
+    assert!(
+        after < before,
+        "index versions should shrink: before={before} after={after}"
+    );
+
+    // The surviving committed row is still correct and index-readable.
+    let rows = get_rows(conn, "SELECT id FROM t WHERE v = 'keep'");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+}
+
 /// Incremental GC uses the lazy path: it empties a chain's version vec but
 /// leaves the (now empty) SkipMap slot in place — slot removal is reserved for
 /// the checkpoint's blocking `_and_slots` sweep.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8120,6 +8120,307 @@ fn test_gc_active_reader_pins_lwm() {
     }
 }
 
+/// The live-version counter is the heuristic that gates inline GC. It must
+/// increment on every committed insert/update and decrement when GC reclaims a
+/// version. Exactness here is convenient for the test but only approximate
+/// accuracy is required by the engine.
+#[test]
+fn test_live_version_count_tracks_inserts_and_gc() {
+    let db = MvccTestDb::new();
+    let table_id: MVTableId = (-2).into();
+    let start = db.mvcc_store.live_version_count();
+
+    // Insert a row + commit -> one live version.
+    let tx = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    db.mvcc_store
+        .insert(tx, generate_simple_string_row(table_id, 1, "v1"))
+        .unwrap();
+    commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
+    assert_eq!(db.mvcc_store.live_version_count(), start + 1);
+
+    // Update the row + commit -> a second version (old one superseded, not
+    // removed, so the count grows to two).
+    let tx = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    db.mvcc_store
+        .update(tx, generate_simple_string_row(table_id, 1, "v2"))
+        .unwrap();
+    commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
+    assert_eq!(db.mvcc_store.live_version_count(), start + 2);
+
+    // No active readers -> the superseded version is reclaimable. GC drops it
+    // and the counter follows.
+    let dropped = db.mvcc_store.drop_unused_row_versions();
+    assert_eq!(dropped, 1);
+    assert_eq!(db.mvcc_store.live_version_count(), start + 1);
+}
+
+/// `should_gc` fires once live-version growth since the last pass crosses the
+/// threshold; a pass resets the baseline; -1 disables it entirely.
+#[test]
+fn test_should_gc_threshold_and_reset() {
+    let db = MvccTestDb::new();
+    let table_id: MVTableId = (-2).into();
+
+    db.mvcc_store.set_gc_threshold(5);
+    assert_eq!(db.mvcc_store.gc_threshold(), 5);
+    assert!(!db.mvcc_store.should_gc());
+
+    // Insert 5 versions in a single open (uncommitted) transaction so we drive
+    // the counter directly without going through the commit path's own inline
+    // GC trigger.
+    let tx = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    for i in 1..=5 {
+        db.mvcc_store
+            .insert(tx, generate_simple_string_row(table_id, i, "x"))
+            .unwrap();
+    }
+    assert!(
+        db.mvcc_store.should_gc(),
+        "growth of 5 versions should reach the threshold"
+    );
+
+    // A pass resets the baseline (regardless of how much it reclaimed — the
+    // open txn pins the LWM, so nothing is reclaimable here).
+    db.mvcc_store
+        .gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
+    assert!(
+        !db.mvcc_store.should_gc(),
+        "baseline should reset after a GC pass"
+    );
+
+    // A negative threshold disables inline GC even past the old threshold.
+    db.mvcc_store.set_gc_threshold(-1);
+    for i in 6..=20 {
+        db.mvcc_store
+            .insert(tx, generate_simple_string_row(table_id, i, "x"))
+            .unwrap();
+    }
+    assert!(
+        !db.mvcc_store.should_gc(),
+        "negative threshold disables inline GC"
+    );
+}
+
+/// The `mvcc_gc_threshold` PRAGMA reads back the configured value and feeds
+/// `set_gc_threshold`, mirroring `mvcc_checkpoint_threshold`.
+#[test]
+fn test_mvcc_gc_threshold_pragma_roundtrip() {
+    let db = MvccTestDb::new();
+
+    // Default reads back the engine default.
+    let rows = get_rows(&db.conn, "PRAGMA mvcc_gc_threshold");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0][0].as_int().unwrap(),
+        MvStore::<MvccClock>::DEFAULT_GC_VERSION_THRESHOLD
+    );
+
+    // Setting it updates the store and reads back.
+    db.conn.execute("PRAGMA mvcc_gc_threshold = 1000").unwrap();
+    assert_eq!(db.mvcc_store.gc_threshold(), 1000);
+    let rows = get_rows(&db.conn, "PRAGMA mvcc_gc_threshold");
+    assert_eq!(rows[0][0].as_int().unwrap(), 1000);
+
+    // -1 disables inline GC.
+    db.conn.execute("PRAGMA mvcc_gc_threshold = -1").unwrap();
+    assert_eq!(db.mvcc_store.gc_threshold(), -1);
+    assert!(!db.mvcc_store.should_gc());
+
+    // Values below -1 are rejected.
+    assert!(db.conn.execute("PRAGMA mvcc_gc_threshold = -2").is_err());
+}
+
+/// Incremental GC must reclaim exactly what the full sweep would, just spread
+/// across resumable bounded passes whose cursor wraps at the end.
+#[test]
+fn test_gc_incremental_reclaims_like_full_sweep() {
+    let db = MvccTestDb::new();
+    let table_id: MVTableId = (-2).into();
+
+    // Build many chains, each with one reclaimable superseded version
+    // (insert+commit then update+commit).
+    let n: i64 = 20;
+    for i in 1..=n {
+        let tx = db
+            .mvcc_store
+            .begin_tx(db.conn.pager.load().clone())
+            .unwrap();
+        db.mvcc_store
+            .insert(tx, generate_simple_string_row(table_id, i, "v1"))
+            .unwrap();
+        commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
+
+        let tx = db
+            .mvcc_store
+            .begin_tx(db.conn.pager.load().clone())
+            .unwrap();
+        db.mvcc_store
+            .update(tx, generate_simple_string_row(table_id, i, "v2"))
+            .unwrap();
+        commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
+    }
+
+    // No active readers -> every superseded version is reclaimable.
+    assert_eq!(db.mvcc_store.compute_lwm(), u64::MAX);
+
+    // Drive GC in tiny chunks (3 chains/pass) until it converges: no versions
+    // reclaimed AND the cursor has wrapped back to the start.
+    let mut total = 0;
+    let mut passes = 0;
+    loop {
+        let dropped = db.mvcc_store.gc_incremental(3);
+        total += dropped;
+        passes += 1;
+        if dropped == 0 && db.mvcc_store.gc_table_cursor.lock().is_none() {
+            break;
+        }
+        assert!(passes < 10_000, "incremental GC failed to converge");
+    }
+    assert!(
+        total >= n as usize,
+        "incremental GC should reclaim at least the {n} superseded versions, got {total}"
+    );
+
+    // A full sweep now finds nothing: incremental GC already reclaimed
+    // everything the full sweep would have.
+    assert_eq!(
+        db.mvcc_store.drop_unused_row_versions(),
+        0,
+        "full sweep should find nothing left after incremental GC converges"
+    );
+
+    // Each chain keeps exactly its surviving current version.
+    for i in 1..=n {
+        let entry = db
+            .mvcc_store
+            .rows
+            .get(&RowID::new(table_id, RowKey::Int(i)))
+            .unwrap();
+        assert_eq!(entry.value().read().len(), 1);
+    }
+}
+
+/// Incremental GC uses the lazy path: it empties a chain's version vec but
+/// leaves the (now empty) SkipMap slot in place — slot removal is reserved for
+/// the checkpoint's blocking `_and_slots` sweep.
+#[test]
+fn test_gc_incremental_lazy_leaves_empty_slots() {
+    let db = MvccTestDb::new();
+    let table_id: MVTableId = (-2).into();
+
+    // Aborted insert leaves aborted garbage (begin=None, end=None) behind.
+    let tx = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    db.mvcc_store
+        .insert(tx, generate_simple_string_row(table_id, 1, "rollback"))
+        .unwrap();
+    db.mvcc_store.rollback_tx(
+        tx,
+        db.conn.pager.load().clone(),
+        &db.conn,
+        crate::MAIN_DB_ID,
+    );
+
+    let row_id = RowID::new(table_id, RowKey::Int(1));
+    assert!(db.mvcc_store.rows.get(&row_id).is_some());
+
+    // Drive incremental GC to completion.
+    for _ in 0..4 {
+        db.mvcc_store
+            .gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
+    }
+
+    let entry = db.mvcc_store.rows.get(&row_id);
+    assert!(entry.is_some(), "lazy path keeps the SkipMap slot in place");
+    assert!(
+        entry.unwrap().value().read().is_empty(),
+        "but the version vec is emptied"
+    );
+}
+
+/// Overlapping transactions: a committed-and-superseded version is reclaimed by
+/// inline incremental GC (no checkpoint), but only after the snapshot that
+/// pinned the LWM ends. While the reader is open, GC must not touch its version.
+#[test]
+fn test_gc_incremental_respects_held_snapshot() {
+    let db = MvccTestDb::new();
+    let table_id: MVTableId = (-2).into();
+    let row_id = RowID::new(table_id, RowKey::Int(1));
+
+    // T1 inserts and commits v1.
+    let tx1 = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    let row_v1 = generate_simple_string_row(table_id, 1, "version_1");
+    db.mvcc_store.insert(tx1, row_v1.clone()).unwrap();
+    commit_tx(db.mvcc_store.clone(), &db.conn, tx1).unwrap();
+
+    // T2 opens a read snapshot and pins the LWM.
+    let conn2 = db.db.connect().unwrap();
+    let tx2 = db.mvcc_store.begin_tx(conn2.pager.load().clone()).unwrap();
+
+    // T3 updates and commits v2, superseding v1.
+    let conn3 = db.db.connect().unwrap();
+    let tx3 = db.mvcc_store.begin_tx(conn3.pager.load().clone()).unwrap();
+    db.mvcc_store
+        .update(tx3, generate_simple_string_row(table_id, 1, "version_2"))
+        .unwrap();
+    commit_tx(db.mvcc_store.clone(), &conn3, tx3).unwrap();
+
+    // Incremental GC while T2 is open must NOT reclaim v1.
+    assert_eq!(
+        db.mvcc_store
+            .gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC),
+        0,
+        "held snapshot pins the LWM; nothing reclaimable"
+    );
+    assert_eq!(
+        db.mvcc_store
+            .rows
+            .get(&row_id)
+            .unwrap()
+            .value()
+            .read()
+            .len(),
+        2
+    );
+    // T2 still sees its snapshot version.
+    assert_eq!(db.mvcc_store.read(tx2, &row_id).unwrap().unwrap(), row_v1);
+
+    // Close the snapshot; now incremental GC reclaims the superseded v1
+    // without any checkpoint having run.
+    db.mvcc_store.remove_tx(tx2);
+    assert_eq!(
+        db.mvcc_store
+            .gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC),
+        1,
+        "superseded version reclaimed by inline GC after snapshot ends"
+    );
+    assert_eq!(
+        db.mvcc_store
+            .rows
+            .get(&row_id)
+            .unwrap()
+            .value()
+            .read()
+            .len(),
+        1,
+        "only the current version remains"
+    );
+}
+
 /// Index rows live in a separate SkipMap from table rows and go through their own
 /// GC path (gc_index_row_versions). This SQL-level test creates an indexed table,
 /// checkpoints, updates the row (creating superseded index versions), checkpoints

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8490,6 +8490,86 @@ fn test_gc_incremental_reclaims_index_chains_resumably() {
     assert_eq!(rows[0][0].as_int().unwrap(), 1);
 }
 
+/// Inline GC must never run concurrently with a stop-the-world checkpoint:
+/// the checkpoint reads version chains to flush them to the B-tree and removes
+/// empty slots, so a concurrent GC mutating those chains would corrupt the
+/// on-disk image (e.g. drop an index version before the checkpoint flushed it,
+/// leaving a table row without its index entry). `gc_incremental` enforces this
+/// by holding the checkpoint read lock; if the checkpoint holds the write lock,
+/// GC must skip entirely. Regression test for the Antithesis integrity-check
+/// failure ("row N missing from index ...").
+#[test]
+fn test_gc_incremental_skips_while_checkpoint_holds_write_lock() {
+    let db = MvccTestDb::new();
+    let table_id: MVTableId = (-2).into();
+
+    // One reclaimable superseded version (insert+commit, then update+commit).
+    let tx = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    db.mvcc_store
+        .insert(tx, generate_simple_string_row(table_id, 1, "v1"))
+        .unwrap();
+    commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
+    let tx = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    db.mvcc_store
+        .update(tx, generate_simple_string_row(table_id, 1, "v2"))
+        .unwrap();
+    commit_tx(db.mvcc_store.clone(), &db.conn, tx).unwrap();
+    // No active txns -> all reader read-locks released, LWM = MAX.
+    assert_eq!(db.mvcc_store.compute_lwm(), u64::MAX);
+
+    let row_id = RowID::new(table_id, RowKey::Int(1));
+
+    // Simulate a stop-the-world checkpoint by taking the write lock.
+    assert!(
+        db.mvcc_store.blocking_checkpoint_lock.write(),
+        "no readers should remain after commits, so write lock is acquirable"
+    );
+
+    // GC cannot take the read lock -> it must skip and reclaim nothing.
+    assert_eq!(
+        db.mvcc_store
+            .gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC),
+        0,
+        "GC must not run while a checkpoint holds the write lock"
+    );
+    assert_eq!(
+        db.mvcc_store
+            .rows
+            .get(&row_id)
+            .unwrap()
+            .value()
+            .read()
+            .len(),
+        2,
+        "superseded version must survive while the checkpoint holds the lock"
+    );
+
+    // Once the checkpoint releases, GC runs and reclaims the superseded version.
+    db.mvcc_store.blocking_checkpoint_lock.unlock();
+    assert_eq!(
+        db.mvcc_store
+            .gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC),
+        1,
+        "GC runs once the checkpoint lock is released"
+    );
+    assert_eq!(
+        db.mvcc_store
+            .rows
+            .get(&row_id)
+            .unwrap()
+            .value()
+            .read()
+            .len(),
+        1
+    );
+}
+
 /// Incremental GC uses the lazy path: it empties a chain's version vec but
 /// leaves the (now empty) SkipMap slot in place — slot removal is reserved for
 /// the checkpoint's blocking `_and_slots` sweep.

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -178,6 +178,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["mvcc_checkpoint_threshold"],
         ),
+        PragmaName::MvccGcThreshold => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["mvcc_gc_threshold"],
+        ),
         ForeignKeys => Pragma::new(
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["foreign_keys"],

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -686,6 +686,15 @@ fn update_pragma(
             connection.set_mvcc_checkpoint_threshold(threshold)?;
             Ok(TransactionMode::None)
         }
+        PragmaName::MvccGcThreshold => {
+            let threshold = match parse_signed_number(&value)? {
+                Value::Numeric(Numeric::Integer(size)) if size >= -1 => size,
+                _ => bail_parse_error!("mvcc_gc_threshold must be -1, 0, or a positive integer"),
+            };
+
+            connection.set_mvcc_gc_threshold(threshold)?;
+            Ok(TransactionMode::None)
+        }
         PragmaName::ForeignKeys => {
             let enabled = parse_pragma_enabled(&value);
             connection.set_foreign_keys_enabled(enabled);
@@ -1514,6 +1523,14 @@ fn query_pragma(
         }
         PragmaName::MvccCheckpointThreshold => {
             let threshold = connection.mvcc_checkpoint_threshold()?;
+            let register = program.alloc_register();
+            program.emit_int(threshold, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::MvccGcThreshold => {
+            let threshold = connection.mvcc_gc_threshold()?;
             let register = program.alloc_register();
             program.emit_int(threshold, register);
             program.emit_result_row(register, 1);

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -687,9 +687,15 @@ fn update_pragma(
             Ok(TransactionMode::None)
         }
         PragmaName::MvccGcThreshold => {
+            // 0 is rejected: it would run an inline GC pass on every commit even
+            // with zero new versions (`should_gc` compares growth `>= threshold`),
+            // which is pure overhead. Use -1 to disable, or a positive growth
+            // threshold.
             let threshold = match parse_signed_number(&value)? {
-                Value::Numeric(Numeric::Integer(size)) if size >= -1 => size,
-                _ => bail_parse_error!("mvcc_gc_threshold must be -1, 0, or a positive integer"),
+                Value::Numeric(Numeric::Integer(size)) if size == -1 || size >= 1 => size,
+                _ => bail_parse_error!(
+                    "mvcc_gc_threshold must be -1 (disabled) or a positive integer"
+                ),
             };
 
             connection.set_mvcc_gc_threshold(threshold)?;

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1867,6 +1867,10 @@ pub enum PragmaName {
     WalCheckpoint,
     /// Sets or queries the threshold (in bytes) at which MVCC triggers an automatic checkpoint.
     MvccCheckpointThreshold,
+    /// Sets or queries the threshold (in newly inserted row versions since the
+    /// last GC pass) at which MVCC runs an inline, non-blocking garbage
+    /// collection pass on the commit path. -1 disables inline GC.
+    MvccGcThreshold,
     /// List all available types (built-in and custom)
     ListTypes,
     /// Deprecated no-op: control whether callback is invoked for empty result sets

--- a/perf/memory/codspeed/benches/memory_profiles.rs
+++ b/perf/memory/codspeed/benches/memory_profiles.rs
@@ -111,6 +111,7 @@ fn bench_workload(
         checkpoint,
         mvcc_checkpoint_threshold: (checkpoint && matches!(mode, JournalMode::Mvcc))
             .then_some(MVCC_CHECKPOINT_THRESHOLD_BYTES),
+        mvcc_gc_threshold: (matches!(mode, JournalMode::Mvcc)).then_some(16384i64),
     };
     let db_path = work_dir
         .join(format!("{mode}_{workload}_{total_ops}{suffix}.db"))

--- a/perf/memory/codspeed/benches/memory_profiles.rs
+++ b/perf/memory/codspeed/benches/memory_profiles.rs
@@ -28,12 +28,13 @@ use memory_benchmark::workload::{
 
 const MODES: [JournalMode; 2] = [JournalMode::Wal, JournalMode::Mvcc];
 
-const WORKLOADS: [WorkloadProfile; 5] = [
+const WORKLOADS: [WorkloadProfile; 6] = [
     WorkloadProfile::InsertHeavy,
     WorkloadProfile::ReadHeavy,
     WorkloadProfile::Mixed,
     WorkloadProfile::ScanHeavy,
     WorkloadProfile::SeriesBlob,
+    WorkloadProfile::UpdateChurn,
 ];
 
 /// Workload scale series: the base iteration count is multiplied by each of

--- a/perf/memory/src/main.rs
+++ b/perf/memory/src/main.rs
@@ -1,5 +1,3 @@
-use std::time::{Duration, Instant};
-
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use memory_benchmark::measure::{MemoryReport, MemorySnapshot, file_size, take_snapshot};
@@ -7,6 +5,7 @@ use memory_benchmark::profile::Phase;
 use memory_benchmark::workload::{
     JournalMode, WorkloadConfig, WorkloadObserver, WorkloadProfile, clean_db_files, run_workload,
 };
+use std::time::{Duration, Instant};
 
 // Workspace Clippy runs with `--all-features`, which enables `turso`'s
 // mimalloc-backed global allocator. Skip the benchmark-only dhat allocator
@@ -62,10 +61,15 @@ struct Args {
     #[arg(long)]
     checkpoint: bool,
 
-    /// MVCC logical-log auto-checkpoint threshold in bytes
-    /// (PRAGMA mvcc_checkpoint_threshold); -1 disables. MVCC mode only
+    /// MVCC only: set `PRAGMA mvcc_checkpoint_threshold` (bytes; -1 disables
+    /// auto-checkpoint). Use -1 to isolate the inline-GC effect.
     #[arg(long = "mvcc-checkpoint-threshold")]
     mvcc_checkpoint_threshold: Option<i64>,
+
+    /// MVCC only: set `PRAGMA mvcc_gc_threshold` (live-version growth per
+    /// inline GC pass; -1 disables inline GC). Toggle this for A/B runs.
+    #[arg(long = "mvcc-gc-threshold")]
+    mvcc_gc_threshold: Option<i64>,
 }
 
 /// Takes RSS snapshots at phase transitions and tracks the RSS peak after
@@ -138,7 +142,44 @@ async fn async_main(args: Args) -> Result<()> {
         snapshots: vec![baseline_snapshot],
         peak_bytes: baseline,
     };
+    let timeout = Duration::from_millis(args.timeout);
+    let mut snapshots: Vec<MemorySnapshot> = Vec::new();
+    snapshots.push(take_snapshot(start, "baseline"));
 
+    let db = turso::Builder::new_local(db_path).build().await?;
+
+    // Setup connection for schema/seeding and journal mode
+    let setup_conn = db.connect()?;
+    setup_conn.busy_timeout(timeout)?;
+
+    let mode_str = match args.mode {
+        JournalMode::Wal => "'wal'",
+        JournalMode::Mvcc => "'mvcc'",
+    };
+    setup_conn.pragma_update("journal_mode", mode_str).await?;
+
+    // MVCC threshold knobs (shared across all connections via the mv_store).
+    if matches!(args.mode, JournalMode::Mvcc) {
+        if let Some(threshold) = args.mvcc_checkpoint_threshold {
+            setup_conn
+                .execute(
+                    &format!("PRAGMA mvcc_checkpoint_threshold = {threshold}"),
+                    (),
+                )
+                .await?;
+        }
+        if let Some(threshold) = args.mvcc_gc_threshold {
+            setup_conn
+                .execute(&format!("PRAGMA mvcc_gc_threshold = {threshold}"), ())
+                .await?;
+        }
+    }
+
+    if let Some(cache_size) = args.cache_size {
+        setup_conn
+            .pragma_update("cache_size", &cache_size.to_string())
+            .await?;
+    }
     let workload_name = run_workload(db_path, &cfg, &mut observer).await?;
 
     // Final snapshot

--- a/perf/memory/src/main.rs
+++ b/perf/memory/src/main.rs
@@ -130,6 +130,7 @@ async fn async_main(args: Args) -> Result<()> {
         cache_size: args.cache_size,
         checkpoint: args.checkpoint,
         mvcc_checkpoint_threshold: args.mvcc_checkpoint_threshold,
+        mvcc_gc_threshold: args.mvcc_gc_threshold,
     };
 
     let start = Instant::now();
@@ -142,44 +143,7 @@ async fn async_main(args: Args) -> Result<()> {
         snapshots: vec![baseline_snapshot],
         peak_bytes: baseline,
     };
-    let timeout = Duration::from_millis(args.timeout);
-    let mut snapshots: Vec<MemorySnapshot> = Vec::new();
-    snapshots.push(take_snapshot(start, "baseline"));
 
-    let db = turso::Builder::new_local(db_path).build().await?;
-
-    // Setup connection for schema/seeding and journal mode
-    let setup_conn = db.connect()?;
-    setup_conn.busy_timeout(timeout)?;
-
-    let mode_str = match args.mode {
-        JournalMode::Wal => "'wal'",
-        JournalMode::Mvcc => "'mvcc'",
-    };
-    setup_conn.pragma_update("journal_mode", mode_str).await?;
-
-    // MVCC threshold knobs (shared across all connections via the mv_store).
-    if matches!(args.mode, JournalMode::Mvcc) {
-        if let Some(threshold) = args.mvcc_checkpoint_threshold {
-            setup_conn
-                .execute(
-                    &format!("PRAGMA mvcc_checkpoint_threshold = {threshold}"),
-                    (),
-                )
-                .await?;
-        }
-        if let Some(threshold) = args.mvcc_gc_threshold {
-            setup_conn
-                .execute(&format!("PRAGMA mvcc_gc_threshold = {threshold}"), ())
-                .await?;
-        }
-    }
-
-    if let Some(cache_size) = args.cache_size {
-        setup_conn
-            .pragma_update("cache_size", &cache_size.to_string())
-            .await?;
-    }
     let workload_name = run_workload(db_path, &cfg, &mut observer).await?;
 
     // Final snapshot

--- a/perf/memory/src/profile/mod.rs
+++ b/perf/memory/src/profile/mod.rs
@@ -4,6 +4,7 @@ pub mod mixed;
 pub mod read;
 pub mod scan;
 pub mod series_blob;
+pub mod update_churn;
 
 /// Fixed RNG seed so randomized profiles generate the same workload on every
 /// run, keeping benchmark measurements comparable across runs.

--- a/perf/memory/src/profile/update_churn.rs
+++ b/perf/memory/src/profile/update_churn.rs
@@ -1,0 +1,118 @@
+use rand::Rng;
+
+use super::{Phase, Profile, WorkItem};
+
+const SEED_ROWS: usize = 10_000;
+
+/// Update-churn workload: seed a fixed set of rows, then repeatedly UPDATE
+/// random rows within that set under (concurrent) short transactions.
+///
+/// Each UPDATE to an existing row creates a new committed version and
+/// supersedes the prior one, so the version store accumulates *superseded*
+/// versions — the exact garbage MVCC GC reclaims once they fall below the
+/// low-water mark. Because the live key set is bounded at `SEED_ROWS`, a
+/// healthy GC keeps memory flat at ~`SEED_ROWS` current versions, while no GC
+/// grows the store with every update. This is the workload that exercises the
+/// inline-GC path (decoupled from the stop-the-world checkpoint).
+pub struct UpdateChurn {
+    iterations: usize,
+    batch_size: usize,
+    current_iteration: usize,
+    phase: InternalPhase,
+    seed_offset: usize,
+}
+
+enum InternalPhase {
+    CreateTable,
+    Seed,
+    Run,
+}
+
+impl UpdateChurn {
+    pub fn new(iterations: usize, batch_size: usize) -> Self {
+        Self {
+            iterations,
+            batch_size,
+            current_iteration: 0,
+            phase: InternalPhase::CreateTable,
+            seed_offset: 0,
+        }
+    }
+}
+
+impl Profile for UpdateChurn {
+    fn name(&self) -> &str {
+        "update-churn"
+    }
+
+    fn next_batch(&mut self, connections: usize) -> (Phase, Vec<Vec<WorkItem>>) {
+        match self.phase {
+            InternalPhase::CreateTable => {
+                self.phase = InternalPhase::Seed;
+                (
+                    Phase::Setup,
+                    vec![vec![WorkItem {
+                        sql: "CREATE TABLE IF NOT EXISTS bench (id INTEGER PRIMARY KEY, data TEXT NOT NULL, value REAL)".to_string(),
+                        params: vec![],
+                    }]],
+                )
+            }
+            InternalPhase::Seed => {
+                let remaining = SEED_ROWS - self.seed_offset;
+                let batch = remaining.min(500);
+                let mut items = Vec::with_capacity(batch);
+                for i in 0..batch {
+                    let id = self.seed_offset + i;
+                    items.push(WorkItem {
+                        sql: "INSERT INTO bench (id, data, value) VALUES (?, ?, ?)".to_string(),
+                        params: vec![
+                            turso::Value::Integer(id as i64),
+                            turso::Value::Text(format!("seed_{id}")),
+                            turso::Value::Real(id as f64 * 0.5),
+                        ],
+                    });
+                }
+                self.seed_offset += batch;
+                if self.seed_offset >= SEED_ROWS {
+                    self.phase = InternalPhase::Run;
+                }
+                (Phase::Setup, vec![items])
+            }
+            InternalPhase::Run => {
+                if self.current_iteration >= self.iterations {
+                    return (Phase::Done, vec![]);
+                }
+
+                let mut rng = rand::rng();
+                let mut batches = Vec::with_capacity(connections);
+                // Partition the key space across connections so concurrent
+                // writers never collide on the same row (no write-write
+                // conflicts), while each still churns its own slice repeatedly.
+                let chunk = (SEED_ROWS / connections.max(1)).max(1) as i64;
+                for c in 0..connections {
+                    let lo = c as i64 * chunk;
+                    let hi = (lo + chunk).min(SEED_ROWS as i64);
+                    let mut items = Vec::with_capacity(self.batch_size);
+                    for _ in 0..self.batch_size {
+                        let id = rng.random_range(lo..hi.max(lo + 1));
+                        items.push(WorkItem {
+                            sql: "UPDATE bench SET data = ?, value = ? WHERE id = ?".to_string(),
+                            params: vec![
+                                turso::Value::Text(format!(
+                                    "upd_{}_{}",
+                                    self.current_iteration, id
+                                )),
+                                turso::Value::Real(id as f64 * 1.1),
+                                turso::Value::Integer(id),
+                            ],
+                        });
+                    }
+                    batches.push(items);
+                }
+
+                self.current_iteration += 1;
+                (Phase::Run, batches)
+            }
+        }
+    }
+}

--- a/perf/memory/src/workload.rs
+++ b/perf/memory/src/workload.rs
@@ -5,9 +5,9 @@ use clap::ValueEnum;
 use turso::Connection;
 use turso::params::Params;
 
-use crate::profile::{
+use super::profile::{
     Phase, Profile, WorkItem, checkpoint::Checkpoint, insert::InsertHeavy, mixed::Mixed,
-    read::ReadHeavy, scan::ScanHeavy, series_blob::SeriesBlob,
+    read::ReadHeavy, scan::ScanHeavy, series_blob::SeriesBlob, update_churn::UpdateChurn,
 };
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -32,6 +32,7 @@ pub enum WorkloadProfile {
     Mixed,
     ScanHeavy,
     SeriesBlob,
+    UpdateChurn,
 }
 
 impl std::fmt::Display for WorkloadProfile {
@@ -42,6 +43,7 @@ impl std::fmt::Display for WorkloadProfile {
             WorkloadProfile::Mixed => write!(f, "mixed"),
             WorkloadProfile::ScanHeavy => write!(f, "scan-heavy"),
             WorkloadProfile::SeriesBlob => write!(f, "series-blob"),
+            WorkloadProfile::UpdateChurn => write!(f, "update-churn"),
         }
     }
 }
@@ -87,6 +89,7 @@ pub fn create_profile(
         WorkloadProfile::Mixed => Box::new(Mixed::new(iterations, batch_size)),
         WorkloadProfile::ScanHeavy => Box::new(ScanHeavy::new(iterations, batch_size)),
         WorkloadProfile::SeriesBlob => Box::new(SeriesBlob::new(iterations, batch_size)),
+        WorkloadProfile::UpdateChurn => Box::new(UpdateChurn::new(iterations, batch_size)),
     };
 
     if checkpoint {

--- a/perf/memory/src/workload.rs
+++ b/perf/memory/src/workload.rs
@@ -64,6 +64,9 @@ pub struct WorkloadConfig {
     /// Only meaningful in MVCC mode; WAL's 1000-frame threshold is not
     /// configurable.
     pub mvcc_checkpoint_threshold: Option<i64>,
+    /// MVCC inline-GC trigger threshold in live-version growth (`PRAGMA
+    /// mvcc_gc_threshold`; -1 disables inline GC). Only meaningful in MVCC mode.
+    pub mvcc_gc_threshold: Option<i64>,
 }
 
 /// Hooks invoked at workload milestones so callers can take measurements.
@@ -130,6 +133,12 @@ pub async fn run_workload(
     if let Some(threshold) = cfg.mvcc_checkpoint_threshold {
         setup_conn
             .pragma_update("mvcc_checkpoint_threshold", &threshold.to_string())
+            .await?;
+    }
+
+    if let Some(threshold) = cfg.mvcc_gc_threshold {
+        setup_conn
+            .pragma_update("mvcc_gc_threshold", &threshold.to_string())
             .await?;
     }
 

--- a/testing/stress/tests/shuttle_mvcc.rs
+++ b/testing/stress/tests/shuttle_mvcc.rs
@@ -1,6 +1,6 @@
 #![cfg(shuttle)]
 
-use shuttle::scheduler::RandomScheduler;
+use shuttle::scheduler::{PctScheduler, RandomScheduler};
 use shuttle::sync::Barrier;
 use turso::Builder;
 use turso_stress::sync::atomic::{AtomicBool, AtomicI64, Ordering};
@@ -646,4 +646,94 @@ fn shuttle_test_speculative_abort_delete_slow() {
     let scheduler = RandomScheduler::new(10);
     let runner = shuttle::Runner::new(scheduler, shuttle_config());
     runner.run(|| shuttle::future::block_on(speculative_abort_delete_scenario(30, 60)));
+}
+
+#[test]
+fn shuttle_test_begin_publish_window_gc_hazard() {
+    let scheduler = PctScheduler::new(5, 10000);
+    let runner = shuttle::Runner::new(scheduler, shuttle_config());
+    runner.run(|| shuttle::future::block_on(begin_publish_window_gc_scenario(3, 5)));
+}
+
+/// Begin-publish-window GC hazard (regression test for PR #7493).
+///
+/// With aggressive inline GC enabled (`PRAGMA mvcc_gc_threshold = 1`), every
+/// committed write runs `gc_incremental` on the commit path. A reader that has
+/// allocated its begin timestamp but is not yet published into `txs` is invisible
+/// to `compute_lwm`; if a writer commits in that window, inline GC could free the
+/// version the reader still needs. The reader then resumes, reads at its old
+/// snapshot, finds the new version invisible, falls through to an empty B-tree
+/// (nothing is checkpointed at this size), and observes NO ROW.
+///
+/// The fix publishes a transaction into `txs` atomically with its begin
+/// timestamp under the clock lock, so a committing writer always sees the
+/// reader's snapshot (or assigns a strictly newer commit timestamp the reader
+/// will see). Row id=1 is inserted once at setup and never deleted, so every
+/// snapshot MUST observe exactly one row for it; a reader seeing zero rows is
+/// the violation.
+async fn begin_publish_window_gc_scenario(num_readers: usize, rounds: i64) {
+    let (db, _dir) = setup_mvcc_db(
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
+         INSERT INTO t VALUES(1, 0);",
+    )
+    .await;
+
+    // Make every committed write trigger an inline GC pass.
+    {
+        db.connect()
+            .unwrap()
+            .execute("PRAGMA mvcc_gc_threshold = 1", ())
+            .await
+            .unwrap();
+    }
+
+    let row_disappeared = Arc::new(AtomicBool::new(false));
+    let mut handles = Vec::new();
+
+    {
+        let conn = db.connect().unwrap();
+        handles.push(turso_stress::future::spawn(async move {
+            for i in 0..rounds {
+                let _ = conn
+                    .execute(&format!("UPDATE t SET val = {} WHERE id = 1", i + 1), ())
+                    .await;
+            }
+        }));
+    }
+
+    for _ in 0..num_readers {
+        let conn = db.connect().unwrap();
+        let row_disappeared = row_disappeared.clone();
+        handles.push(turso_stress::future::spawn(async move {
+            let mut saw_one = false;
+
+            for _ in 0..rounds {
+                if row_disappeared.load(Ordering::Acquire) {
+                    return;
+                }
+                match conn
+                    .query("SELECT val FROM t WHERE id = 1", ())
+                    .await
+                    .unwrap()
+                    .next()
+                    .await
+                {
+                    Ok(Some(_)) => saw_one = true,
+                    Ok(None) if saw_one => {
+                        row_disappeared.store(true, Ordering::Release);
+                    }
+                    _ => {}
+                }
+            }
+        }));
+    }
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+
+    assert!(
+        !row_disappeared.load(Ordering::Acquire),
+        "Observed a row, and then no row. This violates Snapshot Isolation"
+    );
 }


### PR DESCRIPTION
This PR decouples Garbage Collection/reclamation of unneeded RowVersions with checkpointing, in order to reduce memory usage for MVCC journal mode.


### Description:

A _version_ is reclaimable when both watermarks agree:

- **LWM**: the oldest snapshot any active/committing txn holds. A version with `end <= LWM` is invisible to every current txn, and to every future one (new begin timestamps are always `>= LWM`). So it's dead.
- **`ckpt_max` / `durable_txid_max`**: the highest txn already flushed to the B-tree. A *current* version can only be dropped from memory once it's durable (`begin <= ckpt_max`); a read then falls back to the B-tree.

`gc_version_chain()` is the only place versions are freed. Three rules:

1. **Aborted garbage** (no begin, no end): always remove.
2. **Superseded** (`end <= LWM`): remove, *unless* it's a not-yet-durable
   tombstone (`end > ckpt_max`) that's the sole version: keeping it stops a read
   from falling through to a stale B-tree row that the delete hasn't erased yet.
3. **Checkpointed sole survivor** (only version, `begin <= ckpt_max`,
   `begin < LWM`): the in-memory copy is redundant with the B-tree; remove.

Everything else in GC is just *when* and *how often* to apply these rules. The
rules themselves are what make it correct.

One deliberate consequence: one long-open txn pins the LWM low and keeps
everything newer alive, there is really no way around this.

## What changed

Before: reclamation ran only at the **checkpoint**: a stop-the-world pass
triggered by ~4 MB of log bytes. Dead versions piled up between checkpoints, 
and the trigger (log bytes) had nothing to do with how much dead memory was sitting in RAM.

This PR adds a second path that runs inline, in bounded chunks and with no global
lock, on transactions that are already committing:

1. **Counter**: `live_version_count` tracks live versions (up on insert, down
   on reclaim). A *heuristic*: it only decides when to run GC, never what's safe
   to free.
2. **Trigger**: after a commit (when not already checkpointing), `should_gc()`
   fires if the counter grew past `mvcc_gc_threshold` (PRAGMA, default 16384;
   `-1` disables) since the last pass.
3. **`gc_incremental(max_chains)`**: scans at most 4096 chains, resuming from a
   saved cursor and wrapping at the end. Index chains are swept once per full
   table cycle. Sub-millisecond per pass; steady state comes from many small
   passes.

The checkpoint path is unchanged and still does the full sweep. The two triggers
are now independent (log bytes / durability vs. memory pressure).

## Why the inline path is also safe:

1. **Same rules.** It calls the same `gc_version_chain` with the same LWM and
   `ckpt_max`, it cannot free anything that the checkpoint sweep wouldn't.
2. **Per-chain locking.** It edits a chain only under that chain's write lock,
   so it can't race a concurrent writer on the same row.
3. **Lazy removal.** It empties dead chains but never deletes the empty slot from
   the map: deleting a slot could race a writer looking it up to append (TOCTOU).
   Only the stop-the-world checkpoint, which has paused everyone, removes slots.
   This is what lets the inline path skip the global lock. Empty slots are cheap
   and get reused or cleaned up later by the checkpoint.

The approximate counter can't cause a bad free (frees come only from the LWM /
`ckpt_max` rules). Inline GC also skips pruning the finished-txn bookkeeping,
which needs an all-chains-at-once view - that stays on the checkpoint path.

<img width="1086" height="545" alt="image" src="https://github.com/user-attachments/assets/f4f53e15-e2f5-470b-a70b-87cb3951db18" />

