### PR TITLE
mvcc: merge-iterate the index during forward btree scans 

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -338,37 +338,33 @@ macro_rules! static_iterator_hack {
 
 pub(crate) use static_iterator_hack;
 
-/// Forward-scan finger over `index_rows`, co-advanced with the B-tree cursor.
-///
-/// The dual cursor walks the durable B-tree and `index_rows` (ordered by the
-/// same key) together. Rather than an `index_rows.get()` (O(log N)) per scanned
-/// B-tree row to decide whether a newer MVCC version shadows it, the finger is
-/// stepped along with the cursor, turning the shadow check into an amortized-O(1)
-/// merge step. Forward index cursors only; [`reset`](Self::reset) on any
-/// reposition (seek/rewind), since the finger is monotonic.
+/// Forward-scan finger over `index_rows`, co-advanced with the B-tree cursor so
+/// the per-row "is this B-tree row shadowed by MVCC?" check is an amortized-O(1)
+/// merge step instead of an `index_rows.get()` (O(log N)) per scanned row.
+/// Forward index cursors only; [`reset`](Self::reset) on any reposition, since
+/// the finger is monotonic.
 #[derive(Default)]
 struct IndexShadowFinger {
-    /// Live iterator over `index_rows`; `None` until first use or after reset.
+    /// Iterator over `index_rows`; `None` until first use or after reset.
     iter: Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
-    /// Resolved head: the key and whether its chain shadows the B-tree row.
-    /// `None` once the finger runs past the last version.
+    /// Current head: key and whether its chain shadows the B-tree row. `None`
+    /// once the finger runs past the last version.
     peek: Option<(Arc<SortableIndexKey>, bool)>,
-    /// True once the finger has run past the last version; distinguishes
-    /// "not yet created" from "done" while `iter` and `peek` are both `None`.
+    /// Set once the finger runs past the last version; distinguishes "not yet
+    /// created" from "done" while `iter` and `peek` are both `None`.
     exhausted: bool,
 }
 
 impl IndexShadowFinger {
-    /// Drop the finger; it is lazily re-created the next time a shadow check
-    /// runs. Must be called on any B-tree reposition (seek/rewind), otherwise
-    /// the monotonic finger could sit ahead of the new position and report a
-    /// shadowed row as valid.
+    /// Drop the finger so the next shadow check rebuilds it. Required on any
+    /// B-tree reposition (seek/rewind): a finger left ahead of the new position
+    /// would report a shadowed row as valid.
     fn reset(&mut self) {
         *self = Self::default();
     }
 
-    /// Advance one entry, eagerly resolving whether its chain shadows the B-tree
-    /// row (so we never hold a borrowed skiplist `Entry` across calls).
+    /// Advance one entry, resolving its shadow bit up front so no borrowed
+    /// skiplist `Entry` is held across calls.
     fn advance<Clock: LogicalClock>(&mut self, db: &MvStore<Clock>, tx_id: u64) {
         let Some(iter) = self.iter.as_mut() else {
             self.peek = None;
@@ -398,6 +394,7 @@ impl IndexShadowFinger {
         key: &Arc<SortableIndexKey>,
     ) -> bool {
         if self.iter.is_none() && !self.exhausted {
+            // Scoped so the skiplist guard drops before `advance` re-borrows `db`.
             {
                 let index_rows = db.index_rows.get_or_insert_with(table_id, SkipMap::new);
                 let index_rows = index_rows.value();
@@ -517,9 +514,8 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
         let valid = self
             .index_finger
             .btree_row_is_valid(&self.db, self.table_id, self.tx_id, rec);
-        // Safety net: in debug/test/simulator builds, prove the finger agrees with
-        // the authoritative per-row lookup. Any divergence (e.g. a missed reset
-        // after a reposition) fails the MVCC test suite instead of shipping.
+        // Debug-only cross-check: any finger divergence (e.g. a missed reset)
+        // fails the test suite instead of shipping.
         #[cfg(debug_assertions)]
         debug_assert_eq!(
             valid,

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -363,6 +363,17 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static> {
     btree_advance_state: Option<AdvanceBtreeState>,
     /// Dual-cursor peek state for proper iteration
     dual_peek: DualCursorPeek,
+    /// Forward-scan finger over `index_rows`, co-advanced with the B-tree cursor
+    /// so the per-row "is this B-tree row shadowed by MVCC?" check becomes an
+    /// amortized-O(1) merge step instead of a fresh `index_rows.get()` (O(log N))
+    /// per scanned row. Index cursors, forward iteration only; reset to `None`
+    /// on any reposition (seek/rewind) and lazily re-created positioned at the
+    /// current key.
+    index_finger: Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
+    /// Current finger head: (key, whether its version chain shadows the B-tree row).
+    index_finger_peek: Option<(Arc<SortableIndexKey>, bool)>,
+    /// True once the finger has run past the last index version.
+    index_finger_exhausted: bool,
 }
 
 pub enum NextRowidResult {
@@ -413,7 +424,107 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
             count_state: None,
             btree_advance_state: None,
             dual_peek: DualCursorPeek::default(),
+            index_finger: None,
+            index_finger_peek: None,
+            index_finger_exhausted: false,
         })
+    }
+
+    /// Drop the forward-scan finger; it is lazily re-created (positioned at the
+    /// current key) the next time the B-tree advance needs a shadow check.
+    /// Must be called whenever the B-tree cursor is repositioned (seek/rewind),
+    /// otherwise the monotonic finger could sit ahead of the new position and
+    /// report a shadowed row as valid.
+    fn reset_index_finger(&mut self) {
+        self.index_finger = None;
+        self.index_finger_peek = None;
+        self.index_finger_exhausted = false;
+    }
+
+    /// Advance the finger one entry, eagerly resolving whether its chain shadows
+    /// the B-tree row (so we never hold a borrowed skiplist `Entry` across calls).
+    fn advance_index_finger(&mut self) {
+        let db = self.db.clone();
+        let tx_id = self.tx_id;
+        let Some(iter) = self.index_finger.as_mut() else {
+            self.index_finger_peek = None;
+            self.index_finger_exhausted = true;
+            return;
+        };
+        match iter.next() {
+            Some(entry) => {
+                let invalidates = db.index_chain_invalidates_btree(entry.value(), tx_id);
+                self.index_finger_peek = Some((entry.key().clone(), invalidates));
+            }
+            None => {
+                self.index_finger_peek = None;
+                self.index_finger_exhausted = true;
+            }
+        }
+    }
+
+    /// Forward-iteration equivalent of [`query_btree_version_is_valid`] for index
+    /// keys, served from the co-positioned finger. Returns true if the B-tree row
+    /// `key` is visible (not shadowed by an MVCC version).
+    fn index_btree_row_is_valid_forward(&mut self, key: &Arc<SortableIndexKey>) -> bool {
+        // (Re)create the finger positioned at the first index version >= key.
+        if self.index_finger.is_none() && !self.index_finger_exhausted {
+            {
+                let index_rows = self
+                    .db
+                    .index_rows
+                    .get_or_insert_with(self.table_id, SkipMap::new);
+                let index_rows = index_rows.value();
+                let iter_box: Box<
+                    dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RowVersions>> + Send + Sync,
+                > = Box::new(index_rows.iter());
+                // The transmute to 'static launders the borrow of `self.db`; the
+                // outer guard must drop before we touch `&mut self` below.
+                self.index_finger = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));
+            }
+            self.advance_index_finger();
+        }
+        let valid = loop {
+            match &self.index_finger_peek {
+                // No version at or after this key -> B-tree row is visible.
+                None => break true,
+                Some((finger_key, invalidates)) => {
+                    match finger_key.as_ref().cmp(key.as_ref()) {
+                        // Finger is behind the B-tree (a version-only key); catch up.
+                        std::cmp::Ordering::Less => self.advance_index_finger(),
+                        // No version exactly at this key -> visible.
+                        std::cmp::Ordering::Greater => break true,
+                        // Version present at this key -> shadowed iff it invalidates.
+                        std::cmp::Ordering::Equal => break !*invalidates,
+                    }
+                }
+            }
+        };
+        // Safety net: in debug/test/simulator builds, prove the finger agrees with
+        // the authoritative per-row lookup. Any divergence (e.g. a missed reset
+        // after a reposition) fails the MVCC test suite instead of shipping.
+        #[cfg(debug_assertions)]
+        {
+            let reference = self.db.query_btree_version_is_valid(
+                self.table_id,
+                &RowKey::Record(key.clone()),
+                self.tx_id,
+            );
+            debug_assert_eq!(
+                valid, reference,
+                "index finger diverged from query_btree_version_is_valid"
+            );
+        }
+        valid
+    }
+
+    /// Forward-direction shadow check: finger fast-path for index cursors, the
+    /// authoritative per-row lookup for table cursors.
+    fn btree_row_is_valid_forward(&mut self, key: &RowKey) -> bool {
+        match key {
+            RowKey::Record(rec) => self.index_btree_row_is_valid_forward(rec),
+            RowKey::Int(_) => self.query_btree_version_is_valid(key),
+        }
     }
 
     /// Returns the current row as an immutable record.
@@ -617,7 +728,7 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                 Some(AdvanceBtreeState::RewindCheckBtreeKey) => {
                     let key = self.get_btree_current_key()?;
                     match key {
-                        Some(k) if self.query_btree_version_is_valid(&k) => {
+                        Some(k) if self.btree_row_is_valid_forward(&k) => {
                             self.dual_peek.btree_peek = CursorPeek::Row {
                                 key: k,
                                 versions: None,
@@ -651,7 +762,7 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                 Some(AdvanceBtreeState::NextCheckBtreeKey) => {
                     let key = self.get_btree_current_key()?;
                     if let Some(key) = key {
-                        if self.query_btree_version_is_valid(&key) {
+                        if self.btree_row_is_valid_forward(&key) {
                             self.dual_peek.btree_peek = CursorPeek::Row {
                                 key,
                                 versions: None,
@@ -808,6 +919,8 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
     /// Reset dual peek state (called on rewind/last/seek)
     fn reset_dual_peek(&mut self) {
         self.dual_peek = DualCursorPeek::default();
+        // The forward finger is monotonic; a reposition invalidates it.
+        self.reset_index_finger();
     }
 
     /// Seek btree cursor and set btree_peek to the result.

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -344,42 +344,42 @@ pub(crate) use static_iterator_hack;
 /// Forward index cursors only; [`reset`](Self::reset) on any reposition, since
 /// the finger is monotonic.
 #[derive(Default)]
-struct IndexShadowFinger {
-    /// Iterator over `index_rows`; `None` until first use or after reset.
-    iter: Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
-    /// Current head: key and whether its chain shadows the B-tree row. `None`
-    /// once the finger runs past the last version.
-    peek: Option<(Arc<SortableIndexKey>, bool)>,
-    /// Set once the finger runs past the last version; distinguishes "not yet
-    /// created" from "done" while `iter` and `peek` are both `None`.
-    exhausted: bool,
+enum IndexShadowFinger {
+    /// Not yet created; built lazily on the next shadow check.
+    #[default]
+    Uninitialized,
+    /// Positioned at `key`, whose version chain `shadows` the B-tree row or not.
+    Peeked {
+        iter: MvccIterator<'static, Arc<SortableIndexKey>>,
+        key: Arc<SortableIndexKey>,
+        shadows: bool,
+    },
+    /// Ran past the last version; every remaining B-tree row is visible.
+    Exhausted,
 }
 
 impl IndexShadowFinger {
-    /// Drop the finger so the next shadow check rebuilds it. Required on any
-    /// B-tree reposition (seek/rewind): a finger left ahead of the new position
-    /// would report a shadowed row as valid.
+    /// Reset so the next shadow check rebuilds the finger. Required on any B-tree
+    /// reposition (seek/rewind): a finger left ahead of the new position would
+    /// report a shadowed row as valid.
     fn reset(&mut self) {
-        *self = Self::default();
+        *self = Self::Uninitialized;
     }
 
-    /// Advance one entry, resolving its shadow bit up front so no borrowed
-    /// skiplist `Entry` is held across calls.
-    fn advance<Clock: LogicalClock>(&mut self, db: &MvStore<Clock>, tx_id: u64) {
-        let Some(iter) = self.iter.as_mut() else {
-            self.peek = None;
-            self.exhausted = true;
-            return;
-        };
+    /// Advance `iter` to its next entry, resolving the shadow bit up front so no
+    /// borrowed skiplist `Entry` is held afterward.
+    fn advance<Clock: LogicalClock>(
+        mut iter: MvccIterator<'static, Arc<SortableIndexKey>>,
+        db: &MvStore<Clock>,
+        tx_id: u64,
+    ) -> Self {
         match iter.next() {
-            Some(entry) => {
-                let shadows = db.index_chain_invalidates_btree(entry.value(), tx_id);
-                self.peek = Some((entry.key().clone(), shadows));
-            }
-            None => {
-                self.peek = None;
-                self.exhausted = true;
-            }
+            Some(entry) => Self::Peeked {
+                shadows: db.index_chain_invalidates_btree(entry.value(), tx_id),
+                key: entry.key().clone(),
+                iter,
+            },
+            None => Self::Exhausted,
         }
     }
 
@@ -393,33 +393,42 @@ impl IndexShadowFinger {
         tx_id: u64,
         key: &Arc<SortableIndexKey>,
     ) -> bool {
-        if self.iter.is_none() && !self.exhausted {
-            // Scoped so the skiplist guard drops before `advance` re-borrows `db`.
-            {
+        if matches!(self, Self::Uninitialized) {
+            // Scoped so the skiplist guard drops before `step` re-borrows `db`.
+            let iter = {
                 let index_rows = db.index_rows.get_or_insert_with(table_id, SkipMap::new);
-                let index_rows = index_rows.value();
                 let iter_box: Box<
                     dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RowVersions>>
                         + Send
                         + Sync,
-                > = Box::new(index_rows.iter());
-                self.iter = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));
-            }
-            self.advance(db, tx_id);
+                > = Box::new(index_rows.value().iter());
+                static_iterator_hack!(iter_box, Arc<SortableIndexKey>)
+            };
+            *self = Self::advance(iter, db, tx_id);
         }
         loop {
-            match &self.peek {
+            match self {
                 // No version at or after this key -> B-tree row is visible.
-                None => return true,
-                Some((finger_key, shadows)) => match finger_key.as_ref().cmp(key.as_ref()) {
-                    // Finger behind the B-tree (a version-only key); catch up.
-                    std::cmp::Ordering::Less => self.advance(db, tx_id),
+                Self::Exhausted => return true,
+                Self::Uninitialized => unreachable!("created just above"),
+                Self::Peeked {
+                    key: finger_key,
+                    shadows,
+                    ..
+                } => match finger_key.as_ref().cmp(key.as_ref()) {
                     // No version exactly at this key -> visible.
                     std::cmp::Ordering::Greater => return true,
                     // Version present at this key -> shadowed iff it invalidates.
                     std::cmp::Ordering::Equal => return !*shadows,
+                    // Finger behind the B-tree (a version-only key); catch up below.
+                    std::cmp::Ordering::Less => {}
                 },
             }
+            // Step the finger forward; only the `Less` arm above falls through here.
+            let Self::Peeked { iter, .. } = std::mem::replace(self, Self::Uninitialized) else {
+                unreachable!("Less arm matched Peeked")
+            };
+            *self = Self::advance(iter, db, tx_id);
         }
     }
 }

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -338,6 +338,95 @@ macro_rules! static_iterator_hack {
 
 pub(crate) use static_iterator_hack;
 
+/// Forward-scan finger over `index_rows`, co-advanced with the B-tree cursor.
+///
+/// The dual cursor walks the durable B-tree and `index_rows` (ordered by the
+/// same key) together. Rather than an `index_rows.get()` (O(log N)) per scanned
+/// B-tree row to decide whether a newer MVCC version shadows it, the finger is
+/// stepped along with the cursor, turning the shadow check into an amortized-O(1)
+/// merge step. Forward index cursors only; [`reset`](Self::reset) on any
+/// reposition (seek/rewind), since the finger is monotonic.
+#[derive(Default)]
+struct IndexShadowFinger {
+    /// Live iterator over `index_rows`; `None` until first use or after reset.
+    iter: Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
+    /// Resolved head: the key and whether its chain shadows the B-tree row.
+    /// `None` once the finger runs past the last version.
+    peek: Option<(Arc<SortableIndexKey>, bool)>,
+    /// True once the finger has run past the last version; distinguishes
+    /// "not yet created" from "done" while `iter` and `peek` are both `None`.
+    exhausted: bool,
+}
+
+impl IndexShadowFinger {
+    /// Drop the finger; it is lazily re-created the next time a shadow check
+    /// runs. Must be called on any B-tree reposition (seek/rewind), otherwise
+    /// the monotonic finger could sit ahead of the new position and report a
+    /// shadowed row as valid.
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Advance one entry, eagerly resolving whether its chain shadows the B-tree
+    /// row (so we never hold a borrowed skiplist `Entry` across calls).
+    fn advance<Clock: LogicalClock>(&mut self, db: &MvStore<Clock>, tx_id: u64) {
+        let Some(iter) = self.iter.as_mut() else {
+            self.peek = None;
+            self.exhausted = true;
+            return;
+        };
+        match iter.next() {
+            Some(entry) => {
+                let shadows = db.index_chain_invalidates_btree(entry.value(), tx_id);
+                self.peek = Some((entry.key().clone(), shadows));
+            }
+            None => {
+                self.peek = None;
+                self.exhausted = true;
+            }
+        }
+    }
+
+    /// Whether the B-tree row `key` is visible (not shadowed by an MVCC version),
+    /// served from the co-positioned finger. Forward equivalent of
+    /// [`MvStore::query_btree_version_is_valid`] for index keys.
+    fn btree_row_is_valid<Clock: LogicalClock>(
+        &mut self,
+        db: &MvStore<Clock>,
+        table_id: MVTableId,
+        tx_id: u64,
+        key: &Arc<SortableIndexKey>,
+    ) -> bool {
+        if self.iter.is_none() && !self.exhausted {
+            {
+                let index_rows = db.index_rows.get_or_insert_with(table_id, SkipMap::new);
+                let index_rows = index_rows.value();
+                let iter_box: Box<
+                    dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RowVersions>>
+                        + Send
+                        + Sync,
+                > = Box::new(index_rows.iter());
+                self.iter = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));
+            }
+            self.advance(db, tx_id);
+        }
+        loop {
+            match &self.peek {
+                // No version at or after this key -> B-tree row is visible.
+                None => return true,
+                Some((finger_key, shadows)) => match finger_key.as_ref().cmp(key.as_ref()) {
+                    // Finger behind the B-tree (a version-only key); catch up.
+                    std::cmp::Ordering::Less => self.advance(db, tx_id),
+                    // No version exactly at this key -> visible.
+                    std::cmp::Ordering::Greater => return true,
+                    // Version present at this key -> shadowed iff it invalidates.
+                    std::cmp::Ordering::Equal => return !*shadows,
+                },
+            }
+        }
+    }
+}
+
 pub struct MvccLazyCursor<Clock: LogicalClock + 'static> {
     pub db: Arc<MvStore<Clock>>,
     #[cfg(any(test, injected_yields))]
@@ -363,17 +452,8 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static> {
     btree_advance_state: Option<AdvanceBtreeState>,
     /// Dual-cursor peek state for proper iteration
     dual_peek: DualCursorPeek,
-    /// Forward-scan finger over `index_rows`, co-advanced with the B-tree cursor
-    /// so the per-row "is this B-tree row shadowed by MVCC?" check becomes an
-    /// amortized-O(1) merge step instead of a fresh `index_rows.get()` (O(log N))
-    /// per scanned row. Index cursors, forward iteration only; reset to `None`
-    /// on any reposition (seek/rewind) and lazily re-created positioned at the
-    /// current key.
-    index_finger: Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
-    /// Current finger head: (key, whether its version chain shadows the B-tree row).
-    index_finger_peek: Option<(Arc<SortableIndexKey>, bool)>,
-    /// True once the finger has run past the last index version.
-    index_finger_exhausted: bool,
+    /// Forward-scan finger over `index_rows`; see [`IndexShadowFinger`].
+    index_finger: IndexShadowFinger,
 }
 
 pub enum NextRowidResult {
@@ -424,107 +504,33 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
             count_state: None,
             btree_advance_state: None,
             dual_peek: DualCursorPeek::default(),
-            index_finger: None,
-            index_finger_peek: None,
-            index_finger_exhausted: false,
+            index_finger: IndexShadowFinger::default(),
         })
-    }
-
-    /// Drop the forward-scan finger; it is lazily re-created (positioned at the
-    /// current key) the next time the B-tree advance needs a shadow check.
-    /// Must be called whenever the B-tree cursor is repositioned (seek/rewind),
-    /// otherwise the monotonic finger could sit ahead of the new position and
-    /// report a shadowed row as valid.
-    fn reset_index_finger(&mut self) {
-        self.index_finger = None;
-        self.index_finger_peek = None;
-        self.index_finger_exhausted = false;
-    }
-
-    /// Advance the finger one entry, eagerly resolving whether its chain shadows
-    /// the B-tree row (so we never hold a borrowed skiplist `Entry` across calls).
-    fn advance_index_finger(&mut self) {
-        let db = self.db.clone();
-        let tx_id = self.tx_id;
-        let Some(iter) = self.index_finger.as_mut() else {
-            self.index_finger_peek = None;
-            self.index_finger_exhausted = true;
-            return;
-        };
-        match iter.next() {
-            Some(entry) => {
-                let invalidates = db.index_chain_invalidates_btree(entry.value(), tx_id);
-                self.index_finger_peek = Some((entry.key().clone(), invalidates));
-            }
-            None => {
-                self.index_finger_peek = None;
-                self.index_finger_exhausted = true;
-            }
-        }
-    }
-
-    /// Forward-iteration equivalent of [`query_btree_version_is_valid`] for index
-    /// keys, served from the co-positioned finger. Returns true if the B-tree row
-    /// `key` is visible (not shadowed by an MVCC version).
-    fn index_btree_row_is_valid_forward(&mut self, key: &Arc<SortableIndexKey>) -> bool {
-        // (Re)create the finger positioned at the first index version >= key.
-        if self.index_finger.is_none() && !self.index_finger_exhausted {
-            {
-                let index_rows = self
-                    .db
-                    .index_rows
-                    .get_or_insert_with(self.table_id, SkipMap::new);
-                let index_rows = index_rows.value();
-                let iter_box: Box<
-                    dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RowVersions>> + Send + Sync,
-                > = Box::new(index_rows.iter());
-                // The transmute to 'static launders the borrow of `self.db`; the
-                // outer guard must drop before we touch `&mut self` below.
-                self.index_finger = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));
-            }
-            self.advance_index_finger();
-        }
-        let valid = loop {
-            match &self.index_finger_peek {
-                // No version at or after this key -> B-tree row is visible.
-                None => break true,
-                Some((finger_key, invalidates)) => {
-                    match finger_key.as_ref().cmp(key.as_ref()) {
-                        // Finger is behind the B-tree (a version-only key); catch up.
-                        std::cmp::Ordering::Less => self.advance_index_finger(),
-                        // No version exactly at this key -> visible.
-                        std::cmp::Ordering::Greater => break true,
-                        // Version present at this key -> shadowed iff it invalidates.
-                        std::cmp::Ordering::Equal => break !*invalidates,
-                    }
-                }
-            }
-        };
-        // Safety net: in debug/test/simulator builds, prove the finger agrees with
-        // the authoritative per-row lookup. Any divergence (e.g. a missed reset
-        // after a reposition) fails the MVCC test suite instead of shipping.
-        #[cfg(debug_assertions)]
-        {
-            let reference = self.db.query_btree_version_is_valid(
-                self.table_id,
-                &RowKey::Record(key.clone()),
-                self.tx_id,
-            );
-            debug_assert_eq!(
-                valid, reference,
-                "index finger diverged from query_btree_version_is_valid"
-            );
-        }
-        valid
     }
 
     /// Forward-direction shadow check: finger fast-path for index cursors, the
     /// authoritative per-row lookup for table cursors.
     fn btree_row_is_valid_forward(&mut self, key: &RowKey) -> bool {
-        match key {
-            RowKey::Record(rec) => self.index_btree_row_is_valid_forward(rec),
-            RowKey::Int(_) => self.query_btree_version_is_valid(key),
-        }
+        let RowKey::Record(rec) = key else {
+            return self.query_btree_version_is_valid(key);
+        };
+        let valid = self
+            .index_finger
+            .btree_row_is_valid(&self.db, self.table_id, self.tx_id, rec);
+        // Safety net: in debug/test/simulator builds, prove the finger agrees with
+        // the authoritative per-row lookup. Any divergence (e.g. a missed reset
+        // after a reposition) fails the MVCC test suite instead of shipping.
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            valid,
+            self.db.query_btree_version_is_valid(
+                self.table_id,
+                &RowKey::Record(rec.clone()),
+                self.tx_id
+            ),
+            "index finger diverged from query_btree_version_is_valid"
+        );
+        valid
     }
 
     /// Returns the current row as an immutable record.
@@ -920,7 +926,7 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
     fn reset_dual_peek(&mut self) {
         self.dual_peek = DualCursorPeek::default();
         // The forward finger is monotonic; a reposition invalidates it.
-        self.reset_index_finger();
+        self.index_finger.reset();
     }
 
     /// Seek btree cursor and set btree_peek to the result.

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4932,6 +4932,32 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         self.find_next_visible_index_row(tx, mv_store_iterator)
     }
 
+    /// Whether an already-resolved index version chain shadows (invalidates) the
+    /// corresponding B-tree row for `tx_id`.
+    ///
+    /// This is exactly the predicate used by the `RowKey::Record` branch of
+    /// [`Self::query_btree_version_is_valid`], but it takes the version chain
+    /// directly instead of looking it up by key. A forward index scan keeps a
+    /// skiplist finger co-positioned with the B-tree and calls this on the
+    /// chain the finger already points at, replacing one `index_rows.get()`
+    /// (O(log N)) per scanned row with an amortized-O(1) merge step.
+    pub(crate) fn index_chain_invalidates_btree(
+        &self,
+        versions: &RwLock<Vec<RowVersion>>,
+        tx_id: TxID,
+    ) -> bool {
+        let tx = self
+            .txs
+            .get(&tx_id)
+            .expect("transaction should exist in txs map");
+        let tx = tx.value();
+        let versions = versions.read();
+        versions
+            .iter()
+            .rev()
+            .any(|version| version.is_btree_invalidating_version(tx, &self.txs, &self.finalized_tx_states))
+    }
+
     /// Check if the B-tree version of a row should be shown to the given transaction.
     ///
     /// Returns true if the B-tree version is valid (should be shown).

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4952,10 +4952,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             .expect("transaction should exist in txs map");
         let tx = tx.value();
         let versions = versions.read();
-        versions
-            .iter()
-            .rev()
-            .any(|version| version.is_btree_invalidating_version(tx, &self.txs, &self.finalized_tx_states))
+        versions.iter().rev().any(|version| {
+            version.is_btree_invalidating_version(tx, &self.txs, &self.finalized_tx_states)
+        })
     }
 
     /// Check if the B-tree version of a row should be shown to the given transaction.


### PR DESCRIPTION
## Description
This is the description provided by claude which is good enough:

The MVCC dual cursor walks the durable b-tree and the in-memory MVCC
version index together. To decide whether a b-tree row is shadowed by a
newer MVCC version, `_advance_btree_forward` called
`query_btree_version_is_valid` for *every* row it stepped over, and that
does a fresh `index_rows.get()` skiplist search — O(log N)
`SortableIndexKey::compare`s, each re-decoding serial-typed key bytes —
per scanned row. Profiling a write-heavy workload showed ~25% of on-CPU
time in `SortableIndexKey::compare` driven by this path (op_next ->
_advance_btree_forward -> query_btree_version_is_valid -> SkipMap::get).

Both the b-tree and `index_rows` are ordered by the same key, so the
shadow check can be answered by a finger co-advanced with the cursor
instead of a point lookup per row, turning N*log(N) into a linear merge.

Keep a forward finger (`index_finger` + an eagerly-resolved
(key, shadows?) peek) over `index_rows`; on each b-tree row advance it to
the row's key and answer from its position. Reset it on any reposition
(via reset_dual_peek, which rewind/last/seek already call). Only forward
index cursors use it; table and backward paths are unchanged.

Correctness is enforced by a debug_assert cross-check against
`query_btree_version_is_valid` on every call, so any missed reset fails
the test suite/simulator instead of shipping. The full MVCC test suite
(377 tests, incl. dual-cursor isolation, checkpoint/recovery, secondary
indexes) passes with the cross-check active.




## Description of AI Usage

Pekka "calmly" asked claude to fix this issue. I also "calmly" asked him to refactor _fingering_ on index rows.