### PR TITLE
json: fix json_set panics on array append

### DIFF
--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -2596,7 +2596,7 @@ impl Jsonb {
                         }
                         None => {
                             if !mode.allows_insert() {
-                                bail_parse_error!("Can't insert")
+                                bail_parse_error!("Cant insert")
                             }
                             let placeholder = JsonbHeader::new(ElementType::OBJECT, 0).into_bytes();
                             let placeholder_bytes = placeholder.as_bytes();

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -2594,6 +2594,22 @@ impl Jsonb {
                                 bail_parse_error!("Element with negative index not found")
                             }
                         }
+                        None => {
+                            if !mode.allows_insert() {
+                                bail_parse_error!("Can't insert")
+                            }
+                            let placeholder = JsonbHeader::new(ElementType::OBJECT, 0).into_bytes();
+                            let placeholder_bytes = placeholder.as_bytes();
+                            self.data
+                                .splice(end_pos..end_pos, placeholder_bytes.iter().copied());
+
+                            return Ok(JsonTraversalResult::with_array_index(
+                                pos,
+                                JsonLocationKind::ArrayEntry,
+                                placeholder_bytes.len() as isize,
+                                end_pos,
+                            ));
+                        }
                         _ => unreachable!(),
                     }
                 } else {
@@ -2772,6 +2788,23 @@ impl Jsonb {
                             } else {
                                 bail_parse_error!("Element with negative index not found")
                             }
+                        }
+                        None => {
+                            if !mode.allows_insert() {
+                                bail_parse_error!("Cant insert")
+                            }
+                            let placeholder = JsonbHeader::new(ElementType::OBJECT, 0).into_bytes();
+                            let placeholder_bytes = placeholder.as_bytes();
+
+                            self.data
+                                .splice(end_pos..end_pos, placeholder_bytes.iter().copied());
+
+                            return Ok(JsonTraversalResult::with_array_index(
+                                pos,
+                                JsonLocationKind::DocumentRoot,
+                                placeholder_bytes.len() as isize,
+                                end_pos,
+                            ));
                         }
                         _ => unreachable!(),
                     }
@@ -2956,6 +2989,14 @@ impl Jsonb {
                                 let insertion_point = value_idx + value_size + value_header_size;
 
                                 self.data.insert(insertion_point, placeholder_bytes[0]);
+                                let insertion_point = value_idx + value_size + value_header_size;
+
+                                return Ok(JsonTraversalResult::with_array_index(
+                                    value_idx,
+                                    JsonLocationKind::ObjectProperty(key_idx),
+                                    placeholder_bytes.len() as isize,
+                                    insertion_point,
+                                ));
                             } else {
                                 bail_parse_error!("Cant insert")
                             }

--- a/testing/sqltests/tests/json/default.sqltest
+++ b/testing/sqltests/tests/json/default.sqltest
@@ -3315,3 +3315,24 @@ test json-remove-null {
 expect {
   null
 }
+
+test json_set_array_append_at_root {
+    SELECT json_set('[1,2,3]', '$[#]', 4);
+}
+expect {
+    [1,2,3,4]
+}
+
+test json_set_array_append_after_array_index {
+    SELECT json_set('[[1,2,3]]', '$[0][#]', 4);
+}
+expect {
+    [[1,2,3,4]]
+}
+
+test json_set_array_append_after_object_key {
+    SELECT json_set('{"a":[1,2,3]}', '$.a[#]', 4);
+}
+expect {
+    {"a":[1,2,3,4]}
+}


### PR DESCRIPTION
## Description

  Fixes a `json_set` panic by handling `ArrayLocator(None)` (`[#]`) cases that previously
  reached `unreachable!()` in JSON path traversal.

  Covers append paths at the root, after an array index, and after an object key.

  ## Motivation and context

  Fixes #7354.

  ## Description of AI Usage

  Used AI to generate SQL regression tests.
