### PR TITLE
impl collation_list PRAGMA

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -150,7 +150,7 @@ ongoing work to pass the full SQLite TCL test suite.
 | PRAGMA case_sensitive_like       | Not Needed | deprecated in SQLite                         |
 | PRAGMA cell_size_check           | ❌ No         |                                              |
 | PRAGMA checkpoint_fullfsync      | ❌ No         |                                              |
-| PRAGMA collation_list            | ❌ No         |                                              |
+| PRAGMA collation_list            | ✅ Yes        |                                              |
 | PRAGMA compile_options           | ❌ No         |                                              |
 | PRAGMA count_changes             | Not Needed | deprecated in SQLite                         |
 | PRAGMA data_store_directory      | Not Needed | deprecated in SQLite                         |

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3875,6 +3875,20 @@ impl Connection {
         self.syms.read().vtab_modules.keys().cloned().collect()
     }
 
+    /// Returns external (extension) collation names.
+    pub fn get_syms_collations(&self) -> Vec<String> {
+        let mut collations = self
+            .syms
+            .read()
+            .collations
+            .values()
+            .map(|collation| collation.name.clone())
+            .collect::<Vec<_>>();
+        collations.sort();
+        collations.dedup();
+        collations
+    }
+
     /// Returns external (extension) functions: (name, is_aggregate, argc, deterministic)
     pub fn get_syms_functions(&self) -> Vec<(String, bool, i32, bool)> {
         self.syms

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -203,6 +203,7 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["cache_spill"],
         ),
+        CollationList => Pragma::new(PragmaFlags::Result0, &["seq", "name"]),
         #[cfg(target_vendor = "apple")]
         PragmaName::Fullfsync => Pragma::new(
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -47,6 +47,21 @@ static CUSTOM_COLLATION_NAMES: LazyLock<Mutex<CustomCollationNames>> =
     LazyLock::new(|| Mutex::new(CustomCollationNames::default()));
 
 impl CollationSeq {
+    const BUILTIN_SEQUENCES: [Self; 3] = [Self::Binary, Self::NoCase, Self::Rtrim];
+
+    pub fn builtin_sequences() -> &'static [Self] {
+        &Self::BUILTIN_SEQUENCES
+    }
+
+    pub const fn builtin_name(self) -> Option<&'static str> {
+        match self {
+            Self::Binary => Some("BINARY"),
+            Self::NoCase => Some("NOCASE"),
+            Self::Rtrim => Some("RTRIM"),
+            _ => None,
+        }
+    }
+
     pub fn new(collation: &str) -> crate::Result<Self> {
         match crate::util::normalize_ident(collation).as_str() {
             "binary" => return Ok(Self::Binary),

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -20,6 +20,7 @@ use crate::storage::pager::AutoVacuumMode;
 use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
+use crate::translate::collate::CollationSeq;
 use crate::translate::emitter::{Resolver, TransactionMode};
 use crate::translate::plan::BitSet;
 use crate::util::{normalize_ident, parse_signed_number, parse_string, IOExt as _};
@@ -249,6 +250,7 @@ pub fn translate_pragma(
             PragmaName::IndexInfo
             | PragmaName::IndexXinfo
             | PragmaName::IndexList
+            | PragmaName::CollationList
             | PragmaName::ForeignKeyList
             | PragmaName::TableList
             | PragmaName::TableInfo
@@ -435,6 +437,16 @@ fn update_pragma(
             program,
         ),
         PragmaName::ModuleList => Ok(TransactionMode::None),
+        PragmaName::CollationList => query_pragma(
+            PragmaName::CollationList,
+            resolver,
+            Some(value),
+            pager,
+            connection,
+            database_id,
+            schema_was_explicit,
+            program,
+        ),
         PragmaName::PageCount => query_pragma(
             PragmaName::PageCount,
             resolver,
@@ -923,6 +935,41 @@ fn query_pragma(
             }
 
             program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::CollationList => {
+            let base_reg = register;
+            program.alloc_registers(1);
+
+            let mut seq = 0_i64;
+            for collation in CollationSeq::builtin_sequences() {
+                let name = collation
+                    .builtin_name()
+                    .expect("builtin collation sequence must have a PRAGMA name");
+                program.emit_int(seq, base_reg);
+                program.emit_string8(name.to_string(), base_reg + 1);
+                program.emit_result_row(base_reg, 2);
+                seq += 1;
+            }
+
+            for collation in connection.get_syms_collations() {
+                if CollationSeq::builtin_sequences().iter().any(|builtin| {
+                    builtin
+                        .builtin_name()
+                        .is_some_and(|name| name.eq_ignore_ascii_case(&collation))
+                }) {
+                    continue;
+                }
+                program.emit_int(seq, base_reg);
+                program.emit_string8(collation, base_reg + 1);
+                program.emit_result_row(base_reg, 2);
+                seq += 1;
+            }
+
+            let pragma_meta = pragma_for(&pragma);
+            for col_name in pragma_meta.columns.iter() {
+                program.add_pragma_result_column(col_name.to_string());
+            }
             Ok(TransactionMode::None)
         }
         PragmaName::FunctionList => {

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1778,6 +1778,8 @@ pub enum PragmaName {
     CacheSize,
     /// set the cache spill behavior
     CacheSpill,
+    /// List all collating sequences known to the database connection
+    CollationList,
     /// encryption cipher algorithm name for encrypted databases
     #[strum(serialize = "cipher")]
     #[cfg_attr(feature = "serde", serde(rename = "cipher"))]

--- a/testing/sqltests/tests/pragma/default.sqltest
+++ b/testing/sqltests/tests/pragma/default.sqltest
@@ -225,6 +225,27 @@ expect pattern {
     \ngenerate_series\n|^generate_series\n|\ngenerate_series$|^generate_series$
 }
 
+@skip-if sqlite "SQLite builds may register extra collations such as decimal or uint"
+test pragma-collation-list {
+    PRAGMA collation_list;
+}
+expect {
+    0|BINARY
+    1|NOCASE
+    2|RTRIM
+}
+
+test pragma-collation-list-table-valued-function {
+    SELECT name FROM pragma_collation_list
+    WHERE name IN ('BINARY', 'NOCASE', 'RTRIM')
+    ORDER BY name;
+}
+expect {
+    BINARY
+    NOCASE
+    RTRIM
+}
+
 test pragma-temp-store {
 		PRAGMA temp_store;
 }


### PR DESCRIPTION
## Description

Implement `PRAGMA collation_list` and the corresponding table-valued `pragma_collation_list` helper.

The pragma now returns the built-in collation sequences exposed by Turso:

- `BINARY`
- `NOCASE`
- `RTRIM`

It also includes connection-registered external collations.

## Tests

Added test for `collation_list`:

```bash
make -C testing/sqltests run-rust ARGS='--filter pragma-collation-list'
```