### PR TITLE
Feat/pragma compile options

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -151,7 +151,7 @@ ongoing work to pass the full SQLite TCL test suite.
 | PRAGMA cell_size_check           | ❌ No         |                                              |
 | PRAGMA checkpoint_fullfsync      | ❌ No         |                                              |
 | PRAGMA collation_list            | ❌ No         |                                              |
-| PRAGMA compile_options           | ❌ No         |                                              |
+| PRAGMA compile_options           | ✅ Yes        |                                              |
 | PRAGMA count_changes             | Not Needed | deprecated in SQLite                         |
 | PRAGMA data_store_directory      | Not Needed | deprecated in SQLite                         |
 | PRAGMA data_version              | ❌ No         |                                              |

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -46,6 +46,7 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
                 | PragmaFlags::NoColumns1,
             &["cache_size"],
         ),
+        CompileOptions => Pragma::new(PragmaFlags::Result0, &["compile_options"]),
         DataSyncRetry => Pragma::new(
             PragmaFlags::Result0 | PragmaFlags::NoColumns1,
             &["data_sync_retry"],

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -246,7 +246,8 @@ pub fn translate_pragma(
         )?,
         Some(ast::PragmaBody::Equals(value) | ast::PragmaBody::Call(value)) => match pragma {
             // These pragmas take a parameter but are queries, not setters
-            PragmaName::IndexInfo
+            PragmaName::CompileOptions
+            | PragmaName::IndexInfo
             | PragmaName::IndexXinfo
             | PragmaName::IndexList
             | PragmaName::ForeignKeyList
@@ -365,6 +366,16 @@ fn update_pragma(
             connection.bump_prepare_context_generation();
             Ok(TransactionMode::None)
         }
+        PragmaName::CompileOptions => query_pragma(
+            PragmaName::CompileOptions,
+            resolver,
+            Some(value),
+            pager,
+            connection,
+            database_id,
+            schema_was_explicit,
+            program,
+        ),
         PragmaName::Encoding => {
             let year = chrono::Local::now().year();
             bail_parse_error!("It's {year}. UTF-8 won.");
@@ -814,6 +825,15 @@ fn query_pragma(
             program.emit_int(spill_enabled as i64, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::CompileOptions => {
+            for option in compile_options() {
+                program.emit_string8(option.to_string(), register);
+                program.emit_result_row(register, 1);
+            }
+
+            program.add_pragma_result_column("compile_options".to_string());
             Ok(TransactionMode::None)
         }
         PragmaName::DatabaseList => {
@@ -1767,6 +1787,16 @@ fn update_cache_size(
         .map_err(|e| LimboError::InternalError(format!("Failed to update page cache size: {e}")))?;
 
     Ok(())
+}
+
+// current example for test, todo!()
+pub(crate) fn compile_options() -> &'static [&'static str] {
+    &[
+        "MAX_COLUMN=2000",
+        "MAX_LENGTH=1000000000",
+        "MAX_LIKE_PATTERN_LENGTH=50000",
+        "THREADSAFE=1",
+    ]
 }
 
 pub const TURSO_CDC_DEFAULT_TABLE_NAME: &str = "turso_cdc";

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -22,9 +22,11 @@ use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
 use crate::translate::emitter::{Resolver, TransactionMode};
 use crate::translate::plan::BitSet;
+use crate::translate::select::SQLITE_MAX_COLUMN;
 use crate::util::{normalize_ident, parse_signed_number, parse_string, IOExt as _};
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
 use crate::vdbe::insn::{Cookie, Insn};
+use crate::vdbe::value::SQLITE_MAX_LIKE_PATTERN_LENGTH;
 use crate::{bail_parse_error, CaptureDataChangesInfo, LimboError, Numeric, Value};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
@@ -829,7 +831,7 @@ fn query_pragma(
         }
         PragmaName::CompileOptions => {
             for option in compile_options() {
-                program.emit_string8(option.to_string(), register);
+                program.emit_string8(option, register);
                 program.emit_result_row(register, 1);
             }
 
@@ -1789,13 +1791,12 @@ fn update_cache_size(
     Ok(())
 }
 
-// current example for test, todo!()
-pub(crate) fn compile_options() -> &'static [&'static str] {
-    &[
-        "MAX_COLUMN=2000",
-        "MAX_LENGTH=1000000000",
-        "MAX_LIKE_PATTERN_LENGTH=50000",
-        "THREADSAFE=1",
+fn compile_options() -> [String; 4] {
+    [
+        format!("MAX_COLUMN={SQLITE_MAX_COLUMN}"),
+        format!("MAX_LENGTH={}", Value::MAX_BLOB_LENGTH),
+        format!("MAX_LIKE_PATTERN_LENGTH={SQLITE_MAX_LIKE_PATTERN_LENGTH}"),
+        "THREADSAFE=1".to_string(),
     ]
 }
 

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -30,7 +30,7 @@ use turso_parser::ast::{self, CompoundSelect, Expr};
 
 /// Maximum number of columns in a result set.
 /// SQLite's default SQLITE_MAX_COLUMN is 2000, with a hard upper limit of 32767.
-const SQLITE_MAX_COLUMN: usize = 2000;
+pub(crate) const SQLITE_MAX_COLUMN: usize = 2000;
 
 #[turso_macros::trace_stack]
 pub fn translate_select(

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -8,6 +8,8 @@ use crate::{
     LimboError, Result, Value, ValueRef,
 };
 
+pub(crate) const SQLITE_MAX_LIKE_PATTERN_LENGTH: usize = 50000;
+
 // we use math functions from Rust stdlib in order to be as portable as possible for the production version of the tursodb
 #[cfg(not(test))]
 mod cmath {
@@ -1183,8 +1185,7 @@ impl Value {
     }
 
     pub fn exec_like(pattern: &str, text: &str, escape: Option<char>) -> Result<bool, LimboError> {
-        const MAX_LIKE_PATTERN_LENGTH: usize = 50000;
-        if pattern.len() > MAX_LIKE_PATTERN_LENGTH {
+        if pattern.len() > SQLITE_MAX_LIKE_PATTERN_LENGTH {
             return Err(LimboError::Constraint(
                 "LIKE or GLOB pattern too complex".to_string(),
             ));

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1778,6 +1778,8 @@ pub enum PragmaName {
     CacheSize,
     /// set the cache spill behavior
     CacheSpill,
+    /// List compile-time options
+    CompileOptions,
     /// encryption cipher algorithm name for encrypted databases
     #[strum(serialize = "cipher")]
     #[cfg_attr(feature = "serde", serde(rename = "cipher"))]

--- a/testing/sqltests/tests/pragma/compile_options.sqltest
+++ b/testing/sqltests/tests/pragma/compile_options.sqltest
@@ -1,0 +1,25 @@
+@database :memory:
+
+test pragma-compile-options-has-threadsafe {
+    SELECT compile_options FROM pragma_compile_options WHERE compile_options = 'THREADSAFE=1';
+}
+expect {
+    THREADSAFE=1
+}
+
+test pragma-compile-options-table-valued-function {
+    SELECT compile_options FROM pragma_compile_options WHERE compile_options = 'MAX_COLUMN=2000';
+}
+expect {
+    MAX_COLUMN=2000
+}
+
+test pragma-compile-options-equals-syntax {
+    PRAGMA compile_options = 1;
+}
+expect {
+    MAX_COLUMN=2000
+    MAX_LENGTH=1000000000
+    MAX_LIKE_PATTERN_LENGTH=50000
+    THREADSAFE=1
+}


### PR DESCRIPTION
Implement `PRAGMA compile_options` and the corresponding table-valued `pragma_compile_options` helper.

The pragma returns set of SQLite-compatible compile options backed by turso existing limits:

- `MAX_COLUMN`
- `MAX_LENGTH`
- `MAX_LIKE_PATTERN_LENGTH`
- `THREADSAFE`

## Tests

Added SQL tests for `PRAGMA compile_options` and `pragma_compile_options`.

```bash
make -C testing/sqltests run-rust ARGS='--filter pragma-compile-options
```


