### PR TITLE
Add external page codec support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ perf/mobibench/plot/uv.lock
 **/node_modules/
 
 # .NET build outputs
+examples/dotnet/bin/
 examples/dotnet/obj/
 
 # testing

--- a/bindings/dotnet/src/Turso.Data/TursoConnection.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoConnection.cs
@@ -12,6 +12,8 @@ public class TursoConnection : DbConnection
     private TursoConnectionOptions _connectionOptions;
     private bool _disposed;
     private bool _readUncommitted;
+    private ITursoPageCodec? _pageCodec;
+    private byte _pageCodecReservedSpace;
 
     [AllowNull]
     public override string ConnectionString
@@ -36,6 +38,30 @@ public class TursoConnection : DbConnection
 
     protected override DbProviderFactory DbProviderFactory => TursoFactory.Instance;
 
+    public ITursoPageCodec? PageCodec
+    {
+        get => _pageCodec;
+        set
+        {
+            if (State == ConnectionState.Open)
+                throw new InvalidOperationException("PageCodec cannot be set while the connection is open.");
+
+            _pageCodec = value;
+        }
+    }
+
+    public byte PageCodecReservedSpace
+    {
+        get => _pageCodecReservedSpace;
+        set
+        {
+            if (State == ConnectionState.Open)
+                throw new InvalidOperationException("PageCodecReservedSpace cannot be set while the connection is open.");
+
+            _pageCodecReservedSpace = value;
+        }
+    }
+
     public TursoConnection() : this("")
     {
     }
@@ -54,8 +80,18 @@ public class TursoConnection : DbConnection
         var filename = _connectionOptions["Data Source"] ?? ":memory:";
         var cipher = _connectionOptions.GetEncryptionCipher();
         var hexkey = _connectionOptions["Encryption Key"];
+        var readOnly = IsReadOnlyMode(_connectionOptions["Mode"]);
 
-        if (cipher.HasValue)
+        if (_pageCodec is not null)
+        {
+            if (cipher.HasValue)
+                throw new InvalidOperationException("PageCodec cannot be combined with Encryption Cipher.");
+
+            _turso = readOnly
+                ? TursoBindings.OpenDatabaseReadOnlyWithPageCodec(filename, _pageCodec, _pageCodecReservedSpace)
+                : TursoBindings.OpenDatabaseWithPageCodec(filename, _pageCodec, _pageCodecReservedSpace);
+        }
+        else if (cipher.HasValue)
         {
             if (string.IsNullOrWhiteSpace(hexkey))
                 throw new InvalidOperationException("Encryption Key is required when Encryption Cipher is specified.");
@@ -66,6 +102,14 @@ public class TursoConnection : DbConnection
         {
             _turso = TursoBindings.OpenDatabase(filename);
         }
+    }
+
+    private static bool IsReadOnlyMode(string? mode)
+    {
+        return mode is not null
+            && (mode.Equals("ReadOnly", StringComparison.OrdinalIgnoreCase)
+                || mode.Equals("Read Only", StringComparison.OrdinalIgnoreCase)
+                || mode.Equals("ro", StringComparison.OrdinalIgnoreCase));
     }
 
     public override void Close()

--- a/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoDatabaseHandle.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoDatabaseHandle.cs
@@ -31,7 +31,9 @@ public class TursoDatabaseHandle() : SafeHandle(IntPtr.Zero, true)
             throw new NullReferenceException("database is invalid");
     }
 
-    public static TursoDatabaseHandle FromPtrs(IntPtr database, IntPtr connection)
+    public static TursoDatabaseHandle FromPtrs(
+        IntPtr database,
+        IntPtr connection)
     {
         var handle = new TursoDatabaseHandle();
         handle._database = database;

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
@@ -10,7 +10,13 @@ public static class TursoBindings
     public static TursoDatabaseHandle OpenDatabase(string path)
     {
         ArgumentNullException.ThrowIfNull(path);
-        return OpenDatabase(path, cipher: null, hexkey: null);
+        return OpenDatabase(path, cipher: null, hexkey: null, pageCodec: null, readOnly: false);
+    }
+
+    public static TursoDatabaseHandle OpenDatabaseReadOnly(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return OpenDatabase(path, cipher: null, hexkey: null, pageCodec: null, readOnly: true);
     }
 
     /// <summary>
@@ -25,7 +31,45 @@ public static class TursoBindings
         ArgumentNullException.ThrowIfNull(path);
         ArgumentNullException.ThrowIfNull(hexkey);
 
-        return OpenDatabase(path, cipher.ToRustString(), hexkey);
+        return OpenDatabase(path, cipher.ToRustString(), hexkey, pageCodec: null, readOnly: false);
+    }
+
+    private static TursoDatabaseHandle OpenDatabaseWithPageCodec(string path, TursoPageCodec pageCodec)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(pageCodec);
+
+        return OpenDatabase(path, cipher: null, hexkey: null, pageCodec, readOnly: false);
+    }
+
+    private static TursoDatabaseHandle OpenDatabaseReadOnlyWithPageCodec(string path, TursoPageCodec pageCodec)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(pageCodec);
+
+        return OpenDatabase(path, cipher: null, hexkey: null, pageCodec, readOnly: true);
+    }
+
+    public static TursoDatabaseHandle OpenDatabaseWithPageCodec(
+        string path,
+        ITursoPageCodec pageCodec,
+        byte reservedSpace = 0)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(pageCodec);
+
+        return OpenDatabaseWithPageCodec(path, new TursoPageCodec(pageCodec, reservedSpace));
+    }
+
+    public static TursoDatabaseHandle OpenDatabaseReadOnlyWithPageCodec(
+        string path,
+        ITursoPageCodec pageCodec,
+        byte reservedSpace = 0)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(pageCodec);
+
+        return OpenDatabaseReadOnlyWithPageCodec(path, new TursoPageCodec(pageCodec, reservedSpace));
     }
 
     public static TursoStatementHandle PrepareStatement(TursoDatabaseHandle db, string sql)
@@ -286,7 +330,12 @@ public static class TursoBindings
         }
     }
 
-    private static TursoDatabaseHandle OpenDatabase(string path, string? cipher, string? hexkey)
+    private static TursoDatabaseHandle OpenDatabase(
+        string path,
+        string? cipher,
+        string? hexkey,
+        TursoPageCodec? pageCodec,
+        bool readOnly)
     {
         using var pathString = NativeUtf8String.From(path);
         using var featuresString = NativeUtf8String.From(cipher is null ? null : "encryption");
@@ -301,14 +350,20 @@ public static class TursoBindings
             Vfs = IntPtr.Zero,
             EncryptionCipher = cipherString.Pointer,
             EncryptionHexKey = hexkeyString.Pointer,
+            PageCodec = pageCodec?.NativePointer ?? IntPtr.Zero,
+            OpenFlags = readOnly ? TursoDatabaseOpenFlags.ReadOnly : TursoDatabaseOpenFlags.None,
         };
 
-        var status = TursoInterop.DatabaseNew(ref config, out var databasePtr, out var errorPtr);
-        ThrowIfError(status, errorPtr);
-
+        var databasePtr = IntPtr.Zero;
         var connectionPtr = IntPtr.Zero;
         try
         {
+            var status = TursoInterop.DatabaseNew(ref config, out databasePtr, out var errorPtr);
+            ThrowIfError(status, errorPtr);
+            pageCodec?.TransferNativeOwnership();
+            pageCodec?.Dispose();
+            pageCodec = null;
+
             status = TursoInterop.DatabaseOpen(databasePtr, out errorPtr);
             ThrowIfError(status, errorPtr);
 
@@ -323,6 +378,7 @@ public static class TursoBindings
                 TursoInterop.ConnectionDeinit(connectionPtr);
             if (databasePtr != IntPtr.Zero)
                 TursoInterop.DatabaseDeinit(databasePtr);
+            pageCodec?.Dispose();
             throw;
         }
     }

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoPageCodec.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoPageCodec.cs
@@ -1,0 +1,302 @@
+using System.Runtime.InteropServices;
+
+namespace Turso.Raw.Public;
+
+public enum TursoPageCodecLocation : uint
+{
+    Database = 0,
+    Wal = 1,
+}
+
+public readonly record struct TursoPageCodecHeaderInfo(uint PageSize, byte ReservedSpace);
+
+public interface ITursoPageCodec
+{
+    TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix);
+
+    void DecodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output);
+
+    void EncodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output);
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal unsafe delegate int TursoPageCodecProbeHeaderCallback(
+    IntPtr context,
+    byte* rawPage1Prefix,
+    UIntPtr rawLen,
+    TursoNativePageCodecHeaderInfo* headerInfo,
+    IntPtr* error);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal unsafe delegate int TursoPageCodecTransformCallback(
+    IntPtr context,
+    uint pageNo,
+    TursoPageCodecLocation location,
+    byte* input,
+    UIntPtr inputLen,
+    byte* output,
+    UIntPtr outputLen,
+    IntPtr* error);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate void TursoPageCodecDestroyCallback(IntPtr context);
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoNativePageCodecHeaderInfo
+{
+    public uint PageSize;
+    public byte ReservedSpace;
+    public byte IsSupported;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoNativePageCodecV1
+{
+    public uint AbiVersion;
+    public IntPtr Context;
+    public byte ReservedSpace;
+    public IntPtr Destroy;
+    public IntPtr ProbeHeader;
+    public IntPtr DecodePage;
+    public IntPtr EncodePage;
+}
+
+internal sealed unsafe class TursoPageCodec : IDisposable
+{
+    private sealed class State(ITursoPageCodec codec) : IDisposable
+    {
+        private readonly object _lock = new();
+        private readonly List<IntPtr> _errors = [];
+        private bool _disposed;
+
+        public ITursoPageCodec Codec { get; } = codec;
+
+        public IntPtr SetError(Exception exception)
+        {
+            var message = Marshal.StringToCoTaskMemUTF8(exception.Message);
+            lock (_lock)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                _errors.Add(message);
+            }
+
+            return message;
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                    return;
+
+                foreach (var error in _errors)
+                    Marshal.FreeCoTaskMem(error);
+
+                _errors.Clear();
+                _disposed = true;
+            }
+        }
+    }
+
+    private delegate void PageTransform(
+        ITursoPageCodec codec,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output);
+
+    private static readonly TursoPageCodecProbeHeaderCallback ProbeHeaderCallback = ProbeHeader;
+    private static readonly TursoPageCodecTransformCallback DecodePageCallback = DecodePage;
+    private static readonly TursoPageCodecTransformCallback EncodePageCallback = EncodePage;
+    private static readonly TursoPageCodecDestroyCallback DestroyCallback = Destroy;
+
+    private readonly IntPtr _nativeCodec;
+    private readonly GCHandle _stateHandle;
+    private bool _ownsState = true;
+    private bool _disposed;
+
+    public TursoPageCodec(ITursoPageCodec codec, byte reservedSpace)
+    {
+        ArgumentNullException.ThrowIfNull(codec);
+        _stateHandle = GCHandle.Alloc(new State(codec));
+
+        var native = new TursoNativePageCodecV1
+        {
+            AbiVersion = 1,
+            Context = GCHandle.ToIntPtr(_stateHandle),
+            ReservedSpace = reservedSpace,
+            Destroy = Marshal.GetFunctionPointerForDelegate(DestroyCallback),
+            ProbeHeader = Marshal.GetFunctionPointerForDelegate(ProbeHeaderCallback),
+            DecodePage = Marshal.GetFunctionPointerForDelegate(DecodePageCallback),
+            EncodePage = Marshal.GetFunctionPointerForDelegate(EncodePageCallback),
+        };
+
+        _nativeCodec = Marshal.AllocHGlobal(Marshal.SizeOf<TursoNativePageCodecV1>());
+        Marshal.StructureToPtr(native, _nativeCodec, false);
+    }
+
+    internal IntPtr NativePointer
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _nativeCodec;
+        }
+    }
+
+    public void TransferNativeOwnership()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _ownsState = false;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        Marshal.FreeHGlobal(_nativeCodec);
+        if (_ownsState)
+            Destroy(GCHandle.ToIntPtr(_stateHandle));
+
+        _disposed = true;
+    }
+
+    private static int ProbeHeader(
+        IntPtr context,
+        byte* rawPage1Prefix,
+        UIntPtr rawLen,
+        TursoNativePageCodecHeaderInfo* headerInfo,
+        IntPtr* error)
+    {
+        var state = GetState(context);
+        try
+        {
+            var raw = new ReadOnlySpan<byte>(rawPage1Prefix, checked((int)rawLen));
+            var result = state.Codec.ProbeHeader(raw);
+            if (result is null)
+            {
+                *headerInfo = default;
+            }
+            else
+            {
+                *headerInfo = new TursoNativePageCodecHeaderInfo
+                {
+                    PageSize = result.Value.PageSize,
+                    ReservedSpace = result.Value.ReservedSpace,
+                    IsSupported = 1,
+                };
+            }
+            *error = IntPtr.Zero;
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            *error = state.SetError(ex);
+            return 1;
+        }
+    }
+
+    private static int DecodePage(
+        IntPtr context,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        byte* input,
+        UIntPtr inputLen,
+        byte* output,
+        UIntPtr outputLen,
+        IntPtr* error)
+    {
+        return Transform(context, pageNo, location, input, inputLen, output, outputLen, error, DecodePage);
+    }
+
+    private static int EncodePage(
+        IntPtr context,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        byte* input,
+        UIntPtr inputLen,
+        byte* output,
+        UIntPtr outputLen,
+        IntPtr* error)
+    {
+        return Transform(context, pageNo, location, input, inputLen, output, outputLen, error, EncodePage);
+    }
+
+    private static int Transform(
+        IntPtr context,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        byte* input,
+        UIntPtr inputLen,
+        byte* output,
+        UIntPtr outputLen,
+        IntPtr* error,
+        PageTransform transform)
+    {
+        var state = GetState(context);
+        try
+        {
+            var inputSpan = new ReadOnlySpan<byte>(input, checked((int)inputLen));
+            var outputSpan = new Span<byte>(output, checked((int)outputLen));
+            transform(state.Codec, pageNo, location, inputSpan, outputSpan);
+            *error = IntPtr.Zero;
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            *error = state.SetError(ex);
+            return 1;
+        }
+    }
+
+    private static void DecodePage(
+        ITursoPageCodec codec,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        codec.DecodePage(pageNo, location, input, output);
+    }
+
+    private static void EncodePage(
+        ITursoPageCodec codec,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        codec.EncodePage(pageNo, location, input, output);
+    }
+
+    private static State GetState(IntPtr context)
+    {
+        if (context == IntPtr.Zero)
+            throw new InvalidOperationException("Page codec context is not configured.");
+
+        return GCHandle.FromIntPtr(context).Target as State
+            ?? throw new InvalidOperationException("Page codec context is invalid.");
+    }
+
+    private static void Destroy(IntPtr context)
+    {
+        if (context == IntPtr.Zero)
+            return;
+
+        var handle = GCHandle.FromIntPtr(context);
+        if (handle.Target is State state)
+            state.Dispose();
+
+        handle.Free();
+    }
+}

--- a/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
@@ -34,6 +34,13 @@ internal enum TursoNativeValueType : uint
     Null = 5,
 }
 
+[Flags]
+internal enum TursoDatabaseOpenFlags : uint
+{
+    None = 0,
+    ReadOnly = 1,
+}
+
 [StructLayout(LayoutKind.Sequential)]
 internal struct TursoDatabaseConfig
 {
@@ -43,6 +50,8 @@ internal struct TursoDatabaseConfig
     public IntPtr Vfs;
     public IntPtr EncryptionCipher;
     public IntPtr EncryptionHexKey;
+    public IntPtr PageCodec;
+    public TursoDatabaseOpenFlags OpenFlags;
 }
 
 internal static class TursoInterop
@@ -51,20 +60,85 @@ internal static class TursoInterop
 
     static TursoInterop()
     {
-        if (OperatingSystem.IsIOS())
-        {
-            NativeLibrary.SetDllImportResolver(typeof(TursoInterop).Assembly, ResolveDllImport);
-        }
+        NativeLibrary.SetDllImportResolver(typeof(TursoInterop).Assembly, ResolveNativeLibrary);
     }
 
-    private static IntPtr ResolveDllImport(
+    private static IntPtr ResolveNativeLibrary(
         string libraryName,
         Assembly assembly,
         DllImportSearchPath? searchPath)
     {
-        return libraryName == DllName
-            ? NativeLibrary.Load($"Frameworks/lib{libraryName}.framework/lib{libraryName}", assembly, searchPath)
-            : IntPtr.Zero;
+        if (!string.Equals(libraryName, DllName, StringComparison.Ordinal))
+        {
+            return IntPtr.Zero;
+        }
+
+        if (OperatingSystem.IsIOS())
+        {
+            return NativeLibrary.Load($"Frameworks/lib{libraryName}.framework/lib{libraryName}", assembly, searchPath);
+        }
+
+        var rid = GetRuntimeIdentifier();
+        if (rid is null)
+        {
+            return IntPtr.Zero;
+        }
+
+        var libraryPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "runtimes",
+            rid,
+            "native",
+            GetNativeLibraryFileName());
+
+        return File.Exists(libraryPath) ? NativeLibrary.Load(libraryPath) : IntPtr.Zero;
+    }
+
+    private static string? GetRuntimeIdentifier()
+    {
+        var architecture = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            _ => null,
+        };
+
+        if (architecture is null)
+        {
+            return null;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return $"win-{architecture}";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return $"linux-{architecture}";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return $"osx-{architecture}";
+        }
+
+        return null;
+    }
+
+    private static string GetNativeLibraryFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "turso_sdk_kit.dll";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return "libturso_sdk_kit.dylib";
+        }
+
+        return "libturso_sdk_kit.so";
     }
 
     [DllImport(DllName, EntryPoint = "turso_database_new", CallingConvention = CallingConvention.Cdecl)]

--- a/bindings/dotnet/src/Turso.Tests/Support/EncryptedDatabaseDetector.cs
+++ b/bindings/dotnet/src/Turso.Tests/Support/EncryptedDatabaseDetector.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using Turso;
+using Turso.Raw.Public;
+
+namespace Turso.Tests.Support;
+
+internal sealed record ExternalCodecCandidate(
+    string Name,
+    Func<string, ITursoPageCodec> CreateCodec,
+    byte ReservedSpace = 0);
+
+internal sealed class DetectedEncryptedDatabase(
+    string codecName,
+    TursoConnection connection,
+    ITursoPageCodec codec) : IDisposable
+{
+    public string CodecName { get; } = codecName;
+
+    public TursoConnection Connection { get; } = connection;
+
+    public void Dispose()
+    {
+        Connection.Dispose();
+        if (codec is IDisposable disposable)
+            disposable.Dispose();
+    }
+}
+
+internal static class EncryptedDatabaseDetector
+{
+    public static IReadOnlyList<ExternalCodecCandidate> DefaultCandidates()
+    {
+        var candidates = new List<ExternalCodecCandidate>
+        {
+            new(
+                "wxSQLite3/SQLite3MC aes128cbc",
+                password => WxSQLite3Aes128CbcCodec.FromPassword(password)),
+        };
+
+        if (OperatingSystem.IsWindows())
+        {
+            candidates.Add(new(
+                "System.Data.SQLite legacy CryptoAPI RC4 (encrypted page 1)",
+                password => SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password, encryptPage1: true)));
+            candidates.Add(new(
+                "System.Data.SQLite legacy CryptoAPI RC4 (plaintext page 1 header)",
+                password => SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password, encryptPage1: false)));
+        }
+
+        return candidates;
+    }
+
+    public static DetectedEncryptedDatabase Open(
+        string path,
+        string password,
+        IEnumerable<ExternalCodecCandidate>? candidates = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(password);
+        if (!File.Exists(path))
+            throw new FileNotFoundException("Database file does not exist.", path);
+
+        var failures = new List<Exception>();
+        foreach (var candidate in candidates ?? DefaultCandidates())
+        {
+            ITursoPageCodec? codec = null;
+            TursoConnection? connection = null;
+            try
+            {
+                codec = candidate.CreateCodec(password);
+                connection = new TursoConnection(ConnectionStringFor(path))
+                {
+                    PageCodec = codec,
+                    PageCodecReservedSpace = candidate.ReservedSpace,
+                };
+                connection.Open();
+                ValidateConnection(connection);
+                return new DetectedEncryptedDatabase(candidate.Name, connection, codec);
+            }
+            catch (Exception ex) when (IsExpectedCandidateFailure(ex))
+            {
+                connection?.Dispose();
+                if (codec is IDisposable disposable)
+                    disposable.Dispose();
+
+                failures.Add(new InvalidOperationException($"{candidate.Name}: {ex.Message}", ex));
+            }
+        }
+
+        throw new AggregateException(
+            $"None of the configured external SQLite encryption codecs could open '{path}' with the supplied password.",
+            failures);
+    }
+
+    private static string ConnectionStringFor(string path)
+    {
+        return new TursoConnectionStringBuilder
+        {
+            DataSource = path,
+            Mode = "ReadOnly",
+        }.ConnectionString;
+    }
+
+    private static void ValidateConnection(TursoConnection connection)
+    {
+        using var command = new TursoCommand(connection, "SELECT count(*) FROM sqlite_schema");
+        _ = Convert.ToInt64(command.ExecuteScalar(), CultureInfo.InvariantCulture);
+    }
+
+    private static bool IsExpectedCandidateFailure(Exception exception)
+    {
+        return exception is TursoException
+            or CryptographicException
+            or PlatformNotSupportedException
+            or Win32Exception
+            or ArgumentException;
+    }
+}

--- a/bindings/dotnet/src/Turso.Tests/Support/SystemDataSQLiteLegacyCryptoApiCodec.cs
+++ b/bindings/dotnet/src/Turso.Tests/Support/SystemDataSQLiteLegacyCryptoApiCodec.cs
@@ -1,0 +1,263 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using Turso.Raw.Public;
+
+namespace Turso.Tests.Support;
+
+internal sealed class SystemDataSQLiteLegacyCryptoApiCodec : ITursoPageCodec, IDisposable
+{
+    private const uint ProvRsaFull = 1;
+    private const uint CryptVerifyContext = 0xF0000000;
+    private const uint CalgSha1 = 0x00008004;
+    private const uint CalgRc4 = 0x00006801;
+    private const string EnhancedProvider = "Microsoft Enhanced Cryptographic Provider v1.0";
+    private const string LegacyEncryptPage1Variable = "SQLite_LegacyEncryptPage1";
+    private static ReadOnlySpan<byte> SqliteHeader => "SQLite format 3\0"u8;
+
+    private readonly byte[] _password;
+    private readonly bool _encryptPage1;
+    private readonly object _lock = new();
+    private IntPtr _provider;
+    private bool _disposed;
+
+    private SystemDataSQLiteLegacyCryptoApiCodec(ReadOnlySpan<byte> password, bool? encryptPage1)
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("The legacy System.Data.SQLite codec uses Windows CryptoAPI.");
+
+        if (password.IsEmpty)
+            throw new ArgumentException("Password must not be empty.", nameof(password));
+
+        _password = password.ToArray();
+        _encryptPage1 = encryptPage1 ?? Environment.GetEnvironmentVariable(LegacyEncryptPage1Variable) is not null;
+
+        if (!CryptAcquireContext(out _provider, null, EnhancedProvider, ProvRsaFull, CryptVerifyContext))
+            ThrowLastWin32Error("CryptAcquireContext");
+    }
+
+    public static SystemDataSQLiteLegacyCryptoApiCodec FromPassword(string password, bool? encryptPage1 = null)
+    {
+        ArgumentNullException.ThrowIfNull(password);
+        return new SystemDataSQLiteLegacyCryptoApiCodec(Encoding.UTF8.GetBytes(password), encryptPage1);
+    }
+
+    public static SystemDataSQLiteLegacyCryptoApiCodec FromRawPassword(
+        ReadOnlySpan<byte> password,
+        bool? encryptPage1 = null)
+    {
+        return new SystemDataSQLiteLegacyCryptoApiCodec(password, encryptPage1);
+    }
+
+    public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+    {
+        if (TryReadHeader(rawPage1Prefix, out var plainHeader))
+            return plainHeader;
+
+        var decrypted = new byte[rawPage1Prefix.Length];
+        Transform(rawPage1Prefix, decrypted, decrypt: true);
+        return TryReadHeader(decrypted, out var decryptedHeader) ? decryptedHeader : null;
+    }
+
+    public void DecodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        _ = location;
+        TransformPage(pageNo, input, output, decrypt: true);
+    }
+
+    public void EncodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        _ = location;
+        TransformPage(pageNo, input, output, decrypt: false);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        CryptographicOperations.ZeroMemory(_password);
+
+        if (_provider != IntPtr.Zero)
+        {
+            CryptReleaseContext(_provider, 0);
+            _provider = IntPtr.Zero;
+        }
+
+        _disposed = true;
+    }
+
+    private static bool TryReadHeader(
+        ReadOnlySpan<byte> pagePrefix,
+        out TursoPageCodecHeaderInfo headerInfo)
+    {
+        if (pagePrefix.Length < 100 || !pagePrefix[..SqliteHeader.Length].SequenceEqual(SqliteHeader))
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        var pageSizeRaw = (ushort)((pagePrefix[16] << 8) | pagePrefix[17]);
+        var pageSize = pageSizeRaw == 1 ? 65536u : pageSizeRaw;
+        if (!IsValidPageSize(pageSize) || !IsValidFileFormatVersion(pagePrefix[18]) || !IsValidFileFormatVersion(pagePrefix[19]))
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        headerInfo = new TursoPageCodecHeaderInfo(pageSize, pagePrefix[20]);
+        return true;
+    }
+
+    private static bool IsValidPageSize(uint pageSize)
+    {
+        return pageSize is >= 512 and <= 65536 && (pageSize & (pageSize - 1)) == 0;
+    }
+
+    private static bool IsValidFileFormatVersion(byte version)
+    {
+        return version is 1 or 2;
+    }
+
+    private void TransformPage(uint pageNo, ReadOnlySpan<byte> input, Span<byte> output, bool decrypt)
+    {
+        if (pageNo == 0)
+            throw new ArgumentOutOfRangeException(nameof(pageNo), pageNo, "SQLite page numbers are one-based.");
+
+        if (input.Length != output.Length)
+            throw new ArgumentException("Codec input and output page lengths must match.");
+
+        if (!_encryptPage1 && pageNo == 1 && input.Length >= SqliteHeader.Length && input[..SqliteHeader.Length].SequenceEqual(SqliteHeader))
+        {
+            input.CopyTo(output);
+            return;
+        }
+
+        Transform(input, output, decrypt);
+    }
+
+    private void Transform(ReadOnlySpan<byte> input, Span<byte> output, bool decrypt)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var buffer = input.ToArray();
+        lock (_lock)
+        {
+            var key = DeriveKey();
+            try
+            {
+                var dataLength = checked((uint)buffer.Length);
+                var bufferLength = dataLength;
+                var success = decrypt
+                    ? CryptDecrypt(key, IntPtr.Zero, true, 0, buffer, ref dataLength)
+                    : CryptEncrypt(key, IntPtr.Zero, true, 0, buffer, ref dataLength, bufferLength);
+
+                if (!success)
+                    ThrowLastWin32Error(decrypt ? "CryptDecrypt" : "CryptEncrypt");
+
+                if (dataLength != bufferLength)
+                    throw new InvalidOperationException("Legacy CryptoAPI page transform changed the page size.");
+            }
+            finally
+            {
+                CryptDestroyKey(key);
+            }
+        }
+
+        buffer.CopyTo(output);
+    }
+
+    private IntPtr DeriveKey()
+    {
+        if (!CryptCreateHash(_provider, CalgSha1, IntPtr.Zero, 0, out var hash))
+            ThrowLastWin32Error("CryptCreateHash");
+
+        try
+        {
+            if (!CryptHashData(hash, _password, checked((uint)_password.Length), 0))
+                ThrowLastWin32Error("CryptHashData");
+
+            if (!CryptDeriveKey(_provider, CalgRc4, hash, 0, out var key))
+                ThrowLastWin32Error("CryptDeriveKey");
+
+            return key;
+        }
+        finally
+        {
+            CryptDestroyHash(hash);
+        }
+    }
+
+    private static void ThrowLastWin32Error(string function)
+    {
+        throw new Win32Exception(Marshal.GetLastWin32Error(), function);
+    }
+
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CryptAcquireContext(
+        out IntPtr provider,
+        string? keyContainer,
+        string? providerName,
+        uint providerType,
+        uint flags);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptCreateHash(
+        IntPtr provider,
+        uint algorithmId,
+        IntPtr key,
+        uint flags,
+        out IntPtr hash);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptHashData(
+        IntPtr hash,
+        byte[] data,
+        uint dataLength,
+        uint flags);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptDeriveKey(
+        IntPtr provider,
+        uint algorithmId,
+        IntPtr baseData,
+        uint flags,
+        out IntPtr key);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptEncrypt(
+        IntPtr key,
+        IntPtr hash,
+        bool final,
+        uint flags,
+        byte[] data,
+        ref uint dataLength,
+        uint bufferLength);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptDecrypt(
+        IntPtr key,
+        IntPtr hash,
+        bool final,
+        uint flags,
+        byte[] data,
+        ref uint dataLength);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptDestroyHash(IntPtr hash);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptDestroyKey(IntPtr key);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptReleaseContext(IntPtr provider, uint flags);
+}

--- a/bindings/dotnet/src/Turso.Tests/Support/WxSQLite3Aes128CbcCodec.cs
+++ b/bindings/dotnet/src/Turso.Tests/Support/WxSQLite3Aes128CbcCodec.cs
@@ -1,0 +1,339 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using Turso.Raw.Public;
+
+namespace Turso.Tests.Support;
+
+internal sealed class WxSQLite3Aes128CbcCodec : ITursoPageCodec, IDisposable
+{
+    private static ReadOnlySpan<byte> SqliteHeader => "SQLite format 3\0"u8;
+    private static ReadOnlySpan<byte> PageKeySalt => "sAlT"u8;
+    private static ReadOnlySpan<byte> PasswordPadding =>
+    [
+        0x28, 0xBF, 0x4E, 0x5E, 0x4E, 0x75, 0x8A, 0x41,
+        0x64, 0x00, 0x4E, 0x56, 0xFF, 0xFA, 0x01, 0x08,
+        0x2E, 0x2E, 0x00, 0xB6, 0xD0, 0x68, 0x3E, 0x80,
+        0x2F, 0x0C, 0xA9, 0xFE, 0x64, 0x53, 0x69, 0x7A
+    ];
+
+    private readonly byte[] _masterKey;
+    private bool _disposed;
+
+    private WxSQLite3Aes128CbcCodec(ReadOnlySpan<byte> password)
+    {
+        if (password.IsEmpty)
+            throw new ArgumentException("Password must not be empty.", nameof(password));
+
+        _masterKey = DeriveMasterKey(password);
+    }
+
+    public static WxSQLite3Aes128CbcCodec FromPassword(string password)
+    {
+        ArgumentNullException.ThrowIfNull(password);
+
+        var passwordBytes = Encoding.UTF8.GetBytes(password);
+        try
+        {
+            return new WxSQLite3Aes128CbcCodec(passwordBytes);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(passwordBytes);
+        }
+    }
+
+    public static WxSQLite3Aes128CbcCodec FromRawPassword(ReadOnlySpan<byte> password)
+    {
+        return new WxSQLite3Aes128CbcCodec(password);
+    }
+
+    public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+    {
+        if (TryReadSqliteHeader(rawPage1Prefix, out var plainHeader))
+            return plainHeader;
+
+        if (TryReadModernAesHeader(rawPage1Prefix, out var encryptedHeader))
+            return encryptedHeader;
+
+        return null;
+    }
+
+    public void DecodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        _ = location;
+        TransformPage(pageNo, input, output, encrypt: false);
+    }
+
+    public void EncodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        _ = location;
+        TransformPage(pageNo, input, output, encrypt: true);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        CryptographicOperations.ZeroMemory(_masterKey);
+        _disposed = true;
+    }
+
+    private static bool TryReadSqliteHeader(
+        ReadOnlySpan<byte> pagePrefix,
+        out TursoPageCodecHeaderInfo headerInfo)
+    {
+        if (pagePrefix.Length < 100 || !pagePrefix[..SqliteHeader.Length].SequenceEqual(SqliteHeader))
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        return TryReadHeaderFields(pagePrefix, out headerInfo);
+    }
+
+    private static bool TryReadModernAesHeader(
+        ReadOnlySpan<byte> pagePrefix,
+        out TursoPageCodecHeaderInfo headerInfo)
+    {
+        if (pagePrefix.Length < 24 || pagePrefix[..SqliteHeader.Length].SequenceEqual(SqliteHeader))
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        return TryReadHeaderFields(pagePrefix, out headerInfo);
+    }
+
+    private static bool TryReadHeaderFields(
+        ReadOnlySpan<byte> pagePrefix,
+        out TursoPageCodecHeaderInfo headerInfo)
+    {
+        var pageSizeRaw = (ushort)((pagePrefix[16] << 8) | pagePrefix[17]);
+        var pageSize = pageSizeRaw == 1 ? 65536u : pageSizeRaw;
+        if (!IsValidPageSize(pageSize)
+            || !IsValidFileFormatVersion(pagePrefix[18])
+            || !IsValidFileFormatVersion(pagePrefix[19])
+            || pagePrefix[21] != 64
+            || pagePrefix[22] != 32
+            || pagePrefix[23] != 32)
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        headerInfo = new TursoPageCodecHeaderInfo(pageSize, pagePrefix[20]);
+        return true;
+    }
+
+    private static bool IsValidPageSize(uint pageSize)
+    {
+        return pageSize is >= 512 and <= 65536 && (pageSize & (pageSize - 1)) == 0;
+    }
+
+    private static bool IsValidFileFormatVersion(byte version)
+    {
+        return version is 1 or 2;
+    }
+
+    private void TransformPage(uint pageNo, ReadOnlySpan<byte> input, Span<byte> output, bool encrypt)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (pageNo == 0)
+            throw new ArgumentOutOfRangeException(nameof(pageNo), pageNo, "SQLite page numbers are one-based.");
+
+        if (input.Length != output.Length)
+            throw new ArgumentException("Codec input and output page lengths must match.");
+
+        if (input.Length < 512 || input.Length % 16 != 0)
+            throw new ArgumentException("wxSQLite3 AES-128-CBC pages must be at least 512 bytes and block aligned.");
+
+        var buffer = input.ToArray();
+        if (encrypt)
+            EncryptPage(checked((int)pageNo), buffer);
+        else
+            DecryptPage(checked((int)pageNo), buffer);
+
+        buffer.CopyTo(output);
+    }
+
+    private void EncryptPage(int pageNo, Span<byte> data)
+    {
+        if (pageNo != 1)
+        {
+            TransformAes(pageNo, data, data, encrypt: true);
+            return;
+        }
+
+        Span<byte> dbHeader = stackalloc byte[8];
+        data[16..24].CopyTo(dbHeader);
+
+        TransformAes(pageNo, data[..16], data[..16], encrypt: true);
+        TransformAes(pageNo, data[16..], data[16..], encrypt: true);
+
+        data[16..24].CopyTo(data[8..16]);
+        dbHeader.CopyTo(data[16..24]);
+    }
+
+    private void DecryptPage(int pageNo, Span<byte> data)
+    {
+        if (pageNo != 1)
+        {
+            TransformAes(pageNo, data, data, encrypt: false);
+            return;
+        }
+
+        Span<byte> dbHeader = stackalloc byte[8];
+        data[16..24].CopyTo(dbHeader);
+
+        var offset = 0;
+        if (IsModernPageOneHeader(dbHeader))
+        {
+            data[8..16].CopyTo(data[16..24]);
+            offset = 16;
+        }
+
+        TransformAes(pageNo, data[offset..], data[offset..], encrypt: false);
+        if (offset != 0 && data[16..24].SequenceEqual(dbHeader))
+            SqliteHeader.CopyTo(data);
+    }
+
+    private static bool IsModernPageOneHeader(ReadOnlySpan<byte> dbHeader)
+    {
+        var dbPageSize = (dbHeader[0] << 8) | (dbHeader[1] << 16);
+        return IsValidPageSize((uint)dbPageSize)
+            && dbHeader[5] == 0x40
+            && dbHeader[6] == 0x20
+            && dbHeader[7] == 0x20;
+    }
+
+    private void TransformAes(int pageNo, ReadOnlySpan<byte> input, Span<byte> output, bool encrypt)
+    {
+        if (input.Length % 16 != 0)
+            throw new ArgumentException("AES-CBC input length must be block aligned.");
+
+        Span<byte> pageKey = stackalloc byte[16];
+        DerivePageKey(pageNo, pageKey);
+
+        Span<byte> iv = stackalloc byte[16];
+        GenerateInitialVector(pageNo, iv);
+
+        using var aes = Aes.Create();
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.None;
+        aes.Key = pageKey.ToArray();
+        aes.IV = iv.ToArray();
+
+        using var transform = encrypt ? aes.CreateEncryptor() : aes.CreateDecryptor();
+        var transformed = transform.TransformFinalBlock(input.ToArray(), 0, input.Length);
+        transformed.CopyTo(output);
+    }
+
+    private void DerivePageKey(int pageNo, Span<byte> pageKey)
+    {
+        Span<byte> keyMaterial = stackalloc byte[24];
+        _masterKey.CopyTo(keyMaterial);
+        BinaryPrimitives.WriteInt32LittleEndian(keyMaterial[16..20], pageNo);
+        PageKeySalt.CopyTo(keyMaterial[20..24]);
+        MD5.HashData(keyMaterial, pageKey);
+    }
+
+    private static void GenerateInitialVector(int pageNo, Span<byte> iv)
+    {
+        Span<byte> initKey = stackalloc byte[16];
+        var z = (long)pageNo + 1;
+        for (var j = 0; j < 4; j++)
+        {
+            var q = z / 52774;
+            z = 40692 * (z - 52774 * q) - 3791 * q;
+            if (z < 0)
+                z += 2147483399L;
+
+            BinaryPrimitives.WriteInt32LittleEndian(initKey[(4 * j)..(4 * j + 4)], (int)z);
+        }
+
+        MD5.HashData(initKey, iv);
+    }
+
+    private static byte[] DeriveMasterKey(ReadOnlySpan<byte> password)
+    {
+        var userPad = PadPassword(password);
+        var ownerPad = PadPassword([]);
+
+        var digest = MD5.HashData(ownerPad);
+        for (var k = 0; k < 50; k++)
+            digest = MD5.HashData(digest);
+
+        var ownerKey = userPad.ToArray();
+        Span<byte> rc4Key = stackalloc byte[16];
+        for (var i = 0; i < 20; i++)
+        {
+            for (var j = 0; j < rc4Key.Length; j++)
+                rc4Key[j] = (byte)(digest[j] ^ i);
+
+            Rc4(rc4Key, ownerKey, ownerKey);
+        }
+
+        var encryptionKeyMaterial = new byte[64];
+        userPad.CopyTo(encryptionKeyMaterial);
+        ownerKey.CopyTo(encryptionKeyMaterial.AsSpan(32));
+
+        digest = MD5.HashData(encryptionKeyMaterial);
+        for (var k = 0; k < 50; k++)
+            digest = MD5.HashData(digest);
+
+        CryptographicOperations.ZeroMemory(userPad);
+        CryptographicOperations.ZeroMemory(ownerPad);
+        CryptographicOperations.ZeroMemory(ownerKey);
+        CryptographicOperations.ZeroMemory(encryptionKeyMaterial);
+        return digest;
+    }
+
+    private static byte[] PadPassword(ReadOnlySpan<byte> password)
+    {
+        var padded = new byte[32];
+        var passwordLength = Math.Min(password.Length, padded.Length);
+        password[..passwordLength].CopyTo(padded);
+        PasswordPadding[..(padded.Length - passwordLength)].CopyTo(padded.AsSpan(passwordLength));
+        return padded;
+    }
+
+    private static void Rc4(ReadOnlySpan<byte> key, ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        Span<byte> state = stackalloc byte[256];
+        for (var i = 0; i < state.Length; i++)
+            state[i] = (byte)i;
+
+        var j = 0;
+        for (var i = 0; i < state.Length; i++)
+        {
+            var value = state[i];
+            j = (j + value + key[i % key.Length]) & 0xFF;
+            state[i] = state[j];
+            state[j] = value;
+        }
+
+        var a = 0;
+        var b = 0;
+        for (var i = 0; i < input.Length; i++)
+        {
+            a = (a + 1) & 0xFF;
+            var value = state[a];
+            b = (b + value) & 0xFF;
+            state[a] = state[b];
+            state[b] = value;
+            var k = state[(state[a] + state[b]) & 0xFF];
+            output[i] = (byte)(input[i] ^ k);
+        }
+    }
+}

--- a/bindings/dotnet/src/Turso.Tests/Turso.Tests.csproj
+++ b/bindings/dotnet/src/Turso.Tests/Turso.Tests.csproj
@@ -27,4 +27,5 @@
         <ProjectReference Include="..\Turso.Data\Turso.Data.csproj" />
         <ProjectReference Include="..\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj" />
     </ItemGroup>
+
 </Project>

--- a/bindings/dotnet/src/Turso.Tests/TursoPageCodecTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoPageCodecTests.cs
@@ -1,0 +1,1466 @@
+using AwesomeAssertions;
+using System.Data.Common;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using Turso.Raw.Public;
+using Turso.Raw.Public.Handles;
+using Turso.Tests.Support;
+
+namespace Turso.Tests;
+
+public class TursoPageCodecTests
+{
+    private const string LegacyPassword = "legacy-password";
+    private const string WxSQLitePassword = "wxsqlite-password";
+    private const string TursoEncryptionKey = "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
+
+    [Test]
+    public void ManagedPageCodecRoundTripsDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5)))
+            {
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('encrypted')");
+            }
+
+            Assert.Throws<TursoException>(() => TursoBindings.OpenDatabase(path));
+
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5)))
+            {
+                ScalarText(db, "SELECT value FROM data").Should().Be("encrypted");
+                Execute(db, "INSERT INTO data VALUES ('written-through-codec')");
+            }
+
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5)))
+            {
+                ScalarLong(db, "SELECT COUNT(*) FROM data").Should().Be(2);
+            }
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void RawPageCodecApiRejectsNullArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() => TursoBindings.OpenDatabaseWithPageCodec(null!, new XorPageCodec(0xA5)));
+        Assert.Throws<ArgumentNullException>(() => TursoBindings.OpenDatabaseWithPageCodec(":memory:", null!));
+    }
+
+    [Test]
+    public void ReadOnlyRawOpenDoesNotCreateMissingDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-readonly-missing-{Guid.NewGuid():N}.db");
+        try
+        {
+            Assert.Throws<TursoException>(() => TursoBindings.OpenDatabaseReadOnly(path));
+            File.Exists(path).Should().BeFalse();
+
+            Assert.Throws<TursoException>(() =>
+                TursoBindings.OpenDatabaseReadOnlyWithPageCodec(path, new XorPageCodec(0xA5)));
+            File.Exists(path).Should().BeFalse();
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void ManagedPageCodecCallbackErrorsPropagate()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-error-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5)))
+            {
+                Execute(db, "CREATE TABLE data(value TEXT)");
+            }
+
+            var exception = Assert.Throws<TursoException>(() =>
+                TursoBindings.OpenDatabaseWithPageCodec(path, new ThrowingProbeCodec()));
+            exception!.Message.Should().Contain("probe failed");
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void ManagedPageCodecEncodeErrorsPropagate()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-encode-error-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var db = TursoBindings.OpenDatabaseWithPageCodec(path, new ThrowingEncodeCodec());
+            var exception = Assert.Throws<TursoException>(() => Execute(db, "CREATE TABLE data(value TEXT)"));
+            exception!.Message.Should().Contain("encode failed");
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void ManagedPageCodecRejectsOverlappingCachedDatabaseOpen()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-cache-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5));
+            Execute(db, "CREATE TABLE data(value TEXT)");
+
+            Assert.Throws<TursoException>(() =>
+                TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5)));
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void ManagedPageCodecNativeLifetimeKeepsCodecAliveUntilDatabaseDispose()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-lifetime-{Guid.NewGuid():N}.db");
+        try
+        {
+            var (db, codecReference) = OpenDatabaseWithTrackedCodec(path);
+            using (db)
+            {
+                ForceFullCollection();
+                codecReference.IsAlive.Should().BeTrue();
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('callback-still-alive')");
+                ScalarText(db, "SELECT value FROM data").Should().Be("callback-still-alive");
+            }
+
+            ForceFullCollection();
+            codecReference.IsAlive.Should().BeFalse();
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    public void TursoConnectionPageCodecRoundTripsDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-connection-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var connection = new TursoConnection($"Data Source={path}"))
+            {
+                connection.PageCodec = new XorPageCodec(0xA5);
+                connection.Open();
+                connection.ExecuteNonQuery("CREATE TABLE data(value TEXT)");
+                connection.ExecuteNonQuery("INSERT INTO data VALUES ('connection-codec')");
+            }
+
+            Assert.Throws<TursoException>(() =>
+            {
+                using var connection = new TursoConnection($"Data Source={path}");
+                connection.Open();
+                ScalarText(connection, "SELECT value FROM data");
+            });
+
+            using (var connection = new TursoConnection($"Data Source={path}"))
+            {
+                connection.PageCodec = new XorPageCodec(0xA5);
+                connection.Open();
+                ScalarText(connection, "SELECT value FROM data").Should().Be("connection-codec");
+            }
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void TursoConnectionPageCodecPropertiesCannotChangeWhileOpen()
+    {
+        using var connection = new TursoConnection("Data Source=:memory:");
+        connection.PageCodec = new XorPageCodec(0xA5);
+        connection.Open();
+
+        Assert.Throws<InvalidOperationException>(() => connection.PageCodec = new XorPageCodec(0x5A));
+        Assert.Throws<InvalidOperationException>(() => connection.PageCodecReservedSpace = 4);
+    }
+
+    [Test]
+    public void TursoConnectionPageCodecCannotBeCombinedWithBuiltInEncryption()
+    {
+        using var connection = new TursoConnection(
+            "Data Source=:memory:;Encryption Cipher=aegis256;Encryption Key=b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327");
+        connection.PageCodec = new XorPageCodec(0xA5);
+
+        Assert.Throws<InvalidOperationException>(connection.Open);
+    }
+
+    [Test]
+    public void TursoConnectionPageCodecReservedSpaceIsWrittenToDatabaseHeader()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-connection-codec-reserved-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var connection = new TursoConnection($"Data Source={path}"))
+            {
+                connection.PageCodec = new XorPageCodec(0xA5);
+                connection.PageCodecReservedSpace = 4;
+                connection.Open();
+                connection.ExecuteNonQuery("PRAGMA journal_mode=DELETE");
+                connection.ExecuteNonQuery("CREATE TABLE data(value TEXT)");
+            }
+
+            ReadDecodedHeader(path, 0xA5)[20].Should().Be(4);
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void MigratesLegacyExternalCryptoToTursoEncryption()
+    {
+        var legacyPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-legacy-source-{Guid.NewGuid():N}.db");
+        var tursoPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-turso-target-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true))
+            using (var legacySource = new TursoConnection($"Data Source={legacyPath}"))
+            {
+                legacySource.PageCodec = legacyCodec;
+                legacySource.Open();
+                CreateSampleData(legacySource);
+            }
+
+            using (var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true))
+            using (var legacySource = new TursoConnection($"Data Source={legacyPath}"))
+            using (var tursoTarget = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                legacySource.PageCodec = legacyCodec;
+                legacySource.Open();
+                tursoTarget.Open();
+                CopySampleData(legacySource, tursoTarget);
+            }
+
+            AssertPlainConnectionCannotRead(tursoPath);
+
+            using (var tursoTarget = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                tursoTarget.Open();
+                ReadSampleData(tursoTarget).Should().Equal(ExpectedSampleRows());
+            }
+
+            Assert.That(() =>
+            {
+                using var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true);
+                using var legacyConnection = new TursoConnection($"Data Source={tursoPath}");
+                legacyConnection.PageCodec = legacyCodec;
+                legacyConnection.Open();
+                ReadSampleData(legacyConnection);
+            }, Throws.Exception);
+        }
+        finally
+        {
+            DeleteDatabaseFiles(legacyPath);
+            DeleteDatabaseFiles(tursoPath);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void MigratesTursoEncryptionToLegacyExternalCrypto()
+    {
+        var tursoPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-turso-source-{Guid.NewGuid():N}.db");
+        var legacyPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-legacy-target-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var tursoSource = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                tursoSource.Open();
+                CreateSampleData(tursoSource);
+            }
+
+            using (var tursoSource = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            using (var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true))
+            using (var legacyTarget = new TursoConnection($"Data Source={legacyPath}"))
+            {
+                legacyTarget.PageCodec = legacyCodec;
+                tursoSource.Open();
+                legacyTarget.Open();
+                CopySampleData(tursoSource, legacyTarget);
+            }
+
+            AssertPlainConnectionCannotRead(legacyPath);
+
+            using (var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true))
+            using (var legacyTarget = new TursoConnection($"Data Source={legacyPath}"))
+            {
+                legacyTarget.PageCodec = legacyCodec;
+                legacyTarget.Open();
+                ReadSampleData(legacyTarget).Should().Equal(ExpectedSampleRows());
+            }
+
+            Assert.That(() =>
+            {
+                using var tursoConnection = new TursoConnection(TursoEncryptedConnectionString(legacyPath));
+                tursoConnection.Open();
+                ReadSampleData(tursoConnection);
+            }, Throws.Exception);
+        }
+        finally
+        {
+            DeleteDatabaseFiles(tursoPath);
+            DeleteDatabaseFiles(legacyPath);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiCodecRoundTripsDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-legacy-system-data-sqlite-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            const string password = "legacy-password";
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('legacy-cryptoapi')");
+            }
+
+            AssertPlainTursoCannotReadLegacyEncryptedData(path);
+
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarText(db, "SELECT value FROM data").Should().Be("legacy-cryptoapi");
+                Execute(db, "INSERT INTO data VALUES ('written-through-codec')");
+            }
+
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarLong(db, "SELECT COUNT(*) FROM data").Should().Be(2);
+            }
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiCodecMatchesPageOneRules()
+    {
+        var page = CreateSqliteHeaderPage();
+        Span<byte> encoded = stackalloc byte[page.Length];
+        Span<byte> decoded = stackalloc byte[page.Length];
+
+        using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword("legacy-password", encryptPage1: false))
+        {
+            codec.ProbeHeader(page).Should().Be(new TursoPageCodecHeaderInfo(512, 0));
+            codec.EncodePage(1, TursoPageCodecLocation.Database, page, encoded);
+            encoded.SequenceEqual(page).Should().BeTrue();
+        }
+
+        using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword("legacy-password", encryptPage1: true))
+        {
+            codec.EncodePage(1, TursoPageCodecLocation.Database, page, encoded);
+            encoded[..16].SequenceEqual("SQLite format 3\0"u8).Should().BeFalse();
+        }
+
+        using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword("legacy-password", encryptPage1: false))
+        {
+            codec.ProbeHeader(encoded).Should().Be(new TursoPageCodecHeaderInfo(512, 0));
+            codec.DecodePage(1, TursoPageCodecLocation.Database, encoded, decoded);
+            decoded.SequenceEqual(page).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiDatabaseRoundTripsWithManagedCodec()
+    {
+        using var fixture = SystemDataSQLiteFixture.TryLoad();
+        var path = Path.Combine(Path.GetTempPath(), $"turso-system-data-sqlite-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            const string password = "legacy-password";
+            fixture.ExecuteWithPassword(
+                path,
+                password,
+                "PRAGMA journal_mode=DELETE",
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('system-data-sqlite')");
+            var encryptPage1 = IsPageOneEncrypted(path);
+
+            AssertPlainTursoCannotReadLegacyEncryptedData(path);
+
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password, encryptPage1))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarText(db, "SELECT value FROM data").Should().Be("system-data-sqlite");
+                Execute(db, "INSERT INTO data VALUES ('written-through-turso')");
+            }
+
+            fixture.ScalarLongWithPassword(path, password, "SELECT COUNT(*) FROM data").Should().Be(2);
+            fixture.ScalarTextWithPassword(
+                    path,
+                    password,
+                    "SELECT value FROM data ORDER BY rowid DESC LIMIT 1")
+                .Should()
+                .Be("written-through-turso");
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiWrongPasswordFails()
+    {
+        using var fixture = SystemDataSQLiteFixture.TryLoad();
+        var path = Path.Combine(Path.GetTempPath(), $"turso-system-data-sqlite-codec-wrong-password-{Guid.NewGuid():N}.db");
+        try
+        {
+            const string password = "legacy-password";
+            fixture.ExecuteWithPassword(
+                path,
+                password,
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('system-data-sqlite')");
+            var encryptPage1 = IsPageOneEncrypted(path);
+
+            Assert.Throws<TursoException>(() =>
+            {
+                using var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword("wrong-password", encryptPage1);
+                using var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec);
+                ScalarText(db, "SELECT value FROM data");
+            });
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiRekeyAndClearPassword()
+    {
+        using var fixture = SystemDataSQLiteFixture.TryLoad();
+        var path = Path.Combine(Path.GetTempPath(), $"turso-system-data-sqlite-codec-rekey-{Guid.NewGuid():N}.db");
+        try
+        {
+            const string oldPassword = "legacy-password";
+            const string newPassword = "new-legacy-password";
+            fixture.ExecuteWithPassword(
+                path,
+                oldPassword,
+                "PRAGMA journal_mode=DELETE",
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('system-data-sqlite')");
+            var encryptPage1 = IsPageOneEncrypted(path);
+
+            fixture.ChangePassword(path, oldPassword, newPassword);
+
+            Assert.Throws<TursoException>(() =>
+            {
+                using var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(oldPassword, encryptPage1);
+                using var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec);
+                ScalarText(db, "SELECT value FROM data");
+            });
+
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(newPassword, encryptPage1))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                ScalarText(db, "SELECT value FROM data").Should().Be("system-data-sqlite");
+            }
+
+            fixture.ChangePassword(path, newPassword, string.Empty);
+
+            using (var db = TursoBindings.OpenDatabase(path))
+            {
+                ScalarText(db, "SELECT value FROM data").Should().Be("system-data-sqlite");
+            }
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    public void WxSQLite3Aes128CbcCodecMatchesModernPageOneRules()
+    {
+        var page = CreateSqliteHeaderPage(pageSize: 4096);
+        Span<byte> encoded = stackalloc byte[page.Length];
+        Span<byte> decoded = stackalloc byte[page.Length];
+
+        using var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword);
+        codec.ProbeHeader(page).Should().Be(new TursoPageCodecHeaderInfo(4096, 0));
+        codec.EncodePage(1, TursoPageCodecLocation.Database, page, encoded);
+
+        encoded[..16].SequenceEqual("SQLite format 3\0"u8).Should().BeFalse();
+        encoded[16..24].SequenceEqual(page.AsSpan(16, 8)).Should().BeTrue();
+        codec.ProbeHeader(encoded).Should().Be(new TursoPageCodecHeaderInfo(4096, 0));
+
+        codec.DecodePage(1, TursoPageCodecLocation.Database, encoded, decoded);
+        decoded.SequenceEqual(page).Should().BeTrue();
+    }
+
+    [Test]
+    public void WxSQLite3Aes128CbcCodecRoundTripsDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-wxsqlite3-aes128-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('wxsqlite3-aes128cbc')");
+            }
+
+            AssertPlainTursoCannotReadLegacyEncryptedData(path);
+
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarText(db, "SELECT value FROM data").Should().Be("wxsqlite3-aes128cbc");
+                Execute(db, "INSERT INTO data VALUES ('written-through-codec')");
+            }
+
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarLong(db, "SELECT COUNT(*) FROM data").Should().Be(2);
+            }
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    public void DetectsWxSQLite3Aes128CbcCodecAfterEarlierCandidateFails()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-detect-wxsqlite3-aes128-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('detected-wxsqlite3')");
+            }
+
+            var candidates = new[]
+            {
+                new ExternalCodecCandidate("wrong xor codec", _ => new XorPageCodec(0x5A)),
+                new ExternalCodecCandidate(
+                    "wxSQLite3/SQLite3MC aes128cbc",
+                    password => WxSQLite3Aes128CbcCodec.FromPassword(password)),
+            };
+
+            using var detected = EncryptedDatabaseDetector.Open(path, WxSQLitePassword, candidates);
+            detected.CodecName.Should().Be("wxSQLite3/SQLite3MC aes128cbc");
+            ScalarText(detected.Connection, "SELECT value FROM data").Should().Be("detected-wxsqlite3");
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    public void DetectingEncryptedDatabaseReportsCandidateFailures()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-detect-failure-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                Execute(db, "CREATE TABLE data(value TEXT)");
+            }
+
+            var candidates = new[]
+            {
+                new ExternalCodecCandidate("wrong xor codec", _ => new XorPageCodec(0x5A)),
+            };
+
+            var exception = Assert.Throws<AggregateException>(() =>
+                EncryptedDatabaseDetector.Open(path, WxSQLitePassword, candidates));
+            exception!.Message.Should().Contain("None of the configured external SQLite encryption codecs");
+            exception.InnerExceptions.Should().ContainSingle()
+                .Which.Message.Should().Contain("wrong xor codec");
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    public void DetectingEncryptedDatabaseRejectsMissingFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-detect-missing-{Guid.NewGuid():N}.db");
+        var candidates = new[]
+        {
+            new ExternalCodecCandidate("would create if attempted", _ => new XorPageCodec(0xA5)),
+        };
+
+        Assert.Throws<FileNotFoundException>(() =>
+            EncryptedDatabaseDetector.Open(path, WxSQLitePassword, candidates));
+        File.Exists(path).Should().BeFalse();
+    }
+
+    [Test]
+    public void MigratesWxSQLite3Aes128CbcExternalCryptoToTursoEncryption()
+    {
+        var wxPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-wxsqlite3-source-{Guid.NewGuid():N}.db");
+        var tursoPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-wxsqlite3-turso-target-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var wxCodec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var wxSource = new TursoConnection($"Data Source={wxPath}"))
+            {
+                wxSource.PageCodec = wxCodec;
+                wxSource.Open();
+                CreateSampleData(wxSource);
+            }
+
+            using (var wxCodec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var wxSource = new TursoConnection($"Data Source={wxPath}"))
+            using (var tursoTarget = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                wxSource.PageCodec = wxCodec;
+                wxSource.Open();
+                tursoTarget.Open();
+                CopySampleData(wxSource, tursoTarget);
+            }
+
+            AssertPlainConnectionCannotRead(tursoPath);
+
+            using (var tursoTarget = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                tursoTarget.Open();
+                ReadSampleData(tursoTarget).Should().Equal(ExpectedSampleRows());
+            }
+        }
+        finally
+        {
+            DeleteDatabaseFiles(wxPath);
+            DeleteDatabaseFiles(tursoPath);
+        }
+    }
+
+    [Test]
+    public void MigratesTursoEncryptionToWxSQLite3Aes128CbcExternalCrypto()
+    {
+        var tursoPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-turso-wxsqlite3-source-{Guid.NewGuid():N}.db");
+        var wxPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-wxsqlite3-target-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var tursoSource = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                tursoSource.Open();
+                CreateSampleData(tursoSource);
+            }
+
+            using (var tursoSource = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            using (var wxCodec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var wxTarget = new TursoConnection($"Data Source={wxPath}"))
+            {
+                wxTarget.PageCodec = wxCodec;
+                tursoSource.Open();
+                wxTarget.Open();
+                CopySampleData(tursoSource, wxTarget);
+            }
+
+            AssertPlainConnectionCannotRead(wxPath);
+
+            using (var wxCodec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var wxTarget = new TursoConnection($"Data Source={wxPath}"))
+            {
+                wxTarget.PageCodec = wxCodec;
+                wxTarget.Open();
+                ReadSampleData(wxTarget).Should().Equal(ExpectedSampleRows());
+            }
+        }
+        finally
+        {
+            DeleteDatabaseFiles(tursoPath);
+            DeleteDatabaseFiles(wxPath);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void Sqlite3SecureAes128CbcDatabaseRoundTripsWithManagedCodec()
+    {
+        using var fixture = Sqlite3SecureFixture.TryLoad();
+        fixture.DefaultCipherName.Should().Be("aes128cbc");
+
+        var path = Path.Combine(Path.GetTempPath(), $"turso-sqlite3secure-aes128-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            fixture.ExecuteWithPassword(
+                path,
+                WxSQLitePassword,
+                "PRAGMA journal_mode=DELETE",
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('sqlite3secure')");
+
+            AssertPlainTursoCannotReadLegacyEncryptedData(path);
+
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarText(db, "SELECT value FROM data").Should().Be("sqlite3secure");
+                Execute(db, "INSERT INTO data VALUES ('written-through-turso')");
+            }
+
+            fixture.ScalarLongWithPassword(path, WxSQLitePassword, "SELECT COUNT(*) FROM data").Should().Be(2);
+            fixture.ScalarTextWithPassword(
+                    path,
+                    WxSQLitePassword,
+                    "SELECT value FROM data ORDER BY rowid DESC LIMIT 1")
+                .Should()
+                .Be("written-through-turso");
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void Sqlite3SecureAes128CbcWrongPasswordFails()
+    {
+        using var fixture = Sqlite3SecureFixture.TryLoad();
+        fixture.DefaultCipherName.Should().Be("aes128cbc");
+
+        var path = Path.Combine(Path.GetTempPath(), $"turso-sqlite3secure-aes128-wrong-password-{Guid.NewGuid():N}.db");
+        try
+        {
+            fixture.ExecuteWithPassword(
+                path,
+                WxSQLitePassword,
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('sqlite3secure')");
+
+            Assert.Throws<TursoException>(() =>
+            {
+                using var codec = WxSQLite3Aes128CbcCodec.FromPassword("wrong-password");
+                using var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec);
+                ScalarText(db, "SELECT value FROM data");
+            });
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void Sqlite3SecureAes128CbcWalCheckpointRoundTripsWithManagedCodec()
+    {
+        using var fixture = Sqlite3SecureFixture.TryLoad();
+        fixture.DefaultCipherName.Should().Be("aes128cbc");
+
+        var path = Path.Combine(Path.GetTempPath(), $"turso-sqlite3secure-aes128-wal-{Guid.NewGuid():N}.db");
+        try
+        {
+            fixture.ExecuteWithPassword(
+                path,
+                WxSQLitePassword,
+                "PRAGMA journal_mode=WAL",
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('from-sqlite3secure')");
+
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var connection = new TursoConnection($"Data Source={path}"))
+            {
+                connection.PageCodec = codec;
+                connection.Open();
+                connection.ExecuteNonQuery("PRAGMA journal_mode=WAL");
+                ScalarText(connection, "SELECT value FROM data ORDER BY rowid LIMIT 1").Should().Be("from-sqlite3secure");
+                connection.ExecuteNonQuery("INSERT INTO data VALUES ('from-turso-wal')");
+                connection.ExecuteNonQuery("PRAGMA wal_checkpoint(FULL)");
+            }
+
+            fixture.ScalarLongWithPassword(path, WxSQLitePassword, "SELECT COUNT(*) FROM data").Should().Be(2);
+            fixture.ScalarTextWithPassword(
+                    path,
+                    WxSQLitePassword,
+                    "SELECT value FROM data ORDER BY rowid DESC LIMIT 1")
+                .Should()
+                .Be("from-turso-wal");
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    private static byte[] CreateSqliteHeaderPage(int pageSize = 512)
+    {
+        if (pageSize is < 512 or > 65536 || (pageSize & (pageSize - 1)) != 0)
+            throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "SQLite page size must be a power of two between 512 and 65536.");
+
+        var page = new byte[pageSize];
+        "SQLite format 3\0"u8.CopyTo(page);
+        if (pageSize == 65536)
+        {
+            page[16] = 0x00;
+            page[17] = 0x01;
+        }
+        else
+        {
+            page[16] = (byte)(pageSize >> 8);
+            page[17] = (byte)pageSize;
+        }
+
+        page[18] = 1;
+        page[19] = 1;
+        page[20] = 0;
+        page[21] = 64;
+        page[22] = 32;
+        page[23] = 32;
+        page[100] = 13;
+        return page;
+    }
+
+    private static bool IsPageOneEncrypted(string path)
+    {
+        Span<byte> header = stackalloc byte[16];
+        using var file = File.OpenRead(path);
+        file.ReadExactly(header);
+        return !header.SequenceEqual("SQLite format 3\0"u8);
+    }
+
+    private static byte[] ReadDecodedHeader(string path, byte key)
+    {
+        var header = new byte[100];
+        using var file = File.OpenRead(path);
+        file.ReadExactly(header);
+        for (var i = 0; i < header.Length; i++)
+            header[i] ^= key;
+
+        return header;
+    }
+
+    private static string TursoEncryptedConnectionString(string path)
+    {
+        return $"Data Source={path};Encryption Cipher=aegis256;Encryption Key={TursoEncryptionKey}";
+    }
+
+    private static (long Id, string Value)[] ExpectedSampleRows()
+    {
+        return [(1, "alpha"), (2, "bravo"), (3, "charlie")];
+    }
+
+    private static void CreateSampleData(TursoConnection connection)
+    {
+        connection.ExecuteNonQuery("PRAGMA journal_mode=DELETE");
+        connection.ExecuteNonQuery("CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+        foreach (var row in ExpectedSampleRows())
+        {
+            using var command = new TursoCommand(connection, "INSERT INTO data(id, value) VALUES (?, ?)");
+            command.Parameters.Add(row.Id);
+            command.Parameters.Add(row.Value);
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private static void CopySampleData(TursoConnection source, TursoConnection target)
+    {
+        target.ExecuteNonQuery("PRAGMA journal_mode=DELETE");
+        target.ExecuteNonQuery("CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+        foreach (var row in ReadSampleData(source))
+        {
+            using var command = new TursoCommand(target, "INSERT INTO data(id, value) VALUES (?, ?)");
+            command.Parameters.Add(row.Id);
+            command.Parameters.Add(row.Value);
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private static List<(long Id, string Value)> ReadSampleData(TursoConnection connection)
+    {
+        using var command = new TursoCommand(connection, "SELECT id, value FROM data ORDER BY id");
+        using var reader = command.ExecuteReader();
+        var rows = new List<(long Id, string Value)>();
+        while (reader.Read())
+            rows.Add((reader.GetInt64(0), reader.GetString(1)));
+
+        return rows;
+    }
+
+    private static void AssertPlainConnectionCannotRead(string path)
+    {
+        Assert.That(() =>
+        {
+            using var connection = new TursoConnection($"Data Source={path}");
+            connection.Open();
+            ReadSampleData(connection);
+        }, Throws.Exception);
+    }
+
+    private static void DeleteDatabaseFiles(string path)
+    {
+        TryDelete(path);
+        TryDelete($"{path}-wal");
+        TryDelete($"{path}-shm");
+        TryDelete($"{path}-journal");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (TursoDatabaseHandle Database, WeakReference CodecReference) OpenDatabaseWithTrackedCodec(string path)
+    {
+        var codec = new XorPageCodec(0xA5);
+        return (TursoBindings.OpenDatabaseWithPageCodec(path, codec), new WeakReference(codec));
+    }
+
+    private static void ForceFullCollection()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+    private static void Execute(TursoDatabaseHandle db, string sql)
+    {
+        using var statement = TursoBindings.PrepareStatement(db, sql);
+        while (TursoBindings.Read(statement))
+        {
+        }
+    }
+
+    private static string ScalarText(TursoDatabaseHandle db, string sql)
+    {
+        using var statement = TursoBindings.PrepareStatement(db, sql);
+        TursoBindings.Read(statement).Should().BeTrue();
+        var value = TursoBindings.GetValue(statement, 0);
+        return value.StringValue;
+    }
+
+    private static long ScalarLong(TursoDatabaseHandle db, string sql)
+    {
+        using var statement = TursoBindings.PrepareStatement(db, sql);
+        TursoBindings.Read(statement).Should().BeTrue();
+        var value = TursoBindings.GetValue(statement, 0);
+        return value.IntValue;
+    }
+
+    private static string ScalarText(TursoConnection connection, string sql)
+    {
+        using var command = new TursoCommand(connection, sql);
+        using var reader = command.ExecuteReader();
+        reader.Read().Should().BeTrue();
+        return reader.GetString(0);
+    }
+
+    private static void AssertPlainTursoCannotReadLegacyEncryptedData(string path)
+    {
+        Assert.Throws<TursoException>(() =>
+        {
+            using var db = TursoBindings.OpenDatabase(path);
+            ScalarText(db, "SELECT value FROM data");
+        });
+    }
+
+    private static void TryDelete(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    private sealed class XorPageCodec(byte key) : ITursoPageCodec
+    {
+        public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+        {
+            Span<byte> header = stackalloc byte[100];
+            for (var i = 0; i < header.Length; i++)
+                header[i] = (byte)(rawPage1Prefix[i] ^ key);
+
+            if (!header[..16].SequenceEqual("SQLite format 3\0"u8))
+                return null;
+
+            var pageSizeRaw = (ushort)((header[16] << 8) | header[17]);
+            var pageSize = pageSizeRaw == 1 ? 65536u : pageSizeRaw;
+            return new TursoPageCodecHeaderInfo(pageSize, header[20]);
+        }
+
+        public void DecodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            Transform(input, output);
+        }
+
+        public void EncodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            Transform(input, output);
+        }
+
+        private void Transform(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            input.Length.Should().Be(output.Length);
+            for (var i = 0; i < input.Length; i++)
+                output[i] = (byte)(input[i] ^ key);
+        }
+    }
+
+    private sealed class ThrowingProbeCodec : ITursoPageCodec
+    {
+        public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+        {
+            throw new InvalidOperationException("probe failed");
+        }
+
+        public void DecodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            input.CopyTo(output);
+        }
+
+        public void EncodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            input.CopyTo(output);
+        }
+    }
+
+    private sealed class ThrowingEncodeCodec : ITursoPageCodec
+    {
+        public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+        {
+            return null;
+        }
+
+        public void DecodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            input.CopyTo(output);
+        }
+
+        public void EncodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            throw new InvalidOperationException("encode failed");
+        }
+    }
+
+    private sealed class SystemDataSQLiteFixture : IDisposable
+    {
+        private const string AssemblyPathVariable = "TURSO_TEST_SYSTEM_DATA_SQLITE_DLL";
+        private const string InteropPathVariable = "TURSO_TEST_SQLITE_INTEROP_DLL";
+        private readonly Type _connectionType;
+        private readonly IntPtr _interopHandle;
+
+        private SystemDataSQLiteFixture(Type connectionType, IntPtr interopHandle)
+        {
+            _connectionType = connectionType;
+            _interopHandle = interopHandle;
+        }
+
+        public static SystemDataSQLiteFixture TryLoad()
+        {
+            var assemblyPath = Environment.GetEnvironmentVariable(AssemblyPathVariable);
+            if (string.IsNullOrWhiteSpace(assemblyPath))
+                Assert.Ignore($"{AssemblyPathVariable} must point at a codec-enabled System.Data.SQLite.dll.");
+
+            if (!File.Exists(assemblyPath))
+                Assert.Ignore($"{AssemblyPathVariable} does not exist: {assemblyPath}");
+
+            var interopPath = Environment.GetEnvironmentVariable(InteropPathVariable);
+            var interopHandle = IntPtr.Zero;
+            if (!string.IsNullOrWhiteSpace(interopPath))
+            {
+                if (!File.Exists(interopPath))
+                    Assert.Ignore($"{InteropPathVariable} does not exist: {interopPath}");
+
+                interopHandle = NativeLibrary.Load(interopPath);
+            }
+
+            var assembly = Assembly.LoadFrom(assemblyPath);
+            var connectionType = assembly.GetType("System.Data.SQLite.SQLiteConnection", throwOnError: true)!;
+            return new SystemDataSQLiteFixture(connectionType, interopHandle);
+        }
+
+        public void ExecuteWithPassword(string path, string password, params string[] statements)
+        {
+            using var connection = CreateConnection(path, password);
+            connection.Open();
+            foreach (var statement in statements)
+            {
+                using var command = connection.CreateCommand();
+                command.CommandText = statement;
+                command.ExecuteNonQuery();
+            }
+        }
+
+        public string ScalarTextWithPassword(string path, string password, string sql)
+        {
+            var value = ExecuteScalarWithPassword(path, password, sql);
+            return value.Should().BeOfType<string>().Subject;
+        }
+
+        public long ScalarLongWithPassword(string path, string password, string sql)
+        {
+            var value = ExecuteScalarWithPassword(path, password, sql);
+            return Convert.ToInt64(value);
+        }
+
+        public void ChangePassword(string path, string password, string newPassword)
+        {
+            using var connection = CreateConnection(path, password);
+            connection.Open();
+
+            var method = _connectionType.GetMethod(
+                "ChangePassword",
+                BindingFlags.Instance | BindingFlags.Public,
+                binder: null,
+                types: [typeof(string)],
+                modifiers: null);
+
+            if (method is null)
+                throw new MissingMethodException(_connectionType.FullName, "ChangePassword");
+
+            method.Invoke(connection, [newPassword]);
+        }
+
+        public void Dispose()
+        {
+            if (_interopHandle != IntPtr.Zero)
+                NativeLibrary.Free(_interopHandle);
+        }
+
+        private object? ExecuteScalarWithPassword(string path, string password, string sql)
+        {
+            using var connection = CreateConnection(path, password);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            return command.ExecuteScalar();
+        }
+
+        private DbConnection CreateConnection(string path, string password)
+        {
+            var connectionString = $"Data Source={path};Password={password};Pooling=False";
+            var connection = Activator.CreateInstance(_connectionType, connectionString);
+            return connection.Should().BeAssignableTo<DbConnection>().Subject;
+        }
+    }
+
+    private sealed class Sqlite3SecureFixture : IDisposable
+    {
+        private const string LibraryPathVariable = "TURSO_TEST_SQLITE3SECURE_DLL";
+        private readonly IntPtr _libraryHandle;
+        private readonly Sqlite3Open _open;
+        private readonly Sqlite3Close _close;
+        private readonly Sqlite3Key _key;
+        private readonly Sqlite3Exec _exec;
+        private readonly Sqlite3ErrMsg _errmsg;
+        private readonly Sqlite3Free _free;
+        private readonly WxSqlite3Config _config;
+
+        private Sqlite3SecureFixture(IntPtr libraryHandle)
+        {
+            _libraryHandle = libraryHandle;
+            _open = GetExport<Sqlite3Open>(libraryHandle, "sqlite3_open");
+            _close = GetExport<Sqlite3Close>(libraryHandle, "sqlite3_close");
+            _key = GetExport<Sqlite3Key>(libraryHandle, "sqlite3_key");
+            _exec = GetExport<Sqlite3Exec>(libraryHandle, "sqlite3_exec");
+            _errmsg = GetExport<Sqlite3ErrMsg>(libraryHandle, "sqlite3_errmsg");
+            _free = GetExport<Sqlite3Free>(libraryHandle, "sqlite3_free");
+            _config = GetExport<WxSqlite3Config>(libraryHandle, "wxsqlite3_config");
+        }
+
+        public string DefaultCipherName
+        {
+            get
+            {
+                using var parameterName = new NativeUtf8String("default:cipher");
+                return CipherName(_config(IntPtr.Zero, parameterName.Pointer, -1));
+            }
+        }
+
+        public static Sqlite3SecureFixture TryLoad()
+        {
+            var libraryPath = Environment.GetEnvironmentVariable(LibraryPathVariable);
+            if (string.IsNullOrWhiteSpace(libraryPath))
+                Assert.Ignore($"{LibraryPathVariable} must point at sqlite3secure.dll from Devolutions.Sqlite3secure.");
+
+            if (!File.Exists(libraryPath))
+                Assert.Ignore($"{LibraryPathVariable} does not exist: {libraryPath}");
+
+            var handle = NativeLibrary.Load(libraryPath);
+            try
+            {
+                return new Sqlite3SecureFixture(handle);
+            }
+            catch
+            {
+                NativeLibrary.Free(handle);
+                throw;
+            }
+        }
+
+        public void ExecuteWithPassword(string path, string password, params string[] statements)
+        {
+            var db = OpenWithPassword(path, password);
+            try
+            {
+                foreach (var statement in statements)
+                    Execute(db, statement);
+            }
+            finally
+            {
+                _close(db);
+            }
+        }
+
+        public string ScalarTextWithPassword(string path, string password, string sql)
+        {
+            return ExecuteScalarWithPassword(path, password, sql).Should().NotBeNull().And.BeOfType<string>().Subject;
+        }
+
+        public long ScalarLongWithPassword(string path, string password, string sql)
+        {
+            return long.Parse(ScalarTextWithPassword(path, password, sql));
+        }
+
+        public void Dispose()
+        {
+            NativeLibrary.Free(_libraryHandle);
+        }
+
+        private static T GetExport<T>(IntPtr libraryHandle, string name)
+            where T : Delegate
+        {
+            var function = NativeLibrary.GetExport(libraryHandle, name);
+            return Marshal.GetDelegateForFunctionPointer<T>(function);
+        }
+
+        private static string CipherName(int cipherIndex)
+        {
+            return cipherIndex switch
+            {
+                1 => "aes128cbc",
+                2 => "aes256cbc",
+                3 => "chacha20",
+                4 => "sqlcipher",
+                _ => $"unknown:{cipherIndex}"
+            };
+        }
+
+        private IntPtr OpenWithPassword(string path, string password)
+        {
+            using var pathUtf8 = new NativeUtf8String(path);
+            var rc = _open(pathUtf8.Pointer, out var db);
+            if (rc != 0)
+                throw new InvalidOperationException($"sqlite3_open failed: rc={rc}");
+
+            try
+            {
+                var passwordBytes = Encoding.UTF8.GetBytes(password);
+                try
+                {
+                    rc = _key(db, passwordBytes, passwordBytes.Length);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(passwordBytes);
+                }
+
+                if (rc != 0)
+                    throw new InvalidOperationException($"sqlite3_key failed: rc={rc}, message={ErrorMessage(db)}");
+
+                return db;
+            }
+            catch
+            {
+                _close(db);
+                throw;
+            }
+        }
+
+        private object? ExecuteScalarWithPassword(string path, string password, string sql)
+        {
+            var db = OpenWithPassword(path, password);
+            try
+            {
+                object? result = null;
+                var callback = new Sqlite3ExecCallback((_, columns, values, _) =>
+                {
+                    if (columns > 0 && result is null)
+                    {
+                        var value = Marshal.ReadIntPtr(values);
+                        result = value == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(value);
+                    }
+
+                    return 0;
+                });
+                Execute(db, sql, callback);
+                GC.KeepAlive(callback);
+                return result;
+            }
+            finally
+            {
+                _close(db);
+            }
+        }
+
+        private void Execute(IntPtr db, string sql, Sqlite3ExecCallback? callback = null)
+        {
+            callback ??= (_, _, _, _) => 0;
+
+            using var sqlUtf8 = new NativeUtf8String(sql);
+            var rc = _exec(db, sqlUtf8.Pointer, callback, IntPtr.Zero, out var error);
+            GC.KeepAlive(callback);
+            if (rc == 0)
+                return;
+
+            var message = error == IntPtr.Zero ? ErrorMessage(db) : Marshal.PtrToStringUTF8(error);
+            if (error != IntPtr.Zero)
+                _free(error);
+
+            throw new InvalidOperationException($"sqlite3_exec failed: rc={rc}, message={message}");
+        }
+
+        private string ErrorMessage(IntPtr db)
+        {
+            return Marshal.PtrToStringUTF8(_errmsg(db)) ?? string.Empty;
+        }
+
+        private sealed class NativeUtf8String : IDisposable
+        {
+            public NativeUtf8String(string value)
+            {
+                Pointer = Marshal.StringToCoTaskMemUTF8(value);
+            }
+
+            public IntPtr Pointer { get; private set; }
+
+            public void Dispose()
+            {
+                if (Pointer == IntPtr.Zero)
+                    return;
+
+                Marshal.FreeCoTaskMem(Pointer);
+                Pointer = IntPtr.Zero;
+            }
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3Open(IntPtr filename, out IntPtr db);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3Close(IntPtr db);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3Key(IntPtr db, byte[] key, int keyLength);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3Exec(
+            IntPtr db,
+            IntPtr sql,
+            Sqlite3ExecCallback callback,
+            IntPtr arg,
+            out IntPtr errorMessage);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3ExecCallback(IntPtr arg, int columns, IntPtr values, IntPtr names);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate IntPtr Sqlite3ErrMsg(IntPtr db);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void Sqlite3Free(IntPtr value);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int WxSqlite3Config(IntPtr db, IntPtr paramName, int newValue);
+    }
+}

--- a/bindings/go/bindings_db.go
+++ b/bindings/go/bindings_db.go
@@ -145,6 +145,8 @@ type turso_database_config_t struct {
 	vfs                   uintptr // const char* or null
 	encryption_cipher     uintptr // const char* or null
 	encryption_hexkey     uintptr // const char* or null
+	page_codec            uintptr // const turso_page_codec_v1_t* or null
+	open_flags            uint32
 }
 
 // C extern method types

--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -200,6 +200,8 @@ pub fn py_turso_database_open(config: &PyTursoDatabaseConfig) -> PyResult<PyTurs
         vfs: config.vfs.clone(),
         io: None,
         db_file: None,
+        page_codec: None,
+        open_flags: Default::default(),
     });
     let result = database.open().map_err(turso_error_to_py_err)?;
     // async_io is false - so db.open() will return result immediately

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -157,6 +157,8 @@ pub fn py_turso_sync_new(
         vfs: None,
         io: None,
         db_file: None,
+        page_codec: None,
+        open_flags: Default::default(),
     };
     // calculate and set reserved_bytes from cipher if necessary
     let reserved_bytes = sync_config

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -292,6 +292,8 @@ impl Builder {
                 vfs: self.vfs,
                 io: self.io,
                 db_file: None,
+                page_codec: None,
+                open_flags: Default::default(),
             });
         while let Some(io_c) = db.open()?.io() {
             // At this point IO must already be created

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -340,6 +340,8 @@ impl Builder {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: Default::default(),
         };
 
         let url = if let Some(remote_url) = &self.remote_url {

--- a/cli/config/terminal.rs
+++ b/cli/config/terminal.rs
@@ -3,6 +3,7 @@ use std::io::{self, IsTerminal, Read, Write};
 #[cfg(unix)]
 use std::time::Duration;
 
+#[cfg_attr(target_os = "windows", allow(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TerminalTheme {
     Light,
@@ -224,11 +225,9 @@ impl TerminalDetector {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[cfg(unix)]
     mod unix_tests {
-        use super::*;
+        use super::super::*;
 
         #[test]
         fn test_hex_color_parsing() {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -161,7 +161,7 @@ pub use numeric::{nonnan::NonNan, Numeric};
 pub use statement::{ColumnTypeInfo, ColumnTypeKind, Statement, StatementStatusCounter};
 pub use storage::{
     buffer_pool::BufferPool,
-    database::{DatabaseStorage, IOContext},
+    database::{DatabaseStorage, IOContext, PageCodec, PageCodecHeaderInfo, PageCodecLocation},
     encryption::{CipherMode, EncryptionContext, EncryptionKey},
     pager::{Page, PageRef, Pager},
     wal::{CheckpointMode, CheckpointResult, Wal, WalAutoActions, WalFile, WalFileShared},
@@ -623,6 +623,7 @@ pub struct Database {
 
     // Encryption
     encryption_cipher_mode: AtomicCipherMode,
+    page_codec: Option<Arc<dyn PageCodec>>,
 }
 
 // SAFETY: This needs to be audited for thread safety.
@@ -682,23 +683,36 @@ impl fmt::Debug for Database {
     }
 }
 
+struct DatabaseNewArgs<'a> {
+    opts: DatabaseOpts,
+    flags: OpenFlags,
+    path: &'a str,
+    wal_path: &'a str,
+    io: &'a Arc<dyn IO>,
+    db_file: Arc<dyn DatabaseStorage>,
+    encryption_opts: Option<EncryptionOpts>,
+    page_codec: Option<Arc<dyn PageCodec>>,
+}
+
 impl Database {
     /// Returns true if this database is backed by MemoryIO.
     pub fn is_in_memory_db(&self) -> bool {
         is_memory_like(&self.path)
     }
 
-    fn new(
-        opts: DatabaseOpts,
-        flags: OpenFlags,
-        path: impl Into<String>,
-        wal_path: impl Into<String>,
-        io: &Arc<dyn IO>,
-        db_file: Arc<dyn DatabaseStorage>,
-        encryption_opts: Option<EncryptionOpts>,
-    ) -> Result<Self> {
-        let path = path.into();
-        let wal_path = wal_path.into();
+    fn new(args: DatabaseNewArgs<'_>) -> Result<Self> {
+        let DatabaseNewArgs {
+            opts,
+            flags,
+            path,
+            wal_path,
+            io,
+            db_file,
+            encryption_opts,
+            page_codec,
+        } = args;
+        let path = path.to_string();
+        let wal_path = wal_path.to_string();
         let shared_wal = WalFileShared::new_noop();
         let mv_store = ArcSwapOption::empty();
 
@@ -753,6 +767,7 @@ impl Database {
             encryption_cipher_mode: AtomicCipherMode::new(
                 encryption_cipher_mode.unwrap_or(CipherMode::None),
             ),
+            page_codec,
 
             durable_storage: None,
         };
@@ -1085,6 +1100,60 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
     ) -> Result<IOResult<Arc<Database>>> {
+        Self::open_with_flags_async_with_optional_page_codec(
+            state,
+            io,
+            path,
+            db_file,
+            flags,
+            opts,
+            encryption_opts,
+            durable_storage,
+            None,
+        )
+    }
+
+    /// async flow of opening the database with an external page codec.
+    ///
+    /// Uses the database registry to ensure single Database instance per file within a process.
+    /// Caller must drive the IO loop and pass state between calls.
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_with_flags_and_page_codec_async(
+        state: &mut OpenDbAsyncState,
+        io: Arc<dyn IO>,
+        path: &str,
+        db_file: Arc<dyn DatabaseStorage>,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Arc<dyn PageCodec>,
+    ) -> Result<IOResult<Arc<Database>>> {
+        Self::open_with_flags_async_with_optional_page_codec(
+            state,
+            io,
+            path,
+            db_file,
+            flags,
+            opts,
+            encryption_opts,
+            durable_storage,
+            Some(page_codec),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn open_with_flags_async_with_optional_page_codec(
+        state: &mut OpenDbAsyncState,
+        io: Arc<dyn IO>,
+        path: &str,
+        db_file: Arc<dyn DatabaseStorage>,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Option<Arc<dyn PageCodec>>,
+    ) -> Result<IOResult<Arc<Database>>> {
         let result = Self::open_with_flags_async_internal(
             state,
             io,
@@ -1094,6 +1163,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
+            page_codec,
         );
         if result.is_err() {
             // On error, remove the Opening sentinel so other callers can proceed.
@@ -1115,7 +1185,14 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Option<Arc<dyn PageCodec>>,
     ) -> Result<IOResult<Arc<Database>>> {
+        if encryption_opts.is_some() && page_codec.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
+
         // turso-sync-engine creates 2 databases with different names in the same IO if MemoryIO is used
         // in this case we need to bypass registry (as this is MemoryIO DB) but also preserve original distinction in names (e.g. :memory:-draft and :memory:-synced)
         // so, we bypass registry for all in memory dbs (i.e. db paths which starts with ":memory:")
@@ -1139,6 +1216,12 @@ impl Database {
                                 return Err(LimboError::InvalidArgument(
                                     "Database is encrypted but no encryption options provided"
                                         .to_string(),
+                                ));
+                            }
+                            let cached_has_page_codec = db.page_codec.is_some();
+                            if cached_has_page_codec || page_codec.is_some() {
+                                return Err(LimboError::InvalidArgument(
+                                    "Database is already open and external page codec options cannot be verified for cached databases".to_string(),
                                 ));
                             }
                             return Ok(IOResult::Done(db));
@@ -1165,7 +1248,7 @@ impl Database {
         }
 
         // Open the database asynchronously (no registry lock held).
-        let result = Self::open_with_flags_bypass_registry_async(
+        let result = Self::open_with_flags_bypass_registry_async_with_optional_page_codec(
             state,
             io.clone(),
             path,
@@ -1175,6 +1258,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
+            page_codec,
         )?;
 
         if let IOResult::Done(ref db) = result {
@@ -1235,6 +1319,62 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
     ) -> Result<IOResult<Arc<Database>>> {
+        Self::open_with_flags_bypass_registry_async_with_optional_page_codec(
+            state,
+            io,
+            path,
+            wal_path,
+            db_file,
+            flags,
+            opts,
+            encryption_opts,
+            durable_storage,
+            None,
+        )
+    }
+
+    /// Async version of database opening with an external page codec.
+    /// Caller must drive the IO loop and pass state between calls.
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_with_flags_bypass_registry_and_page_codec_async(
+        state: &mut OpenDbAsyncState,
+        io: Arc<dyn IO>,
+        path: &str,
+        wal_path: Option<&str>,
+        db_file: Arc<dyn DatabaseStorage>,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Arc<dyn PageCodec>,
+    ) -> Result<IOResult<Arc<Database>>> {
+        Self::open_with_flags_bypass_registry_async_with_optional_page_codec(
+            state,
+            io,
+            path,
+            wal_path,
+            db_file,
+            flags,
+            opts,
+            encryption_opts,
+            durable_storage,
+            Some(page_codec),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn open_with_flags_bypass_registry_async_with_optional_page_codec(
+        state: &mut OpenDbAsyncState,
+        io: Arc<dyn IO>,
+        path: &str,
+        wal_path: Option<&str>,
+        db_file: Arc<dyn DatabaseStorage>,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Option<Arc<dyn PageCodec>>,
+    ) -> Result<IOResult<Arc<Database>>> {
         let result = Self::open_with_flags_bypass_registry_async_internal(
             state,
             io,
@@ -1245,6 +1385,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
+            page_codec,
         );
         if result.is_err() {
             // schema_guard is set by the open_with_flags_bypass_registry_async_internal - so we release it in case of error
@@ -1265,6 +1406,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Option<Arc<dyn PageCodec>>,
     ) -> Result<IOResult<Arc<Database>>> {
         loop {
             tracing::debug!(
@@ -1285,15 +1427,16 @@ impl Database {
                     } else {
                         &format!("{path}-wal")
                     };
-                    let mut db = Self::new(
+                    let mut db = Self::new(DatabaseNewArgs {
                         opts,
                         flags,
                         path,
                         wal_path,
-                        &io,
-                        db_file.clone(),
-                        encryption_opts.clone(),
-                    )?;
+                        io: &io,
+                        db_file: db_file.clone(),
+                        encryption_opts: encryption_opts.clone(),
+                        page_codec: page_codec.clone(),
+                    })?;
                     db.durable_storage.clone_from(&durable_storage);
 
                     // Header validation + WAL recovery runs as a sub state
@@ -1537,6 +1680,8 @@ impl Database {
                     if let Some(key) = encryption_key {
                         let cipher_mode = self.encryption_cipher_mode.get();
                         pager.set_encryption_context(cipher_mode, key)?;
+                    } else if let Some(codec) = &self.page_codec {
+                        pager.set_page_codec(codec.clone())?;
                     }
 
                     // Start a read transaction before reading page 1 to prevent a concurrent
@@ -2550,10 +2695,33 @@ impl Database {
         // on-disk page size from it.
         let (header_reserved_bytes, header_page_size) = if self.initialized() {
             let buf = return_if_io!(self.read_db_header_buf(hdr_st));
-            let reserved = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
-            let ps_raw = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
-            let page_size = PageSize::new_from_header_u16(ps_raw)?;
-            (Some(reserved), Some(page_size))
+            if let Some(codec) = &self.page_codec {
+                if let Some(header_info) = codec.probe_header(buf.as_slice())? {
+                    let page_size_u32 = u32::try_from(header_info.page_size).map_err(|_| {
+                        LimboError::InvalidArgument(format!(
+                            "page codec reported invalid page size {}",
+                            header_info.page_size
+                        ))
+                    })?;
+                    let Some(page_size) = PageSize::new(page_size_u32) else {
+                        return Err(LimboError::InvalidArgument(format!(
+                            "page codec reported invalid page size {}",
+                            header_info.page_size
+                        )));
+                    };
+                    (Some(header_info.reserved_space), Some(page_size))
+                } else {
+                    let reserved = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
+                    let ps_raw = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
+                    let page_size = PageSize::new_from_header_u16(ps_raw)?;
+                    (Some(reserved), Some(page_size))
+                }
+            } else {
+                let reserved = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
+                let ps_raw = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
+                let page_size = PageSize::new_from_header_u16(ps_raw)?;
+                (Some(reserved), Some(page_size))
+            }
         } else {
             (None, None)
         };

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -9,9 +9,67 @@ use crate::{
 };
 use tracing::{instrument, Level};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageCodecHeaderInfo {
+    pub page_size: usize,
+    pub reserved_space: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageCodecLocation {
+    Database,
+    Wal,
+}
+
+/// Transforms page images between their on-disk and in-memory representation.
+pub trait PageCodec: std::fmt::Debug + Send + Sync {
+    fn probe_header(&self, _raw_page1_prefix: &[u8]) -> Result<Option<PageCodecHeaderInfo>> {
+        Ok(None)
+    }
+
+    fn required_reserved_bytes(&self) -> u8;
+    fn encode_page(
+        &self,
+        page: &[u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> Result<Vec<u8>>;
+    fn decode_page(
+        &self,
+        page: &[u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> Result<Vec<u8>>;
+}
+
+impl PageCodec for EncryptionContext {
+    fn required_reserved_bytes(&self) -> u8 {
+        self.required_reserved_bytes()
+    }
+
+    fn encode_page(
+        &self,
+        page: &[u8],
+        page_idx: usize,
+        _location: PageCodecLocation,
+    ) -> Result<Vec<u8>> {
+        self.encrypt_page(page, page_idx)
+    }
+
+    fn decode_page(
+        &self,
+        page: &[u8],
+        page_idx: usize,
+        _location: PageCodecLocation,
+    ) -> Result<Vec<u8>> {
+        self.decrypt_page(page, page_idx)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum EncryptionOrChecksum {
     Encryption(EncryptionContext),
+    PageCodec(Arc<dyn PageCodec>),
     Checksum(ChecksumContext),
     None,
 }
@@ -32,6 +90,7 @@ impl IOContext {
     pub fn get_reserved_space_bytes(&self) -> u8 {
         match &self.encryption_or_checksum {
             EncryptionOrChecksum::Encryption(ctx) => ctx.required_reserved_bytes(),
+            EncryptionOrChecksum::PageCodec(ctx) => ctx.required_reserved_bytes(),
             EncryptionOrChecksum::Checksum(ctx) => ctx.required_reserved_bytes(),
             EncryptionOrChecksum::None => Default::default(),
         }
@@ -39,6 +98,17 @@ impl IOContext {
 
     pub fn set_encryption(&mut self, encryption_ctx: EncryptionContext) {
         self.encryption_or_checksum = EncryptionOrChecksum::Encryption(encryption_ctx);
+    }
+
+    pub fn set_page_codec(&mut self, codec: Arc<dyn PageCodec>) {
+        self.encryption_or_checksum = EncryptionOrChecksum::PageCodec(codec);
+    }
+
+    pub fn has_page_codec(&self) -> bool {
+        matches!(
+            self.encryption_or_checksum,
+            EncryptionOrChecksum::Encryption(_) | EncryptionOrChecksum::PageCodec(_)
+        )
     }
 
     pub fn encryption_or_checksum(&self) -> &EncryptionOrChecksum {
@@ -137,7 +207,11 @@ impl DatabaseStorage for DatabaseFile {
                             "database: expected to read data on success for encrypted page",
                             { "page_idx": page_idx }
                         );
-                        match encryption_ctx.decrypt_page(buf.as_slice(), page_idx) {
+                        match encryption_ctx.decode_page(
+                            buf.as_slice(),
+                            page_idx,
+                            PageCodecLocation::Database,
+                        ) {
                             Ok(decrypted_data) => {
                                 let original_buf = original_c.as_read().buf();
                                 original_buf.as_mut_slice().copy_from_slice(&decrypted_data);
@@ -158,6 +232,53 @@ impl DatabaseStorage for DatabaseFile {
                         }
                     });
                 let wrapped_completion = Completion::new_read(read_buffer, decrypt_complete);
+                self.file.pread(pos, wrapped_completion)
+            }
+            EncryptionOrChecksum::PageCodec(ctx) => {
+                let page_codec = ctx.clone();
+                let read_buffer = r.buf_arc();
+                let original_c = c.clone();
+                let decode_complete =
+                    Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                        let (buf, bytes_read) = match res {
+                            Ok((buf, bytes_read)) => (buf, bytes_read),
+                            Err(err) => {
+                                tracing::error!(err = ?err);
+                                original_c.error(err);
+                                return original_c.get_error();
+                            }
+                        };
+                        turso_assert_greater_than!(
+                            bytes_read,
+                            0,
+                            "database: expected to read data on success for encoded page",
+                            { "page_idx": page_idx }
+                        );
+                        match page_codec.decode_page(
+                            buf.as_slice(),
+                            page_idx,
+                            PageCodecLocation::Database,
+                        ) {
+                            Ok(decoded_data) => {
+                                let original_buf = original_c.as_read().buf();
+                                original_buf.as_mut_slice().copy_from_slice(&decoded_data);
+                                original_c.complete(bytes_read);
+                                original_c.get_error()
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to decode page data for page_id={page_idx}: {e}"
+                                );
+                                turso_assert!(
+                                    !original_c.failed(),
+                                    "Original completion already has an error"
+                                );
+                                original_c.error(CompletionError::DecryptionError { page_idx });
+                                original_c.get_error()
+                            }
+                        }
+                    });
+                let wrapped_completion = Completion::new_read(read_buffer, decode_complete);
                 self.file.pread(pos, wrapped_completion)
             }
             EncryptionOrChecksum::Checksum(ctx) => {
@@ -222,7 +343,12 @@ impl DatabaseStorage for DatabaseFile {
             return Err(LimboError::IntegerOverflow);
         };
         let buffer = match &io_ctx.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => encrypt_buffer(page_idx, buffer, ctx),
+            EncryptionOrChecksum::Encryption(ctx) => {
+                encode_buffer(page_idx, buffer, ctx, PageCodecLocation::Database)?
+            }
+            EncryptionOrChecksum::PageCodec(ctx) => {
+                encode_buffer(page_idx, buffer, ctx.as_ref(), PageCodecLocation::Database)?
+            }
             EncryptionOrChecksum::Checksum(ctx) => checksum_buffer(page_idx, buffer, ctx),
             EncryptionOrChecksum::None => buffer,
         };
@@ -249,8 +375,22 @@ impl DatabaseStorage for DatabaseFile {
             EncryptionOrChecksum::Encryption(ctx) => buffers
                 .into_iter()
                 .enumerate()
-                .map(|(i, buffer)| encrypt_buffer(first_page_idx + i, buffer, ctx))
-                .collect::<Vec<_>>(),
+                .map(|(i, buffer)| {
+                    encode_buffer(first_page_idx + i, buffer, ctx, PageCodecLocation::Database)
+                })
+                .collect::<Result<Vec<_>>>()?,
+            EncryptionOrChecksum::PageCodec(ctx) => buffers
+                .into_iter()
+                .enumerate()
+                .map(|(i, buffer)| {
+                    encode_buffer(
+                        first_page_idx + i,
+                        buffer,
+                        ctx.as_ref(),
+                        PageCodecLocation::Database,
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?,
             EncryptionOrChecksum::Checksum(ctx) => buffers
                 .into_iter()
                 .enumerate()
@@ -286,9 +426,14 @@ impl DatabaseFile {
     }
 }
 
-fn encrypt_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &EncryptionContext) -> Arc<Buffer> {
-    let encrypted_data = ctx.encrypt_page(buffer.as_slice(), page_idx).unwrap();
-    Arc::new(Buffer::new(encrypted_data.to_vec()))
+fn encode_buffer(
+    page_idx: usize,
+    buffer: Arc<Buffer>,
+    ctx: &dyn PageCodec,
+    location: PageCodecLocation,
+) -> Result<Arc<Buffer>> {
+    let encrypted_data = ctx.encode_page(buffer.as_slice(), page_idx, location)?;
+    Ok(Arc::new(Buffer::new(encrypted_data.to_vec())))
 }
 
 fn checksum_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &ChecksumContext) -> Arc<Buffer> {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -27,7 +27,7 @@ use crate::{
     io::CompletionGroup, return_if_io, types::WalFrameInfo, Completion, Connection, IOResult,
     LimboError, Result, TransactionState,
 };
-use crate::{io_yield_one, Buffer, CompletionError, IOContext, OpenFlags, SyncMode, IO};
+use crate::{io_yield_one, Buffer, CompletionError, IOContext, OpenFlags, PageCodec, SyncMode, IO};
 #[allow(unused_imports)]
 use crate::{
     turso_assert, turso_assert_eq, turso_assert_greater_than, turso_assert_greater_than_or_equal,
@@ -5468,7 +5468,7 @@ impl Pager {
     }
 
     pub fn is_encryption_ctx_set(&self) -> bool {
-        self.io_ctx.read().encryption_context().is_some()
+        self.io_ctx.read().has_page_codec()
     }
 
     pub fn is_encryption_enabled(&self) -> bool {
@@ -5504,6 +5504,21 @@ impl Pager {
         // clear the cache.
         self.clear_page_cache(false);
         // Also invalidate cached schema cookie to force re-read of page 1 with encryption
+        self.set_schema_cookie(None);
+        Ok(())
+    }
+
+    pub fn set_page_codec(&self, codec: Arc<dyn PageCodec>) -> Result<()> {
+        {
+            let mut io_ctx = self.io_ctx.write();
+            io_ctx.set_page_codec(codec);
+        }
+        let Some(wal) = self.wal.as_ref() else {
+            return Ok(());
+        };
+        let io_ctx = self.io_ctx.read().clone();
+        wal.set_io_context(io_ctx);
+        self.clear_page_cache(false);
         self.set_schema_cookie(None);
         Ok(())
     }
@@ -6160,7 +6175,9 @@ mod ptrmap_tests {
 #[cfg(all(test, feature = "fs", host_shared_wal))]
 mod checkpoint_phase_tests {
     use super::*;
-    use crate::io::{PlatformIO, IO};
+    #[cfg(not(all(target_os = "windows", feature = "experimental_win_iocp")))]
+    use crate::io::PlatformIO;
+    use crate::io::IO;
     use crate::storage::sqlite3_ondisk::DatabaseHeader;
     use crate::storage::wal::CheckpointMode;
     use crate::sync::atomic::Ordering;

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -62,7 +62,7 @@ use crate::io::{Buffer, Completion, FileSyncType, ReadComplete};
 use crate::numeric::Numeric;
 use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_threshold_min};
 use crate::storage::buffer_pool::BufferPool;
-use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum};
+use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum, PageCodecLocation};
 use crate::storage::pager::Pager;
 use crate::storage::wal::READMARK_NOT_USED;
 use crate::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
@@ -640,7 +640,7 @@ pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completio
         })
     };
     let c = Completion::new_write(write_complete);
-    let io_ctx = pager.io_ctx.read();
+    let io_ctx = pager.io_ctx.read().clone();
     page_source.write_page(page_id, buffer, &io_ctx, c)
 }
 
@@ -729,7 +729,7 @@ pub fn write_pages_vectored(
                 done_cl.store(true, Ordering::Release);
             }
         });
-        let io_ctx = pager.io_ctx.read();
+        let io_ctx = pager.io_ctx.read().clone();
         let bufs = std::mem::replace(&mut run_bufs, Vec::with_capacity(EST_BUFF_CAPACITY));
         match pager
             .db_file
@@ -1994,6 +1994,44 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
                 });
 
             let new_completion = Completion::new_read(buf, decrypt_complete);
+            io.pread(offset, new_completion)
+        }
+        EncryptionOrChecksum::PageCodec(ctx) => {
+            let page_codec = ctx.clone();
+            let original_complete = complete;
+
+            let decode_complete =
+                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                    let Ok((encoded_buf, bytes_read)) = res else {
+                        return original_complete(res);
+                    };
+                    turso_assert_greater_than!(
+                        bytes_read,
+                        0,
+                        "expected to read data for encoded page",
+                        { "page_idx": page_idx }
+                    );
+                    match page_codec.decode_page(
+                        encoded_buf.as_slice(),
+                        page_idx,
+                        PageCodecLocation::Wal,
+                    ) {
+                        Ok(decoded_data) => {
+                            encoded_buf.as_mut_slice().copy_from_slice(&decoded_data);
+                            original_complete(Ok((encoded_buf, bytes_read)))
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to decode WAL frame data for page_idx={page_idx}: {e}"
+                            );
+                            let err = CompletionError::DecryptionError { page_idx };
+                            original_complete(Err(err));
+                            Some(err)
+                        }
+                    }
+                });
+
+            let new_completion = Completion::new_read(buf, decode_complete);
             io.pread(offset, new_completion)
         }
         EncryptionOrChecksum::Checksum(ctx) => {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -28,7 +28,7 @@ use crate::fast_lock::SpinLock;
 use crate::io::clock::MonotonicInstant;
 use crate::io::CompletionGroup;
 use crate::io::{File, IO};
-use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum};
+use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum, PageCodecLocation};
 #[cfg(host_shared_wal)]
 use crate::storage::shared_wal_coordination::SharedWalCoordinationOpenMode;
 #[cfg(host_shared_wal)]
@@ -3366,13 +3366,14 @@ impl Wal for WalFile {
         // important not to hold shared state locks beyond this point to avoid deadlock with
         // completions that re-enter WAL state while a writer is waiting.
         let file = self.coordination.wal_file()?;
+        let io_ctx = self.io_ctx.read().clone();
         begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
             buffer_pool,
             complete,
             page_idx,
-            &self.io_ctx.read(),
+            &io_ctx,
         )
     }
 
@@ -3500,6 +3501,22 @@ impl Wal for WalFile {
                             }
                         }
                     }
+                    EncryptionOrChecksum::PageCodec(ctx) => {
+                        match ctx.decode_page(body_slice, expected_page_id, PageCodecLocation::Wal)
+                        {
+                            Ok(decoded) => body_slice.copy_from_slice(&decoded),
+                            Err(e) => {
+                                mark_unlikely();
+                                tracing::error!(
+                                    "Failed to decode WAL batch frame for page_idx={expected_page_id}: {e}"
+                                );
+                                clear_slots_on_err(&slots);
+                                return Some(CompletionError::DecryptionError {
+                                    page_idx: expected_page_id,
+                                });
+                            }
+                        }
+                    }
                     EncryptionOrChecksum::Checksum(ctx) => {
                         if let Err(e) = ctx.verify_checksum(body_slice, expected_page_id) {
                             mark_unlikely();
@@ -3542,6 +3559,13 @@ impl Wal for WalFile {
             let io_ctx = self.io_ctx.read();
             io_ctx.encryption_context().cloned()
         };
+        let page_codec = {
+            let io_ctx = self.io_ctx.read();
+            match io_ctx.encryption_or_checksum() {
+                EncryptionOrChecksum::PageCodec(ctx) => Some(ctx.clone()),
+                _ => None,
+            }
+        };
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 return None; // IO error already captured in completion
@@ -3582,6 +3606,24 @@ impl Wal for WalFile {
                     }
                     Err(_) => {
                         tracing::debug!("Failed to decrypt page data for frame_id={frame_id}");
+                    }
+                }
+            } else if let Some(ctx) = page_codec.clone() {
+                match ctx.decode_page(
+                    raw_page,
+                    header.page_number as usize,
+                    PageCodecLocation::Wal,
+                ) {
+                    Ok(decoded_data) => {
+                        turso_assert!(
+                            (frame_len - WAL_FRAME_HEADER_SIZE) == decoded_data.len(),
+                            "frame_len minus header_size does not equal expected decoded data length",
+                            { "frame_len_minus_header": frame_len - WAL_FRAME_HEADER_SIZE, "decoded_data_len": decoded_data.len() }
+                        );
+                        frame_ref[WAL_FRAME_HEADER_SIZE..].copy_from_slice(&decoded_data);
+                    }
+                    Err(_) => {
+                        tracing::debug!("Failed to decode page data for frame_id={frame_id}");
                     }
                 }
             }
@@ -3659,13 +3701,14 @@ impl Wal for WalFile {
                 }
             });
             let file = self.coordination.wal_file()?;
+            let io_ctx = self.io_ctx.read().clone();
             let c = begin_read_wal_frame(
                 file.as_ref(),
                 offset + WAL_FRAME_HEADER_SIZE as u64,
                 buffer_pool,
                 complete,
                 page_id as usize,
-                &self.io_ctx.read(),
+                &io_ctx,
             )?;
             self.io.wait_for_completion(c)?;
             return if *conflict.lock() {
@@ -4114,23 +4157,24 @@ impl Wal for WalFile {
 
         let mut bufs: Vec<Arc<Buffer>> = Vec::with_capacity(pages.len());
         let mut metadata = Vec::with_capacity(pages.len());
+        let enc_or_csum = self.io_ctx.read().encryption_or_checksum().clone();
 
         for (idx, page) in pages.iter().enumerate() {
             let page_id = page.get().id;
             let plain = page.get_contents().as_ptr();
 
-            let data: Cow<[u8]> = {
-                let io_ctx = self.io_ctx.read();
-                match io_ctx.encryption_or_checksum() {
-                    EncryptionOrChecksum::Encryption(ctx) => {
-                        Cow::Owned(ctx.encrypt_page(plain, page_id)?)
-                    }
-                    EncryptionOrChecksum::Checksum(ctx) => {
-                        ctx.add_checksum_to_page(plain, page_id)?;
-                        Cow::Borrowed(plain)
-                    }
-                    EncryptionOrChecksum::None => Cow::Borrowed(plain),
+            let data: Cow<[u8]> = match &enc_or_csum {
+                EncryptionOrChecksum::Encryption(ctx) => {
+                    Cow::Owned(ctx.encrypt_page(plain, page_id)?)
                 }
+                EncryptionOrChecksum::PageCodec(ctx) => {
+                    Cow::Owned(ctx.encode_page(plain, page_id, PageCodecLocation::Wal)?)
+                }
+                EncryptionOrChecksum::Checksum(ctx) => {
+                    ctx.add_checksum_to_page(plain, page_id)?;
+                    Cow::Borrowed(plain)
+                }
+                EncryptionOrChecksum::None => Cow::Borrowed(plain),
             };
 
             // if DB size is included for commit frame, it will need to be included only in the last frame of the batch.
@@ -4225,6 +4269,7 @@ impl Wal for WalFile {
         let mut iovecs: Vec<Arc<Buffer>> = Vec::with_capacity(pages.len());
         let mut page_frame_and_checksum: Vec<(PageRef, u64, (u32, u32))> =
             Vec::with_capacity(pages.len());
+        let enc_or_csum = self.io_ctx.read().encryption_or_checksum().clone();
 
         // Rolling checksum input to each frame build
         let mut rolling_checksum: (u32, u32) = *self.last_checksum.read();
@@ -4236,18 +4281,18 @@ impl Wal for WalFile {
             let page_id = page.get().id;
             let plain = page.get_contents().as_ptr();
 
-            let data_to_write: std::borrow::Cow<[u8]> = {
-                let io_ctx = self.io_ctx.read();
-                match &io_ctx.encryption_or_checksum() {
-                    EncryptionOrChecksum::Encryption(ctx) => {
-                        Cow::Owned(ctx.encrypt_page(plain, page_id)?)
-                    }
-                    EncryptionOrChecksum::Checksum(ctx) => {
-                        ctx.add_checksum_to_page(plain, page_id)?;
-                        Cow::Borrowed(plain)
-                    }
-                    EncryptionOrChecksum::None => Cow::Borrowed(plain),
+            let data_to_write: std::borrow::Cow<[u8]> = match &enc_or_csum {
+                EncryptionOrChecksum::Encryption(ctx) => {
+                    Cow::Owned(ctx.encrypt_page(plain, page_id)?)
                 }
+                EncryptionOrChecksum::PageCodec(ctx) => {
+                    Cow::Owned(ctx.encode_page(plain, page_id, PageCodecLocation::Wal)?)
+                }
+                EncryptionOrChecksum::Checksum(ctx) => {
+                    ctx.add_checksum_to_page(plain, page_id)?;
+                    Cow::Borrowed(plain)
+                }
+                EncryptionOrChecksum::None => Cow::Borrowed(plain),
             };
 
             let frame_db_size = 0; // this method is not used for the commit path
@@ -4965,13 +5010,14 @@ impl WalFile {
         };
         // schedule read of the page payload
         let file = self.coordination.wal_file()?;
+        let io_ctx = self.io_ctx.read().clone();
         let c = begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
             self.buffer_pool.clone(),
             complete,
             page_id,
-            &self.io_ctx.read(),
+            &io_ctx,
         )?;
 
         Ok(InflightRead {

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -126,7 +126,7 @@ impl Affinity {
     }
 
     /// Convert affinity to the corresponding Type enum
-    pub fn to_type(&self) -> crate::schema::Type {
+    pub fn to_type(self) -> crate::schema::Type {
         use crate::schema::Type;
         match self {
             Affinity::Blob => Type::Blob,

--- a/examples/dotnet/Encryption.cs
+++ b/examples/dotnet/Encryption.cs
@@ -4,135 +4,120 @@
  * This example demonstrates how to use local database encryption
  * with the Turso .NET SDK.
  *
- * Supported ciphers:
- *   - Aes128Gcm
- *   - Aes256Gcm
- *   - Aegis256
- *   - Aegis256x2
- *   - Aegis128l
- *   - Aegis128x2
- *   - Aegis128x4
+ * Supported ciphers include:
+ *   - aes128gcm
+ *   - aes256gcm
+ *   - aegis256
+ *   - aegis256x2
+ *   - aegis128l
+ *   - aegis128x2
+ *   - aegis128x4
  */
 
-using System;
-using System.IO;
 using System.Text;
 using Turso;
 
-class EncryptionExample
+const string DatabasePath = "encrypted.db";
+
+// 32-byte hex key for aegis256 (256 bits = 32 bytes = 64 hex chars).
+const string EncryptionKey =
+    "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
+
+Console.WriteLine("=== Turso Local Encryption Example ===");
+
+DeleteDatabaseFiles(DatabasePath);
+
+Console.WriteLine("\n1. Creating encrypted database...");
+using (var connection = OpenEncryptedConnection(DatabasePath, EncryptionKey))
 {
-    private const string DB_PATH = "encrypted.db";
-    // 32-byte hex key for aegis256 (256 bits = 32 bytes = 64 hex chars)
-    private const string ENCRYPTION_KEY =
-        "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
-
-    public static void Main(string[] args)
+    using (var create = new TursoCommand(
+        connection,
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, ssn TEXT NOT NULL)"))
     {
-        Console.WriteLine("=== Turso Local Encryption Example ===\n");
-
-        // Create an encrypted database
-        Console.WriteLine("1. Creating encrypted database...");
-        using (var connection = new TursoConnection(
-            $"Data Source={DB_PATH};Encryption Cipher=aegis256;Encryption Key={ENCRYPTION_KEY}"))
-        {
-            connection.Open();
-
-            // Create a table and insert sensitive data
-            Console.WriteLine("2. Creating table and inserting data...");
-            using (var create = new TursoCommand(connection,
-                "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, ssn TEXT)"))
-            {
-                create.ExecuteNonQuery();
-            }
-
-            using (var insert = new TursoCommand(connection,
-                "INSERT INTO users (name, ssn) VALUES ('Alice', '123-45-6789')"))
-            {
-                insert.ExecuteNonQuery();
-            }
-
-            using (var insert = new TursoCommand(connection,
-                "INSERT INTO users (name, ssn) VALUES ('Bob', '987-65-4321')"))
-            {
-                insert.ExecuteNonQuery();
-            }
-
-            // Checkpoint to flush data to disk
-            using (var checkpoint = new TursoCommand(connection,
-                "PRAGMA wal_checkpoint(truncate)"))
-            {
-                checkpoint.ExecuteNonQuery();
-            }
-
-            // Query the data
-            Console.WriteLine("3. Querying data...");
-            using (var select = new TursoCommand(connection, "SELECT * FROM users"))
-            using (var reader = select.ExecuteReader())
-            {
-                while (reader.Read())
-                {
-                    Console.WriteLine($"   User: id={reader.GetInt64(0)}, name={reader.GetString(1)}, ssn={reader.GetString(2)}");
-                }
-            }
-        }
-
-        // Verify the data is encrypted on disk
-        Console.WriteLine("\n4. Verifying encryption...");
-        var rawContent = File.ReadAllBytes(DB_PATH);
-        var contentStr = Encoding.UTF8.GetString(rawContent);
-        var containsPlaintext = contentStr.Contains("Alice") || contentStr.Contains("123-45-6789");
-
-        if (containsPlaintext)
-        {
-            Console.WriteLine("   WARNING: Data appears to be unencrypted!");
-        }
-        else
-        {
-            Console.WriteLine("   Data is encrypted on disk (plaintext not found)");
-        }
-
-        // Reopen with the same key
-        Console.WriteLine("\n5. Reopening database with correct key...");
-        using (var connection2 = new TursoConnection(
-            $"Data Source={DB_PATH};Encryption Cipher=aegis256;Encryption Key={ENCRYPTION_KEY}"))
-        {
-            connection2.Open();
-            using (var select = new TursoCommand(connection2, "SELECT name FROM users"))
-            using (var reader = select.ExecuteReader())
-            {
-                Console.Write("   Successfully read users: ");
-                var names = new System.Collections.Generic.List<string>();
-                while (reader.Read())
-                {
-                    names.Add(reader.GetString(0));
-                }
-                Console.WriteLine(string.Join(", ", names));
-            }
-        }
-
-        // Demonstrate that wrong key fails
-        Console.WriteLine("\n6. Attempting to open with wrong key (should fail)...");
-        try
-        {
-            using (var connection3 = new TursoConnection(
-                $"Data Source={DB_PATH};Encryption Cipher=aegis256;Encryption Key=aaaaaaa4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327"))
-            {
-                connection3.Open();
-                using (var select = new TursoCommand(connection3, "SELECT * FROM users"))
-                using (var reader = select.ExecuteReader())
-                {
-                    reader.Read();
-                    Console.WriteLine("   ERROR: Should have failed with wrong key!");
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine($"   Correctly failed: {e.Message}");
-        }
-
-        // Cleanup
-        File.Delete(DB_PATH);
-        Console.WriteLine("\n=== Example completed successfully ===");
+        create.ExecuteNonQuery();
     }
+
+    using (var insert = new TursoCommand(
+        connection,
+        "INSERT INTO users (name, ssn) VALUES ('Alice', '123-45-6789'), ('Bob', '987-65-4321')"))
+    {
+        insert.ExecuteNonQuery();
+    }
+
+    using (var checkpoint = new TursoCommand(connection, "PRAGMA wal_checkpoint(truncate)"))
+    {
+        checkpoint.ExecuteNonQuery();
+    }
+
+    Console.WriteLine("2. Querying encrypted database...");
+    using (var select = new TursoCommand(connection, "SELECT id, name, ssn FROM users ORDER BY id"))
+    using (var reader = select.ExecuteReader())
+    {
+        while (reader.Read())
+        {
+            Console.WriteLine(
+                $"   User: id={reader.GetInt64(0)}, name={reader.GetString(1)}, ssn={reader.GetString(2)}");
+        }
+    }
+}
+
+Console.WriteLine("\n3. Verifying encryption on disk...");
+var rawContent = File.ReadAllBytes(DatabasePath);
+var content = Encoding.UTF8.GetString(rawContent);
+if (content.Contains("Alice", StringComparison.Ordinal) ||
+    content.Contains("123-45-6789", StringComparison.Ordinal))
+{
+    throw new InvalidOperationException("Plaintext data was found in the encrypted database file.");
+}
+
+Console.WriteLine("   Plaintext values were not found in the database file.");
+
+Console.WriteLine("\n4. Reopening database with the correct key...");
+using (var connection = OpenEncryptedConnection(DatabasePath, EncryptionKey))
+using (var select = new TursoCommand(connection, "SELECT group_concat(name, ', ') FROM users"))
+using (var reader = select.ExecuteReader())
+{
+    reader.Read();
+    Console.WriteLine($"   Successfully read users: {reader.GetString(0)}");
+}
+
+Console.WriteLine("\n5. Attempting to read with the wrong key...");
+var wrongKeySucceeded = false;
+try
+{
+    using var connection = OpenEncryptedConnection(
+        DatabasePath,
+        "aaaaaaa4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327");
+    using var select = new TursoCommand(connection, "SELECT count(*) FROM users");
+    select.ExecuteScalar();
+
+    wrongKeySucceeded = true;
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"   Correctly failed: {ex.Message}");
+}
+
+if (wrongKeySucceeded)
+{
+    throw new InvalidOperationException("Reading with the wrong encryption key unexpectedly succeeded.");
+}
+
+DeleteDatabaseFiles(DatabasePath);
+
+Console.WriteLine("\n=== Example completed successfully ===");
+
+static TursoConnection OpenEncryptedConnection(string path, string key)
+{
+    var connection = new TursoConnection(
+        $"Data Source={path};Encryption Cipher=aegis256;Encryption Key={key}");
+    connection.Open();
+    return connection;
+}
+
+static void DeleteDatabaseFiles(string path)
+{
+    File.Delete(path);
+    File.Delete(path + "-wal");
+    File.Delete(path + "-shm");
 }

--- a/examples/dotnet/EncryptionExample.csproj
+++ b/examples/dotnet/EncryptionExample.csproj
@@ -2,26 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>EncryptionExample</RootNamespace>
+    <RootNamespace>Turso.EncryptionExample</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../bindings/dotnet/src/Turso.Data/Turso.Data.csproj" />
-  </ItemGroup>
-
-  <!-- Copy native library to output directory -->
-  <ItemGroup>
-    <None Include="../../target/release/libturso_dotnet.dylib" Condition="Exists('../../target/release/libturso_dotnet.dylib')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>libturso_dotnet.dylib</Link>
-    </None>
-    <None Include="../../target/debug/libturso_dotnet.dylib" Condition="Exists('../../target/debug/libturso_dotnet.dylib') And !Exists('../../target/release/libturso_dotnet.dylib')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>libturso_dotnet.dylib</Link>
-    </None>
+    <ProjectReference Include="..\..\bindings\dotnet\src\Turso.Data\Turso.Data.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -1,19 +1,21 @@
 # .NET Examples
 
-## Prerequisites
+## Local encryption
 
-1. .NET 9.0 SDK
-2. Build the native library:
-   ```bash
-   cd /path/to/limbo
-   cargo build --release -p turso-dotnet
-   ```
+This example demonstrates local database encryption with the Turso .NET SDK.
 
-## Encryption
+Build the native SDK library first so the project reference can copy the runtime asset:
 
-This example demonstrates how to use local database encryption with the Turso .NET SDK.
-
-```bash
-cd examples/dotnet
-dotnet run
+```powershell
+cargo build -p turso_sdk_kit --target-dir bindings\dotnet\rs_compiled --target x86_64-pc-windows-msvc
 ```
+
+Then run the example from the repository root:
+
+```powershell
+dotnet run --project examples\dotnet\EncryptionExample.csproj
+```
+
+## External page codecs
+
+The managed wxSQLite3/SQLite3MC AES-128-CBC, System.Data.SQLite legacy CryptoAPI, and ordered detector reference code lives in `bindings\dotnet\src\Turso.Tests\Support`, with coverage in `bindings\dotnet\src\Turso.Tests\TursoPageCodecTests.cs`. Keeping that code test-owned avoids duplicating compatibility crypto in the sample app.

--- a/sdk-kit/README.md
+++ b/sdk-kit/README.md
@@ -9,8 +9,25 @@ Key ideas:
 - Clear status codes: Done/Row/Io/Error/etc. No hidden blocking or exceptions.
 - Minimal surface: open database, connect, prepare, bind, step/execute, read rows, finalize.
 - Ownership model and lifetimes are explicit for C consumers.
+- Optional page codecs: callers can provide a synchronous page transform callback table to decode/encode legacy encrypted database pages without linking that crypto into Turso core.
 
 Note: turso.h is the single C header exported by the crate and can be translated to bindings.rs with rust-bindgen.
+
+## External page codecs
+
+`turso_database_config_t.page_codec` accepts a versioned `turso_page_codec_v1_t` callback table. The callbacks transform complete page images between on-disk bytes and plaintext SQLite pages. They are intended for compatibility layers such as legacy SQLite codec formats where the application supplies the crypto implementation.
+
+Codec rules:
+
+- callbacks are synchronous and must not perform Turso I/O or re-enter the same database;
+- `probe_header` may inspect the raw first 512 bytes and report page size/reserved bytes before Turso parses page 1;
+- `decode_page` and `encode_page` receive a page number and location (`DATABASE` or `WAL`) and must write exactly one page to the output buffer;
+- the callback context and function pointers must remain valid until `turso_database_deinit`;
+- callback failures are surfaced as database open/read/write errors.
+
+The .NET binding exposes this through `ITursoPageCodec`, `TursoBindings.OpenDatabaseWithPageCodec`, and `TursoConnection.PageCodec`.
+
+The .NET tests include compatibility codecs that exercise this generic surface against legacy encrypted SQLite formats. Those codecs are examples of consumer-supplied page transforms and are intentionally not part of the Turso core or C ABI.
 
 ## Rust example
 

--- a/sdk-kit/src/bindings.rs
+++ b/sdk-kit/src/bindings.rs
@@ -307,6 +307,62 @@ impl Default for turso_config_t {
         }
     }
 }
+pub const turso_codec_location_t_TURSO_CODEC_LOCATION_DATABASE: turso_codec_location_t = 0;
+pub const turso_codec_location_t_TURSO_CODEC_LOCATION_WAL: turso_codec_location_t = 1;
+pub type turso_codec_location_t = ::std::os::raw::c_uint;
+pub const turso_database_open_flags_t_TURSO_DATABASE_OPEN_DEFAULT: turso_database_open_flags_t = 0;
+pub const turso_database_open_flags_t_TURSO_DATABASE_OPEN_READONLY: turso_database_open_flags_t = 1;
+pub type turso_database_open_flags_t = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct turso_page_codec_header_info_t {
+    pub page_size: u32,
+    pub reserved_space: u8,
+    pub is_supported: u8,
+}
+pub type turso_page_codec_probe_header_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        ctx: *mut ::std::os::raw::c_void,
+        raw_page1_prefix: *const u8,
+        raw_len: usize,
+        out: *mut turso_page_codec_header_info_t,
+        error: *mut *const ::std::os::raw::c_char,
+    ) -> i32,
+>;
+pub type turso_page_codec_transform_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        ctx: *mut ::std::os::raw::c_void,
+        page_no: u32,
+        location: turso_codec_location_t,
+        input: *const u8,
+        input_len: usize,
+        output: *mut u8,
+        output_len: usize,
+        error: *mut *const ::std::os::raw::c_char,
+    ) -> i32,
+>;
+pub type turso_page_codec_destroy_t =
+    ::std::option::Option<unsafe extern "C" fn(ctx: *mut ::std::os::raw::c_void)>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct turso_page_codec_v1_t {
+    pub abi_version: u32,
+    pub ctx: *mut ::std::os::raw::c_void,
+    pub reserved_space: u8,
+    pub destroy: turso_page_codec_destroy_t,
+    pub probe_header: turso_page_codec_probe_header_t,
+    pub decode_page: turso_page_codec_transform_t,
+    pub encode_page: turso_page_codec_transform_t,
+}
+impl Default for turso_page_codec_v1_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[doc = " Database description."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -323,6 +379,10 @@ pub struct turso_database_config_t {
     pub encryption_cipher: *const ::std::os::raw::c_char,
     #[doc = " optional encryption hexkey\n as encryption is experimental - experimental_features must have \"encryption\" in the list"]
     pub encryption_hexkey: *const ::std::os::raw::c_char,
+    #[doc = " optional external page codec; callback context must remain valid and thread-safe until destroy is called"]
+    pub page_codec: *const turso_page_codec_v1_t,
+    #[doc = " optional bitmask of turso_database_open_flags_t values"]
+    pub open_flags: u32,
 }
 impl Default for turso_database_config_t {
     fn default() -> Self {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    ffi::CString,
+    ffi::{CStr, CString},
     fmt::Display,
     ops::Deref,
     sync::{
@@ -20,8 +20,8 @@ use tracing_subscriber::{
 };
 use turso_core::{
     storage::database::DatabaseFile, types::AsValueRef, Connection, Database, DatabaseOpts,
-    DatabaseStorage, EncryptionKey, IOResult, LimboError, OpenDbAsyncState, OpenFlags, QueryMode,
-    Statement, StepResult, IO,
+    DatabaseStorage, EncryptionKey, IOResult, LimboError, OpenDbAsyncState, OpenFlags, PageCodec,
+    PageCodecHeaderInfo, PageCodecLocation, QueryMode, Statement, StepResult, IO,
 };
 
 use crate::{
@@ -147,6 +147,184 @@ pub struct TursoDatabaseConfig {
     /// optional custom DatabaseStorage provided by the caller
     /// if provided, caller must guarantee that IO used by the TursoDatabase will be consistent with underlying DatabaseStorage IO
     pub db_file: Option<Arc<dyn DatabaseStorage>>,
+
+    /// optional external page codec provided by the caller
+    pub page_codec: Option<Arc<dyn PageCodec>>,
+
+    /// database open flags
+    pub open_flags: OpenFlags,
+}
+
+#[derive(Clone)]
+struct CApiPageCodec {
+    inner: Arc<CApiPageCodecInner>,
+}
+
+struct CApiPageCodecInner {
+    raw: c::turso_page_codec_v1_t,
+}
+
+// SAFETY: external page codecs are an FFI contract. Callers that install a codec must keep the
+// context and callbacks valid and thread-safe for the database lifetime.
+unsafe impl Send for CApiPageCodecInner {}
+// SAFETY: see the Send impl; Turso may read/write pages through shared database state.
+unsafe impl Sync for CApiPageCodecInner {}
+
+impl std::fmt::Debug for CApiPageCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CApiPageCodec")
+            .field("abi_version", &self.inner.raw.abi_version)
+            .field("ctx", &"<opaque>")
+            .finish()
+    }
+}
+
+impl Drop for CApiPageCodecInner {
+    fn drop(&mut self) {
+        if let Some(destroy) = self.raw.destroy {
+            unsafe { destroy(self.raw.ctx) };
+        }
+    }
+}
+
+impl CApiPageCodec {
+    unsafe fn from_capi(codec: *const c::turso_page_codec_v1_t) -> Result<Self, TursoError> {
+        if codec.is_null() {
+            return Err(TursoError::Misuse(
+                "page codec pointer must be not null".to_string(),
+            ));
+        }
+        let raw = unsafe { *codec };
+        if raw.abi_version != 1 {
+            return Err(TursoError::Misuse(format!(
+                "unsupported page codec ABI version {}",
+                raw.abi_version
+            )));
+        }
+        if raw.decode_page.is_none() || raw.encode_page.is_none() {
+            return Err(TursoError::Misuse(
+                "page codec decode_page and encode_page callbacks are required".to_string(),
+            ));
+        }
+        Ok(Self {
+            inner: Arc::new(CApiPageCodecInner { raw }),
+        })
+    }
+
+    fn callback_error(error: *const std::ffi::c_char, operation: &str) -> LimboError {
+        if error.is_null() {
+            return LimboError::InvalidArgument(format!("page codec {operation} failed"));
+        }
+        let message = unsafe { CStr::from_ptr(error) }.to_string_lossy();
+        LimboError::InvalidArgument(format!("page codec {operation} failed: {message}"))
+    }
+
+    fn location_to_c(location: PageCodecLocation) -> c::turso_codec_location_t {
+        match location {
+            PageCodecLocation::Database => c::turso_codec_location_t_TURSO_CODEC_LOCATION_DATABASE,
+            PageCodecLocation::Wal => c::turso_codec_location_t_TURSO_CODEC_LOCATION_WAL,
+        }
+    }
+
+    fn transform(
+        &self,
+        operation: &str,
+        callback: c::turso_page_codec_transform_t,
+        page: &[u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> Result<Vec<u8>, LimboError> {
+        let Some(callback) = callback else {
+            return Err(LimboError::InvalidArgument(format!(
+                "page codec {operation} callback is not configured"
+            )));
+        };
+        let page_no = u32::try_from(page_idx).map_err(|_| LimboError::IntegerOverflow)?;
+        let mut output = vec![0; page.len()];
+        let mut error = std::ptr::null();
+        let status = unsafe {
+            callback(
+                self.inner.raw.ctx,
+                page_no,
+                Self::location_to_c(location),
+                page.as_ptr(),
+                page.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                &mut error,
+            )
+        };
+        if status != 0 {
+            return Err(Self::callback_error(error, operation));
+        }
+        Ok(output)
+    }
+}
+
+impl PageCodec for CApiPageCodec {
+    fn probe_header(
+        &self,
+        raw_page1_prefix: &[u8],
+    ) -> Result<Option<PageCodecHeaderInfo>, LimboError> {
+        let Some(probe_header) = self.inner.raw.probe_header else {
+            return Ok(None);
+        };
+        let mut out = c::turso_page_codec_header_info_t::default();
+        let mut error = std::ptr::null();
+        let status = unsafe {
+            probe_header(
+                self.inner.raw.ctx,
+                raw_page1_prefix.as_ptr(),
+                raw_page1_prefix.len(),
+                &mut out,
+                &mut error,
+            )
+        };
+        if status != 0 {
+            return Err(Self::callback_error(error, "probe_header"));
+        }
+        if out.is_supported == 0 {
+            return Ok(None);
+        }
+        Ok(Some(PageCodecHeaderInfo {
+            page_size: out.page_size as usize,
+            reserved_space: out.reserved_space,
+        }))
+    }
+
+    fn required_reserved_bytes(&self) -> u8 {
+        self.inner.raw.reserved_space
+    }
+
+    fn encode_page(
+        &self,
+        page: &[u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> Result<Vec<u8>, LimboError> {
+        self.transform(
+            "encode_page",
+            self.inner.raw.encode_page,
+            page,
+            page_idx,
+            location,
+        )
+    }
+
+    fn decode_page(
+        &self,
+        page: &[u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> Result<Vec<u8>, LimboError> {
+        self.transform(
+            "decode_page",
+            self.inner.raw.decode_page,
+            page,
+            page_idx,
+            location,
+        )
+    }
 }
 
 impl TursoDatabaseConfig {
@@ -301,6 +479,12 @@ impl TursoDatabaseConfig {
                 "either both encryption cipher and key must be set or no".to_string(),
             ));
         }
+        if encryption_cipher.is_some() && !config.page_codec.is_null() {
+            return Err(TursoError::Misuse(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
+        let open_flags = open_flags_from_capi(config.open_flags)?;
         Ok(Self {
             path: str_from_c_str(config.path)?.to_string(),
             experimental_features: if !config.experimental_features.is_null() {
@@ -320,7 +504,28 @@ impl TursoDatabaseConfig {
             },
             io: None,
             db_file: None,
+            page_codec: if !config.page_codec.is_null() {
+                Some(Arc::new(CApiPageCodec::from_capi(config.page_codec)?))
+            } else {
+                None
+            },
+            open_flags,
         })
+    }
+}
+
+fn open_flags_from_capi(flags: u32) -> Result<OpenFlags, TursoError> {
+    const READONLY: u32 = c::turso_database_open_flags_t_TURSO_DATABASE_OPEN_READONLY;
+    if flags & !READONLY != 0 {
+        return Err(TursoError::Misuse(format!(
+            "unknown database open flags: 0x{flags:x}"
+        )));
+    }
+
+    if flags & READONLY != 0 {
+        Ok(OpenFlags::ReadOnly)
+    } else {
+        Ok(OpenFlags::default())
     }
 }
 
@@ -346,6 +551,7 @@ pub struct TursoDatabaseOpenState {
     io: Option<Arc<dyn IO>>,
     db_file: Option<Arc<dyn DatabaseStorage>>,
     opts: Option<DatabaseOpts>,
+    open_flags: OpenFlags,
     open_db_state: OpenDbAsyncState,
 }
 
@@ -362,6 +568,7 @@ impl TursoDatabaseOpenState {
             io: None,
             db_file: None,
             opts: None,
+            open_flags: OpenFlags::default(),
             open_db_state: OpenDbAsyncState::new(),
         }
     }
@@ -696,7 +903,7 @@ impl TursoDatabase {
                         ));
                     }
 
-                    let mut open_flags = OpenFlags::default();
+                    let mut open_flags = self.config.open_flags;
                     if opts.enable_multiprocess_wal {
                         open_flags |= OpenFlags::NoLock;
                     }
@@ -710,6 +917,7 @@ impl TursoDatabase {
                     state.io = Some(io);
                     state.db_file = Some(db_file);
                     state.opts = Some(opts);
+                    state.open_flags = open_flags;
                     state.phase = TursoDatabaseOpenPhase::Opening;
                 }
 
@@ -725,17 +933,34 @@ impl TursoDatabase {
                         .expect("db_file must be initialized in Init phase")
                         .clone();
                     let opts = state.opts.expect("opts must be initialized in Init phase");
+                    let open_flags = state.open_flags;
 
-                    match Database::open_with_flags_async(
-                        &mut state.open_db_state,
-                        io.clone(),
-                        &self.config.path,
-                        db_file,
-                        OpenFlags::default(),
-                        opts,
-                        self.config.encryption.clone(),
-                        None,
-                    )? {
+                    let open_result = if let Some(page_codec) = self.config.page_codec.clone() {
+                        Database::open_with_flags_and_page_codec_async(
+                            &mut state.open_db_state,
+                            io.clone(),
+                            &self.config.path,
+                            db_file,
+                            open_flags,
+                            opts,
+                            self.config.encryption.clone(),
+                            None,
+                            page_codec,
+                        )
+                    } else {
+                        Database::open_with_flags_async(
+                            &mut state.open_db_state,
+                            io.clone(),
+                            &self.config.path,
+                            db_file,
+                            open_flags,
+                            opts,
+                            self.config.encryption.clone(),
+                            None,
+                        )
+                    }?;
+
+                    match open_result {
                         IOResult::Done(db) => {
                             let mut inner_db = self.db.lock().unwrap();
                             *inner_db = Some(db);
@@ -1440,7 +1665,7 @@ impl TursoStatement {
 #[cfg(test)]
 mod tests {
     use crate::rsapi::{
-        TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode, FINALIZED_ERR,
+        OpenFlags, TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode, FINALIZED_ERR,
     };
     use turso_core::Value;
 
@@ -1453,6 +1678,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         }
     }
 
@@ -1503,6 +1730,8 @@ mod tests {
                 vfs: None,
                 io: None,
                 db_file: None,
+                page_codec: None,
+                open_flags: OpenFlags::default(),
             });
             let result = db.open().unwrap();
             assert!(!result.is_io());
@@ -1564,6 +1793,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1584,6 +1815,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1614,6 +1847,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1637,6 +1872,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1687,6 +1924,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1746,6 +1985,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1778,6 +2019,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1807,6 +2050,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1832,6 +2077,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1858,6 +2105,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1908,6 +2157,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1996,6 +2247,8 @@ mod tests {
                     vfs: None,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 let result = db.open().unwrap();
                 assert!(!result.is_io());
@@ -2036,6 +2289,8 @@ mod tests {
                     vfs: None,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 let result = db.open().unwrap();
                 assert!(!result.is_io());
@@ -2062,6 +2317,8 @@ mod tests {
                     vfs: None,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 assert!(db.open().is_err(), "Opening with wrong key should fail");
             }
@@ -2076,6 +2333,8 @@ mod tests {
                     vfs: None,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 let result = db.open();
                 println!("result: {result:?}");
@@ -2111,6 +2370,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let _ = db_a.open().unwrap();
         let conn_a = db_a.connect().unwrap();
@@ -2148,6 +2409,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let _ = db_a2.open().unwrap();
         let conn_a2 = db_a2.connect().unwrap();
@@ -2182,6 +2445,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2216,6 +2481,8 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());

--- a/sdk-kit/turso.h
+++ b/sdk-kit/turso.h
@@ -196,6 +196,55 @@ typedef struct
     const char *log_level;
 } turso_config_t;
 
+typedef enum
+{
+    TURSO_CODEC_LOCATION_DATABASE = 0,
+    TURSO_CODEC_LOCATION_WAL = 1,
+} turso_codec_location_t;
+
+typedef enum
+{
+    TURSO_DATABASE_OPEN_DEFAULT = 0,
+    TURSO_DATABASE_OPEN_READONLY = 1,
+} turso_database_open_flags_t;
+
+typedef struct
+{
+    uint32_t page_size;
+    uint8_t reserved_space;
+    uint8_t is_supported;
+} turso_page_codec_header_info_t;
+
+typedef int32_t (*turso_page_codec_probe_header_t)(
+    void *ctx,
+    const uint8_t *raw_page1_prefix,
+    size_t raw_len,
+    turso_page_codec_header_info_t *out,
+    const char **error);
+
+typedef int32_t (*turso_page_codec_transform_t)(
+    void *ctx,
+    uint32_t page_no,
+    turso_codec_location_t location,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_len,
+    const char **error);
+
+typedef void (*turso_page_codec_destroy_t)(void *ctx);
+
+typedef struct
+{
+    uint32_t abi_version;
+    void *ctx;
+    uint8_t reserved_space;
+    turso_page_codec_destroy_t destroy;
+    turso_page_codec_probe_header_t probe_header;
+    turso_page_codec_transform_t decode_page;
+    turso_page_codec_transform_t encode_page;
+} turso_page_codec_v1_t;
+
 /**
  * Database description.
  */
@@ -227,6 +276,10 @@ typedef struct
      * as encryption is experimental - experimental_features must have "encryption" in the list
      */
     const char *encryption_hexkey;
+    /** optional external page codec; callback context must remain valid and thread-safe until destroy is called */
+    const turso_page_codec_v1_t *page_codec;
+    /** optional bitmask of turso_database_open_flags_t values */
+    uint32_t open_flags;
 } turso_database_config_t;
 
 /** Setup global database info */

--- a/sync/sdk-kit/bindgen.sh
+++ b/sync/sdk-kit/bindgen.sh
@@ -19,6 +19,9 @@ bindgen turso_sync.h -o src/bindings.rs \
     --blocklist-type "turso_connection_t" \
     --blocklist-type "turso_status_t" \
     --blocklist-type "turso_slice_ref_t" \
+    --blocklist-type "turso_codec_location_t" \
+    --blocklist-type "turso_database_open_flags_t" \
+    --blocklist-type "turso_page_codec_.*_t" \
     --rustified-enum "turso_sync_io_request_type_t" \
     --rustified-enum "turso_sync_database_io_request_type_t" \
     --rustified-enum "turso_sync_operation_result_type_t" \

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -53,7 +53,7 @@ use crate::{
 pub fn multiprocess_platform_io() -> anyhow::Result<Arc<dyn IO>> {
     #[cfg(target_os = "windows")]
     {
-        return Ok(Arc::new(WindowsIOCP::new()?));
+        Ok(Arc::new(WindowsIOCP::new()?))
     }
 
     #[cfg(unix)]

--- a/testing/sqltests/src/main.rs
+++ b/testing/sqltests/src/main.rs
@@ -25,6 +25,7 @@ struct Cli {
     command: Commands,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 enum Commands {
     /// Run tests

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -94,6 +94,8 @@ fn test_sdk_close_finalizes_leaked_statements() {
         vfs: None,
         io: None,
         db_file: None,
+        page_codec: None,
+        open_flags: Default::default(),
     });
     let _ = db_a.open().unwrap();
     let conn_a = db_a.connect().unwrap();


### PR DESCRIPTION
## Summary

This PR adds a generic external SQLite page-codec path that lets embedders transform database and WAL pages outside Turso core. The intent is to support compatibility codecs such as wxSQLite3/SQLite3MC and legacy System.Data.SQLite from consumers of the SDK, without baking those product-specific crypto implementations into the Rust core.

The implementation wires the codec seam through Turso core, sdk-kit, and the .NET bindings, then keeps concrete compatibility codec implementations in the .NET test project as executable reference fixtures.

## Core Rust changes

- Add a generic `PageCodec` abstraction in `core/storage/database.rs`:
  - `probe_header(raw_page1_prefix)` lets a codec identify encrypted page 1 metadata before normal SQLite header parsing.
  - `required_reserved_bytes()` reports per-page reserved bytes.
  - `encode_page(...)` and `decode_page(...)` transform pages between in-memory and on-disk form.
  - `PageCodecLocation::{Database, Wal}` tells codecs whether the page came from the main database file or WAL.
- Implement `PageCodec` for the existing `EncryptionContext`, so built-in encryption and external codecs share the same page-transform shape internally.
- Thread an optional `Arc<dyn PageCodec>` through `Database`, `IOContext`, and `Pager`.
- Apply codec transforms in all relevant page IO paths:
  - database page reads and writes,
  - batch database writes,
  - WAL frame reads,
  - WAL frame writes,
  - WAL recovery/checkpoint-style paths that materialize page images.
- Extend database header validation so encrypted databases can be opened by asking the codec to probe page 1 for page size and reserved-space metadata before falling back to plaintext SQLite header parsing.
- Preserve existing public `Database::open_*` signatures where callers already depend on them, and add codec-specific sibling APIs instead:
  - `Database::open_with_flags_and_page_codec_async`
  - `Database::open_with_flags_bypass_registry_and_page_codec_async`
- Reject invalid or unsafe combinations early:
  - built-in Turso encryption cannot be combined with an external page codec,
  - cached database handles are not reused for external-codec opens because the cached handle's codec configuration cannot be verified safely.
- Refactor the private `Database::new` argument list into an internal args struct while keeping public open APIs source-compatible.

## sdk-kit C ABI and Rust wrapper

- Add C ABI types for external page codecs:
  - `turso_codec_location_t`
  - `turso_page_codec_header_info_t`
  - `turso_page_codec_probe_header_t`
  - `turso_page_codec_transform_t`
  - `turso_page_codec_destroy_t`
  - `turso_page_codec_v1_t`
- Add `turso_database_open_flags_t` and `open_flags` on `turso_database_config_t`, including `TURSO_DATABASE_OPEN_READONLY` for read-only/no-create probing.
- Add `page_codec` on `turso_database_config_t` so sdk-kit callers can pass a callback table and context pointer.
- Implement the Rust-side `CApiPageCodec` wrapper in `sdk-kit/src/rsapi.rs`:
  - validates callback ABI/version and required pointers,
  - maps C callback locations to core `PageCodecLocation`,
  - propagates callback error messages into Turso errors,
  - owns/destroys the C codec context through the provided destroy callback,
  - routes codec opens through the additive core sibling API.
- Preserve the existing sdk-kit path when no codec is configured.
- Keep built-in encryption and external page codecs mutually exclusive at the sdk-kit boundary.
- Update generated bindings and blocklist the core page-codec C types from the sync sdk bindgen output.

## .NET bindings

- Add `ITursoPageCodec` as the managed codec interface.
- Add `TursoPageCodec` in `Turso.Raw` to bridge managed codec implementations to the sdk-kit C callbacks.
- Add raw binding helpers for:
  - `OpenDatabaseWithPageCodec`,
  - `OpenDatabaseReadOnlyWithPageCodec`,
  - read-only/no-create database opens.
- Manage callback lifetime safely by tying native callback state to the database handle lifetime.
- Propagate managed callback failures back through native open/query errors instead of swallowing them.
- Validate callback output sizes and reserved-space behavior at the managed/native boundary.
- Add a native resolver in `Turso.Raw` so project-reference consumers can load copied `runtimes/<rid>/native/turso_sdk_kit` assets without sample-specific native-copy targets.
- Extend `TursoConnection` with:
  - `PageCodec`,
  - `PageCodecReservedSpace`,
  - validation that codec properties cannot be changed while the connection is open,
  - validation that external codecs cannot be combined with built-in Turso encryption,
  - read-only open behavior when the connection string requests `Mode=ReadOnly`.

## .NET compatibility reference tests

The concrete compatibility codecs live in `bindings/dotnet/src/Turso.Tests/Support` rather than in production bindings or the sample app:

- `WxSQLite3Aes128CbcCodec.cs`
  - managed wxSQLite3/SQLite3MC AES-128-CBC reference codec,
  - handles the modern page-1 header behavior used by SQLite3MC/wxSQLite3.
- `SystemDataSQLiteLegacyCryptoApiCodec.cs`
  - legacy System.Data.SQLite CryptoAPI RC4 reference codec,
  - intentionally Windows-only because it depends on Windows CryptoAPI semantics through `advapi32.dll`.
- `EncryptedDatabaseDetector.cs`
  - ordered candidate detector that opens read-only/no-create and validates candidates with `sqlite_schema`.

`TursoPageCodecTests.cs` covers:

- managed page-codec round trips,
- raw API null-argument validation,
- read-only/no-create opens for missing files,
- callback error propagation,
- native callback lifetime ownership,
- cached database overlap rejection,
- ADO.NET `TursoConnection.PageCodec` behavior,
- reserved-space header writes,
- built-in encryption plus external-codec rejection,
- migrations between legacy external crypto and built-in Turso encryption,
- wxSQLite3/SQLite3MC AES-128-CBC round trips and page-1 rules,
- System.Data.SQLite legacy CryptoAPI round trips and page-1 rules,
- ordered encrypted-database detection and failure aggregation,
- optional provider-backed interop tests for Devolutions.Sqlite3secure and System.Data.SQLite when local provider paths are configured.

## .NET example and docs

- Keep `examples/dotnet` as a focused built-in Turso local-encryption example.
- The sample demonstrates `Encryption Cipher=aegis256`, inserts/query data, checkpoints WAL, verifies plaintext is not visible on disk, reopens with the correct key, and confirms a wrong key fails.
- The sample intentionally does not duplicate wxSQLite3/System.Data.SQLite compatibility crypto.
- The example README points readers to the test-owned compatibility codec fixtures when they need external page-codec reference implementations.
- Update sdk-kit README with the new external page-codec configuration shape.

## Compatibility notes

- Existing high-level core Rust opens remain compatible.
- Existing public async `Database::open_with_flags_async` and `Database::open_with_flags_bypass_registry_async` signatures are preserved; codec support is exposed through additive sibling APIs.
- Existing .NET APIs are additive.
- Existing built-in Turso encryption behavior is unchanged for normal opens.
- The sdk-kit C configuration struct is extended with `page_codec` and `open_flags`; C consumers should rebuild against the updated header and continue zero-initializing configs.

## Validation

- `cargo fmt --check`
- `cargo check -p turso_core -p turso_sdk_kit -p turso_sync_engine`
- `cargo clippy -p turso_core -p turso_sdk_kit -p turso_sync_engine --all-features --all-targets --locked -- --deny=warnings`
- `cargo build -p turso_sdk_kit --target-dir bindings\dotnet\rs_compiled --target x86_64-pc-windows-msvc`
- `dotnet test bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --no-restore`
- `dotnet run --project examples\dotnet\EncryptionExample.csproj --no-restore`