### PR TITLE
mvcc: lazily resolve shadow in new IndexShadowFinger

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -348,11 +348,15 @@ enum IndexShadowFinger {
     /// Not yet created; built lazily on the next shadow check.
     #[default]
     Uninitialized,
-    /// Positioned at `key`, whose version chain `shadows` the B-tree row or not.
+    /// Positioned at `key`, holding its version chain. The shadow bit is resolved
+    /// lazily (only when a B-tree row matches this key exactly), so stepping over
+    /// MVCC-only keys is a pure pointer-chase with no lock/iterate and, crucially,
+    /// no `is_btree_invalidating_version` side effects (commit-dependency
+    /// registration) on rows the scan never observes.
     Peeked {
         iter: MvccIterator<'static, Arc<SortableIndexKey>>,
         key: Arc<SortableIndexKey>,
-        shadows: bool,
+        versions: RowVersions,
     },
     /// Ran past the last version; every remaining B-tree row is visible.
     Exhausted,
@@ -366,17 +370,14 @@ impl IndexShadowFinger {
         *self = Self::Uninitialized;
     }
 
-    /// Advance `iter` to its next entry, resolving the shadow bit up front so no
-    /// borrowed skiplist `Entry` is held afterward.
-    fn advance<Clock: LogicalClock>(
-        mut iter: MvccIterator<'static, Arc<SortableIndexKey>>,
-        db: &MvStore<Clock>,
-        tx_id: u64,
-    ) -> Self {
+    /// Advance `iter` to its next entry, cloning the key and version-chain `Arc`
+    /// (both cheap) so no borrowed skiplist `Entry` is held afterward. The shadow
+    /// bit is deliberately not resolved here — see [`Self::Peeked`].
+    fn advance(mut iter: MvccIterator<'static, Arc<SortableIndexKey>>) -> Self {
         match iter.next() {
             Some(entry) => Self::Peeked {
-                shadows: db.index_chain_invalidates_btree(entry.value(), tx_id),
                 key: entry.key().clone(),
+                versions: entry.value().clone(),
                 iter,
             },
             None => Self::Exhausted,
@@ -397,14 +398,20 @@ impl IndexShadowFinger {
             // Scoped so the skiplist guard drops before `step` re-borrows `db`.
             let iter = {
                 let index_rows = db.index_rows.get_or_insert_with(table_id, SkipMap::new);
+                // Seed the finger at the first index key >= the B-tree key rather
+                // than at the start of `index_rows`, so a seek-initiated scan does
+                // not re-walk every preceding version on its first row check.
                 let iter_box: Box<
                     dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RowVersions>>
                         + Send
                         + Sync,
-                > = Box::new(index_rows.value().iter());
+                > = Box::new(index_rows.value().range::<SortableIndexKey, _>((
+                    std::ops::Bound::Included(key.as_ref()),
+                    std::ops::Bound::Unbounded,
+                )));
                 static_iterator_hack!(iter_box, Arc<SortableIndexKey>)
             };
-            *self = Self::advance(iter, db, tx_id);
+            *self = Self::advance(iter);
         }
         loop {
             match self {
@@ -413,13 +420,16 @@ impl IndexShadowFinger {
                 Self::Uninitialized => unreachable!("created just above"),
                 Self::Peeked {
                     key: finger_key,
-                    shadows,
+                    versions,
                     ..
                 } => match finger_key.as_ref().cmp(key.as_ref()) {
                     // No version exactly at this key -> visible.
                     std::cmp::Ordering::Greater => return true,
-                    // Version present at this key -> shadowed iff it invalidates.
-                    std::cmp::Ordering::Equal => return !*shadows,
+                    // Version present at this key -> resolve the shadow bit now,
+                    // on the one key that actually matches a B-tree row.
+                    std::cmp::Ordering::Equal => {
+                        return !db.index_chain_invalidates_btree(versions, tx_id)
+                    }
                     // Finger behind the B-tree (a version-only key); catch up below.
                     std::cmp::Ordering::Less => {}
                 },
@@ -428,7 +438,7 @@ impl IndexShadowFinger {
             let Self::Peeked { iter, .. } = std::mem::replace(self, Self::Uninitialized) else {
                 unreachable!("Less arm matched Peeked")
             };
-            *self = Self::advance(iter, db, tx_id);
+            *self = Self::advance(iter);
         }
     }
 }

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -344,15 +344,12 @@ pub(crate) use static_iterator_hack;
 /// Forward index cursors only; [`reset`](Self::reset) on any reposition, since
 /// the finger is monotonic.
 #[derive(Default)]
-enum IndexShadowFinger {
+pub(crate) enum IndexShadowFinger {
     /// Not yet created; built lazily on the next shadow check.
     #[default]
     Uninitialized,
     /// Positioned at `key`, holding its version chain. The shadow bit is resolved
-    /// lazily (only when a B-tree row matches this key exactly), so stepping over
-    /// MVCC-only keys is a pure pointer-chase with no lock/iterate and, crucially,
-    /// no `is_btree_invalidating_version` side effects (commit-dependency
-    /// registration) on rows the scan never observes.
+    /// lazily (only when a B-tree row matches this key exactly)
     Peeked {
         iter: MvccIterator<'static, Arc<SortableIndexKey>>,
         key: Arc<SortableIndexKey>,
@@ -387,7 +384,7 @@ impl IndexShadowFinger {
     /// Whether the B-tree row `key` is visible (not shadowed by an MVCC version),
     /// served from the co-positioned finger. Forward equivalent of
     /// [`MvStore::query_btree_version_is_valid`] for index keys.
-    fn btree_row_is_valid<Clock: LogicalClock>(
+    pub(crate) fn btree_row_is_valid<Clock: LogicalClock>(
         &mut self,
         db: &MvStore<Clock>,
         table_id: MVTableId,

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -5058,6 +5058,95 @@ fn test_commit_dependency_speculative_ignore() {
     );
 }
 
+/// Regression: the forward-scan [`IndexShadowFinger`] must NOT evaluate the
+/// shadow predicate (and thus must not fire its `register_commit_dependency`
+/// side effect) for index versions whose keys it merely *steps over* — i.e.
+/// MVCC-only keys with no matching B-tree row. The authoritative
+/// `query_btree_version_is_valid` path only ever evaluates the version chain for
+/// keys that exactly match a B-tree row (`index_rows.get(btree_key)`), so an
+/// eager finger that resolved the shadow bit on every advance would register a
+/// commit dependency on a `Preparing` writer for a row the scan never observes —
+/// a spurious dependency that cascade-aborts the reader if that writer aborts.
+///
+/// Setup: B-tree keys 10 and 30 (no MVCC versions), plus a single MVCC-only
+/// tombstone at key 20 deleted by a `Preparing` writer that the reader would
+/// speculatively invalidate. A forward scan checks 10 (finger ahead → visible)
+/// then 30 (finger behind → steps over key 20). Key 20 is never an exact match,
+/// so no dependency may be registered.
+#[test]
+fn test_index_finger_no_spurious_dep_on_stepped_over_key() {
+    use crate::mvcc::cursor::IndexShadowFinger;
+
+    let db = MvccTestDb::new();
+    let store = &db.mvcc_store;
+    let table_id = MVTableId::from(-999_i64);
+
+    // Single-column ascending integer index key.
+    let info = std::sync::Arc::new(crate::types::IndexInfo {
+        key_info: vec![crate::types::KeyInfo {
+            sort_order: turso_parser::ast::SortOrder::Asc,
+            collation: crate::translate::collate::CollationSeq::Binary,
+            nulls_order: None,
+        }],
+        has_rowid: false,
+        num_cols: 1,
+        is_unique: false,
+    });
+    let idx_key = |v: i64| {
+        let rec = crate::types::ImmutableRecord::from_values(&[Value::from_i64(v)], 1).unwrap();
+        std::sync::Arc::new(SortableIndexKey::new_from_record(rec, info.clone()))
+    };
+
+    // Reader started after the writer's prepared end_ts → speculatively
+    // invalidates the writer's tombstone (the dependency-registering path).
+    let reader_id: TxID = 9_000_100;
+    let writer_id: TxID = 9_000_050;
+    store.txs.insert(
+        writer_id,
+        new_tx(writer_id, 1, TransactionState::Preparing(40)),
+    );
+    store
+        .txs
+        .insert(reader_id, new_tx(reader_id, 100, TransactionState::Active));
+
+    // MVCC-only tombstone at key 20: committed insert (begin Timestamp) deleted
+    // by the Preparing writer (end TxID). Not present in the B-tree.
+    let key20 = idx_key(20);
+    let row_id = RowID::new(table_id, RowKey::Record(key20.clone()));
+    let tombstone = RowVersion {
+        id: 20,
+        begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(5))),
+        end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::TxID(writer_id))),
+        row: Row::new_index_row(row_id, 1),
+        btree_resident: false,
+    };
+    store
+        .index_rows
+        .get_or_insert_with(table_id, SkipMap::new)
+        .value()
+        .insert(key20, Arc::new(RwLock::new(vec![tombstone])));
+
+    let mut finger = IndexShadowFinger::default();
+    // B-tree key 10: finger seeds at the first index key >= 10 (key 20), which is
+    // ahead → row visible, predicate not evaluated.
+    assert!(finger.btree_row_is_valid(store, table_id, reader_id, &idx_key(10)));
+    // B-tree key 30: finger (at key 20) is behind → steps over the tombstone.
+    // It must advance past it WITHOUT evaluating the shadow predicate.
+    assert!(finger.btree_row_is_valid(store, table_id, reader_id, &idx_key(30)));
+
+    let reader = store.txs.get(&reader_id).unwrap();
+    assert_eq!(
+        reader.value().commit_dep_counter.load(Ordering::Acquire),
+        0,
+        "finger registered a spurious commit dependency for a key it only stepped over"
+    );
+    let writer = store.txs.get(&writer_id).unwrap();
+    assert!(
+        writer.value().commit_dep_set.lock().is_empty(),
+        "writer's commit-dep set must stay empty: reader never observed the tombstoned row"
+    );
+}
+
 /// Test that multiple speculative reads from the same preparing tx only
 /// register one commit dependency (dedup).
 #[test]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -5083,7 +5083,7 @@ fn test_index_finger_no_spurious_dep_on_stepped_over_key() {
 
     // Single-column ascending integer index key.
     let info = std::sync::Arc::new(crate::types::IndexInfo {
-        key_info: vec![crate::types::KeyInfo {
+        key_info: crate::alloc::vec![crate::types::KeyInfo {
             sort_order: turso_parser::ast::SortOrder::Asc,
             collation: crate::translate::collate::CollationSeq::Binary,
             nulls_order: None,


### PR DESCRIPTION
**1. Lazy shadow resolution.** (correctness + perf) `IndexShadowFinger::advance` previously called `index_chain_invalidates_btree` on **every** index key the finger landed on. That function reaches `register_commit_dependency`, which *mutates* transaction state (bumps `commit_dep_counter`, joins the depended-on tx's `commit_dep_set`, and can set `abort_now`). Because the finger steps over MVCC-only keys (the `Less`/`Greater` arms — keys with no matching b-tree row), it was firing those side effects on rows the scan never observes. The original `query_btree_version_is_valid` only evaluates the chain for keys that exactly match a b-tree row, so this was a real divergence: a reader passing over another tx's `Preparing` tombstones could register a spurious commit dependency and cascade-abort for no reason if that tx later aborted. The `debug_assert` cross-check couldn't catch it, it compares the returned bool and not the side effects.

Fix: `Peeked` now holds the version-chain `Arc` (just 'cheap' clone) instead of a pre-resolved `shadows: bool`, and then `index_chain_invalidates_btree` is called only in the `Equal` arm for exactly the one key that matches a b-tree row. This matches the original semantics and also drops the per-advance `RwLock` read + version-vector scan + `txs.get` for every stepped-over key.

**2. (perf) Seed the finger via `range(key..)` instead of `iter()`.** On any reposition the finger rebuilt from the *start* of `index_rows` and linearly caught up to the cursor's key. It now starts at the first index key `>= ` the b-tree key, so a seek-initiated scan doesn't re-walk every preceding version on its first check. making this O(log N) instead of O(M-before-key).
