### PR TITLE
mvcc: add on_commit_end durability hook to DurableStorage

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1252,6 +1252,12 @@ pub enum CommitState<Clock: LogicalClock> {
         end_ts: u64,
         log_record: LogRecord,
     },
+    /// Await durable persistence of the just-written logical-log bytes (e.g.
+    /// upload to object storage in diskless server deployments) before the
+    /// commit is made visible. See `DurableStorage::persist_log_durably`.
+    PersistLogDurably {
+        end_ts: u64,
+    },
     EndCommitLogicalLog {
         end_ts: u64,
     },
@@ -2947,7 +2953,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 let end_ts = *end_ts;
                 let log_record = match std::mem::replace(
                     &mut self.state,
-                    CommitState::SyncLogicalLog { end_ts },
+                    CommitState::PersistLogDurably { end_ts },
                 ) {
                     CommitState::WriteLogicalLog { log_record, .. } => log_record,
                     _ => unreachable!(),
@@ -2955,6 +2961,22 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 let (c, append_bytes) = mvcc_store.storage.log_tx(log_record, None)?;
                 self.pending_log_append_bytes = Some(append_bytes);
                 // if Completion Completed without errors we can continue
+                if c.succeeded() {
+                    Ok(TransitionResult::Continue)
+                } else {
+                    Ok(TransitionResult::Io(IOCompletions::Single(c)))
+                }
+            }
+
+            CommitState::PersistLogDurably { end_ts } => {
+                // Wait for the just-written logical-log bytes to become durable
+                // (e.g. uploaded to object storage) before the commit is made
+                // visible in `CommitEnd`. Runs outside the logical-log lock, so
+                // backends are free to surface async I/O through the returned
+                // completion without risking a deadlock against that lock.
+                let end_ts = *end_ts;
+                let c = mvcc_store.storage.on_commit_end()?;
+                self.state = CommitState::SyncLogicalLog { end_ts };
                 if c.succeeded() {
                     Ok(TransitionResult::Continue)
                 } else {
@@ -8186,6 +8208,10 @@ impl<Clock: LogicalClock> Debug for CommitState<Clock> {
                 .debug_struct("WriteLogicalLog")
                 .field("end_ts", end_ts)
                 .field("log_record", log_record)
+                .finish(),
+            Self::PersistLogDurably { end_ts } => f
+                .debug_struct("PersistLogDurably")
+                .field("end_ts", end_ts)
                 .finish(),
             Self::EndCommitLogicalLog { end_ts } => f
                 .debug_struct("EndCommitLogicalLog")

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -57,6 +57,25 @@ pub trait DurableStorage: Send + Sync + Debug {
         Ok(())
     }
 
+    /// Called as the final durability step of a write commit, after the
+    /// logical-log bytes have been written but before the commit is made
+    /// visible (i.e. before the logical-log offset is advanced).
+    ///
+    /// Mirrors `on_checkpoint_end`, but returns a `Completion`: the commit is
+    /// NOT made visible until the returned completion succeeds, so backends
+    /// that durably persist the captured bytes elsewhere (e.g. uploading them
+    /// to object storage in diskless deployments) can surface that async work
+    /// through the completion. It is invoked at a point where no internal
+    /// storage lock is held; implementations must therefore not perform
+    /// inline/blocking I/O that could re-enter those locks — they should kick
+    /// off the work asynchronously and report completion here.
+    ///
+    /// The default returns an already-completed completion (no durable storage
+    /// beyond the logical log itself).
+    fn on_commit_end(&self) -> Result<Completion> {
+        Ok(Completion::new_yield())
+    }
+
     /// Persist the current logical-log header to durable storage.
     ///
     /// This is used by MVCC recovery/checkpoint flows. Keeping this in the trait avoids


### PR DESCRIPTION
## What

Adds a new `DurableStorage` trait method and a commit state so a durable-storage backend can persist a committing transaction's just-written logical-log bytes **asynchronously** and have the commit **wait for that to become durable** before it is made visible — without doing inline I/O while the internal logical-log write lock is held.

- `DurableStorage::on_commit_end(&self) -> Result<Completion>` — called on every write commit after the logical-log write but before the logical-log offset is advanced. Returns a `Completion` the commit awaits; the default returns an already-completed completion (non-diskless storage is unaffected). Mirrors `on_checkpoint_end`, but returns a `Completion` because the work it gates (e.g. an object-storage upload) is async.
- `CommitState::PersistLogDurably` — new step between `WriteLogicalLog` and `SyncLogicalLog` that calls `on_commit_end` and yields on the returned completion before `CommitEnd` makes the transaction visible.

## Why

This is the core-side half of fixing a deadlock in the diskless tursodb server (turso-server PR). There, the only hook to capture serialized log bytes was the `log_tx` serialization callback, which runs **while the logical-log write lock is held**. Uploading to S3 there suspends the SQL coroutine across that lock, deadlocking the single-threaded event loop.

`on_commit_end` runs at a point where no logical-log lock is held and lets the backend surface async durability work through a `Completion`, so it can be driven off the coroutine while the commit correctly blocks until everything is durable.

## Testing

`cargo test -p turso_core mvcc::database` — 315 passed. The default no-op `on_commit_end` keeps all existing (non-diskless) commit paths unchanged.

https://claude.ai/code/session_01Qt9H6SSqPrqeDJ4HkGFRCt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qt9H6SSqPrqeDJ4HkGFRCt)_