### PR TITLE
Mvcc sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6623,6 +6623,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
+ "crc32c",
  "csv",
  "ctrlc",
  "dirs 5.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6866,6 +6866,7 @@ version = "0.7.0-pre.18"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "crc32c",
  "ctor 0.4.2",
  "futures",
  "genawaiter",

--- a/bindings/javascript/sync/packages/native/index.d.ts
+++ b/bindings/javascript/sync/packages/native/index.d.ts
@@ -330,6 +330,8 @@ export interface SyncEngineOpts {
    * partial-sync uses the query bootstrap strategy.
    */
   pullBytesThreshold?: number
+  /** Use MVCC logical-log stream for incremental V1 pulls. */
+  logicalMvccPull?: boolean
 }
 
 export declare const enum SyncEngineProtocolVersion {

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -163,6 +163,8 @@ pub struct SyncEngineOpts {
     /// `None` (default) bootstraps in a single round-trip. No-op when
     /// partial-sync uses the query bootstrap strategy.
     pub pull_bytes_threshold: Option<u32>,
+    /// Use MVCC logical-log stream for incremental V1 pulls.
+    pub logical_mvcc_pull: Option<bool>,
 }
 
 struct SyncEngineOptsFilled {
@@ -181,6 +183,7 @@ struct SyncEngineOptsFilled {
     pub partial_sync_opts: Option<PartialSyncOpts>,
     pub push_operations_threshold: Option<usize>,
     pub pull_bytes_threshold: Option<usize>,
+    pub logical_mvcc_pull: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -333,6 +336,7 @@ impl SyncEngine {
             remote_encryption_key: opts.remote_encryption_key.clone(),
             push_operations_threshold: opts.push_operations_threshold.map(|x| x as usize),
             pull_bytes_threshold: opts.pull_bytes_threshold.map(|x| x as usize),
+            logical_mvcc_pull: opts.logical_mvcc_pull.unwrap_or(false),
         };
         Ok(SyncEngine {
             opts: opts_filled,
@@ -366,6 +370,7 @@ impl SyncEngine {
             remote_encryption_key: self.opts.remote_encryption_key.clone(),
             push_operations_threshold: self.opts.push_operations_threshold,
             pull_bytes_threshold: self.opts.pull_bytes_threshold,
+            logical_mvcc_pull: self.opts.logical_mvcc_pull,
         };
 
         let io = self.io()?;

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -110,6 +110,8 @@ pub struct PyTursoSyncDatabaseConfig {
     // /pull-updates HTTP requests of >= this many bytes each. None (default) bootstraps
     // in a single round-trip. no-op when partial-sync uses the query bootstrap strategy.
     pub pull_bytes_threshold: Option<usize>,
+    // use MVCC logical-log stream for incremental V1 pulls
+    pub logical_mvcc_pull: bool,
 }
 
 #[pymethods]
@@ -127,6 +129,7 @@ impl PyTursoSyncDatabaseConfig {
         remote_encryption_cipher=None,
         push_operations_threshold=None,
         pull_bytes_threshold=None,
+        logical_mvcc_pull=false,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -141,6 +144,7 @@ impl PyTursoSyncDatabaseConfig {
         remote_encryption_cipher: Option<PyRemoteEncryptionCipher>,
         push_operations_threshold: Option<usize>,
         pull_bytes_threshold: Option<usize>,
+        logical_mvcc_pull: bool,
     ) -> Self {
         Self {
             path,
@@ -154,6 +158,7 @@ impl PyTursoSyncDatabaseConfig {
             remote_encryption_cipher,
             push_operations_threshold,
             pull_bytes_threshold,
+            logical_mvcc_pull,
         }
     }
 }
@@ -211,6 +216,7 @@ pub fn py_turso_sync_new(
         remote_encryption_key: sync_config.remote_encryption_key.clone(),
         push_operations_threshold: sync_config.push_operations_threshold,
         pull_bytes_threshold: sync_config.pull_bytes_threshold,
+        logical_mvcc_pull: sync_config.logical_mvcc_pull,
     };
     let database =
         TursoDatabaseSync::<Vec<u8>>::new(db_config, sync_config).map_err(turso_error_to_py_err)?;

--- a/bindings/rust/src/connection.rs
+++ b/bindings/rust/src/connection.rs
@@ -68,7 +68,7 @@ impl Clone for Connection {
 }
 
 impl Connection {
-    pub fn create(
+    pub(crate) fn create(
         conn: Arc<turso_sdk_kit::rsapi::TursoConnection>,
         extra_io: Option<Arc<dyn Fn(Waker) -> Result<()> + Send + Sync>>,
     ) -> Self {

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -26,6 +26,8 @@ pub use turso_sync_sdk_kit::rsapi::PartialSyncOpts;
 
 // Constants used across the sync module
 const DEFAULT_CLIENT_NAME: &str = "turso-sync-rust";
+const CHECKPOINT_BUSY_RETRY_DELAY: Duration = Duration::from_millis(10);
+const CHECKPOINT_BUSY_MAX_ATTEMPTS: usize = 100;
 
 /// Future returned by an auth token provider. Resolves to a bearer token string
 /// (without the `Bearer ` prefix — that prefix is added when building the header).
@@ -445,8 +447,19 @@ impl Database {
 
     // Force WAL checkpoint for the main database.
     pub async fn checkpoint(&self) -> Result<()> {
-        let op = self.sync.checkpoint();
-        drive_operation(op, self.io.clone()).await?;
+        for attempt in 0..CHECKPOINT_BUSY_MAX_ATTEMPTS {
+            let op = self.sync.checkpoint();
+            let result = drive_operation(op, self.io.clone()).await;
+            match result {
+                Ok(()) => return Ok(()),
+                Err(error)
+                    if is_sync_busy_error(&error) && attempt + 1 < CHECKPOINT_BUSY_MAX_ATTEMPTS =>
+                {
+                    tokio::time::sleep(CHECKPOINT_BUSY_RETRY_DELAY).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
         Ok(())
     }
 
@@ -506,6 +519,14 @@ async fn drive_operation_result(
 ) -> Result<Option<turso_sync_sdk_kit::turso_async_operation::TursoAsyncOperationResult>> {
     let fut = AsyncOpFuture::new(op, io);
     fut.await
+}
+
+fn is_sync_busy_error(error: &Error) -> bool {
+    match error {
+        Error::Busy(_) => true,
+        Error::Error(message) => message.contains("Database is busy"),
+        _ => false,
+    }
 }
 
 // Custom Future that integrates with TursoDatabaseAsyncOperation and our IO worker.
@@ -2043,7 +2064,16 @@ mod tests {
                         Err(crate::Error::Busy(_)) => continue,
                         Err(e) => panic!("reader query failed: {e:?}"),
                     };
-                    let all = all_rows(rows).await.unwrap();
+                    let all = match all_rows(rows).await {
+                        Ok(all) => all,
+                        Err(e)
+                            if e.downcast_ref::<crate::Error>()
+                                .is_some_and(|error| matches!(error, crate::Error::Busy(_))) =>
+                        {
+                            continue;
+                        }
+                        Err(e) => panic!("reader query failed: {e:?}"),
+                    };
                     let Value::Integer(n) = all[0][0] else {
                         panic!("unexpected reader value: {:?}", all[0][0]);
                     };
@@ -2071,7 +2101,15 @@ mod tests {
             total += cnt as i64;
 
             applied_total.store(total, Ordering::Release);
-            db.pull().await.unwrap();
+            loop {
+                match db.pull().await {
+                    Ok(_) => break,
+                    Err(e) if super::is_sync_busy_error(&e) => {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                    Err(e) => panic!("pull failed: {e:?}"),
+                }
+            }
 
             let _ = db.checkpoint().await;
 

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -104,6 +104,8 @@ pub struct Builder {
     remote_encryption_key: Option<String>,
     // Encryption cipher for the Turso Cloud database
     remote_encryption_cipher: Option<RemoteEncryptionCipher>,
+    // Use MVCC logical-log incremental pulls instead of page-stream pulls.
+    logical_mvcc_pull: bool,
     // Experimental engine features to enable on the local synced database.
     // These mirror the local [`crate::Builder`] flags so synced databases
     // expose the same SQL surface as their local-only counterparts. Local
@@ -133,6 +135,7 @@ impl Builder {
             partial_sync_config_experimental: None,
             remote_encryption_key: None,
             remote_encryption_cipher: None,
+            logical_mvcc_pull: false,
             enable_attach: false,
             enable_custom_types: false,
             enable_index_method: false,
@@ -286,6 +289,15 @@ impl Builder {
         self
     }
 
+    /// Use MVCC logical-log incremental pulls.
+    ///
+    /// MVCC-mode remotes accept page-stream pulls only for bootstrap; callers
+    /// using legacy WAL/page sync should keep the default `false` value.
+    pub fn with_logical_mvcc_pull(mut self, enable: bool) -> Self {
+        self.logical_mvcc_pull = enable;
+        self
+    }
+
     /// Compose the `experimental_features` comma-separated string consumed by
     /// [`turso_sdk_kit::rsapi::TursoDatabaseConfig`] (and ultimately
     /// `turso_core::DatabaseOpts::with_experimental_feature`) from the boolean
@@ -370,6 +382,7 @@ impl Builder {
             remote_encryption_key: self.remote_encryption_key.clone(),
             push_operations_threshold: None,
             pull_bytes_threshold: None,
+            logical_mvcc_pull: self.logical_mvcc_pull,
         };
 
         // Create sync wrapper.
@@ -950,6 +963,18 @@ mod tests {
                 .experimental_features_string()
                 .as_deref(),
             Some("attach,custom_types,index_method,views,vacuum,generated_columns,multiprocess_wal,without_rowid")
+        );
+    }
+
+    #[test]
+    fn logical_mvcc_pull_is_opt_in() {
+        use crate::sync::Builder;
+
+        assert!(!Builder::new_remote(":memory:").logical_mvcc_pull);
+        assert!(
+            Builder::new_remote(":memory:")
+                .with_logical_mvcc_pull(true)
+                .logical_mvcc_pull
         );
     }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,7 @@ clap_complete = { version = "=4.5.47", features = ["unstable-dynamic"] }
 comfy-table = "7.1.4"
 csv = "1.3.1"
 ctrlc = "3.4.4"
+crc32c = "0.6.8"
 dirs = "5.0.1"
 env_logger = { workspace = true }
 libc = "0.2.172"

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -50,8 +50,9 @@ fn run_mcp_server(app: app::Limbo) -> anyhow::Result<()> {
 fn run_sync_server(app: app::Limbo) -> anyhow::Result<()> {
     let address = app.opts.sync_server_address.clone().unwrap();
     let conn = app.get_connection();
+    let db_path = app.opts.db_file.clone();
     let interrupt_count = app.get_interrupt_count();
-    let sync_server = TursoSyncServer::new(address, conn, interrupt_count);
+    let sync_server = TursoSyncServer::new(address, db_path, conn, interrupt_count)?;
 
     sync_server.run()
 }

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -14,28 +15,51 @@ use tracing::{debug, error, info};
 use turso_core::{Connection, Value as CoreValue};
 use turso_sync_engine::server_proto::{
     BatchCond, BatchResult, BatchStep, BatchStreamReq, BatchStreamResp, Col, Error,
-    ExecuteStreamReq, ExecuteStreamResp, PageData, PageSetRawEncodingProto, PageUpdatesEncodingReq,
-    PipelineReqBody, PipelineRespBody, PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, Row,
-    StmtResult, StreamRequest, StreamResponse, StreamResult, Value,
+    ExecuteStreamReq, ExecuteStreamResp, MvccLogicalLogMetadataProto, MvccLogicalLogRangeProto,
+    PageData, PageSetRawEncodingProto, PageUpdatesEncodingReq, PipelineReqBody, PipelineRespBody,
+    PullUpdatesApplyMode, PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, PullUpdatesStreamKind,
+    Row, StmtResult, StreamRequest, StreamResponse, StreamResult, Value,
 };
 
 const WAL_FRAME_HEADER_SIZE: usize = 24;
 const PAGE_SIZE: usize = 4096;
+const MVCC_LOG_MAGIC: u32 = 0x4C4D4C32;
+const MVCC_LOG_VERSION: u8 = 3;
+const MVCC_LOG_HEADER_SIZE: usize = 56;
+const MVCC_LOG_HEADER_SALT_START: usize = 8;
+const MVCC_LOG_HEADER_SALT_END: usize = 16;
+const MVCC_LOG_HEADER_RESERVED_START: usize = 16;
+const MVCC_LOG_HEADER_CRC_START: usize = 52;
+const MVCC_TX_FRAME_MAGIC: u32 = 0x5854564D;
+const MVCC_TX_EXT_FRAME_MAGIC: u32 = 0x5845564D;
+const MVCC_TX_END_MAGIC: u32 = 0x4554564D;
+const MVCC_TX_HEADER_SIZE: usize = 24;
+const MVCC_TX_EXT_HEADER_SIZE: usize = 40;
+const MVCC_TX_TRAILER_SIZE: usize = 8;
+const MVCC_TX_FRAME_FLAG_HAS_EXTENSION_BLOCK: u32 = 1 << 0;
 
 pub struct TursoSyncServer {
     address: String,
+    db_path: String,
     conn: Arc<Mutex<Arc<Connection>>>,
     interrupt_count: Arc<AtomicUsize>,
 }
 
 impl TursoSyncServer {
-    pub fn new(address: String, conn: Arc<Connection>, interrupt_count: Arc<AtomicUsize>) -> Self {
+    pub fn new(
+        address: String,
+        db_path: String,
+        conn: Arc<Connection>,
+        interrupt_count: Arc<AtomicUsize>,
+    ) -> Result<Self> {
         conn.wal_auto_actions_disable();
-        Self {
+
+        Ok(Self {
             address,
+            db_path,
             conn: Arc::new(Mutex::new(conn)),
             interrupt_count,
-        }
+        })
     }
 
     pub fn run(&self) -> Result<()> {
@@ -466,6 +490,20 @@ impl TursoSyncServer {
             return Err(anyhow!("Zstd encoding is not supported"));
         }
 
+        if PullUpdatesStreamKind::try_from(req.stream_kind).unwrap_or(PullUpdatesStreamKind::Pages)
+            == PullUpdatesStreamKind::MvccLogicalLog
+        {
+            return self.handle_logical_pull_updates(&req);
+        }
+
+        self.handle_page_pull_updates(&req, PullUpdatesApplyMode::Incremental)
+    }
+
+    fn handle_page_pull_updates(
+        &self,
+        req: &PullUpdatesReqProtoBody,
+        apply_mode: PullUpdatesApplyMode,
+    ) -> Result<HttpResponse> {
         let conn = self.conn.lock().unwrap();
 
         let wal_state = conn.wal_state()?;
@@ -549,19 +587,16 @@ impl TursoSyncServer {
         );
         pages_to_send.reverse();
 
-        let db_size = if wal_state.max_frame > 0 {
-            let mut last_frame = vec![0u8; frame_size];
-            let last_info = conn.wal_get_frame(wal_state.max_frame, &mut last_frame)?;
-            last_info.db_size as u64
-        } else {
-            0
-        };
+        let db_size = current_db_size_pages(&conn, wal_state.max_frame)?;
 
         let header = PullUpdatesRespProtoBody {
             server_revision: server_revision.to_string(),
             db_size,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: apply_mode as i32,
+            mvcc_log: None,
         };
 
         let mut response_body = Vec::new();
@@ -589,12 +624,499 @@ impl TursoSyncServer {
             body: response_body,
         })
     }
+
+    fn handle_logical_pull_updates(&self, req: &PullUpdatesReqProtoBody) -> Result<HttpResponse> {
+        let (db_size, fallback_revision, legacy_current_revision) = {
+            let conn = self.conn.lock().unwrap();
+            let wal_state = conn.wal_state()?;
+            (
+                current_db_size_pages(&conn, wal_state.max_frame)?,
+                format!("page:{}", wal_state.max_frame),
+                wal_state.max_frame.to_string(),
+            )
+        };
+        let log_path = match logical_log_path(&self.db_path) {
+            Ok(path) => path,
+            Err(_) if is_in_memory_db_path(&self.db_path) => {
+                info!(
+                    "logical pull requested for in-memory sync server database; returning incremental pages"
+                );
+                return self.handle_page_pull_updates(req, PullUpdatesApplyMode::Incremental);
+            }
+            Err(err) => return Err(err),
+        };
+        let log = match std::fs::read(&log_path) {
+            Ok(log) => log,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                info!(
+                    "logical pull requested but no MVCC log exists at {}; returning replace-base fallback",
+                    log_path.display()
+                );
+                return self.handle_logical_fallback(
+                    req,
+                    fallback_revision,
+                    &legacy_current_revision,
+                    db_size,
+                );
+            }
+            Err(err) => return Err(err.into()),
+        };
+        let snapshot = match scan_mvcc_log(&log) {
+            Ok(snapshot) => snapshot,
+            Err(err) if is_nonportable_mvcc_log_error(&err) => {
+                info!(
+                    "logical pull requested but MVCC log is not portable; returning replace-base pages: {err}"
+                );
+                return self.handle_logical_fallback(
+                    req,
+                    fallback_revision,
+                    &legacy_current_revision,
+                    db_size,
+                );
+            }
+            Err(err) => return Err(err),
+        };
+        let start_offset = parse_mvcc_revision_offset(&req.client_revision, snapshot.end_offset)?;
+        if start_offset > snapshot.end_offset {
+            return Err(anyhow!(
+                "MVCC logical pull revision is from the future: client_offset={} server_offset={}",
+                start_offset,
+                snapshot.end_offset
+            ));
+        }
+        let start = usize::try_from(start_offset)
+            .map_err(|_| anyhow!("MVCC logical pull start offset overflows usize"))?;
+        let end = usize::try_from(snapshot.end_offset)
+            .map_err(|_| anyhow!("MVCC logical pull end offset overflows usize"))?;
+
+        let mut response_body = Vec::new();
+        let (mvcc_log, body) = if start == end {
+            (None, Vec::new())
+        } else {
+            let crc_seed = if start_offset == 0 {
+                None
+            } else {
+                let seed = snapshot.crc_seed_at(start_offset)?;
+                Some(seed.to_le_bytes().to_vec())
+            };
+            (
+                Some(MvccLogicalLogMetadataProto {
+                    format: "lml3".to_string(),
+                    checkpoint_transition: false,
+                    ranges: vec![MvccLogicalLogRangeProto {
+                        generation: 1,
+                        start_offset,
+                        end_offset: snapshot.end_offset,
+                        starts_with_header: start_offset == 0,
+                        crc_seed,
+                    }],
+                }),
+                log[start..end].to_vec(),
+            )
+        };
+
+        let header = PullUpdatesRespProtoBody {
+            server_revision: format!("g1:o{}", snapshot.end_offset),
+            db_size,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log,
+        };
+
+        let header_bytes = header.encode_to_vec();
+        encode_length_delimited(&mut response_body, &header_bytes);
+        response_body.extend_from_slice(&body);
+
+        debug!(
+            "pull-updates logical: path={} client_revision={} end_offset={} body_bytes={}",
+            log_path.display(),
+            req.client_revision,
+            snapshot.end_offset,
+            body.len()
+        );
+
+        Ok(HttpResponse {
+            status: 200,
+            content_type: "application/protobuf".to_string(),
+            body: response_body,
+        })
+    }
+
+    fn handle_logical_fallback(
+        &self,
+        req: &PullUpdatesReqProtoBody,
+        server_revision: String,
+        legacy_current_revision: &str,
+        db_size: u64,
+    ) -> Result<HttpResponse> {
+        if req.client_revision == server_revision {
+            return self.handle_empty_logical_pull(server_revision, db_size);
+        }
+        if req.client_revision == legacy_current_revision {
+            return self.handle_empty_logical_pull(req.client_revision.clone(), db_size);
+        }
+
+        self.handle_replace_base_pages(server_revision)
+    }
+
+    fn handle_empty_logical_pull(
+        &self,
+        server_revision: String,
+        db_size: u64,
+    ) -> Result<HttpResponse> {
+        let header = PullUpdatesRespProtoBody {
+            server_revision,
+            db_size,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+        };
+
+        let mut response_body = Vec::new();
+        let header_bytes = header.encode_to_vec();
+        encode_length_delimited(&mut response_body, &header_bytes);
+
+        Ok(HttpResponse {
+            status: 200,
+            content_type: "application/protobuf".to_string(),
+            body: response_body,
+        })
+    }
+
+    fn handle_replace_base_pages(&self, server_revision: String) -> Result<HttpResponse> {
+        let (db_size, pages) = self.read_replace_base_pages()?;
+
+        let header = PullUpdatesRespProtoBody {
+            server_revision,
+            db_size,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::ReplaceBase as i32,
+            mvcc_log: None,
+        };
+
+        let mut response_body = Vec::new();
+        let header_bytes = header.encode_to_vec();
+        encode_length_delimited(&mut response_body, &header_bytes);
+
+        for (page_id, page) in pages {
+            let page_msg = PageData {
+                page_id,
+                encoded_page: Bytes::from(page),
+            };
+            let page_bytes = page_msg.encode_to_vec();
+            encode_length_delimited(&mut response_body, &page_bytes);
+        }
+
+        Ok(HttpResponse {
+            status: 200,
+            content_type: "application/protobuf".to_string(),
+            body: response_body,
+        })
+    }
+
+    fn read_replace_base_pages(&self) -> Result<(u64, Vec<(u64, Vec<u8>)>)> {
+        let conn = self.conn.lock().unwrap();
+        let wal_state = conn.wal_state()?;
+        let frame_watermark = Some(wal_state.max_frame);
+        let db_size = current_snapshot_db_size_pages(&conn, wal_state.max_frame)?;
+        let pages_capacity = usize::try_from(db_size)
+            .map_err(|_| anyhow!("database page count does not fit usize: {db_size}"))?;
+        let mut pages = Vec::with_capacity(pages_capacity);
+
+        for page_no in 1..=db_size {
+            let page_no_u32 = u32::try_from(page_no)
+                .map_err(|_| anyhow!("database page number does not fit u32: {page_no}"))?;
+            let mut page = vec![0; PAGE_SIZE];
+            let found =
+                conn.try_wal_watermark_read_page(page_no_u32, &mut page, frame_watermark)?;
+            if !found {
+                return Err(anyhow!(
+                    "database page {} is missing from replace-base snapshot",
+                    page_no
+                ));
+            }
+            pages.push((page_no - 1, page));
+        }
+
+        Ok((db_size, pages))
+    }
 }
 
 struct HttpResponse {
     status: u16,
     content_type: String,
     body: Vec<u8>,
+}
+
+struct MvccLogSnapshot {
+    end_offset: u64,
+    crc_by_offset: Vec<(u64, u32)>,
+}
+
+impl MvccLogSnapshot {
+    fn crc_seed_at(&self, offset: u64) -> Result<u32> {
+        self.crc_by_offset
+            .iter()
+            .find_map(|(boundary, crc)| (*boundary == offset).then_some(*crc))
+            .ok_or_else(|| {
+                anyhow!("MVCC logical pull offset is not a transaction boundary: {offset}")
+            })
+    }
+}
+
+fn logical_log_path(db_path: &str) -> Result<PathBuf> {
+    Ok(db_file_path(db_path)?.with_extension("db-log"))
+}
+
+fn is_in_memory_db_path(db_path: &str) -> bool {
+    db_path == ":memory:"
+}
+
+fn db_file_path(db_path: &str) -> Result<PathBuf> {
+    if is_in_memory_db_path(db_path) {
+        return Err(anyhow!(
+            "MVCC logical pull is not supported for in-memory sync server databases"
+        ));
+    }
+    let path = if let Some(rest) = db_path.strip_prefix("file:") {
+        rest.split_once('?').map_or(rest, |(path, _)| path)
+    } else {
+        db_path
+    };
+    Ok(PathBuf::from(path))
+}
+
+fn parse_mvcc_revision_offset(revision: &str, legacy_default: u64) -> Result<u64> {
+    if revision.is_empty() {
+        return Ok(0);
+    }
+    if let Some((generation, offset)) = revision.split_once(":o") {
+        let generation = generation
+            .strip_prefix('g')
+            .ok_or_else(|| anyhow!("invalid MVCC pull revision generation: {revision}"))?
+            .parse::<u64>()
+            .map_err(|err| anyhow!("invalid MVCC pull revision generation: {revision}: {err}"))?;
+        if generation != 1 {
+            return Err(anyhow!(
+                "sync_server supports only single-generation MVCC logical pulls: {revision}"
+            ));
+        }
+        return offset
+            .parse::<u64>()
+            .map_err(|err| anyhow!("invalid MVCC pull revision offset: {revision}: {err}"));
+    }
+    // Older page bootstrap responses from this test server used WAL frame
+    // numbers. Treat them as "the page snapshot already includes the current
+    // logical log" so the required follow-up logical pull becomes a no-op.
+    Ok(legacy_default)
+}
+
+fn scan_mvcc_log(log: &[u8]) -> Result<MvccLogSnapshot> {
+    if log.is_empty() {
+        return Ok(MvccLogSnapshot {
+            end_offset: 0,
+            crc_by_offset: vec![(0, 0)],
+        });
+    }
+    if log.len() < MVCC_LOG_HEADER_SIZE {
+        return Err(anyhow!(
+            "truncated MVCC logical log header: len={} header_size={}",
+            log.len(),
+            MVCC_LOG_HEADER_SIZE
+        ));
+    }
+    validate_mvcc_log_header(log)?;
+    let mut running_crc = initial_mvcc_log_crc(log)?;
+    let mut offset = MVCC_LOG_HEADER_SIZE;
+    let mut crc_by_offset = vec![(MVCC_LOG_HEADER_SIZE as u64, running_crc)];
+
+    while offset < log.len() {
+        let Some((frame_end, frame_crc)) = read_mvcc_frame_boundary(log, offset, running_crc)?
+        else {
+            break;
+        };
+        running_crc = frame_crc;
+        offset = frame_end;
+        crc_by_offset.push((offset as u64, running_crc));
+    }
+
+    Ok(MvccLogSnapshot {
+        end_offset: offset as u64,
+        crc_by_offset,
+    })
+}
+
+fn is_nonportable_mvcc_log_error(err: &anyhow::Error) -> bool {
+    let message = err.to_string();
+    message.starts_with("unsupported MVCC logical log version ")
+}
+
+fn validate_mvcc_log_header(log: &[u8]) -> Result<()> {
+    if read_u32_le(log, 0)? != MVCC_LOG_MAGIC {
+        return Err(anyhow!("invalid MVCC logical log magic"));
+    }
+    if log[4] != MVCC_LOG_VERSION {
+        return Err(anyhow!("unsupported MVCC logical log version {}", log[4]));
+    }
+    if log[5] & 0b1111_1110 != 0 {
+        return Err(anyhow!("invalid MVCC logical log header flags"));
+    }
+    let header_len = u16::from_le_bytes([log[6], log[7]]) as usize;
+    if header_len != MVCC_LOG_HEADER_SIZE {
+        return Err(anyhow!(
+            "invalid MVCC logical log header length: {header_len}"
+        ));
+    }
+    if log[MVCC_LOG_HEADER_RESERVED_START..MVCC_LOG_HEADER_CRC_START]
+        .iter()
+        .any(|byte| *byte != 0)
+    {
+        return Err(anyhow!(
+            "MVCC logical log header reserved bytes must be zero"
+        ));
+    }
+    let stored_crc = read_u32_le(log, MVCC_LOG_HEADER_CRC_START)?;
+    let mut crc_buf = [0u8; MVCC_LOG_HEADER_SIZE];
+    crc_buf.copy_from_slice(&log[..MVCC_LOG_HEADER_SIZE]);
+    crc_buf[MVCC_LOG_HEADER_CRC_START..MVCC_LOG_HEADER_SIZE].fill(0);
+    let expected_crc = crc32c::crc32c(&crc_buf);
+    if stored_crc != expected_crc {
+        return Err(anyhow!("MVCC logical log header checksum mismatch"));
+    }
+    Ok(())
+}
+
+fn initial_mvcc_log_crc(log: &[u8]) -> Result<u32> {
+    let salt = u64::from_le_bytes(
+        log[MVCC_LOG_HEADER_SALT_START..MVCC_LOG_HEADER_SALT_END]
+            .try_into()
+            .expect("fixed-size salt slice"),
+    );
+    Ok(crc32c::crc32c(&salt.to_le_bytes()))
+}
+
+fn read_mvcc_frame_boundary(
+    log: &[u8],
+    offset: usize,
+    running_crc: u32,
+) -> Result<Option<(usize, u32)>> {
+    if log.len() - offset < MVCC_TX_HEADER_SIZE + MVCC_TX_TRAILER_SIZE {
+        return Ok(None);
+    }
+    let frame_magic = read_u32_le(log, offset)?;
+    let has_extension_header = frame_magic == MVCC_TX_EXT_FRAME_MAGIC;
+    if frame_magic != MVCC_TX_FRAME_MAGIC && !has_extension_header {
+        return Err(anyhow!(
+            "invalid MVCC logical log frame magic at offset {offset}: {frame_magic:#x}"
+        ));
+    }
+    let header_size = if has_extension_header {
+        MVCC_TX_EXT_HEADER_SIZE
+    } else {
+        MVCC_TX_HEADER_SIZE
+    };
+    if log.len() - offset < header_size + MVCC_TX_TRAILER_SIZE {
+        return Ok(None);
+    }
+    let payload_size = usize::try_from(read_u64_le(log, offset + 4)?)
+        .map_err(|_| anyhow!("MVCC logical log payload size overflows usize"))?;
+    let extension_size = if has_extension_header {
+        let extension_size = usize::try_from(read_u64_le(log, offset + 24)?)
+            .map_err(|_| anyhow!("MVCC logical log extension size overflows usize"))?;
+        let extension_record_count = read_u32_le(log, offset + 32)?;
+        let frame_flags = read_u32_le(log, offset + 36)?;
+        if frame_flags & !MVCC_TX_FRAME_FLAG_HAS_EXTENSION_BLOCK != 0 {
+            return Err(anyhow!(
+                "unsupported MVCC logical log frame flags at offset {offset}: {frame_flags:#x}"
+            ));
+        }
+        if extension_size == 0 && extension_record_count != 0 {
+            return Err(anyhow!(
+                "MVCC logical log extension record count without extension block at offset {offset}"
+            ));
+        }
+        if extension_size > 0 && frame_flags & MVCC_TX_FRAME_FLAG_HAS_EXTENSION_BLOCK == 0 {
+            return Err(anyhow!(
+                "MVCC logical log extension block missing flag at offset {offset}"
+            ));
+        }
+        extension_size
+    } else {
+        0
+    };
+    let trailer_start = offset
+        .checked_add(header_size)
+        .and_then(|value| value.checked_add(payload_size))
+        .and_then(|value| value.checked_add(extension_size))
+        .ok_or_else(|| anyhow!("MVCC logical log frame offset overflow"))?;
+    let frame_end = trailer_start
+        .checked_add(MVCC_TX_TRAILER_SIZE)
+        .ok_or_else(|| anyhow!("MVCC logical log frame end overflow"))?;
+    if frame_end > log.len() {
+        return Ok(None);
+    }
+    let expected_crc = crc32c::crc32c_append(running_crc, &log[offset..trailer_start]);
+    let stored_crc = read_u32_le(log, trailer_start)?;
+    if stored_crc != expected_crc {
+        return Err(anyhow!(
+            "MVCC logical log frame checksum mismatch at offset {offset}"
+        ));
+    }
+    let end_magic = read_u32_le(log, trailer_start + 4)?;
+    if end_magic != MVCC_TX_END_MAGIC {
+        return Err(anyhow!(
+            "invalid MVCC logical log frame end magic at offset {offset}"
+        ));
+    }
+    Ok(Some((frame_end, stored_crc)))
+}
+
+fn read_u32_le(buf: &[u8], offset: usize) -> Result<u32> {
+    let bytes = buf
+        .get(offset..offset + 4)
+        .ok_or_else(|| anyhow!("buffer too short for u32 at offset {offset}"))?;
+    Ok(u32::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn read_u64_le(buf: &[u8], offset: usize) -> Result<u64> {
+    let bytes = buf
+        .get(offset..offset + 8)
+        .ok_or_else(|| anyhow!("buffer too short for u64 at offset {offset}"))?;
+    Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn current_db_size_pages(conn: &Connection, max_frame: u64) -> Result<u64> {
+    if max_frame > 0 {
+        let frame_size = WAL_FRAME_HEADER_SIZE + PAGE_SIZE;
+        let mut last_frame = vec![0u8; frame_size];
+        let last_info = conn.wal_get_frame(max_frame, &mut last_frame)?;
+        Ok(last_info.db_size as u64)
+    } else {
+        Ok(0)
+    }
+}
+
+fn current_snapshot_db_size_pages(conn: &Connection, max_frame: u64) -> Result<u64> {
+    if max_frame > 0 {
+        return current_db_size_pages(conn, max_frame);
+    }
+
+    let mut page = vec![0u8; PAGE_SIZE];
+    if conn.try_wal_watermark_read_page(1, &mut page, Some(max_frame))? {
+        Ok(db_size_from_page(&page) as u64)
+    } else {
+        Ok(0)
+    }
+}
+
+fn db_size_from_page(page: &[u8]) -> u32 {
+    u32::from_be_bytes(page[28..32].try_into().unwrap())
 }
 
 fn find_header_end(data: &[u8]) -> Option<usize> {

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -820,6 +820,7 @@ impl TursoSyncServer {
         })
     }
 
+    #[allow(clippy::type_complexity)]
     fn read_replace_base_pages(&self) -> Result<(u64, Vec<(u64, Vec<u8>)>)> {
         let conn = self.conn.lock().unwrap();
         let wal_state = conn.wal_state()?;

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1170,6 +1170,19 @@ impl Connection {
     /// pages, so cookie-based refresh would keep stale btree metadata.
     #[cfg(feature = "conn_raw_api")]
     pub fn force_reparse_schema(self: &Arc<Connection>) -> Result<()> {
+        self.force_reparse_schema_inner(true)
+    }
+
+    /// Like [`Self::force_reparse_schema`], but refreshes only this connection's
+    /// own schema snapshot without publishing it to the shared database cache.
+    ///
+    /// Use this when the caller must further mutate the schema before it becomes
+    /// visible to other connections.
+    pub fn force_reparse_schema_without_publish(self: &Arc<Connection>) -> Result<()> {
+        self.force_reparse_schema_inner(false)
+    }
+
+    fn force_reparse_schema_inner(self: &Arc<Connection>, publish: bool) -> Result<()> {
         if self.get_tx_state() != TransactionState::None {
             return Err(LimboError::Busy);
         }
@@ -1197,8 +1210,10 @@ impl Connection {
 
         reparse_result?;
 
-        let schema = self.schema.read().clone();
-        self.db.update_schema_if_newer(schema);
+        if publish {
+            let schema = self.schema.read().clone();
+            self.db.update_schema_if_newer(schema);
+        }
         Ok(())
     }
 

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1083,6 +1083,7 @@ impl Connection {
         if self.get_tx_state() != TransactionState::None {
             return Ok(());
         }
+        let had_main_mv_tx = self.get_mv_tx().is_some();
 
         if self.db.shared_wal_coordination()?.is_some() {
             // Cross-process schema changes can leave page 1 and sqlite_schema
@@ -1151,6 +1152,9 @@ impl Connection {
         if previous == TransactionState::Read {
             pager.end_read_tx();
         }
+        if !had_main_mv_tx {
+            self.clear_internal_main_mvcc_tx(&pager);
+        }
 
         reparse_result?;
 
@@ -1167,10 +1171,10 @@ impl Connection {
     #[cfg(feature = "conn_raw_api")]
     pub fn force_reparse_schema(self: &Arc<Connection>) -> Result<()> {
         if self.get_tx_state() != TransactionState::None {
-            return Ok(());
+            return Err(LimboError::Busy);
         }
         if self.get_mv_tx().is_some() || self.next_attached_mv_tx().is_some() {
-            return Ok(());
+            return Err(LimboError::Busy);
         }
 
         let pager = self.pager.load().clone();
@@ -1189,12 +1193,29 @@ impl Connection {
         if previous == TransactionState::Read {
             pager.end_read_tx();
         }
+        self.clear_internal_main_mvcc_tx(&pager);
 
         reparse_result?;
 
         let schema = self.schema.read().clone();
         self.db.update_schema_if_newer(schema);
         Ok(())
+    }
+
+    fn clear_internal_main_mvcc_tx(&self, pager: &Arc<Pager>) {
+        let Some(tx_id) = self.get_mv_tx_id() else {
+            return;
+        };
+        if let Some(mv_store) = self.mv_store().as_ref() {
+            if mv_store.is_tx_rollbackable(tx_id) {
+                mv_store.rollback_tx(tx_id, pager.clone(), self, MAIN_DB_ID);
+            } else {
+                self.set_mv_tx(None);
+            }
+        } else {
+            self.set_mv_tx(None);
+        }
+        pager.cleanup_read_tx();
     }
 
     /// Blocking shim: drives [`Self::reparse_schema_nonblock`] to completion.
@@ -2239,7 +2260,14 @@ impl Connection {
     /// case the shared schema cache must be replaced rather than updated
     /// monotonically, otherwise new connections can re-adopt stale metadata.
     #[cfg(feature = "conn_raw_api")]
-    pub fn publish_schema_after_external_restore(&self) {
+    pub fn publish_schema_after_external_restore(&self) -> Result<()> {
+        if self.get_tx_state() != TransactionState::None {
+            return Err(LimboError::Busy);
+        }
+        if self.get_mv_tx().is_some() || self.next_attached_mv_tx().is_some() {
+            return Err(LimboError::Busy);
+        }
+
         let schema = self.schema.read().clone();
         self.db
             .with_schema_mut(|current| {
@@ -2247,6 +2275,7 @@ impl Connection {
                 Ok(())
             })
             .expect("external restore schema replacement should be infallible");
+        Ok(())
     }
 
     /// Roll back the main-database MVCC transaction while keeping the
@@ -2262,6 +2291,14 @@ impl Connection {
         };
         let pager = self.pager.load();
         mv_store.rollback_tx(tx_id, pager.clone(), self, MAIN_DB_ID);
+    }
+
+    /// Discard the main-db MVCC transaction left by a sync raw-WAL session
+    /// before reparsing state after external file replacement.
+    #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
+    pub fn discard_main_mvcc_tx_after_external_restore(&self) {
+        let pager = self.pager.load();
+        self.clear_internal_main_mvcc_tx(&pager);
     }
 
     /// Returns whether the main database currently has a live MVCC transaction.

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1159,6 +1159,44 @@ impl Connection {
         Ok(())
     }
 
+    /// Parse schema from scratch even if the schema cookie did not change.
+    ///
+    /// Sync replace-base can install a page snapshot outside ordinary SQL DDL.
+    /// The replacement may reuse the same schema cookie while changing root
+    /// pages, so cookie-based refresh would keep stale btree metadata.
+    #[cfg(feature = "conn_raw_api")]
+    pub fn force_reparse_schema(self: &Arc<Connection>) -> Result<()> {
+        if self.get_tx_state() != TransactionState::None {
+            return Ok(());
+        }
+        if self.get_mv_tx().is_some() || self.next_attached_mv_tx().is_some() {
+            return Ok(());
+        }
+
+        let pager = self.pager.load().clone();
+        pager.clear_page_cache(false);
+        pager.set_schema_cookie(None);
+        pager.begin_read_tx()?;
+        self.set_tx_state(TransactionState::Read);
+
+        let reparse_result = self.reparse_schema();
+
+        let previous = self.transaction_state.swap(TransactionState::None);
+        turso_assert!(
+            matches!(previous, TransactionState::None | TransactionState::Read),
+            "unexpected end transaction state"
+        );
+        if previous == TransactionState::Read {
+            pager.end_read_tx();
+        }
+
+        reparse_result?;
+
+        let schema = self.schema.read().clone();
+        self.db.update_schema_if_newer(schema);
+        Ok(())
+    }
+
     /// Blocking shim: drives [`Self::reparse_schema_nonblock`] to completion.
     /// Retained for the many synchronous callers (statement reprepare, attach,
     /// extension load, vacuum). The genuinely non-blocking callers (MVCC
@@ -2185,6 +2223,78 @@ impl Connection {
             return WalAutoActions::empty();
         }
         WalAutoActions::from_bits_truncate(self.wal_auto_actions.load(Ordering::SeqCst))
+    }
+
+    /// Publish the connection's current schema snapshot to the shared database
+    /// cache after a successful commit so other live connections can refresh.
+    pub fn publish_schema_if_newer(&self) {
+        let schema = self.schema.read().clone();
+        self.db.update_schema_if_newer(schema);
+    }
+
+    /// Publish the connection's current schema snapshot after pages were
+    /// replaced outside normal SQL commit ordering.
+    ///
+    /// External restore paths can move the schema cookie backwards. In that
+    /// case the shared schema cache must be replaced rather than updated
+    /// monotonically, otherwise new connections can re-adopt stale metadata.
+    #[cfg(feature = "conn_raw_api")]
+    pub fn publish_schema_after_external_restore(&self) {
+        let schema = self.schema.read().clone();
+        self.db
+            .with_schema_mut(|current| {
+                *current = schema.as_ref().clone();
+                Ok(())
+            })
+            .expect("external restore schema replacement should be infallible");
+    }
+
+    /// Roll back the main-database MVCC transaction while keeping the
+    /// surrounding raw WAL-insert session open.
+    #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
+    pub fn reset_main_mvcc_tx_for_wal_session(&self) {
+        let mv_store = self.mv_store();
+        let Some(mv_store) = mv_store.as_ref() else {
+            return;
+        };
+        let Some(tx_id) = self.get_mv_tx_id() else {
+            return;
+        };
+        let pager = self.pager.load();
+        mv_store.rollback_tx(tx_id, pager.clone(), self, MAIN_DB_ID);
+    }
+
+    /// Returns whether the main database currently has a live MVCC transaction.
+    #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
+    pub fn has_main_mvcc_tx_for_wal_session(&self) -> bool {
+        self.get_mv_tx_id().is_some()
+    }
+
+    /// Commit the main-database MVCC transaction while keeping the surrounding
+    /// raw WAL-insert session open.
+    #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
+    pub fn commit_main_mvcc_tx_for_wal_session(self: &Arc<Self>) -> Result<()> {
+        let mv_store_handle = self.mv_store();
+        let Some(mv_store) = mv_store_handle.as_ref() else {
+            return Ok(());
+        };
+        let Some(tx_id) = self.get_mv_tx_id() else {
+            return Ok(());
+        };
+
+        let mut state_machine = mv_store.commit_tx(tx_id, self, MAIN_DB_ID)?;
+        while let IOResult::IO(io) = state_machine.step(mv_store)? {
+            io.wait(self.db.io.as_ref())?;
+        }
+        assert!(state_machine.is_finalized());
+        self.set_mv_tx(None);
+        self.publish_schema_if_newer();
+        Ok(())
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    pub fn reload_wal_after_external_restore(&self) -> Result<()> {
+        self.db.reload_wal_after_external_restore()
     }
 
     /// Enable or disable writing portable logical-change metadata into MVCC

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2081,6 +2081,7 @@ impl Database {
                 self.open_flags,
                 self.durable_storage.clone(),
                 None,
+                self.mv_store_allocator.clone(),
             )?;
             self.mv_store.store(Some(mv_store.clone()));
             let mvcc_bootstrap_conn = self._connect(true, None, None)?;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2031,6 +2031,73 @@ impl Database {
         }
     }
 
+    #[cfg(feature = "conn_raw_api")]
+    /// Rebuild the process-local shared WAL view after a caller restores the
+    /// database and WAL files outside the pager.
+    pub fn reload_wal_after_external_restore(self: &Arc<Self>) -> Result<()> {
+        let flags = self.open_flags;
+        #[cfg(host_shared_wal)]
+        let shared_authority = self.open_shared_wal_coordination_for_open()?;
+        #[cfg(not(host_shared_wal))]
+        let shared_authority: Option<()> = None;
+
+        let new_shared_wal = {
+            #[cfg(host_shared_wal)]
+            {
+                if let Some(authority) = shared_authority.as_ref() {
+                    if !authority.frame_index_overflowed() {
+                        WalFileShared::open_shared_from_authority_if_exists(
+                            &self.io,
+                            &self.wal_path,
+                            flags,
+                            authority,
+                            &self.db_file,
+                        )?
+                    } else {
+                        WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
+                    }
+                } else {
+                    WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
+                }
+            }
+            #[cfg(not(host_shared_wal))]
+            {
+                WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
+            }
+        };
+        let new_shared_wal = Arc::try_unwrap(new_shared_wal).map_err(|_| {
+            LimboError::InternalError(
+                "new WAL state unexpectedly shared during external restore reload".to_string(),
+            )
+        })?;
+        self.shared_wal
+            .write()
+            .replace_after_external_restore(new_shared_wal.into_inner());
+        if self.mvcc_enabled() || journal_mode::logical_log_exists(std::path::Path::new(&self.path))
+        {
+            let mv_store = journal_mode::open_mv_store(
+                self.io.clone(),
+                &self.path,
+                self.open_flags,
+                self.durable_storage.clone(),
+                None,
+            )?;
+            self.mv_store.store(Some(mv_store.clone()));
+            let mvcc_bootstrap_conn = self._connect(true, None, None)?;
+            match mv_store.bootstrap(mvcc_bootstrap_conn.clone()) {
+                Ok(()) => {}
+                Err(LimboError::SchemaUpdated) => {
+                    mvcc_bootstrap_conn.force_reparse_schema()?;
+                    mv_store.bootstrap(mvcc_bootstrap_conn)?;
+                }
+                Err(error) => return Err(error),
+            }
+        } else {
+            self.mv_store.store(None);
+        }
+        Ok(())
+    }
+
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn connect(self: &Arc<Database>) -> Result<Arc<Connection>> {
         self._connect(false, None, None)

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1270,13 +1270,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         // through WAL even if the later WAL checkpoint/log truncation is busy.
         let mut schema_ref = self.connection.db.schema.lock();
         let schema = Arc::make_mut(&mut *schema_ref);
-        for table in schema.tables.values_mut() {
+        for (name, table) in schema.tables.iter_mut() {
             let table = Arc::get_mut(table).expect("this should be the only reference");
             let Some(btree_table) = table.btree_mut() else {
                 continue;
             };
             let btree_table = Arc::make_mut(btree_table);
             if btree_table.root_page < 0 {
+                let old_root_page = btree_table.root_page;
                 let table_id = MVTableId::from(btree_table.root_page);
                 let entry = self
                     .mvstore
@@ -1287,6 +1288,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     .value()
                     .expect("table with id {table_id:?} should have a mapping");
                 btree_table.root_page = value as i64;
+                #[cfg(feature = "conn_raw_api")]
+                {
+                    schema.table_names_by_root_page.remove(&old_root_page);
+                    schema
+                        .table_names_by_root_page
+                        .insert(btree_table.root_page, name.clone());
+                }
             }
         }
         for table_index_list in schema.indexes.values_mut() {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -73,8 +73,8 @@ use super::persistent_storage::logical_log::{
 };
 #[cfg(feature = "conn_raw_api")]
 use super::portable_logical::{
-    is_portable_logical_name, is_portable_table_schema_row, portable_schema_row_from_record,
-    PortableLogicalBuilder, PortableObjectMapEntry,
+    is_portable_logical_name, is_portable_schema_row, is_portable_table_schema_row,
+    portable_schema_row_from_record, PortableLogicalBuilder, PortableObjectMapEntry,
 };
 
 #[cfg(test)]
@@ -505,6 +505,10 @@ pub struct LogRecord {
     /// frames, even if this transaction has no client-visible metadata.
     #[cfg(feature = "conn_raw_api")]
     pub portable_changes_enabled: bool,
+    /// True when a frame must carry a portable transaction wrapper even if
+    /// the wrapper metadata itself is empty.
+    #[cfg(feature = "conn_raw_api")]
+    pub portable_changes_required: bool,
 }
 
 impl LogRecord {
@@ -524,6 +528,8 @@ impl LogRecord {
             portable_changes: Vec::new(),
             #[cfg(feature = "conn_raw_api")]
             portable_changes_enabled: false,
+            #[cfg(feature = "conn_raw_api")]
+            portable_changes_required: false,
         }
     }
 
@@ -610,16 +616,10 @@ fn rootpage_for_mv_table_id<Clock: LogicalClock, A: ConcurrentAllocator>(
 }
 
 #[cfg(feature = "conn_raw_api")]
-fn portable_table_name_for_mv_table_id<Clock: LogicalClock, A: ConcurrentAllocator>(
-    connection: &Connection,
-    mvcc_store: &MvStore<Clock, A>,
-    table_id: MVTableId,
-) -> Option<String> {
-    let rootpage = rootpage_for_mv_table_id(mvcc_store, table_id);
+fn table_name_for_rootpage_in_schema(schema: &Schema, rootpage: i64) -> Option<String> {
     if rootpage == 0 {
         return None;
     }
-    let schema = connection.schema.read();
     if let Some(name) = schema.table_name_for_root_page(rootpage) {
         return Some(name.to_string());
     }
@@ -630,6 +630,59 @@ fn portable_table_name_for_mv_table_id<Clock: LogicalClock, A: ConcurrentAllocat
     schema
         .table_name_for_root_page(alternate_rootpage)
         .map(ToString::to_string)
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn table_name_for_rootpage(connection: &Connection, rootpage: i64) -> Option<String> {
+    {
+        let schema = connection.schema.read();
+        if let Some(name) = table_name_for_rootpage_in_schema(&schema, rootpage) {
+            return Some(name);
+        }
+    }
+
+    let schema = connection.db.schema.lock();
+    table_name_for_rootpage_in_schema(&schema, rootpage)
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn table_name_for_rootpage_in_mvcc_schema<Clock: LogicalClock, A: ConcurrentAllocator>(
+    mvcc_store: &MvStore<Clock, A>,
+    rootpage: i64,
+) -> Option<String> {
+    if rootpage == 0 {
+        return None;
+    }
+    let alternate_rootpage = -rootpage;
+    for entry in mvcc_store.rows.iter() {
+        if entry.key().table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+            continue;
+        }
+        let row_versions = entry.value().read();
+        for row_version in row_versions.iter().rev() {
+            if row_version.end().is_some() {
+                continue;
+            }
+            let Ok(row) = portable_schema_row_from_record(row_version.row.payload()) else {
+                continue;
+            };
+            if row.rootpage == rootpage || row.rootpage == alternate_rootpage {
+                return Some(row.name);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn portable_table_name_for_mv_table_id<Clock: LogicalClock, A: ConcurrentAllocator>(
+    connection: &Connection,
+    mvcc_store: &MvStore<Clock, A>,
+    table_id: MVTableId,
+) -> Option<String> {
+    let rootpage = rootpage_for_mv_table_id(mvcc_store, table_id);
+    table_name_for_rootpage(connection, rootpage)
+        .or_else(|| table_name_for_rootpage_in_mvcc_schema(mvcc_store, rootpage))
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -2366,6 +2419,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             let mut schema_deletes = HashMap::default();
             let mut schema_rowids = Vec::new();
             let mut data_table_ids = HashSet::default();
+            let mut has_portable_schema_changes = false;
             for op in &parsed_ops {
                 match op {
                     ParsedOp::UpsertTable {
@@ -2376,6 +2430,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                     } if *table_id == SQLITE_SCHEMA_MVCC_TABLE_ID => {
                         let rowid = rowid.row_id.to_int_or_panic();
                         let row = portable_schema_row_from_record(record_bytes)?;
+                        has_portable_schema_changes |= is_portable_schema_row(&row);
                         schema_rowids.push(rowid);
                         schema_upserts.insert(rowid, row);
                     }
@@ -2391,6 +2446,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                         }
                         let schema_rowid = rowid.row_id.to_int_or_panic();
                         let row = portable_schema_row_from_record(record_bytes)?;
+                        has_portable_schema_changes |= is_portable_schema_row(&row);
                         schema_rowids.push(schema_rowid);
                         schema_deletes.insert(schema_rowid, row);
                     }
@@ -2485,44 +2541,15 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             }
 
             if !needed_rootpages.is_empty() {
-                let schema = self.connection.schema.read();
                 for rootpage in needed_rootpages {
-                    let (resolved_table_id, table_ref) = if let Some(name) =
-                        schema.table_name_for_root_page(rootpage)
-                    {
-                        (
-                            portable_table_id_from_rootpage(rootpage),
-                            PortableTableRef {
-                                name: name.to_string(),
-                            },
-                        )
-                    } else if rootpage < 0 {
-                        let checkpointed_rootpage = -rootpage;
-                        let Some(name) = schema.table_name_for_root_page(checkpointed_rootpage)
-                        else {
-                            continue;
-                        };
-                        (
-                            portable_table_id_from_rootpage(checkpointed_rootpage),
-                            PortableTableRef {
-                                name: name.to_string(),
-                            },
-                        )
-                    } else if rootpage > 0 {
-                        let uncheckpointed_rootpage = -rootpage;
-                        let Some(name) = schema.table_name_for_root_page(uncheckpointed_rootpage)
-                        else {
-                            continue;
-                        };
-                        (
-                            portable_table_id_from_rootpage(rootpage),
-                            PortableTableRef {
-                                name: name.to_string(),
-                            },
-                        )
-                    } else {
+                    let Some(name) = table_name_for_rootpage(&self.connection, rootpage)
+                        .or_else(|| table_name_for_rootpage_in_mvcc_schema(mvcc_store, rootpage))
+                    else {
                         continue;
                     };
+                    let resolved_rootpage = if rootpage < 0 { -rootpage } else { rootpage };
+                    let resolved_table_id = portable_table_id_from_rootpage(resolved_rootpage);
+                    let table_ref = PortableTableRef { name };
                     table_refs_by_id.insert(resolved_table_id, table_ref);
                 }
 
@@ -2549,8 +2576,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
 
             for table_id in data_table_ids {
                 let Some(table_ref) = table_refs_by_id.get(&table_id) else {
-                    return Err(LimboError::InternalError(format!(
-                        "unable to resolve MVCC table id for portable changes: table_id={table_id}"
+                    return Err(LimboError::Corrupt(format!(
+                        "portable changes cannot resolve user data table id {table_id}"
                     )));
                 };
                 if !is_portable_logical_name(&table_ref.name) {
@@ -2559,6 +2586,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             }
 
             log_record.portable_changes = builder.finish();
+            log_record.portable_changes_required = has_portable_schema_changes;
             Ok(())
         }
     }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -13678,6 +13678,89 @@ fn test_mvcc_portable_changes_use_checkpointed_schema_after_restart() {
 
 #[cfg(feature = "conn_raw_api")]
 #[test]
+fn test_mvcc_portable_changes_resolve_user_table_after_cross_connection_checkpoint() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:").unwrap();
+    let creator = db.connect().unwrap();
+    creator.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    creator.set_portable_logical_changes_enabled(true);
+    creator
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+
+    let checkpoint = db.connect().unwrap();
+    checkpoint
+        .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        .unwrap();
+    let rows = get_rows(
+        &checkpoint,
+        "SELECT rootpage FROM sqlite_schema WHERE name = 'items'",
+    );
+    let rootpage = rows[0][0].as_int().unwrap();
+    assert!(rootpage > 0);
+
+    let writer = db.connect().unwrap();
+    writer.set_portable_logical_changes_enabled(true);
+    writer
+        .execute("INSERT INTO items(id, payload) VALUES (1, 'after-checkpoint')")
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&writer);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
+
+    assert!(
+        objects.iter().any(|object| object.name == "items"),
+        "DML-only portable frame should resolve user table after cross-connection checkpoint"
+    );
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_resolve_table_after_alter_backfill() {
+    let db = MvccTestDb::new_with_portable_logical_changes();
+    db.conn
+        .execute(
+            "CREATE TABLE items(
+                id INTEGER PRIMARY KEY,
+                owner TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                rev INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .unwrap();
+    db.conn
+        .execute("CREATE INDEX items_owner_rev_idx ON items(owner, rev)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items (id, owner, payload, rev) VALUES (1, 'seed-a', 'alpha', 1)")
+        .unwrap();
+
+    db.conn
+        .execute("ALTER TABLE items ADD COLUMN note TEXT")
+        .unwrap();
+    db.conn
+        .execute("UPDATE items SET note = 'schema-note'")
+        .unwrap();
+
+    db.conn
+        .execute(
+            "INSERT INTO items (id, owner, payload, rev, note)
+             VALUES (1000000, 'remote-owner', 'remote-bootstrap-5', 1, 'remote-owner-note-1000000')",
+        )
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let txns = decode_portable_change_txns(&portable_changes);
+    assert!(
+        txns.len() >= 6,
+        "expected every portable-enabled commit to be encoded, got {} txns",
+        txns.len()
+    );
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
 fn test_mvcc_portable_changes_emit_ddl_and_backfill_rows_in_same_transaction() {
     let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -13536,6 +13536,56 @@ fn test_mvcc_portable_changes_resolve_rows_through_object_map_in_same_txn() {
     assert!(object.mv_table_id < 0);
 }
 
+#[test]
+fn test_mvcc_mode_supports_cdc_for_client_push() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:").unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute("PRAGMA capture_data_changes_conn('full,turso_cdc')")
+        .unwrap();
+
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO items VALUES (1, 'alpha')")
+        .unwrap();
+    conn.execute("UPDATE items SET payload = 'beta' WHERE id = 1")
+        .unwrap();
+    conn.execute("DELETE FROM items WHERE id = 1").unwrap();
+
+    let item_rows = get_rows(
+        &conn,
+        "SELECT change_id, change_txn_id, change_type
+         FROM turso_cdc
+         WHERE table_name = 'items'
+         ORDER BY change_id",
+    );
+    let item_change_types = item_rows
+        .iter()
+        .map(|row| row[2].as_int().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(item_change_types, vec![1, 0, -1]);
+    assert!(item_rows.iter().all(|row| row[1].as_int().unwrap() > 0));
+
+    let all_rows = get_rows(
+        &conn,
+        "SELECT change_id, change_type
+         FROM turso_cdc
+         ORDER BY change_id",
+    );
+    let change_ids = all_rows
+        .iter()
+        .map(|row| row[0].as_int().unwrap())
+        .collect::<Vec<_>>();
+    let commit_count = all_rows
+        .iter()
+        .filter(|row| row[1].as_int() == Some(2))
+        .count();
+
+    assert_eq!(change_ids, (1..=all_rows.len() as i64).collect::<Vec<_>>());
+    assert_eq!(commit_count, 4);
+}
+
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_emit_index_drop_for_drop_table() {
@@ -13687,6 +13737,12 @@ fn test_mvcc_portable_changes_resolve_user_table_after_cross_connection_checkpoi
     creator
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
         .unwrap();
+    let rows = get_rows(
+        &creator,
+        "SELECT rootpage FROM sqlite_schema WHERE name = 'items'",
+    );
+    let initial_rootpage = rows[0][0].as_int().unwrap();
+    assert!(initial_rootpage < 0);
 
     let checkpoint = db.connect().unwrap();
     checkpoint
@@ -13698,6 +13754,16 @@ fn test_mvcc_portable_changes_resolve_user_table_after_cross_connection_checkpoi
     );
     let rootpage = rows[0][0].as_int().unwrap();
     assert!(rootpage > 0);
+    {
+        let schema = checkpoint.db.schema.lock();
+        assert_eq!(schema.table_name_for_root_page(rootpage), Some("items"));
+        assert_eq!(schema.table_name_for_root_page(initial_rootpage), None);
+    }
+    {
+        let schema = checkpoint.schema.read();
+        assert_eq!(schema.table_name_for_root_page(rootpage), Some("items"));
+        assert_eq!(schema.table_name_for_root_page(initial_rootpage), None);
+    }
 
     let writer = db.connect().unwrap();
     writer.set_portable_logical_changes_enabled(true);

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -631,7 +631,7 @@ impl LogicalLog {
         let payload_size_u64 = payload_size as u64;
 
         #[cfg(feature = "conn_raw_api")]
-        let has_portable_changes = !tx.portable_changes.is_empty();
+        let has_portable_changes = tx.portable_changes_required || !tx.portable_changes.is_empty();
         #[cfg(not(feature = "conn_raw_api"))]
         let has_portable_changes = false;
         #[cfg(feature = "conn_raw_api")]

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -110,7 +110,15 @@ pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<Por
 }
 
 pub(crate) fn is_portable_table_schema_row(row: &PortableSchemaRow) -> bool {
-    row.rootpage != 0 && row.row_type.eq_ignore_ascii_case("table")
+    row.rootpage != 0 && row.row_type.eq_ignore_ascii_case("table") && is_portable_schema_row(row)
+}
+
+pub(crate) fn is_portable_schema_row(row: &PortableSchemaRow) -> bool {
+    is_portable_logical_name(&row.name)
+        && (row.row_type.eq_ignore_ascii_case("table")
+            || row.row_type.eq_ignore_ascii_case("index")
+            || row.row_type.eq_ignore_ascii_case("trigger")
+            || row.row_type.eq_ignore_ascii_case("view"))
 }
 
 #[derive(Default)]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3168,8 +3168,6 @@ impl Pager {
             // Clear dirty pages and page cache before releasing the write lock
             self.clear_page_cache(true);
             self.dirty_pages.write().clear();
-            // saveAllCursors at sqlite3BtreeRollback (btree.c:4485).
-            self.invalidate_all_cursors();
             self.reset_internal_states();
             self.set_schema_cookie(None);
             wal.rollback(None);
@@ -4855,6 +4853,7 @@ impl Pager {
 
                     // Clear page cache only if requested (explicit checkpoints do this, auto-checkpoint does not)
                     if clear_page_cache {
+                        self.invalidate_all_cursors();
                         self.page_cache.write().clear(false).map_err(|e| {
                             res.release_guard();
                             LimboError::InternalError(format!("Failed to clear page cache: {e:?}"))
@@ -4903,6 +4902,7 @@ impl Pager {
     /// of a rollback or in case we want to invalidate page cache after starting a read transaction
     /// right after new writes happened which would invalidate current page cache.
     pub fn clear_page_cache(&self, clear_dirty: bool) {
+        self.invalidate_all_cursors();
         let dirty_pages = self.dirty_pages.write();
         let mut cache = self.page_cache.write();
         for page_id in dirty_pages.iter() {
@@ -5527,8 +5527,6 @@ impl Pager {
             // since we only need to clear the dirty pages that were modified by the write transaction.
             self.clear_page_cache(clear_dirty);
             self.dirty_pages.write().clear();
-            // saveAllCursors at sqlite3BtreeRollback (btree.c:4485).
-            self.invalidate_all_cursors();
         } else {
             turso_assert!(
                 self.dirty_pages.read().is_empty(),

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -5651,6 +5651,27 @@ impl WalFileShared {
             lock.set_value_exclusive(READMARK_NOT_USED);
         }
     }
+
+    /// Replace restored WAL state while preserving process-local locks owned by
+    /// existing connections.
+    ///
+    /// External restore paths rebuild metadata/cache/file state from disk while
+    /// other connections may still hold read guards. Those guards are tied to
+    /// the process-local lock objects, not to the restored on-disk WAL view, so
+    /// replacing the lock objects would make normal `end_read_tx` unlock a
+    /// fresh empty lock. Keep lock identity stable and refresh only state
+    /// derived from storage.
+    #[cfg(feature = "conn_raw_api")]
+    pub fn replace_after_external_restore(&mut self, restored: WalFileShared) {
+        self.metadata = restored.metadata;
+        self.runtime.frame_cache = restored.runtime.frame_cache;
+        self.runtime.file = restored.runtime.file;
+        self.runtime.epoch.store(
+            restored.runtime.epoch.load(Ordering::Acquire),
+            Ordering::Release,
+        );
+        self.runtime.overflow_fallback_coverage = restored.runtime.overflow_fallback_coverage;
+    }
 }
 
 #[cfg(test)]
@@ -5787,6 +5808,50 @@ pub mod test {
             self.inner.truncate(len, c)
         }
     }
+
+    #[cfg(feature = "conn_raw_api")]
+    #[test]
+    fn replace_after_external_restore_preserves_lock_identity() {
+        let shared = WalFileShared::new_noop();
+        let restored = WalFileShared::new_noop();
+
+        let read_lock_ptrs = {
+            let shared = shared.read();
+            shared
+                .runtime
+                .read_locks
+                .iter()
+                .map(std::ptr::from_ref)
+                .collect::<Vec<_>>()
+        };
+        {
+            let shared = shared.read();
+            assert!(shared.runtime.read_locks[1].write());
+            shared.runtime.read_locks[1].set_value_exclusive(7);
+            shared.runtime.read_locks[1].unlock();
+        }
+        {
+            let restored = restored.read();
+            restored.metadata.max_frame.store(42, Ordering::Release);
+            assert!(restored.runtime.read_locks[1].write());
+            restored.runtime.read_locks[1].set_value_exclusive(99);
+            restored.runtime.read_locks[1].unlock();
+        }
+
+        let restored = match Arc::try_unwrap(restored) {
+            Ok(restored) => restored.into_inner(),
+            Err(_) => panic!("restored WAL test state should not be shared"),
+        };
+        shared.write().replace_after_external_restore(restored);
+
+        let shared = shared.read();
+        assert_eq!(shared.metadata.max_frame.load(Ordering::Acquire), 42);
+        assert_eq!(shared.runtime.read_locks[1].get_value(), 7);
+        for (idx, lock) in shared.runtime.read_locks.iter().enumerate() {
+            assert_eq!(std::ptr::from_ref(lock), read_lock_ptrs[idx]);
+        }
+    }
+
     #[test]
     fn test_truncate_file() {
         let (db, _path) = get_database();

--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -778,6 +778,7 @@ fn emit_delete_row_common(
             };
             emit_cdc_insns(
                 program,
+                &t_ctx.resolver,
                 OperationMode::DELETE,
                 cdc_cursor_id,
                 rowid_reg,

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1204,8 +1204,64 @@ pub fn emit_cdc_full_record(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Allocate the rowid for a CDC row into `dest_reg`. The CDC table's `change_id`
+/// column is `INTEGER PRIMARY KEY`, so the rowid IS the change id.
+///
+/// In MVCC journal mode the id is drawn from the CDC table's implicit
+/// AUTOINCREMENT sequence. This makes change ids monotonic and never reused after
+/// CDC rows are pruned, and registers each in-flight allocation with the MVCC
+/// store so the sync push loop can call `sequence_watermark_experimental` to
+/// avoid advancing the push watermark past a change id that a concurrent
+/// transaction commits out of change-id order under snapshot isolation. In WAL
+/// mode we keep the cheaper `NewRowid` (max rowid + 1) assignment; the WAL push
+/// loop does not depend on the sequence watermark, so its insert path is
+/// unchanged and pays no per-row sequence cost.
+fn emit_cdc_change_id(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    cdc_cursor_id: usize,
+    dest_reg: usize,
+) -> Result<()> {
+    if !program.is_mvcc_enabled() {
+        program.emit_insn(Insn::NewRowid {
+            cursor: cdc_cursor_id,
+            rowid_reg: dest_reg,
+            prev_largest_reg: 0,
+        });
+        return Ok(());
+    }
+    let Some(cdc_table) = program
+        .capture_data_changes_info()
+        .as_ref()
+        .map(|info| info.table.clone())
+    else {
+        return Err(crate::LimboError::InternalError(
+            "CDC change-id allocation requested without an active CDC config".to_string(),
+        ));
+    };
+    let seq_name = crate::schema::autoincrement_sequence_name(&cdc_table);
+    let seq = resolver
+        .with_schema(crate::MAIN_DB_ID, |s| s.get_sequence(&seq_name).cloned())
+        .ok_or_else(|| {
+            crate::LimboError::InternalError(format!(
+                "missing implicit AUTOINCREMENT sequence for CDC table \"{cdc_table}\""
+            ))
+        })?;
+    crate::translate::sequence::emit_disk_read_nextval(
+        program,
+        resolver,
+        crate::MAIN_DB_ID,
+        &seq_name,
+        &seq,
+        dest_reg,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn emit_cdc_insns(
     program: &mut ProgramBuilder,
+    resolver: &Resolver,
     operation_mode: OperationMode,
     cdc_cursor_id: usize,
     rowid_reg: usize,
@@ -1218,6 +1274,7 @@ pub fn emit_cdc_insns(
     match cdc_info.map(|info| info.cdc_version()) {
         Some(crate::CdcVersion::V2) => emit_cdc_insns_v2(
             program,
+            resolver,
             operation_mode,
             cdc_cursor_id,
             rowid_reg,
@@ -1352,8 +1409,10 @@ fn emit_cdc_insns_v1(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn emit_cdc_insns_v2(
     program: &mut ProgramBuilder,
+    resolver: &Resolver,
     operation_mode: OperationMode,
     cdc_cursor_id: usize,
     rowid_reg: usize,
@@ -1382,14 +1441,12 @@ fn emit_cdc_insns_v2(
         func: unixepoch_fn_ctx,
     });
 
-    // change_txn_id = conn_txn_id(new_rowid)
-    // First generate a candidate rowid, then pass it to conn_txn_id for get-or-set.
+    // change_txn_id = conn_txn_id(change_id)
+    // First allocate the change id (the CDC rowid), then pass it to conn_txn_id
+    // for get-or-set. In MVCC mode this draws from the CDC AUTOINCREMENT sequence
+    // (see `emit_cdc_change_id`); in WAL mode it is a plain NewRowid.
     let candidate_reg = program.alloc_register();
-    program.emit_insn(Insn::NewRowid {
-        cursor: cdc_cursor_id,
-        rowid_reg: candidate_reg,
-        prev_largest_reg: 0,
-    });
+    emit_cdc_change_id(program, resolver, cdc_cursor_id, candidate_reg)?;
     let conn_txn_id_fn_ctx = crate::function::FuncCtx {
         func: Func::Scalar(crate::function::ScalarFunc::ConnTxnId),
         arg_count: 1,
@@ -1538,12 +1595,11 @@ pub fn emit_cdc_commit_insns(
     });
     program.mark_last_insn_constant();
 
+    // Allocate the COMMIT record's change id from the same source as row records
+    // (the CDC AUTOINCREMENT sequence in MVCC mode) so COMMIT and row change ids
+    // stay in one monotonic, never-reused stream.
     let rowid_reg = program.alloc_register();
-    program.emit_insn(Insn::NewRowid {
-        cursor: cdc_cursor_id,
-        rowid_reg,
-        prev_largest_reg: 0,
-    });
+    emit_cdc_change_id(program, resolver, cdc_cursor_id, rowid_reg)?;
 
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2565,6 +2565,7 @@ fn emit_update_insns<'a>(
                 if updates_rowid {
                     emit_cdc_insns(
                         program,
+                        &t_ctx.resolver,
                         OperationMode::DELETE,
                         cdc_cursor_id,
                         cdc_rowid_before_reg,
@@ -2575,6 +2576,7 @@ fn emit_update_insns<'a>(
                     )?;
                     emit_cdc_insns(
                         program,
+                        &t_ctx.resolver,
                         OperationMode::INSERT,
                         cdc_cursor_id,
                         cdc_rowid_after_reg,
@@ -2586,6 +2588,7 @@ fn emit_update_insns<'a>(
                 } else {
                     emit_cdc_insns(
                         program,
+                        &t_ctx.resolver,
                         OperationMode::UPDATE(if uses_write_set {
                             UpdateRowSource::PrebuiltEphemeralTable {
                                 ephemeral_table_cursor_id: iteration_cursor_id,

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1310,6 +1310,7 @@ pub fn translate_drop_index(
         };
         emit_cdc_insns(
             program,
+            resolver,
             OperationMode::DELETE,
             cdc_cursor_id,
             row_id_reg,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1089,6 +1089,7 @@ pub fn translate_insert(
         };
         emit_cdc_insns(
             program,
+            resolver,
             OperationMode::INSERT,
             *cdc_cursor_id,
             insertion.key_register(),
@@ -3873,6 +3874,7 @@ fn emit_replace_delete_conflicting_row(
         };
         emit_cdc_insns(
             program,
+            resolver,
             OperationMode::DELETE,
             cdc_cursor_id,
             ctx.conflict_rowid_reg,

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -88,13 +88,19 @@ pub fn translate(
             | ast::Stmt::Update { .. }
     );
 
+    let capture_data_changes_info = if connection.is_mvcc_bootstrap_connection() {
+        None
+    } else {
+        connection.get_capture_data_changes_info().clone()
+    };
     // Boxed so the ~800 B builder sits on the heap instead of the prepare frame.
     let mut program = Box::new(ProgramBuilder::new(
         query_mode,
-        connection.get_capture_data_changes_info().clone(),
+        capture_data_changes_info,
         // These options will be extended whithin each translate program
         ProgramBuilderOpts::new(1, 32, 2),
     ));
+    program.set_mvcc_enabled(connection.mvcc_enabled());
 
     program.prologue();
     let mut resolver = Resolver::new(

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -591,9 +591,6 @@ fn update_pragma(
         PragmaName::CaptureDataChangesConn | PragmaName::UnstableCaptureDataChangesConn => {
             let value = parse_string(&value)?;
             let opts = CaptureDataChangesInfo::parse(&value, Some(CDC_VERSION_CURRENT))?;
-            if opts.is_some() && connection.mvcc_enabled() {
-                bail_parse_error!("CDC is not supported in MVCC mode");
-            }
             // InitCdcVersion handles everything at execution time:
             // - For enable: creates CDC table + version table, records version,
             //   reads back actual version, defers CDC state to Halt

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1554,6 +1554,7 @@ pub fn emit_schema_entry(
         };
         emit_cdc_insns(
             program,
+            resolver,
             OperationMode::INSERT,
             cdc_table_cursor_id,
             rowid_reg,
@@ -1913,6 +1914,7 @@ pub fn translate_drop_table(
         };
         emit_cdc_insns(
             program,
+            resolver,
             OperationMode::DELETE,
             cdc_cursor_id,
             row_id_reg,

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -1281,6 +1281,7 @@ pub fn emit_upsert(
             };
             emit_cdc_insns(
                 program,
+                resolver,
                 OperationMode::DELETE,
                 cdc_id,
                 ctx.conflict_rowid_reg,
@@ -1300,6 +1301,7 @@ pub fn emit_upsert(
             };
             emit_cdc_insns(
                 program,
+                resolver,
                 OperationMode::INSERT,
                 cdc_id,
                 new_rowid,
@@ -1334,6 +1336,7 @@ pub fn emit_upsert(
             };
             emit_cdc_insns(
                 program,
+                resolver,
                 OperationMode::UPDATE(UpdateRowSource::Normal),
                 cdc_id,
                 ctx.conflict_rowid_reg,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -225,6 +225,8 @@ pub struct ProgramBuilder {
     /// Curr collation sequence. Bool indicates whether it was set by a COLLATE expr
     collation: Option<(CollationSeq, bool)>,
     capture_data_changes_info: Option<CaptureDataChangesInfo>,
+    /// Whether the main database uses MVCC journal mode, set once at translation time from the connection.
+    mvcc_enabled: bool,
     // TODO: when we support multiple dbs, this should be a write mask to track which DBs need to be written
     txn_mode: TransactionMode,
     /// Set of database IDs that need write transactions (for attached databases).
@@ -668,6 +670,7 @@ impl ProgramBuilder {
             init_label: BranchOffset::Placeholder,
             start_offset: BranchOffset::Placeholder,
             capture_data_changes_info,
+            mvcc_enabled: false,
             txn_mode: TransactionMode::None,
             write_databases: BitSet::default(),
             read_databases: BitSet::default(),
@@ -835,6 +838,15 @@ impl ProgramBuilder {
 
     pub const fn capture_data_changes_info(&self) -> &Option<CaptureDataChangesInfo> {
         &self.capture_data_changes_info
+    }
+
+    /// Whether the main database uses MVCC journal mode. See [`Self::mvcc_enabled`].
+    pub const fn is_mvcc_enabled(&self) -> bool {
+        self.mvcc_enabled
+    }
+
+    pub fn set_mvcc_enabled(&mut self, enabled: bool) {
+        self.mvcc_enabled = enabled;
     }
 
     pub fn extend(&mut self, opts: &ProgramBuilderOpts) {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12787,17 +12787,12 @@ fn drive_init_cdc_version(
             },
             StepResult::Done => match inner.phase {
                 OpInitCdcVersionPhase::CheckTable => {
-                    let change_id_column = if conn.mvcc_enabled() {
-                        "change_id INTEGER PRIMARY KEY"
-                    } else {
-                        "change_id INTEGER PRIMARY KEY AUTOINCREMENT"
-                    };
                     let create_sql = match version {
                         CdcVersion::V1 => format!(
-                            "CREATE TABLE IF NOT EXISTS {cdc_table_name} ({change_id_column}, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)",
+                            "CREATE TABLE IF NOT EXISTS {cdc_table_name} (change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)",
                         ),
                         CdcVersion::V2 => format!(
-                            "CREATE TABLE IF NOT EXISTS {cdc_table_name} ({change_id_column}, change_time INTEGER, change_txn_id INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)",
+                            "CREATE TABLE IF NOT EXISTS {cdc_table_name} (change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_txn_id INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)",
                         ),
                     };
                     inner.stmt = prepare_cdc_internal(conn, create_sql)?;

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::Display,
     ops::Deref,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Mutex, Once, RwLock, Weak,
     },
     task::Waker,
@@ -32,6 +32,38 @@ use crate::{
 
 assert_send!(TursoDatabase, TursoConnection, TursoStatement);
 assert_sync!(TursoDatabase);
+
+#[derive(Default)]
+pub struct SyncBusyGate {
+    active: AtomicBool,
+}
+
+impl SyncBusyGate {
+    pub fn set_active(&self, active: bool) {
+        self.active.store(active, Ordering::Release);
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+}
+
+pub struct SyncBusyGuard {
+    gate: Arc<SyncBusyGate>,
+}
+
+impl SyncBusyGuard {
+    pub fn new(gate: Arc<SyncBusyGate>) -> Self {
+        gate.set_active(true);
+        Self { gate }
+    }
+}
+
+impl Drop for SyncBusyGuard {
+    fn drop(&mut self) {
+        self.gate.set_active(false);
+    }
+}
 
 pub use turso_core::types::FromValue;
 pub use turso_ext::{
@@ -489,6 +521,32 @@ impl From<LimboError> for TursoError {
     }
 }
 
+fn sync_busy_error() -> TursoError {
+    TursoError::Busy("database is locked".to_string())
+}
+
+fn sync_operation_active(sync_busy: Option<&Arc<SyncBusyGate>>) -> bool {
+    sync_busy.is_some_and(|gate| gate.is_active())
+}
+
+fn map_sync_transient_error(
+    sync_busy: Option<&Arc<SyncBusyGate>>,
+    error: TursoError,
+) -> TursoError {
+    if sync_busy.is_none() {
+        return error;
+    }
+    match error {
+        TursoError::Error(message)
+            if message == "Database schema changed"
+                || message.starts_with("I/O error: short read on page") =>
+        {
+            sync_busy_error()
+        }
+        other => other,
+    }
+}
+
 static LOGGER: RwLock<Option<Box<Logger>>> = RwLock::new(None);
 static SETUP: Once = Once::new();
 
@@ -825,6 +883,7 @@ pub struct TursoConnection {
     async_io: bool,
     concurrent_guard: Arc<ConcurrentGuard>,
     connection: Arc<Connection>,
+    sync_busy: Option<Arc<SyncBusyGate>>,
     cached_statements: Arc<Mutex<HashMap<String, Arc<CachedStatement>>>>,
     /// Weak refs to every statement handle created by this connection, keyed
     /// by a monotonic ID. Statements remove themselves on drop, so this map
@@ -836,14 +895,31 @@ pub struct TursoConnection {
 
 impl TursoConnection {
     pub fn new(config: &TursoDatabaseConfig, connection: Arc<Connection>) -> Arc<Self> {
+        Self::new_with_sync_busy(config, connection, None)
+    }
+
+    pub fn new_with_sync_busy(
+        config: &TursoDatabaseConfig,
+        connection: Arc<Connection>,
+        sync_busy: Option<Arc<SyncBusyGate>>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             async_io: config.async_io,
             connection,
+            sync_busy,
             concurrent_guard: Arc::new(ConcurrentGuard::new()),
             cached_statements: Arc::new(Mutex::new(HashMap::new())),
             stmts: Arc::new(Mutex::new(HashMap::new())),
             next_stmt_id: Arc::new(AtomicUsize::new(0)),
         })
+    }
+
+    fn sync_operation_active(&self) -> bool {
+        sync_operation_active(self.sync_busy.as_ref())
+    }
+
+    fn map_sync_transient_error(&self, error: TursoError) -> TursoError {
+        map_sync_transient_error(self.sync_busy.as_ref(), error)
     }
     /// Set busy timeout for the connection
     pub fn set_busy_timeout(&self, duration: Duration) {
@@ -981,12 +1057,20 @@ impl TursoConnection {
 
     /// prepares single SQL statement
     pub fn prepare_single(&self, sql: impl AsRef<str>) -> Result<Box<TursoStatement>, TursoError> {
-        let statement = self.connection.prepare(sql)?;
+        if self.sync_operation_active() {
+            return Err(sync_busy_error());
+        }
+        let statement = self
+            .connection
+            .prepare(sql)
+            .map_err(TursoError::from)
+            .map_err(|error| self.map_sync_transient_error(error))?;
         let handle: StatementHandle = Arc::new(Mutex::new(Some(statement)));
         let stmt_id = self.track_stmt(&handle);
         Ok(Box::new(TursoStatement {
             concurrent_guard: self.concurrent_guard.clone(),
             async_io: self.async_io,
+            sync_busy: self.sync_busy.clone(),
             handle,
             stmt_id,
             stmts: self.stmts.clone(),
@@ -995,6 +1079,9 @@ impl TursoConnection {
 
     /// Prepare a statement from the provided SQL string and cache it for future use.
     pub fn prepare_cached(&self, sql: impl AsRef<str>) -> Result<Box<TursoStatement>, TursoError> {
+        if self.sync_operation_active() {
+            return Err(sync_busy_error());
+        }
         let sql_str = sql.as_ref();
 
         // Check if we have a cached version
@@ -1011,6 +1098,7 @@ impl TursoConnection {
                 return Ok(Box::new(TursoStatement {
                     concurrent_guard: self.concurrent_guard.clone(),
                     async_io: self.async_io,
+                    sync_busy: self.sync_busy.clone(),
                     handle,
                     stmt_id,
                     stmts: self.stmts.clone(),
@@ -1019,7 +1107,11 @@ impl TursoConnection {
         }
 
         // Not cached, prepare it fresh
-        let statement = self.connection.prepare(sql_str)?;
+        let statement = self
+            .connection
+            .prepare(sql_str)
+            .map_err(TursoError::from)
+            .map_err(|error| self.map_sync_transient_error(error))?;
 
         // Cache it for future use
         let cached = Arc::new(CachedStatement {
@@ -1036,6 +1128,7 @@ impl TursoConnection {
         Ok(Box::new(TursoStatement {
             concurrent_guard: self.concurrent_guard.clone(),
             async_io: self.async_io,
+            sync_busy: self.sync_busy.clone(),
             handle,
             stmt_id,
             stmts: self.stmts.clone(),
@@ -1048,7 +1141,15 @@ impl TursoConnection {
         &self,
         sql: impl AsRef<str>,
     ) -> Result<Option<(Box<TursoStatement>, usize)>, TursoError> {
-        match self.connection.consume_stmt(sql)? {
+        if self.sync_operation_active() {
+            return Err(sync_busy_error());
+        }
+        match self
+            .connection
+            .consume_stmt(sql)
+            .map_err(TursoError::from)
+            .map_err(|error| self.map_sync_transient_error(error))?
+        {
             Some((statement, position)) => {
                 let handle: StatementHandle = Arc::new(Mutex::new(Some(statement)));
                 let stmt_id = self.track_stmt(&handle);
@@ -1056,6 +1157,7 @@ impl TursoConnection {
                     Box::new(TursoStatement {
                         async_io: self.async_io,
                         concurrent_guard: Arc::new(ConcurrentGuard::new()),
+                        sync_busy: self.sync_busy.clone(),
                         handle,
                         stmt_id,
                         stmts: self.stmts.clone(),
@@ -1180,6 +1282,7 @@ fn step_inner(
 pub struct TursoStatement {
     async_io: bool,
     concurrent_guard: Arc<ConcurrentGuard>,
+    sync_busy: Option<Arc<SyncBusyGate>>,
     pub(crate) handle: StatementHandle,
     stmt_id: usize,
     stmts: StmtRegistry,
@@ -1281,6 +1384,9 @@ impl TursoStatement {
     /// method returns [TursoStatusCode::Io] if async_io was set and execution needs IO in order to make progress
     #[inline]
     pub fn step(&mut self, waker: Option<&Waker>) -> Result<TursoStatusCode, TursoError> {
+        if sync_operation_active(self.sync_busy.as_ref()) {
+            return Err(sync_busy_error());
+        }
         let guard = self.concurrent_guard.clone();
         let _guard = guard.try_use()?;
         let mut handle = self.handle.lock().unwrap();
@@ -1288,12 +1394,16 @@ impl TursoStatement {
             .as_mut()
             .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
         step_inner(stmt, self.async_io, waker)
+            .map_err(|error| map_sync_transient_error(self.sync_busy.as_ref(), error))
     }
 
     /// execute statement to completion
     /// method returns [TursoStatusCode::Done] if execution completed
     /// method returns [TursoStatusCode::Io] if async_io was set and execution needs IO in order to make progress
     pub fn execute(&mut self, waker: Option<&Waker>) -> Result<TursoExecutionResult, TursoError> {
+        if sync_operation_active(self.sync_busy.as_ref()) {
+            return Err(sync_busy_error());
+        }
         let guard = self.concurrent_guard.clone();
         let _guard = guard.try_use()?;
         let mut handle = self.handle.lock().unwrap();
@@ -1302,7 +1412,8 @@ impl TursoStatement {
             .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
 
         loop {
-            let status = step_inner(stmt, self.async_io, waker)?;
+            let status = step_inner(stmt, self.async_io, waker)
+                .map_err(|error| map_sync_transient_error(self.sync_busy.as_ref(), error))?;
             if status == TursoStatusCode::Row {
                 continue;
             } else if status == TursoStatusCode::Io {
@@ -1333,6 +1444,9 @@ impl TursoStatement {
     /// get row value as an owned Value
     #[inline]
     pub fn row_value(&self, index: usize) -> Result<turso_core::Value, TursoError> {
+        if sync_operation_active(self.sync_busy.as_ref()) {
+            return Err(sync_busy_error());
+        }
         let handle = self.handle.lock().unwrap();
         let stmt = handle
             .as_ref()

--- a/sync/engine/Cargo.toml
+++ b/sync/engine/Cargo.toml
@@ -21,6 +21,7 @@ uuid = "1.17.0"
 base64 = "0.22.1"
 prost = "0.14.1"
 roaring = "0.11.2"
+crc32c = "0.6.8"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { version = "0.2.172" }

--- a/sync/engine/src/client_proto.rs
+++ b/sync/engine/src/client_proto.rs
@@ -1,0 +1,175 @@
+use bytes::Bytes;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, prost::Enumeration)]
+#[repr(i32)]
+/// Logical operation kind decoded from the server's MVCC log.
+pub enum LogicalOpType {
+    Unspecified = 0,
+    /// Insert or replace one row by rowid.
+    UpsertRow = 1,
+    /// Delete one row by rowid.
+    DeleteRow = 2,
+    /// Replay a schema create/drop/refresh/alter operation.
+    Schema = 3,
+    /// Replay database-header fields such as `user_version` and `application_id`.
+    UpdateHeader = 4,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, prost::Enumeration)]
+#[repr(i32)]
+/// Schema action represented by a logical schema operation.
+pub enum LogicalSchemaAction {
+    Unspecified = 0,
+    /// Create the schema object if it does not already exist.
+    Create = 1,
+    /// Drop the schema object.
+    Drop = 2,
+    /// Replace the client-side schema object definition with the supplied SQL.
+    Refresh = 3,
+    /// Replay an ALTER statement exactly as supplied by the server.
+    Alter = 4,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, prost::Enumeration)]
+#[repr(i32)]
+/// Type of schema object affected by a logical schema operation.
+pub enum LogicalSchemaKind {
+    Unspecified = 0,
+    /// A table entry in `sqlite_schema`.
+    Table = 1,
+    /// An index entry in `sqlite_schema`.
+    Index = 2,
+    /// A trigger entry in `sqlite_schema`.
+    Trigger = 3,
+    /// A view entry in `sqlite_schema`.
+    View = 4,
+}
+
+#[derive(prost::Message, Clone, PartialEq, Eq)]
+/// One logical operation decoded from a portable MVCC logical-log frame.
+///
+/// Only the fields required by `op_type` are populated. Row operations use
+/// `table_name`, `rowid`, and optionally `record`; schema operations use the
+/// schema fields; header updates use `user_version` and/or `application_id`.
+pub struct LogicalOp {
+    /// Encoded [`LogicalOpType`].
+    #[prost(enumeration = "LogicalOpType", tag = "1")]
+    pub op_type: i32,
+    /// User table affected by row operations.
+    #[prost(string, tag = "2")]
+    pub table_name: String,
+    /// Rowid affected by row operations.
+    #[prost(sint64, tag = "3")]
+    pub rowid: i64,
+    /// SQLite record bytes for upsert operations.
+    #[prost(bytes, tag = "4")]
+    pub record: Bytes,
+    /// SQL used for schema create, refresh, or alter operations.
+    #[prost(string, tag = "5")]
+    pub sql: String,
+    /// New `PRAGMA user_version`, when the operation updates it.
+    #[prost(optional, uint32, tag = "6")]
+    pub user_version: Option<u32>,
+    /// New `PRAGMA application_id`, when the operation updates it.
+    #[prost(optional, uint32, tag = "7")]
+    pub application_id: Option<u32>,
+    /// Encoded [`LogicalSchemaAction`] for schema operations.
+    #[prost(optional, enumeration = "LogicalSchemaAction", tag = "8")]
+    pub schema_action: Option<i32>,
+    /// Encoded [`LogicalSchemaKind`] for schema operations.
+    #[prost(optional, enumeration = "LogicalSchemaKind", tag = "9")]
+    pub schema_kind: Option<i32>,
+    /// Schema object name for schema operations.
+    #[prost(string, tag = "10")]
+    pub schema_name: String,
+    /// Stable table/object identifier carried by portable MVCC logical changes.
+    ///
+    /// Row operations may omit `table_name` when this is set. The sync engine
+    /// maintains the stable-id-to-name map from schema operations, and still
+    /// accepts named row operations for compatibility with older logical paths.
+    #[prost(uint64, tag = "11")]
+    pub stable_table_id: u64,
+}
+
+#[derive(prost::Message, Clone, PartialEq, Eq)]
+/// One committed MVCC transaction decoded from a portable MVCC logical-log frame.
+pub struct LogicalTxnData {
+    /// Logical-log byte offset immediately after this transaction.
+    #[prost(uint64, tag = "1")]
+    pub end_offset: u64,
+    /// MVCC commit timestamp used as the replay change time.
+    ///
+    /// TODO: confirm the long-term replay-time semantics before relying on
+    /// this as user-visible change time.
+    #[prost(uint64, tag = "2")]
+    pub commit_ts: u64,
+    /// Logical operations in commit order.
+    #[prost(message, repeated, tag = "3")]
+    pub ops: Vec<LogicalOp>,
+    /// Client that originated this transaction, when known.
+    #[prost(string, tag = "4")]
+    pub origin_client_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogicalOp, LogicalOpType, LogicalSchemaAction, LogicalSchemaKind, LogicalTxnData};
+    use bytes::Bytes;
+    use prost::Message;
+
+    #[test]
+    fn logical_txn_data_round_trips_schema_and_row_ops() {
+        let txn = LogicalTxnData {
+            end_offset: 128,
+            commit_ts: 42,
+            origin_client_id: "client-a".to_string(),
+            ops: vec![
+                LogicalOp {
+                    op_type: LogicalOpType::Schema as i32,
+                    table_name: String::new(),
+                    rowid: 0,
+                    record: Bytes::new(),
+                    sql: "CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)".to_string(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: Some(LogicalSchemaAction::Create as i32),
+                    schema_kind: Some(LogicalSchemaKind::Table as i32),
+                    schema_name: "items".to_string(),
+                    stable_table_id: 2,
+                },
+                LogicalOp {
+                    op_type: LogicalOpType::UpsertRow as i32,
+                    table_name: "items".to_string(),
+                    rowid: 1,
+                    record: Bytes::from_static(b"record"),
+                    sql: String::new(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: None,
+                    schema_kind: None,
+                    schema_name: String::new(),
+                    stable_table_id: 2,
+                },
+            ],
+        };
+
+        let decoded = LogicalTxnData::decode(txn.encode_to_vec().as_slice()).unwrap();
+        assert_eq!(decoded.end_offset, 128);
+        assert_eq!(decoded.commit_ts, 42);
+        assert_eq!(decoded.origin_client_id, "client-a");
+        assert_eq!(decoded.ops.len(), 2);
+        assert_eq!(
+            LogicalOpType::try_from(decoded.ops[0].op_type).unwrap(),
+            LogicalOpType::Schema
+        );
+        assert_eq!(
+            LogicalSchemaAction::try_from(decoded.ops[0].schema_action.unwrap()).unwrap(),
+            LogicalSchemaAction::Create
+        );
+        assert_eq!(
+            LogicalSchemaKind::try_from(decoded.ops[0].schema_kind.unwrap()).unwrap(),
+            LogicalSchemaKind::Table
+        );
+        assert_eq!(decoded.ops[1].record.as_ref(), b"record");
+    }
+}

--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -22,6 +22,7 @@ pub struct ReplayInfo {
     pub change_type: DatabaseChangeType,
     pub query: String,
     pub pk_column_indices: Option<Vec<usize>>,
+    pub rowid_alias_pk_column_index: Option<usize>,
     pub column_names: Vec<String>,
     pub is_ddl_replay: bool,
 }
@@ -130,20 +131,27 @@ impl DatabaseReplayGenerator {
         }
         match change {
             DatabaseChangeType::Delete => {
-                if self.opts.use_implicit_rowid || info.pk_column_indices.is_none() {
-                    crate::alloc::vec![turso_core::Value::from_i64(id)]
-                } else {
+                if let Some(pk_column_indices) = info.pk_column_indices.as_ref() {
                     let mut values = <crate::alloc::Vec<turso_core::Value> as TursoAllocExt>::new();
-                    let pk_column_indices = info.pk_column_indices.as_ref().unwrap();
                     for pk in pk_column_indices {
-                        let value = std::mem::replace(&mut record[*pk], turso_core::Value::Null);
+                        let value = if info.rowid_alias_pk_column_index == Some(*pk) {
+                            turso_core::Value::from_i64(id)
+                        } else {
+                            std::mem::replace(&mut record[*pk], turso_core::Value::Null)
+                        };
                         values.push(value);
                     }
                     values
+                } else {
+                    crate::alloc::vec![turso_core::Value::from_i64(id)]
                 }
             }
             DatabaseChangeType::Insert => {
-                if self.opts.use_implicit_rowid {
+                if let Some(pk) = info.rowid_alias_pk_column_index {
+                    record[pk] = turso_core::Value::from_i64(id);
+                    return record;
+                }
+                if self.opts.use_implicit_rowid && info.pk_column_indices.is_none() {
                     record.push(turso_core::Value::from_i64(id));
                 }
                 record
@@ -175,7 +183,11 @@ impl DatabaseReplayGenerator {
                 }
                 if let Some(pk_column_indices) = &info.pk_column_indices {
                     for pk in pk_column_indices {
-                        let value = std::mem::replace(&mut record[*pk], turso_core::Value::Null);
+                        let value = if info.rowid_alias_pk_column_index == Some(*pk) {
+                            turso_core::Value::from_i64(id)
+                        } else {
+                            std::mem::replace(&mut record[*pk], turso_core::Value::Null)
+                        };
                         values.push(value);
                     }
                 } else {
@@ -219,6 +231,7 @@ impl DatabaseReplayGenerator {
                         change_type: DatabaseChangeType::Delete,
                         query,
                         pk_column_indices: None,
+                        rowid_alias_pk_column_index: None,
                         column_names: Vec::new(),
                         is_ddl_replay: true,
                     };
@@ -236,6 +249,7 @@ impl DatabaseReplayGenerator {
                         change_type: DatabaseChangeType::Insert,
                         query: sql.as_str().to_string(),
                         pk_column_indices: None,
+                        rowid_alias_pk_column_index: None,
                         column_names: Vec::new(),
                         is_ddl_replay: true,
                     };
@@ -259,6 +273,7 @@ impl DatabaseReplayGenerator {
                         change_type: DatabaseChangeType::Update,
                         query: ddl_stmt.as_str().to_string(),
                         pk_column_indices: None,
+                        rowid_alias_pk_column_index: None,
                         column_names: Vec::new(),
                         is_ddl_replay: true,
                     };
@@ -302,7 +317,8 @@ impl DatabaseReplayGenerator {
         table_name: &str,
         columns: &[bool],
     ) -> Result<ReplayInfo> {
-        let (column_names, pk_column_indices) = self.table_columns_info(coro, table_name).await?;
+        let (column_names, pk_column_indices, rowid_alias_pk_column_index) =
+            self.table_columns_info(coro, table_name).await?;
         // The CDC record may have fewer columns than the current schema
         // (e.g. records captured before ALTER TABLE ADD COLUMN).
         // Only reference columns present in the record.
@@ -329,30 +345,30 @@ impl DatabaseReplayGenerator {
             }
         }
         let quoted_table_name = quote_ident(table_name);
-        let (query, pk_column_indices) =
-            if self.opts.use_implicit_rowid || pk_column_indices.is_empty() {
-                (
-                    format!(
-                        "UPDATE {quoted_table_name} SET {} WHERE rowid = ?",
-                        column_updates.join(", ")
-                    ),
-                    None,
-                )
-            } else {
-                (
-                    format!(
-                        "UPDATE {quoted_table_name} SET {} WHERE {}",
-                        column_updates.join(", "),
-                        pk_predicates.join(" AND ")
-                    ),
-                    Some(pk_column_indices),
-                )
-            };
+        let (query, pk_column_indices) = if pk_column_indices.is_empty() {
+            (
+                format!(
+                    "UPDATE {quoted_table_name} SET {} WHERE rowid = ?",
+                    column_updates.join(", ")
+                ),
+                None,
+            )
+        } else {
+            (
+                format!(
+                    "UPDATE {quoted_table_name} SET {} WHERE {}",
+                    column_updates.join(", "),
+                    pk_predicates.join(" AND ")
+                ),
+                Some(pk_column_indices),
+            )
+        };
         Ok(ReplayInfo {
             change_type: DatabaseChangeType::Update,
             query,
             column_names: record_columns.to_vec(),
             pk_column_indices,
+            rowid_alias_pk_column_index,
             is_ddl_replay: false,
         })
     }
@@ -362,7 +378,8 @@ impl DatabaseReplayGenerator {
         table_name: &str,
         columns: usize,
     ) -> Result<ReplayInfo> {
-        let (column_names, pk_column_indices) = self.table_columns_info(coro, table_name).await?;
+        let (column_names, pk_column_indices, rowid_alias_pk_column_index) =
+            self.table_columns_info(coro, table_name).await?;
         // The CDC record may have fewer columns than the current schema
         // (e.g. records captured before ALTER TABLE ADD COLUMN).
         // Only reference columns present in the record.
@@ -396,7 +413,7 @@ impl DatabaseReplayGenerator {
             String::new()
         };
         let quoted_table_name = quote_ident(table_name);
-        if !self.opts.use_implicit_rowid {
+        if !self.opts.use_implicit_rowid || !pk_column_indices.is_empty() {
             let col_list = record_columns
                 .iter()
                 .map(|name| quote_ident(name))
@@ -409,7 +426,8 @@ impl DatabaseReplayGenerator {
             return Ok(ReplayInfo {
                 change_type: DatabaseChangeType::Insert,
                 query,
-                pk_column_indices: None,
+                pk_column_indices: (!pk_column_indices.is_empty()).then_some(pk_column_indices),
+                rowid_alias_pk_column_index,
                 column_names: record_columns.to_vec(),
                 is_ddl_replay: false,
             });
@@ -437,6 +455,7 @@ impl DatabaseReplayGenerator {
             query,
             column_names: original_column_names,
             pk_column_indices: None,
+            rowid_alias_pk_column_index: None,
             is_ddl_replay: false,
         })
     }
@@ -445,14 +464,15 @@ impl DatabaseReplayGenerator {
         coro: &Coro<Ctx>,
         table_name: &str,
     ) -> Result<ReplayInfo> {
-        let (column_names, pk_column_indices) = self.table_columns_info(coro, table_name).await?;
+        let (column_names, pk_column_indices, rowid_alias_pk_column_index) =
+            self.table_columns_info(coro, table_name).await?;
         let mut pk_predicates = Vec::with_capacity(1);
         for &idx in &pk_column_indices {
             pk_predicates.push(format!("{} = ?", quote_ident(&column_names[idx])));
         }
         let use_implicit_rowid = self.opts.use_implicit_rowid;
         let quoted_table_name = quote_ident(table_name);
-        if pk_column_indices.is_empty() || use_implicit_rowid {
+        if pk_column_indices.is_empty() {
             let query = format!("DELETE FROM {quoted_table_name} WHERE rowid = ?");
             tracing::trace!("delete_query: table_name={table_name}, query={query}, use_implicit_rowid={use_implicit_rowid}");
             return Ok(ReplayInfo {
@@ -460,6 +480,7 @@ impl DatabaseReplayGenerator {
                 query,
                 column_names,
                 pk_column_indices: None,
+                rowid_alias_pk_column_index: None,
                 is_ddl_replay: false,
             });
         }
@@ -472,6 +493,7 @@ impl DatabaseReplayGenerator {
             query,
             column_names,
             pk_column_indices: Some(pk_column_indices),
+            rowid_alias_pk_column_index,
             is_ddl_replay: false,
         })
     }
@@ -495,7 +517,7 @@ impl DatabaseReplayGenerator {
             } => {
                 *if_not_exists = true;
                 let table_name = tbl_name.name.as_str();
-                let (current_columns, _) = self.table_columns_info(coro, table_name).await?;
+                let (current_columns, _, _) = self.table_columns_info(coro, table_name).await?;
                 if current_columns.is_empty() {
                     self.execute_ddl(ddl)?;
                     return Ok(());
@@ -557,7 +579,7 @@ impl DatabaseReplayGenerator {
             return Ok(());
         };
         let table_name = tbl_name.name.as_str();
-        let (current_columns, _) = self.table_columns_info(coro, table_name).await?;
+        let (current_columns, _, _) = self.table_columns_info(coro, table_name).await?;
         let col_name = col_def.col_name.as_str();
         if current_columns.iter().any(|c| c == col_name) {
             tracing::debug!(
@@ -593,13 +615,14 @@ impl DatabaseReplayGenerator {
         &self,
         coro: &Coro<Ctx>,
         table_name: &str,
-    ) -> Result<(Vec<String>, Vec<usize>)> {
+    ) -> Result<(Vec<String>, Vec<usize>, Option<usize>)> {
         let table_name_literal = sql_string_literal(table_name);
         let mut table_info_stmt = self.conn.prepare(format!(
-            "SELECT cid, name, pk FROM pragma_table_info({table_name_literal})"
+            "SELECT cid, name, type, pk FROM pragma_table_info({table_name_literal})"
         ))?;
         let mut pk_column_indices = Vec::with_capacity(1);
         let mut column_names = Vec::new();
+        let mut column_types = Vec::new();
         while let Some(column) = run_stmt_once(coro, &mut table_info_stmt).await? {
             let turso_core::Value::Numeric(turso_core::Numeric::Integer(column_id)) =
                 column.get_value(0)
@@ -613,7 +636,12 @@ impl DatabaseReplayGenerator {
                     "unexpected column type for pragma_table_info query".to_string(),
                 ));
             };
-            let turso_core::Value::Numeric(turso_core::Numeric::Integer(pk)) = column.get_value(2)
+            let turso_core::Value::Text(column_type) = column.get_value(2) else {
+                return Err(Error::DatabaseTapeError(
+                    "unexpected column type for pragma_table_info query".to_string(),
+                ));
+            };
+            let turso_core::Value::Numeric(turso_core::Numeric::Integer(pk)) = column.get_value(3)
             else {
                 return Err(Error::DatabaseTapeError(
                     "unexpected column type for pragma_table_info query".to_string(),
@@ -623,7 +651,17 @@ impl DatabaseReplayGenerator {
                 pk_column_indices.push(*column_id as usize);
             }
             column_names.push(name.as_str().to_string());
+            column_types.push(column_type.as_str().to_string());
         }
-        Ok((column_names, pk_column_indices))
+        let rowid_alias_pk_column_index = if pk_column_indices.len() == 1 {
+            let pk = pk_column_indices[0];
+            column_types
+                .get(pk)
+                .is_some_and(|column_type| column_type.eq_ignore_ascii_case("INTEGER"))
+                .then_some(pk)
+        } else {
+            None
+        };
+        Ok((column_names, pk_column_indices, rowid_alias_pk_column_index))
     }
 }

--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -27,6 +27,15 @@ pub struct ReplayInfo {
 }
 
 const SQLITE_SCHEMA_TABLE: &str = "sqlite_schema";
+
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
 impl DatabaseReplayGenerator {
     pub fn new(conn: Arc<turso_core::Connection>, opts: DatabaseReplaySessionOpts) -> Self {
         Self { conn, opts }
@@ -223,43 +232,9 @@ impl DatabaseReplayGenerator {
                             after.last()
                         )));
                     };
-                    let mut parser = Parser::new(sql.as_str().as_bytes());
-                    let mut ast = parser
-                        .next()
-                        .ok_or_else(|| {
-                            Error::DatabaseTapeError(format!(
-                                "unexpected DDL query: {}",
-                                sql.as_str()
-                            ))
-                        })?
-                        .map_err(|e| {
-                            Error::DatabaseTapeError(format!(
-                                "unexpected DDL query {}: {}",
-                                e,
-                                sql.as_str()
-                            ))
-                        })?;
-                    let turso_parser::ast::Cmd::Stmt(stmt) = &mut ast else {
-                        return Err(Error::DatabaseTapeError(format!(
-                            "unexpected DDL query: {}",
-                            sql.as_str()
-                        )));
-                    };
-                    match stmt {
-                        turso_parser::ast::Stmt::CreateTable { if_not_exists, .. }
-                        | turso_parser::ast::Stmt::CreateIndex { if_not_exists, .. }
-                        | turso_parser::ast::Stmt::CreateTrigger { if_not_exists, .. }
-                        | turso_parser::ast::Stmt::CreateMaterializedView {
-                            if_not_exists, ..
-                        }
-                        | turso_parser::ast::Stmt::CreateView { if_not_exists, .. } => {
-                            *if_not_exists = true
-                        }
-                        _ => {}
-                    }
                     let insert = ReplayInfo {
                         change_type: DatabaseChangeType::Insert,
-                        query: ast.to_string(),
+                        query: sql.as_str().to_string(),
                         pk_column_indices: None,
                         column_names: Vec::new(),
                         is_ddl_replay: true,
@@ -346,18 +321,19 @@ impl DatabaseReplayGenerator {
                     idx, record_columns.len(), table_name
                 )));
             }
-            pk_predicates.push(format!("{} = ?", record_columns[idx]));
+            pk_predicates.push(format!("{} = ?", quote_ident(&record_columns[idx])));
         }
         for (idx, name) in record_columns.iter().enumerate() {
             if columns[idx] {
-                column_updates.push(format!("{name} = ?"));
+                column_updates.push(format!("{} = ?", quote_ident(name)));
             }
         }
+        let quoted_table_name = quote_ident(table_name);
         let (query, pk_column_indices) =
             if self.opts.use_implicit_rowid || pk_column_indices.is_empty() {
                 (
                     format!(
-                        "UPDATE {table_name} SET {} WHERE rowid = ?",
+                        "UPDATE {quoted_table_name} SET {} WHERE rowid = ?",
                         column_updates.join(", ")
                     ),
                     None,
@@ -365,7 +341,7 @@ impl DatabaseReplayGenerator {
             } else {
                 (
                     format!(
-                        "UPDATE {table_name} SET {} WHERE {}",
+                        "UPDATE {quoted_table_name} SET {} WHERE {}",
                         column_updates.join(", "),
                         pk_predicates.join(" AND ")
                     ),
@@ -404,10 +380,11 @@ impl DatabaseReplayGenerator {
                         idx, record_columns.len(), table_name
                     )));
                 }
-                pk_column_names.push(record_columns[idx].clone());
+                pk_column_names.push(quote_ident(&record_columns[idx]));
             }
             let mut update_clauses = Vec::new();
             for name in record_columns {
+                let name = quote_ident(name);
                 update_clauses.push(format!("{name} = excluded.{name}"));
             }
             format!(
@@ -418,11 +395,16 @@ impl DatabaseReplayGenerator {
         } else {
             String::new()
         };
+        let quoted_table_name = quote_ident(table_name);
         if !self.opts.use_implicit_rowid {
-            let col_list = record_columns.join(", ");
+            let col_list = record_columns
+                .iter()
+                .map(|name| quote_ident(name))
+                .collect::<Vec<_>>()
+                .join(", ");
             let placeholders = ["?"].repeat(columns).join(",");
             let query = format!(
-                "INSERT INTO {table_name}({col_list}) VALUES ({placeholders}){conflict_clause}"
+                "INSERT INTO {quoted_table_name}({col_list}) VALUES ({placeholders}){conflict_clause}"
             );
             return Ok(ReplayInfo {
                 change_type: DatabaseChangeType::Insert,
@@ -437,8 +419,19 @@ impl DatabaseReplayGenerator {
         insert_columns.push("rowid".to_string());
 
         let placeholders = ["?"].repeat(columns + 1).join(",");
-        let col_list = insert_columns.join(", ");
-        let query = format!("INSERT INTO {table_name}({col_list}) VALUES ({placeholders})");
+        let col_list = insert_columns
+            .iter()
+            .map(|name| quote_ident(name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let insert_kind = if conflict_clause.is_empty() {
+            "INSERT OR REPLACE"
+        } else {
+            "INSERT"
+        };
+        let query = format!(
+            "{insert_kind} INTO {quoted_table_name}({col_list}) VALUES ({placeholders}){conflict_clause}"
+        );
         Ok(ReplayInfo {
             change_type: DatabaseChangeType::Insert,
             query,
@@ -455,11 +448,12 @@ impl DatabaseReplayGenerator {
         let (column_names, pk_column_indices) = self.table_columns_info(coro, table_name).await?;
         let mut pk_predicates = Vec::with_capacity(1);
         for &idx in &pk_column_indices {
-            pk_predicates.push(format!("{} = ?", column_names[idx]));
+            pk_predicates.push(format!("{} = ?", quote_ident(&column_names[idx])));
         }
         let use_implicit_rowid = self.opts.use_implicit_rowid;
+        let quoted_table_name = quote_ident(table_name);
         if pk_column_indices.is_empty() || use_implicit_rowid {
-            let query = format!("DELETE FROM {table_name} WHERE rowid = ?");
+            let query = format!("DELETE FROM {quoted_table_name} WHERE rowid = ?");
             tracing::trace!("delete_query: table_name={table_name}, query={query}, use_implicit_rowid={use_implicit_rowid}");
             return Ok(ReplayInfo {
                 change_type: DatabaseChangeType::Delete,
@@ -470,7 +464,7 @@ impl DatabaseReplayGenerator {
             });
         }
         let pk_predicates = pk_predicates.join(" AND ");
-        let query = format!("DELETE FROM {table_name} WHERE {pk_predicates}");
+        let query = format!("DELETE FROM {quoted_table_name} WHERE {pk_predicates}");
 
         tracing::trace!("delete_query: table_name={table_name}, query={query}, use_implicit_rowid={use_implicit_rowid}");
         Ok(ReplayInfo {
@@ -482,17 +476,82 @@ impl DatabaseReplayGenerator {
         })
     }
 
-    /// Execute a DDL statement idempotently: for CREATE TABLE statements,
-    /// check which columns already exist and only ALTER TABLE ADD COLUMN
-    /// for missing ones. Falls back to direct execution for non-CREATE TABLE DDL.
+    /// Execute a DDL statement idempotently: CREATE TABLE is replayed with
+    /// `IF NOT EXISTS`, named schema objects are skipped when already present,
+    /// and `ALTER TABLE ADD COLUMN` only adds missing columns. Falls back to
+    /// direct execution for other DDL.
     pub async fn execute_ddl_idempotent<Ctx>(&self, coro: &Coro<Ctx>, ddl: &str) -> Result<()> {
         let mut parser = Parser::new(ddl.as_bytes());
-        let Some(Ok(turso_parser::ast::Cmd::Stmt(turso_parser::ast::Stmt::AlterTable(
-            turso_parser::ast::AlterTable {
-                name: tbl_name,
-                body: turso_parser::ast::AlterTableBody::AddColumn(col_def),
-            },
-        )))) = parser.next()
+        let Some(Ok(turso_parser::ast::Cmd::Stmt(mut stmt))) = parser.next() else {
+            self.execute_ddl(ddl)?;
+            return Ok(());
+        };
+        match &mut stmt {
+            turso_parser::ast::Stmt::CreateTable {
+                if_not_exists,
+                tbl_name,
+                body,
+                ..
+            } => {
+                *if_not_exists = true;
+                let table_name = tbl_name.name.as_str();
+                let (current_columns, _) = self.table_columns_info(coro, table_name).await?;
+                if current_columns.is_empty() {
+                    self.execute_ddl(ddl)?;
+                    return Ok(());
+                }
+                if let turso_parser::ast::CreateTableBody::ColumnsAndConstraints {
+                    columns, ..
+                } = body
+                {
+                    for column in columns {
+                        let col_name = column.col_name.as_str();
+                        if current_columns.iter().any(|c| c == col_name) {
+                            continue;
+                        }
+                        let add_column = format!("ALTER TABLE {tbl_name} ADD COLUMN {column}");
+                        self.execute_ddl(&add_column)?;
+                    }
+                }
+                return Ok(());
+            }
+            turso_parser::ast::Stmt::CreateIndex { idx_name, .. } => {
+                if self
+                    .schema_object_exists(coro, "index", idx_name.name.as_str())
+                    .await?
+                {
+                    return Ok(());
+                }
+                self.execute_ddl(ddl)?;
+                return Ok(());
+            }
+            turso_parser::ast::Stmt::CreateTrigger { trigger_name, .. } => {
+                if self
+                    .schema_object_exists(coro, "trigger", trigger_name.name.as_str())
+                    .await?
+                {
+                    return Ok(());
+                }
+                self.execute_ddl(ddl)?;
+                return Ok(());
+            }
+            turso_parser::ast::Stmt::CreateMaterializedView { view_name, .. }
+            | turso_parser::ast::Stmt::CreateView { view_name, .. } => {
+                if self
+                    .schema_object_exists(coro, "view", view_name.name.as_str())
+                    .await?
+                {
+                    return Ok(());
+                }
+                self.execute_ddl(ddl)?;
+                return Ok(());
+            }
+            _ => {}
+        }
+        let turso_parser::ast::Stmt::AlterTable(turso_parser::ast::AlterTable {
+            name: tbl_name,
+            body: turso_parser::ast::AlterTableBody::AddColumn(col_def),
+        }) = stmt
         else {
             self.conn.execute(ddl)?;
             return Ok(());
@@ -506,8 +565,28 @@ impl DatabaseReplayGenerator {
             );
             return Ok(());
         }
-        self.conn.execute(ddl)?;
+        self.execute_ddl(ddl)?;
         Ok(())
+    }
+
+    fn execute_ddl(&self, ddl: &str) -> Result<()> {
+        self.conn.execute(ddl).map_err(|error| {
+            Error::DatabaseTapeError(format!("failed to execute DDL `{ddl}`: {error}"))
+        })
+    }
+
+    async fn schema_object_exists<Ctx>(
+        &self,
+        coro: &Coro<Ctx>,
+        object_type: &str,
+        name: &str,
+    ) -> Result<bool> {
+        let object_type = sql_string_literal(object_type);
+        let name = sql_string_literal(name);
+        let query =
+            format!("SELECT 1 FROM sqlite_schema WHERE type = {object_type} AND name = {name}");
+        let mut stmt = self.conn.prepare(query)?;
+        Ok(run_stmt_once(coro, &mut stmt).await?.is_some())
     }
 
     async fn table_columns_info<Ctx>(
@@ -515,8 +594,9 @@ impl DatabaseReplayGenerator {
         coro: &Coro<Ctx>,
         table_name: &str,
     ) -> Result<(Vec<String>, Vec<usize>)> {
+        let table_name_literal = sql_string_literal(table_name);
         let mut table_info_stmt = self.conn.prepare(format!(
-            "SELECT cid, name, pk FROM pragma_table_info('{table_name}')"
+            "SELECT cid, name, pk FROM pragma_table_info({table_name_literal})"
         ))?;
         let mut pk_column_indices = Vec::with_capacity(1);
         let mut column_names = Vec::new();

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -4146,7 +4146,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             if replace_base_pages || raw_page_replay_on_sql_conn {
                 publish_schema_after_raw_wal_replay(&main_conn, "raw WAL replay")?;
             }
-            if replace_base_pages || had_cdc_table && raw_page_replay_on_sql_conn {
+            if replace_base_pages || had_cdc_table && stream_kind_applies_remote_pages(stream_kind)
+            {
                 tracing::info!(
                     "apply_changes(path={}): reinitialize CDC pragma after WAL replay commit",
                     self.main_db_path,

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
@@ -100,14 +100,13 @@ mod tests {
     use super::{
         create_main_db_log_path, create_main_db_wal_path, create_meta_path,
         create_replace_base_marker_path, create_revert_db_wal_path,
-        ensure_stream_kind_can_use_legacy_page_apply, filter_pushed_self_changes_touched_by_remote,
-        logical_mvcc_pull_disable_reason, replace_base_backup_path,
-        resolve_local_replay_floor_change_id, should_replay_raw_pages_on_sql_conn,
-        should_request_logical_pull, should_use_logical_mvcc_pull,
-        stream_kind_applies_remote_pages, stream_kind_for_pull_updates_v1_result,
-        synced_change_id_after_remote_apply, use_pushed_change_hint_for_local_replay,
-        DatabaseSyncEngine, DatabaseSyncEngineOpts, ReplaceBaseApplyGuard,
-        REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
+        ensure_stream_kind_can_use_legacy_page_apply, logical_mvcc_pull_disable_reason,
+        replace_base_backup_path, resolve_local_replay_floor_change_id,
+        should_replay_raw_pages_on_sql_conn, should_request_logical_pull,
+        should_use_logical_mvcc_pull, stream_kind_applies_remote_pages,
+        stream_kind_for_pull_updates_v1_result, synced_change_id_after_remote_apply,
+        use_pushed_change_hint_for_local_replay, DatabaseSyncEngine, DatabaseSyncEngineOpts,
+        ReplaceBaseApplyGuard, REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
     };
     use crate::{
         client_proto::{
@@ -127,16 +126,14 @@ mod tests {
         },
         types::{
             Coro, DatabaseMetadata, DatabasePullRevision, DatabaseSavedConfiguration,
-            DatabaseSyncEngineProtocolVersion, DatabaseTapeRowChange, DatabaseTapeRowChangeType,
-            DbChangesStatus, DbChangesStreamKind, PartialSyncOpts, SyncEngineIoResult,
-            DATABASE_METADATA_VERSION,
+            DatabaseSyncEngineProtocolVersion, DbChangesStatus, DbChangesStreamKind,
+            PartialSyncOpts, SyncEngineIoResult, DATABASE_METADATA_VERSION,
         },
         Result,
     };
     use bytes::Bytes;
     use prost::Message;
     use std::{
-        collections::BTreeSet,
         sync::{Arc, Mutex},
         time::Duration,
     };
@@ -315,24 +312,12 @@ mod tests {
     }
 
     #[test]
-    fn logical_replay_does_not_use_last_pushed_hint_when_sync_row_is_stale() {
-        let floor = resolve_local_replay_floor_change_id(false, true, 7, 7, Some(12), 7, 34, 12);
-        assert_eq!(floor, Some(12));
-    }
-
-    #[test]
-    fn logical_replay_uses_pre_push_floor_when_remote_sync_row_matches_last_push() {
-        let floor = resolve_local_replay_floor_change_id(false, true, 7, 7, Some(34), 7, 34, 12);
-        assert_eq!(floor, Some(12));
-    }
-
-    #[test]
     fn v1_page_replay_uses_remote_snapshot_sync_row_not_later_push_hint() {
         assert!(!use_pushed_change_hint_for_local_replay(
             DbChangesStreamKind::Pages,
             false
         ));
-        let floor = resolve_local_replay_floor_change_id(false, false, 7, 7, Some(12), 7, 34, 12);
+        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), 7, 34);
         assert_eq!(floor, Some(12));
     }
 
@@ -342,75 +327,19 @@ mod tests {
             DbChangesStreamKind::LegacyPages,
             false
         ));
-        let floor = resolve_local_replay_floor_change_id(true, false, 7, 7, Some(12), 7, 34, 12);
+        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), 7, 34);
         assert_eq!(floor, Some(34));
     }
 
     #[test]
     fn local_replay_ignores_last_pushed_hint_from_stale_pull_generation() {
-        let floor = resolve_local_replay_floor_change_id(true, false, 7, 7, Some(12), 6, 34, 12);
+        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), 6, 34);
         assert_eq!(floor, Some(12));
     }
 
     #[test]
-    fn logical_replay_skips_pushed_self_rows_touched_by_remote() {
-        let local_changes = vec![
-            DatabaseTapeRowChange {
-                change_id: 13,
-                change_time: 1,
-                table_name: "items".to_string(),
-                id: 1,
-                change: DatabaseTapeRowChangeType::Update {
-                    before: vec![turso_core::Value::build_text("old")],
-                    after: vec![turso_core::Value::build_text("pushed")],
-                    updates: None,
-                },
-            },
-            DatabaseTapeRowChange {
-                change_id: 14,
-                change_time: 1,
-                table_name: "items".to_string(),
-                id: 2,
-                change: DatabaseTapeRowChangeType::Update {
-                    before: vec![turso_core::Value::build_text("old")],
-                    after: vec![turso_core::Value::build_text("untouched")],
-                    updates: None,
-                },
-            },
-            DatabaseTapeRowChange {
-                change_id: 35,
-                change_time: 1,
-                table_name: "items".to_string(),
-                id: 1,
-                change: DatabaseTapeRowChangeType::Update {
-                    before: vec![turso_core::Value::build_text("pushed")],
-                    after: vec![turso_core::Value::build_text("unpushed")],
-                    updates: None,
-                },
-            },
-        ];
-        let remote_touched_rows = BTreeSet::from([("items".to_string(), 1)]);
-
-        let (filtered, skipped) = filter_pushed_self_changes_touched_by_remote(
-            local_changes,
-            true,
-            34,
-            &remote_touched_rows,
-        );
-
-        assert_eq!(skipped, 1);
-        assert_eq!(
-            filtered
-                .iter()
-                .map(|change| change.change_id)
-                .collect::<Vec<_>>(),
-            vec![14, 35]
-        );
-    }
-
-    #[test]
     fn raw_wal_replay_preserves_existing_floor_when_hints_are_disabled() {
-        let floor = resolve_local_replay_floor_change_id(false, false, 7, 7, Some(12), 7, 34, 12);
+        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), 7, 34);
         assert_eq!(floor, Some(12));
     }
 
@@ -1724,6 +1653,42 @@ fn remove_file_if_present(io: &Arc<dyn turso_core::IO>, path: &str) -> Result<()
     Ok(())
 }
 
+/// Fsync the directory that contains `path`, making newly created or removed
+/// directory entries (the replace-base marker and backups) durable across a
+/// crash. Fsyncing a file's contents does not guarantee its *directory entry*
+/// survives a crash, so the guard's crash-safety ordering (marker/backups
+/// created before the apply mutates real files; marker removed before backups
+/// during cleanup) is only meaningful once the containing directory is synced.
+///
+/// The replace-base guard requires real durable storage (memory paths are
+/// rejected in [`ReplaceBaseApplyGuard::create`]), so a direct `std::fs`
+/// directory fsync is appropriate here even though normal file IO flows through
+/// [`turso_core::IO`], which has no directory concept. On platforms without
+/// POSIX directory-fsync semantics this is a no-op.
+fn sync_parent_dir(path: &str) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let parent = std::path::Path::new(path)
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let dir = std::fs::File::open(&parent).map_err(|err| {
+            Error::DatabaseSyncEngineError(format!(
+                "failed to open directory {parent:?} for fsync: {err}"
+            ))
+        })?;
+        dir.sync_all().map_err(|err| {
+            Error::DatabaseSyncEngineError(format!("failed to fsync directory {parent:?}: {err}"))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
 async fn copy_sync_engine_file<Ctx, IO: SyncEngineIo>(
     coro: &Coro<Ctx>,
     io: Arc<dyn turso_core::IO>,
@@ -1815,6 +1780,12 @@ impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
         )
         .await?;
         sync_path_if_present(coro, &io, &marker_path).await?;
+        // Barrier: the marker and all backups (contents already fsynced above and
+        // in `copy_sync_engine_file`) must have durable *directory entries* before
+        // the caller begins mutating the real db/wal/log/meta files. Otherwise a
+        // crash mid-apply could leave the real files partially replaced with no
+        // recoverable marker to roll them back.
+        sync_parent_dir(main_db_path)?;
         Ok(Self {
             io,
             sync_engine_io,
@@ -1890,13 +1861,21 @@ impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
     }
 
     async fn cleanup<Ctx>(&self, coro: &Coro<Ctx>) -> Result<()> {
-        for file in &self.manifest.files {
-            remove_file_if_present(&self.io, &file.backup_path)?;
-        }
+        // Remove the marker BEFORE the backups. The marker is the sole signal
+        // that "backups are authoritative and must be restored on recovery", so
+        // its removal must be made durable before any backup disappears.
+        // Removing backups first would let a crash in this window leave a marker
+        // pointing at missing backups, which fails `restore` on the next open and
+        // bricks the database. Once the marker is durably gone, leftover backups
+        // are merely orphaned files (harmless, overwritten by the next apply).
         remove_file_if_present(
             &self.io,
             &create_replace_base_marker_path(&self.main_db_path),
         )?;
+        sync_parent_dir(&self.main_db_path)?;
+        for file in &self.manifest.files {
+            remove_file_if_present(&self.io, &file.backup_path)?;
+        }
         sync_path_if_present(coro, &self.io, &self.main_db_path).await?;
         Ok(())
     }
@@ -2197,31 +2176,19 @@ fn should_replay_raw_pages_on_sql_conn(
         )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn resolve_local_replay_floor_change_id(
     use_pushed_change_hint: bool,
-    use_pushed_replay_floor_hint: bool,
     local_pull_gen: i64,
     remote_pull_gen: i64,
     remote_last_change_id: Option<i64>,
     last_pushed_pull_gen_hint: i64,
     last_pushed_change_id_hint: i64,
-    last_pushed_replay_floor_change_id_hint: i64,
 ) -> Option<i64> {
     let mut last_change_id = if remote_pull_gen == local_pull_gen {
         remote_last_change_id
     } else {
         Some(0)
     };
-
-    if use_pushed_replay_floor_hint
-        && last_pushed_pull_gen_hint == local_pull_gen
-        && last_pushed_change_id_hint > 0
-        && last_change_id == Some(last_pushed_change_id_hint)
-        && last_pushed_replay_floor_change_id_hint < last_pushed_change_id_hint
-    {
-        last_change_id = Some(last_pushed_replay_floor_change_id_hint);
-    }
 
     if use_pushed_change_hint
         && last_pushed_pull_gen_hint == local_pull_gen
@@ -2252,38 +2219,6 @@ fn use_pushed_change_hint_for_local_replay(
     raw_page_replay_on_sql_conn: bool,
 ) -> bool {
     !raw_page_replay_on_sql_conn && matches!(stream_kind, DbChangesStreamKind::LegacyPages)
-}
-
-fn use_pushed_replay_floor_hint_for_local_replay(stream_kind: DbChangesStreamKind) -> bool {
-    matches!(stream_kind, DbChangesStreamKind::Logical)
-}
-
-fn filter_pushed_self_changes_touched_by_remote(
-    local_changes: Vec<DatabaseTapeRowChange>,
-    replaying_pushed_self_range: bool,
-    last_pushed_change_id_hint: i64,
-    remote_logical_touched_rows: &BTreeSet<(String, i64)>,
-) -> (Vec<DatabaseTapeRowChange>, usize) {
-    if !replaying_pushed_self_range || remote_logical_touched_rows.is_empty() {
-        return (local_changes, 0);
-    }
-
-    let mut skipped = 0usize;
-    let local_changes = local_changes
-        .into_iter()
-        .filter(|change| {
-            let already_pushed_self_change = change.change_id <= last_pushed_change_id_hint;
-            let touched_by_remote =
-                remote_logical_touched_rows.contains(&(change.table_name.clone(), change.id));
-            if already_pushed_self_change && touched_by_remote {
-                skipped += 1;
-                false
-            } else {
-                true
-            }
-        })
-        .collect::<Vec<_>>();
-    (local_changes, skipped)
 }
 
 impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
@@ -3182,43 +3117,31 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 	                remote_apply_stats.touched_rows.len()
 	            );
 
-            let (
-                last_pushed_pull_gen_hint,
-                last_pushed_change_id_hint,
-                last_pushed_replay_floor_change_id_hint,
-            ) = {
+            let (last_pushed_pull_gen_hint, last_pushed_change_id_hint) = {
                 let meta = self.meta();
                 (
                     meta.last_pushed_pull_gen_hint,
                     meta.last_pushed_change_id_hint,
-                    meta.last_pushed_replay_floor_change_id_hint,
                 )
             };
+            // Raise the replay floor to the pushed change-id hint so already-pushed
+            // local changes are excluded from replay. A subsequent remote update to
+            // a row this replica pushed (e.g. sync-fuzzer phase 3 push then phase 4
+            // remote update of the same rows) then wins, instead of being clobbered
+            // by re-replaying the stale pushed value.
             let last_change_id = resolve_local_replay_floor_change_id(
                 true,
-                false,
                 local_pull_gen,
                 local_pull_gen,
                 local_last_change_id,
                 last_pushed_pull_gen_hint,
                 last_pushed_change_id_hint,
-                last_pushed_replay_floor_change_id_hint,
             );
             let replay_floor = last_change_id.unwrap_or(0);
             let local_changes = precollected_local_changes
                 .into_iter()
                 .filter(|change| change.change_id > replay_floor)
                 .collect::<Vec<_>>();
-            let replaying_pushed_self_range = last_pushed_change_id_hint > 0
-                && last_pushed_replay_floor_change_id_hint < last_pushed_change_id_hint
-                && replay_floor == last_pushed_replay_floor_change_id_hint;
-            let (local_changes, skipped_pushed_self_changes_touched_by_remote) =
-                filter_pushed_self_changes_touched_by_remote(
-                    local_changes,
-                    replaying_pushed_self_range,
-                    last_pushed_change_id_hint,
-                    &remote_apply_stats.touched_rows,
-                );
             let mut skipped_internal_local_changes = 0usize;
             let local_changes = local_changes
                 .into_iter()
@@ -3233,10 +3156,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 .collect::<Result<Vec<_>>>()?;
             let replayed_local_changes = !local_changes.is_empty();
             tracing::info!(
-                "apply_logical_mvcc_changes(path={}): logical local replay floor={replay_floor}; local_changes={} skipped_pushed_self_changes_touched_by_remote={} skipped_internal_local_changes={}",
+                "apply_logical_mvcc_changes(path={}): logical local replay floor={replay_floor}; local_changes={} skipped_internal_local_changes={}",
                 self.main_db_path,
                 local_changes.len(),
-                skipped_pushed_self_changes_touched_by_remote,
                 skipped_internal_local_changes,
             );
 
@@ -3413,16 +3335,11 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             local_last_change_id,
             replace_base_pages,
         );
-        let (
-            last_pushed_pull_gen_hint,
-            last_pushed_change_id_hint,
-            last_pushed_replay_floor_change_id_hint,
-        ) = {
+        let (last_pushed_pull_gen_hint, last_pushed_change_id_hint) = {
             let meta = self.meta();
             (
                 meta.last_pushed_pull_gen_hint,
                 meta.last_pushed_change_id_hint,
-                meta.last_pushed_replay_floor_change_id_hint,
             )
         };
 
@@ -3445,13 +3362,11 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             } else {
                 resolve_local_replay_floor_change_id(
                     true,
-                    false,
                     local_pull_gen,
                     local_pull_gen,
                     local_last_change_id,
                     last_pushed_pull_gen_hint,
                     last_pushed_change_id_hint,
-                    last_pushed_replay_floor_change_id_hint,
                 )
             }
         } else {
@@ -3553,7 +3468,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
             // Phase 2: after revert DB has no local changes in its latest state - so its safe to apply changes from remote
             let mut logical_replay_conn = None;
-            let mut remote_logical_touched_rows = BTreeSet::new();
             let applied_raw_db_size: u32;
             let mut revert_since_wal_watermark = None;
             let mut followup_revision = None;
@@ -3740,21 +3654,19 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                                                 },
                                             },
                                         };
-                                        let replay_stats =
-                                            apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats(
-                                                coro,
-                                                &mut replay,
-                                                changes_file,
-                                                &self.client_unique_id,
-                                                &mut logical_table_names_by_stable_id,
-                                            )
-                                            .await
-                                            .map_err(|error| {
-                                                Error::DatabaseSyncEngineError(format!(
-                                                    "failed to apply replace-base follow-up logical transactions: {error}",
-                                                ))
-                                            })?;
-                                        remote_logical_touched_rows = replay_stats.touched_rows;
+                                        apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats(
+                                            coro,
+                                            &mut replay,
+                                            changes_file,
+                                            &self.client_unique_id,
+                                            &mut logical_table_names_by_stable_id,
+                                        )
+                                        .await
+                                        .map_err(|error| {
+                                            Error::DatabaseSyncEngineError(format!(
+                                                "failed to apply replace-base follow-up logical transactions: {error}",
+                                            ))
+                                        })?;
                                     }
                                 }
                                 (_, PullUpdatesV1Result::Pages { replace_base }) => {
@@ -3835,8 +3747,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             }
             let use_pushed_change_hint =
                 use_pushed_change_hint_for_local_replay(stream_kind, raw_page_replay_on_sql_conn);
-            let use_pushed_replay_floor_hint =
-                use_pushed_replay_floor_hint_for_local_replay(stream_kind);
 
             // Phase 4: as now DB has all data from remote - let's read pull generation and last change id for current client
             let (remote_pull_gen, remote_last_change_id) = if replace_base_pages {
@@ -3871,25 +3781,21 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             }
             let last_change_id = resolve_local_replay_floor_change_id(
                 use_pushed_change_hint,
-                use_pushed_replay_floor_hint,
                 local_pull_gen,
                 remote_pull_gen,
                 remote_last_change_id,
                 last_pushed_pull_gen_hint,
                 last_pushed_change_id_hint,
-                last_pushed_replay_floor_change_id_hint,
             );
             tracing::info!(
-                "apply_changes(path={}): local replay floor: use_pushed_change_hint={} use_pushed_replay_floor_hint={} local_pull_gen={} remote_pull_gen={} remote_last_change_id={:?} last_pushed_pull_gen_hint={} last_pushed_change_id_hint={} last_pushed_replay_floor_change_id_hint={} resolved_last_change_id={:?}",
+                "apply_changes(path={}): local replay floor: use_pushed_change_hint={} local_pull_gen={} remote_pull_gen={} remote_last_change_id={:?} last_pushed_pull_gen_hint={} last_pushed_change_id_hint={} resolved_last_change_id={:?}",
                 self.main_db_path,
                 use_pushed_change_hint,
-                use_pushed_replay_floor_hint,
                 local_pull_gen,
                 remote_pull_gen,
                 remote_last_change_id,
                 last_pushed_pull_gen_hint,
                 last_pushed_change_id_hint,
-                last_pushed_replay_floor_change_id_hint,
                 last_change_id,
             );
 
@@ -3921,17 +3827,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 }
                 local_changes
             };
-            let replaying_pushed_self_range = use_pushed_replay_floor_hint
-                && last_pushed_change_id_hint > 0
-                && last_pushed_replay_floor_change_id_hint < last_pushed_change_id_hint
-                && replay_floor == last_pushed_replay_floor_change_id_hint;
-            let (local_changes, skipped_pushed_self_changes_touched_by_remote) =
-                filter_pushed_self_changes_touched_by_remote(
-                    local_changes,
-                    replaying_pushed_self_range,
-                    last_pushed_change_id_hint,
-                    &remote_logical_touched_rows,
-                );
             let mut skipped_internal_local_changes = 0usize;
             let local_changes = local_changes
                 .into_iter()
@@ -3945,19 +3840,12 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 })
                 .collect::<Result<Vec<_>>>()?;
             let replayed_local_changes = !local_changes.is_empty();
-            let delay_cdc_for_pushed_self_replay = logical_replay_conn.is_some()
-                && replaying_pushed_self_range
-                && had_cdc_table;
-            let mut recaptured_local_changes = replayed_local_changes;
-            if delay_cdc_for_pushed_self_replay {
-                recaptured_local_changes = false;
-            }
+            let recaptured_local_changes = replayed_local_changes;
             let mut preserve_local_replay_floor = None;
             tracing::info!(
-                "apply_changes(path={}): collected {} changes, skipped_pushed_self_changes_touched_by_remote={} skipped_internal_local_changes={}",
+                "apply_changes(path={}): collected {} changes, skipped_internal_local_changes={}",
                 self.main_db_path,
                 local_changes.len(),
-                skipped_pushed_self_changes_touched_by_remote,
                 skipped_internal_local_changes,
             );
             let post_remote_apply_change_id = if replace_base_pages || raw_page_replay_on_sql_conn {
@@ -3998,7 +3886,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 }
 
                 let mut cdc_enabled_for_local_replay = false;
-                if replayed_local_changes && had_cdc_table && !delay_cdc_for_pushed_self_replay {
+                if replayed_local_changes && had_cdc_table {
                     tracing::info!(
                         "apply_changes(path={}): reinitialize CDC pragma before local replay",
                         self.main_db_path,
@@ -4059,10 +3947,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
                 assert!(!replay.conn().get_auto_commit());
                 for (i, change) in local_changes.into_iter().enumerate() {
-                    let should_recapture_change = !delay_cdc_for_pushed_self_replay
-                        || change.change_id > last_pushed_change_id_hint;
-                    let preserve_original_change_floor = should_recapture_change
-                        && matches!(&change.change, DatabaseTapeRowChangeType::Delete { .. });
+                    let preserve_original_change_floor =
+                        matches!(&change.change, DatabaseTapeRowChangeType::Delete { .. });
                     let original_change_floor = change.change_id.saturating_sub(1);
                     let operation = if should_transform_local_change(&change) {
                         if let Some(transformed) = &mut transformed {
@@ -4086,7 +3972,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     } else {
                         DatabaseTapeOperation::RowChange(change)
                     };
-                    if should_recapture_change && had_cdc_table && !cdc_enabled_for_local_replay {
+                    if had_cdc_table && !cdc_enabled_for_local_replay {
                         tracing::info!(
                             "apply_changes(path={}): reinitialize CDC pragma before unpushed local replay",
                             self.main_db_path,
@@ -4099,9 +3985,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                                 ))
                             })?;
                         cdc_enabled_for_local_replay = true;
-                    }
-                    if should_recapture_change {
-                        recaptured_local_changes = true;
                     }
                     if preserve_original_change_floor {
                         preserve_local_replay_floor = Some(

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -105,8 +105,9 @@ mod tests {
         resolve_local_replay_floor_change_id, should_replay_raw_pages_on_sql_conn,
         should_request_logical_pull, should_use_logical_mvcc_pull,
         stream_kind_applies_remote_pages, stream_kind_for_pull_updates_v1_result,
-        synced_change_id_after_remote_apply, DatabaseSyncEngine, DatabaseSyncEngineOpts,
-        ReplaceBaseApplyGuard, REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
+        synced_change_id_after_remote_apply, use_pushed_change_hint_for_local_replay,
+        DatabaseSyncEngine, DatabaseSyncEngineOpts, ReplaceBaseApplyGuard,
+        REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
     };
     use crate::{
         client_proto::{
@@ -312,7 +313,21 @@ mod tests {
     }
 
     #[test]
-    fn page_replay_uses_last_pushed_hint_when_requested_and_sync_row_is_stale() {
+    fn v1_page_replay_uses_remote_snapshot_sync_row_not_later_push_hint() {
+        assert!(!use_pushed_change_hint_for_local_replay(
+            DbChangesStreamKind::Pages,
+            false
+        ));
+        let floor = resolve_local_replay_floor_change_id(false, false, 7, 7, Some(12), 7, 34, 12);
+        assert_eq!(floor, Some(12));
+    }
+
+    #[test]
+    fn legacy_page_replay_can_use_last_pushed_hint_when_sync_row_is_stale() {
+        assert!(use_pushed_change_hint_for_local_replay(
+            DbChangesStreamKind::LegacyPages,
+            false
+        ));
         let floor = resolve_local_replay_floor_change_id(true, false, 7, 7, Some(12), 7, 34, 12);
         assert_eq!(floor, Some(34));
     }
@@ -2189,8 +2204,11 @@ fn synced_change_id_after_remote_apply(
     }
 }
 
-fn use_pushed_change_hint_for_local_replay(stream_kind: DbChangesStreamKind) -> bool {
-    !matches!(stream_kind, DbChangesStreamKind::Logical)
+fn use_pushed_change_hint_for_local_replay(
+    stream_kind: DbChangesStreamKind,
+    raw_page_replay_on_sql_conn: bool,
+) -> bool {
+    !raw_page_replay_on_sql_conn && matches!(stream_kind, DbChangesStreamKind::LegacyPages)
 }
 
 fn use_pushed_replay_floor_hint_for_local_replay(stream_kind: DbChangesStreamKind) -> bool {
@@ -3764,7 +3782,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     );
                 }
             }
-            let use_pushed_change_hint = use_pushed_change_hint_for_local_replay(stream_kind);
+            let use_pushed_change_hint =
+                use_pushed_change_hint_for_local_replay(stream_kind, raw_page_replay_on_sql_conn);
             let use_pushed_replay_floor_hint =
                 use_pushed_replay_floor_hint_for_local_replay(stream_kind);
 

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -1,23 +1,26 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
     },
 };
 
-use turso_core::{Buffer, Completion, DatabaseStorage, OpenDbAsyncState, OpenFlags};
+use turso_core::{Buffer, Completion, DatabaseStorage, LimboError, OpenDbAsyncState, OpenFlags};
 
 use crate::{
     database_replay_generator::DatabaseReplayGenerator,
     database_sync_engine_io::SyncEngineIo,
     database_sync_lazy_storage::LazyDatabaseStorage,
     database_sync_operations::{
-        acquire_slot, apply_transformation, bootstrap_db_file, connect_untracked,
-        count_local_changes, has_table, push_logical_changes, read_last_change_id, read_wal_salt,
-        reset_wal_file, sync_file, update_last_change_id, wait_all_results, wal_apply_from_file,
-        wal_pull_to_file, SyncEngineIoStats, SyncOperationCtx, PAGE_SIZE, WAL_FRAME_HEADER,
-        WAL_FRAME_SIZE,
+        acquire_slot,
+        apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats,
+        apply_transformation, bootstrap_db_file, connect_untracked, count_local_changes, has_table,
+        is_logically_replayable_table, max_local_change_id, pull_updates_v1, push_logical_changes,
+        read_last_change_id, read_logical_replay_table_map, read_wal_salt, reset_wal_file,
+        should_replay_local_change, sync_file, update_last_change_id, wait_all_results,
+        wal_apply_from_file, wal_pull_to_file, PullUpdatesV1Result, SyncEngineIoStats,
+        SyncOperationCtx, PAGE_SIZE, WAL_FRAME_HEADER, WAL_FRAME_SIZE,
     },
     database_tape::{
         try_wal_watermark_read_page, DatabaseChangesIteratorMode, DatabaseChangesIteratorOpts,
@@ -29,8 +32,8 @@ use crate::{
     types::{
         Coro, DatabaseMetadata, DatabasePullRevision, DatabaseRowTransformResult,
         DatabaseSavedConfiguration, DatabaseSyncEngineProtocolVersion, DatabaseTapeOperation,
-        DbChangesStatus, PartialSyncOpts, SyncEngineIoResult, SyncEngineStats,
-        DATABASE_METADATA_VERSION,
+        DatabaseTapeRowChange, DatabaseTapeRowChangeType, DbChangesStatus, DbChangesStreamKind,
+        PartialSyncOpts, SyncEngineIoResult, SyncEngineStats, DATABASE_METADATA_VERSION,
     },
     wal_session::WalSession,
     Result,
@@ -75,6 +78,10 @@ pub struct DatabaseSyncEngineOpts {
     /// `Query` bootstrap strategy** — the server picks the page set, so the
     /// client can't chunk it locally.
     pub pull_bytes_threshold: Option<usize>,
+    /// Opt into raw MVCC logical-log pull-updates streams when the server and
+    /// local configuration can support them. Call sites should keep this
+    /// `false` until logical apply is wired end to end.
+    pub logical_mvcc_pull: bool,
 }
 
 pub struct DataStats {
@@ -85,6 +92,1369 @@ pub struct DataStats {
 impl Default for DataStats {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        create_main_db_log_path, create_main_db_wal_path, create_meta_path,
+        create_replace_base_marker_path, create_revert_db_wal_path,
+        ensure_stream_kind_can_use_legacy_page_apply, filter_pushed_self_changes_touched_by_remote,
+        logical_mvcc_pull_disable_reason, replace_base_backup_path,
+        resolve_local_replay_floor_change_id, should_replay_raw_pages_on_sql_conn,
+        should_request_logical_pull, should_use_logical_mvcc_pull,
+        stream_kind_applies_remote_pages, stream_kind_for_pull_updates_v1_result,
+        synced_change_id_after_remote_apply, DatabaseSyncEngine, DatabaseSyncEngineOpts,
+        ReplaceBaseApplyGuard, REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
+    };
+    use crate::{
+        client_proto::{
+            LogicalOp, LogicalOpType, LogicalSchemaAction, LogicalSchemaKind, LogicalTxnData,
+        },
+        database_sync_engine_io::{DataCompletion, DataPollResult, SyncEngineIo},
+        database_sync_operations::{
+            count_local_changes, max_local_change_id, read_last_change_id, update_last_change_id,
+            MutexSlot, PullUpdatesV1Result, SyncEngineIoStats,
+        },
+        database_tape::{run_stmt_once, DatabaseTape, DatabaseTapeOpts},
+        errors::Error,
+        io_operations::IoOperations,
+        server_proto::{
+            PullUpdatesApplyMode, PullUpdatesReqProtoBody, PullUpdatesRespProtoBody,
+            PullUpdatesStreamKind,
+        },
+        types::{
+            Coro, DatabaseMetadata, DatabasePullRevision, DatabaseSavedConfiguration,
+            DatabaseSyncEngineProtocolVersion, DatabaseTapeRowChange, DatabaseTapeRowChangeType,
+            DbChangesStatus, DbChangesStreamKind, PartialSyncOpts, SyncEngineIoResult,
+            DATABASE_METADATA_VERSION,
+        },
+        Result,
+    };
+    use bytes::Bytes;
+    use prost::Message;
+    use std::{
+        collections::BTreeSet,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn logical_mvcc_pull_disabled_by_config_falls_back_to_page_pull() {
+        assert_eq!(
+            logical_mvcc_pull_disable_reason(false, false, None),
+            Some("logical MVCC pull is disabled by configuration")
+        );
+        assert!(!should_use_logical_mvcc_pull(false, false, None));
+    }
+
+    #[test]
+    fn logical_mvcc_pull_with_partial_sync_falls_back_to_page_pull() {
+        assert_eq!(
+            logical_mvcc_pull_disable_reason(true, true, None),
+            Some("partial sync is active")
+        );
+        assert!(!should_use_logical_mvcc_pull(true, true, None));
+    }
+
+    #[test]
+    fn logical_mvcc_pull_with_remote_encryption_falls_back_to_page_pull() {
+        assert_eq!(
+            logical_mvcc_pull_disable_reason(true, false, Some("key")),
+            Some("remote encryption is enabled; MVCC logical sync is unsupported for encrypted remotes")
+        );
+        assert!(!should_use_logical_mvcc_pull(true, false, Some("key")));
+    }
+
+    #[test]
+    fn logical_mvcc_pull_remains_enabled_for_plain_full_sync() {
+        assert_eq!(logical_mvcc_pull_disable_reason(true, false, None), None);
+        assert!(should_use_logical_mvcc_pull(true, false, None));
+    }
+
+    #[test]
+    fn logical_pull_is_requested_only_for_active_v1_revisions() {
+        assert!(!should_request_logical_pull(false, &None));
+        assert!(!should_request_logical_pull(true, &None));
+        assert!(!should_request_logical_pull(
+            true,
+            &Some(DatabasePullRevision::Legacy {
+                generation: 1,
+                synced_frame_no: Some(10),
+            })
+        ));
+        assert!(should_request_logical_pull(
+            true,
+            &Some(DatabasePullRevision::V1 {
+                revision: "g1:o42".to_string(),
+            })
+        ));
+    }
+
+    #[test]
+    fn legacy_page_apply_rejects_non_page_streams() {
+        assert!(
+            ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::LegacyPages).is_ok()
+        );
+        assert!(ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::Pages).is_ok());
+        let logical_err =
+            ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::Logical).unwrap_err();
+        assert!(
+            logical_err.to_string().contains("logical MVCC apply"),
+            "unexpected error: {logical_err:?}"
+        );
+        let replace_base_err =
+            ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::ReplaceBasePages)
+                .unwrap_err();
+        assert!(
+            replace_base_err
+                .to_string()
+                .contains("replace-base page apply"),
+            "unexpected error: {replace_base_err:?}"
+        );
+    }
+
+    #[test]
+    fn logical_pull_page_fallback_preserves_replace_base_kind() {
+        assert_eq!(
+            stream_kind_for_pull_updates_v1_result(&PullUpdatesV1Result::Pages {
+                replace_base: false
+            }),
+            DbChangesStreamKind::Pages
+        );
+        assert_eq!(
+            stream_kind_for_pull_updates_v1_result(&PullUpdatesV1Result::Pages {
+                replace_base: true
+            }),
+            DbChangesStreamKind::ReplaceBasePages
+        );
+        assert_eq!(
+            stream_kind_for_pull_updates_v1_result(&PullUpdatesV1Result::Logical {
+                txns: 1,
+                ops: 2
+            }),
+            DbChangesStreamKind::Logical
+        );
+    }
+
+    #[test]
+    fn replace_base_pages_use_remote_page_transport() {
+        assert!(stream_kind_applies_remote_pages(
+            DbChangesStreamKind::LegacyPages
+        ));
+        assert!(stream_kind_applies_remote_pages(DbChangesStreamKind::Pages));
+        assert!(stream_kind_applies_remote_pages(
+            DbChangesStreamKind::ReplaceBasePages
+        ));
+        assert!(!stream_kind_applies_remote_pages(
+            DbChangesStreamKind::Logical
+        ));
+    }
+
+    #[test]
+    fn sql_replay_page_routing_keeps_legacy_on_wal_session() {
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::Legacy,
+            false,
+            DbChangesStreamKind::LegacyPages,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::Legacy,
+            false,
+            DbChangesStreamKind::ReplaceBasePages,
+        ));
+        assert!(should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            false,
+            DbChangesStreamKind::Pages,
+        ));
+        assert!(should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            false,
+            DbChangesStreamKind::ReplaceBasePages,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            true,
+            DbChangesStreamKind::ReplaceBasePages,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            false,
+            DbChangesStreamKind::Logical,
+        ));
+    }
+
+    #[test]
+    fn logical_replay_does_not_use_last_pushed_hint_when_sync_row_is_stale() {
+        let floor = resolve_local_replay_floor_change_id(false, true, 7, 7, Some(12), 7, 34, 12);
+        assert_eq!(floor, Some(12));
+    }
+
+    #[test]
+    fn logical_replay_uses_pre_push_floor_when_remote_sync_row_matches_last_push() {
+        let floor = resolve_local_replay_floor_change_id(false, true, 7, 7, Some(34), 7, 34, 12);
+        assert_eq!(floor, Some(12));
+    }
+
+    #[test]
+    fn page_replay_uses_last_pushed_hint_when_requested_and_sync_row_is_stale() {
+        let floor = resolve_local_replay_floor_change_id(true, false, 7, 7, Some(12), 7, 34, 12);
+        assert_eq!(floor, Some(34));
+    }
+
+    #[test]
+    fn local_replay_ignores_last_pushed_hint_from_stale_pull_generation() {
+        let floor = resolve_local_replay_floor_change_id(true, false, 7, 7, Some(12), 6, 34, 12);
+        assert_eq!(floor, Some(12));
+    }
+
+    #[test]
+    fn logical_replay_skips_pushed_self_rows_touched_by_remote() {
+        let local_changes = vec![
+            DatabaseTapeRowChange {
+                change_id: 13,
+                change_time: 1,
+                table_name: "items".to_string(),
+                id: 1,
+                change: DatabaseTapeRowChangeType::Update {
+                    before: vec![turso_core::Value::build_text("old")],
+                    after: vec![turso_core::Value::build_text("pushed")],
+                    updates: None,
+                },
+            },
+            DatabaseTapeRowChange {
+                change_id: 14,
+                change_time: 1,
+                table_name: "items".to_string(),
+                id: 2,
+                change: DatabaseTapeRowChangeType::Update {
+                    before: vec![turso_core::Value::build_text("old")],
+                    after: vec![turso_core::Value::build_text("untouched")],
+                    updates: None,
+                },
+            },
+            DatabaseTapeRowChange {
+                change_id: 35,
+                change_time: 1,
+                table_name: "items".to_string(),
+                id: 1,
+                change: DatabaseTapeRowChangeType::Update {
+                    before: vec![turso_core::Value::build_text("pushed")],
+                    after: vec![turso_core::Value::build_text("unpushed")],
+                    updates: None,
+                },
+            },
+        ];
+        let remote_touched_rows = BTreeSet::from([("items".to_string(), 1)]);
+
+        let (filtered, skipped) = filter_pushed_self_changes_touched_by_remote(
+            local_changes,
+            true,
+            34,
+            &remote_touched_rows,
+        );
+
+        assert_eq!(skipped, 1);
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|change| change.change_id)
+                .collect::<Vec<_>>(),
+            vec![14, 35]
+        );
+    }
+
+    #[test]
+    fn raw_wal_replay_preserves_existing_floor_when_hints_are_disabled() {
+        let floor = resolve_local_replay_floor_change_id(false, false, 7, 7, Some(12), 7, 34, 12);
+        assert_eq!(floor, Some(12));
+    }
+
+    #[test]
+    fn remote_apply_acknowledges_pre_apply_cdc_when_local_changes_are_recaptured() {
+        assert_eq!(
+            synced_change_id_after_remote_apply(false, Some(12), 40),
+            40,
+            "without local replay, all CDC generated by remote apply is acknowledged"
+        );
+        assert_eq!(
+            synced_change_id_after_remote_apply(true, Some(12), 40),
+            12,
+            "with local replay, preserve the replay floor so local rows remain pushable"
+        );
+        assert_eq!(
+            synced_change_id_after_remote_apply(true, None, 40),
+            0,
+            "a database with no pre-existing CDC still starts from zero"
+        );
+    }
+
+    struct EmptyPollResult<T>(Vec<T>);
+
+    impl<T: Send + Sync + 'static> DataPollResult<T> for EmptyPollResult<T> {
+        fn data(&self) -> &[T] {
+            &self.0
+        }
+    }
+
+    struct EmptyCompletion<T> {
+        data: Mutex<Option<Vec<T>>>,
+    }
+
+    impl<T> EmptyCompletion<T> {
+        fn empty() -> Self {
+            Self {
+                data: Mutex::new(Some(Vec::new())),
+            }
+        }
+
+        fn with_data(data: Vec<T>) -> Self {
+            Self {
+                data: Mutex::new(Some(data)),
+            }
+        }
+    }
+
+    impl<T: Send + Sync + 'static> DataCompletion<T> for EmptyCompletion<T> {
+        type DataPollResult = EmptyPollResult<T>;
+
+        fn status(&self) -> Result<Option<u16>> {
+            Ok(Some(200))
+        }
+
+        fn poll_data(&self) -> Result<Option<Self::DataPollResult>> {
+            let data = self.data.lock().unwrap().take().unwrap_or_default();
+            if data.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(EmptyPollResult(data)))
+            }
+        }
+
+        fn is_done(&self) -> Result<bool> {
+            Ok(self.data.lock().unwrap().as_ref().is_none_or(Vec::is_empty))
+        }
+    }
+
+    #[derive(Default)]
+    struct NoopSyncEngineIo;
+
+    impl SyncEngineIo for NoopSyncEngineIo {
+        type DataCompletionBytes = EmptyCompletion<u8>;
+        type DataCompletionTransform = EmptyCompletion<crate::types::DatabaseRowTransformResult>;
+
+        fn full_read(&self, path: &str) -> Result<Self::DataCompletionBytes> {
+            let data = match std::fs::read(path) {
+                Ok(data) => data,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+                Err(error) => {
+                    return Err(crate::errors::Error::DatabaseSyncEngineError(format!(
+                        "test full_read failed for {path}: {error}"
+                    )));
+                }
+            };
+            Ok(EmptyCompletion::with_data(data))
+        }
+
+        fn full_write(&self, path: &str, content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
+            std::fs::write(path, content).map_err(|error| {
+                crate::errors::Error::DatabaseSyncEngineError(format!(
+                    "test full_write failed for {path}: {error}"
+                ))
+            })?;
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn transform(
+            &self,
+            _mutations: Vec<crate::types::DatabaseRowMutation>,
+        ) -> Result<Self::DataCompletionTransform> {
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn http(
+            &self,
+            _url: Option<&str>,
+            _method: &str,
+            _path: &str,
+            _body: Option<Vec<u8>>,
+            _headers: &[(&str, &str)],
+        ) -> Result<Self::DataCompletionBytes> {
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
+
+        fn step_io_callbacks(&self) {}
+    }
+
+    struct CapturingSyncEngineIo {
+        response: Mutex<Option<Vec<u8>>>,
+        request: Mutex<Option<(String, String, Option<Vec<u8>>)>>,
+    }
+
+    impl SyncEngineIo for CapturingSyncEngineIo {
+        type DataCompletionBytes = EmptyCompletion<u8>;
+        type DataCompletionTransform = EmptyCompletion<crate::types::DatabaseRowTransformResult>;
+
+        fn full_read(&self, path: &str) -> Result<Self::DataCompletionBytes> {
+            let data = std::fs::read(path).unwrap_or_default();
+            Ok(EmptyCompletion::with_data(data))
+        }
+
+        fn full_write(&self, path: &str, content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
+            std::fs::write(path, content).map_err(|error| {
+                crate::errors::Error::DatabaseSyncEngineError(format!(
+                    "test full_write failed for {path}: {error}"
+                ))
+            })?;
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn transform(
+            &self,
+            _mutations: Vec<crate::types::DatabaseRowMutation>,
+        ) -> Result<Self::DataCompletionTransform> {
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn http(
+            &self,
+            _url: Option<&str>,
+            method: &str,
+            path: &str,
+            body: Option<Vec<u8>>,
+            _headers: &[(&str, &str)],
+        ) -> Result<Self::DataCompletionBytes> {
+            self.request
+                .lock()
+                .unwrap()
+                .replace((method.to_string(), path.to_string(), body));
+            let response = self.response.lock().unwrap().take().unwrap_or_default();
+            Ok(EmptyCompletion::with_data(response))
+        }
+
+        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
+
+        fn step_io_callbacks(&self) {}
+    }
+
+    fn record(values: &[turso_core::Value]) -> Bytes {
+        Bytes::from(
+            turso_core::types::ImmutableRecord::from_values(values, values.len())
+                .unwrap()
+                .into_payload(),
+        )
+    }
+
+    fn encoded_logical_txns(txns: &[LogicalTxnData]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for txn in txns {
+            bytes.extend_from_slice(&txn.encode_length_delimited_to_vec());
+        }
+        bytes
+    }
+
+    fn default_test_opts() -> DatabaseSyncEngineOpts {
+        DatabaseSyncEngineOpts {
+            remote_url: None,
+            client_name: "test-client".to_string(),
+            tables_ignore: vec![],
+            use_transform: false,
+            wal_pull_batch_size: 0,
+            long_poll_timeout: Some(Duration::from_millis(1)),
+            protocol_version_hint: DatabaseSyncEngineProtocolVersion::V1,
+            bootstrap_if_empty: false,
+            reserved_bytes: 0,
+            db_opts: turso_core::DatabaseOpts::default(),
+            partial_sync_opts: None::<PartialSyncOpts>,
+            remote_encryption_key: None,
+            push_operations_threshold: None,
+            pull_bytes_threshold: None,
+            logical_mvcc_pull: true,
+        }
+    }
+
+    fn replace_base_guard_test_paths(
+        main_path: &str,
+    ) -> Vec<(&'static str, String, Option<&'static [u8]>)> {
+        vec![
+            ("main-db", main_path.to_string(), Some(b"main-old")),
+            (
+                "main-wal",
+                create_main_db_wal_path(main_path),
+                Some(b"wal-old"),
+            ),
+            (
+                "main-log",
+                create_main_db_log_path(main_path),
+                Some(b"log-old"),
+            ),
+            ("revert-wal", create_revert_db_wal_path(main_path), None),
+            ("metadata", create_meta_path(main_path), Some(b"meta-old")),
+        ]
+    }
+
+    fn write_replace_base_guard_test_files(main_path: &str) {
+        for (_, path, content) in replace_base_guard_test_paths(main_path) {
+            if let Some(content) = content {
+                std::fs::write(path, content).unwrap();
+            }
+        }
+    }
+
+    fn assert_replace_base_backups_removed(main_path: &str) {
+        assert!(std::fs::read(create_replace_base_marker_path(main_path)).is_err());
+        for (name, _, _) in replace_base_guard_test_paths(main_path) {
+            assert!(std::fs::read(replace_base_backup_path(main_path, name)).is_err());
+        }
+    }
+
+    async fn write_replace_base_pages_file<Ctx>(
+        coro: &Coro<Ctx>,
+        io: &Arc<dyn turso_core::IO>,
+        source_db_path: &str,
+        changes_path: &str,
+    ) -> Result<Arc<dyn turso_core::File>> {
+        let pages = std::fs::read(source_db_path).unwrap();
+        assert_eq!(pages.len() % super::PAGE_SIZE, 0);
+        let db_size = (pages.len() / super::PAGE_SIZE) as u32;
+        let changes_file = io.open_file(changes_path, turso_core::OpenFlags::Create, false)?;
+
+        let truncate = changes_file.truncate(0, turso_core::Completion::new_trunc(|_| {}))?;
+        while !truncate.succeeded() {
+            coro.yield_(SyncEngineIoResult::IO).await?;
+        }
+
+        for (page_idx, page) in pages.chunks_exact(super::PAGE_SIZE).enumerate() {
+            let mut frame = vec![0; super::WAL_FRAME_SIZE];
+            frame[super::WAL_FRAME_HEADER..].copy_from_slice(page);
+            let frame_info = turso_core::types::WalFrameInfo {
+                page_no: page_idx as u32 + 1,
+                db_size: if page_idx + 1 == db_size as usize {
+                    db_size
+                } else {
+                    0
+                },
+            };
+            frame_info.put_to_frame_header(&mut frame);
+            let offset = (page_idx * super::WAL_FRAME_SIZE) as u64;
+            let len = frame.len();
+            let write = changes_file.pwrite(
+                offset,
+                Arc::new(turso_core::Buffer::new(frame)),
+                turso_core::Completion::new_write(move |result| {
+                    let Ok(size) = result else {
+                        return;
+                    };
+                    assert_eq!(size as usize, len);
+                }),
+            )?;
+            while !write.succeeded() {
+                coro.yield_(SyncEngineIoResult::IO).await?;
+            }
+        }
+
+        let sync = changes_file.sync(
+            turso_core::Completion::new_sync(|_| {}),
+            turso_core::io::FileSyncType::Fsync,
+        )?;
+        while !sync.succeeded() {
+            coro.yield_(SyncEngineIoResult::IO).await?;
+        }
+        Ok(changes_file)
+    }
+
+    #[test]
+    fn replace_base_guard_restores_original_files_and_removes_created_files() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let main_path = temp_dir
+            .path()
+            .join("guard-restore.db")
+            .to_string_lossy()
+            .to_string();
+        write_replace_base_guard_test_files(&main_path);
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(None),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io);
+        let old_revision = DatabasePullRevision::V1 {
+            revision: "old-revision".to_string(),
+        };
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let guard = ReplaceBaseApplyGuard::create(
+                    &coro,
+                    io.clone(),
+                    sync_stats,
+                    &main_path,
+                    Some(old_revision),
+                )
+                .await?;
+
+                std::fs::write(&main_path, b"main-new").unwrap();
+                std::fs::write(create_main_db_wal_path(&main_path), b"wal-new").unwrap();
+                std::fs::write(create_main_db_log_path(&main_path), b"log-new").unwrap();
+                std::fs::write(create_revert_db_wal_path(&main_path), b"revert-created").unwrap();
+                std::fs::write(create_meta_path(&main_path), b"meta-new").unwrap();
+
+                guard.restore(&coro).await?;
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        assert_eq!(std::fs::read(&main_path).unwrap(), b"main-old");
+        assert_eq!(
+            std::fs::read(create_main_db_wal_path(&main_path)).unwrap(),
+            b"wal-old"
+        );
+        assert_eq!(
+            std::fs::read(create_main_db_log_path(&main_path)).unwrap(),
+            b"log-old"
+        );
+        assert!(std::fs::read(create_revert_db_wal_path(&main_path)).is_err());
+        assert_eq!(
+            std::fs::read(create_meta_path(&main_path)).unwrap(),
+            b"meta-old"
+        );
+        assert_replace_base_backups_removed(&main_path);
+    }
+
+    #[test]
+    fn replace_base_guard_recovers_pending_marker() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let main_path = temp_dir
+            .path()
+            .join("guard-recover.db")
+            .to_string_lossy()
+            .to_string();
+        write_replace_base_guard_test_files(&main_path);
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(None),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io);
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let _guard = ReplaceBaseApplyGuard::create(
+                    &coro,
+                    io.clone(),
+                    sync_stats.clone(),
+                    &main_path,
+                    None,
+                )
+                .await?;
+
+                std::fs::write(&main_path, b"main-new").unwrap();
+                std::fs::write(create_meta_path(&main_path), b"meta-new").unwrap();
+
+                let recovered = ReplaceBaseApplyGuard::recover_pending(
+                    &coro,
+                    io.clone(),
+                    sync_stats,
+                    &main_path,
+                )
+                .await?;
+                assert!(recovered);
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        assert_eq!(std::fs::read(&main_path).unwrap(), b"main-old");
+        assert_eq!(
+            std::fs::read(create_meta_path(&main_path)).unwrap(),
+            b"meta-old"
+        );
+        assert_replace_base_backups_removed(&main_path);
+    }
+
+    #[test]
+    fn replace_base_guard_mark_complete_removes_marker_without_restoring() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let main_path = temp_dir
+            .path()
+            .join("guard-complete.db")
+            .to_string_lossy()
+            .to_string();
+        write_replace_base_guard_test_files(&main_path);
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(None),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io);
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let mut guard =
+                    ReplaceBaseApplyGuard::create(&coro, io.clone(), sync_stats, &main_path, None)
+                        .await?;
+                std::fs::write(&main_path, b"main-new").unwrap();
+                guard.mark_complete(&coro).await?;
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        assert_eq!(std::fs::read(&main_path).unwrap(), b"main-new");
+        assert_replace_base_backups_removed(&main_path);
+    }
+
+    #[test]
+    fn initial_logical_mvcc_pull_page_bootstrap_uses_replace_base_apply() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let main_path = temp_file.path().to_str().unwrap().to_string();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let main_db = turso_core::Database::open_file(io.clone(), &main_path).unwrap();
+
+        let meta = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "initial-client".to_string(),
+            synced_revision: None,
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            logical_mvcc_pull_active: true,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: Some("https://example.com".to_string()),
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        std::fs::write(create_meta_path(&main_path), meta.dump().unwrap()).unwrap();
+
+        let header = PullUpdatesRespProtoBody {
+            server_revision: "g1:o10".to_string(),
+            db_size: 0,
+            raw_encoding: None,
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+        };
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(Some(header.encode_length_delimited_to_vec())),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io.clone());
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.logical_mvcc_pull = true;
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_db = main_db.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine =
+                    DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
+                let status = engine.wait_changes_from_remote(&coro).await?;
+                assert!(status.file_slot.is_none());
+                assert!(matches!(
+                    status.stream_kind,
+                    DbChangesStreamKind::ReplaceBasePages
+                ));
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        let (_method, path, body) = sync_io.request.lock().unwrap().clone().unwrap();
+        assert_eq!(path, "/pull-updates");
+        let request = PullUpdatesReqProtoBody::decode(body.unwrap().as_slice()).unwrap();
+        assert_eq!(request.stream_kind, PullUpdatesStreamKind::Pages as i32);
+        assert_eq!(request.client_revision, "");
+        assert_eq!(request.server_revision, "");
+    }
+
+    #[test]
+    fn apply_changes_from_remote_applies_logical_stream_without_local_replay() {
+        let db_temp = NamedTempFile::new().unwrap();
+        let meta_temp = NamedTempFile::new().unwrap();
+        let changes_temp = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+
+        let txns = vec![
+            LogicalTxnData {
+                end_offset: 1,
+                commit_ts: 1,
+                origin_client_id: "remote".to_string(),
+                ops: vec![LogicalOp {
+                    op_type: LogicalOpType::Schema as i32,
+                    table_name: String::new(),
+                    rowid: 0,
+                    record: Bytes::new(),
+                    sql: "CREATE TABLE items(x TEXT)".to_string(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: Some(LogicalSchemaAction::Create as i32),
+                    schema_kind: Some(LogicalSchemaKind::Table as i32),
+                    schema_name: "items".to_string(),
+                    stable_table_id: 7,
+                }],
+            },
+            LogicalTxnData {
+                end_offset: 2,
+                commit_ts: 2,
+                origin_client_id: "remote".to_string(),
+                ops: vec![LogicalOp {
+                    op_type: LogicalOpType::UpsertRow as i32,
+                    table_name: String::new(),
+                    rowid: 2,
+                    record: record(&[turso_core::Value::Text(turso_core::types::Text::new(
+                        "remote".to_string(),
+                    ))]),
+                    sql: String::new(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: None,
+                    schema_kind: None,
+                    schema_name: String::new(),
+                    stable_table_id: 7,
+                }],
+            },
+        ];
+        std::fs::write(changes_temp.path(), encoded_logical_txns(&txns)).unwrap();
+
+        let db =
+            turso_core::Database::open_file(io.clone(), db_temp.path().to_str().unwrap()).unwrap();
+        let db_file = db.db_file.clone();
+        let db_io = db.io.clone();
+        let main_tape = DatabaseTape::new_with_opts(
+            db,
+            DatabaseTapeOpts {
+                cdc_table: None,
+                cdc_mode: Some("full".to_string()),
+                disable_auto_checkpoint: true,
+            },
+        );
+        let sync_io = Arc::new(NoopSyncEngineIo);
+        let sync_engine_io = SyncEngineIoStats::new(sync_io);
+        let changes_file = io
+            .open_file(
+                changes_temp.path().to_str().unwrap(),
+                turso_core::OpenFlags::None,
+                false,
+            )
+            .unwrap();
+        let slot = Arc::new(Mutex::new(None));
+        let meta = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "client-a".to_string(),
+            synced_revision: Some(DatabasePullRevision::V1 {
+                revision: "g1:o1".to_string(),
+            }),
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            logical_mvcc_pull_active: true,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: None,
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        let engine = DatabaseSyncEngine {
+            io: db_io,
+            sync_engine_io,
+            db_file,
+            main_tape,
+            main_db_path: db_temp.path().to_str().unwrap().to_string(),
+            main_db_wal_path: super::create_main_db_wal_path(db_temp.path().to_str().unwrap()),
+            revert_db_wal_path: super::create_revert_db_wal_path(db_temp.path().to_str().unwrap()),
+            meta_path: meta_temp.path().to_str().unwrap().to_string(),
+            changes_file: Arc::new(Mutex::new(None)),
+            opts: default_test_opts(),
+            meta: Mutex::new(meta),
+            client_unique_id: "client-a".to_string(),
+        };
+        let remote_changes = DbChangesStatus {
+            time: io.current_time_wall_clock(),
+            revision: DatabasePullRevision::V1 {
+                revision: "g1:o2".to_string(),
+            },
+            file_slot: Some(crate::database_sync_operations::MutexSlot {
+                value: changes_file,
+                slot,
+            }),
+            stream_kind: DbChangesStreamKind::Logical,
+        };
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let engine = engine;
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                engine
+                    .apply_changes_from_remote(&coro, remote_changes)
+                    .await
+                    .unwrap();
+                let conn = engine.main_tape.connect(&coro).await.unwrap();
+                let mut stmt = conn.prepare("SELECT rowid, x FROM items").unwrap();
+                let mut rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                let (pull_gen, change_id) =
+                    read_last_change_id(&coro, &conn, &engine.client_unique_id)
+                        .await
+                        .unwrap();
+                let pending_local_changes = count_local_changes(&coro, &conn, change_id.unwrap())
+                    .await
+                    .unwrap();
+                let meta = engine.meta.lock().unwrap().clone();
+                (rows, meta, pull_gen, change_id, pending_local_changes)
+            }
+        });
+        let (rows, meta, pull_gen, change_id, pending_local_changes) = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+
+        assert_eq!(
+            rows,
+            vec![vec![
+                turso_core::Value::from_i64(2),
+                turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
+            ]]
+        );
+        assert_eq!(
+            meta.synced_revision,
+            Some(DatabasePullRevision::V1 {
+                revision: "g1:o2".to_string(),
+            })
+        );
+        assert_eq!(
+            meta.logical_table_names_by_stable_id.get(&7).unwrap(),
+            "items"
+        );
+        assert_eq!(meta.revert_since_wal_watermark, 0);
+        assert_eq!(pull_gen, 0);
+        assert!(change_id.is_some());
+        assert_eq!(pending_local_changes, 0);
+    }
+
+    #[test]
+    fn apply_changes_from_remote_replays_pending_local_changes() {
+        let db_temp = NamedTempFile::new().unwrap();
+        let meta_temp = NamedTempFile::new().unwrap();
+        let changes_temp = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+
+        let txns = vec![LogicalTxnData {
+            end_offset: 1,
+            commit_ts: 1,
+            origin_client_id: "remote".to_string(),
+            ops: vec![
+                LogicalOp {
+                    op_type: LogicalOpType::Schema as i32,
+                    table_name: String::new(),
+                    rowid: 0,
+                    record: Bytes::new(),
+                    sql: "CREATE TABLE remote_items(id INTEGER PRIMARY KEY, x TEXT)".to_string(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: Some(LogicalSchemaAction::Create as i32),
+                    schema_kind: Some(LogicalSchemaKind::Table as i32),
+                    schema_name: "remote_items".to_string(),
+                    stable_table_id: 9,
+                },
+                LogicalOp {
+                    op_type: LogicalOpType::UpsertRow as i32,
+                    table_name: String::new(),
+                    rowid: 2,
+                    record: record(&[
+                        turso_core::Value::from_i64(2),
+                        turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
+                    ]),
+                    sql: String::new(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: None,
+                    schema_kind: None,
+                    schema_name: String::new(),
+                    stable_table_id: 9,
+                },
+            ],
+        }];
+        std::fs::write(changes_temp.path(), encoded_logical_txns(&txns)).unwrap();
+
+        let db =
+            turso_core::Database::open_file(io.clone(), db_temp.path().to_str().unwrap()).unwrap();
+        let db_file = db.db_file.clone();
+        let db_io = db.io.clone();
+        let main_tape = DatabaseTape::new_with_opts(
+            db,
+            DatabaseTapeOpts {
+                cdc_table: None,
+                cdc_mode: Some("full".to_string()),
+                disable_auto_checkpoint: true,
+            },
+        );
+        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
+        let changes_file = io
+            .open_file(
+                changes_temp.path().to_str().unwrap(),
+                turso_core::OpenFlags::None,
+                false,
+            )
+            .unwrap();
+        let old_revision = DatabasePullRevision::V1 {
+            revision: "g1:o1".to_string(),
+        };
+        let meta = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "client-a".to_string(),
+            synced_revision: Some(old_revision.clone()),
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            logical_mvcc_pull_active: true,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: None,
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        let engine = DatabaseSyncEngine {
+            io: db_io,
+            sync_engine_io,
+            db_file,
+            main_tape,
+            main_db_path: db_temp.path().to_str().unwrap().to_string(),
+            main_db_wal_path: super::create_main_db_wal_path(db_temp.path().to_str().unwrap()),
+            revert_db_wal_path: super::create_revert_db_wal_path(db_temp.path().to_str().unwrap()),
+            meta_path: meta_temp.path().to_str().unwrap().to_string(),
+            changes_file: Arc::new(Mutex::new(None)),
+            opts: default_test_opts(),
+            meta: Mutex::new(meta),
+            client_unique_id: "client-a".to_string(),
+        };
+        let remote_changes = DbChangesStatus {
+            time: io.current_time_wall_clock(),
+            revision: DatabasePullRevision::V1 {
+                revision: "g1:o2".to_string(),
+            },
+            file_slot: Some(crate::database_sync_operations::MutexSlot {
+                value: changes_file,
+                slot: Arc::new(Mutex::new(None)),
+            }),
+            stream_kind: DbChangesStreamKind::Logical,
+        };
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let engine = engine;
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = engine.main_tape.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE local_items(id INTEGER PRIMARY KEY, x TEXT)")
+                    .unwrap();
+                conn.execute("INSERT INTO local_items(id, x) VALUES (1, 'local')")
+                    .unwrap();
+
+                engine
+                    .apply_changes_from_remote(&coro, remote_changes)
+                    .await
+                    .unwrap();
+
+                let mut stmt = conn
+                    .prepare("SELECT id, x FROM remote_items ORDER BY id")
+                    .unwrap();
+                let remote_row = run_stmt_once(&coro, &mut stmt)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .get_values()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                assert!(run_stmt_once(&coro, &mut stmt).await.unwrap().is_none());
+
+                let mut stmt = conn
+                    .prepare("SELECT id, x FROM local_items ORDER BY id")
+                    .unwrap();
+                let local_row = run_stmt_once(&coro, &mut stmt)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .get_values()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                assert!(run_stmt_once(&coro, &mut stmt).await.unwrap().is_none());
+
+                let (_, synced_change_id) =
+                    read_last_change_id(&coro, &conn, &engine.client_unique_id)
+                        .await
+                        .unwrap();
+                let pending_local_changes =
+                    count_local_changes(&coro, &conn, synced_change_id.unwrap())
+                        .await
+                        .unwrap();
+                let meta = engine.meta.lock().unwrap().clone();
+                (remote_row, local_row, pending_local_changes, meta)
+            }
+        });
+        let (remote_row, local_row, pending_local_changes, meta) = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+        assert_eq!(
+            remote_row,
+            vec![
+                turso_core::Value::from_i64(2),
+                turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
+            ]
+        );
+        assert_eq!(
+            local_row,
+            vec![
+                turso_core::Value::from_i64(1),
+                turso_core::Value::Text(turso_core::types::Text::new("local".to_string())),
+            ]
+        );
+        assert!(
+            pending_local_changes > 0,
+            "recaptured local CDC should remain pending for push"
+        );
+        assert_eq!(
+            meta.synced_revision,
+            Some(DatabasePullRevision::V1 {
+                revision: "g1:o2".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn failed_replace_base_local_replay_does_not_advance_synced_revision() {
+        let main_file = NamedTempFile::new().unwrap();
+        let remote_file = NamedTempFile::new().unwrap();
+        let changes_file = NamedTempFile::new().unwrap();
+        let main_path = main_file.path().to_str().unwrap().to_string();
+        let remote_path = remote_file.path().to_str().unwrap().to_string();
+        let changes_path = changes_file.path().to_str().unwrap().to_string();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let remote_db = turso_core::Database::open_file(io.clone(), &remote_path).unwrap();
+        let remote_conn = remote_db.connect().unwrap();
+        remote_conn
+            .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        remote_conn
+            .execute("INSERT INTO items VALUES (1, 'duplicate'), (2, 'duplicate')")
+            .unwrap();
+        remote_conn
+            .checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            })
+            .unwrap();
+
+        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
+        let old_revision = DatabasePullRevision::V1 {
+            revision: "old-revision".to_string(),
+        };
+        let new_revision = DatabasePullRevision::V1 {
+            revision: "new-revision".to_string(),
+        };
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let sync_engine_io = sync_engine_io.clone();
+            let main_path = main_path.clone();
+            let remote_path = remote_path.clone();
+            let changes_path = changes_path.clone();
+            let old_revision = old_revision.clone();
+            let new_revision = new_revision.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine = DatabaseSyncEngine::create_db(
+                    &coro,
+                    io.clone(),
+                    sync_engine_io.clone(),
+                    &main_path,
+                    default_test_opts(),
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
+                })?;
+                engine
+                    .update_meta(&coro, |meta| {
+                        meta.synced_revision = Some(old_revision.clone());
+                        meta.logical_mvcc_pull_active = false;
+                    })
+                    .await
+                    .map_err(|error| {
+                        Error::DatabaseSyncEngineError(format!("test update_meta failed: {error}"))
+                    })?;
+
+                let conn = engine.connect_rw(&coro).await.map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test connect_rw failed: {error}"))
+                })?;
+                conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")?;
+                conn.execute("INSERT INTO items VALUES (1, 'local-only')")?;
+                let base_change_id = max_local_change_id(&coro, &conn).await?.unwrap_or(0);
+                update_last_change_id(&coro, &conn, &engine.client_unique_id, 1, base_change_id)
+                    .await?;
+                conn.execute("CREATE UNIQUE INDEX items_value_unique ON items(value)")?;
+
+                let changes_file =
+                    write_replace_base_pages_file(&coro, &io, &remote_path, &changes_path).await?;
+                let slot = Arc::new(Mutex::new(Some(changes_file)));
+                let file_slot = MutexSlot {
+                    value: slot.lock().unwrap().take().unwrap(),
+                    slot: slot.clone(),
+                };
+
+                REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.set(0));
+                let result = engine
+                    .apply_changes_from_remote(
+                        &coro,
+                        DbChangesStatus {
+                            time: turso_core::WallClockInstant {
+                                secs: 10,
+                                micros: 0,
+                            },
+                            revision: new_revision.clone(),
+                            file_slot: Some(file_slot),
+                            stream_kind: DbChangesStreamKind::ReplaceBasePages,
+                        },
+                    )
+                    .await;
+                REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.set(usize::MAX));
+
+                let err = result.unwrap_err();
+                assert!(
+                    format!("{err:#}").contains("injected replace-base local replay failure"),
+                    "{err:#}"
+                );
+                assert_eq!(engine.meta().synced_revision, Some(old_revision.clone()));
+
+                let on_disk_meta = DatabaseSyncEngine::<NoopSyncEngineIo>::read_db_meta(
+                    &coro,
+                    Some(io.clone()),
+                    sync_engine_io.clone(),
+                    &main_path,
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test read_db_meta failed: {error}"))
+                })?
+                .unwrap();
+                assert_eq!(on_disk_meta.synced_revision, Some(old_revision));
+                assert!(io
+                    .try_open(&create_replace_base_marker_path(&main_path))?
+                    .is_none());
+
+                drop(conn);
+                drop(engine);
+                let verify_db =
+                    turso_core::Database::open_file(io.clone(), &main_path).map_err(|error| {
+                        Error::DatabaseSyncEngineError(format!("test verify open failed: {error}"))
+                    })?;
+                let verify_conn = verify_db.connect().map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test verify connect failed: {error}"))
+                })?;
+                let mut value_stmt = verify_conn
+                    .prepare("SELECT value FROM items WHERE id = 1")
+                    .unwrap();
+                let row = run_stmt_once(&coro, &mut value_stmt).await?.unwrap();
+                assert_eq!(
+                    row.get_values().cloned().collect::<Vec<_>>(),
+                    vec![turso_core::Value::Text(turso_core::types::Text::new(
+                        "local-only"
+                    ))]
+                );
+                assert!(run_stmt_once(&coro, &mut value_stmt).await?.is_none());
+
+                let mut index_stmt = verify_conn
+                    .prepare("SELECT sql FROM sqlite_schema WHERE name = 'items_value_unique'")
+                    .unwrap();
+                let row = run_stmt_once(&coro, &mut index_stmt).await?.unwrap();
+                assert!(row
+                    .get_value(0)
+                    .to_text()
+                    .unwrap()
+                    .contains("CREATE UNIQUE INDEX items_value_unique"));
+                assert!(run_stmt_once(&coro, &mut index_stmt).await?.is_none());
+                Result::Ok(())
+            }
+        });
+
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => {
+                    REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.set(usize::MAX));
+                    result.unwrap();
+                    break;
+                }
+            }
+        }
     }
 }
 
@@ -127,6 +1497,12 @@ fn is_memory(main_db_path: &str) -> bool {
 fn create_main_db_wal_path(main_db_path: &str) -> String {
     format!("{main_db_path}-wal")
 }
+fn create_main_db_log_path(main_db_path: &str) -> String {
+    std::path::Path::new(main_db_path)
+        .with_extension("db-log")
+        .to_string_lossy()
+        .to_string()
+}
 fn create_revert_db_wal_path(main_db_path: &str) -> String {
     format!("{main_db_path}-wal-revert")
 }
@@ -135,6 +1511,62 @@ fn create_meta_path(main_db_path: &str) -> String {
 }
 fn create_changes_path(main_db_path: &str) -> String {
     format!("{main_db_path}-changes")
+}
+fn create_replace_base_marker_path(main_db_path: &str) -> String {
+    format!("{main_db_path}-replace-base-apply")
+}
+fn replace_base_backup_path(main_db_path: &str, name: &str) -> String {
+    format!("{main_db_path}-replace-base-apply-{name}.backup")
+}
+
+#[cfg(test)]
+thread_local! {
+    static REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(usize::MAX) };
+}
+
+#[cfg(test)]
+fn replace_base_local_replay_failure_after() -> usize {
+    REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.get())
+}
+
+fn maybe_inject_replace_base_local_replay_failure(
+    replace_base_pages: bool,
+    replay_index: usize,
+) -> Result<()> {
+    #[cfg(test)]
+    {
+        if replace_base_pages && replay_index == replace_base_local_replay_failure_after() {
+            return Err(Error::DatabaseSyncEngineError(format!(
+                "injected replace-base local replay failure at change {replay_index}"
+            )));
+        }
+    }
+    let _ = (replace_base_pages, replay_index);
+    Ok(())
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct ReplaceBaseBackupFile {
+    path: String,
+    backup_path: String,
+    present: bool,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct ReplaceBaseBackupManifest {
+    version: u32,
+    operation: String,
+    main_db_path: String,
+    previous_synced_revision: Option<DatabasePullRevision>,
+    files: Vec<ReplaceBaseBackupFile>,
+}
+
+struct ReplaceBaseApplyGuard<IO: SyncEngineIo> {
+    io: Arc<dyn turso_core::IO>,
+    sync_engine_io: SyncEngineIoStats<IO>,
+    main_db_path: String,
+    manifest: ReplaceBaseBackupManifest,
 }
 
 /// caller has no access to the memory io - so we handle it here implicitly
@@ -220,6 +1652,552 @@ async fn full_write<Ctx, IO: SyncEngineIo>(
     Ok(())
 }
 
+async fn sync_path_if_present<Ctx>(
+    coro: &Coro<Ctx>,
+    io: &Arc<dyn turso_core::IO>,
+    path: &str,
+) -> Result<()> {
+    let Some(file) = io.try_open(path)? else {
+        return Ok(());
+    };
+    let sync = file.sync(
+        Completion::new_sync(|_| {}),
+        turso_core::io::FileSyncType::Fsync,
+    )?;
+    while !sync.succeeded() {
+        coro.yield_(SyncEngineIoResult::IO).await?;
+    }
+    Ok(())
+}
+
+fn remove_file_if_present(io: &Arc<dyn turso_core::IO>, path: &str) -> Result<()> {
+    if io.try_open(path)?.is_some() {
+        io.remove_file(path)?;
+    }
+    Ok(())
+}
+
+async fn copy_sync_engine_file<Ctx, IO: SyncEngineIo>(
+    coro: &Coro<Ctx>,
+    io: Arc<dyn turso_core::IO>,
+    sync_engine_io: Arc<IO>,
+    source_path: &str,
+    target_path: &str,
+    is_memory: bool,
+) -> Result<bool> {
+    let Some(content) = full_read(
+        coro,
+        Some(io.clone()),
+        sync_engine_io.clone(),
+        source_path,
+        is_memory,
+    )
+    .await?
+    else {
+        remove_file_if_present(&io, target_path)?;
+        return Ok(false);
+    };
+    full_write(
+        coro,
+        io.clone(),
+        sync_engine_io,
+        target_path,
+        is_memory,
+        content,
+    )
+    .await?;
+    sync_path_if_present(coro, &io, target_path).await?;
+    Ok(true)
+}
+
+impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
+    #[allow(dead_code)]
+    async fn create<Ctx>(
+        coro: &Coro<Ctx>,
+        io: Arc<dyn turso_core::IO>,
+        sync_engine_io: SyncEngineIoStats<IO>,
+        main_db_path: &str,
+        previous_synced_revision: Option<DatabasePullRevision>,
+    ) -> Result<Self> {
+        if is_memory(main_db_path) {
+            return Err(Error::DatabaseSyncEngineError(
+                "replace-base local replay preservation requires durable local storage".to_string(),
+            ));
+        }
+        let is_memory = is_memory(main_db_path);
+        let file_specs = [
+            (main_db_path.to_string(), "main-db"),
+            (create_main_db_wal_path(main_db_path), "main-wal"),
+            (create_main_db_log_path(main_db_path), "main-log"),
+            (create_revert_db_wal_path(main_db_path), "revert-wal"),
+            (create_meta_path(main_db_path), "metadata"),
+        ];
+        let mut files = Vec::with_capacity(file_specs.len());
+        for (path, name) in file_specs {
+            let backup_path = replace_base_backup_path(main_db_path, name);
+            let present = copy_sync_engine_file(
+                coro,
+                io.clone(),
+                sync_engine_io.io.clone(),
+                &path,
+                &backup_path,
+                is_memory,
+            )
+            .await?;
+            files.push(ReplaceBaseBackupFile {
+                path,
+                backup_path,
+                present,
+            });
+        }
+        let manifest = ReplaceBaseBackupManifest {
+            version: 1,
+            operation: "replace_base_apply".to_string(),
+            main_db_path: main_db_path.to_string(),
+            previous_synced_revision,
+            files,
+        };
+        let marker_path = create_replace_base_marker_path(main_db_path);
+        full_write(
+            coro,
+            io.clone(),
+            sync_engine_io.io.clone(),
+            &marker_path,
+            is_memory,
+            serde_json::to_vec(&manifest)?,
+        )
+        .await?;
+        sync_path_if_present(coro, &io, &marker_path).await?;
+        Ok(Self {
+            io,
+            sync_engine_io,
+            main_db_path: main_db_path.to_string(),
+            manifest,
+        })
+    }
+
+    async fn recover_pending<Ctx>(
+        coro: &Coro<Ctx>,
+        io: Arc<dyn turso_core::IO>,
+        sync_engine_io: SyncEngineIoStats<IO>,
+        main_db_path: &str,
+    ) -> Result<bool> {
+        let marker_path = create_replace_base_marker_path(main_db_path);
+        let is_memory = is_memory(main_db_path);
+        let Some(marker) = full_read(
+            coro,
+            Some(io.clone()),
+            sync_engine_io.io.clone(),
+            &marker_path,
+            is_memory,
+        )
+        .await?
+        else {
+            return Ok(false);
+        };
+        let manifest: ReplaceBaseBackupManifest =
+            serde_json::from_slice(&marker).map_err(|err| {
+                Error::DatabaseSyncEngineError(format!(
+                    "failed to parse pending replace-base recovery marker {marker_path}: {err}"
+                ))
+            })?;
+        tracing::warn!(
+            "recover_pending_replace_base(path={}): restoring local files from pending marker",
+            main_db_path
+        );
+        Self {
+            io,
+            sync_engine_io,
+            main_db_path: main_db_path.to_string(),
+            manifest,
+        }
+        .restore(coro)
+        .await?;
+        Ok(true)
+    }
+
+    async fn restore<Ctx>(&self, coro: &Coro<Ctx>) -> Result<()> {
+        let is_memory = is_memory(&self.main_db_path);
+        for file in &self.manifest.files {
+            if file.present {
+                let restored = copy_sync_engine_file(
+                    coro,
+                    self.io.clone(),
+                    self.sync_engine_io.io.clone(),
+                    &file.backup_path,
+                    &file.path,
+                    is_memory,
+                )
+                .await?;
+                if !restored {
+                    return Err(Error::DatabaseSyncEngineError(format!(
+                        "replace-base recovery backup is missing: {}",
+                        file.backup_path
+                    )));
+                }
+            } else {
+                remove_file_if_present(&self.io, &file.path)?;
+            }
+        }
+        self.cleanup(coro).await
+    }
+
+    async fn cleanup<Ctx>(&self, coro: &Coro<Ctx>) -> Result<()> {
+        for file in &self.manifest.files {
+            remove_file_if_present(&self.io, &file.backup_path)?;
+        }
+        remove_file_if_present(
+            &self.io,
+            &create_replace_base_marker_path(&self.main_db_path),
+        )?;
+        sync_path_if_present(coro, &self.io, &self.main_db_path).await?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    async fn mark_complete<Ctx>(&mut self, coro: &Coro<Ctx>) -> Result<()> {
+        self.cleanup(coro).await
+    }
+
+    #[allow(dead_code)]
+    async fn restore_after_error<Ctx>(&self, coro: &Coro<Ctx>, apply_error: Error) -> Error {
+        match self.restore(coro).await {
+            Ok(()) => apply_error,
+            Err(restore_error) => Error::DatabaseSyncEngineError(format!(
+                "{apply_error}; additionally failed to restore replace-base backup: {restore_error}"
+            )),
+        }
+    }
+}
+
+fn should_use_logical_mvcc_pull(
+    logical_mvcc_pull_requested: bool,
+    partial_sync_active: bool,
+    remote_encryption_key: Option<&str>,
+) -> bool {
+    logical_mvcc_pull_disable_reason(
+        logical_mvcc_pull_requested,
+        partial_sync_active,
+        remote_encryption_key,
+    )
+    .is_none()
+}
+
+fn logical_mvcc_pull_disable_reason(
+    logical_mvcc_pull_requested: bool,
+    partial_sync_active: bool,
+    remote_encryption_key: Option<&str>,
+) -> Option<&'static str> {
+    if !logical_mvcc_pull_requested {
+        return Some("logical MVCC pull is disabled by configuration");
+    }
+    if partial_sync_active {
+        return Some("partial sync is active");
+    }
+    if remote_encryption_key.is_some() {
+        return Some(
+            "remote encryption is enabled; MVCC logical sync is unsupported for encrypted remotes",
+        );
+    }
+    None
+}
+
+#[cfg(test)]
+fn should_request_logical_pull(
+    logical_mvcc_pull_active: bool,
+    revision: &Option<DatabasePullRevision>,
+) -> bool {
+    logical_mvcc_pull_active && matches!(revision, Some(DatabasePullRevision::V1 { .. }))
+}
+
+#[cfg(test)]
+fn ensure_stream_kind_can_use_legacy_page_apply(stream_kind: DbChangesStreamKind) -> Result<()> {
+    match stream_kind {
+        DbChangesStreamKind::LegacyPages | DbChangesStreamKind::Pages => Ok(()),
+        DbChangesStreamKind::Logical => Err(Error::DatabaseSyncEngineError(
+            "logical MVCC apply is not wired into the sync loop yet".to_string(),
+        )),
+        DbChangesStreamKind::ReplaceBasePages => Err(Error::DatabaseSyncEngineError(
+            "replace-base page apply is not wired into the sync loop yet".to_string(),
+        )),
+    }
+}
+
+fn stream_kind_for_pull_updates_v1_result(result: &PullUpdatesV1Result) -> DbChangesStreamKind {
+    match result {
+        PullUpdatesV1Result::Logical { .. } => DbChangesStreamKind::Logical,
+        PullUpdatesV1Result::Pages {
+            replace_base: false,
+        } => DbChangesStreamKind::Pages,
+        PullUpdatesV1Result::Pages { replace_base: true } => DbChangesStreamKind::ReplaceBasePages,
+    }
+}
+
+/// Executes schema-sensitive SQL and retries transient schema-cookie races.
+///
+/// Replace-base and raw-page apply can swap database files underneath an open
+/// connection. A `SchemaUpdated` error in that window usually means the SQL
+/// applied or observed the new schema boundary; reparsing and retrying lets the
+/// connection converge without masking persistent SQL errors.
+#[allow(dead_code)]
+fn execute_with_schema_retry(conn: &Arc<turso_core::Connection>, sql: &str) -> Result<()> {
+    for attempt in 0..=4 {
+        match conn.execute(sql) {
+            Ok(()) => return Ok(()),
+            Err(LimboError::SchemaUpdated) if attempt < 4 => {
+                force_reparse_schema_with_retry(conn)?;
+                conn.publish_schema_after_external_restore();
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+/// Forces a schema reparse with a small bounded retry for restore races.
+#[allow(dead_code)]
+fn force_reparse_schema_with_retry(conn: &Arc<turso_core::Connection>) -> Result<()> {
+    for attempt in 0..=2 {
+        match conn.force_reparse_schema() {
+            Ok(()) => return Ok(()),
+            Err(LimboError::SchemaUpdated) if attempt < 2 => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+/// Refreshes an open connection after sync has restored files outside SQLite.
+///
+/// This rebuilds WAL/MVCC state, clears cached pages, reparses schema, and
+/// publishes that schema so subsequent replay uses the restored database view.
+#[allow(dead_code)]
+fn reload_connection_after_external_restore(
+    conn: &Arc<turso_core::Connection>,
+    context: &str,
+) -> Result<()> {
+    match conn.reload_wal_after_external_restore() {
+        Ok(()) => {}
+        Err(LimboError::SchemaUpdated) => {
+            force_reparse_schema_with_retry(conn).map_err(|error| {
+                Error::DatabaseSyncEngineError(format!(
+                    "failed to refresh schema before retrying WAL reload after {context}: {error}",
+                ))
+            })?;
+            conn.reload_wal_after_external_restore().map_err(|error| {
+                Error::DatabaseSyncEngineError(format!(
+                    "failed to reload WAL state after {context}: {error}",
+                ))
+            })?;
+        }
+        Err(error) => {
+            return Err(Error::DatabaseSyncEngineError(format!(
+                "failed to reload WAL state after {context}: {error}",
+            )));
+        }
+    }
+    conn.get_pager().clear_page_cache(true);
+    force_reparse_schema_with_retry(conn).map_err(|error| {
+        Error::DatabaseSyncEngineError(
+            format!("failed to refresh schema after {context}: {error}",),
+        )
+    })?;
+    conn.publish_schema_after_external_restore();
+    Ok(())
+}
+
+/// Publishes schema after raw WAL replay mutates database pages externally.
+#[allow(dead_code)]
+fn publish_schema_after_raw_wal_replay(
+    conn: &Arc<turso_core::Connection>,
+    context: &str,
+) -> Result<()> {
+    conn.get_pager().clear_page_cache(true);
+    force_reparse_schema_with_retry(conn).map_err(|error| {
+        Error::DatabaseSyncEngineError(
+            format!("failed to refresh schema after {context}: {error}",),
+        )
+    })?;
+    conn.publish_schema_after_external_restore();
+    Ok(())
+}
+
+/// Marks all current CDC rows as already observed by `client_id`.
+#[allow(dead_code)]
+async fn acknowledge_existing_cdc_for_client<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+    client_id: &str,
+    context: &str,
+) -> Result<()> {
+    let Some(max_change_id) = max_local_change_id(coro, conn).await? else {
+        tracing::info!("{context}: no existing local CDC rows to acknowledge");
+        return Ok(());
+    };
+    let (pull_gen, current_change_id) = read_last_change_id(coro, conn, client_id).await?;
+    if current_change_id.is_some_and(|change_id| change_id >= max_change_id) {
+        tracing::info!(
+            "{context}: local CDC already acknowledged through change_id={max_change_id}"
+        );
+        return Ok(());
+    }
+    tracing::info!(
+        "{context}: acknowledging imported local CDC through change_id={max_change_id} for client_id={client_id}"
+    );
+    update_last_change_id(coro, conn, client_id, pull_gen, max_change_id).await
+}
+
+/// Recreates the local sync metadata table after page-level restore.
+///
+/// Raw page replay can replace the table contents along with ordinary pages.
+/// This helper resets the table and writes the high-water mark that should
+/// survive the restore.
+#[allow(dead_code)]
+async fn rebuild_local_sync_metadata_table<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+    client_id: &str,
+    pull_gen: i64,
+    change_id: i64,
+) -> Result<()> {
+    execute_with_schema_retry(conn, "DROP TABLE IF EXISTS turso_sync_last_change_id").map_err(
+        |error| {
+            Error::DatabaseSyncEngineError(format!(
+                "failed to reset local sync high-water mark table after raw page replay: {error}",
+            ))
+        },
+    )?;
+    conn.publish_schema_after_external_restore();
+    update_last_change_id(coro, conn, client_id, pull_gen, change_id).await
+}
+
+/// Drives a core I/O completion from the sync coroutine executor.
+#[allow(dead_code)]
+async fn drive_core_completion<Ctx>(
+    coro: &Coro<Ctx>,
+    io: &Arc<dyn turso_core::IO>,
+    completion: Completion,
+) -> Result<()> {
+    while !completion.succeeded() {
+        coro.yield_(SyncEngineIoResult::IO).await?;
+    }
+    io.wait_for_completion(completion)?;
+    Ok(())
+}
+
+/// Returns true for pull-update streams that physically install remote pages.
+#[allow(dead_code)]
+fn stream_kind_applies_remote_pages(stream_kind: DbChangesStreamKind) -> bool {
+    matches!(
+        stream_kind,
+        DbChangesStreamKind::LegacyPages
+            | DbChangesStreamKind::Pages
+            | DbChangesStreamKind::ReplaceBasePages
+    )
+}
+
+/// Decides whether page updates should be replayed through a SQL connection.
+///
+/// Legacy protocol keeps the original WAL-session path. V1 page streams use the
+/// SQL connection only when there is no active logical replay connection.
+#[allow(dead_code)]
+fn should_replay_raw_pages_on_sql_conn(
+    protocol_version_hint: DatabaseSyncEngineProtocolVersion,
+    logical_replay_conn_active: bool,
+    stream_kind: DbChangesStreamKind,
+) -> bool {
+    protocol_version_hint != DatabaseSyncEngineProtocolVersion::Legacy
+        && !logical_replay_conn_active
+        && matches!(
+            stream_kind,
+            DbChangesStreamKind::Pages | DbChangesStreamKind::ReplaceBasePages
+        )
+}
+
+fn resolve_local_replay_floor_change_id(
+    use_pushed_change_hint: bool,
+    use_pushed_replay_floor_hint: bool,
+    local_pull_gen: i64,
+    remote_pull_gen: i64,
+    remote_last_change_id: Option<i64>,
+    last_pushed_pull_gen_hint: i64,
+    last_pushed_change_id_hint: i64,
+    last_pushed_replay_floor_change_id_hint: i64,
+) -> Option<i64> {
+    let mut last_change_id = if remote_pull_gen == local_pull_gen {
+        remote_last_change_id
+    } else {
+        Some(0)
+    };
+
+    if use_pushed_replay_floor_hint
+        && last_pushed_pull_gen_hint == local_pull_gen
+        && last_pushed_change_id_hint > 0
+        && last_change_id == Some(last_pushed_change_id_hint)
+        && last_pushed_replay_floor_change_id_hint < last_pushed_change_id_hint
+    {
+        last_change_id = Some(last_pushed_replay_floor_change_id_hint);
+    }
+
+    if use_pushed_change_hint
+        && last_pushed_pull_gen_hint == local_pull_gen
+        && last_pushed_change_id_hint > 0
+        && last_change_id.unwrap_or(0) < last_pushed_change_id_hint
+    {
+        last_change_id = Some(last_pushed_change_id_hint);
+    }
+
+    last_change_id
+}
+
+fn synced_change_id_after_remote_apply(
+    replayed_local_changes: bool,
+    local_replay_floor_change_id: Option<i64>,
+    post_apply_change_id: i64,
+) -> i64 {
+    if replayed_local_changes {
+        local_replay_floor_change_id.unwrap_or(0)
+    } else {
+        post_apply_change_id
+    }
+}
+
+fn use_pushed_change_hint_for_local_replay(stream_kind: DbChangesStreamKind) -> bool {
+    !matches!(stream_kind, DbChangesStreamKind::Logical)
+}
+
+fn use_pushed_replay_floor_hint_for_local_replay(stream_kind: DbChangesStreamKind) -> bool {
+    matches!(stream_kind, DbChangesStreamKind::Logical)
+}
+
+fn filter_pushed_self_changes_touched_by_remote(
+    local_changes: Vec<DatabaseTapeRowChange>,
+    replaying_pushed_self_range: bool,
+    last_pushed_change_id_hint: i64,
+    remote_logical_touched_rows: &BTreeSet<(String, i64)>,
+) -> (Vec<DatabaseTapeRowChange>, usize) {
+    if !replaying_pushed_self_range || remote_logical_touched_rows.is_empty() {
+        return (local_changes, 0);
+    }
+
+    let mut skipped = 0usize;
+    let local_changes = local_changes
+        .into_iter()
+        .filter(|change| {
+            let already_pushed_self_change = change.change_id <= last_pushed_change_id_hint;
+            let touched_by_remote =
+                remote_logical_touched_rows.contains(&(change.table_name.clone(), change.id));
+            if already_pushed_self_change && touched_by_remote {
+                skipped += 1;
+                false
+            } else {
+                true
+            }
+        })
+        .collect::<Vec<_>>();
+    (local_changes, skipped)
+}
+
 impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
     pub async fn read_db_meta<Ctx>(
         coro: &Coro<Ctx>,
@@ -248,6 +2226,18 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         let meta_path = create_meta_path(main_db_path);
         let partial_sync_opts = opts.partial_sync_opts.clone();
         let partial = partial_sync_opts.is_some();
+        let logical_mvcc_pull_active = should_use_logical_mvcc_pull(
+            opts.logical_mvcc_pull,
+            partial,
+            opts.remote_encryption_key.as_deref(),
+        );
+        if let Some(reason) = logical_mvcc_pull_disable_reason(
+            opts.logical_mvcc_pull,
+            partial,
+            opts.remote_encryption_key.as_deref(),
+        ) {
+            tracing::debug!("logical MVCC pull disabled: {reason}");
+        }
 
         let configuration = DatabaseSavedConfiguration {
             remote_url: opts.remote_url.clone(),
@@ -256,7 +2246,12 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         };
         let meta = match meta {
             Some(mut meta) => {
-                if meta.update_configuration(configuration) {
+                let mut metadata_changed = meta.update_configuration(configuration);
+                if meta.logical_mvcc_pull_active != logical_mvcc_pull_active {
+                    meta.logical_mvcc_pull_active = logical_mvcc_pull_active;
+                    metadata_changed = true;
+                }
+                if metadata_changed {
                     full_write(
                         coro,
                         io.clone(),
@@ -293,6 +2288,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     revert_since_wal_watermark: 0,
                     last_pushed_change_id_hint: 0,
                     last_pushed_pull_gen_hint: 0,
+                    last_pushed_replay_floor_change_id_hint: 0,
                     last_pull_unix_time: Some(io.current_time_wall_clock().secs),
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: if partial {
@@ -300,6 +2296,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     } else {
                         None
                     },
+                    fresh_bootstrap_pending_cdc_ack: false,
+                    logical_mvcc_pull_active,
+                    logical_table_names_by_stable_id: Default::default(),
                     saved_configuration: Some(configuration),
                 };
                 tracing::info!("write meta after successful bootstrap: meta={meta:?}");
@@ -336,9 +2335,13 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     revert_since_wal_watermark: 0,
                     last_pushed_change_id_hint: 0,
                     last_pushed_pull_gen_hint: 0,
+                    last_pushed_replay_floor_change_id_hint: 0,
                     last_pull_unix_time: None,
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: None,
+                    fresh_bootstrap_pending_cdc_ack: false,
+                    logical_mvcc_pull_active,
+                    logical_table_names_by_stable_id: Default::default(),
                     saved_configuration: Some(configuration),
                 };
                 tracing::info!("write meta after successful bootstrap: meta={meta:?}");
@@ -426,6 +2429,21 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
     ) -> Result<Self> {
         let main_db_path = main_db.path.to_string();
         tracing::info!("open_db(path={}): opts={:?}", main_db_path, opts);
+        // A previous process may have crashed after writing the replace-base
+        // marker but before completing local replay. Restore the backed-up
+        // files before reading metadata or creating tape connections.
+        let recovered = ReplaceBaseApplyGuard::recover_pending(
+            coro,
+            io.clone(),
+            sync_engine_io.clone(),
+            &main_db_path,
+        )
+        .await?;
+        if recovered {
+            // Recovery restored files behind this already-open Database handle,
+            // so rebuild its shared WAL/MVCC view before continuing.
+            main_db.reload_wal_after_external_restore()?;
+        }
 
         let meta_path = create_meta_path(&main_db_path);
 
@@ -507,6 +2525,13 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         main_db_path: &str,
         opts: DatabaseSyncEngineOpts,
     ) -> Result<Self> {
+        ReplaceBaseApplyGuard::recover_pending(
+            coro,
+            io.clone(),
+            sync_engine_io.clone(),
+            main_db_path,
+        )
+        .await?;
         let meta = Self::read_db_meta(coro, Some(io.clone()), sync_engine_io.clone(), main_db_path)
             .await?;
         let meta = Self::bootstrap_db(
@@ -808,14 +2833,89 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             self.meta().remote_url(),
             self.opts.remote_encryption_key.as_deref(),
         );
-        let next_revision = wal_pull_to_file(
-            ctx,
-            &file.value,
-            &revision,
-            self.opts.wal_pull_batch_size,
-            self.opts.long_poll_timeout,
-        )
-        .await?;
+        let mut stream_kind =
+            if self.opts.protocol_version_hint == DatabaseSyncEngineProtocolVersion::Legacy {
+                DbChangesStreamKind::LegacyPages
+            } else {
+                DbChangesStreamKind::Pages
+            };
+        let logical_mvcc_pull_active = self.meta().logical_mvcc_pull_active;
+        let next_revision = if logical_mvcc_pull_active {
+            match &revision {
+                Some(DatabasePullRevision::V1 { revision }) => {
+                    match pull_updates_v1(
+                        ctx,
+                        &file.value,
+                        revision,
+                        self.opts.long_poll_timeout,
+                        true,
+                    )
+                    .await?
+                    {
+                        (next_revision, result @ PullUpdatesV1Result::Logical { txns, ops }) => {
+                            tracing::info!(
+                                "wait_changes(path={}): logical pull returned {} transactions / {} ops",
+                                self.main_db_path,
+                                txns,
+                                ops
+                            );
+                            stream_kind = stream_kind_for_pull_updates_v1_result(&result);
+                            next_revision
+                        }
+                        (next_revision, result @ PullUpdatesV1Result::Pages { replace_base }) => {
+                            tracing::info!(
+                                "wait_changes(path={}): logical pull returned a page stream fallback; replace_base={replace_base}",
+                                self.main_db_path,
+                            );
+                            stream_kind = stream_kind_for_pull_updates_v1_result(&result);
+                            next_revision
+                        }
+                    }
+                }
+                None => {
+                    let (next_revision, result) =
+                        pull_updates_v1(ctx, &file.value, "", self.opts.long_poll_timeout, false)
+                            .await?;
+                    tracing::info!(
+                        "wait_changes(path={}): initial logical MVCC sync returned page base",
+                        self.main_db_path,
+                    );
+                    stream_kind = match result {
+                        PullUpdatesV1Result::Pages { .. } => DbChangesStreamKind::ReplaceBasePages,
+                        PullUpdatesV1Result::Logical { txns, ops } => {
+                            tracing::info!(
+                                "wait_changes(path={}): initial logical MVCC sync returned logical stream with {} transactions / {} ops",
+                                self.main_db_path,
+                                txns,
+                                ops
+                            );
+                            DbChangesStreamKind::Logical
+                        }
+                    };
+                    next_revision
+                }
+                Some(DatabasePullRevision::Legacy { .. }) => {
+                    stream_kind = DbChangesStreamKind::LegacyPages;
+                    wal_pull_to_file(
+                        ctx,
+                        &file.value,
+                        &revision,
+                        self.opts.wal_pull_batch_size,
+                        self.opts.long_poll_timeout,
+                    )
+                    .await?
+                }
+            }
+        } else {
+            wal_pull_to_file(
+                ctx,
+                &file.value,
+                &revision,
+                self.opts.wal_pull_batch_size,
+                self.opts.long_poll_timeout,
+            )
+            .await?
+        };
 
         if file.value.size()? == 0 {
             tracing::info!(
@@ -823,6 +2923,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 self.main_db_path
             );
             self.update_meta(coro, |m| {
+                m.synced_revision = Some(next_revision.clone());
                 m.last_pull_unix_time = Some(now.secs);
             })
             .await?;
@@ -830,6 +2931,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 time: now,
                 revision: next_revision,
                 file_slot: None,
+                stream_kind,
             });
         }
 
@@ -844,6 +2946,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             time: now,
             revision: next_revision,
             file_slot: Some(file),
+            stream_kind,
         })
     }
 
@@ -855,19 +2958,54 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         coro: &Coro<Ctx>,
         remote_changes: DbChangesStatus,
     ) -> Result<()> {
-        if remote_changes.file_slot.is_none() {
+        let mut new_revision = remote_changes.revision.clone();
+        if remote_changes.is_empty() {
             self.update_meta(coro, |m| {
+                m.synced_revision = Some(new_revision.clone());
                 m.last_pull_unix_time = Some(remote_changes.time.secs);
             })
             .await?;
             return Ok(());
         }
-        assert!(remote_changes.file_slot.is_some(), "file_slot must be set");
-        let changes_file = remote_changes.file_slot.as_ref().unwrap().value.clone();
-        let pull_result = self.apply_changes_internal(coro, &changes_file).await;
-        let Ok(revert_since_wal_watermark) = pull_result else {
+        let changes_file = remote_changes
+            .file_slot
+            .as_ref()
+            .expect("non-empty remote changes must keep a file slot")
+            .value
+            .clone();
+        if matches!(remote_changes.stream_kind, DbChangesStreamKind::Logical) {
+            let logical_table_names_by_stable_id = self
+                .apply_logical_mvcc_changes_internal(coro, &changes_file)
+                .await?;
+            self.update_meta(coro, |m| {
+                m.revert_since_wal_salt = None;
+                m.revert_since_wal_watermark = 0;
+                m.synced_revision = Some(new_revision.clone());
+                m.last_pushed_pull_gen_hint = 0;
+                m.last_pushed_change_id_hint = 0;
+                m.last_pushed_replay_floor_change_id_hint = 0;
+                m.last_pull_unix_time = Some(remote_changes.time.secs);
+                m.logical_table_names_by_stable_id = logical_table_names_by_stable_id;
+            })
+            .await?;
+            return Ok(());
+        }
+        let pull_result = self
+            .apply_changes_internal(
+                coro,
+                &changes_file,
+                remote_changes.stream_kind,
+                &remote_changes.revision,
+            )
+            .await;
+        let Ok((revert_since_wal_watermark, logical_table_names_by_stable_id, followup_revision)) =
+            pull_result
+        else {
             return Err(pull_result.err().unwrap());
         };
+        if let Some(revision) = followup_revision {
+            new_revision = revision;
+        }
 
         let revert_wal_file = self.io.open_file(
             &self.revert_db_wal_path,
@@ -878,24 +3016,271 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
         self.update_meta(coro, |m| {
             m.revert_since_wal_watermark = revert_since_wal_watermark;
-            m.synced_revision = Some(remote_changes.revision);
+            m.synced_revision = Some(new_revision);
+            m.last_pushed_pull_gen_hint = 0;
             m.last_pushed_change_id_hint = 0;
+            m.last_pushed_replay_floor_change_id_hint = 0;
             m.last_pull_unix_time = Some(remote_changes.time.secs);
+            m.logical_table_names_by_stable_id = logical_table_names_by_stable_id;
         })
         .await?;
         Ok(())
     }
+
+    async fn apply_logical_mvcc_changes_internal<Ctx>(
+        &self,
+        coro: &Coro<Ctx>,
+        changes_file: &Arc<dyn turso_core::File>,
+    ) -> Result<BTreeMap<u64, String>> {
+        tracing::info!("apply_logical_mvcc_changes(path={})", self.main_db_path);
+
+        let conn = connect_untracked(&self.main_tape)?;
+        let had_cdc_table = has_table(coro, &conn, "turso_cdc").await?;
+        let (local_pull_gen, local_last_change_id) =
+            read_last_change_id(coro, &conn, &self.client_unique_id).await?;
+        let mut precollected_local_changes = Vec::new();
+        if had_cdc_table {
+            let iterate_opts = DatabaseChangesIteratorOpts {
+                first_change_id: None,
+                mode: DatabaseChangesIteratorMode::Apply,
+                ignore_schema_changes: false,
+                ..Default::default()
+            };
+            let mut iterator = self.main_tape.iterate_changes(iterate_opts)?;
+            while let Some(operation) = iterator.next(coro).await? {
+                match operation {
+                    DatabaseTapeOperation::RowChange(change) => {
+                        precollected_local_changes.push(change)
+                    }
+                    DatabaseTapeOperation::Commit => continue,
+                    DatabaseTapeOperation::StmtReplay(_)
+                    | DatabaseTapeOperation::SchemaReplay(_) => {
+                        panic!("changes iterator must not use replay-only operations")
+                    }
+                }
+            }
+        }
+
+        conn.execute("BEGIN IMMEDIATE")?;
+        let mut logical_table_names_by_stable_id =
+            self.meta().logical_table_names_by_stable_id.clone();
+        let mut replay = DatabaseReplaySession {
+            conn: conn.clone(),
+            cached_delete_stmt: HashMap::new(),
+            cached_insert_stmt: HashMap::new(),
+            cached_update_stmt: HashMap::new(),
+            in_txn: true,
+            generator: DatabaseReplayGenerator {
+                conn: conn.clone(),
+                opts: DatabaseReplaySessionOpts {
+                    use_implicit_rowid: true,
+                },
+            },
+        };
+        let apply_result = async {
+            let remote_apply_stats =
+                apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats(
+                    coro,
+                    &mut replay,
+                    changes_file,
+                    &self.client_unique_id,
+                    &mut logical_table_names_by_stable_id,
+                )
+                .await?;
+	            tracing::info!(
+	                "apply_logical_mvcc_changes(path={}): applied remote logical transactions; touched_rows={}",
+	                self.main_db_path,
+	                remote_apply_stats.touched_rows.len()
+	            );
+
+            let (
+                last_pushed_pull_gen_hint,
+                last_pushed_change_id_hint,
+                last_pushed_replay_floor_change_id_hint,
+            ) = {
+                let meta = self.meta();
+                (
+                    meta.last_pushed_pull_gen_hint,
+                    meta.last_pushed_change_id_hint,
+                    meta.last_pushed_replay_floor_change_id_hint,
+                )
+            };
+            let last_change_id = resolve_local_replay_floor_change_id(
+                true,
+                false,
+                local_pull_gen,
+                local_pull_gen,
+                local_last_change_id,
+                last_pushed_pull_gen_hint,
+                last_pushed_change_id_hint,
+                last_pushed_replay_floor_change_id_hint,
+            );
+            let replay_floor = last_change_id.unwrap_or(0);
+            let local_changes = precollected_local_changes
+                .into_iter()
+                .filter(|change| change.change_id > replay_floor)
+                .collect::<Vec<_>>();
+            let replaying_pushed_self_range = last_pushed_change_id_hint > 0
+                && last_pushed_replay_floor_change_id_hint < last_pushed_change_id_hint
+                && replay_floor == last_pushed_replay_floor_change_id_hint;
+            let (local_changes, skipped_pushed_self_changes_touched_by_remote) =
+                filter_pushed_self_changes_touched_by_remote(
+                    local_changes,
+                    replaying_pushed_self_range,
+                    last_pushed_change_id_hint,
+                    &remote_apply_stats.touched_rows,
+                );
+            let mut skipped_internal_local_changes = 0usize;
+            let local_changes = local_changes
+                .into_iter()
+                .filter_map(|change| match should_replay_local_change(&change) {
+                    Ok(true) => Some(Ok(change)),
+                    Ok(false) => {
+                        skipped_internal_local_changes += 1;
+                        None
+                    }
+                    Err(error) => Some(Err(error)),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let replayed_local_changes = !local_changes.is_empty();
+            tracing::info!(
+                "apply_logical_mvcc_changes(path={}): logical local replay floor={replay_floor}; local_changes={} skipped_pushed_self_changes_touched_by_remote={} skipped_internal_local_changes={}",
+                self.main_db_path,
+                local_changes.len(),
+                skipped_pushed_self_changes_touched_by_remote,
+                skipped_internal_local_changes,
+            );
+
+            if replayed_local_changes {
+                let mut local_replay = DatabaseReplaySession {
+                    conn: conn.clone(),
+                    cached_delete_stmt: HashMap::new(),
+                    cached_insert_stmt: HashMap::new(),
+                    cached_update_stmt: HashMap::new(),
+                    in_txn: true,
+                    generator: DatabaseReplayGenerator {
+                        conn: conn.clone(),
+                        opts: DatabaseReplaySessionOpts {
+                            use_implicit_rowid: false,
+                        },
+                    },
+                };
+
+                let mut transformed = if self.opts.use_transform {
+                    let ctx = &SyncOperationCtx::new(
+                        coro,
+                        &self.sync_engine_io,
+                        self.meta().remote_url(),
+                        self.opts.remote_encryption_key.as_deref(),
+                    );
+                    Some(apply_transformation(ctx, &local_changes, &local_replay.generator).await?)
+                } else {
+                    None
+                };
+
+                assert!(!local_replay.conn().get_auto_commit());
+                for (i, change) in local_changes.into_iter().enumerate() {
+                    let operation = if let Some(transformed) = &mut transformed {
+                        match std::mem::replace(
+                            &mut transformed[i],
+                            DatabaseRowTransformResult::Skip,
+                        ) {
+                            DatabaseRowTransformResult::Keep => {
+                                DatabaseTapeOperation::RowChange(change)
+                            }
+                            DatabaseRowTransformResult::Skip => continue,
+                            DatabaseRowTransformResult::Rewrite(replay) => {
+                                DatabaseTapeOperation::StmtReplay(replay)
+                            }
+                        }
+                    } else {
+                        DatabaseTapeOperation::RowChange(change)
+                    };
+                    local_replay.replay(coro, operation).await?;
+                }
+                assert!(!local_replay.conn().get_auto_commit());
+            }
+
+            tracing::info!(
+                "apply_logical_mvcc_changes(path={}): logical local replay complete; reading CDC high-water",
+                self.main_db_path
+            );
+            let post_apply_change_id = max_local_change_id(coro, &conn).await?.unwrap_or(0);
+            let synced_change_id = synced_change_id_after_remote_apply(
+                replayed_local_changes,
+                last_change_id,
+                post_apply_change_id,
+            );
+            tracing::info!(
+                "apply_logical_mvcc_changes(path={}): updating sync high-water to {synced_change_id}",
+                self.main_db_path
+            );
+            update_last_change_id(
+                coro,
+                &conn,
+                &self.client_unique_id,
+                local_pull_gen,
+                synced_change_id,
+            )
+            .await?;
+            replay.replay(coro, DatabaseTapeOperation::Commit).await?;
+            Result::Ok(logical_table_names_by_stable_id)
+        }
+        .await;
+
+        if let Err(error) = &apply_result {
+            tracing::error!(
+                "apply_logical_mvcc_changes(path={}): rolling back failed logical apply: {error}",
+                self.main_db_path
+            );
+            if !conn.get_auto_commit() {
+                if let Err(rollback_error) = conn.execute("ROLLBACK") {
+                    tracing::error!(
+                        "apply_logical_mvcc_changes(path={}): rollback failed after logical apply error: {rollback_error}",
+                        self.main_db_path
+                    );
+                }
+            }
+        }
+        apply_result
+    }
+
+    #[allow(dead_code)]
+    async fn reject_replace_base_pages_apply_until_wired<Ctx>(
+        &self,
+        coro: &Coro<Ctx>,
+    ) -> Result<()> {
+        let conn = connect_untracked(&self.main_tape)?;
+        if has_table(coro, &conn, "turso_cdc").await? {
+            let (_, local_last_change_id) =
+                read_last_change_id(coro, &conn, &self.client_unique_id).await?;
+            let pending_local_changes =
+                count_local_changes(coro, &conn, local_last_change_id.unwrap_or(0)).await?;
+            if pending_local_changes != 0 {
+                return Err(Error::DatabaseSyncEngineError(format!(
+                    "replace-base page apply with pending local CDC changes is not wired yet: {pending_local_changes} local changes need replay"
+                )));
+            }
+        }
+        Err(Error::DatabaseSyncEngineError(
+            "replace-base page apply is not wired yet".to_string(),
+        ))
+    }
+
     async fn apply_changes_internal<Ctx>(
         &self,
         coro: &Coro<Ctx>,
         changes_file: &Arc<dyn turso_core::File>,
-    ) -> Result<u64> {
+        stream_kind: DbChangesStreamKind,
+        remote_revision: &DatabasePullRevision,
+    ) -> Result<(u64, BTreeMap<u64, String>, Option<DatabasePullRevision>)> {
         tracing::info!("apply_changes(path={})", self.main_db_path);
 
         let (_, watermark) = self.checkpoint_passive(coro).await?;
 
         let revert_conn = self.open_revert_db_conn(coro).await?;
         let main_conn = connect_untracked(&self.main_tape)?;
+        let replace_base_pages = matches!(stream_kind, DbChangesStreamKind::ReplaceBasePages);
 
         let mut revert_session = WalSession::new(revert_conn.clone());
         revert_session.begin()?;
@@ -916,190 +3301,901 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         main_conn.start_nested();
 
         let had_cdc_table = has_table(coro, &main_conn, "turso_cdc").await?;
+        let pre_apply_local_change_id = if had_cdc_table {
+            max_local_change_id(coro, &main_conn).await?
+        } else {
+            None
+        };
+        tracing::info!(
+            "apply_changes(path={}): pre-apply local CDC high-water mark: {:?}",
+            self.main_db_path,
+            pre_apply_local_change_id
+        );
 
         // read current pull generation from local table for the given client
-        let (local_pull_gen, _) =
+        let (local_pull_gen, local_last_change_id) =
             read_last_change_id(coro, &main_conn, &self.client_unique_id).await?;
+        let no_checkpoint_replace_base = replace_base_pages && self.meta().logical_mvcc_pull_active;
+        tracing::info!(
+            "apply_changes(path={}): local sync high-water before remote apply: client_id={} pull_gen={} change_id={:?} replace_base={}",
+            self.main_db_path,
+            self.client_unique_id,
+            local_pull_gen,
+            local_last_change_id,
+            replace_base_pages,
+        );
+        let (
+            last_pushed_pull_gen_hint,
+            last_pushed_change_id_hint,
+            last_pushed_replay_floor_change_id_hint,
+        ) = {
+            let meta = self.meta();
+            (
+                meta.last_pushed_pull_gen_hint,
+                meta.last_pushed_change_id_hint,
+                meta.last_pushed_replay_floor_change_id_hint,
+            )
+        };
 
         // read schema version after initiating WAL session (in order to read it with consistent max_frame_no)
         // note, that as we initiated WAL session earlier - no changes can be made in between and we will have consistent race-free view of schema version
         let main_conn_schema_version = main_conn.read_schema_version()?;
 
-        let mut main_session = DatabaseWalSession::new(coro, main_session).await?;
-
-        // Phase 1 (start): rollback local changes from the WAL
-
-        // Phase 1.a: rollback local changes not checkpointed to the revert-db
-        tracing::info!(
-            "apply_changes(path={}): rolling back frames after {} watermark, max_frame={}",
-            self.main_db_path,
-            watermark,
-            main_conn.wal_state()?.max_frame
-        );
-        let local_rollback = main_session.rollback_changes_after(coro, watermark).await?;
-        let mut frame = [0u8; WAL_FRAME_SIZE];
-
-        let remote_rollback = revert_conn.wal_state()?.max_frame;
-        tracing::info!(
-            "apply_changes(path={}): rolling back {} frames from revert DB",
-            self.main_db_path,
-            remote_rollback
-        );
-        // Phase 1.b: rollback local changes by using frames from revert-db
-        // it's important to append pages from revert-db after local revert - because pages from revert-db must overwrite rollback from main DB
-        for frame_no in 1..=remote_rollback {
-            let info = revert_session.read_at(frame_no, &mut frame)?;
-            main_session.append_page(info.page_no, &frame[WAL_FRAME_HEADER..])?;
-        }
-
-        // Phase 2: after revert DB has no local changes in its latest state - so its safe to apply changes from remote
-        let db_size = wal_apply_from_file(coro, changes_file, &mut main_session).await?;
-        tracing::info!(
-            "apply_changes(path={}): applied changes from remote: db_size={}",
-            self.main_db_path,
-            db_size,
-        );
-
-        main_session.commit(0)?;
-        // now DB is equivalent to the some remote state (all local changes reverted, all remote changes applied)
-        // remember this frame watermark as a checkpoint for revert for pull operations in future
-        let revert_since_wal_watermark = main_session.frames_count()?;
-
-        // Phase 3: DB now has sane WAL - but schema cookie can be arbitrary - so we need to bump it (potentially forcing re-prepare for cached statement)
-        let current_schema_version = main_conn.read_schema_version()?;
-        let final_schema_version = current_schema_version.max(main_conn_schema_version) + 1;
-        main_conn.write_schema_version(final_schema_version)?;
-        tracing::info!(
-            "apply_changes(path={}): updated schema version to {}",
-            self.main_db_path,
-            final_schema_version
-        );
-
-        // Phase 4: as now DB has all data from remote - let's read pull generation and last change id for current client
-        // we will use last_change_id in order to replay local changes made strictly after that id locally
-        let (remote_pull_gen, remote_last_change_id) =
-            read_last_change_id(coro, &main_conn, &self.client_unique_id).await?;
-
-        // we update pull generation and last_change_id at remote on push, but locally its updated on pull
-        // so its impossible to have remote pull generation to be greater than local one
-        if remote_pull_gen > local_pull_gen {
-            return Err(Error::DatabaseSyncEngineError(format!("protocol error: remote_pull_gen > local_pull_gen: {remote_pull_gen} > {local_pull_gen}")));
-        }
-        let last_change_id = if remote_pull_gen == local_pull_gen {
-            // if remote_pull_gen == local_pull gen - this means that remote portion of WAL have overlap with our local changes
-            // (because we did one or more push operations since last pull) - so we need to take some suffix of local changes for replay
-            remote_last_change_id
+        let precollect_local_changes_before_remote_apply = replace_base_pages
+            || matches!(stream_kind, DbChangesStreamKind::Logical)
+            || should_replay_raw_pages_on_sql_conn(
+                self.opts.protocol_version_hint,
+                false,
+                stream_kind,
+            );
+        let replace_base_precollection_floor = if replace_base_pages {
+            if no_checkpoint_replace_base {
+                None
+            } else {
+                resolve_local_replay_floor_change_id(
+                    true,
+                    false,
+                    local_pull_gen,
+                    local_pull_gen,
+                    local_last_change_id,
+                    last_pushed_pull_gen_hint,
+                    last_pushed_change_id_hint,
+                    last_pushed_replay_floor_change_id_hint,
+                )
+            }
         } else {
-            // if remove_pull_gen < local_pull_gen - this means that remote portion of WAL have no overlaps with all our local changes and we need to replay all of them
-            Some(0)
+            None
         };
-
-        // Phase 5: collect local changes
-        // note, that collecting chanages from main_conn will yield zero rows as we already rolled back everything from it
-        // but since we didn't commited these changes yet - we can just collect changes from another connection
-        let iterate_opts = DatabaseChangesIteratorOpts {
-            first_change_id: last_change_id.map(|x| x + 1),
-            mode: DatabaseChangesIteratorMode::Apply,
-            ignore_schema_changes: false,
-            ..Default::default()
-        };
-        let mut local_changes = Vec::new();
-        {
-            // it's important here that DatabaseTape create fresh connection under the hood
+        let mut precollected_local_changes = Vec::with_capacity(64);
+        if precollect_local_changes_before_remote_apply {
+            let iterate_opts = DatabaseChangesIteratorOpts {
+                first_change_id: if replace_base_pages {
+                    replace_base_precollection_floor.map(|change_id| change_id + 1)
+                } else {
+                    None
+                },
+                mode: DatabaseChangesIteratorMode::Apply,
+                ignore_schema_changes: false,
+                ..Default::default()
+            };
             let mut iterator = self.main_tape.iterate_changes(iterate_opts)?;
             while let Some(operation) = iterator.next(coro).await? {
                 match operation {
-                    DatabaseTapeOperation::StmtReplay(_) => {
-                        panic!("changes iterator must not use StmtReplay option")
+                    DatabaseTapeOperation::RowChange(change) => {
+                        precollected_local_changes.push(change)
                     }
-                    DatabaseTapeOperation::RowChange(change) => local_changes.push(change),
                     DatabaseTapeOperation::Commit => continue,
+                    DatabaseTapeOperation::StmtReplay(_)
+                    | DatabaseTapeOperation::SchemaReplay(_) => {
+                        panic!("changes iterator must not use replay-only operations")
+                    }
+                }
+            }
+            tracing::info!(
+                "apply_changes(path={}): precollected {} local changes for replay",
+                self.main_db_path,
+                precollected_local_changes.len(),
+            );
+        } else {
+            tracing::info!(
+                "apply_changes(path={}): using post-apply local change collection",
+                self.main_db_path,
+            );
+        }
+        let previous_synced_revision = self.meta().synced_revision.clone();
+        let mut logical_table_names_by_stable_id =
+            self.meta().logical_table_names_by_stable_id.clone();
+        let mut replace_base_guard = if replace_base_pages {
+            Some(
+                ReplaceBaseApplyGuard::create(
+                    coro,
+                    self.io.clone(),
+                    self.sync_engine_io.clone(),
+                    &self.main_db_path,
+                    previous_synced_revision,
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
+
+        let apply_result: Result<(
+            u64,
+            BTreeMap<u64, String>,
+            Option<DatabasePullRevision>,
+        )> = async {
+            let mut main_session = Some(DatabaseWalSession::new(coro, main_session).await?);
+
+            // Phase 1 (start): rollback local changes from the WAL
+
+            // Phase 1.a: rollback local changes not checkpointed to the revert-db
+            tracing::info!(
+                "apply_changes(path={}): rolling back frames after {} watermark, max_frame={}",
+                self.main_db_path,
+                watermark,
+                main_conn.wal_state()?.max_frame
+            );
+            let local_rollback = main_session
+                .as_mut()
+                .expect("main WAL session must be active")
+                .rollback_changes_after(coro, watermark)
+                .await?;
+            let mut frame = [0u8; WAL_FRAME_SIZE];
+
+            let remote_rollback = revert_conn.wal_state()?.max_frame;
+            tracing::info!(
+                "apply_changes(path={}): rolling back {} frames from revert DB",
+                self.main_db_path,
+                remote_rollback
+            );
+            // Phase 1.b: rollback local changes by using frames from revert-db
+            // it's important to append pages from revert-db after local revert - because pages from revert-db must overwrite rollback from main DB
+            for frame_no in 1..=remote_rollback {
+                let info = revert_session.read_at(frame_no, &mut frame)?;
+                main_session
+                    .as_mut()
+                    .expect("main WAL session must be active")
+                    .append_page(info.page_no, &frame[WAL_FRAME_HEADER..])?;
+            }
+            revert_session.end(false)?;
+
+            // Phase 2: after revert DB has no local changes in its latest state - so its safe to apply changes from remote
+            let mut logical_replay_conn = None;
+            let mut remote_logical_touched_rows = BTreeSet::new();
+            let applied_raw_db_size: u32;
+            let mut followup_revision = None;
+            match stream_kind {
+                stream_kind if stream_kind_applies_remote_pages(stream_kind) => {
+                    if matches!(stream_kind, DbChangesStreamKind::ReplaceBasePages) {
+                        tracing::warn!(
+                            "apply_changes(path={}): applying replace-base page snapshot from remote",
+                            self.main_db_path,
+                        );
+                    }
+                    let db_size = wal_apply_from_file(
+                        coro,
+                        changes_file,
+                        main_session
+                            .as_mut()
+                            .expect("main WAL session must be active"),
+                    )
+                    .await?;
+                    tracing::info!(
+                        "apply_changes(path={}): applied changes from remote: db_size={}",
+                        self.main_db_path,
+                        db_size,
+                    );
+                    applied_raw_db_size = db_size;
+                    if replace_base_pages {
+                        let mut finished_main_session = main_session
+                            .take()
+                            .expect("main WAL session must be active");
+                        finished_main_session.commit(applied_raw_db_size)?;
+                        main_conn.end_nested();
+                        finished_main_session.wal_session.end(true).map_err(|error| {
+                            Error::DatabaseSyncEngineError(format!(
+                                "failed to finalize replace-base raw WAL session: {error}",
+                            ))
+                        })?;
+                        drop(finished_main_session);
+                        if let Some(mv_store) = main_conn.mv_store().as_ref() {
+                            let pager = main_conn.get_pager();
+                            let reset = mv_store.reset_logical_log_after_external_restore().map_err(
+                                |error| {
+                                    Error::DatabaseSyncEngineError(format!(
+                                        "failed to reset MVCC logical log after replace-base snapshot: {error}",
+                                    ))
+                                },
+                            )?;
+                            drive_core_completion(coro, &pager.io, reset).await.map_err(
+                                |error| {
+                                    Error::DatabaseSyncEngineError(format!(
+                                        "failed to complete MVCC logical log reset after replace-base snapshot: {error}",
+                                    ))
+                                },
+                            )?;
+                            if let Some(sync) = mv_store
+                                .sync_logical_log_after_external_restore(&main_conn)
+                                .map_err(|error| {
+                                    Error::DatabaseSyncEngineError(format!(
+                                        "failed to sync MVCC logical log after replace-base snapshot: {error}",
+                                    ))
+                                })?
+                            {
+                                drive_core_completion(coro, &pager.io, sync).await.map_err(
+                                    |error| {
+                                        Error::DatabaseSyncEngineError(format!(
+                                            "failed to complete MVCC logical log sync after replace-base snapshot: {error}",
+                                        ))
+                                    },
+                                )?;
+                            }
+                        }
+                        reload_connection_after_external_restore(
+                            &main_conn,
+                            "replace-base snapshot",
+                        )?;
+
+                        let mut conn = match connect_untracked(&self.main_tape) {
+                            Ok(conn) => conn,
+                            Err(Error::TursoError(LimboError::SchemaUpdated)) => {
+                                force_reparse_schema_with_retry(&main_conn).map_err(|error| {
+                                    Error::DatabaseSyncEngineError(format!(
+                                        "failed to refresh schema after replace-base reconnect schema update: {error}",
+                                    ))
+                                })?;
+                                connect_untracked(&self.main_tape).map_err(|error| {
+                                    Error::DatabaseSyncEngineError(format!(
+                                        "failed to reconnect after replace-base schema refresh: {error}",
+                                    ))
+                                })?
+                            }
+                            Err(error) => return Err(error),
+                        };
+                        force_reparse_schema_with_retry(&conn).map_err(|error| {
+                            Error::DatabaseSyncEngineError(format!(
+                                "failed to refresh replay connection schema after replace-base snapshot: {error}",
+                            ))
+                        })?;
+                        crate::database_sync_operations::ensure_sync_last_change_id_table(
+                            coro,
+                            &conn,
+                            &self.client_unique_id,
+                        )
+                        .await
+                        .map_err(|error| {
+                            Error::DatabaseSyncEngineError(format!(
+                                "failed to initialize sync high-water mark table after replace-base snapshot: {error}"
+                            ))
+                        })?;
+                        conn.publish_schema_after_external_restore();
+                        conn = match connect_untracked(&self.main_tape) {
+                            Ok(conn) => conn,
+                            Err(Error::TursoError(LimboError::SchemaUpdated)) => {
+                                force_reparse_schema_with_retry(&main_conn).map_err(|error| {
+                                    Error::DatabaseSyncEngineError(format!(
+                                        "failed to refresh schema after replace-base sync table initialization: {error}",
+                                    ))
+                                })?;
+                                connect_untracked(&self.main_tape).map_err(|error| {
+                                    Error::DatabaseSyncEngineError(format!(
+                                        "failed to reconnect after replace-base sync table initialization: {error}",
+                                    ))
+                                })?
+                            }
+                            Err(error) => return Err(error),
+                        };
+                        force_reparse_schema_with_retry(&conn).map_err(|error| {
+                            Error::DatabaseSyncEngineError(format!(
+                                "failed to refresh replay connection schema after replace-base sync table initialization: {error}",
+                            ))
+                        })?;
+                        conn.publish_schema_after_external_restore();
+                        execute_with_schema_retry(&conn, "BEGIN IMMEDIATE").map_err(|error| {
+                            Error::DatabaseSyncEngineError(format!(
+                                "failed to begin replace-base replay transaction: {error}",
+                            ))
+                        })?;
+                        logical_replay_conn = Some(conn);
+
+                        if self.meta().logical_mvcc_pull_active {
+                            let DatabasePullRevision::V1 { revision } = remote_revision else {
+                                return Err(Error::DatabaseSyncEngineError(format!(
+                                    "replace-base follow-up logical pull requires a V1 revision, got {remote_revision:?}"
+                                )));
+                            };
+                            tracing::info!(
+                                "apply_changes(path={}): replace-base snapshot installed; issuing one follow-up logical pull from revision {} before local replay",
+                                self.main_db_path,
+                                revision,
+                            );
+                            let ctx = &SyncOperationCtx::new(
+                                coro,
+                                &self.sync_engine_io,
+                                self.meta().remote_url(),
+                                self.opts.remote_encryption_key.as_deref(),
+                            );
+                            match pull_updates_v1(ctx, changes_file, revision, None, true).await? {
+                                (next_revision, PullUpdatesV1Result::Logical { txns, ops }) => {
+                                    tracing::info!(
+                                        "apply_changes(path={}): replace-base follow-up logical pull returned {} transactions / {} ops",
+                                        self.main_db_path,
+                                        txns,
+                                        ops,
+                                    );
+                                    followup_revision = Some(next_revision);
+                                    if txns != 0 || ops != 0 || changes_file.size()? != 0 {
+                                        let replay_conn = logical_replay_conn
+                                            .as_ref()
+                                            .expect("replace-base replay connection should exist");
+                                        let mut replay = DatabaseReplaySession {
+                                            conn: replay_conn.clone(),
+                                            cached_delete_stmt: HashMap::new(),
+                                            cached_insert_stmt: HashMap::new(),
+                                            cached_update_stmt: HashMap::new(),
+                                            in_txn: true,
+                                            generator: DatabaseReplayGenerator {
+                                                conn: replay_conn.clone(),
+                                                opts: DatabaseReplaySessionOpts {
+                                                    use_implicit_rowid: true,
+                                                },
+                                            },
+                                        };
+                                        let replay_stats =
+                                            apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats(
+                                                coro,
+                                                &mut replay,
+                                                changes_file,
+                                                &self.client_unique_id,
+                                                &mut logical_table_names_by_stable_id,
+                                            )
+                                            .await
+                                            .map_err(|error| {
+                                                Error::DatabaseSyncEngineError(format!(
+                                                    "failed to apply replace-base follow-up logical transactions: {error}",
+                                                ))
+                                            })?;
+                                        remote_logical_touched_rows = replay_stats.touched_rows;
+                                    }
+                                }
+                                (_, PullUpdatesV1Result::Pages { replace_base }) => {
+                                    return Err(Error::DatabaseSyncEngineError(format!(
+                                        "replace-base follow-up logical pull unexpectedly returned a page stream: replace_base={replace_base}"
+                                    )));
+                                }
+                            }
+                        }
+                    }
+                }
+                DbChangesStreamKind::Logical => {
+                    unreachable!("logical streams are handled by apply_logical_mvcc_changes_internal")
+                }
+                DbChangesStreamKind::LegacyPages
+                | DbChangesStreamKind::Pages
+                | DbChangesStreamKind::ReplaceBasePages => {
+                    unreachable!("page stream kinds are handled by stream_kind_applies_remote_pages")
+                }
+            }
+
+            let raw_page_replay_on_sql_conn = should_replay_raw_pages_on_sql_conn(
+                self.opts.protocol_version_hint,
+                logical_replay_conn.is_some(),
+                stream_kind,
+            );
+            if raw_page_replay_on_sql_conn {
+                let mut finished_main_session = main_session
+                    .take()
+                    .expect("main WAL session must be active");
+                finished_main_session.commit(applied_raw_db_size)?;
+                main_conn.end_nested();
+                finished_main_session.wal_session.end(true).map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!(
+                        "failed to finalize raw page WAL session before local replay: {error}",
+                    ))
+                })?;
+                drop(finished_main_session);
+                publish_schema_after_raw_wal_replay(&main_conn, "raw WAL replay")?;
+
+                let conn = connect_untracked(&self.main_tape).map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!(
+                        "failed to open post-raw-apply replay connection: {error}",
+                    ))
+                })?;
+                execute_with_schema_retry(&conn, "BEGIN IMMEDIATE").map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!(
+                        "failed to begin post-raw-apply replay transaction: {error}",
+                    ))
+                })?;
+                logical_replay_conn = Some(conn);
+            }
+            let phase_conn = logical_replay_conn.as_ref().unwrap_or(&main_conn);
+            if logical_replay_conn.is_none() {
+                main_session
+                    .as_mut()
+                    .expect("main WAL session must be active")
+                    .commit(applied_raw_db_size)?;
+                if stream_kind_applies_remote_pages(stream_kind)
+                    && !replace_base_pages
+                    && raw_page_replay_on_sql_conn
+                {
+                    let current_schema_version = main_conn.read_schema_version()?;
+                    let final_schema_version =
+                        current_schema_version.max(main_conn_schema_version) + 1;
+                    main_conn.write_schema_version(final_schema_version)?;
+                    tracing::info!(
+                        "apply_changes(path={}): updated schema version to {}",
+                        self.main_db_path,
+                        final_schema_version
+                    );
+                }
+            }
+            let use_pushed_change_hint = use_pushed_change_hint_for_local_replay(stream_kind);
+            let use_pushed_replay_floor_hint =
+                use_pushed_replay_floor_hint_for_local_replay(stream_kind);
+
+            // Phase 4: as now DB has all data from remote - let's read pull generation and last change id for current client
+            let (remote_pull_gen, remote_last_change_id) = if replace_base_pages {
+                tracing::info!(
+                    "apply_changes(path={}): using local acknowledged high-water mark for replace-base replay floor: pull_gen={} change_id={:?}",
+                    self.main_db_path,
+                    local_pull_gen,
+                    local_last_change_id,
+                );
+                (
+                    local_pull_gen,
+                    if no_checkpoint_replace_base {
+                        None
+                    } else {
+                        local_last_change_id
+                    },
+                )
+            } else {
+                read_last_change_id(coro, phase_conn, &self.client_unique_id)
+                    .await
+                    .map_err(|error| {
+                        Error::DatabaseSyncEngineError(format!(
+                            "failed to read last_change_id after remote apply: {error}",
+                        ))
+                    })?
+            };
+
+            if remote_pull_gen > local_pull_gen {
+                return Err(Error::DatabaseSyncEngineError(format!(
+                    "protocol error: remote_pull_gen > local_pull_gen: {remote_pull_gen} > {local_pull_gen}"
+                )));
+            }
+            let last_change_id = resolve_local_replay_floor_change_id(
+                use_pushed_change_hint,
+                use_pushed_replay_floor_hint,
+                local_pull_gen,
+                remote_pull_gen,
+                remote_last_change_id,
+                last_pushed_pull_gen_hint,
+                last_pushed_change_id_hint,
+                last_pushed_replay_floor_change_id_hint,
+            );
+            tracing::info!(
+                "apply_changes(path={}): local replay floor: use_pushed_change_hint={} use_pushed_replay_floor_hint={} local_pull_gen={} remote_pull_gen={} remote_last_change_id={:?} last_pushed_pull_gen_hint={} last_pushed_change_id_hint={} last_pushed_replay_floor_change_id_hint={} resolved_last_change_id={:?}",
+                self.main_db_path,
+                use_pushed_change_hint,
+                use_pushed_replay_floor_hint,
+                local_pull_gen,
+                remote_pull_gen,
+                remote_last_change_id,
+                last_pushed_pull_gen_hint,
+                last_pushed_change_id_hint,
+                last_pushed_replay_floor_change_id_hint,
+                last_change_id,
+            );
+
+            // Phase 5: collect/filter local changes for replay.
+            let replay_floor = last_change_id.unwrap_or(0);
+            let local_changes = if precollect_local_changes_before_remote_apply {
+                precollected_local_changes
+                    .into_iter()
+                    .filter(|change| change.change_id > replay_floor)
+                    .collect::<Vec<_>>()
+            } else {
+                let iterate_opts = DatabaseChangesIteratorOpts {
+                    first_change_id: Some(replay_floor + 1),
+                    mode: DatabaseChangesIteratorMode::Apply,
+                    ignore_schema_changes: false,
+                    ..Default::default()
+                };
+                let mut local_changes = Vec::new();
+                let mut iterator = self.main_tape.iterate_changes(iterate_opts)?;
+                while let Some(operation) = iterator.next(coro).await? {
+                    match operation {
+                        DatabaseTapeOperation::RowChange(change) => local_changes.push(change),
+                        DatabaseTapeOperation::Commit => continue,
+                        DatabaseTapeOperation::StmtReplay(_)
+                        | DatabaseTapeOperation::SchemaReplay(_) => {
+                            panic!("changes iterator must not use replay-only operations")
+                        }
+                    }
+                }
+                local_changes
+            };
+            let replaying_pushed_self_range = use_pushed_replay_floor_hint
+                && last_pushed_change_id_hint > 0
+                && last_pushed_replay_floor_change_id_hint < last_pushed_change_id_hint
+                && replay_floor == last_pushed_replay_floor_change_id_hint;
+            let (local_changes, skipped_pushed_self_changes_touched_by_remote) =
+                filter_pushed_self_changes_touched_by_remote(
+                    local_changes,
+                    replaying_pushed_self_range,
+                    last_pushed_change_id_hint,
+                    &remote_logical_touched_rows,
+                );
+            let mut skipped_internal_local_changes = 0usize;
+            let local_changes = local_changes
+                .into_iter()
+                .filter_map(|change| match should_replay_local_change(&change) {
+                    Ok(true) => Some(Ok(change)),
+                    Ok(false) => {
+                        skipped_internal_local_changes += 1;
+                        None
+                    }
+                    Err(error) => Some(Err(error)),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let replayed_local_changes = !local_changes.is_empty();
+            let delay_cdc_for_pushed_self_replay = logical_replay_conn.is_some()
+                && replaying_pushed_self_range
+                && had_cdc_table;
+            let mut recaptured_local_changes = replayed_local_changes;
+            if delay_cdc_for_pushed_self_replay {
+                recaptured_local_changes = false;
+            }
+            let mut preserve_local_replay_floor = None;
+            tracing::info!(
+                "apply_changes(path={}): collected {} changes, skipped_pushed_self_changes_touched_by_remote={} skipped_internal_local_changes={}",
+                self.main_db_path,
+                local_changes.len(),
+                skipped_pushed_self_changes_touched_by_remote,
+                skipped_internal_local_changes,
+            );
+            let post_remote_apply_change_id = if replace_base_pages || raw_page_replay_on_sql_conn {
+                max_local_change_id(coro, phase_conn).await?.unwrap_or(0)
+            } else {
+                0
+            };
+
+            // Phase 6: replay local changes.
+            if !local_changes.is_empty()
+                || local_rollback != 0
+                || remote_rollback != 0
+                || had_cdc_table
+            {
+                if logical_replay_conn.is_none() {
+                    phase_conn.reset_main_mvcc_tx_for_wal_session();
+                }
+                if replace_base_pages || raw_page_replay_on_sql_conn {
+                    tracing::info!(
+                        "apply_changes(path={}): skipping pre-replay sync high-water reset; final high-water will be persisted after replay commit",
+                        self.main_db_path
+                    );
+                } else {
+                    update_last_change_id(
+                        coro,
+                        phase_conn,
+                        &self.client_unique_id,
+                        local_pull_gen + 1,
+                        0,
+                    )
+                    .await
+                    .map_err(|error| {
+                        Error::DatabaseSyncEngineError(format!(
+                            "failed to reset sync high-water mark before local replay: {error}",
+                        ))
+                    })
+                    .inspect_err(|e| tracing::error!("update_last_change_id failed: {e}"))?;
+                }
+
+                let mut cdc_enabled_for_local_replay = false;
+                if replayed_local_changes && had_cdc_table && !delay_cdc_for_pushed_self_replay {
+                    tracing::info!(
+                        "apply_changes(path={}): reinitialize CDC pragma before local replay",
+                        self.main_db_path,
+                    );
+                    phase_conn
+                        .pragma_update(CDC_PRAGMA_NAME, "'full'")
+                        .map_err(|error| {
+                            Error::DatabaseSyncEngineError(format!(
+                                "failed to reinitialize CDC pragma before local replay: {error}",
+                            ))
+                        })?;
+                    if replace_base_pages || raw_page_replay_on_sql_conn {
+                        phase_conn.publish_schema_after_external_restore();
+                    }
+                    cdc_enabled_for_local_replay = true;
+                }
+
+                let mut replay = DatabaseReplaySession {
+                    conn: phase_conn.clone(),
+                    cached_delete_stmt: HashMap::new(),
+                    cached_insert_stmt: HashMap::new(),
+                    cached_update_stmt: HashMap::new(),
+                    in_txn: true,
+                    generator: DatabaseReplayGenerator {
+                        conn: phase_conn.clone(),
+                        opts: DatabaseReplaySessionOpts {
+                            use_implicit_rowid: raw_page_replay_on_sql_conn,
+                        },
+                    },
+                };
+
+                let should_transform_local_change = |change: &DatabaseTapeRowChange| {
+                    is_logically_replayable_table(&change.table_name)
+                        && !self
+                            .opts
+                            .tables_ignore
+                            .iter()
+                            .any(|table| table == &change.table_name)
+                };
+                let transform_changes = if self.opts.use_transform {
+                    local_changes
+                        .iter()
+                        .filter(|change| should_transform_local_change(change))
+                        .cloned()
+                        .collect::<Vec<_>>()
+                } else {
+                    Vec::new()
+                };
+                let mut transformed = if self.opts.use_transform {
+                    let ctx = &SyncOperationCtx::new(
+                        coro,
+                        &self.sync_engine_io,
+                        self.meta().remote_url(),
+                        self.opts.remote_encryption_key.as_deref(),
+                    );
+                    Some(apply_transformation(ctx, &transform_changes, &replay.generator).await?)
+                } else {
+                    None
+                };
+                let mut transform_index = 0usize;
+
+                assert!(!replay.conn().get_auto_commit());
+                for (i, change) in local_changes.into_iter().enumerate() {
+                    let should_recapture_change = !delay_cdc_for_pushed_self_replay
+                        || change.change_id > last_pushed_change_id_hint;
+                    let preserve_original_change_floor = should_recapture_change
+                        && matches!(&change.change, DatabaseTapeRowChangeType::Delete { .. });
+                    let original_change_floor = change.change_id.saturating_sub(1);
+                    let operation = if should_transform_local_change(&change) {
+                        if let Some(transformed) = &mut transformed {
+                            let transform_result = std::mem::replace(
+                                &mut transformed[transform_index],
+                                DatabaseRowTransformResult::Skip,
+                            );
+                            transform_index += 1;
+                            match transform_result {
+                                DatabaseRowTransformResult::Keep => {
+                                    DatabaseTapeOperation::RowChange(change)
+                                }
+                                DatabaseRowTransformResult::Skip => continue,
+                                DatabaseRowTransformResult::Rewrite(replay) => {
+                                    DatabaseTapeOperation::StmtReplay(replay)
+                                }
+                            }
+                        } else {
+                            DatabaseTapeOperation::RowChange(change)
+                        }
+                    } else {
+                        DatabaseTapeOperation::RowChange(change)
+                    };
+                    if should_recapture_change && had_cdc_table && !cdc_enabled_for_local_replay {
+                        tracing::info!(
+                            "apply_changes(path={}): reinitialize CDC pragma before unpushed local replay",
+                            self.main_db_path,
+                        );
+                        phase_conn
+                            .pragma_update(CDC_PRAGMA_NAME, "'full'")
+                            .map_err(|error| {
+                                Error::DatabaseSyncEngineError(format!(
+                                    "failed to reinitialize CDC pragma before unpushed local replay: {error}",
+                                ))
+                            })?;
+                        cdc_enabled_for_local_replay = true;
+                    }
+                    if should_recapture_change {
+                        recaptured_local_changes = true;
+                    }
+                    if preserve_original_change_floor {
+                        preserve_local_replay_floor = Some(
+                            preserve_local_replay_floor.map_or(
+                                original_change_floor,
+                                |floor: i64| floor.min(original_change_floor),
+                            ),
+                        );
+                    }
+                    maybe_inject_replace_base_local_replay_failure(replace_base_pages, i)?;
+                    replay.replay(coro, operation).await.map_err(|error| {
+                        Error::DatabaseSyncEngineError(format!(
+                            "failed to replay local change after remote apply: {error}",
+                        ))
+                    })?;
+                }
+                assert!(!replay.conn().get_auto_commit());
+            }
+
+            if let Some(logical_conn) = logical_replay_conn {
+                logical_conn.execute("COMMIT").map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!(
+                        "failed to commit remote apply replay transaction: {error}",
+                    ))
+                })?;
+                logical_conn.publish_schema_if_newer();
+                if had_cdc_table || replace_base_pages {
+                    tracing::info!(
+                        "apply_changes(path={}): reinitialize CDC pragma after logical replay commit",
+                        self.main_db_path,
+                    );
+                    logical_conn
+                        .pragma_update(CDC_PRAGMA_NAME, "'full'")
+                        .map_err(|error| {
+                            Error::DatabaseSyncEngineError(format!(
+                                "failed to reinitialize CDC pragma after remote apply: {error}",
+                            ))
+                        })?;
+                    logical_conn.publish_schema_if_newer();
+                    let change_id = max_local_change_id(coro, &logical_conn).await?.unwrap_or(0);
+                    tracing::info!(
+                        "apply_changes(path={}): post-logical-replay CDC high-water mark: {}",
+                        self.main_db_path,
+                        change_id
+                    );
+                    let synced_change_id = synced_change_id_after_remote_apply(
+                        recaptured_local_changes,
+                        pre_apply_local_change_id,
+                        change_id,
+                    );
+                    let synced_change_id = if recaptured_local_changes && raw_page_replay_on_sql_conn
+                    {
+                        post_remote_apply_change_id
+                    } else {
+                        synced_change_id
+                    };
+                    let synced_change_id = preserve_local_replay_floor
+                        .map_or(synced_change_id, |floor| synced_change_id.min(floor));
+                    if raw_page_replay_on_sql_conn {
+                        rebuild_local_sync_metadata_table(
+                            coro,
+                            &logical_conn,
+                            &self.client_unique_id,
+                            local_pull_gen + 1,
+                            synced_change_id,
+                        )
+                        .await?;
+                    } else {
+                        update_last_change_id(
+                            coro,
+                            &logical_conn,
+                            &self.client_unique_id,
+                            local_pull_gen + 1,
+                            synced_change_id,
+                        )
+                        .await?;
+                    }
+                }
+                let logical_table_names_by_stable_id =
+                    read_logical_replay_table_map(coro, &logical_conn).await?;
+                return Ok((
+                    logical_conn.wal_state()?.max_frame,
+                    logical_table_names_by_stable_id,
+                    followup_revision,
+                ));
+            }
+            if main_conn.has_main_mvcc_tx_for_wal_session() {
+                main_conn
+                    .commit_main_mvcc_tx_for_wal_session()
+                    .map_err(|error| {
+                        Error::DatabaseSyncEngineError(format!(
+                            "failed to commit main MVCC transaction after remote apply: {error}",
+                        ))
+                    })?;
+            }
+            main_conn.end_nested();
+            // wal_session.end(force_commit=true) fsyncs the WAL before returning, so the
+            // caller can durably record this revision as synced in the metadata.
+            main_session
+                .take()
+                .expect("main WAL session must be active")
+                .wal_session
+                .end(true)
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!(
+                        "failed to finalize raw WAL session after remote apply: {error}",
+                    ))
+                })?;
+            if replace_base_pages || raw_page_replay_on_sql_conn {
+                publish_schema_after_raw_wal_replay(&main_conn, "raw WAL replay")?;
+            }
+            if replace_base_pages || had_cdc_table && raw_page_replay_on_sql_conn {
+                tracing::info!(
+                    "apply_changes(path={}): reinitialize CDC pragma after WAL replay commit",
+                    self.main_db_path,
+                );
+                execute_with_schema_retry(
+                    &main_conn,
+                    &format!("PRAGMA {CDC_PRAGMA_NAME} = 'full'"),
+                )
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!(
+                        "failed to reinitialize CDC pragma after remote apply: {error}",
+                    ))
+                })?;
+                main_conn.publish_schema_after_external_restore();
+                let change_id = max_local_change_id(coro, &main_conn).await?.unwrap_or(0);
+                tracing::info!(
+                    "apply_changes(path={}): post-WAL-replay CDC high-water mark: {}",
+                    self.main_db_path,
+                    change_id
+                );
+                let synced_change_id = synced_change_id_after_remote_apply(
+                    recaptured_local_changes,
+                    pre_apply_local_change_id,
+                    change_id,
+                );
+                let synced_change_id =
+                    if recaptured_local_changes && (replace_base_pages || raw_page_replay_on_sql_conn)
+                    {
+                        post_remote_apply_change_id
+                    } else {
+                        synced_change_id
+                    };
+                let synced_change_id = preserve_local_replay_floor
+                    .map_or(synced_change_id, |floor| synced_change_id.min(floor));
+                update_last_change_id(
+                    coro,
+                    &main_conn,
+                    &self.client_unique_id,
+                    local_pull_gen + 1,
+                    synced_change_id,
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!(
+                        "failed to persist sync high-water mark after raw remote apply: {error}",
+                    ))
+                })?;
+            }
+
+            let logical_table_names_by_stable_id =
+                read_logical_replay_table_map(coro, &main_conn).await?;
+            Ok((
+                main_conn.wal_state()?.max_frame,
+                logical_table_names_by_stable_id,
+                followup_revision,
+            ))
+        }
+        .await;
+
+        match apply_result {
+            Ok(frame) => {
+                if let Some(guard) = &mut replace_base_guard {
+                    guard.mark_complete(coro).await?;
+                }
+                Ok(frame)
+            }
+            Err(error) => {
+                if let Some(guard) = &replace_base_guard {
+                    let error = guard.restore_after_error(coro, error).await;
+                    match reload_connection_after_external_restore(
+                        &main_conn,
+                        "replace-base error recovery",
+                    ) {
+                        Ok(()) => Err(error),
+                        Err(reload_error) => Err(Error::DatabaseSyncEngineError(format!(
+                            "{error}; additionally failed to reload restored database state: {reload_error}",
+                        ))),
+                    }
+                } else {
+                    Err(error)
                 }
             }
         }
-        tracing::info!(
-            "apply_changes(path={}): collected {} changes",
-            self.main_db_path,
-            local_changes.len()
-        );
-
-        // Phase 6: replay local changes
-        // we can skip this phase if we are sure that we had no local changes before
-        if !local_changes.is_empty() || local_rollback != 0 || remote_rollback != 0 || had_cdc_table
-        {
-            // first, we update last_change id in the local meta table for sync
-            update_last_change_id(
-                coro,
-                &main_conn,
-                &self.client_unique_id,
-                local_pull_gen + 1,
-                0,
-            )
-            .await
-            .inspect_err(|e| tracing::error!("update_last_change_id failed: {e}"))?;
-
-            if had_cdc_table {
-                tracing::info!(
-                    "apply_changes(path={}): initiate CDC pragma again in order to recreate CDC table",
-                    self.main_db_path,
-                );
-                let _ = main_conn.pragma_update(CDC_PRAGMA_NAME, "'full'")?;
-            }
-
-            let mut replay = DatabaseReplaySession {
-                conn: main_conn.clone(),
-                cached_delete_stmt: HashMap::new(),
-                cached_insert_stmt: HashMap::new(),
-                cached_update_stmt: HashMap::new(),
-                in_txn: true,
-                generator: DatabaseReplayGenerator {
-                    conn: main_conn.clone(),
-                    opts: DatabaseReplaySessionOpts {
-                        use_implicit_rowid: false,
-                    },
-                },
-            };
-
-            let mut transformed = if self.opts.use_transform {
-                let ctx = &SyncOperationCtx::new(
-                    coro,
-                    &self.sync_engine_io,
-                    self.meta().remote_url(),
-                    self.opts.remote_encryption_key.as_deref(),
-                );
-                Some(apply_transformation(ctx, &local_changes, &replay.generator).await?)
-            } else {
-                None
-            };
-
-            assert!(!replay.conn().get_auto_commit());
-            // Replay local changes collected on Phase 5
-            for (i, change) in local_changes.into_iter().enumerate() {
-                let operation = if let Some(transformed) = &mut transformed {
-                    match std::mem::replace(&mut transformed[i], DatabaseRowTransformResult::Skip) {
-                        DatabaseRowTransformResult::Keep => {
-                            DatabaseTapeOperation::RowChange(change)
-                        }
-                        DatabaseRowTransformResult::Skip => continue,
-                        DatabaseRowTransformResult::Rewrite(replay) => {
-                            DatabaseTapeOperation::StmtReplay(replay)
-                        }
-                    }
-                } else {
-                    DatabaseTapeOperation::RowChange(change)
-                };
-                replay.replay(coro, operation).await?;
-            }
-            assert!(!replay.conn().get_auto_commit());
-        }
-
-        // Final: now we did all necessary operations as one big transaction and we are ready to commit.
-        // wal_insert_end(force_commit=true) fsyncs the WAL before returning, so the
-        // caller can durably record this revision as synced in the metadata.
-        main_conn.end_nested();
-        main_session.wal_session.end(true)?;
-
-        Ok(revert_since_wal_watermark)
     }
 
     /// Sync local changes to remote DB
@@ -1114,10 +4210,12 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             self.meta().remote_url(),
             self.opts.remote_encryption_key.as_deref(),
         );
-        let (_, change_id) =
+        let (pull_gen, replay_floor_change_id, change_id) =
             push_logical_changes(ctx, &self.main_tape, &self.client_unique_id, &self.opts).await?;
 
         self.update_meta(coro, |m| {
+            m.last_pushed_pull_gen_hint = pull_gen;
+            m.last_pushed_replay_floor_change_id_hint = replay_floor_change_id;
             m.last_pushed_change_id_hint = change_id;
             m.last_push_unix_time = Some(self.io.current_time_wall_clock().secs);
         })

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -259,31 +259,43 @@ mod tests {
             DatabaseSyncEngineProtocolVersion::Legacy,
             false,
             DbChangesStreamKind::LegacyPages,
+            true,
         ));
         assert!(!should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::Legacy,
             false,
             DbChangesStreamKind::ReplaceBasePages,
+            true,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            false,
+            DbChangesStreamKind::Pages,
+            false,
         ));
         assert!(should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::V1,
             false,
             DbChangesStreamKind::Pages,
+            true,
         ));
         assert!(should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::V1,
             false,
             DbChangesStreamKind::ReplaceBasePages,
+            true,
         ));
         assert!(!should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::V1,
             true,
             DbChangesStreamKind::ReplaceBasePages,
+            true,
         ));
         assert!(!should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::V1,
             false,
             DbChangesStreamKind::Logical,
+            true,
         ));
     }
 
@@ -2117,8 +2129,10 @@ fn should_replay_raw_pages_on_sql_conn(
     protocol_version_hint: DatabaseSyncEngineProtocolVersion,
     logical_replay_conn_active: bool,
     stream_kind: DbChangesStreamKind,
+    mvcc_active: bool,
 ) -> bool {
     protocol_version_hint != DatabaseSyncEngineProtocolVersion::Legacy
+        && mvcc_active
         && !logical_replay_conn_active
         && matches!(
             stream_kind,
@@ -3361,6 +3375,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 self.opts.protocol_version_hint,
                 false,
                 stream_kind,
+                main_conn.mv_store().as_ref().is_some(),
             );
         let replace_base_precollection_floor = if replace_base_pages {
             if no_checkpoint_replace_base {
@@ -3478,6 +3493,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             let mut logical_replay_conn = None;
             let mut remote_logical_touched_rows = BTreeSet::new();
             let applied_raw_db_size: u32;
+            let mut revert_since_wal_watermark = None;
             let mut followup_revision = None;
             match stream_kind {
                 stream_kind if stream_kind_applies_remote_pages(stream_kind) => {
@@ -3696,6 +3712,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 self.opts.protocol_version_hint,
                 logical_replay_conn.is_some(),
                 stream_kind,
+                main_conn.mv_store().as_ref().is_some(),
             );
             if raw_page_replay_on_sql_conn {
                 let mut finished_main_session = main_session
@@ -3728,11 +3745,14 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 main_session
                     .as_mut()
                     .expect("main WAL session must be active")
-                    .commit(applied_raw_db_size)?;
-                if stream_kind_applies_remote_pages(stream_kind)
-                    && !replace_base_pages
-                    && raw_page_replay_on_sql_conn
-                {
+                    .commit(0)?;
+                revert_since_wal_watermark = Some(
+                    main_session
+                        .as_ref()
+                        .expect("main WAL session must be active")
+                        .frames_count()?,
+                );
+                if stream_kind_applies_remote_pages(stream_kind) && !replace_base_pages {
                     let current_schema_version = main_conn.read_schema_version()?;
                     let final_schema_version =
                         current_schema_version.max(main_conn_schema_version) + 1;
@@ -4178,8 +4198,10 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
             let logical_table_names_by_stable_id =
                 read_logical_replay_table_map(coro, &main_conn).await?;
+            let revert_since_wal_watermark =
+                revert_since_wal_watermark.unwrap_or(main_conn.wal_state()?.max_frame);
             Ok((
-                main_conn.wal_state()?.max_frame,
+                revert_since_wal_watermark,
                 logical_table_names_by_stable_id,
                 followup_revision,
             ))

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -493,6 +493,7 @@ mod tests {
 
     struct CapturingSyncEngineIo {
         response: Mutex<Option<Vec<u8>>>,
+        #[allow(clippy::type_complexity)]
         request: Mutex<Option<(String, String, Option<Vec<u8>>)>>,
     }
 
@@ -2125,6 +2126,7 @@ fn should_replay_raw_pages_on_sql_conn(
         )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_local_replay_floor_change_id(
     use_pushed_change_hint: bool,
     use_pushed_replay_floor_hint: bool,

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -427,6 +427,11 @@ mod tests {
             "with local replay, preserve the replay floor so local rows remain pushable"
         );
         assert_eq!(
+            synced_change_id_after_remote_apply(true, Some(11), 8),
+            8,
+            "the persisted sync floor must never advance beyond the local CDC high-water"
+        );
+        assert_eq!(
             synced_change_id_after_remote_apply(true, None, 40),
             0,
             "a database with no pre-existing CDC still starts from zero"
@@ -1988,7 +1993,7 @@ fn execute_with_schema_retry(conn: &Arc<turso_core::Connection>, sql: &str) -> R
             Ok(()) => return Ok(()),
             Err(LimboError::SchemaUpdated) if attempt < 4 => {
                 force_reparse_schema_with_retry(conn)?;
-                conn.publish_schema_after_external_restore();
+                publish_schema_after_external_restore(conn, "schema retry")?;
             }
             Err(error) => return Err(error.into()),
         }
@@ -2018,6 +2023,7 @@ fn reload_connection_after_external_restore(
     conn: &Arc<turso_core::Connection>,
     context: &str,
 ) -> Result<()> {
+    conn.discard_main_mvcc_tx_after_external_restore();
     match conn.reload_wal_after_external_restore() {
         Ok(()) => {}
         Err(LimboError::SchemaUpdated) => {
@@ -2044,7 +2050,7 @@ fn reload_connection_after_external_restore(
             format!("failed to refresh schema after {context}: {error}",),
         )
     })?;
-    conn.publish_schema_after_external_restore();
+    publish_schema_after_external_restore(conn, context)?;
     Ok(())
 }
 
@@ -2060,17 +2066,25 @@ fn publish_schema_after_raw_wal_replay(
             format!("failed to refresh schema after {context}: {error}",),
         )
     })?;
-    conn.publish_schema_after_external_restore();
+    publish_schema_after_external_restore(conn, context)?;
     Ok(())
 }
 
 fn publish_schema_after_sync_checkpoint(conn: &Arc<turso_core::Connection>) -> Result<()> {
     conn.get_pager().clear_page_cache(true);
     match force_reparse_schema_with_retry(conn) {
-        Ok(()) => {
-            conn.publish_schema_after_external_restore();
-            Ok(())
-        }
+        Ok(()) => match conn.publish_schema_after_external_restore() {
+            Ok(()) => Ok(()),
+            Err(LimboError::Busy) => {
+                tracing::debug!(
+                        "checkpoint: schema publish after sync checkpoint skipped due to local busy connection"
+                    );
+                Ok(())
+            }
+            Err(error) => Err(Error::DatabaseSyncEngineError(format!(
+                "failed to publish schema after sync checkpoint: {error}",
+            ))),
+        },
         Err(Error::TursoError(LimboError::Busy)) => {
             tracing::debug!(
                 "checkpoint: schema refresh after sync checkpoint skipped due to local busy connection"
@@ -2081,6 +2095,18 @@ fn publish_schema_after_sync_checkpoint(conn: &Arc<turso_core::Connection>) -> R
             "failed to refresh schema after sync checkpoint: {error}",
         ))),
     }
+}
+
+fn publish_schema_after_external_restore(
+    conn: &Arc<turso_core::Connection>,
+    context: &str,
+) -> Result<()> {
+    conn.publish_schema_after_external_restore()
+        .map_err(|error| {
+            Error::DatabaseSyncEngineError(format!(
+                "failed to publish schema after {context}: {error}",
+            ))
+        })
 }
 
 /// Marks all current CDC rows as already observed by `client_id`.
@@ -2120,7 +2146,7 @@ async fn rebuild_local_sync_metadata_table<Ctx>(
     pull_gen: i64,
     change_id: i64,
 ) -> Result<()> {
-    conn.publish_schema_after_external_restore();
+    publish_schema_after_external_restore(conn, "local sync metadata rebuild")?;
     update_last_change_id(coro, conn, client_id, pull_gen, change_id).await
 }
 
@@ -2213,11 +2239,12 @@ fn synced_change_id_after_remote_apply(
     local_replay_floor_change_id: Option<i64>,
     post_apply_change_id: i64,
 ) -> i64 {
-    if replayed_local_changes {
+    let change_id = if replayed_local_changes {
         local_replay_floor_change_id.unwrap_or(0)
     } else {
         post_apply_change_id
-    }
+    };
+    change_id.min(post_apply_change_id)
 }
 
 fn use_pushed_change_hint_for_local_replay(
@@ -3634,7 +3661,10 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                                 "failed to initialize sync high-water mark table after replace-base snapshot: {error}"
                             ))
                         })?;
-                        conn.publish_schema_after_external_restore();
+                        publish_schema_after_external_restore(
+                            &conn,
+                            "replace-base sync table initialization",
+                        )?;
                         conn = match connect_untracked(&self.main_tape) {
                             Ok(conn) => conn,
                             Err(Error::TursoError(LimboError::SchemaUpdated)) => {
@@ -3656,7 +3686,10 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                                 "failed to refresh replay connection schema after replace-base sync table initialization: {error}",
                             ))
                         })?;
-                        conn.publish_schema_after_external_restore();
+                        publish_schema_after_external_restore(
+                            &conn,
+                            "replace-base sync table reconnect",
+                        )?;
                         execute_with_schema_retry(&conn, "BEGIN IMMEDIATE").map_err(|error| {
                             Error::DatabaseSyncEngineError(format!(
                                 "failed to begin replace-base replay transaction: {error}",
@@ -3977,9 +4010,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                                 "failed to reinitialize CDC pragma before local replay: {error}",
                             ))
                         })?;
-                    if replace_base_pages || raw_page_replay_on_sql_conn {
-                        phase_conn.publish_schema_after_external_restore();
-                    }
                     cdc_enabled_for_local_replay = true;
                 }
 
@@ -4130,6 +4160,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     };
                     let synced_change_id = preserve_local_replay_floor
                         .map_or(synced_change_id, |floor| synced_change_id.min(floor));
+                    let synced_change_id = synced_change_id.min(change_id);
                     if raw_page_replay_on_sql_conn {
                         rebuild_local_sync_metadata_table(
                             coro,
@@ -4198,7 +4229,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         "failed to reinitialize CDC pragma after remote apply: {error}",
                     ))
                 })?;
-                main_conn.publish_schema_after_external_restore();
+                publish_schema_after_external_restore(&main_conn, "post-WAL-replay CDC refresh")?;
                 let change_id = max_local_change_id(coro, &main_conn).await?.unwrap_or(0);
                 tracing::info!(
                     "apply_changes(path={}): post-WAL-replay CDC high-water mark: {}",
@@ -4216,9 +4247,10 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         post_remote_apply_change_id
                     } else {
                         synced_change_id
-                    };
+                };
                 let synced_change_id = preserve_local_replay_floor
                     .map_or(synced_change_id, |floor| synced_change_id.min(floor));
+                let synced_change_id = synced_change_id.min(change_id);
                 update_last_change_id(
                     coro,
                     &main_conn,

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -1993,6 +1993,38 @@ fn force_reparse_schema_with_retry(conn: &Arc<turso_core::Connection>) -> Result
     Ok(())
 }
 
+/// Reparse only this connection's own schema after a raw page/WAL replay,
+/// without publishing it to the shared database cache. The caller must publish
+/// once the schema is complete (see [`Connection::force_reparse_schema_without_publish`]).
+fn force_reparse_schema_without_publish_with_retry(
+    conn: &Arc<turso_core::Connection>,
+) -> Result<()> {
+    for attempt in 0..=2 {
+        match conn.force_reparse_schema_without_publish() {
+            Ok(()) => return Ok(()),
+            Err(LimboError::SchemaUpdated) if attempt < 2 => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+/// Refresh this connection's own schema from freshly replayed pages without
+/// publishing to the shared cache. Publishing is deferred to the caller so the
+/// shared schema is only ever updated once the CDC table has been recreated,
+/// preventing concurrent statements from observing a `turso_cdc`-less schema.
+fn refresh_schema_after_raw_wal_replay_local(
+    conn: &Arc<turso_core::Connection>,
+    context: &str,
+) -> Result<()> {
+    conn.get_pager().clear_page_cache(true);
+    force_reparse_schema_without_publish_with_retry(conn).map_err(|error| {
+        Error::DatabaseSyncEngineError(
+            format!("failed to refresh schema after {context}: {error}",),
+        )
+    })
+}
+
 /// Refreshes an open connection after sync has restored files outside SQLite.
 ///
 /// This rebuilds WAL/MVCC state, clears cached pages, reparses schema, and
@@ -2023,22 +2055,6 @@ fn reload_connection_after_external_restore(
             )));
         }
     }
-    conn.get_pager().clear_page_cache(true);
-    force_reparse_schema_with_retry(conn).map_err(|error| {
-        Error::DatabaseSyncEngineError(
-            format!("failed to refresh schema after {context}: {error}",),
-        )
-    })?;
-    publish_schema_after_external_restore(conn, context)?;
-    Ok(())
-}
-
-/// Publishes schema after raw WAL replay mutates database pages externally.
-#[allow(dead_code)]
-fn publish_schema_after_raw_wal_replay(
-    conn: &Arc<turso_core::Connection>,
-    context: &str,
-) -> Result<()> {
     conn.get_pager().clear_page_cache(true);
     force_reparse_schema_with_retry(conn).map_err(|error| {
         Error::DatabaseSyncEngineError(
@@ -3707,13 +3723,23 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     ))
                 })?;
                 drop(finished_main_session);
-                publish_schema_after_raw_wal_replay(&main_conn, "raw WAL replay")?;
+                // Refresh main_conn's own schema from the replayed pages, but do NOT publish
+                // it to the shared cache. Publishing the intermediate schema here would expose
+                // a turso_cdc-less view (the raw pages replace the local-only CDC table) to
+                // concurrent CDC-enabled statements on other connections, which would then fail
+                // to compile with "no such table: turso_cdc". The shared cache is published
+                // once, at the end of apply, after the replay connection recreates turso_cdc.
+                refresh_schema_after_raw_wal_replay_local(&main_conn, "raw WAL replay")?;
 
                 let conn = connect_untracked(&self.main_tape).map_err(|error| {
                     Error::DatabaseSyncEngineError(format!(
                         "failed to open post-raw-apply replay connection: {error}",
                     ))
                 })?;
+                // The replay connection is seeded from the (deliberately not-yet-updated)
+                // shared schema, so reparse it locally from the freshly replayed pages before
+                // it replays local changes.
+                refresh_schema_after_raw_wal_replay_local(&conn, "raw WAL replay replay-conn")?;
                 execute_with_schema_retry(&conn, "BEGIN IMMEDIATE").map_err(|error| {
                     Error::DatabaseSyncEngineError(format!(
                         "failed to begin post-raw-apply replay transaction: {error}",
@@ -4010,7 +4036,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         "failed to commit remote apply replay transaction: {error}",
                     ))
                 })?;
-                logical_conn.publish_schema_if_newer();
                 if had_cdc_table || replace_base_pages {
                     tracing::info!(
                         "apply_changes(path={}): reinitialize CDC pragma after logical replay commit",
@@ -4023,7 +4048,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                                 "failed to reinitialize CDC pragma after remote apply: {error}",
                             ))
                         })?;
-                    logical_conn.publish_schema_if_newer();
                     let change_id = max_local_change_id(coro, &logical_conn).await?.unwrap_or(0);
                     tracing::info!(
                         "apply_changes(path={}): post-logical-replay CDC high-water mark: {}",
@@ -4064,6 +4088,11 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         .await?;
                     }
                 }
+                // Publish the post-apply schema to the shared cache exactly once, and only
+                // after any turso_cdc recreation above. Publishing between the replay commit
+                // and the CDC-table recreation would briefly expose a version-bumped schema
+                // that omits turso_cdc.
+                logical_conn.publish_schema_if_newer();
                 let logical_table_names_by_stable_id =
                     read_logical_replay_table_map(coro, &logical_conn).await?;
                 return Ok((
@@ -4072,6 +4101,35 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     followup_revision,
                 ));
             }
+            let raw_replay_refresh = replace_base_pages || raw_page_replay_on_sql_conn;
+            let recreate_cdc =
+                replace_base_pages || had_cdc_table && stream_kind_applies_remote_pages(stream_kind);
+
+            // Common path (no external page replacement): recreate turso_cdc *inside* the apply
+            // transaction, before the commit below, so the committed on-disk state is never
+            // observed without turso_cdc. A concurrent reader that sees the new schema cookie
+            // reparses its schema from disk (see Connection::maybe_reparse_schema); if turso_cdc
+            // were missing from the committed image at that instant, a CDC-enabled statement
+            // would fail to compile with "no such table: turso_cdc". Recreating within the same
+            // commit keeps the transition atomic (this matches the pre-MVCC apply ordering).
+            //
+            // The raw-replay path cannot do this: it must commit first so the schema can be
+            // reparsed from the externally replaced pages, so it recreates turso_cdc after the
+            // commit instead (see below).
+            if recreate_cdc && !raw_replay_refresh {
+                tracing::info!(
+                    "apply_changes(path={}): reinitialize CDC pragma before remote apply commit",
+                    self.main_db_path,
+                );
+                main_conn
+                    .pragma_update(CDC_PRAGMA_NAME, "'full'")
+                    .map_err(|error| {
+                        Error::DatabaseSyncEngineError(format!(
+                            "failed to reinitialize CDC pragma before remote apply commit: {error}",
+                        ))
+                    })?;
+            }
+
             if main_conn.has_main_mvcc_tx_for_wal_session() {
                 main_conn
                     .commit_main_mvcc_tx_for_wal_session()
@@ -4094,25 +4152,42 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         "failed to finalize raw WAL session after remote apply: {error}",
                     ))
                 })?;
-            if replace_base_pages || raw_page_replay_on_sql_conn {
-                publish_schema_after_raw_wal_replay(&main_conn, "raw WAL replay")?;
+            if raw_replay_refresh {
+                // Refresh this connection's own schema from the replayed pages, but do NOT
+                // publish it to the shared cache yet. Publishing happens once below, after
+                // any turso_cdc recreation, so a concurrent CDC-enabled statement on another
+                // connection never reparses to a schema that lacks turso_cdc.
+                refresh_schema_after_raw_wal_replay_local(&main_conn, "raw WAL replay")?;
+                if recreate_cdc {
+                    tracing::info!(
+                        "apply_changes(path={}): reinitialize CDC pragma after WAL replay commit",
+                        self.main_db_path,
+                    );
+                    execute_with_schema_retry(
+                        &main_conn,
+                        &format!("PRAGMA {CDC_PRAGMA_NAME} = 'full'"),
+                    )
+                    .map_err(|error| {
+                        Error::DatabaseSyncEngineError(format!(
+                            "failed to reinitialize CDC pragma after remote apply: {error}",
+                        ))
+                    })?;
+                }
             }
-            if replace_base_pages || had_cdc_table && stream_kind_applies_remote_pages(stream_kind)
-            {
-                tracing::info!(
-                    "apply_changes(path={}): reinitialize CDC pragma after WAL replay commit",
-                    self.main_db_path,
-                );
-                execute_with_schema_retry(
+            // Publish the post-replay schema to the shared cache once turso_cdc has been
+            // recreated (either pre-commit for the common path, or just above for the
+            // raw-replay path) and before the high-water-mark bookkeeping below. The published
+            // schema always contains turso_cdc, so the transition is atomic — a concurrent
+            // CDC-enabled statement never observes a schema lacking turso_cdc ("no such table:
+            // turso_cdc"). Publishing before the bookkeeping also lets concurrent readers adopt
+            // the shared schema cheaply instead of reparsing from disk during that window.
+            if raw_replay_refresh || recreate_cdc {
+                publish_schema_after_external_restore(
                     &main_conn,
-                    &format!("PRAGMA {CDC_PRAGMA_NAME} = 'full'"),
-                )
-                .map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!(
-                        "failed to reinitialize CDC pragma after remote apply: {error}",
-                    ))
-                })?;
-                publish_schema_after_external_restore(&main_conn, "post-WAL-replay CDC refresh")?;
+                    "post-raw-WAL-replay schema publish",
+                )?;
+            }
+            if recreate_cdc {
                 let change_id = max_local_change_id(coro, &main_conn).await?.unwrap_or(0);
                 tracing::info!(
                     "apply_changes(path={}): post-WAL-replay CDC high-water mark: {}",

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -258,30 +258,42 @@ mod tests {
     fn sql_replay_page_routing_keeps_legacy_on_wal_session() {
         assert!(!should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::Legacy,
+            true,
             false,
             DbChangesStreamKind::LegacyPages,
             true,
         ));
         assert!(!should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::Legacy,
+            true,
             false,
             DbChangesStreamKind::ReplaceBasePages,
             true,
         ));
         assert!(!should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::V1,
+            false,
+            false,
+            DbChangesStreamKind::Pages,
+            true,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            true,
             false,
             DbChangesStreamKind::Pages,
             false,
         ));
         assert!(should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::V1,
+            true,
             false,
             DbChangesStreamKind::Pages,
             true,
         ));
         assert!(should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::V1,
+            true,
             false,
             DbChangesStreamKind::ReplaceBasePages,
             true,
@@ -289,11 +301,13 @@ mod tests {
         assert!(!should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::V1,
             true,
+            true,
             DbChangesStreamKind::ReplaceBasePages,
             true,
         ));
         assert!(!should_replay_raw_pages_on_sql_conn(
             DatabaseSyncEngineProtocolVersion::V1,
+            true,
             false,
             DbChangesStreamKind::Logical,
             true,
@@ -2142,11 +2156,13 @@ fn stream_kind_applies_remote_pages(stream_kind: DbChangesStreamKind) -> bool {
 #[allow(dead_code)]
 fn should_replay_raw_pages_on_sql_conn(
     protocol_version_hint: DatabaseSyncEngineProtocolVersion,
+    logical_mvcc_pull_active: bool,
     logical_replay_conn_active: bool,
     stream_kind: DbChangesStreamKind,
     mvcc_active: bool,
 ) -> bool {
     protocol_version_hint != DatabaseSyncEngineProtocolVersion::Legacy
+        && logical_mvcc_pull_active
         && mvcc_active
         && !logical_replay_conn_active
         && matches!(
@@ -3391,6 +3407,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             || matches!(stream_kind, DbChangesStreamKind::Logical)
             || should_replay_raw_pages_on_sql_conn(
                 self.opts.protocol_version_hint,
+                self.meta().logical_mvcc_pull_active,
                 false,
                 stream_kind,
                 main_conn.mv_store().as_ref().is_some(),
@@ -3728,6 +3745,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
             let raw_page_replay_on_sql_conn = should_replay_raw_pages_on_sql_conn(
                 self.opts.protocol_version_hint,
+                self.meta().logical_mvcc_pull_active,
                 logical_replay_conn.is_some(),
                 stream_kind,
                 main_conn.mv_store().as_ref().is_some(),

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -2022,6 +2022,25 @@ fn publish_schema_after_raw_wal_replay(
     Ok(())
 }
 
+fn publish_schema_after_sync_checkpoint(conn: &Arc<turso_core::Connection>) -> Result<()> {
+    conn.get_pager().clear_page_cache(true);
+    match force_reparse_schema_with_retry(conn) {
+        Ok(()) => {
+            conn.publish_schema_after_external_restore();
+            Ok(())
+        }
+        Err(Error::TursoError(LimboError::Busy)) => {
+            tracing::debug!(
+                "checkpoint: schema refresh after sync checkpoint skipped due to local busy connection"
+            );
+            Ok(())
+        }
+        Err(error) => Err(Error::DatabaseSyncEngineError(format!(
+            "failed to refresh schema after sync checkpoint: {error}",
+        ))),
+    }
+}
+
 /// Marks all current CDC rows as already observed by `client_id`.
 #[allow(dead_code)]
 async fn acknowledge_existing_cdc_for_client<Ctx>(
@@ -2050,8 +2069,7 @@ async fn acknowledge_existing_cdc_for_client<Ctx>(
 /// Recreates the local sync metadata table after page-level restore.
 ///
 /// Raw page replay can replace the table contents along with ordinary pages.
-/// This helper resets the table and writes the high-water mark that should
-/// survive the restore.
+/// This helper writes the high-water mark that should survive the restore.
 #[allow(dead_code)]
 async fn rebuild_local_sync_metadata_table<Ctx>(
     coro: &Coro<Ctx>,
@@ -2060,13 +2078,6 @@ async fn rebuild_local_sync_metadata_table<Ctx>(
     pull_gen: i64,
     change_id: i64,
 ) -> Result<()> {
-    execute_with_schema_retry(conn, "DROP TABLE IF EXISTS turso_sync_last_change_id").map_err(
-        |error| {
-            Error::DatabaseSyncEngineError(format!(
-                "failed to reset local sync high-water mark table after raw page replay: {error}",
-            ))
-        },
-    )?;
     conn.publish_schema_after_external_restore();
     update_last_change_id(coro, conn, client_id, pull_gen, change_id).await
 }
@@ -2816,6 +2827,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             self.main_db_path,
             result
         );
+        publish_schema_after_sync_checkpoint(&main_conn)?;
 
         Ok(())
     }

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -4073,11 +4073,8 @@ mod tests {
                 assert!(max_change_id.is_some_and(|change_id| change_id > 0));
             }
         });
-        loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(()) => break,
-            }
+        while let genawaiter::GeneratorState::Yielded(..) = gen.resume_with(Ok(())) {
+            io.step().unwrap()
         }
     }
 
@@ -5146,7 +5143,7 @@ mod tests {
             table_name: "sqlite_schema".to_string(),
             id: 1,
             change: DatabaseTapeRowChangeType::Insert {
-                after: parse_bin_record(&record(&[
+                after: parse_bin_record(record(&[
                     turso_core::Value::build_text("table"),
                     turso_core::Value::build_text("__turso_internal_mvcc_meta"),
                     turso_core::Value::build_text("__turso_internal_mvcc_meta"),
@@ -5164,7 +5161,7 @@ mod tests {
             table_name: "sqlite_schema".to_string(),
             id: 2,
             change: DatabaseTapeRowChangeType::Insert {
-                after: parse_bin_record(&record(&[
+                after: parse_bin_record(record(&[
                     turso_core::Value::build_text("table"),
                     turso_core::Value::build_text("items"),
                     turso_core::Value::build_text("items"),
@@ -5187,7 +5184,7 @@ mod tests {
             id: 2,
             change: DatabaseTapeRowChangeType::Update {
                 before: Vec::new(),
-                after: parse_bin_record(&record(&[
+                after: parse_bin_record(record(&[
                     turso_core::Value::build_text("table"),
                     turso_core::Value::build_text("items"),
                     turso_core::Value::build_text("items"),
@@ -5196,7 +5193,7 @@ mod tests {
                 ]))
                 .unwrap(),
                 updates: Some(
-                    parse_bin_record(&record(&[
+                    parse_bin_record(record(&[
                         turso_core::Value::from_i64(0),
                         turso_core::Value::from_i64(0),
                         turso_core::Value::from_i64(0),

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -2487,8 +2487,10 @@ pub async fn update_last_change_id<Ctx>(
     tracing::info!(
         "update_last_change_id(client_id={client_id}): pull_gen={pull_gen}, change_id={change_id}"
     );
-    conn.execute(TURSO_SYNC_CREATE_TABLE)?;
-    tracing::info!("update_last_change_id(client_id={client_id}): initialized table");
+    if !has_table(coro, conn, TURSO_SYNC_TABLE_NAME).await? {
+        ensure_sync_last_change_id_table(coro, conn, client_id).await?;
+        tracing::info!("update_last_change_id(client_id={client_id}): initialized table");
+    }
     let mut select_stmt = conn.prepare(TURSO_SYNC_SELECT_LAST_CHANGE_ID)?;
     select_stmt.bind_at(
         1.try_into().unwrap(),

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -193,7 +193,7 @@ fn logical_op_to_tape_operations(
                     change_id: 0,
                     change_time: commit_ts,
                     change: DatabaseTapeRowChangeType::Delete {
-                        before: Default::default(),
+                        before: turso_core::alloc::vec![],
                     },
                     table_name: op.table_name,
                     id: op.rowid,
@@ -2558,7 +2558,10 @@ pub async fn ensure_sync_last_change_id_table<Ctx>(
                     "update_last_change_id(client_id={client_id}): schema updated while initializing sync table; refreshing schema"
                 );
                 force_reparse_schema_with_retry(conn)?;
-                conn.publish_schema_after_external_restore();
+                publish_schema_after_external_restore(
+                    conn,
+                    "sync high-water mark table initialization",
+                )?;
                 if attempt == 2 {
                     return Ok(());
                 }
@@ -2586,6 +2589,18 @@ fn force_reparse_schema_with_retry(conn: &Arc<turso_core::Connection>) -> Result
         }
     }
     Ok(())
+}
+
+fn publish_schema_after_external_restore(
+    conn: &Arc<turso_core::Connection>,
+    context: &str,
+) -> Result<()> {
+    conn.publish_schema_after_external_restore()
+        .map_err(|error| {
+            Error::DatabaseSyncEngineError(format!(
+                "failed to publish schema after {context}: {error}",
+            ))
+        })
 }
 
 pub async fn read_last_change_id<Ctx>(

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -193,7 +193,7 @@ fn logical_op_to_tape_operations(
                     change_id: 0,
                     change_time: commit_ts,
                     change: DatabaseTapeRowChangeType::Delete {
-                        before: crate::alloc::Vec::new(),
+                        before: Default::default(),
                     },
                     table_name: op.table_name,
                     id: op.rowid,

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -1,35 +1,44 @@
 use std::{
+    collections::BTreeMap,
     ops::Deref,
     sync::{Arc, Mutex},
 };
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use prost::Message;
 use roaring::RoaringBitmap;
 use turso_core::{
     io::FileSyncType,
+    storage::sqlite3_ondisk::read_varint as read_sqlite_varint,
     types::{Text, WalFrameInfo},
     Buffer, Completion, LimboError, OpenFlags, Value,
 };
 
 use crate::{
+    client_proto::{
+        LogicalOp, LogicalOpType, LogicalSchemaAction, LogicalSchemaKind, LogicalTxnData,
+    },
     database_replay_generator::DatabaseReplayGenerator,
     database_sync_engine::{DataStats, DatabaseSyncEngineOpts},
     database_sync_engine_io::{DataCompletion, DataPollResult, SyncEngineIo},
     database_tape::{
-        run_stmt_expect_one_row, run_stmt_ignore_rows, DatabaseChangesIteratorMode,
-        DatabaseChangesIteratorOpts, DatabaseReplaySessionOpts, DatabaseTape, DatabaseWalSession,
+        run_stmt_expect_one_row, run_stmt_ignore_rows, run_stmt_once, DatabaseChangesIteratorMode,
+        DatabaseChangesIteratorOpts, DatabaseReplaySession, DatabaseReplaySessionOpts,
+        DatabaseTape, DatabaseWalSession,
     },
     errors::Error,
     io_operations::IoOperations,
     server_proto::{
         self, Batch, BatchCond, BatchStep, BatchStreamReq, PageData, PageUpdatesEncodingReq,
-        PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, Stmt, StmtResult, StreamRequest,
+        PullUpdatesApplyMode, PullUpdatesReqProtoBody, PullUpdatesRespProtoBody,
+        PullUpdatesStreamKind, Stmt, StmtResult, StreamRequest,
     },
     types::{
-        Coro, DatabasePullRevision, DatabaseRowTransformResult, DatabaseSyncEngineProtocolVersion,
-        DatabaseTapeOperation, DatabaseTapeRowChange, DatabaseTapeRowChangeType, DbSyncInfo,
-        DbSyncStatus, PartialBootstrapStrategy, PartialSyncOpts, SyncEngineIoResult,
+        parse_bin_record, Coro, DatabasePullRevision, DatabaseRowTransformResult,
+        DatabaseSchemaKind, DatabaseSchemaReplay, DatabaseStatementReplay,
+        DatabaseSyncEngineProtocolVersion, DatabaseTapeOperation, DatabaseTapeRowChange,
+        DatabaseTapeRowChangeType, DbSyncInfo, DbSyncStatus, PartialBootstrapStrategy,
+        PartialSyncOpts, SyncEngineIoResult,
     },
     wal_session::WalSession,
     Result,
@@ -39,6 +48,639 @@ pub const WAL_HEADER: usize = 32;
 pub const WAL_FRAME_HEADER: usize = 24;
 pub const PAGE_SIZE: usize = 4096;
 pub const WAL_FRAME_SIZE: usize = WAL_FRAME_HEADER + PAGE_SIZE;
+const MVCC_LOG_MAGIC: u32 = 0x4C4D4C32;
+const MVCC_LOG_VERSION: u8 = 3;
+const MVCC_LOG_HEADER_SIZE: usize = 56;
+const MVCC_TX_FRAME_MAGIC: u32 = 0x5854564D;
+const MVCC_TX_EXT_FRAME_MAGIC: u32 = 0x5845564D;
+const MVCC_TX_END_MAGIC: u32 = 0x4554564D;
+const MVCC_TX_HEADER_SIZE: usize = 24;
+const MVCC_TX_EXT_HEADER_SIZE: usize = 40;
+const MVCC_TX_TRAILER_SIZE: usize = 8;
+const MVCC_TX_FLAG_HAS_EXTENSION_BLOCK: u32 = 1 << 0;
+const MVCC_EXTENSION_RECORD_HEADER_SIZE: usize = 8;
+const MVCC_EXTENSION_TYPE_PORTABLE_CHANGES: u16 = 1;
+const MVCC_LOG_HEADER_SALT_START: usize = 8;
+const MVCC_LOG_HEADER_SALT_END: usize = 16;
+const MVCC_LOG_HEADER_RESERVED_START: usize = 16;
+const MVCC_LOG_HEADER_CRC_START: usize = 52;
+const MVCC_OP_UPSERT_TABLE: u8 = 0;
+const MVCC_OP_DELETE_TABLE: u8 = 1;
+const MVCC_OP_UPSERT_INDEX: u8 = 2;
+const MVCC_OP_DELETE_INDEX: u8 = 3;
+const MVCC_OP_UPDATE_HEADER: u8 = 4;
+const MVCC_OP_FLAG_PORTABLE_EXTENSION: u8 = 1 << 1;
+const MVCC_SQLITE_SCHEMA_TABLE_ID: i64 = -1;
+const MVCC_DELETE_EXT_IDENTITY_RECORD_FIELD: u64 = 1;
+const PORTABLE_TXN_META_CLIENT_KEY: &str = "client";
+const SQLITE_INTERNAL_PREFIX: &str = "sqlite_";
+const SQLITE_SCHEMA_TABLE: &str = "sqlite_schema";
+const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
+const TURSO_CDC_TABLE_NAME: &str = "turso_cdc";
+const TURSO_CDC_VERSION_TABLE_NAME: &str = "turso_cdc_version";
+
+#[derive(prost::Message, Clone, PartialEq, Eq)]
+struct PortableLogicalTxn {
+    #[prost(uint64, tag = "1")]
+    end_offset: u64,
+    #[prost(uint64, tag = "2")]
+    commit_ts: u64,
+    #[prost(bytes = "bytes", repeated, tag = "12")]
+    string_table: Vec<Bytes>,
+    #[prost(message, repeated, tag = "13")]
+    object_map: Vec<PortableObjectMap>,
+    #[prost(message, repeated, tag = "14")]
+    meta: Vec<PortableMeta>,
+}
+
+#[derive(prost::Message, Clone, PartialEq, Eq)]
+struct PortableObjectMap {
+    #[prost(sint64, tag = "1")]
+    mv_table_id: i64,
+    #[prost(uint64, tag = "2")]
+    name_ref: u64,
+}
+
+#[derive(prost::Message, Clone, PartialEq, Eq)]
+struct PortableMeta {
+    #[prost(uint64, tag = "1")]
+    key_ref: u64,
+    #[prost(uint64, tag = "2")]
+    value_ref: u64,
+}
+
+fn pull_updates_stream_kind(header: &PullUpdatesRespProtoBody) -> Result<PullUpdatesStreamKind> {
+    PullUpdatesStreamKind::try_from(header.stream_kind).map_err(|_| {
+        Error::DatabaseSyncEngineError(format!(
+            "unknown pull-updates stream kind: {}",
+            header.stream_kind
+        ))
+    })
+}
+
+fn pull_updates_apply_mode(header: &PullUpdatesRespProtoBody) -> Result<PullUpdatesApplyMode> {
+    PullUpdatesApplyMode::try_from(header.apply_mode).map_err(|_| {
+        Error::DatabaseSyncEngineError(format!(
+            "unknown pull-updates apply mode: {}",
+            header.apply_mode
+        ))
+    })
+}
+
+fn ensure_page_stream(header: &PullUpdatesRespProtoBody, context: &str) -> Result<()> {
+    let stream_kind = pull_updates_stream_kind(header)?;
+    let _apply_mode = pull_updates_apply_mode(header)?;
+    match stream_kind {
+        PullUpdatesStreamKind::Pages => Ok(()),
+        PullUpdatesStreamKind::MvccLogicalLog => Err(Error::DatabaseSyncEngineError(format!(
+            "{context} does not support raw MVCC logical-log pull-updates streams yet"
+        ))),
+    }
+}
+
+fn ensure_incremental_page_stream(header: &PullUpdatesRespProtoBody, context: &str) -> Result<()> {
+    ensure_page_stream(header, context)?;
+    match pull_updates_apply_mode(header)? {
+        PullUpdatesApplyMode::Incremental => Ok(()),
+        PullUpdatesApplyMode::ReplaceBase => Err(Error::DatabaseSyncEngineError(format!(
+            "{context} does not support replace-base page streams yet"
+        ))),
+    }
+}
+
+fn logical_op_to_tape_operations(
+    op: LogicalOp,
+    commit_ts: u64,
+) -> Result<Vec<DatabaseTapeOperation>> {
+    let op_type = LogicalOpType::try_from(op.op_type).map_err(|_| {
+        Error::DatabaseSyncEngineError(format!("unknown logical op type: {}", op.op_type))
+    })?;
+    match op_type {
+        LogicalOpType::Unspecified => Err(Error::DatabaseSyncEngineError(
+            "logical op type must not be unspecified".to_string(),
+        )),
+        LogicalOpType::UpsertRow => {
+            if op.table_name.is_empty() {
+                return Err(Error::DatabaseSyncEngineError(
+                    "logical upsert_row must include table_name".to_string(),
+                ));
+            }
+            if op.record.is_empty() {
+                return Err(Error::DatabaseSyncEngineError(
+                    "logical upsert_row must include record bytes".to_string(),
+                ));
+            }
+            Ok(vec![DatabaseTapeOperation::RowChange(
+                DatabaseTapeRowChange {
+                    change_id: 0,
+                    change_time: commit_ts,
+                    change: DatabaseTapeRowChangeType::Insert {
+                        after: parse_bin_record(&op.record)?,
+                    },
+                    table_name: op.table_name,
+                    id: op.rowid,
+                },
+            )])
+        }
+        LogicalOpType::DeleteRow => {
+            if op.table_name.is_empty() {
+                return Err(Error::DatabaseSyncEngineError(
+                    "logical delete_row must include table_name".to_string(),
+                ));
+            }
+            Ok(vec![DatabaseTapeOperation::RowChange(
+                DatabaseTapeRowChange {
+                    change_id: 0,
+                    change_time: commit_ts,
+                    change: DatabaseTapeRowChangeType::Delete { before: Vec::new() },
+                    table_name: op.table_name,
+                    id: op.rowid,
+                },
+            )])
+        }
+        LogicalOpType::Schema => {
+            if op.schema_name.is_empty() {
+                return Err(Error::DatabaseSyncEngineError(
+                    "logical schema op must include schema_name".to_string(),
+                ));
+            }
+            if !is_logically_replayable_table(&op.schema_name) {
+                return Ok(Vec::new());
+            }
+            let schema_action =
+                LogicalSchemaAction::try_from(op.schema_action.ok_or_else(|| {
+                    Error::DatabaseSyncEngineError(
+                        "logical schema op must include schema_action".to_string(),
+                    )
+                })?)
+                .map_err(|_| {
+                    Error::DatabaseSyncEngineError(format!(
+                        "unknown logical schema action: {:?}",
+                        op.schema_action
+                    ))
+                })?;
+            let schema_kind = logical_schema_kind(op.schema_kind.ok_or_else(|| {
+                Error::DatabaseSyncEngineError(
+                    "logical schema op must include schema_kind".to_string(),
+                )
+            })?)?;
+            let operation = match schema_action {
+                LogicalSchemaAction::Unspecified => {
+                    return Err(Error::DatabaseSyncEngineError(
+                        "logical schema action must not be unspecified".to_string(),
+                    ));
+                }
+                LogicalSchemaAction::Create => {
+                    if op.sql.is_empty() {
+                        return Err(Error::DatabaseSyncEngineError(
+                            "logical schema create must include sql".to_string(),
+                        ));
+                    }
+                    DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Create {
+                        sql: op.sql,
+                    })
+                }
+                LogicalSchemaAction::Drop => {
+                    if !op.sql.is_empty() {
+                        return Err(Error::DatabaseSyncEngineError(
+                            "logical schema drop must not include sql".to_string(),
+                        ));
+                    }
+                    DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Drop {
+                        kind: schema_kind,
+                        name: op.schema_name,
+                    })
+                }
+                LogicalSchemaAction::Refresh => {
+                    if op.sql.is_empty() {
+                        return Err(Error::DatabaseSyncEngineError(
+                            "logical schema refresh must include sql".to_string(),
+                        ));
+                    }
+                    DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Refresh {
+                        kind: schema_kind,
+                        name: op.schema_name,
+                        sql: op.sql,
+                    })
+                }
+                LogicalSchemaAction::Alter => {
+                    if op.sql.is_empty() {
+                        return Err(Error::DatabaseSyncEngineError(
+                            "logical schema alter must include sql".to_string(),
+                        ));
+                    }
+                    DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Alter { sql: op.sql })
+                }
+            };
+            Ok(vec![operation])
+        }
+        LogicalOpType::UpdateHeader => {
+            let mut operations = Vec::with_capacity(2);
+            if let Some(user_version) = op.user_version {
+                operations.push(DatabaseTapeOperation::StmtReplay(DatabaseStatementReplay {
+                    sql: format!("PRAGMA user_version = {user_version}"),
+                    values: Vec::new(),
+                }));
+            }
+            if let Some(application_id) = op.application_id {
+                operations.push(DatabaseTapeOperation::StmtReplay(DatabaseStatementReplay {
+                    sql: format!("PRAGMA application_id = {application_id}"),
+                    values: Vec::new(),
+                }));
+            }
+            if operations.is_empty() {
+                return Err(Error::DatabaseSyncEngineError(
+                    "logical update_header must include at least one field".to_string(),
+                ));
+            }
+            Ok(operations)
+        }
+    }
+}
+
+pub(crate) fn is_logically_replayable_table(name: &str) -> bool {
+    !name.starts_with(SQLITE_INTERNAL_PREFIX)
+        && !name.starts_with(TURSO_INTERNAL_PREFIX)
+        && name != TURSO_SYNC_TABLE_NAME
+        && name != TURSO_CDC_TABLE_NAME
+        && name != TURSO_CDC_VERSION_TABLE_NAME
+}
+
+fn sqlite_schema_change_name(change: &DatabaseTapeRowChange) -> Result<Option<String>> {
+    if change.table_name != SQLITE_SCHEMA_TABLE {
+        return Ok(None);
+    }
+    let values = match &change.change {
+        DatabaseTapeRowChangeType::Delete { before } => before,
+        DatabaseTapeRowChangeType::Insert { after } => after,
+        DatabaseTapeRowChangeType::Update { after, .. } => after,
+    };
+    match values.get(1) {
+        Some(Value::Text(name)) => Ok(Some(name.as_str().to_string())),
+        Some(Value::Null) | None => Ok(None),
+        Some(other) => Err(Error::DatabaseSyncEngineError(format!(
+            "sqlite_schema.name must be text while filtering push changes, got {other:?}"
+        ))),
+    }
+}
+
+fn sqlite_schema_change_updates_sql(change: &DatabaseTapeRowChange) -> Result<bool> {
+    if change.table_name != SQLITE_SCHEMA_TABLE {
+        return Ok(true);
+    }
+    let DatabaseTapeRowChangeType::Update { updates, .. } = &change.change else {
+        return Ok(true);
+    };
+    let Some(updates) = updates else {
+        return Err(Error::DatabaseSyncEngineError(
+            "sqlite_schema update must include update flags while filtering changes".to_string(),
+        ));
+    };
+    if updates.len() != 10 {
+        return Err(Error::DatabaseSyncEngineError(format!(
+            "sqlite_schema update must contain 5 update flags and 5 values, got {} values",
+            updates.len()
+        )));
+    }
+    match updates.get(4) {
+        Some(Value::Numeric(turso_core::Numeric::Integer(0))) => Ok(false),
+        Some(Value::Numeric(turso_core::Numeric::Integer(1))) => Ok(true),
+        Some(other) => Err(Error::DatabaseSyncEngineError(format!(
+            "sqlite_schema.sql update flag must be integer 0 or 1 while filtering changes, got {other:?}"
+        ))),
+        None => unreachable!("sqlite_schema update length was validated"),
+    }
+}
+
+fn should_push_change(
+    change: &DatabaseTapeRowChange,
+    opts: &DatabaseSyncEngineOpts,
+) -> Result<bool> {
+    if change.table_name == TURSO_SYNC_TABLE_NAME {
+        return Ok(false);
+    }
+    if opts.tables_ignore.iter().any(|x| &change.table_name == x) {
+        return Ok(false);
+    }
+    if change.table_name == SQLITE_SCHEMA_TABLE {
+        if !sqlite_schema_change_updates_sql(change)? {
+            return Ok(false);
+        }
+        return Ok(sqlite_schema_change_name(change)?
+            .as_deref()
+            .is_some_and(is_logically_replayable_table));
+    }
+    Ok(is_logically_replayable_table(&change.table_name))
+}
+
+pub(crate) fn should_replay_local_change(change: &DatabaseTapeRowChange) -> Result<bool> {
+    if change.table_name == TURSO_SYNC_TABLE_NAME {
+        return Ok(false);
+    }
+    if change.table_name == SQLITE_SCHEMA_TABLE {
+        if !sqlite_schema_change_updates_sql(change)? {
+            return Ok(false);
+        }
+        return Ok(sqlite_schema_change_name(change)?
+            .as_deref()
+            .is_some_and(is_logically_replayable_table));
+    }
+    Ok(is_logically_replayable_table(&change.table_name))
+}
+
+fn logical_schema_kind(kind: i32) -> Result<DatabaseSchemaKind> {
+    let kind = LogicalSchemaKind::try_from(kind).map_err(|_| {
+        Error::DatabaseSyncEngineError(format!("unknown logical schema kind: {kind}"))
+    })?;
+    Ok(match kind {
+        LogicalSchemaKind::Unspecified => {
+            return Err(Error::DatabaseSyncEngineError(
+                "logical schema kind must not be unspecified".to_string(),
+            ));
+        }
+        LogicalSchemaKind::Table => DatabaseSchemaKind::Table,
+        LogicalSchemaKind::Index => DatabaseSchemaKind::Index,
+        LogicalSchemaKind::Trigger => DatabaseSchemaKind::Trigger,
+        LogicalSchemaKind::View => DatabaseSchemaKind::View,
+    })
+}
+
+#[derive(Clone, Default)]
+struct LogicalReplayTableMap {
+    names_by_stable_id: BTreeMap<u64, String>,
+}
+
+impl LogicalReplayTableMap {
+    fn from_persisted(names_by_stable_id: BTreeMap<u64, String>) -> Self {
+        Self { names_by_stable_id }
+    }
+
+    fn into_persisted(self) -> BTreeMap<u64, String> {
+        self.names_by_stable_id
+    }
+
+    fn resolve_row_table_name(&self, op: &LogicalOp) -> Result<String> {
+        if !op.table_name.is_empty() {
+            return Ok(op.table_name.clone());
+        }
+        if op.stable_table_id == 0 {
+            return Err(Error::DatabaseSyncEngineError(
+                "logical row op must include table_name or stable_table_id".to_string(),
+            ));
+        }
+        self.names_by_stable_id
+            .get(&op.stable_table_id)
+            .cloned()
+            .ok_or_else(|| {
+                Error::DatabaseSyncEngineError(format!(
+                    "logical row op references unknown stable_table_id {}",
+                    op.stable_table_id
+                ))
+            })
+    }
+
+    fn observe_schema_op(
+        &mut self,
+        stable_table_id: u64,
+        schema_name: &str,
+        schema_kind: DatabaseSchemaKind,
+        schema_action: LogicalSchemaAction,
+    ) {
+        if stable_table_id == 0 || schema_kind != DatabaseSchemaKind::Table {
+            return;
+        }
+        match schema_action {
+            LogicalSchemaAction::Unspecified => {}
+            LogicalSchemaAction::Create
+            | LogicalSchemaAction::Refresh
+            | LogicalSchemaAction::Alter => {
+                self.names_by_stable_id
+                    .insert(stable_table_id, schema_name.to_string());
+            }
+            LogicalSchemaAction::Drop => {
+                self.names_by_stable_id.remove(&stable_table_id);
+            }
+        }
+    }
+}
+
+pub fn logical_txn_to_tape_operations(txn: &LogicalTxnData) -> Result<Vec<DatabaseTapeOperation>> {
+    let mut table_map = LogicalReplayTableMap::default();
+    logical_txn_to_tape_operations_with_table_map(txn, &mut table_map)
+}
+
+fn logical_txn_to_tape_operations_with_table_map(
+    txn: &LogicalTxnData,
+    table_map: &mut LogicalReplayTableMap,
+) -> Result<Vec<DatabaseTapeOperation>> {
+    let mut operations = Vec::new();
+    for op in txn.ops.iter().cloned() {
+        let op_type = LogicalOpType::try_from(op.op_type).map_err(|_| {
+            Error::DatabaseSyncEngineError(format!("unknown logical op type: {}", op.op_type))
+        })?;
+        match op_type {
+            LogicalOpType::Unspecified => {
+                return Err(Error::DatabaseSyncEngineError(
+                    "logical op type must not be unspecified".to_string(),
+                ));
+            }
+            LogicalOpType::UpsertRow | LogicalOpType::DeleteRow => {
+                let table_name = table_map.resolve_row_table_name(&op)?;
+                if !is_logically_replayable_table(&table_name) {
+                    continue;
+                }
+                let mut op = op;
+                op.table_name = table_name;
+                operations.extend(logical_op_to_tape_operations(op, txn.commit_ts)?);
+            }
+            LogicalOpType::Schema => {
+                if !is_logically_replayable_table(&op.schema_name) {
+                    continue;
+                }
+                let schema_action =
+                    LogicalSchemaAction::try_from(op.schema_action.ok_or_else(|| {
+                        Error::DatabaseSyncEngineError(
+                            "logical schema op must include schema_action".to_string(),
+                        )
+                    })?)
+                    .map_err(|_| {
+                        Error::DatabaseSyncEngineError(format!(
+                            "unknown logical schema action: {:?}",
+                            op.schema_action
+                        ))
+                    })?;
+                let schema_kind = logical_schema_kind(op.schema_kind.ok_or_else(|| {
+                    Error::DatabaseSyncEngineError(
+                        "logical schema op must include schema_kind".to_string(),
+                    )
+                })?)?;
+                table_map.observe_schema_op(
+                    op.stable_table_id,
+                    &op.schema_name,
+                    schema_kind,
+                    schema_action,
+                );
+                operations.extend(logical_op_to_tape_operations(op, txn.commit_ts)?);
+            }
+            LogicalOpType::UpdateHeader => {
+                operations.extend(logical_op_to_tape_operations(op, txn.commit_ts)?);
+            }
+        }
+    }
+    Ok(operations)
+}
+
+#[derive(Debug, Default)]
+pub struct LogicalReplayApplyStats {
+    pub touched_rows: std::collections::BTreeSet<(String, i64)>,
+}
+
+fn logical_operations_touched_rows(
+    operations: &[DatabaseTapeOperation],
+) -> std::collections::BTreeSet<(String, i64)> {
+    operations
+        .iter()
+        .filter_map(|operation| match operation {
+            DatabaseTapeOperation::RowChange(change)
+                if is_logically_replayable_table(&change.table_name) =>
+            {
+                Some((change.table_name.clone(), change.id))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn logical_txn_acknowledges_client(txn: &LogicalTxnData, client_id: &str) -> Result<bool> {
+    if txn.origin_client_id == client_id {
+        return Ok(true);
+    }
+
+    for op in &txn.ops {
+        if LogicalOpType::try_from(op.op_type) != Ok(LogicalOpType::UpsertRow) {
+            continue;
+        }
+        if op.table_name != TURSO_SYNC_TABLE_NAME {
+            continue;
+        }
+        let values = parse_bin_record(&op.record)?;
+        if values
+            .first()
+            .and_then(|value| value.to_text())
+            .is_some_and(|value| value == client_id)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+async fn read_proto_file_chunk<Ctx>(
+    coro: &Coro<Ctx>,
+    file: &Arc<dyn turso_core::File>,
+    size: u64,
+    file_offset: &mut u64,
+    bytes: &mut BytesMut,
+) -> Result<()> {
+    if *file_offset >= size {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        return Err(Error::DatabaseSyncEngineError(
+            "unexpected end of protobuf message in file".to_string(),
+        ));
+    }
+
+    let to_read = (size - *file_offset).min(64 * 1024) as usize;
+    let buffer = Arc::new(Buffer::new_temporary(to_read));
+    let read_len = Arc::new(Mutex::new(Ok(0usize)));
+    let c = Completion::new_read(buffer.clone(), {
+        let read_len = read_len.clone();
+        move |result| {
+            *read_len.lock().unwrap() = result
+                .map(|(_, len)| len as usize)
+                .map_err(|err| Error::IoError(err.to_string()));
+            None
+        }
+    });
+    let c = file.pread(*file_offset, c)?;
+    while !c.succeeded() {
+        coro.yield_(SyncEngineIoResult::IO).await?;
+    }
+    let read_len = read_len.lock().unwrap().clone()?;
+    if read_len == 0 {
+        return Err(Error::DatabaseSyncEngineError(
+            "unexpected EOF while reading protobuf messages from file".to_string(),
+        ));
+    }
+    *file_offset += read_len as u64;
+    bytes.extend_from_slice(&buffer.as_slice()[..read_len]);
+    Ok(())
+}
+
+async fn replay_logical_transactions_from_file<Ctx>(
+    coro: &Coro<Ctx>,
+    replay: &mut DatabaseReplaySession,
+    txns_file: &Arc<dyn turso_core::File>,
+    excluded_client_id: Option<&str>,
+    table_names_by_stable_id: &mut BTreeMap<u64, String>,
+) -> Result<LogicalReplayApplyStats> {
+    let size = txns_file.size()?;
+    let mut file_offset = 0u64;
+    let mut bytes = BytesMut::new();
+    let mut stats = LogicalReplayApplyStats::default();
+    let mut table_map =
+        LogicalReplayTableMap::from_persisted(std::mem::take(table_names_by_stable_id));
+    loop {
+        while let Some(txn) = take_proto_message_from_bytes::<LogicalTxnData>(&mut bytes)? {
+            let mut decoded_table_map = table_map.clone();
+            let operations =
+                logical_txn_to_tape_operations_with_table_map(&txn, &mut decoded_table_map)?;
+            if let Some(excluded_client_id) = excluded_client_id {
+                if logical_txn_acknowledges_client(&txn, excluded_client_id)? {
+                    continue;
+                }
+            }
+            table_map = decoded_table_map;
+            for operation in operations {
+                for row in logical_operations_touched_rows(std::slice::from_ref(&operation)) {
+                    stats.touched_rows.insert(row);
+                }
+                replay.replay(coro, operation).await?;
+            }
+        }
+        if file_offset >= size {
+            if bytes.is_empty() {
+                break;
+            }
+            return Err(Error::DatabaseSyncEngineError(
+                "unexpected end of protobuf message in file".to_string(),
+            ));
+        }
+        read_proto_file_chunk(coro, txns_file, size, &mut file_offset, &mut bytes).await?;
+    }
+    *table_names_by_stable_id = table_map.into_persisted();
+    Ok(stats)
+}
+
+pub async fn apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats<
+    Ctx,
+>(
+    coro: &Coro<Ctx>,
+    replay: &mut DatabaseReplaySession,
+    txns_file: &Arc<dyn turso_core::File>,
+    excluded_client_id: &str,
+    table_names_by_stable_id: &mut BTreeMap<u64, String>,
+) -> Result<LogicalReplayApplyStats> {
+    replay_logical_transactions_from_file(
+        coro,
+        replay,
+        txns_file,
+        Some(excluded_client_id),
+        table_names_by_stable_id,
+    )
+    .await
+}
 
 pub struct MutexSlot<T: Clone> {
     pub value: T,
@@ -104,6 +746,12 @@ pub enum WalPushResult {
     NeedCheckpoint,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PullUpdatesV1Result {
+    Pages { replace_base: bool },
+    Logical { txns: usize, ops: usize },
+}
+
 pub fn connect_untracked(tape: &DatabaseTape) -> Result<Arc<turso_core::Connection>> {
     let conn = tape.connect_untracked()?;
     assert_eq!(
@@ -159,6 +807,879 @@ impl<'a, IO: SyncEngineIo, Ctx> SyncOperationCtx<'a, IO, Ctx> {
         self.io
             .http(self.remote_url.as_deref(), method, path, body, &all_headers)
     }
+}
+
+async fn truncate_file<Ctx>(coro: &Coro<Ctx>, file: &Arc<dyn turso_core::File>) -> Result<()> {
+    let c = Completion::new_trunc(move |result| {
+        let Ok(rc) = result else {
+            return;
+        };
+        assert_eq!(rc, 0);
+    });
+    let c = file.truncate(0, c)?;
+    while !c.succeeded() {
+        coro.yield_(SyncEngineIoResult::IO).await?;
+    }
+    Ok(())
+}
+
+async fn append_file_bytes<Ctx>(
+    coro: &Coro<Ctx>,
+    file: &Arc<dyn turso_core::File>,
+    offset: &mut u64,
+    data: &[u8],
+) -> Result<()> {
+    if data.is_empty() {
+        return Ok(());
+    }
+    let buffer = Arc::new(Buffer::new(data.to_vec()));
+    let len = data.len();
+    let c = Completion::new_write(move |result| {
+        let Ok(size) = result else {
+            return;
+        };
+        assert_eq!(size as usize, len);
+    });
+    let c = file.pwrite(*offset, buffer, c)?;
+    while !c.succeeded() {
+        coro.yield_(SyncEngineIoResult::IO).await?;
+    }
+    *offset += len as u64;
+    Ok(())
+}
+
+fn read_u32_le(buf: &[u8], offset: usize) -> Result<u32> {
+    let bytes = buf.get(offset..offset + 4).ok_or_else(|| {
+        Error::DatabaseSyncEngineError("truncated MVCC logical-log frame".to_string())
+    })?;
+    Ok(u32::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn read_u16_le(buf: &[u8], offset: usize) -> Result<u16> {
+    let bytes = buf.get(offset..offset + 2).ok_or_else(|| {
+        Error::DatabaseSyncEngineError("truncated MVCC logical-log frame".to_string())
+    })?;
+    Ok(u16::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn read_u64_le(buf: &[u8], offset: usize) -> Result<u64> {
+    let bytes = buf.get(offset..offset + 8).ok_or_else(|| {
+        Error::DatabaseSyncEngineError("truncated MVCC logical-log frame".to_string())
+    })?;
+    Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn find_mvcc_extension_payload(
+    extension_block: &[u8],
+    extension_record_count: u32,
+    wanted_type: u16,
+) -> Result<Vec<u8>> {
+    let mut offset = 0usize;
+    let mut payload = Vec::new();
+    for _ in 0..extension_record_count {
+        let header_end = offset
+            .checked_add(MVCC_EXTENSION_RECORD_HEADER_SIZE)
+            .ok_or_else(|| {
+                Error::DatabaseSyncEngineError(
+                    "MVCC logical-log extension record offset overflow".to_string(),
+                )
+            })?;
+        if header_end > extension_block.len() {
+            return Err(Error::DatabaseSyncEngineError(
+                "MVCC logical-log extension record header is truncated".to_string(),
+            ));
+        }
+        let extension_type = read_u16_le(extension_block, offset)?;
+        let extension_flags = read_u16_le(extension_block, offset + 2)?;
+        if extension_flags != 0 {
+            return Err(Error::DatabaseSyncEngineError(format!(
+                "unsupported MVCC logical-log extension flags for type {extension_type}: {extension_flags:#x}"
+            )));
+        }
+        let extension_len = read_u32_le(extension_block, offset + 4)? as usize;
+        let payload_start = header_end;
+        let payload_end = payload_start.checked_add(extension_len).ok_or_else(|| {
+            Error::DatabaseSyncEngineError(
+                "MVCC logical-log extension record payload offset overflow".to_string(),
+            )
+        })?;
+        if payload_end > extension_block.len() {
+            return Err(Error::DatabaseSyncEngineError(
+                "MVCC logical-log extension record payload is truncated".to_string(),
+            ));
+        }
+        if extension_type == wanted_type {
+            payload.extend_from_slice(&extension_block[payload_start..payload_end]);
+        }
+        offset = payload_end;
+    }
+    if offset != extension_block.len() {
+        return Err(Error::DatabaseSyncEngineError(
+            "MVCC logical-log extension block has trailing bytes".to_string(),
+        ));
+    }
+    Ok(payload)
+}
+
+fn validate_mvcc_log_header(buf: &[u8]) -> Result<u32> {
+    if buf.len() < MVCC_LOG_HEADER_SIZE {
+        return Err(Error::DatabaseSyncEngineError(
+            "truncated MVCC logical-log header".to_string(),
+        ));
+    }
+    if read_u32_le(buf, 0)? != MVCC_LOG_MAGIC {
+        return Err(Error::DatabaseSyncEngineError(
+            "invalid MVCC logical-log header magic".to_string(),
+        ));
+    }
+    if buf[4] != MVCC_LOG_VERSION {
+        return Err(Error::DatabaseSyncEngineError(format!(
+            "unsupported MVCC logical-log version {}",
+            buf[4]
+        )));
+    }
+    if buf[5] & 0b1111_1110 != 0 {
+        return Err(Error::DatabaseSyncEngineError(
+            "invalid MVCC logical-log header flags".to_string(),
+        ));
+    }
+    let hdr_len = u16::from_le_bytes([buf[6], buf[7]]) as usize;
+    if hdr_len != MVCC_LOG_HEADER_SIZE {
+        return Err(Error::DatabaseSyncEngineError(format!(
+            "invalid MVCC logical-log header length {hdr_len}"
+        )));
+    }
+    let stored_crc = read_u32_le(buf, MVCC_LOG_HEADER_CRC_START)?;
+    let mut crc_buf = [0u8; MVCC_LOG_HEADER_SIZE];
+    crc_buf.copy_from_slice(&buf[..MVCC_LOG_HEADER_SIZE]);
+    crc_buf[MVCC_LOG_HEADER_CRC_START..MVCC_LOG_HEADER_SIZE].fill(0);
+    if crc32c::crc32c(&crc_buf) != stored_crc {
+        return Err(Error::DatabaseSyncEngineError(
+            "MVCC logical-log header checksum mismatch".to_string(),
+        ));
+    }
+    if buf[MVCC_LOG_HEADER_RESERVED_START..MVCC_LOG_HEADER_CRC_START]
+        .iter()
+        .any(|byte| *byte != 0)
+    {
+        return Err(Error::DatabaseSyncEngineError(
+            "MVCC logical-log header reserved bytes must be zero".to_string(),
+        ));
+    }
+    let salt = u64::from_le_bytes(
+        buf[MVCC_LOG_HEADER_SALT_START..MVCC_LOG_HEADER_SALT_END]
+            .try_into()
+            .expect("fixed-size salt slice"),
+    );
+    Ok(crc32c::crc32c(&salt.to_le_bytes()))
+}
+
+fn decode_mvcc_log_crc_seed(seed: &[u8]) -> Result<u32> {
+    if seed.len() != std::mem::size_of::<u32>() {
+        return Err(Error::DatabaseSyncEngineError(format!(
+            "invalid MVCC logical-log CRC seed length {}",
+            seed.len()
+        )));
+    }
+    Ok(u32::from_le_bytes(
+        seed.try_into().expect("validated CRC seed length"),
+    ))
+}
+
+fn read_mvcc_proto_varint(buf: &[u8], cursor: &mut usize) -> Result<u64> {
+    let mut value = 0u64;
+    let mut shift = 0;
+    while *cursor < buf.len() {
+        let byte = buf[*cursor];
+        *cursor += 1;
+        value |= ((byte & 0x7f) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(Error::DatabaseSyncEngineError(
+                "MVCC logical-log varint overflows u64".to_string(),
+            ));
+        }
+    }
+    Err(Error::DatabaseSyncEngineError(
+        "truncated MVCC logical-log varint".to_string(),
+    ))
+}
+
+fn read_mvcc_sqlite_varint(buf: &[u8], cursor: &mut usize) -> Result<u64> {
+    let (value, len) = read_sqlite_varint(&buf[*cursor..]).map_err(|err| {
+        Error::DatabaseSyncEngineError(format!("invalid MVCC logical-log SQLite varint: {err}"))
+    })?;
+    *cursor = cursor.checked_add(len).ok_or_else(|| {
+        Error::DatabaseSyncEngineError("MVCC logical-log SQLite varint offset overflow".to_string())
+    })?;
+    Ok(value)
+}
+
+fn skip_mvcc_proto_field(buf: &[u8], cursor: &mut usize, wire_type: u64) -> Result<()> {
+    match wire_type {
+        0 => {
+            let _ = read_mvcc_proto_varint(buf, cursor)?;
+        }
+        2 => {
+            let len = usize::try_from(read_mvcc_proto_varint(buf, cursor)?).map_err(|_| {
+                Error::DatabaseSyncEngineError(
+                    "MVCC logical-log protobuf length overflows usize".to_string(),
+                )
+            })?;
+            let end = cursor.checked_add(len).ok_or_else(|| {
+                Error::DatabaseSyncEngineError(
+                    "MVCC logical-log protobuf length overflow".to_string(),
+                )
+            })?;
+            if end > buf.len() {
+                return Err(Error::DatabaseSyncEngineError(
+                    "truncated MVCC logical-log protobuf field".to_string(),
+                ));
+            }
+            *cursor = end;
+        }
+        other => {
+            return Err(Error::DatabaseSyncEngineError(format!(
+                "unsupported MVCC logical-log protobuf wire type {other}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn decode_mvcc_delete_identity_record(extension: &[u8]) -> Result<Vec<u8>> {
+    let mut cursor = 0usize;
+    let mut identity_record = Vec::new();
+    while cursor < extension.len() {
+        let key = read_mvcc_proto_varint(extension, &mut cursor)?;
+        let field = key >> 3;
+        let wire_type = key & 7;
+        if field == MVCC_DELETE_EXT_IDENTITY_RECORD_FIELD && wire_type == 2 {
+            let len =
+                usize::try_from(read_mvcc_proto_varint(extension, &mut cursor)?).map_err(|_| {
+                    Error::DatabaseSyncEngineError(
+                        "MVCC delete identity record length overflows usize".to_string(),
+                    )
+                })?;
+            let end = cursor.checked_add(len).ok_or_else(|| {
+                Error::DatabaseSyncEngineError(
+                    "MVCC delete identity record length overflow".to_string(),
+                )
+            })?;
+            if end > extension.len() {
+                return Err(Error::DatabaseSyncEngineError(
+                    "truncated MVCC delete identity record".to_string(),
+                ));
+            }
+            identity_record = extension[cursor..end].to_vec();
+            cursor = end;
+        } else {
+            skip_mvcc_proto_field(extension, &mut cursor, wire_type)?;
+        }
+    }
+    Ok(identity_record)
+}
+
+fn portable_string(strings: &[String], idx: u64, context: &str) -> Result<String> {
+    let idx = usize::try_from(idx).map_err(|_| {
+        Error::DatabaseSyncEngineError(format!("{context} string ref overflows usize"))
+    })?;
+    strings.get(idx).cloned().ok_or_else(|| {
+        Error::DatabaseSyncEngineError(format!("{context} references missing string {idx}"))
+    })
+}
+
+fn portable_txn_strings(txn: &PortableLogicalTxn) -> Result<Vec<String>> {
+    txn.string_table
+        .iter()
+        .map(|bytes| {
+            String::from_utf8(bytes.to_vec()).map_err(|err| {
+                Error::DatabaseSyncEngineError(format!(
+                    "portable MVCC logical-log string is not UTF-8: {err}"
+                ))
+            })
+        })
+        .collect()
+}
+
+fn portable_object_names(txn: &PortableLogicalTxn) -> Result<BTreeMap<i64, String>> {
+    let strings = portable_txn_strings(txn)?;
+    let mut names = BTreeMap::new();
+    for object in &txn.object_map {
+        names.insert(
+            object.mv_table_id,
+            portable_string(&strings, object.name_ref, "portable object map")?,
+        );
+    }
+    Ok(names)
+}
+
+fn portable_origin_client_id(txn: &PortableLogicalTxn) -> Result<String> {
+    let strings = portable_txn_strings(txn)?;
+    for meta in &txn.meta {
+        let key = portable_string(&strings, meta.key_ref, "portable metadata key")?;
+        if key == PORTABLE_TXN_META_CLIENT_KEY {
+            return portable_string(&strings, meta.value_ref, "portable metadata value");
+        }
+    }
+    Ok(String::new())
+}
+
+#[derive(Clone)]
+struct DecodedSchemaRow {
+    row_type: String,
+    name: String,
+    sql: String,
+}
+
+#[derive(Default)]
+struct SchemaRowDelta {
+    old: Option<DecodedSchemaRow>,
+    new: Option<DecodedSchemaRow>,
+}
+
+fn schema_text_value(value: &Value, field: &str) -> Result<String> {
+    match value {
+        Value::Text(text) => Ok(text.as_str().to_string()),
+        Value::Null => Ok(String::new()),
+        other => Err(Error::DatabaseSyncEngineError(format!(
+            "sqlite_schema.{field} must be text, got {other:?}"
+        ))),
+    }
+}
+
+fn schema_integer_value(value: &Value, field: &str) -> Result<i64> {
+    match value.as_int() {
+        Some(value) => Ok(value),
+        None => Err(Error::DatabaseSyncEngineError(format!(
+            "sqlite_schema.{field} must be integer, got {value:?}"
+        ))),
+    }
+}
+
+fn decode_schema_row(record: &[u8]) -> Result<DecodedSchemaRow> {
+    let values = parse_bin_record(record)?;
+    if values.len() < 5 {
+        return Err(Error::DatabaseSyncEngineError(format!(
+            "sqlite_schema record must have at least 5 columns, got {}",
+            values.len()
+        )));
+    }
+    Ok(DecodedSchemaRow {
+        row_type: schema_text_value(&values[0], "type")?,
+        name: schema_text_value(&values[1], "name")?,
+        sql: {
+            let _rootpage = schema_integer_value(&values[3], "rootpage")?;
+            schema_text_value(&values[4], "sql")?
+        },
+    })
+}
+
+fn logical_schema_kind_from_row(row: &DecodedSchemaRow) -> Result<LogicalSchemaKind> {
+    if row.row_type.eq_ignore_ascii_case("table") {
+        Ok(LogicalSchemaKind::Table)
+    } else if row.row_type.eq_ignore_ascii_case("index") {
+        Ok(LogicalSchemaKind::Index)
+    } else if row.row_type.eq_ignore_ascii_case("trigger") {
+        Ok(LogicalSchemaKind::Trigger)
+    } else if row.row_type.eq_ignore_ascii_case("view") {
+        Ok(LogicalSchemaKind::View)
+    } else {
+        Err(Error::DatabaseSyncEngineError(format!(
+            "unsupported sqlite_schema object type {}",
+            row.row_type
+        )))
+    }
+}
+
+fn schema_logical_op(row: &DecodedSchemaRow, action: LogicalSchemaAction) -> Result<LogicalOp> {
+    Ok(LogicalOp {
+        op_type: LogicalOpType::Schema as i32,
+        table_name: String::new(),
+        rowid: 0,
+        record: Bytes::new(),
+        sql: if action == LogicalSchemaAction::Drop {
+            String::new()
+        } else {
+            row.sql.clone()
+        },
+        user_version: None,
+        application_id: None,
+        schema_action: Some(action as i32),
+        schema_kind: Some(logical_schema_kind_from_row(row)? as i32),
+        schema_name: row.name.clone(),
+        stable_table_id: 0,
+    })
+}
+
+fn append_schema_ops(
+    deltas: BTreeMap<i64, SchemaRowDelta>,
+    ops: &mut Vec<LogicalOp>,
+) -> Result<()> {
+    for delta in deltas.into_values() {
+        match (delta.old, delta.new) {
+            (Some(old), Some(new)) => {
+                if is_logically_replayable_table(&old.name) {
+                    ops.push(schema_logical_op(&new, LogicalSchemaAction::Refresh)?);
+                }
+            }
+            (None, Some(new)) => {
+                if is_logically_replayable_table(&new.name) {
+                    ops.push(schema_logical_op(&new, LogicalSchemaAction::Create)?);
+                }
+            }
+            (Some(old), None) => {
+                if is_logically_replayable_table(&old.name) {
+                    ops.push(schema_logical_op(&old, LogicalSchemaAction::Drop)?);
+                }
+            }
+            (None, None) => {}
+        }
+    }
+    Ok(())
+}
+
+fn decode_update_header_op(payload: &[u8]) -> Result<LogicalOp> {
+    if payload.len() < 72 || &payload[..16] != b"SQLite format 3\0" {
+        return Err(Error::DatabaseSyncEngineError(
+            "invalid MVCC UPDATE_HEADER payload".to_string(),
+        ));
+    }
+    Ok(LogicalOp {
+        op_type: LogicalOpType::UpdateHeader as i32,
+        table_name: String::new(),
+        rowid: 0,
+        record: Bytes::new(),
+        sql: String::new(),
+        user_version: Some(u32::from_be_bytes(payload[60..64].try_into().unwrap())),
+        application_id: Some(u32::from_be_bytes(payload[68..72].try_into().unwrap())),
+        schema_action: None,
+        schema_kind: None,
+        schema_name: String::new(),
+        stable_table_id: 0,
+    })
+}
+
+fn decode_recovery_ops_to_logical_txn(
+    portable_txn: PortableLogicalTxn,
+    recovery_payload: &[u8],
+    op_count: u32,
+) -> Result<LogicalTxnData> {
+    let object_names = portable_object_names(&portable_txn)?;
+    let origin_client_id = portable_origin_client_id(&portable_txn)?;
+    let mut cursor = 0usize;
+    let mut schema_deltas = BTreeMap::<i64, SchemaRowDelta>::new();
+    let mut row_ops = Vec::new();
+    let mut header_ops = Vec::new();
+
+    for _ in 0..op_count {
+        if recovery_payload.len().saturating_sub(cursor) < 6 {
+            return Err(Error::DatabaseSyncEngineError(
+                "truncated MVCC logical-log recovery op".to_string(),
+            ));
+        }
+        let tag = recovery_payload[cursor];
+        let flags = recovery_payload[cursor + 1];
+        let table_id =
+            i32::from_le_bytes(recovery_payload[cursor + 2..cursor + 6].try_into().unwrap()) as i64;
+        cursor += 6;
+        let payload_len = usize::try_from(read_mvcc_sqlite_varint(recovery_payload, &mut cursor)?)
+            .map_err(|_| {
+                Error::DatabaseSyncEngineError(
+                    "MVCC logical-log op payload length overflows usize".to_string(),
+                )
+            })?;
+        let payload_end = cursor.checked_add(payload_len).ok_or_else(|| {
+            Error::DatabaseSyncEngineError("MVCC logical-log op payload overflow".to_string())
+        })?;
+        if payload_end > recovery_payload.len() {
+            return Err(Error::DatabaseSyncEngineError(
+                "truncated MVCC logical-log op payload".to_string(),
+            ));
+        }
+        let payload = &recovery_payload[cursor..payload_end];
+        cursor = payload_end;
+        let portable_extension = if flags & MVCC_OP_FLAG_PORTABLE_EXTENSION == 0 {
+            &[][..]
+        } else {
+            let extension_len =
+                usize::try_from(read_mvcc_sqlite_varint(recovery_payload, &mut cursor)?).map_err(
+                    |_| {
+                        Error::DatabaseSyncEngineError(
+                            "MVCC logical-log op extension length overflows usize".to_string(),
+                        )
+                    },
+                )?;
+            let extension_end = cursor.checked_add(extension_len).ok_or_else(|| {
+                Error::DatabaseSyncEngineError(
+                    "MVCC logical-log op extension length overflow".to_string(),
+                )
+            })?;
+            if extension_end > recovery_payload.len() {
+                return Err(Error::DatabaseSyncEngineError(
+                    "truncated MVCC logical-log op extension".to_string(),
+                ));
+            }
+            let extension = &recovery_payload[cursor..extension_end];
+            cursor = extension_end;
+            extension
+        };
+
+        match tag {
+            MVCC_OP_UPSERT_TABLE => {
+                let mut payload_cursor = 0usize;
+                let rowid = read_mvcc_sqlite_varint(payload, &mut payload_cursor)? as i64;
+                let record = &payload[payload_cursor..];
+                if table_id == MVCC_SQLITE_SCHEMA_TABLE_ID {
+                    schema_deltas.entry(rowid).or_default().new = Some(decode_schema_row(record)?);
+                } else if let Some(table_name) = object_names.get(&table_id) {
+                    row_ops.push(LogicalOp {
+                        op_type: LogicalOpType::UpsertRow as i32,
+                        table_name: table_name.clone(),
+                        rowid,
+                        record: Bytes::copy_from_slice(record),
+                        sql: String::new(),
+                        user_version: None,
+                        application_id: None,
+                        schema_action: None,
+                        schema_kind: None,
+                        schema_name: String::new(),
+                        stable_table_id: 0,
+                    });
+                }
+            }
+            MVCC_OP_DELETE_TABLE => {
+                let mut payload_cursor = 0usize;
+                let rowid = read_mvcc_sqlite_varint(payload, &mut payload_cursor)? as i64;
+                if table_id == MVCC_SQLITE_SCHEMA_TABLE_ID {
+                    let identity_record = decode_mvcc_delete_identity_record(portable_extension)?;
+                    if identity_record.is_empty() {
+                        return Err(Error::DatabaseSyncEngineError(
+                            "MVCC sqlite_schema delete is missing portable identity record"
+                                .to_string(),
+                        ));
+                    }
+                    schema_deltas.entry(rowid).or_default().old =
+                        Some(decode_schema_row(&identity_record)?);
+                } else if let Some(table_name) = object_names.get(&table_id) {
+                    row_ops.push(LogicalOp {
+                        op_type: LogicalOpType::DeleteRow as i32,
+                        table_name: table_name.clone(),
+                        rowid,
+                        record: Bytes::new(),
+                        sql: String::new(),
+                        user_version: None,
+                        application_id: None,
+                        schema_action: None,
+                        schema_kind: None,
+                        schema_name: String::new(),
+                        stable_table_id: 0,
+                    });
+                }
+            }
+            MVCC_OP_UPSERT_INDEX | MVCC_OP_DELETE_INDEX => {}
+            MVCC_OP_UPDATE_HEADER => {
+                header_ops.push(decode_update_header_op(payload)?);
+            }
+            other => {
+                return Err(Error::DatabaseSyncEngineError(format!(
+                    "unknown MVCC logical-log recovery op tag {other}"
+                )));
+            }
+        }
+    }
+    if cursor != recovery_payload.len() {
+        return Err(Error::DatabaseSyncEngineError(
+            "MVCC logical-log recovery payload has trailing bytes".to_string(),
+        ));
+    }
+
+    let mut ops = header_ops;
+    append_schema_ops(schema_deltas, &mut ops)?;
+    ops.extend(row_ops);
+
+    Ok(LogicalTxnData {
+        end_offset: portable_txn.end_offset,
+        commit_ts: portable_txn.commit_ts,
+        ops,
+        origin_client_id,
+    })
+}
+
+fn take_proto_message_from_bytes<T: prost::Message + Default>(
+    bytes: &mut BytesMut,
+) -> Result<Option<T>> {
+    let Some((message_length, prefix_length)) = read_varint(bytes)? else {
+        return Ok(None);
+    };
+    if message_length + prefix_length > bytes.len() {
+        return Ok(None);
+    }
+    let message = T::decode_length_delimited(&**bytes).map_err(|e| {
+        Error::DatabaseSyncEngineError(format!(
+            "unable to deserialize protobuf message from file: {e}"
+        ))
+    })?;
+    let _ = bytes.split_to(message_length + prefix_length);
+    Ok(Some(message))
+}
+
+async fn append_decoded_mvcc_frame_to_txns_file<Ctx>(
+    coro: &Coro<Ctx>,
+    txns_file: &Arc<dyn turso_core::File>,
+    txns_offset: &mut u64,
+    portable_payload: &[u8],
+    recovery_payload: &[u8],
+    op_count: u32,
+) -> Result<(usize, usize)> {
+    let mut payload_bytes = BytesMut::from(portable_payload);
+    let mut txns = 0usize;
+    let mut ops = 0usize;
+    while let Some(portable_txn) =
+        take_proto_message_from_bytes::<PortableLogicalTxn>(&mut payload_bytes)?
+    {
+        let txn = decode_recovery_ops_to_logical_txn(portable_txn, recovery_payload, op_count)?;
+        if txn.ops.is_empty() {
+            continue;
+        }
+        ops += txn.ops.len();
+        txns += 1;
+        append_file_bytes(
+            coro,
+            txns_file,
+            txns_offset,
+            &txn.encode_length_delimited_to_vec(),
+        )
+        .await?;
+    }
+    if !payload_bytes.is_empty() {
+        return Err(Error::DatabaseSyncEngineError(
+            "MVCC logical-log portable payload has trailing partial protobuf message".to_string(),
+        ));
+    }
+    Ok((txns, ops))
+}
+
+pub async fn decode_raw_mvcc_logical_log_to_file<Ctx>(
+    coro: &Coro<Ctx>,
+    txns_file: &Arc<dyn turso_core::File>,
+    body: &[u8],
+    header: &PullUpdatesRespProtoBody,
+) -> Result<(usize, usize)> {
+    let Some(metadata) = header.mvcc_log.as_ref() else {
+        if body.is_empty() {
+            truncate_file(coro, txns_file).await?;
+            return Ok((0, 0));
+        }
+        return Err(Error::DatabaseSyncEngineError(
+            "raw MVCC logical-log stream is missing metadata".to_string(),
+        ));
+    };
+    if metadata.format != "lml3" {
+        return Err(Error::DatabaseSyncEngineError(format!(
+            "unsupported MVCC logical-log format {}",
+            metadata.format
+        )));
+    }
+    if metadata.ranges.is_empty() {
+        return Err(Error::DatabaseSyncEngineError(
+            "raw MVCC logical-log stream has no ranges".to_string(),
+        ));
+    }
+
+    truncate_file(coro, txns_file).await?;
+    let mut body_offset = 0usize;
+    let mut txns_offset = 0u64;
+    let mut txns = 0usize;
+    let mut ops = 0usize;
+    let mut running_crc: Option<u32> = None;
+    let mut previous_range_boundary: Option<(u64, u64)> = None;
+
+    for range in &metadata.ranges {
+        if previous_range_boundary != Some((range.generation, range.start_offset)) {
+            running_crc = None;
+        }
+        let range_len = usize::try_from(
+            range
+                .end_offset
+                .checked_sub(range.start_offset)
+                .ok_or_else(|| {
+                    Error::DatabaseSyncEngineError(format!(
+                        "invalid MVCC logical-log range {}..{}",
+                        range.start_offset, range.end_offset
+                    ))
+                })?,
+        )
+        .map_err(|_| {
+            Error::DatabaseSyncEngineError(
+                "MVCC logical-log range length overflows usize".to_string(),
+            )
+        })?;
+        let range_end = body_offset.checked_add(range_len).ok_or_else(|| {
+            Error::DatabaseSyncEngineError("MVCC logical-log range length overflow".to_string())
+        })?;
+        let range_body = body.get(body_offset..range_end).ok_or_else(|| {
+            Error::DatabaseSyncEngineError(format!(
+                "raw MVCC logical-log body is shorter than advertised range {}..{}",
+                range.start_offset, range.end_offset
+            ))
+        })?;
+        body_offset = range_end;
+
+        let mut pos = 0usize;
+        if range.starts_with_header {
+            running_crc = Some(validate_mvcc_log_header(range_body)?);
+            pos = MVCC_LOG_HEADER_SIZE;
+        } else if let Some(seed) = range.crc_seed.as_deref() {
+            running_crc = Some(decode_mvcc_log_crc_seed(seed)?);
+        } else if running_crc.is_none() {
+            return Err(Error::DatabaseSyncEngineError(format!(
+                "raw MVCC logical-log range {}..{} is missing CRC seed",
+                range.start_offset, range.end_offset
+            )));
+        }
+
+        while pos < range_body.len() {
+            let frame_start = pos;
+            if range_body.len() - pos < MVCC_TX_HEADER_SIZE + MVCC_TX_TRAILER_SIZE {
+                return Err(Error::DatabaseSyncEngineError(
+                    "truncated MVCC logical-log transaction frame".to_string(),
+                ));
+            }
+            let frame_magic = read_u32_le(range_body, pos)?;
+            let has_extension_header = frame_magic == MVCC_TX_EXT_FRAME_MAGIC;
+            if frame_magic != MVCC_TX_FRAME_MAGIC && !has_extension_header {
+                return Err(Error::DatabaseSyncEngineError(format!(
+                    "invalid MVCC logical-log transaction frame magic at range offset {frame_start}"
+                )));
+            }
+            let header_size = if has_extension_header {
+                if range_body.len() - pos < MVCC_TX_EXT_HEADER_SIZE + MVCC_TX_TRAILER_SIZE {
+                    return Err(Error::DatabaseSyncEngineError(
+                        "truncated MVCC logical-log transaction frame".to_string(),
+                    ));
+                }
+                MVCC_TX_EXT_HEADER_SIZE
+            } else {
+                MVCC_TX_HEADER_SIZE
+            };
+            let payload_size =
+                usize::try_from(read_u64_le(range_body, pos + 4)?).map_err(|_| {
+                    Error::DatabaseSyncEngineError(
+                        "MVCC logical-log recovery payload size overflows usize".to_string(),
+                    )
+                })?;
+            let op_count = read_u32_le(range_body, pos + 12)?;
+            let (extension_size, extension_record_count) = if has_extension_header {
+                let extension_size =
+                    usize::try_from(read_u64_le(range_body, pos + 24)?).map_err(|_| {
+                        Error::DatabaseSyncEngineError(
+                            "MVCC logical-log extension size overflows usize".to_string(),
+                        )
+                    })?;
+                let extension_record_count = read_u32_le(range_body, pos + 32)?;
+                let frame_flags = read_u32_le(range_body, pos + 36)?;
+                if frame_flags & !MVCC_TX_FLAG_HAS_EXTENSION_BLOCK != 0 {
+                    return Err(Error::DatabaseSyncEngineError(format!(
+                        "unsupported MVCC logical-log transaction flags {frame_flags:#x}"
+                    )));
+                }
+                if extension_size == 0 && extension_record_count != 0 {
+                    return Err(Error::DatabaseSyncEngineError(
+                        "MVCC logical-log frame has extension record count without extension block"
+                            .to_string(),
+                    ));
+                }
+                if extension_size > 0 && frame_flags & MVCC_TX_FLAG_HAS_EXTENSION_BLOCK == 0 {
+                    return Err(Error::DatabaseSyncEngineError(
+                        "MVCC logical-log frame has extension block without extension flag"
+                            .to_string(),
+                    ));
+                }
+                (extension_size, extension_record_count)
+            } else {
+                (0, 0)
+            };
+
+            let extension_start = pos.checked_add(header_size).ok_or_else(|| {
+                Error::DatabaseSyncEngineError("MVCC logical-log frame offset overflow".to_string())
+            })?;
+            let recovery_start = extension_start.checked_add(extension_size).ok_or_else(|| {
+                Error::DatabaseSyncEngineError("MVCC logical-log frame offset overflow".to_string())
+            })?;
+            let trailer_start = recovery_start.checked_add(payload_size).ok_or_else(|| {
+                Error::DatabaseSyncEngineError("MVCC logical-log frame offset overflow".to_string())
+            })?;
+            let frame_end = trailer_start
+                .checked_add(MVCC_TX_TRAILER_SIZE)
+                .ok_or_else(|| {
+                    Error::DatabaseSyncEngineError(
+                        "MVCC logical-log frame offset overflow".to_string(),
+                    )
+                })?;
+            if frame_end > range_body.len() {
+                return Err(Error::DatabaseSyncEngineError(
+                    "truncated MVCC logical-log transaction frame".to_string(),
+                ));
+            }
+            if read_u32_le(range_body, trailer_start + 4)? != MVCC_TX_END_MAGIC {
+                return Err(Error::DatabaseSyncEngineError(
+                    "invalid MVCC logical-log transaction trailer magic".to_string(),
+                ));
+            }
+            if let Some(prev_crc) = running_crc {
+                let expected_crc =
+                    crc32c::crc32c_append(prev_crc, &range_body[frame_start..trailer_start]);
+                let stored_crc = read_u32_le(range_body, trailer_start)?;
+                if expected_crc != stored_crc {
+                    return Err(Error::DatabaseSyncEngineError(format!(
+                        "MVCC logical-log transaction checksum mismatch at range offset {frame_start}"
+                    )));
+                }
+                running_crc = Some(stored_crc);
+            }
+
+            if extension_size == 0 {
+                pos = frame_end;
+                continue;
+            }
+            let extension_block = &range_body[extension_start..recovery_start];
+            let recovery_payload = &range_body[recovery_start..trailer_start];
+            let portable_payload = find_mvcc_extension_payload(
+                extension_block,
+                extension_record_count,
+                MVCC_EXTENSION_TYPE_PORTABLE_CHANGES,
+            )?;
+            if portable_payload.is_empty() {
+                pos = frame_end;
+                continue;
+            }
+            let (frame_txns, frame_ops) = append_decoded_mvcc_frame_to_txns_file(
+                coro,
+                txns_file,
+                &mut txns_offset,
+                &portable_payload,
+                recovery_payload,
+                op_count,
+            )
+            .await?;
+            txns += frame_txns;
+            ops += frame_ops;
+            pos = frame_end;
+        }
+        previous_range_boundary = Some((range.generation, range.end_offset));
+    }
+
+    if body_offset != body.len() {
+        return Err(Error::DatabaseSyncEngineError(
+            "raw MVCC logical-log body has trailing bytes after advertised ranges".to_string(),
+        ));
+    }
+    sync_file(coro, txns_file).await?;
+    Ok((txns, ops))
 }
 
 /// Bootstrap multiple DB files from latest generation from remote
@@ -283,6 +1804,181 @@ pub async fn wal_pull_to_file<IO: SyncEngineIo, Ctx>(
     }
 }
 
+/// Pulls V1 updates as either page frames or raw MVCC logical-log bytes.
+///
+/// Existing WAL sync calls this with `logical_updates=false`, which keeps the
+/// request and scratch-file format page-based. Logical callers opt in
+/// explicitly and receive decoded `LogicalTxnData` messages in `frames_file`.
+pub async fn pull_updates_v1<IO: SyncEngineIo, Ctx>(
+    ctx: &SyncOperationCtx<'_, IO, Ctx>,
+    frames_file: &Arc<dyn turso_core::File>,
+    revision: &str,
+    long_poll_timeout: Option<std::time::Duration>,
+    logical_updates: bool,
+) -> Result<(DatabasePullRevision, PullUpdatesV1Result)> {
+    tracing::info!(
+        "pull_updates_v1: remote_url={:?} revision={} logical_updates={} long_poll_timeout_ms={}",
+        ctx.remote_url,
+        revision,
+        logical_updates,
+        long_poll_timeout.map(|x| x.as_millis()).unwrap_or(0)
+    );
+    if logical_updates && ctx.remote_encryption_key.is_some() {
+        return Err(Error::DatabaseSyncEngineError(
+            "MVCC logical pull is not supported with encrypted remote databases".to_string(),
+        ));
+    }
+    let mut bytes = BytesMut::new();
+
+    let request = PullUpdatesReqProtoBody {
+        encoding: PageUpdatesEncodingReq::Raw as i32,
+        stream_kind: if logical_updates {
+            PullUpdatesStreamKind::MvccLogicalLog as i32
+        } else {
+            PullUpdatesStreamKind::Pages as i32
+        },
+        server_revision: String::new(),
+        client_revision: revision.to_string(),
+        long_poll_timeout_ms: long_poll_timeout.map(|x| x.as_millis() as u32).unwrap_or(0),
+        server_pages_selector: BytesMut::new().into(),
+        server_query_selector: String::new(),
+        client_pages: BytesMut::new().into(),
+    };
+    let request = request.encode_to_vec();
+    ctx.io.network_stats.write(request.len());
+    let completion = ctx.http(
+        "POST",
+        "/pull-updates",
+        Some(request),
+        &[
+            ("content-type", "application/protobuf"),
+            ("accept-encoding", "application/protobuf"),
+        ],
+    )?;
+    let Some(header) = wait_proto_message::<Ctx, PullUpdatesRespProtoBody>(
+        ctx.coro,
+        &completion,
+        &ctx.io.network_stats,
+        &mut bytes,
+    )
+    .await?
+    else {
+        return Err(Error::DatabaseSyncEngineError(
+            "no header returned in the pull-updates protobuf call".to_string(),
+        ));
+    };
+    tracing::info!(
+        "pull_updates_v1: got header: remote_url={:?} server_revision={} stream_kind={} apply_mode={} db_size={} raw_encoding={:?} zstd_encoding={:?} mvcc_log={:?}",
+        ctx.remote_url,
+        header.server_revision,
+        header.stream_kind,
+        header.apply_mode,
+        header.db_size,
+        header.raw_encoding,
+        header.zstd_encoding,
+        header.mvcc_log
+    );
+
+    let next_revision = DatabasePullRevision::V1 {
+        revision: header.server_revision.clone(),
+    };
+    let apply_mode = pull_updates_apply_mode(&header)?;
+    match pull_updates_stream_kind(&header)? {
+        PullUpdatesStreamKind::Pages => {
+            let replace_base = matches!(apply_mode, PullUpdatesApplyMode::ReplaceBase);
+            truncate_file(ctx.coro, frames_file).await?;
+
+            let mut offset = 0;
+            #[allow(clippy::arc_with_non_send_sync)]
+            let buffer = Arc::new(Buffer::new_temporary(WAL_FRAME_SIZE));
+
+            let mut page_data_opt = wait_proto_message::<Ctx, PageData>(
+                ctx.coro,
+                &completion,
+                &ctx.io.network_stats,
+                &mut bytes,
+            )
+            .await?;
+            while let Some(page_data) = page_data_opt.take() {
+                let page_id = page_data.page_id;
+                tracing::debug!("received page {}", page_id);
+                let page = decode_page(&header, page_data)?;
+                if page.len() != PAGE_SIZE {
+                    return Err(Error::DatabaseSyncEngineError(format!(
+                        "page has unexpected size: {} != {}",
+                        page.len(),
+                        PAGE_SIZE
+                    )));
+                }
+                buffer.as_mut_slice()[WAL_FRAME_HEADER..].copy_from_slice(&page);
+                page_data_opt =
+                    wait_proto_message(ctx.coro, &completion, &ctx.io.network_stats, &mut bytes)
+                        .await?;
+                let mut frame_info = WalFrameInfo {
+                    db_size: 0,
+                    page_no: page_id as u32 + 1,
+                };
+                if page_data_opt.is_none() {
+                    frame_info.db_size = header.db_size as u32;
+                }
+                tracing::debug!("page_data_opt: {}", page_data_opt.is_some());
+                frame_info.put_to_frame_header(buffer.as_mut_slice());
+
+                let c = Completion::new_write(move |result| {
+                    let Ok(size) = result else {
+                        return;
+                    };
+                    assert!(size as usize == WAL_FRAME_SIZE);
+                });
+
+                let c = frames_file.pwrite(offset, buffer.clone(), c)?;
+                while !c.succeeded() {
+                    ctx.coro.yield_(SyncEngineIoResult::IO).await?;
+                }
+                offset += WAL_FRAME_SIZE as u64;
+            }
+
+            sync_file(ctx.coro, frames_file).await?;
+
+            tracing::info!(
+                "pull_updates_v1: completed page stream: remote_url={:?} next_revision={:?} replace_base={}",
+                ctx.remote_url,
+                next_revision,
+                replace_base
+            );
+            Ok((next_revision, PullUpdatesV1Result::Pages { replace_base }))
+        }
+        PullUpdatesStreamKind::MvccLogicalLog => {
+            if matches!(apply_mode, PullUpdatesApplyMode::ReplaceBase) {
+                return Err(Error::DatabaseSyncEngineError(
+                    "server returned replace_base apply mode with raw MVCC logical-log stream"
+                        .to_string(),
+                ));
+            }
+            if !logical_updates {
+                return Err(Error::DatabaseSyncEngineError(
+                    "server returned a raw MVCC logical-log stream but logical_updates was not requested"
+                        .to_string(),
+                ));
+            }
+            let mut body = bytes.split().to_vec();
+            body.extend_from_slice(
+                &wait_all_results(ctx.coro, &completion, Some(&ctx.io.network_stats)).await?,
+            );
+            let (txns, ops) =
+                decode_raw_mvcc_logical_log_to_file(ctx.coro, frames_file, &body, &header).await?;
+            tracing::info!(
+                "pull_updates_v1: completed raw MVCC logical-log stream: remote_url={:?} next_revision={:?} txns={} ops={}",
+                ctx.remote_url,
+                next_revision,
+                txns,
+                ops
+            );
+            Ok((next_revision, PullUpdatesV1Result::Logical { txns, ops }))
+        }
+    }
+}
+
 /// Pull updates from remote to the separate file
 pub async fn wal_pull_to_file_v1<IO: SyncEngineIo, Ctx>(
     ctx: &SyncOperationCtx<'_, IO, Ctx>,
@@ -295,6 +1991,7 @@ pub async fn wal_pull_to_file_v1<IO: SyncEngineIo, Ctx>(
 
     let request = PullUpdatesReqProtoBody {
         encoding: PageUpdatesEncodingReq::Raw as i32,
+        stream_kind: PullUpdatesStreamKind::Pages as i32,
         server_revision: String::new(),
         client_revision: revision.to_string(),
         long_poll_timeout_ms: long_poll_timeout.map(|x| x.as_millis() as u32).unwrap_or(0),
@@ -326,6 +2023,7 @@ pub async fn wal_pull_to_file_v1<IO: SyncEngineIo, Ctx>(
         ));
     };
     tracing::info!("wal_pull_to_file: got header={:?}", header);
+    ensure_incremental_page_stream(&header, "wal_pull_to_file_v1")?;
 
     let mut offset = 0;
     #[allow(clippy::arc_with_non_send_sync)]
@@ -418,6 +2116,7 @@ pub async fn pull_pages_v1<IO: SyncEngineIo, Ctx>(
 
     let request = PullUpdatesReqProtoBody {
         encoding: PageUpdatesEncodingReq::Raw as i32,
+        stream_kind: PullUpdatesStreamKind::Pages as i32,
         server_revision: server_revision.to_string(),
         client_revision: String::new(),
         long_poll_timeout_ms: 0,
@@ -449,6 +2148,7 @@ pub async fn pull_pages_v1<IO: SyncEngineIo, Ctx>(
         ));
     };
     tracing::info!("pull_pages_v1: got header={:?}", header);
+    ensure_page_stream(&header, "pull_pages_v1")?;
 
     let mut pages = Vec::with_capacity(pages.len());
 
@@ -720,6 +2420,63 @@ pub async fn count_local_changes<Ctx>(
     Ok(count)
 }
 
+/// Rebuilds the portable logical-replay table identity map from the current
+/// local schema. This is used after page-based apply paths, where no logical
+/// schema identity operations are decoded but future logical pulls may depend
+/// on an existing map.
+pub async fn read_logical_replay_table_map<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+) -> Result<BTreeMap<u64, String>> {
+    let mut stmt = conn.prepare(
+        "SELECT rootpage, name FROM sqlite_schema WHERE type = 'table' AND rootpage != 0",
+    )?;
+    let mut map = BTreeMap::new();
+    while let Some(row) = run_stmt_once(coro, &mut stmt).await? {
+        let rootpage = row.get_value(0).as_int().ok_or_else(|| {
+            Error::DatabaseSyncEngineError(format!(
+                "unexpected sqlite_schema.rootpage type while rebuilding logical table map: {:?}",
+                row.get_value(0)
+            ))
+        })?;
+        let name = match row.get_value(1) {
+            Value::Text(text) => text.as_str().to_string(),
+            other => {
+                return Err(Error::DatabaseSyncEngineError(format!(
+                    "unexpected sqlite_schema.name type while rebuilding logical table map: {other:?}"
+                )));
+            }
+        };
+        if rootpage != 0 && is_logically_replayable_table(&name) {
+            map.insert(rootpage.unsigned_abs(), name);
+        }
+    }
+    Ok(map)
+}
+
+pub async fn max_local_change_id<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+) -> Result<Option<i64>> {
+    let mut stmt = match conn.prepare("SELECT MAX(change_id) FROM turso_cdc") {
+        Ok(stmt) => stmt,
+        Err(LimboError::ParseError(err)) if err.contains("no such table") => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+
+    let value = match run_stmt_expect_one_row(coro, &mut stmt).await? {
+        Some(row) => row[0].clone(),
+        None => return Ok(None),
+    };
+    match value {
+        Value::Null => Ok(None),
+        Value::Numeric(turso_core::Numeric::Integer(value)) => Ok(Some(value)),
+        other => Err(Error::DatabaseSyncEngineError(format!(
+            "unexpected MAX(change_id) column type: {other:?}"
+        ))),
+    }
+}
+
 pub async fn update_last_change_id<Ctx>(
     coro: &Coro<Ctx>,
     conn: &Arc<turso_core::Connection>,
@@ -770,6 +2527,60 @@ pub async fn update_last_change_id<Ctx>(
         );
     }
 
+    Ok(())
+}
+
+/// Ensures the local high-water mark table exists and publishes schema changes.
+pub async fn ensure_sync_last_change_id_table<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+    client_id: &str,
+) -> Result<()> {
+    for attempt in 0..=2 {
+        match conn.execute(TURSO_SYNC_CREATE_TABLE) {
+            Ok(()) => {
+                conn.publish_schema_if_newer();
+                return Ok(());
+            }
+            Err(LimboError::ParseError(err)) if err.contains("already exists") => {
+                tracing::debug!(
+                    "update_last_change_id(client_id={client_id}): sync table already exists while initializing; refreshing schema"
+                );
+                conn.publish_schema_if_newer();
+                return Ok(());
+            }
+            Err(LimboError::SchemaUpdated) => {
+                tracing::debug!(
+                    "update_last_change_id(client_id={client_id}): schema updated while initializing sync table; refreshing schema"
+                );
+                force_reparse_schema_with_retry(conn)?;
+                conn.publish_schema_after_external_restore();
+                if attempt == 2 {
+                    return Ok(());
+                }
+                match has_table(coro, conn, TURSO_SYNC_TABLE_NAME).await {
+                    Ok(true) => return Ok(()),
+                    Ok(false) => continue,
+                    Err(Error::TursoError(LimboError::SchemaUpdated)) => continue,
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+    Err(Error::DatabaseSyncEngineError(format!(
+        "failed to initialize sync high-water mark table after schema refresh: client_id={client_id}"
+    )))
+}
+
+fn force_reparse_schema_with_retry(conn: &Arc<turso_core::Connection>) -> Result<()> {
+    for attempt in 0..=2 {
+        match conn.force_reparse_schema() {
+            Ok(()) => return Ok(()),
+            Err(LimboError::SchemaUpdated) if attempt < 2 => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
     Ok(())
 }
 
@@ -901,12 +2712,13 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
     source: &DatabaseTape,
     client_id: &str,
     opts: &DatabaseSyncEngineOpts,
-) -> Result<(i64, i64)> {
+) -> Result<(i64, i64, i64)> {
     tracing::info!("push_logical_changes: client_id={client_id}");
     let source_conn = connect_untracked(source)?;
 
     let (source_pull_gen, mut last_change_id) =
         fetch_last_change_id(ctx, &source_conn, client_id).await?;
+    let replay_floor_change_id = last_change_id.unwrap_or(0);
 
     tracing::debug!("push_logical_changes: last_change_id={:?}", last_change_id);
     let replay_opts = DatabaseReplaySessionOpts {
@@ -939,14 +2751,11 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
         }
 
         match operation {
-            DatabaseTapeOperation::StmtReplay(_) => {
-                panic!("changes iterator must not use StmtReplay option")
+            DatabaseTapeOperation::StmtReplay(_) | DatabaseTapeOperation::SchemaReplay(_) => {
+                panic!("changes iterator must not use replay-only operations")
             }
             DatabaseTapeOperation::RowChange(change) => {
-                if change.table_name == TURSO_SYNC_TABLE_NAME {
-                    continue;
-                }
-                if opts.tables_ignore.iter().any(|x| &change.table_name == x) {
+                if !should_push_change(&change, opts)? {
                     continue;
                 }
                 batch.push(change);
@@ -984,7 +2793,11 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
         "push_logical_changes: rows_changed={total_rows_changed}, last_change_id={:?}",
         last_change_id
     );
-    Ok((source_pull_gen, last_change_id.unwrap_or(0)))
+    Ok((
+        source_pull_gen,
+        replay_floor_change_id,
+        last_change_id.unwrap_or(0),
+    ))
 }
 
 /// Build and send a single push batch over HTTP. The caller owns the
@@ -1305,6 +3118,7 @@ async fn pull_chunk_into_file<IO: SyncEngineIo, Ctx>(
 ) -> Result<PullUpdatesRespProtoBody> {
     let request = PullUpdatesReqProtoBody {
         encoding: PageUpdatesEncodingReq::Raw as i32,
+        stream_kind: PullUpdatesStreamKind::Pages as i32,
         server_revision: server_revision.to_string(),
         client_revision: String::new(),
         long_poll_timeout_ms: 0,
@@ -1337,6 +3151,7 @@ async fn pull_chunk_into_file<IO: SyncEngineIo, Ctx>(
         ));
     };
     tracing::info!("bootstrap_db_file: got header={:?}", header);
+    ensure_page_stream(&header, "pull_chunk_into_file")?;
     if truncate_on_first_response {
         let c = Completion::new_trunc(move |result| {
             let Ok(rc) = result else {
@@ -1860,17 +3675,41 @@ pub async fn wait_all_results<Ctx, T: Clone>(
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
+    use std::{
+        cell::RefCell,
+        collections::BTreeMap,
+        sync::{Arc, Mutex},
+    };
 
     use bytes::{Bytes, BytesMut};
     use prost::Message;
+    use tempfile::NamedTempFile;
 
     use crate::{
+        client_proto::{
+            LogicalOp, LogicalOpType, LogicalSchemaAction, LogicalSchemaKind, LogicalTxnData,
+        },
         database_sync_engine::DataStats,
-        database_sync_engine_io::{DataCompletion, DataPollResult},
-        database_sync_operations::wait_proto_message,
-        server_proto::PageData,
-        types::Coro,
+        database_sync_engine::DatabaseSyncEngineOpts,
+        database_sync_engine_io::{DataCompletion, DataPollResult, SyncEngineIo},
+        database_sync_operations::{
+            apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats,
+            ensure_incremental_page_stream, ensure_page_stream, is_logically_replayable_table,
+            logical_txn_to_tape_operations, pull_pages_v1, pull_updates_v1, should_push_change,
+            should_replay_local_change, wait_proto_message, wal_pull_to_file_v1,
+            PullUpdatesV1Result, SyncEngineIoStats, SyncOperationCtx,
+        },
+        database_tape::{run_stmt_once, DatabaseReplaySessionOpts, DatabaseTape},
+        server_proto,
+        server_proto::{
+            PageData, PageSetRawEncodingProto, PullUpdatesApplyMode, PullUpdatesReqProtoBody,
+            PullUpdatesRespProtoBody, PullUpdatesStreamKind,
+        },
+        types::{
+            parse_bin_record, Coro, DatabasePullRevision, DatabaseRowMutation,
+            DatabaseRowTransformResult, DatabaseSchemaReplay, DatabaseTapeOperation,
+            DatabaseTapeRowChange, DatabaseTapeRowChangeType,
+        },
         Result,
     };
 
@@ -1909,6 +3748,87 @@ mod tests {
         fn is_done(&self) -> crate::Result<bool> {
             Ok(self.data.borrow().is_empty())
         }
+    }
+
+    struct TestTransformPollResult(Vec<DatabaseRowTransformResult>);
+
+    impl DataPollResult<DatabaseRowTransformResult> for TestTransformPollResult {
+        fn data(&self) -> &[DatabaseRowTransformResult] {
+            &self.0
+        }
+    }
+
+    struct TestTransformCompletion;
+
+    impl DataCompletion<DatabaseRowTransformResult> for TestTransformCompletion {
+        type DataPollResult = TestTransformPollResult;
+
+        fn status(&self) -> crate::Result<Option<u16>> {
+            Ok(Some(200))
+        }
+
+        fn poll_data(&self) -> crate::Result<Option<Self::DataPollResult>> {
+            Ok(None)
+        }
+
+        fn is_done(&self) -> crate::Result<bool> {
+            Ok(true)
+        }
+    }
+
+    #[derive(Default)]
+    struct TestHttpIo {
+        response: Vec<u8>,
+        chunk: usize,
+        request: Mutex<Option<(String, String, Vec<u8>)>>,
+        headers: Mutex<Vec<(String, String)>>,
+    }
+
+    impl SyncEngineIo for TestHttpIo {
+        type DataCompletionBytes = TestCompletion;
+        type DataCompletionTransform = TestTransformCompletion;
+
+        fn full_read(&self, _path: &str) -> Result<Self::DataCompletionBytes> {
+            panic!("full_read is not used in this test")
+        }
+
+        fn full_write(&self, _path: &str, _content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
+            panic!("full_write is not used in this test")
+        }
+
+        fn transform(
+            &self,
+            _mutations: Vec<DatabaseRowMutation>,
+        ) -> Result<Self::DataCompletionTransform> {
+            panic!("transform is not used in this test")
+        }
+
+        fn http(
+            &self,
+            _url: Option<&str>,
+            method: &str,
+            path: &str,
+            body: Option<Vec<u8>>,
+            headers: &[(&str, &str)],
+        ) -> Result<Self::DataCompletionBytes> {
+            self.request.lock().unwrap().replace((
+                method.to_string(),
+                path.to_string(),
+                body.unwrap_or_default(),
+            ));
+            *self.headers.lock().unwrap() = headers
+                .iter()
+                .map(|(name, value)| ((*name).to_string(), (*value).to_string()))
+                .collect();
+            Ok(TestCompletion {
+                data: RefCell::new(self.response.clone().into()),
+                chunk: self.chunk,
+            })
+        }
+
+        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
+
+        fn step_io_callbacks(&self) {}
     }
 
     #[test]
@@ -2065,5 +3985,1310 @@ mod tests {
             "reset_wal_file must fsync the truncation"
         );
         assert_eq!(counting.size().unwrap(), 0, "wal must be truncated to zero");
+    }
+
+    fn record(values: &[turso_core::Value]) -> Bytes {
+        Bytes::from(
+            turso_core::types::ImmutableRecord::from_values(values, values.len())
+                .unwrap()
+                .into_payload(),
+        )
+    }
+
+    fn encoded_logical_txns(txns: &[LogicalTxnData]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for txn in txns {
+            bytes.extend_from_slice(&txn.encode_length_delimited_to_vec());
+        }
+        bytes
+    }
+
+    fn logical_schema_op(
+        action: LogicalSchemaAction,
+        kind: LogicalSchemaKind,
+        name: &str,
+        sql: Option<&str>,
+        stable_table_id: u64,
+    ) -> LogicalOp {
+        LogicalOp {
+            op_type: LogicalOpType::Schema as i32,
+            table_name: String::new(),
+            rowid: 0,
+            record: Bytes::new(),
+            sql: sql.unwrap_or_default().to_string(),
+            user_version: None,
+            application_id: None,
+            schema_action: Some(action as i32),
+            schema_kind: Some(kind as i32),
+            schema_name: name.to_string(),
+            stable_table_id,
+        }
+    }
+
+    fn logical_upsert_op(
+        table_name: &str,
+        stable_table_id: u64,
+        rowid: i64,
+        value: &str,
+    ) -> LogicalOp {
+        LogicalOp {
+            op_type: LogicalOpType::UpsertRow as i32,
+            table_name: table_name.to_string(),
+            rowid,
+            record: record(&[turso_core::Value::Text(turso_core::types::Text::new(
+                value.to_string(),
+            ))]),
+            sql: String::new(),
+            user_version: None,
+            application_id: None,
+            schema_action: None,
+            schema_kind: None,
+            schema_name: String::new(),
+            stable_table_id,
+        }
+    }
+
+    #[test]
+    fn max_local_change_id_reads_cdc_high_water_mark() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(io.clone(), temp_file.path().to_str().unwrap())
+            .unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                assert_eq!(
+                    super::max_local_change_id(&coro, &conn).await.unwrap(),
+                    None
+                );
+                conn.execute("CREATE TABLE t(x)").unwrap();
+                conn.execute("INSERT INTO t VALUES (1), (2)").unwrap();
+                let max_change_id = super::max_local_change_id(&coro, &conn).await.unwrap();
+                assert!(max_change_id.is_some_and(|change_id| change_id > 0));
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(()) => break,
+            }
+        }
+    }
+
+    fn write_test_varint(value: u64, out: &mut Vec<u8>) {
+        turso_core::storage::sqlite3_ondisk::write_varint_to_vec(value, out);
+    }
+
+    fn test_schema_record(op: &LogicalOp) -> Bytes {
+        let kind = LogicalSchemaKind::try_from(op.schema_kind.unwrap()).unwrap();
+        let row_type = match kind {
+            LogicalSchemaKind::Unspecified => panic!("test schema kind must be specified"),
+            LogicalSchemaKind::Table => "table",
+            LogicalSchemaKind::Index => "index",
+            LogicalSchemaKind::Trigger => "trigger",
+            LogicalSchemaKind::View => "view",
+        };
+        let rootpage = if op.stable_table_id == 0 {
+            2
+        } else {
+            op.stable_table_id as i64
+        };
+        record(&[
+            turso_core::Value::build_text(row_type),
+            turso_core::Value::Text(turso_core::types::Text::new(op.schema_name.clone())),
+            turso_core::Value::Text(turso_core::types::Text::new(op.schema_name.clone())),
+            turso_core::Value::from_i64(rootpage),
+            turso_core::Value::Text(turso_core::types::Text::new(op.sql.clone())),
+        ])
+    }
+
+    fn append_test_table_upsert(
+        recovery_payload: &mut Vec<u8>,
+        table_id: i64,
+        rowid: i64,
+        record: &[u8],
+    ) {
+        let mut payload = Vec::new();
+        write_test_varint(rowid as u64, &mut payload);
+        payload.extend_from_slice(record);
+        recovery_payload.push(super::MVCC_OP_UPSERT_TABLE);
+        recovery_payload.push(0);
+        recovery_payload.extend_from_slice(&(table_id as i32).to_le_bytes());
+        write_test_varint(payload.len() as u64, recovery_payload);
+        recovery_payload.extend_from_slice(&payload);
+    }
+
+    fn raw_mvcc_log_frame_from_payloads(
+        commit_ts: u64,
+        portable_payload: &[u8],
+        recovery_payload: &[u8],
+        op_count: u32,
+    ) -> Vec<u8> {
+        let mut extension_block = Vec::new();
+        extension_block
+            .extend_from_slice(&super::MVCC_EXTENSION_TYPE_PORTABLE_CHANGES.to_le_bytes());
+        extension_block.extend_from_slice(&0u16.to_le_bytes());
+        extension_block.extend_from_slice(&(portable_payload.len() as u32).to_le_bytes());
+        extension_block.extend_from_slice(portable_payload);
+
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&super::MVCC_TX_EXT_FRAME_MAGIC.to_le_bytes());
+        frame.extend_from_slice(&(recovery_payload.len() as u64).to_le_bytes());
+        frame.extend_from_slice(&op_count.to_le_bytes());
+        frame.extend_from_slice(&commit_ts.to_le_bytes());
+        frame.extend_from_slice(&(extension_block.len() as u64).to_le_bytes());
+        frame.extend_from_slice(&1u32.to_le_bytes());
+        frame.extend_from_slice(&super::MVCC_TX_FLAG_HAS_EXTENSION_BLOCK.to_le_bytes());
+        frame.extend_from_slice(&extension_block);
+        frame.extend_from_slice(recovery_payload);
+        frame.extend_from_slice(&0u32.to_le_bytes());
+        frame.extend_from_slice(&super::MVCC_TX_END_MAGIC.to_le_bytes());
+        frame
+    }
+
+    fn raw_mvcc_log_header(salt: u64) -> Vec<u8> {
+        let mut header = vec![0u8; super::MVCC_LOG_HEADER_SIZE];
+        header[0..4].copy_from_slice(&super::MVCC_LOG_MAGIC.to_le_bytes());
+        header[4] = super::MVCC_LOG_VERSION;
+        header[6..8].copy_from_slice(&(super::MVCC_LOG_HEADER_SIZE as u16).to_le_bytes());
+        header[8..16].copy_from_slice(&salt.to_le_bytes());
+        let crc = crc32c::crc32c(&header);
+        header[super::MVCC_LOG_HEADER_CRC_START..super::MVCC_LOG_HEADER_SIZE]
+            .copy_from_slice(&crc.to_le_bytes());
+        header
+    }
+
+    fn raw_mvcc_log_frame_with_crc(
+        commit_ts: u64,
+        portable_payload: &[u8],
+        recovery_payload: &[u8],
+        op_count: u32,
+        previous_crc: u32,
+    ) -> (Vec<u8>, u32) {
+        let mut frame = raw_mvcc_log_frame_from_payloads(
+            commit_ts,
+            portable_payload,
+            recovery_payload,
+            op_count,
+        );
+        let trailer_start = frame.len() - super::MVCC_TX_TRAILER_SIZE;
+        let crc = crc32c::crc32c_append(previous_crc, &frame[..trailer_start]);
+        frame[trailer_start..trailer_start + 4].copy_from_slice(&crc.to_le_bytes());
+        (frame, crc)
+    }
+
+    fn decode_raw_mvcc_log_for_test(
+        header: PullUpdatesRespProtoBody,
+        body: Vec<u8>,
+    ) -> Result<Vec<LogicalTxnData>> {
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_owned();
+        let core_io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let file = core_io
+            .open_file(path.to_str().unwrap(), turso_core::OpenFlags::Create, false)
+            .unwrap();
+        let mut gen = genawaiter::sync::Gen::new({
+            let file = file.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                super::decode_raw_mvcc_logical_log_to_file(&coro, &file, &body, &header).await?;
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => {}
+                genawaiter::GeneratorState::Complete(result) => {
+                    result?;
+                    break;
+                }
+            }
+        }
+
+        let mut bytes = BytesMut::from(std::fs::read(path).unwrap().as_slice());
+        let mut txns = Vec::new();
+        while let Some(txn) = super::take_proto_message_from_bytes::<LogicalTxnData>(&mut bytes)? {
+            txns.push(txn);
+        }
+        Ok(txns)
+    }
+
+    fn read_logical_txns_from_path(path: &std::path::Path) -> Result<Vec<LogicalTxnData>> {
+        let mut bytes = BytesMut::from(std::fs::read(path).unwrap().as_slice());
+        let mut txns = Vec::new();
+        while let Some(txn) = super::take_proto_message_from_bytes::<LogicalTxnData>(&mut bytes)? {
+            txns.push(txn);
+        }
+        Ok(txns)
+    }
+
+    #[test]
+    fn raw_mvcc_log_decoder_decodes_portable_schema_and_row_ops() {
+        let table_id = -42;
+        let schema = logical_schema_op(
+            LogicalSchemaAction::Create,
+            LogicalSchemaKind::Table,
+            "t",
+            Some("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)"),
+            0,
+        );
+        let schema_record = test_schema_record(&schema);
+        let row_record = record(&[
+            turso_core::Value::from_i64(1),
+            turso_core::Value::build_text("one"),
+        ]);
+        let portable_txn = super::PortableLogicalTxn {
+            end_offset: 104,
+            commit_ts: 77,
+            string_table: vec![
+                Bytes::from_static(b"t"),
+                Bytes::from_static(super::PORTABLE_TXN_META_CLIENT_KEY.as_bytes()),
+                Bytes::from_static(b"client-a"),
+            ],
+            object_map: vec![super::PortableObjectMap {
+                mv_table_id: table_id,
+                name_ref: 0,
+            }],
+            meta: vec![super::PortableMeta {
+                key_ref: 1,
+                value_ref: 2,
+            }],
+        };
+        let portable_payload = portable_txn.encode_length_delimited_to_vec();
+        let mut recovery_payload = Vec::new();
+        append_test_table_upsert(
+            &mut recovery_payload,
+            super::MVCC_SQLITE_SCHEMA_TABLE_ID,
+            1,
+            &schema_record,
+        );
+        append_test_table_upsert(&mut recovery_payload, table_id, 1, &row_record);
+
+        let salt = 0x0123_4567_89ab_cdefu64;
+        let log_header = raw_mvcc_log_header(salt);
+        let initial_crc = crc32c::crc32c(&salt.to_le_bytes());
+        let (frame, _) =
+            raw_mvcc_log_frame_with_crc(77, &portable_payload, &recovery_payload, 2, initial_crc);
+        let end_offset = (log_header.len() + frame.len()) as u64;
+        let header = PullUpdatesRespProtoBody {
+            server_revision: format!("g1:o{end_offset}"),
+            db_size: 0,
+            raw_encoding: None,
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: Some(server_proto::MvccLogicalLogMetadataProto {
+                format: "lml3".to_string(),
+                checkpoint_transition: false,
+                ranges: vec![server_proto::MvccLogicalLogRangeProto {
+                    generation: 1,
+                    start_offset: 0,
+                    end_offset,
+                    starts_with_header: true,
+                    crc_seed: None,
+                }],
+            }),
+        };
+        let mut body = log_header;
+        body.extend_from_slice(&frame);
+
+        let txns = decode_raw_mvcc_log_for_test(header, body).unwrap();
+        assert_eq!(txns.len(), 1);
+        assert_eq!(txns[0].end_offset, 104);
+        assert_eq!(txns[0].commit_ts, 77);
+        assert_eq!(txns[0].origin_client_id, "client-a");
+        assert_eq!(txns[0].ops.len(), 2);
+        assert_eq!(txns[0].ops[0].op_type, LogicalOpType::Schema as i32);
+        assert_eq!(txns[0].ops[0].schema_name, "t");
+        assert_eq!(txns[0].ops[0].stable_table_id, 0);
+        assert_eq!(txns[0].ops[1].op_type, LogicalOpType::UpsertRow as i32);
+        assert_eq!(txns[0].ops[1].table_name, "t");
+        assert_eq!(txns[0].ops[1].rowid, 1);
+        assert_eq!(txns[0].ops[1].record, row_record);
+    }
+
+    #[test]
+    fn pull_updates_v1_decodes_raw_mvcc_log_stream() {
+        let table_id = -42;
+        let record = record(&[turso_core::Value::build_text("logical")]);
+        let expected_txn = LogicalTxnData {
+            end_offset: 104,
+            commit_ts: 77,
+            origin_client_id: String::new(),
+            ops: vec![LogicalOp {
+                op_type: LogicalOpType::UpsertRow as i32,
+                table_name: "t".to_string(),
+                rowid: 7,
+                record: record.clone(),
+                sql: String::new(),
+                user_version: None,
+                application_id: None,
+                schema_action: None,
+                schema_kind: None,
+                schema_name: String::new(),
+                stable_table_id: 0,
+            }],
+        };
+        let portable_txn = super::PortableLogicalTxn {
+            end_offset: expected_txn.end_offset,
+            commit_ts: expected_txn.commit_ts,
+            string_table: vec![Bytes::from_static(b"t")],
+            object_map: vec![super::PortableObjectMap {
+                mv_table_id: table_id,
+                name_ref: 0,
+            }],
+            meta: Vec::new(),
+        };
+        let portable_payload = portable_txn.encode_length_delimited_to_vec();
+        let mut recovery_payload = Vec::new();
+        append_test_table_upsert(&mut recovery_payload, table_id, 7, &record);
+        let crc_seed = crc32c::crc32c(&1234u64.to_le_bytes());
+        let (raw_frame, _) =
+            raw_mvcc_log_frame_with_crc(77, &portable_payload, &recovery_payload, 1, crc_seed);
+        let range_start = super::MVCC_LOG_HEADER_SIZE as u64;
+        let range_end = range_start + raw_frame.len() as u64;
+        let header = PullUpdatesRespProtoBody {
+            server_revision: format!("g1:o{range_end}"),
+            db_size: 0,
+            raw_encoding: None,
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: Some(server_proto::MvccLogicalLogMetadataProto {
+                format: "lml3".to_string(),
+                checkpoint_transition: false,
+                ranges: vec![server_proto::MvccLogicalLogRangeProto {
+                    generation: 1,
+                    start_offset: range_start,
+                    end_offset: range_end,
+                    starts_with_header: false,
+                    crc_seed: Some(crc_seed.to_le_bytes().to_vec()),
+                }],
+            }),
+        };
+        let mut response = Vec::new();
+        response.extend_from_slice(&header.encode_length_delimited_to_vec());
+        response.extend_from_slice(&raw_frame);
+
+        let io = Arc::new(TestHttpIo {
+            response,
+            chunk: 7,
+            request: Mutex::new(None),
+            headers: Mutex::new(Vec::new()),
+        });
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_owned();
+        let core_io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let file = core_io
+            .open_file(path.to_str().unwrap(), turso_core::OpenFlags::Create, false)
+            .unwrap();
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let file = file.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let stats = SyncEngineIoStats::new(io.clone());
+                let ctx = SyncOperationCtx::new(
+                    &coro,
+                    &stats,
+                    Some("https://example.com".to_string()),
+                    None,
+                );
+                let (revision, result) = pull_updates_v1(&ctx, &file, "g1:o56", None, true).await?;
+                let DatabasePullRevision::V1 { revision } = revision else {
+                    panic!("expected V1 revision");
+                };
+                assert_eq!(revision, format!("g1:o{range_end}"));
+                assert_eq!(result, PullUpdatesV1Result::Logical { txns: 1, ops: 1 });
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => {}
+                genawaiter::GeneratorState::Complete(result) => {
+                    result.unwrap();
+                    break;
+                }
+            }
+        }
+
+        assert_eq!(
+            read_logical_txns_from_path(&path).unwrap(),
+            vec![expected_txn]
+        );
+        let request = io.request.lock().unwrap().clone().unwrap();
+        let req = PullUpdatesReqProtoBody::decode(request.2.as_slice()).unwrap();
+        assert_eq!(
+            req.stream_kind,
+            PullUpdatesStreamKind::MvccLogicalLog as i32
+        );
+    }
+
+    #[test]
+    fn pull_updates_v1_accepts_page_stream_when_logical_pull_is_requested() {
+        let page = vec![7u8; super::PAGE_SIZE];
+        let header = PullUpdatesRespProtoBody {
+            server_revision: "g1:o45".to_string(),
+            db_size: 1,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+        };
+        let page_data = PageData {
+            page_id: 0,
+            encoded_page: page.clone().into(),
+        };
+        let mut response = Vec::new();
+        response.extend_from_slice(&header.encode_length_delimited_to_vec());
+        response.extend_from_slice(&page_data.encode_length_delimited_to_vec());
+
+        let io = Arc::new(TestHttpIo {
+            response,
+            chunk: 11,
+            request: Mutex::new(None),
+            headers: Mutex::new(Vec::new()),
+        });
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_owned();
+        let core_io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let file = core_io
+            .open_file(path.to_str().unwrap(), turso_core::OpenFlags::Create, false)
+            .unwrap();
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let file = file.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let stats = SyncEngineIoStats::new(io.clone());
+                let ctx = SyncOperationCtx::new(
+                    &coro,
+                    &stats,
+                    Some("https://example.com".to_string()),
+                    None,
+                );
+                let (revision, result) = pull_updates_v1(&ctx, &file, "g1:o40", None, true).await?;
+                let DatabasePullRevision::V1 { revision } = revision else {
+                    panic!("expected V1 revision");
+                };
+                assert_eq!(revision, "g1:o45");
+                assert_eq!(
+                    result,
+                    PullUpdatesV1Result::Pages {
+                        replace_base: false
+                    }
+                );
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => {}
+                genawaiter::GeneratorState::Complete(result) => {
+                    result.unwrap();
+                    break;
+                }
+            }
+        }
+
+        let bytes = std::fs::read(path).unwrap();
+        assert_eq!(bytes.len(), super::WAL_FRAME_SIZE);
+        let info =
+            turso_core::types::WalFrameInfo::from_frame_header(&bytes[..super::WAL_FRAME_HEADER]);
+        assert_eq!(info.page_no, 1);
+        assert_eq!(info.db_size, 1);
+        assert_eq!(&bytes[super::WAL_FRAME_HEADER..], page.as_slice());
+        let request = io.request.lock().unwrap().clone().unwrap();
+        let req = PullUpdatesReqProtoBody::decode(request.2.as_slice()).unwrap();
+        assert_eq!(
+            req.stream_kind,
+            PullUpdatesStreamKind::MvccLogicalLog as i32
+        );
+    }
+
+    #[test]
+    fn pull_updates_v1_preserves_replace_base_page_fallback() {
+        let page = vec![9u8; super::PAGE_SIZE];
+        let header = PullUpdatesRespProtoBody {
+            server_revision: "g1:o80".to_string(),
+            db_size: 1,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::ReplaceBase as i32,
+            mvcc_log: None,
+        };
+        let page_data = PageData {
+            page_id: 0,
+            encoded_page: page.clone().into(),
+        };
+        let mut response = Vec::new();
+        response.extend_from_slice(&header.encode_length_delimited_to_vec());
+        response.extend_from_slice(&page_data.encode_length_delimited_to_vec());
+
+        let io = Arc::new(TestHttpIo {
+            response,
+            chunk: 13,
+            request: Mutex::new(None),
+            headers: Mutex::new(Vec::new()),
+        });
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_owned();
+        let core_io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let file = core_io
+            .open_file(path.to_str().unwrap(), turso_core::OpenFlags::Create, false)
+            .unwrap();
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let file = file.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let stats = SyncEngineIoStats::new(io.clone());
+                let ctx = SyncOperationCtx::new(
+                    &coro,
+                    &stats,
+                    Some("https://example.com".to_string()),
+                    None,
+                );
+                let (revision, result) = pull_updates_v1(&ctx, &file, "g1:o40", None, true).await?;
+                let DatabasePullRevision::V1 { revision } = revision else {
+                    panic!("expected V1 revision");
+                };
+                assert_eq!(revision, "g1:o80");
+                assert_eq!(result, PullUpdatesV1Result::Pages { replace_base: true });
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => {}
+                genawaiter::GeneratorState::Complete(result) => {
+                    result.unwrap();
+                    break;
+                }
+            }
+        }
+
+        let bytes = std::fs::read(path).unwrap();
+        assert_eq!(bytes.len(), super::WAL_FRAME_SIZE);
+        let info =
+            turso_core::types::WalFrameInfo::from_frame_header(&bytes[..super::WAL_FRAME_HEADER]);
+        assert_eq!(info.page_no, 1);
+        assert_eq!(info.db_size, 1);
+        assert_eq!(&bytes[super::WAL_FRAME_HEADER..], page.as_slice());
+    }
+
+    #[test]
+    fn wal_pull_to_file_v1_rejects_replace_base_page_stream() {
+        let header = PullUpdatesRespProtoBody {
+            server_revision: "g1:o80".to_string(),
+            db_size: 1,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::ReplaceBase as i32,
+            mvcc_log: None,
+        };
+        let response = header.encode_length_delimited_to_vec();
+
+        let io = Arc::new(TestHttpIo {
+            response,
+            chunk: 13,
+            request: Mutex::new(None),
+            headers: Mutex::new(Vec::new()),
+        });
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_owned();
+        let core_io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let file = core_io
+            .open_file(path.to_str().unwrap(), turso_core::OpenFlags::Create, false)
+            .unwrap();
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let file = file.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let stats = SyncEngineIoStats::new(io.clone());
+                let ctx = SyncOperationCtx::new(
+                    &coro,
+                    &stats,
+                    Some("https://example.com".to_string()),
+                    None,
+                );
+                let err = wal_pull_to_file_v1(&ctx, &file, "g1:o40", None)
+                    .await
+                    .unwrap_err();
+                assert!(
+                    err.to_string().contains("replace-base page streams"),
+                    "unexpected error: {err:?}"
+                );
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => {}
+                genawaiter::GeneratorState::Complete(result) => {
+                    result.unwrap();
+                    break;
+                }
+            }
+        }
+
+        assert_eq!(file.size().unwrap(), 0);
+        let request = io.request.lock().unwrap().clone().unwrap();
+        let req = PullUpdatesReqProtoBody::decode(request.2.as_slice()).unwrap();
+        assert_eq!(req.stream_kind, PullUpdatesStreamKind::Pages as i32);
+    }
+
+    #[test]
+    fn pull_pages_v1_accepts_replace_base_page_stream_for_revision_pinned_reads() {
+        let page = vec![11u8; super::PAGE_SIZE];
+        let header = PullUpdatesRespProtoBody {
+            server_revision: "g1:o80".to_string(),
+            db_size: 3,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::ReplaceBase as i32,
+            mvcc_log: None,
+        };
+        let page_data = PageData {
+            page_id: 2,
+            encoded_page: page.clone().into(),
+        };
+        let mut response = Vec::new();
+        response.extend_from_slice(&header.encode_length_delimited_to_vec());
+        response.extend_from_slice(&page_data.encode_length_delimited_to_vec());
+
+        let io = Arc::new(TestHttpIo {
+            response,
+            chunk: 13,
+            request: Mutex::new(None),
+            headers: Mutex::new(Vec::new()),
+        });
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let stats = SyncEngineIoStats::new(io.clone());
+                let ctx = SyncOperationCtx::new(
+                    &coro,
+                    &stats,
+                    Some("https://example.com".to_string()),
+                    None,
+                );
+                let loaded = pull_pages_v1(&ctx, "g1:o40", &[2]).await?;
+                assert_eq!(loaded.db_pages, 3);
+                assert_eq!(loaded.pages.len(), 1);
+                assert_eq!(loaded.pages[0].page_id, 2);
+                assert_eq!(loaded.pages[0].page, page);
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => {}
+                genawaiter::GeneratorState::Complete(result) => {
+                    result.unwrap();
+                    break;
+                }
+            }
+        }
+
+        let request = io.request.lock().unwrap().clone().unwrap();
+        let req = PullUpdatesReqProtoBody::decode(request.2.as_slice()).unwrap();
+        assert_eq!(request.0, "POST");
+        assert_eq!(request.1, "/pull-updates");
+        assert_eq!(req.stream_kind, PullUpdatesStreamKind::Pages as i32);
+        assert_eq!(req.server_revision, "g1:o40");
+        assert_eq!(req.client_revision, "");
+    }
+
+    #[test]
+    fn pull_updates_v1_rejects_remote_encryption_for_logical_pull() {
+        let io = Arc::new(TestHttpIo {
+            response: Vec::new(),
+            chunk: 32,
+            request: Mutex::new(None),
+            headers: Mutex::new(Vec::new()),
+        });
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_owned();
+        let core_io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let file = core_io
+            .open_file(path.to_str().unwrap(), turso_core::OpenFlags::Create, false)
+            .unwrap();
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let file = file.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let stats = SyncEngineIoStats::new(io.clone());
+                let ctx = SyncOperationCtx::new(
+                    &coro,
+                    &stats,
+                    Some("https://example.com".to_string()),
+                    Some("dGVzdC1lbmNyeXB0aW9uLWtleQ=="),
+                );
+                let err = pull_updates_v1(&ctx, &file, "g1:o40", None, true)
+                    .await
+                    .unwrap_err();
+                assert!(
+                    err.to_string()
+                        .contains("not supported with encrypted remote databases"),
+                    "unexpected error: {err:?}"
+                );
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => {}
+                genawaiter::GeneratorState::Complete(result) => {
+                    result.unwrap();
+                    break;
+                }
+            }
+        }
+
+        assert!(io.request.lock().unwrap().is_none());
+        assert!(io.headers.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn raw_mvcc_log_decoder_requires_crc_seed_for_mid_log_range() {
+        let portable_txn = super::PortableLogicalTxn {
+            end_offset: 104,
+            commit_ts: 77,
+            string_table: Vec::new(),
+            object_map: Vec::new(),
+            meta: Vec::new(),
+        };
+        let portable_payload = portable_txn.encode_length_delimited_to_vec();
+        let crc_seed = crc32c::crc32c(&1234u64.to_le_bytes());
+        let (frame, _) = raw_mvcc_log_frame_with_crc(77, &portable_payload, &[], 0, crc_seed);
+        let range_start = super::MVCC_LOG_HEADER_SIZE as u64;
+        let range_end = range_start + frame.len() as u64;
+        let header = PullUpdatesRespProtoBody {
+            server_revision: format!("g1:o{range_end}"),
+            db_size: 0,
+            raw_encoding: None,
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: Some(server_proto::MvccLogicalLogMetadataProto {
+                format: "lml3".to_string(),
+                checkpoint_transition: false,
+                ranges: vec![server_proto::MvccLogicalLogRangeProto {
+                    generation: 1,
+                    start_offset: range_start,
+                    end_offset: range_end,
+                    starts_with_header: false,
+                    crc_seed: None,
+                }],
+            }),
+        };
+
+        let err = decode_raw_mvcc_log_for_test(header, frame).unwrap_err();
+        assert!(
+            err.to_string().contains("missing CRC seed"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn raw_mvcc_log_decoder_validates_header_and_frame_crc() {
+        let portable_txn = super::PortableLogicalTxn {
+            end_offset: 104,
+            commit_ts: 77,
+            string_table: Vec::new(),
+            object_map: Vec::new(),
+            meta: Vec::new(),
+        };
+        let portable_payload = portable_txn.encode_length_delimited_to_vec();
+        let salt = 0x1020_3040_5060_7080u64;
+        let mut log_header = raw_mvcc_log_header(salt);
+        let initial_crc = crc32c::crc32c(&salt.to_le_bytes());
+        let (frame, _) = raw_mvcc_log_frame_with_crc(77, &portable_payload, &[], 0, initial_crc);
+        log_header[super::MVCC_LOG_HEADER_CRC_START] ^= 0x01;
+        let end_offset = (log_header.len() + frame.len()) as u64;
+        let header = PullUpdatesRespProtoBody {
+            server_revision: format!("g1:o{end_offset}"),
+            db_size: 0,
+            raw_encoding: None,
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: Some(server_proto::MvccLogicalLogMetadataProto {
+                format: "lml3".to_string(),
+                checkpoint_transition: false,
+                ranges: vec![server_proto::MvccLogicalLogRangeProto {
+                    generation: 1,
+                    start_offset: 0,
+                    end_offset,
+                    starts_with_header: true,
+                    crc_seed: None,
+                }],
+            }),
+        };
+        let mut body = log_header;
+        body.extend_from_slice(&frame);
+
+        let err = decode_raw_mvcc_log_for_test(header, body).unwrap_err();
+        assert!(
+            err.to_string().contains("header checksum mismatch"),
+            "unexpected error: {err:?}"
+        );
+
+        let log_header = raw_mvcc_log_header(salt);
+        let initial_crc = crc32c::crc32c(&salt.to_le_bytes());
+        let (mut frame, _) =
+            raw_mvcc_log_frame_with_crc(77, &portable_payload, &[], 0, initial_crc);
+        frame[super::MVCC_TX_EXT_HEADER_SIZE + super::MVCC_EXTENSION_RECORD_HEADER_SIZE] ^= 0x01;
+        let end_offset = (log_header.len() + frame.len()) as u64;
+        let header = PullUpdatesRespProtoBody {
+            server_revision: format!("g1:o{end_offset}"),
+            db_size: 0,
+            raw_encoding: None,
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: Some(server_proto::MvccLogicalLogMetadataProto {
+                format: "lml3".to_string(),
+                checkpoint_transition: false,
+                ranges: vec![server_proto::MvccLogicalLogRangeProto {
+                    generation: 1,
+                    start_offset: 0,
+                    end_offset,
+                    starts_with_header: true,
+                    crc_seed: None,
+                }],
+            }),
+        };
+        let mut body = log_header;
+        body.extend_from_slice(&frame);
+
+        let err = decode_raw_mvcc_log_for_test(header, body).unwrap_err();
+        assert!(
+            err.to_string().contains("transaction checksum mismatch"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn logical_txn_acknowledges_client_from_origin_or_sync_metadata_row() {
+        let origin_txn = LogicalTxnData {
+            end_offset: 1,
+            commit_ts: 1,
+            origin_client_id: "client-a".to_string(),
+            ops: Vec::new(),
+        };
+        assert!(super::logical_txn_acknowledges_client(&origin_txn, "client-a").unwrap());
+        assert!(!super::logical_txn_acknowledges_client(&origin_txn, "client-b").unwrap());
+
+        let metadata_txn = LogicalTxnData {
+            end_offset: 2,
+            commit_ts: 2,
+            origin_client_id: String::new(),
+            ops: vec![LogicalOp {
+                op_type: LogicalOpType::UpsertRow as i32,
+                table_name: super::TURSO_SYNC_TABLE_NAME.to_string(),
+                rowid: 1,
+                record: record(&[
+                    turso_core::Value::Text(turso_core::types::Text::new("client-b".to_string())),
+                    turso_core::Value::from_i64(42),
+                ]),
+                sql: String::new(),
+                user_version: None,
+                application_id: None,
+                schema_action: None,
+                schema_kind: None,
+                schema_name: String::new(),
+                stable_table_id: 0,
+            }],
+        };
+        assert!(super::logical_txn_acknowledges_client(&metadata_txn, "client-b").unwrap());
+        assert!(!super::logical_txn_acknowledges_client(&metadata_txn, "client-a").unwrap());
+    }
+
+    #[test]
+    fn file_backed_logical_replay_skips_self_origin_and_keeps_table_map() {
+        let db_temp = NamedTempFile::new().unwrap();
+        let txns_temp = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+
+        let txns = vec![
+            LogicalTxnData {
+                end_offset: 1,
+                commit_ts: 1,
+                origin_client_id: "client-a".to_string(),
+                ops: vec![logical_schema_op(
+                    LogicalSchemaAction::Create,
+                    LogicalSchemaKind::Table,
+                    "local_only",
+                    Some("CREATE TABLE local_only(x TEXT)"),
+                    99,
+                )],
+            },
+            LogicalTxnData {
+                end_offset: 2,
+                commit_ts: 2,
+                origin_client_id: "remote".to_string(),
+                ops: vec![logical_schema_op(
+                    LogicalSchemaAction::Create,
+                    LogicalSchemaKind::Table,
+                    "items",
+                    Some("CREATE TABLE items(x TEXT)"),
+                    7,
+                )],
+            },
+            LogicalTxnData {
+                end_offset: 3,
+                commit_ts: 3,
+                origin_client_id: "client-a".to_string(),
+                ops: vec![logical_upsert_op("items", 0, 1, "local")],
+            },
+            LogicalTxnData {
+                end_offset: 4,
+                commit_ts: 4,
+                origin_client_id: "remote".to_string(),
+                ops: vec![logical_upsert_op("", 7, 2, "remote")],
+            },
+            LogicalTxnData {
+                end_offset: 5,
+                commit_ts: 5,
+                origin_client_id: "client-a".to_string(),
+                ops: vec![logical_upsert_op("", 7, 2, "local-overwrite")],
+            },
+        ];
+        std::fs::write(txns_temp.path(), encoded_logical_txns(&txns)).unwrap();
+
+        let db =
+            turso_core::Database::open_file(io.clone(), db_temp.path().to_str().unwrap()).unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+        let txns_file = io
+            .open_file(
+                txns_temp.path().to_str().unwrap(),
+                turso_core::OpenFlags::None,
+                false,
+            )
+            .unwrap();
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            let txns_file = txns_file.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let opts = DatabaseReplaySessionOpts {
+                    use_implicit_rowid: true,
+                };
+                let mut replay = db.start_replay_session(&coro, opts).await.unwrap();
+                let mut table_names_by_stable_id = BTreeMap::new();
+                let stats =
+                    apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats(
+                        &coro,
+                        &mut replay,
+                        &txns_file,
+                        "client-a",
+                        &mut table_names_by_stable_id,
+                    )
+                    .await
+                    .unwrap();
+                replay
+                    .replay(&coro, DatabaseTapeOperation::Commit)
+                    .await
+                    .unwrap();
+
+                let conn = db.connect(&coro).await.unwrap();
+                let mut stmt = conn.prepare("SELECT rowid, x FROM items").unwrap();
+                let mut rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                (stats.touched_rows, table_names_by_stable_id, rows)
+            }
+        });
+        let (touched_rows, table_names_by_stable_id, rows) = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+
+        assert_eq!(table_names_by_stable_id.get(&7).unwrap(), "items");
+        assert!(!table_names_by_stable_id.contains_key(&99));
+        assert!(touched_rows.contains(&("items".to_string(), 2)));
+        assert!(!touched_rows.contains(&("items".to_string(), 1)));
+        assert_eq!(
+            rows,
+            vec![vec![
+                turso_core::Value::from_i64(2),
+                turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
+            ]]
+        );
+    }
+
+    #[test]
+    fn logical_txn_to_tape_operations_maps_schema_and_stable_table_rows() {
+        let txn = LogicalTxnData {
+            end_offset: 128,
+            commit_ts: 77,
+            origin_client_id: String::new(),
+            ops: vec![
+                logical_schema_op(
+                    LogicalSchemaAction::Create,
+                    LogicalSchemaKind::Table,
+                    "items",
+                    Some("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)"),
+                    9,
+                ),
+                LogicalOp {
+                    op_type: LogicalOpType::UpsertRow as i32,
+                    table_name: String::new(),
+                    rowid: 1,
+                    record: record(&[
+                        turso_core::Value::from_i64(1),
+                        turso_core::Value::build_text("alpha"),
+                    ]),
+                    sql: String::new(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: None,
+                    schema_kind: None,
+                    schema_name: String::new(),
+                    stable_table_id: 9,
+                },
+            ],
+        };
+
+        let operations = logical_txn_to_tape_operations(&txn).unwrap();
+        assert_eq!(operations.len(), 2);
+        assert!(matches!(
+            &operations[0],
+            DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Create { sql })
+                if sql.contains("CREATE TABLE items")
+        ));
+        match &operations[1] {
+            DatabaseTapeOperation::RowChange(change) => {
+                assert_eq!(change.table_name, "items");
+                assert_eq!(change.id, 1);
+                assert_eq!(change.change_time, 77);
+                assert!(matches!(
+                    change.change,
+                    DatabaseTapeRowChangeType::Insert { .. }
+                ));
+            }
+            other => panic!("expected row change, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn logical_txn_to_tape_operations_filters_internal_tables() {
+        assert!(!is_logically_replayable_table("turso_sync_last_change_id"));
+        assert!(!is_logically_replayable_table("turso_cdc"));
+        assert!(!is_logically_replayable_table("sqlite_sequence"));
+        assert!(!is_logically_replayable_table("__turso_internal_mvcc_meta"));
+
+        let txn = LogicalTxnData {
+            end_offset: 128,
+            commit_ts: 77,
+            origin_client_id: String::new(),
+            ops: vec![logical_schema_op(
+                LogicalSchemaAction::Create,
+                LogicalSchemaKind::Table,
+                "turso_sync_last_change_id",
+                Some("CREATE TABLE turso_sync_last_change_id(client_id TEXT PRIMARY KEY)"),
+                1,
+            )],
+        };
+
+        let operations = logical_txn_to_tape_operations(&txn).unwrap();
+        assert!(operations.is_empty());
+    }
+
+    #[test]
+    fn push_change_filter_skips_internal_sqlite_schema_objects() {
+        let opts = DatabaseSyncEngineOpts {
+            remote_url: None,
+            client_name: "test-client".to_string(),
+            tables_ignore: Vec::new(),
+            use_transform: false,
+            wal_pull_batch_size: 0,
+            long_poll_timeout: None,
+            protocol_version_hint: crate::types::DatabaseSyncEngineProtocolVersion::V1,
+            bootstrap_if_empty: false,
+            reserved_bytes: 0,
+            db_opts: turso_core::DatabaseOpts::default(),
+            partial_sync_opts: None,
+            remote_encryption_key: None,
+            push_operations_threshold: None,
+            pull_bytes_threshold: None,
+            logical_mvcc_pull: true,
+        };
+        let internal_schema_change = DatabaseTapeRowChange {
+            change_id: 1,
+            change_time: 77,
+            table_name: "sqlite_schema".to_string(),
+            id: 1,
+            change: DatabaseTapeRowChangeType::Insert {
+                after: parse_bin_record(&record(&[
+                    turso_core::Value::build_text("table"),
+                    turso_core::Value::build_text("__turso_internal_mvcc_meta"),
+                    turso_core::Value::build_text("__turso_internal_mvcc_meta"),
+                    turso_core::Value::from_i64(42),
+                    turso_core::Value::build_text(
+                        "CREATE TABLE __turso_internal_mvcc_meta(k TEXT, v INTEGER)",
+                    ),
+                ]))
+                .unwrap(),
+            },
+        };
+        let user_schema_change = DatabaseTapeRowChange {
+            change_id: 2,
+            change_time: 77,
+            table_name: "sqlite_schema".to_string(),
+            id: 2,
+            change: DatabaseTapeRowChangeType::Insert {
+                after: parse_bin_record(&record(&[
+                    turso_core::Value::build_text("table"),
+                    turso_core::Value::build_text("items"),
+                    turso_core::Value::build_text("items"),
+                    turso_core::Value::from_i64(43),
+                    turso_core::Value::build_text("CREATE TABLE items(id INTEGER PRIMARY KEY)"),
+                ]))
+                .unwrap(),
+            },
+        };
+
+        assert!(!should_push_change(&internal_schema_change, &opts).unwrap());
+        assert!(should_push_change(&user_schema_change, &opts).unwrap());
+        assert!(!should_replay_local_change(&internal_schema_change).unwrap());
+        assert!(should_replay_local_change(&user_schema_change).unwrap());
+
+        let rootpage_only_schema_update = DatabaseTapeRowChange {
+            change_id: 3,
+            change_time: 77,
+            table_name: "sqlite_schema".to_string(),
+            id: 2,
+            change: DatabaseTapeRowChangeType::Update {
+                before: Vec::new(),
+                after: parse_bin_record(&record(&[
+                    turso_core::Value::build_text("table"),
+                    turso_core::Value::build_text("items"),
+                    turso_core::Value::build_text("items"),
+                    turso_core::Value::from_i64(44),
+                    turso_core::Value::build_text("CREATE TABLE items(id INTEGER PRIMARY KEY)"),
+                ]))
+                .unwrap(),
+                updates: Some(
+                    parse_bin_record(&record(&[
+                        turso_core::Value::from_i64(0),
+                        turso_core::Value::from_i64(0),
+                        turso_core::Value::from_i64(0),
+                        turso_core::Value::from_i64(1),
+                        turso_core::Value::from_i64(0),
+                        turso_core::Value::Null,
+                        turso_core::Value::Null,
+                        turso_core::Value::Null,
+                        turso_core::Value::from_i64(44),
+                        turso_core::Value::Null,
+                    ]))
+                    .unwrap(),
+                ),
+            },
+        };
+
+        assert!(!should_push_change(&rootpage_only_schema_update, &opts).unwrap());
+        assert!(!should_replay_local_change(&rootpage_only_schema_update).unwrap());
+    }
+
+    fn page_header(stream_kind: i32, apply_mode: i32) -> PullUpdatesRespProtoBody {
+        PullUpdatesRespProtoBody {
+            server_revision: "rev".to_string(),
+            db_size: 1,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind,
+            apply_mode,
+            mvcc_log: None,
+        }
+    }
+
+    #[test]
+    fn ensure_page_stream_accepts_default_page_header() {
+        ensure_page_stream(
+            &page_header(
+                PullUpdatesStreamKind::Pages as i32,
+                PullUpdatesApplyMode::Incremental as i32,
+            ),
+            "test",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn ensure_incremental_page_stream_rejects_replace_base() {
+        ensure_page_stream(
+            &page_header(
+                PullUpdatesStreamKind::Pages as i32,
+                PullUpdatesApplyMode::ReplaceBase as i32,
+            ),
+            "test",
+        )
+        .unwrap();
+        let err = ensure_incremental_page_stream(
+            &page_header(
+                PullUpdatesStreamKind::Pages as i32,
+                PullUpdatesApplyMode::ReplaceBase as i32,
+            ),
+            "test",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("replace-base page streams"));
+    }
+
+    #[test]
+    fn ensure_page_stream_rejects_logical_log_header() {
+        let err = ensure_page_stream(
+            &page_header(
+                PullUpdatesStreamKind::MvccLogicalLog as i32,
+                PullUpdatesApplyMode::Incremental as i32,
+            ),
+            "test",
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("does not support raw MVCC logical-log"));
+    }
+
+    #[test]
+    fn ensure_page_stream_rejects_unknown_enums() {
+        let err = ensure_page_stream(
+            &page_header(99, PullUpdatesApplyMode::Incremental as i32),
+            "test",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("unknown pull-updates stream kind"));
+
+        let err = ensure_page_stream(
+            &page_header(PullUpdatesStreamKind::Pages as i32, 99),
+            "test",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("unknown pull-updates apply mode"));
     }
 }

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -192,7 +192,9 @@ fn logical_op_to_tape_operations(
                 DatabaseTapeRowChange {
                     change_id: 0,
                     change_time: commit_ts,
-                    change: DatabaseTapeRowChangeType::Delete { before: Vec::new() },
+                    change: DatabaseTapeRowChangeType::Delete {
+                        before: crate::alloc::Vec::new(),
+                    },
                     table_name: op.table_name,
                     id: op.rowid,
                 },

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -2479,6 +2479,33 @@ pub async fn max_local_change_id<Ctx>(
     }
 }
 
+/// Read the CDC change-id sequence watermark: the first change id that is NOT
+/// yet safe for the push loop to consume.
+pub async fn read_cdc_sequence_watermark<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+    cdc_table: &str,
+) -> Result<Option<i64>> {
+    let seq_name = turso_core::schema::autoincrement_sequence_name(cdc_table);
+    let mut stmt = conn.prepare("SELECT sequence_watermark_experimental(?)")?;
+    stmt.bind_at(
+        1.try_into().unwrap(),
+        turso_core::Value::build_text(seq_name),
+    )?;
+
+    let value = match run_stmt_expect_one_row(coro, &mut stmt).await? {
+        Some(row) => row[0].clone(),
+        None => return Ok(None),
+    };
+    match value {
+        Value::Null => Ok(None),
+        Value::Numeric(turso_core::Numeric::Integer(value)) => Ok(Some(value)),
+        other => Err(Error::DatabaseSyncEngineError(format!(
+            "unexpected sequence_watermark_experimental column type: {other:?}"
+        ))),
+    }
+}
+
 pub async fn update_last_change_id<Ctx>(
     coro: &Coro<Ctx>,
     conn: &Arc<turso_core::Connection>,
@@ -2740,6 +2767,21 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
     let replay_floor_change_id = last_change_id.unwrap_or(0);
 
     tracing::debug!("push_logical_changes: last_change_id={:?}", last_change_id);
+
+    // In MVCC mode, bound the scan by the CDC sequence watermark so snapshot
+    // isolation cannot make us skip a change id that a concurrent transaction
+    // commits below the current max after we advance the push watermark. WAL mode
+    // keeps its unbounded scan (change ids there come from NewRowid, and the WAL
+    // push loop does not rely on the sequence watermark).
+    let max_change_id_exclusive = if source_conn.mvcc_enabled() {
+        let watermark =
+            read_cdc_sequence_watermark(ctx.coro, &source_conn, source.cdc_table()).await?;
+        tracing::debug!("push_logical_changes: cdc sequence watermark={watermark:?}");
+        watermark
+    } else {
+        None
+    };
+
     let replay_opts = DatabaseReplaySessionOpts {
         use_implicit_rowid: false,
     };
@@ -2750,6 +2792,7 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
         first_change_id: last_change_id.map(|x| x + 1),
         mode: DatabaseChangesIteratorMode::Apply,
         ignore_schema_changes: false,
+        max_change_id_exclusive,
         ..Default::default()
     };
 

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -1023,7 +1023,7 @@ mod tests {
                                 id: 1,
                                 change: DatabaseTapeRowChangeType::Insert {
                                     after: crate::alloc::vec![
-                                        turso_core::Value::from_i64(1),
+                                        turso_core::Value::Null,
                                         turso_core::Value::build_text("new"),
                                     ],
                                 },
@@ -1036,18 +1036,108 @@ mod tests {
                         .await
                         .unwrap();
                 }
-                let mut stmt = conn.prepare("SELECT value FROM t WHERE id = 1").unwrap();
-                let row = run_stmt_once(&coro, &mut stmt).await.unwrap().unwrap();
-                row.get_values().cloned().collect::<Vec<_>>()
+                let mut stmt = conn.prepare("SELECT id, value FROM t ORDER BY id").unwrap();
+                let mut rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                rows
             }
         });
-        let row = loop {
+        let rows = loop {
             match gen.resume_with(Ok(())) {
                 genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
                 genawaiter::GeneratorState::Complete(result) => break result,
             }
         };
-        assert_eq!(row, vec![turso_core::Value::build_text("new")]);
+        assert_eq!(
+            rows,
+            vec![vec![
+                turso_core::Value::from_i64(1),
+                turso_core::Value::build_text("new")
+            ]]
+        );
+    }
+
+    #[test]
+    pub fn test_implicit_rowid_replay_prefers_explicit_primary_key() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE t(x TEXT PRIMARY KEY, value TEXT)")
+                    .unwrap();
+                conn.execute("INSERT INTO t(rowid, x, value) VALUES (4, 'remote', 'kept')")
+                    .unwrap();
+                conn.execute("INSERT INTO t(rowid, x, value) VALUES (5, 'local', 'old')")
+                    .unwrap();
+                {
+                    let opts = DatabaseReplaySessionOpts {
+                        use_implicit_rowid: true,
+                    };
+                    let mut session = db.start_replay_session(&coro, opts).await.unwrap();
+                    session
+                        .replay(
+                            &coro,
+                            DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                                change_id: 1,
+                                change_time: 1,
+                                table_name: "t".to_string(),
+                                id: 4,
+                                change: DatabaseTapeRowChangeType::Insert {
+                                    after: crate::alloc::vec![
+                                        turso_core::Value::build_text("local"),
+                                        turso_core::Value::build_text("new"),
+                                    ],
+                                },
+                            }),
+                        )
+                        .await
+                        .unwrap();
+                    session
+                        .replay(&coro, DatabaseTapeOperation::Commit)
+                        .await
+                        .unwrap();
+                }
+                let mut stmt = conn
+                    .prepare("SELECT rowid, x, value FROM t ORDER BY x")
+                    .unwrap();
+                let mut rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                rows
+            }
+        });
+        let rows = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+        assert_eq!(
+            rows,
+            vec![
+                vec![
+                    turso_core::Value::from_i64(5),
+                    turso_core::Value::build_text("local"),
+                    turso_core::Value::build_text("new")
+                ],
+                vec![
+                    turso_core::Value::from_i64(4),
+                    turso_core::Value::build_text("remote"),
+                    turso_core::Value::build_text("kept")
+                ],
+            ]
+        );
     }
 
     #[test]

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -216,6 +216,11 @@ impl DatabaseTape {
     }
 
     /// Builds an iterator which emits [DatabaseTapeOperation] by extracting data from CDC table
+    /// Name of the CDC table this tape reads/writes (default `turso_cdc`).
+    pub fn cdc_table(&self) -> &str {
+        &self.cdc_table
+    }
+
     pub fn iterate_changes(
         &self,
         opts: DatabaseChangesIteratorOpts,
@@ -243,6 +248,7 @@ impl DatabaseTape {
             mode: opts.mode,
             batch_size: opts.batch_size,
             ignore_schema_changes: opts.ignore_schema_changes,
+            max_change_id_exclusive: opts.max_change_id_exclusive,
         })
     }
     /// Start raw WAL edit session which can append or rollback pages directly in the current WAL
@@ -407,13 +413,22 @@ pub enum DatabaseChangesIteratorMode {
 }
 
 impl DatabaseChangesIteratorMode {
-    pub fn query(&self, table_name: &str, limit: usize) -> String {
+    pub fn query(&self, table_name: &str, limit: usize, bounded_above: bool) -> String {
         let (operation, order) = match self {
             DatabaseChangesIteratorMode::Apply => (">=", "ASC"),
             DatabaseChangesIteratorMode::Revert => ("<=", "DESC"),
         };
+        // `change_id < ?` (bound param 2) restricts the scan to change ids the
+        // caller has deemed safe to consume — used by the sync push loop to stop
+        // at `sequence_watermark_experimental` so it never reads a change id that
+        // a concurrent MVCC transaction may still commit below the current max.
+        let upper_bound = if bounded_above {
+            " AND change_id < ?"
+        } else {
+            ""
+        };
         format!(
-            "SELECT * FROM {table_name} WHERE change_id {operation} ? ORDER BY change_id {order} LIMIT {limit}",
+            "SELECT * FROM {table_name} WHERE change_id {operation} ?{upper_bound} ORDER BY change_id {order} LIMIT {limit}",
         )
     }
     pub fn first_id(&self) -> i64 {
@@ -436,6 +451,11 @@ pub struct DatabaseChangesIteratorOpts {
     pub batch_size: usize,
     pub mode: DatabaseChangesIteratorMode,
     pub ignore_schema_changes: bool,
+    /// Exclusive upper bound on `change_id`: only rows with `change_id < bound`
+    /// are returned. `None` means unbounded. The sync push loop sets this to the
+    /// CDC sequence watermark so snapshot-isolation reordering cannot make it skip
+    /// a not-yet-committed lower change id.
+    pub max_change_id_exclusive: Option<i64>,
 }
 
 impl Default for DatabaseChangesIteratorOpts {
@@ -445,6 +465,7 @@ impl Default for DatabaseChangesIteratorOpts {
             batch_size: DEFAULT_CHANGES_BATCH_SIZE,
             mode: DatabaseChangesIteratorMode::Apply,
             ignore_schema_changes: true,
+            max_change_id_exclusive: None,
         }
     }
 }
@@ -460,6 +481,7 @@ pub struct DatabaseChangesIterator {
     mode: DatabaseChangesIteratorMode,
     batch_size: usize,
     ignore_schema_changes: bool,
+    max_change_id_exclusive: Option<i64>,
 }
 
 const SQLITE_SCHEMA_TABLE: &str = "sqlite_schema";
@@ -491,7 +513,11 @@ impl DatabaseChangesIterator {
     }
     async fn refill<Ctx>(&mut self, coro: &Coro<Ctx>) -> Result<()> {
         if self.query_stmt.is_none() {
-            let query = self.mode.query(&self.cdc_table, self.batch_size);
+            let query = self.mode.query(
+                &self.cdc_table,
+                self.batch_size,
+                self.max_change_id_exclusive.is_some(),
+            );
             let stmt = match self.conn.prepare(&query) {
                 Ok(stmt) => stmt,
                 Err(LimboError::ParseError(err)) if err.contains("no such table") => return Ok(()),
@@ -507,6 +533,12 @@ impl DatabaseChangesIterator {
             1.try_into().unwrap(),
             turso_core::Value::from_i64(change_id_filter),
         )?;
+        if let Some(max_change_id_exclusive) = self.max_change_id_exclusive {
+            query_stmt.bind_at(
+                2.try_into().unwrap(),
+                turso_core::Value::from_i64(max_change_id_exclusive),
+            )?;
+        }
 
         let mut last_change_id = None;
         while let Some(row) = run_stmt_once(coro, query_stmt).await? {
@@ -1274,6 +1306,106 @@ mod tests {
             }) if table_name == "t"
         ));
         assert!(matches!(changes[4], DatabaseTapeOperation::Commit));
+    }
+
+    /// in MVCC mode the CDC `change_id` is drawn from the CDC
+    /// table's AUTOINCREMENT sequence, so ids are never reused after CDC rows are
+    /// pruned, and `read_cdc_sequence_watermark` reports the exclusive safe upper
+    /// bound the push loop scans up to. Bounding the scan by that watermark is
+    /// what stops the push loop from skipping a change id a concurrent
+    /// transaction commits below the current max under snapshot isolation.
+    #[test]
+    pub fn test_mvcc_cdc_change_id_sequence_backed_and_watermark_bounds_scan() {
+        fn row_change_ids(changes: &[DatabaseTapeOperation]) -> Vec<i64> {
+            changes
+                .iter()
+                .filter_map(|change| match change {
+                    DatabaseTapeOperation::RowChange(change) => Some(change.change_id),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        let temp_file1 = NamedTempFile::new().unwrap();
+        let db_path1 = temp_file1.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        db1.connect()
+            .unwrap()
+            .execute("PRAGMA journal_mode = 'mvcc'")
+            .unwrap();
+        let db1 = Arc::new(DatabaseTape::new(db1));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db1 = db1.clone();
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db1.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE t(x)").unwrap();
+                conn.execute("INSERT INTO t VALUES (1), (2), (3)").unwrap();
+
+                // No in-flight allocations: watermark == max(change_id) + 1.
+                let watermark = crate::database_sync_operations::read_cdc_sequence_watermark(
+                    &coro,
+                    &conn,
+                    db1.cdc_table(),
+                )
+                .await
+                .unwrap();
+
+                let mut opts = DatabaseChangesIteratorOpts {
+                    ignore_schema_changes: false,
+                    ..Default::default()
+                };
+                let mut unbounded = Vec::new();
+                let mut iterator = db1.iterate_changes(opts.clone()).unwrap();
+                while let Some(change) = iterator.next(&coro).await.unwrap() {
+                    unbounded.push(change);
+                }
+
+                // Bounded scan stops strictly below the bound.
+                opts.max_change_id_exclusive = Some(4);
+                let mut bounded = Vec::new();
+                let mut iterator = db1.iterate_changes(opts).unwrap();
+                while let Some(change) = iterator.next(&coro).await.unwrap() {
+                    bounded.push(change);
+                }
+
+                // Prune the CDC table, then write again: the new change id must
+                // continue past the old high-water mark, not reuse a low id.
+                conn.execute("DELETE FROM turso_cdc").unwrap();
+                conn.execute("INSERT INTO t VALUES (4)").unwrap();
+                let mut after_prune = Vec::new();
+                let mut iterator = db1
+                    .iterate_changes(DatabaseChangesIteratorOpts {
+                        ignore_schema_changes: false,
+                        ..Default::default()
+                    })
+                    .unwrap();
+                while let Some(change) = iterator.next(&coro).await.unwrap() {
+                    after_prune.push(change);
+                }
+
+                (watermark, unbounded, bounded, after_prune)
+            }
+        });
+        let (watermark, unbounded, bounded, after_prune) = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+
+        // CREATE TABLE row (change_id 1) + COMMIT (2) + three inserts (3,4,5) +
+        // COMMIT (6). Watermark is the first unallocated id: 7.
+        assert_eq!(watermark, Some(7));
+        assert_eq!(row_change_ids(&unbounded), vec![1, 3, 4, 5]);
+        // Bound of 4 keeps only change ids < 4 (the schema row 1 and insert 3).
+        assert_eq!(row_change_ids(&bounded), vec![1, 3]);
+        // After pruning, the reinserted row's change id continues at 7 (the old
+        // watermark), never reusing an id at or below the previously pushed max.
+        assert_eq!(row_change_ids(&after_prune), vec![7]);
     }
 
     #[test]

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -10,8 +10,8 @@ use crate::{
     database_sync_operations::WAL_FRAME_HEADER,
     errors::Error,
     types::{
-        Coro, DatabaseChange, DatabaseChangeType, DatabaseTapeOperation, DatabaseTapeRowChangeType,
-        SyncEngineIoResult,
+        Coro, DatabaseChange, DatabaseChangeType, DatabaseSchemaKind, DatabaseSchemaReplay,
+        DatabaseTapeOperation, DatabaseTapeRowChangeType, SyncEngineIoResult,
     },
     wal_session::WalSession,
     Result,
@@ -571,6 +571,24 @@ async fn replay_stmt<Ctx>(
 }
 
 impl DatabaseReplaySession {
+    fn clear_cached_statements(&mut self) {
+        self.cached_delete_stmt.clear();
+        self.cached_insert_stmt.clear();
+        self.cached_update_stmt.clear();
+    }
+
+    fn schema_drop_sql(kind: DatabaseSchemaKind, name: &str) -> String {
+        let object = match kind {
+            DatabaseSchemaKind::Table => "TABLE",
+            DatabaseSchemaKind::Index => "INDEX",
+            DatabaseSchemaKind::Trigger => "TRIGGER",
+            DatabaseSchemaKind::View => "VIEW",
+        };
+        format!("DROP {object} IF EXISTS {}", quote_ident(name))
+    }
+}
+
+impl DatabaseReplaySession {
     pub fn conn(&self) -> Arc<turso_core::Connection> {
         self.conn.clone()
     }
@@ -588,8 +606,43 @@ impl DatabaseReplaySession {
                 }
             }
             DatabaseTapeOperation::StmtReplay(replay) => {
+                self.clear_cached_statements();
                 let mut stmt = self.conn.prepare(&replay.sql)?;
                 replay_stmt(coro, &mut stmt, replay.values).await?;
+                self.clear_cached_statements();
+                return Ok(());
+            }
+            DatabaseTapeOperation::SchemaReplay(replay) => {
+                self.clear_cached_statements();
+                match replay {
+                    DatabaseSchemaReplay::Create { sql } | DatabaseSchemaReplay::Alter { sql } => {
+                        self.generator
+                            .execute_ddl_idempotent(coro, &sql)
+                            .await
+                            .map_err(|err| {
+                                Error::DatabaseTapeError(format!(
+                                    "failed to replay schema DDL `{sql}`: {err}"
+                                ))
+                            })?;
+                    }
+                    DatabaseSchemaReplay::Refresh { kind, name, sql } => {
+                        if kind != DatabaseSchemaKind::Table {
+                            self.conn.execute(Self::schema_drop_sql(kind, &name))?;
+                        }
+                        self.generator
+                            .execute_ddl_idempotent(coro, &sql)
+                            .await
+                            .map_err(|err| {
+                                Error::DatabaseTapeError(format!(
+                                    "failed to replay schema refresh DDL `{sql}`: {err}"
+                                ))
+                            })?;
+                    }
+                    DatabaseSchemaReplay::Drop { kind, name } => {
+                        self.conn.execute(Self::schema_drop_sql(kind, &name))?;
+                    }
+                }
+                self.clear_cached_statements();
                 return Ok(());
             }
             DatabaseTapeOperation::RowChange(change) => {
@@ -603,7 +656,12 @@ impl DatabaseReplaySession {
 
                 if table == SQLITE_SCHEMA_TABLE {
                     let replay_info = self.generator.replay_info(coro, &change).await?;
-                    if replay_info.change_type == DatabaseChangeType::Update {
+                    if replay_info.is_ddl_replay
+                        && matches!(
+                            replay_info.change_type,
+                            DatabaseChangeType::Insert | DatabaseChangeType::Update
+                        )
+                    {
                         self.generator
                             .execute_ddl_idempotent(coro, &replay_info.query)
                             .await?;
@@ -774,6 +832,10 @@ impl DatabaseReplaySession {
     }
 }
 
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -784,7 +846,10 @@ mod tests {
         database_tape::{
             run_stmt_once, DatabaseChangesIteratorOpts, DatabaseReplaySessionOpts, DatabaseTape,
         },
-        types::{Coro, DatabaseTapeOperation, DatabaseTapeRowChange, DatabaseTapeRowChangeType},
+        types::{
+            Coro, DatabaseSchemaKind, DatabaseSchemaReplay, DatabaseStatementReplay,
+            DatabaseTapeOperation, DatabaseTapeRowChange, DatabaseTapeRowChangeType,
+        },
     };
 
     #[test]
@@ -815,6 +880,174 @@ mod tests {
             }
         };
         assert_eq!(rows, vec![] as Vec<Vec<turso_core::Value>>);
+    }
+
+    #[test]
+    pub fn test_database_tape_stmt_replay_allows_zero_bind_dml() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE t(x)").unwrap();
+                {
+                    let opts = DatabaseReplaySessionOpts {
+                        use_implicit_rowid: false,
+                    };
+                    let mut session = db.start_replay_session(&coro, opts).await.unwrap();
+                    session
+                        .replay(
+                            &coro,
+                            DatabaseTapeOperation::StmtReplay(DatabaseStatementReplay {
+                                sql: "INSERT INTO t VALUES (42)".to_string(),
+                                values: Vec::new(),
+                            }),
+                        )
+                        .await
+                        .unwrap();
+                    session
+                        .replay(&coro, DatabaseTapeOperation::Commit)
+                        .await
+                        .unwrap();
+                }
+                let mut stmt = conn.prepare("SELECT x FROM t").unwrap();
+                let mut rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                rows
+            }
+        });
+        let rows = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+        assert_eq!(rows, vec![vec![turso_core::Value::from_i64(42)]]);
+    }
+
+    #[test]
+    pub fn test_schema_refresh_create_table_is_idempotent() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY)")
+                    .unwrap();
+                {
+                    let opts = DatabaseReplaySessionOpts {
+                        use_implicit_rowid: false,
+                    };
+                    let mut session = db.start_replay_session(&coro, opts).await.unwrap();
+                    session
+                        .replay(
+                            &coro,
+                            DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Refresh {
+                                kind: DatabaseSchemaKind::Table,
+                                name: "t".to_string(),
+                                sql: "CREATE TABLE t(x INTEGER PRIMARY KEY, note TEXT)".to_string(),
+                            }),
+                        )
+                        .await
+                        .unwrap();
+                    session
+                        .replay(
+                            &coro,
+                            DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Create {
+                                sql: "CREATE INDEX t_note_idx ON t(note)".to_string(),
+                            }),
+                        )
+                        .await
+                        .unwrap();
+                    session
+                        .replay(&coro, DatabaseTapeOperation::Commit)
+                        .await
+                        .unwrap();
+                }
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(()) => break,
+            }
+        }
+    }
+
+    #[test]
+    pub fn test_implicit_rowid_replay_upserts_primary_key_rows() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)")
+                    .unwrap();
+                conn.execute("INSERT INTO t(id, value) VALUES (1, 'old')")
+                    .unwrap();
+                {
+                    let opts = DatabaseReplaySessionOpts {
+                        use_implicit_rowid: true,
+                    };
+                    let mut session = db.start_replay_session(&coro, opts).await.unwrap();
+                    session
+                        .replay(
+                            &coro,
+                            DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                                change_id: 1,
+                                change_time: 1,
+                                table_name: "t".to_string(),
+                                id: 1,
+                                change: DatabaseTapeRowChangeType::Insert {
+                                    after: crate::alloc::vec![
+                                        turso_core::Value::from_i64(1),
+                                        turso_core::Value::build_text("new"),
+                                    ],
+                                },
+                            }),
+                        )
+                        .await
+                        .unwrap();
+                    session
+                        .replay(&coro, DatabaseTapeOperation::Commit)
+                        .await
+                        .unwrap();
+                }
+                let mut stmt = conn.prepare("SELECT value FROM t WHERE id = 1").unwrap();
+                let row = run_stmt_once(&coro, &mut stmt).await.unwrap().unwrap();
+                row.get_values().cloned().collect::<Vec<_>>()
+            }
+        });
+        let row = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+        assert_eq!(row, vec![turso_core::Value::build_text("new")]);
     }
 
     #[test]
@@ -851,6 +1084,77 @@ mod tests {
         tracing::info!("changes: {:?}", changes);
         assert_eq!(changes.len(), 5);
         // CREATE TABLE emits a COMMIT record (schema INSERT is filtered by ignore_schema_changes)
+        assert!(matches!(changes[0], DatabaseTapeOperation::Commit));
+        assert!(matches!(
+            changes[1],
+            DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                change_id: 3,
+                id: 1,
+                ref table_name,
+                change: DatabaseTapeRowChangeType::Insert { .. },
+                ..
+            }) if table_name == "t"
+        ));
+        assert!(matches!(
+            changes[2],
+            DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                change_id: 4,
+                id: 2,
+                ref table_name,
+                change: DatabaseTapeRowChangeType::Insert { .. },
+                ..
+            }) if table_name == "t"
+        ));
+        assert!(matches!(
+            changes[3],
+            DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                change_id: 5,
+                id: 3,
+                ref table_name,
+                change: DatabaseTapeRowChangeType::Insert { .. },
+                ..
+            }) if table_name == "t"
+        ));
+        assert!(matches!(changes[4], DatabaseTapeOperation::Commit));
+    }
+
+    #[test]
+    pub fn test_database_tape_iterate_changes_in_mvcc_mode() {
+        let temp_file1 = NamedTempFile::new().unwrap();
+        let db_path1 = temp_file1.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        db1.connect()
+            .unwrap()
+            .execute("PRAGMA journal_mode = 'mvcc'")
+            .unwrap();
+        let db1 = Arc::new(DatabaseTape::new(db1));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db1 = db1.clone();
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db1.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE t(x)").unwrap();
+                conn.execute("INSERT INTO t VALUES (1), (2), (3)").unwrap();
+                let opts = Default::default();
+                let mut iterator = db1.iterate_changes(opts).unwrap();
+                let mut changes = Vec::new();
+                while let Some(change) = iterator.next(&coro).await.unwrap() {
+                    changes.push(change);
+                }
+                changes
+            }
+        });
+        let changes = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+        tracing::info!("changes: {:?}", changes);
+        assert_eq!(changes.len(), 5);
         assert!(matches!(changes[0], DatabaseTapeOperation::Commit));
         assert!(matches!(
             changes[1],
@@ -1320,10 +1624,86 @@ mod tests {
                             turso_core::Value::Text(turso_core::types::Text::new("t")),
                             turso_core::Value::from_i64(9),
                             turso_core::Value::Text(turso_core::types::Text::new(
-                                "CREATE INDEX IF NOT EXISTS t_idx ON t (y)"
+                                "CREATE INDEX t_idx ON t (y)"
                             )),
                         ]
                     ]
+                );
+                crate::Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => {
+                    result.unwrap();
+                    break;
+                }
+            }
+        }
+    }
+
+    #[test]
+    pub fn test_database_tape_replay_quoted_create_index_idempotent() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")
+                    .unwrap();
+
+                let opts = DatabaseReplaySessionOpts {
+                    use_implicit_rowid: false,
+                };
+                let mut session = db.start_replay_session(&coro, opts).await.unwrap();
+                let sql = "CREATE INDEX \"t remote mixed idx 93136628163651980\" ON t(payload)";
+                session
+                    .replay(
+                        &coro,
+                        DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Create {
+                            sql: sql.to_string(),
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                session
+                    .replay(
+                        &coro,
+                        DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Create {
+                            sql: sql.to_string(),
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                session
+                    .replay(&coro, DatabaseTapeOperation::Commit)
+                    .await
+                    .unwrap();
+
+                let mut stmt = conn
+                    .prepare("SELECT type, name, sql FROM sqlite_schema ORDER BY type, name")
+                    .unwrap();
+                let mut rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                assert!(
+                    rows.iter().any(|row| row
+                        == &vec![
+                        turso_core::Value::build_text("index"),
+                        turso_core::Value::build_text("t remote mixed idx 93136628163651980"),
+                        turso_core::Value::build_text(
+                            "CREATE INDEX \"t remote mixed idx 93136628163651980\" ON t (payload)"
+                        ),
+                    ]),
+                    "quoted index schema row missing; rows={rows:?}"
                 );
                 crate::Result::Ok(())
             }

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -982,11 +982,8 @@ mod tests {
                 }
             }
         });
-        loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(()) => break,
-            }
+        while let genawaiter::GeneratorState::Yielded(..) = gen.resume_with(Ok(())) {
+            io.step().unwrap()
         }
     }
 

--- a/sync/engine/src/lib.rs
+++ b/sync/engine/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod alloc;
+pub mod client_proto;
 pub mod database_replay_generator;
 pub mod database_sync_engine;
 pub mod database_sync_engine_io;

--- a/sync/engine/src/server_proto.rs
+++ b/sync/engine/src/server_proto.rs
@@ -17,6 +17,12 @@ pub struct PullUpdatesReqProtoBody {
     /// requested encoding of the pages
     #[prost(enumeration = "PageUpdatesEncodingReq", tag = "1")]
     pub encoding: i32,
+    /// requested update stream kind
+    ///
+    /// Kept at tag 8 so older boolean clients remain wire-compatible:
+    /// false/absent decodes as Pages(0), true decodes as MvccLogicalLog(1).
+    #[prost(enumeration = "PullUpdatesStreamKind", tag = "8")]
+    pub stream_kind: i32,
     /// revision of the requested pages on server side; can be None - in which case server will pick latest revision
     #[prost(string, tag = "2")]
     pub server_revision: String,
@@ -48,6 +54,24 @@ pub struct PageData {
     pub encoded_page: Bytes,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+#[derive(prost::Enumeration)]
+#[repr(i32)]
+pub enum PullUpdatesStreamKind {
+    Pages = 0,
+    MvccLogicalLog = 1,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+#[derive(prost::Enumeration)]
+#[repr(i32)]
+pub enum PullUpdatesApplyMode {
+    Incremental = 0,
+    ReplaceBase = 1,
+}
+
 #[derive(prost::Message)]
 pub struct PageSetRawEncodingProto {}
 
@@ -57,6 +81,30 @@ pub struct PageSetZstdEncodingProto {
     pub level: i32,
     #[prost(uint32, repeated, tag = "2")]
     pub pages_dict: Vec<u32>,
+}
+
+#[derive(prost::Message, Clone, PartialEq, Eq)]
+pub struct MvccLogicalLogRangeProto {
+    #[prost(uint64, tag = "1")]
+    pub generation: u64,
+    #[prost(uint64, tag = "2")]
+    pub start_offset: u64,
+    #[prost(uint64, tag = "3")]
+    pub end_offset: u64,
+    #[prost(bool, tag = "4")]
+    pub starts_with_header: bool,
+    #[prost(bytes, optional, tag = "5")]
+    pub crc_seed: Option<Vec<u8>>,
+}
+
+#[derive(prost::Message, Clone, PartialEq, Eq)]
+pub struct MvccLogicalLogMetadataProto {
+    #[prost(string, tag = "1")]
+    pub format: String,
+    #[prost(bool, tag = "2")]
+    pub checkpoint_transition: bool,
+    #[prost(message, repeated, tag = "3")]
+    pub ranges: Vec<MvccLogicalLogRangeProto>,
 }
 
 #[derive(prost::Message)]
@@ -70,6 +118,12 @@ pub struct PullUpdatesRespProtoBody {
     pub raw_encoding: Option<PageSetRawEncodingProto>,
     #[prost(optional, message, tag = "4")]
     pub zstd_encoding: Option<PageSetZstdEncodingProto>,
+    #[prost(enumeration = "PullUpdatesStreamKind", tag = "5")]
+    pub stream_kind: i32,
+    #[prost(enumeration = "PullUpdatesApplyMode", tag = "6")]
+    pub apply_mode: i32,
+    #[prost(optional, message, tag = "7")]
+    pub mvcc_log: Option<MvccLogicalLogMetadataProto>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -471,5 +525,79 @@ pub(crate) mod bytes_as_base64_pad {
             D::Error::invalid_value(de::Unexpected::Str(text), &"binary data encoded as base64")
         })?;
         Ok(Bytes::from(bytes))
+    }
+}
+
+#[cfg(test)]
+mod pull_updates_tests {
+    use super::{
+        MvccLogicalLogMetadataProto, MvccLogicalLogRangeProto, PageSetRawEncodingProto,
+        PageUpdatesEncodingReq, PullUpdatesApplyMode, PullUpdatesReqProtoBody,
+        PullUpdatesRespProtoBody, PullUpdatesStreamKind,
+    };
+    use prost::Message;
+
+    #[test]
+    fn pull_updates_request_stream_kind_round_trips_proto() {
+        let req = PullUpdatesReqProtoBody {
+            encoding: PageUpdatesEncodingReq::Raw as i32,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            server_revision: "server-rev".to_string(),
+            client_revision: "client-rev".to_string(),
+            long_poll_timeout_ms: 123,
+            server_pages_selector: Vec::new().into(),
+            server_query_selector: String::new(),
+            client_pages: Vec::new().into(),
+        };
+
+        let decoded = PullUpdatesReqProtoBody::decode(req.encode_to_vec().as_slice()).unwrap();
+        assert_eq!(
+            PullUpdatesStreamKind::try_from(decoded.stream_kind).unwrap(),
+            PullUpdatesStreamKind::MvccLogicalLog
+        );
+    }
+
+    #[test]
+    fn pull_updates_mvcc_log_header_round_trips_metadata() {
+        let header = PullUpdatesRespProtoBody {
+            server_revision: "rev-42".to_string(),
+            db_size: 3,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: Some(MvccLogicalLogMetadataProto {
+                format: "lml3".to_string(),
+                checkpoint_transition: true,
+                ranges: vec![MvccLogicalLogRangeProto {
+                    generation: 7,
+                    start_offset: 11,
+                    end_offset: 99,
+                    starts_with_header: false,
+                    crc_seed: Some(vec![1, 2, 3, 4]),
+                }],
+            }),
+        };
+
+        let decoded = PullUpdatesRespProtoBody::decode_length_delimited(
+            header.encode_length_delimited_to_vec().as_slice(),
+        )
+        .unwrap();
+        assert_eq!(
+            PullUpdatesStreamKind::try_from(decoded.stream_kind).unwrap(),
+            PullUpdatesStreamKind::MvccLogicalLog
+        );
+        assert_eq!(
+            PullUpdatesApplyMode::try_from(decoded.apply_mode).unwrap(),
+            PullUpdatesApplyMode::Incremental
+        );
+        let mvcc_log = decoded.mvcc_log.unwrap();
+        assert_eq!(mvcc_log.format, "lml3");
+        assert!(mvcc_log.checkpoint_transition);
+        assert_eq!(mvcc_log.ranges[0].end_offset, 99);
+        assert_eq!(
+            mvcc_log.ranges[0].crc_seed.as_deref(),
+            Some(&[1, 2, 3, 4][..])
+        );
     }
 }

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::{Arc, Mutex},
 };
 
@@ -72,10 +72,25 @@ pub struct DbSyncStatus {
     pub max_frame_no: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DbChangesStreamKind {
+    LegacyPages,
+    Pages,
+    Logical,
+    ReplaceBasePages,
+}
+
 pub struct DbChangesStatus {
     pub time: turso_core::WallClockInstant,
     pub revision: DatabasePullRevision,
     pub file_slot: Option<MutexSlot<Arc<dyn turso_core::File>>>,
+    pub stream_kind: DbChangesStreamKind,
+}
+
+impl DbChangesStatus {
+    pub fn is_empty(&self) -> bool {
+        self.file_slot.is_none()
+    }
 }
 
 impl std::fmt::Debug for DbChangesStatus {
@@ -84,6 +99,7 @@ impl std::fmt::Debug for DbChangesStatus {
             .field("time", &self.time)
             .field("revision", &self.revision)
             .field("file_slot.is_some()", &self.file_slot.is_some())
+            .field("stream_kind", &self.stream_kind)
             .finish()
     }
 }
@@ -126,7 +142,15 @@ pub struct DatabaseMetadata {
     pub last_push_unix_time: Option<i64>,
     pub last_pushed_pull_gen_hint: i64,
     pub last_pushed_change_id_hint: i64,
+    #[serde(default)]
+    pub last_pushed_replay_floor_change_id_hint: i64,
     pub partial_bootstrap_server_revision: Option<DatabasePullRevision>,
+    #[serde(default)]
+    pub fresh_bootstrap_pending_cdc_ack: bool,
+    #[serde(default)]
+    pub logical_mvcc_pull_active: bool,
+    #[serde(default)]
+    pub logical_table_names_by_stable_id: BTreeMap<u64, String>,
     /// optional saved configuration
     /// this will be used by sync engine if some parameters were omitted
     pub saved_configuration: Option<DatabaseSavedConfiguration>,
@@ -406,8 +430,16 @@ impl DatabaseChange {
         let change_id = get_core_value_i64(row, 0)?;
         let change_time = get_core_value_i64(row, 1)? as u64;
         let change_txn_id = get_core_value_i64_or_null(row, 2)?;
-        let change_type = get_core_value_i64(row, 3)?;
-        let change_type = parse_change_type(change_type)?;
+        let change_type = match get_core_value_i64_or_null(row, 3)? {
+            Some(change_type) => parse_change_type(change_type)?,
+            None if is_null_cdc_v2_commit_payload(row) => DatabaseChangeType::Commit,
+            None => {
+                return Err(Error::DatabaseTapeError(
+                    "column 3 type mismatch: expected integer for non-COMMIT CDC row, got NULL"
+                        .to_string(),
+                ))
+            }
+        };
         // COMMIT records have NULL for table_name and id
         let table_name = get_core_value_text_or_null(row, 4)?.unwrap_or_default();
         let id = get_core_value_i64_or_null(row, 5)?.unwrap_or(0);
@@ -433,6 +465,10 @@ impl DatabaseChange {
             turso_core::CdcVersion::V1 => Self::from_row_v1(row),
         }
     }
+}
+
+fn is_null_cdc_v2_commit_payload(row: &turso_core::Row) -> bool {
+    (4..=8).all(|index| matches!(row.get_value(index), turso_core::Value::Null))
 }
 
 pub struct DatabaseRowMutation {
@@ -490,8 +526,36 @@ impl From<&DatabaseTapeRowChangeType> for DatabaseChangeType {
 #[derive(Debug)]
 pub enum DatabaseTapeOperation {
     StmtReplay(DatabaseStatementReplay),
+    SchemaReplay(DatabaseSchemaReplay),
     RowChange(DatabaseTapeRowChange),
     Commit,
+}
+
+#[derive(Debug)]
+pub enum DatabaseSchemaReplay {
+    Create {
+        sql: String,
+    },
+    Drop {
+        kind: DatabaseSchemaKind,
+        name: String,
+    },
+    Refresh {
+        kind: DatabaseSchemaKind,
+        name: String,
+        sql: String,
+    },
+    Alter {
+        sql: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatabaseSchemaKind {
+    Table,
+    Index,
+    Trigger,
+    View,
 }
 
 /// [DatabaseTapeRowChange] is the specific operation over single row which can be performed on database
@@ -592,5 +656,35 @@ pub fn parse_bin_record(
         Err(err) => Err(Error::DatabaseTapeError(format!(
             "unable to parse bin record: {err}"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DatabaseMetadata;
+
+    #[test]
+    fn metadata_load_defaults_missing_logical_table_map() {
+        let meta = DatabaseMetadata::load(
+            br#"{
+                "version": "v1",
+                "client_unique_id": "client-a",
+                "synced_revision": null,
+                "revert_since_wal_salt": null,
+                "revert_since_wal_watermark": 0,
+                "last_pull_unix_time": null,
+                "last_push_unix_time": null,
+                "last_pushed_pull_gen_hint": 0,
+                "last_pushed_change_id_hint": 0,
+                "partial_bootstrap_server_revision": null,
+                "saved_configuration": null
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(meta.last_pushed_replay_floor_change_id_hint, 0);
+        assert!(!meta.fresh_bootstrap_pending_cdc_ack);
+        assert!(!meta.logical_mvcc_pull_active);
+        assert!(meta.logical_table_names_by_stable_id.is_empty());
     }
 }

--- a/sync/sdk-kit/src/bindings.rs
+++ b/sync/sdk-kit/src/bindings.rs
@@ -124,6 +124,7 @@ pub struct turso_sync_database_config_t {
     pub remote_encryption_cipher: *const ::std::os::raw::c_char,
     pub push_operations_threshold: usize,
     pub pull_bytes_threshold: usize,
+    pub logical_mvcc_pull: bool,
 }
 impl Default for turso_sync_database_config_t {
     fn default() -> Self {

--- a/sync/sdk-kit/src/rsapi.rs
+++ b/sync/sdk-kit/src/rsapi.rs
@@ -37,6 +37,10 @@ pub struct TursoDatabaseSyncConfig {
     /// `None` => single-request bootstrap. No-op when partial-sync uses the
     /// query bootstrap strategy.
     pub pull_bytes_threshold: Option<usize>,
+    /// Use the MVCC logical-log stream for incremental V1 pulls. This is
+    /// required when syncing against an MVCC-mode remote; legacy page/WAL sync
+    /// keeps the default `false` value.
+    pub logical_mvcc_pull: bool,
 }
 
 pub type PartialSyncOpts = turso_sync_engine::types::PartialSyncOpts;
@@ -118,6 +122,7 @@ impl TursoDatabaseSyncConfig {
             } else {
                 Some(config.pull_bytes_threshold)
             },
+            logical_mvcc_pull: config.logical_mvcc_pull,
         })
     }
 }
@@ -251,6 +256,7 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
             remote_encryption_key: sync_config.remote_encryption_key.clone(),
             push_operations_threshold: sync_config.push_operations_threshold,
             pull_bytes_threshold: sync_config.pull_bytes_threshold,
+            logical_mvcc_pull: sync_config.logical_mvcc_pull,
         };
         let is_memory = db_config.path == ":memory:";
         let db_io: Option<Arc<dyn IO>> = if is_memory {

--- a/sync/sdk-kit/src/rsapi.rs
+++ b/sync/sdk-kit/src/rsapi.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use turso_core::{MemoryIO, IO};
-use turso_sdk_kit::rsapi::{str_from_c_str, TursoError};
+use turso_sdk_kit::rsapi::{str_from_c_str, SyncBusyGate, SyncBusyGuard, TursoError};
 use turso_sync_engine::{
     database_sync_engine::{self, DatabaseSyncEngine},
     database_sync_engine_io::SyncEngineIo,
@@ -169,6 +169,7 @@ pub struct TursoDatabaseSync<TBytes: AsRef<[u8]> + Send + Sync + 'static> {
     sync_engine_io_queue: SyncEngineIoStats<SyncEngineIoQueue<TBytes>>,
     sync_engine: Arc<Mutex<Option<DatabaseSyncEngine<SyncEngineIoQueue<TBytes>>>>>,
     db_io: Option<Arc<dyn IO>>,
+    sync_busy: Arc<SyncBusyGate>,
 }
 
 #[allow(unused_variables)]
@@ -273,6 +274,7 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
             sync_engine_io_queue,
             sync_engine: Arc::new(Mutex::new(None)),
             db_io,
+            sync_busy: Arc::new(SyncBusyGate::default()),
         }))
     }
     /// open the database which must be created earlier (e.g. through [Self::init])
@@ -398,6 +400,7 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
     pub fn connect(&self) -> Box<TursoDatabaseAsyncOperation> {
         let db_config = self.db_config.clone();
         let sync_engine = self.sync_engine.clone();
+        let sync_busy = self.sync_busy.clone();
         Box::new(TursoDatabaseAsyncOperation::new(Box::new(move |coro| {
             Box::pin(async move {
                 let sync_engine = sync_engine.lock_arc();
@@ -408,7 +411,11 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
                 };
                 let connection = sync_engine.connect_rw(&coro).await?;
                 Ok(Some(TursoAsyncOperationResult::Connection {
-                    connection: turso_sdk_kit::rsapi::TursoConnection::new(&db_config, connection),
+                    connection: turso_sdk_kit::rsapi::TursoConnection::new_with_sync_busy(
+                        &db_config,
+                        connection,
+                        Some(sync_busy),
+                    ),
                 }))
             })
         })))
@@ -433,6 +440,7 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
     /// checkpoint WAL of synced database
     pub fn checkpoint(&self) -> Box<TursoDatabaseAsyncOperation> {
         let sync_engine = self.sync_engine.clone();
+        let sync_busy = self.sync_busy.clone();
         Box::new(TursoDatabaseAsyncOperation::new(Box::new(move |coro| {
             Box::pin(async move {
                 let sync_engine = sync_engine.lock_arc();
@@ -441,6 +449,7 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
                         "sync engine must be initialized".to_string(),
                     ));
                 };
+                let _sync_busy = SyncBusyGuard::new(sync_busy);
                 sync_engine.checkpoint(&coro).await?;
                 Ok(None)
             })
@@ -486,6 +495,7 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
         changes: Box<TursoDatabaseSyncChanges>,
     ) -> Box<TursoDatabaseAsyncOperation> {
         let sync_engine = self.sync_engine.clone();
+        let sync_busy = self.sync_busy.clone();
         Box::new(TursoDatabaseAsyncOperation::new(Box::new(move |coro| {
             Box::pin(async move {
                 let sync_engine = sync_engine.lock_arc();
@@ -495,6 +505,7 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
                     ));
                 };
                 let changes = changes.changes;
+                let _sync_busy = SyncBusyGuard::new(sync_busy);
                 sync_engine
                     .apply_changes_from_remote(&coro, changes)
                     .await?;

--- a/sync/sdk-kit/turso_sync.h
+++ b/sync/sdk-kit/turso_sync.h
@@ -138,6 +138,9 @@ typedef struct
     // is fetched in chunks via the server_pages_selector bitmap. 0 (default) bootstraps
     // in a single round-trip. no-op when partial-sync uses the query bootstrap strategy.
     size_t pull_bytes_threshold;
+    // when true, V1 incremental pulls use the MVCC logical-log stream instead of
+    // the page stream. required for MVCC-mode remotes; leave false for legacy sync.
+    bool logical_mvcc_pull;
 } turso_sync_database_config_t;
 
 /// opaque pointer to the TursoDatabaseSync instance

--- a/testing/sqltests/turso-tests/mvcc_feature_compat.sqltest
+++ b/testing/sqltests/turso-tests/mvcc_feature_compat.sqltest
@@ -1,17 +1,5 @@
 @database :memory:
 
-# Test that incompatible features are properly rejected when MVCC is enabled.
-# These tests only run against tursodb since MVCC is turso-specific.
-
-test mvcc-rejects-cdc {
-    PRAGMA journal_mode = 'mvcc';
-    CREATE TABLE t4 (id INTEGER PRIMARY KEY, val TEXT);
-    PRAGMA capture_data_changes_conn = 'full';
-}
-expect error {
-    CDC is not supported in MVCC mode
-}
-
 # DDL statements inside BEGIN CONCURRENT should produce a clear error message
 # instead of the confusing "database table is locked".
 


### PR DESCRIPTION
# MVCC sync engine support

This PR adds the client/sync-engine side of MVCC sync for tursodb databases.

After an initial page bootstrap, the sync engine can request raw MVCC
logical-log streams from `/pull-updates`, validate the LML3 bytes, decode the
portable logical-change metadata written by tursodb at commit time, and replay
those changes through the existing sync tape/replay path.

'legacy' sync continues to use the existing page/WAL flow. MVCC page pulls are reserved for bootstrap and replace-base recovery.

## How it works

- Core MVCC commits can optionally attach portable logical-change metadata to logical log frames (LML3).
- The metadata records stable table names, schema changes, rowids, and record bytes so replay does not depend on temporary MVCC table ids
- The sync engine asks for `logical_updates=true` after bootstrap.
- It parses the pull response metadata, validates the raw header/frame CRC chain, decodes the portable extension records, and writes replayable logical transactions into the existing scratch/tape format.
- Replace-base installs a page snapshot, then preserves and replays local CDC changes above the new base.
- Push/pull high-water hints prevent already-pushed local changes from being replayed over newer remote state, while keeping genuinely unpushed changes pushable.
