### PR TITLE
core/mvcc: pass tx_id to durable storage trait methods

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2955,7 +2955,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     CommitState::WriteLogicalLog { log_record, .. } => log_record,
                     _ => unreachable!(),
                 };
-                let (c, append_bytes) = mvcc_store.storage.log_tx(log_record, None)?;
+                let (c, append_bytes) = mvcc_store.storage.log_tx(self.tx_id, log_record, None)?;
                 self.pending_log_append_bytes = Some(append_bytes);
                 // if Completion Completed without errors we can continue
                 if c.succeeded() {
@@ -2966,7 +2966,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
             }
 
             CommitState::FinishLogicalLogWrite { end_ts } => {
-                let c = mvcc_store.storage.on_log_write_complete()?;
+                let c = mvcc_store.storage.on_log_write_complete(self.tx_id)?;
                 self.state = CommitState::SyncLogicalLog { end_ts: *end_ts };
                 if c.succeeded() {
                     Ok(TransitionResult::Continue)

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -14403,7 +14403,7 @@ fn dropped_attached_commit_rolls_back_remaining_attached_mvcc_txs() {
 fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
     use crate::io::FileSyncType;
     use crate::mvcc;
-    use crate::mvcc::database::{LogRecord, RowVersion};
+    use crate::mvcc::database::{LogRecord, RowVersion, TxID};
     use crate::mvcc::persistent_storage::logical_log::{LogHeader, OnSerializationComplete};
     use crate::mvcc::persistent_storage::DurableStorage;
     use crate::storage::encryption::EncryptionContext;
@@ -14447,19 +14447,23 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         }
         fn log_tx(
             &self,
+            tx_id: TxID,
             m: LogRecord,
             c: OnSerializationComplete<'_>,
         ) -> Result<(Completion, u64)> {
             if self.arm_log_tx_busy.swap(false, Ordering::AcqRel) {
                 return Err(LimboError::Busy);
             }
-            self.inner.log_tx(m, c)
+            self.inner.log_tx(tx_id, m, c)
         }
         fn upgrade_header_for_log_tx(&self, m: &LogRecord) -> Result<Option<Completion>> {
             self.inner.upgrade_header_for_log_tx(m)
         }
         fn sync(&self, t: FileSyncType) -> Result<Completion> {
             self.inner.sync(t)
+        }
+        fn on_log_write_complete(&self, tx_id: TxID) -> Result<Completion> {
+            self.inner.on_log_write_complete(tx_id)
         }
         fn update_header(&self) -> Result<Completion> {
             self.inner.update_header()

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -8,7 +8,7 @@ use crate::turso_assert;
 use std::fmt::Debug;
 
 pub mod logical_log;
-use crate::mvcc::database::{LogRecord, RowVersion};
+use crate::mvcc::database::{LogRecord, RowVersion, TxID};
 use crate::mvcc::persistent_storage::logical_log::{
     serialize_header_entry, serialize_op_entry, LogicalLog, OnSerializationComplete,
     DEFAULT_LOG_CHECKPOINT_THRESHOLD,
@@ -34,12 +34,16 @@ pub trait DurableStorage: Send + Sync + Debug {
 
     /// Write a transaction to the logical log without advancing the writer offset.
     ///
+    /// `tx_id` is the in-memory MVCC transaction id whose record is being
+    /// appended. It is not part of the logical-log wire format.
+    ///
     /// If `on_serialization_complete` is provided, it is called with shared
     /// ownership of the framed bytes and the running CRC after framing but
     /// before the disk write. The callback runs while the internal write lock
     /// is held, so it should be fast.
     fn log_tx(
         &self,
+        tx_id: TxID,
         m: LogRecord,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)>;
@@ -56,7 +60,7 @@ pub trait DurableStorage: Send + Sync + Debug {
     ///
     /// Implementations may return a completion for any additional durability
     /// work that must finish before commit publication.
-    fn on_log_write_complete(&self) -> Result<Completion> {
+    fn on_log_write_complete(&self, _tx_id: TxID) -> Result<Completion> {
         Ok(Completion::new_yield())
     }
 
@@ -173,6 +177,7 @@ impl DurableStorage for Storage {
 
     fn log_tx(
         &self,
+        _tx_id: TxID,
         m: LogRecord,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1,5 +1,6 @@
 use crate::common::{ExecRows, TempDatabase};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use turso_core::{Database, DatabaseOpts, EncryptionKey, EncryptionOpts, OpenFlags, StepResult};
 
@@ -26,19 +27,30 @@ fn create_mvcc_db(io: &Arc<dyn turso_core::io::IO + Send>, path: &Path) -> anyho
 #[derive(Debug)]
 struct RecordingDurableStorage {
     inner: Arc<dyn turso_core::mvcc::persistent_storage::DurableStorage>,
-    used_log_tx: std::sync::atomic::AtomicBool,
+    used_log_tx: AtomicBool,
+    last_log_tx_id: AtomicU64,
+    last_completed_tx_id: AtomicU64,
 }
 
 impl RecordingDurableStorage {
     fn new(inner: Arc<dyn turso_core::mvcc::persistent_storage::DurableStorage>) -> Self {
         Self {
             inner,
-            used_log_tx: std::sync::atomic::AtomicBool::new(false),
+            used_log_tx: AtomicBool::new(false),
+            last_log_tx_id: AtomicU64::new(0),
+            last_completed_tx_id: AtomicU64::new(0),
         }
     }
 
     fn saw_log_tx(&self) -> bool {
-        self.used_log_tx.load(std::sync::atomic::Ordering::SeqCst)
+        self.used_log_tx.load(Ordering::SeqCst)
+    }
+
+    fn last_tx_ids(&self) -> (u64, u64) {
+        (
+            self.last_log_tx_id.load(Ordering::SeqCst),
+            self.last_completed_tx_id.load(Ordering::SeqCst),
+        )
     }
 }
 
@@ -63,14 +75,15 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
 
     fn log_tx(
         &self,
+        tx_id: turso_core::mvcc::database::TxID,
         m: turso_core::mvcc::database::LogRecord,
         on_serialization_complete: Option<
             &dyn Fn(turso_core::SharedBufferData, u32) -> turso_core::Result<()>,
         >,
     ) -> turso_core::Result<(turso_core::Completion, u64)> {
-        self.used_log_tx
-            .store(true, std::sync::atomic::Ordering::SeqCst);
-        self.inner.log_tx(m, on_serialization_complete)
+        self.used_log_tx.store(true, Ordering::SeqCst);
+        self.last_log_tx_id.store(tx_id, Ordering::SeqCst);
+        self.inner.log_tx(tx_id, m, on_serialization_complete)
     }
 
     fn sync(
@@ -78,6 +91,14 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
         sync_type: turso_core::io::FileSyncType,
     ) -> turso_core::Result<turso_core::Completion> {
         self.inner.sync(sync_type)
+    }
+
+    fn on_log_write_complete(
+        &self,
+        tx_id: turso_core::mvcc::database::TxID,
+    ) -> turso_core::Result<turso_core::Completion> {
+        self.last_completed_tx_id.store(tx_id, Ordering::SeqCst);
+        self.inner.on_log_write_complete(tx_id)
     }
 
     fn update_header(&self) -> turso_core::Result<turso_core::Completion> {
@@ -205,6 +226,12 @@ fn test_mvcc_custom_durable_storage_injected(tmp_db: TempDatabase) -> anyhow::Re
     assert!(
         recording.saw_log_tx(),
         "expected MVCC commit to call injected DurableStorage::log_tx()"
+    );
+    let (log_tx_id, completed_tx_id) = recording.last_tx_ids();
+    assert_ne!(log_tx_id, 0, "expected log_tx to receive a live tx_id");
+    assert_eq!(
+        completed_tx_id, log_tx_id,
+        "expected DurableStorage hooks to receive the same tx_id"
     );
 
     conn.close()?;


### PR DESCRIPTION
## Description
If we can correlate some transaction logging to a commit, we can later ensure that they are uploaded in that order grouped by `tx_id` or are aborted together by that `tx_id`. 

## Motivation and context
Server stuff
