### PR TITLE
whopper: add allocation fault injection

### DIFF
--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -1,0 +1,96 @@
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::alloc::{alloc, dealloc};
+use std::ptr::NonNull;
+use std::sync::Mutex;
+use turso_core::alloc::{AllocError, Layout, SetAllocatorError, TursoAllocBackend, set_allocator};
+
+pub(crate) struct AllocationFaultAllocator {
+    probability: f64,
+    rng: Mutex<ChaCha8Rng>,
+}
+
+impl AllocationFaultAllocator {
+    pub(crate) fn new(seed: u64, probability: f64) -> Self {
+        Self {
+            probability,
+            rng: Mutex::new(ChaCha8Rng::seed_from_u64(seed)),
+        }
+    }
+
+    fn should_fail(&self) -> bool {
+        let mut rng = self.rng.lock().unwrap();
+        rng.random_bool(self.probability)
+    }
+}
+
+unsafe impl TursoAllocBackend for AllocationFaultAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        if self.should_fail() {
+            return Err(AllocError);
+        }
+        if layout.size() == 0 {
+            return Ok(NonNull::slice_from_raw_parts(NonNull::<u8>::dangling(), 0));
+        }
+        let ptr = unsafe { alloc(layout) };
+        NonNull::new(ptr)
+            .map(|ptr| NonNull::slice_from_raw_parts(ptr, layout.size()))
+            .ok_or(AllocError)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        if layout.size() != 0 {
+            unsafe {
+                dealloc(ptr.as_ptr(), layout);
+            }
+        }
+    }
+}
+
+pub(crate) fn validate_probability(probability: f64) -> anyhow::Result<bool> {
+    if probability == 0.0 {
+        return Ok(false);
+    }
+    if !probability.is_finite() || !(0.0..=1.0).contains(&probability) {
+        anyhow::bail!("allocation fault probability must be between 0.0 and 1.0");
+    }
+    Ok(true)
+}
+
+pub(crate) fn install(seed: u64, probability: f64) -> anyhow::Result<bool> {
+    if !validate_probability(probability)? {
+        return Ok(false);
+    }
+
+    let allocator = Box::leak(Box::new(AllocationFaultAllocator::new(seed, probability)));
+    unsafe {
+        set_allocator(allocator).map_err(|err| match err {
+            SetAllocatorError::AlreadyInitialized => anyhow::anyhow!(
+                "Turso allocator was already initialized before Whopper installed allocation faults"
+            ),
+        })?;
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocator_fails_when_probability_is_one() {
+        let allocator = AllocationFaultAllocator::new(1, 1.0);
+        let layout = Layout::from_size_align(8, 8).unwrap();
+        assert!(allocator.allocate(layout).is_err());
+    }
+
+    #[test]
+    fn allocator_delegates_when_probability_is_zero() {
+        let allocator = AllocationFaultAllocator::new(1, 0.0);
+        let layout = Layout::from_size_align(8, 8).unwrap();
+        let ptr = allocator.allocate(layout).expect("allocation succeeds");
+        unsafe {
+            allocator.deallocate(ptr.cast(), layout);
+        }
+    }
+}

--- a/testing/concurrent-simulator/error_handling.rs
+++ b/testing/concurrent-simulator/error_handling.rs
@@ -34,7 +34,11 @@ pub enum ErrorAction {
 /// transaction that needs rolling back (i.e. not autocommit). The
 /// drivers compute this from their own fiber-state tracking before
 /// calling in.
-pub fn classify_op_error(err: &LimboError, in_tx: bool) -> ErrorAction {
+pub fn classify_op_error(
+    err: &LimboError,
+    in_tx: bool,
+    allocation_faults_enabled: bool,
+) -> ErrorAction {
     // DatabaseFull is overloaded — it is raised for both real storage
     // exhaustion (pager.rs) and autoincrement max-rowid overflow
     // (translate/insert.rs). Only swallow the well-defined "non-
@@ -75,6 +79,13 @@ pub fn classify_op_error(err: &LimboError, in_tx: bool) -> ErrorAction {
                 ErrorAction::ClearTxn
             }
         }
+        LimboError::OutOfMemory if allocation_faults_enabled => {
+            if in_tx {
+                ErrorAction::Rollback
+            } else {
+                ErrorAction::ClearTxn
+            }
+        }
         LimboError::Corrupt(_) | LimboError::CheckpointFailed(_) => ErrorAction::Respawn,
         _ => ErrorAction::Fatal,
     }
@@ -87,38 +98,46 @@ mod tests {
     #[test]
     fn parse_error_in_tx_queues_rollback() {
         let err = LimboError::ParseError("nope".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Rollback);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Rollback);
     }
 
     #[test]
     fn parse_error_autocommit_clears_txn() {
         let err = LimboError::ParseError("nope".into());
-        assert_eq!(classify_op_error(&err, false), ErrorAction::ClearTxn);
+        assert_eq!(classify_op_error(&err, false, false), ErrorAction::ClearTxn);
     }
 
     #[test]
     fn sequence_exhaustion_is_swallowed() {
         let err = LimboError::DatabaseFull("nextval: reached minimum value of \"s\"".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Rollback);
-        assert_eq!(classify_op_error(&err, false), ErrorAction::ClearTxn);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Rollback);
+        assert_eq!(classify_op_error(&err, false, false), ErrorAction::ClearTxn);
     }
 
     #[test]
     fn generic_database_full_is_fatal() {
         let err = LimboError::DatabaseFull("disk image is full".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Fatal);
-        assert_eq!(classify_op_error(&err, false), ErrorAction::Fatal);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Fatal);
+        assert_eq!(classify_op_error(&err, false, false), ErrorAction::Fatal);
     }
 
     #[test]
     fn corrupt_respawns() {
         let err = LimboError::Corrupt("bad page".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Respawn);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Respawn);
+    }
+
+    #[test]
+    fn out_of_memory_is_recoverable_only_when_faults_are_enabled() {
+        let err = LimboError::OutOfMemory;
+        assert_eq!(classify_op_error(&err, true, true), ErrorAction::Rollback);
+        assert_eq!(classify_op_error(&err, false, true), ErrorAction::ClearTxn);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Fatal);
     }
 
     #[test]
     fn unknown_error_is_fatal() {
         let err = LimboError::InternalError("unexpected".into());
-        assert_eq!(classify_op_error(&err, true), ErrorAction::Fatal);
+        assert_eq!(classify_op_error(&err, true, false), ErrorAction::Fatal);
     }
 }

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -22,6 +22,7 @@ use turso_core::{
 };
 use turso_parser::ast::{ColumnConstraint, SortOrder};
 
+mod allocation_fault;
 pub mod chaotic_elle;
 pub mod elle;
 pub mod error_handling;
@@ -278,6 +279,8 @@ pub struct WhopperOpts {
     pub close_connections_gracefully: bool,
     /// Probabilty of a reopen fault.
     pub reopen_probability: f64,
+    /// Probability that a Turso fallible allocation fails.
+    pub allocation_fault_probability: f64,
 }
 
 /// Schema-generation bias
@@ -324,6 +327,7 @@ impl Default for WhopperOpts {
             disable_mvcc_auto_checkpoint: false,
             close_connections_gracefully: true,
             reopen_probability: 0.0,
+            allocation_fault_probability: 0.05,
         }
     }
 }
@@ -430,6 +434,11 @@ impl WhopperOpts {
         profiles: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)>,
     ) -> Self {
         self.chaotic_profiles = profiles;
+        self
+    }
+
+    pub fn with_allocation_fault_probability(mut self, probability: f64) -> Self {
+        self.allocation_fault_probability = probability;
         self
     }
 }
@@ -585,6 +594,7 @@ pub struct Whopper {
     disable_mvcc_auto_checkpoint: bool,
     /// If false, drop fiber connections without first closing them.
     close_connections_gracefully: bool,
+    allocation_faults_enabled: bool,
 }
 
 impl Whopper {
@@ -596,6 +606,7 @@ impl Whopper {
         });
 
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        allocation_fault::validate_probability(opts.allocation_fault_probability)?;
 
         // Create a separate RNG for IO operations with a derived seed
         let io_rng = ChaCha8Rng::seed_from_u64(seed.wrapping_add(1));
@@ -730,9 +741,12 @@ impl Whopper {
             chaotic_profiles: opts.chaotic_profiles,
             disable_mvcc_auto_checkpoint: opts.disable_mvcc_auto_checkpoint,
             close_connections_gracefully: opts.close_connections_gracefully,
+            allocation_faults_enabled: false,
         };
 
         whopper.open_connections()?;
+        whopper.allocation_faults_enabled =
+            allocation_fault::install(seed, opts.allocation_fault_probability)?;
 
         Ok(whopper)
     }
@@ -904,7 +918,11 @@ impl Whopper {
 
             if let Err(error) = op_result {
                 let in_tx = ctx.fiber.state.is_in_tx() && !ctx.fiber.connection.get_auto_commit();
-                match crate::error_handling::classify_op_error(&error, in_tx) {
+                match crate::error_handling::classify_op_error(
+                    &error,
+                    in_tx,
+                    self.allocation_faults_enabled,
+                ) {
                     crate::error_handling::ErrorAction::Rollback => {
                         ctx.fiber.current_op = Some(Operation::Rollback);
                     }
@@ -992,6 +1010,11 @@ impl Whopper {
                 self.seed, fiber_idx,
             )));
             if let Err(e) = op.init_op(&mut ctx) {
+                if self.allocation_faults_enabled
+                    && matches!(e, turso_core::LimboError::OutOfMemory)
+                {
+                    return Ok(());
+                }
                 let err = e.to_string().to_lowercase();
                 // Allow "no such table/index" and "already exists" errors
                 if err.contains("no such")

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -81,6 +81,9 @@ struct Args {
     /// Probability of restarting the full worker cohort per step (multiprocess mode only)
     #[arg(long, default_value_t = 0.0)]
     restart_probability: f64,
+    /// Probability that a Turso fallible allocation fails.
+    #[arg(long, default_value_t = 0.05)]
+    allocation_fault_probability: f64,
     /// Stream multiprocess operation/lifecycle history as JSONL for deterministic debugging
     #[arg(long)]
     history_output: Option<PathBuf>,
@@ -99,6 +102,11 @@ enum SubCmd {
         /// Number of connections to open inside this worker process
         #[arg(long, default_value_t = 1)]
         connections_per_process: usize,
+        /// Probability that a Turso fallible allocation fails.
+        #[arg(long, default_value_t = 0.0)]
+        allocation_fault_probability: f64,
+        #[arg(long, default_value_t = 0, hide = true)]
+        allocation_fault_seed: u64,
     },
 }
 
@@ -111,6 +119,8 @@ fn main() -> anyhow::Result<()> {
         db_path,
         enable_mvcc,
         connections_per_process,
+        allocation_fault_probability,
+        allocation_fault_seed,
     }) = &args.subcommand
     {
         #[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]
@@ -119,6 +129,8 @@ fn main() -> anyhow::Result<()> {
                 db_path,
                 *enable_mvcc,
                 *connections_per_process,
+                *allocation_fault_probability,
+                *allocation_fault_seed,
             );
         }
         #[cfg(not(all(any(unix, target_os = "windows"), target_pointer_width = "64")))]
@@ -182,6 +194,7 @@ fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
         restart_probability: args.restart_probability,
         history_output: args.history_output.clone(),
         keep_files: args.keep,
+        allocation_fault_probability: args.allocation_fault_probability,
     };
 
     println!(
@@ -198,6 +211,12 @@ fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
     }
     if let Some(path) = &args.history_output {
         println!("history_output = {}", path.display());
+    }
+    if args.allocation_fault_probability > 0.0 {
+        println!(
+            "allocation_fault_probability = {}",
+            args.allocation_fault_probability
+        );
     }
 
     let mut whopper = MultiprocessWhopper::new(opts)?;
@@ -248,6 +267,12 @@ fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
 
     if opts.cosmic_ray_probability > 0.0 {
         println!("cosmic ray probability = {}", opts.cosmic_ray_probability);
+    }
+    if opts.allocation_fault_probability > 0.0 {
+        println!(
+            "allocation_fault_probability = {}",
+            opts.allocation_fault_probability
+        );
     }
 
     let reopen_probability = args.reopen_probability.unwrap_or(opts.reopen_probability);
@@ -436,7 +461,8 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         .with_elle_tables(elle_tables)
         .with_workloads(workloads)
         .with_properties(properties)
-        .with_chaotic_profiles(chaotic_profiles);
+        .with_chaotic_profiles(chaotic_profiles)
+        .with_allocation_fault_probability(args.allocation_fault_probability);
 
     Ok(opts)
 }

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -49,6 +49,7 @@ pub struct MultiprocessOpts {
     pub restart_probability: f64,
     pub history_output: Option<PathBuf>,
     pub keep_files: bool,
+    pub allocation_fault_probability: f64,
 }
 
 struct OperationHistoryWriter {
@@ -223,6 +224,8 @@ pub struct MultiprocessWhopper {
     kill_probability: f64,
     restart_probability: f64,
     keep_files: bool,
+    allocation_faults_enabled: bool,
+    allocation_fault_probability: f64,
 }
 
 impl MultiprocessWhopper {
@@ -242,6 +245,8 @@ impl MultiprocessWhopper {
             rng.next_u64()
         });
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let allocation_faults_enabled =
+            crate::allocation_fault::validate_probability(opts.allocation_fault_probability)?;
 
         // Create database file on disk.
         // Use an atomic counter alongside the timestamp to guarantee uniqueness
@@ -339,6 +344,8 @@ impl MultiprocessWhopper {
                 &db_path,
                 opts.enable_mvcc,
                 opts.connections_per_process,
+                opts.allocation_fault_probability,
+                allocation_fault_worker_seed(seed, process_idx),
             )?;
             debug!("process {} ready: {:?}", handle.process_idx, telemetry);
             history.record(&HistoryEvent::WorkerSpawned {
@@ -387,6 +394,8 @@ impl MultiprocessWhopper {
             kill_probability: opts.kill_probability,
             restart_probability: opts.restart_probability,
             keep_files: opts.keep_files,
+            allocation_faults_enabled,
+            allocation_fault_probability: opts.allocation_fault_probability,
         })
     }
 
@@ -585,8 +594,14 @@ impl MultiprocessWhopper {
     ) -> anyhow::Result<(WorkerStartupTelemetry, OpResult)> {
         let sql = sql.into();
         let probe_worker_id = self.processes.len();
-        let (mut worker, telemetry) =
-            spawn_ready_worker(probe_worker_id, &self.db_path, self.enable_mvcc, 1)?;
+        let (mut worker, telemetry) = spawn_ready_worker(
+            probe_worker_id,
+            &self.db_path,
+            self.enable_mvcc,
+            1,
+            self.allocation_fault_probability,
+            allocation_fault_worker_seed(self.seed, probe_worker_id),
+        )?;
 
         let result = (|| -> anyhow::Result<OpResult> {
             for _ in 0..8 {
@@ -679,6 +694,8 @@ impl MultiprocessWhopper {
                 &self.db_path,
                 self.enable_mvcc,
                 self.connections_per_process,
+                self.allocation_fault_probability,
+                allocation_fault_worker_seed(self.seed, process_idx),
             )?;
             self.history.record(&HistoryEvent::WorkerSpawned {
                 step: Some(self.current_step),
@@ -973,7 +990,11 @@ impl MultiprocessWhopper {
             let in_tx = self.connection_states[connection_idx]
                 .fiber_state
                 .is_in_tx();
-            match crate::error_handling::classify_op_error(error, in_tx) {
+            match crate::error_handling::classify_op_error(
+                error,
+                in_tx,
+                self.allocation_faults_enabled,
+            ) {
                 crate::error_handling::ErrorAction::Rollback => {
                     debug!(
                         "connection {}: auto-rollback after {:?}",
@@ -1137,6 +1158,8 @@ impl MultiprocessWhopper {
             &self.db_path,
             self.enable_mvcc,
             self.connections_per_process,
+            self.allocation_fault_probability,
+            allocation_fault_worker_seed(self.seed, location.process_idx),
         )?;
         self.history.record(&HistoryEvent::WorkerSpawned {
             step: Some(self.current_step),
@@ -1205,8 +1228,17 @@ fn spawn_ready_worker(
     db_path: &Path,
     enable_mvcc: bool,
     connections_per_process: usize,
+    allocation_fault_probability: f64,
+    allocation_fault_seed: u64,
 ) -> anyhow::Result<(WorkerProcessHandle, WorkerStartupTelemetry)> {
-    let mut handle = spawn_worker(process_idx, db_path, enable_mvcc, connections_per_process)?;
+    let mut handle = spawn_worker(
+        process_idx,
+        db_path,
+        enable_mvcc,
+        connections_per_process,
+        allocation_fault_probability,
+        allocation_fault_seed,
+    )?;
     let response = recv_response(&mut handle)?;
     match response {
         WorkerResponse::Ready { telemetry } => Ok((handle, telemetry)),
@@ -1224,6 +1256,8 @@ fn spawn_worker(
     db_path: &Path,
     enable_mvcc: bool,
     connections_per_process: usize,
+    allocation_fault_probability: f64,
+    allocation_fault_seed: u64,
 ) -> anyhow::Result<WorkerProcessHandle> {
     let exe = worker_executable()?;
     let mut cmd = Command::new(&exe);
@@ -1232,6 +1266,10 @@ fn spawn_worker(
         .arg(db_path)
         .arg("--connections-per-process")
         .arg(connections_per_process.to_string())
+        .arg("--allocation-fault-probability")
+        .arg(allocation_fault_probability.to_string())
+        .arg("--allocation-fault-seed")
+        .arg(allocation_fault_seed.to_string())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit());
@@ -1254,6 +1292,10 @@ fn spawn_worker(
         responses,
         process_idx,
     })
+}
+
+fn allocation_fault_worker_seed(seed: u64, process_idx: usize) -> u64 {
+    seed ^ ((process_idx as u64).wrapping_add(1)).wrapping_mul(0x9e37_79b9_7f4a_7c15)
 }
 
 fn worker_executable() -> anyhow::Result<PathBuf> {

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -259,6 +259,7 @@ impl Property for IntegrityCheckProperty {
                         | LimboError::CommitDependencyAborted
                         | LimboError::SchemaUpdated
                         | LimboError::SchemaConflict
+                        | LimboError::OutOfMemory
                 ) {
                     return Ok(());
                 }
@@ -1169,6 +1170,7 @@ impl Property for SequenceCorrectnessProperty {
                     || err_msg.contains("Write-write conflict")
                     || err_msg.contains("Commit dependency aborted")
                     || err_msg.contains("Database schema conflict")
+                    || err_msg.contains("Out of memory")
                     || err_msg.contains("setval requires an exclusive transaction")
                 {
                     self.fiber_last_nextval

--- a/testing/concurrent-simulator/protocol.rs
+++ b/testing/concurrent-simulator/protocol.rs
@@ -143,6 +143,7 @@ pub fn limbo_error_to_kind(err: &LimboError) -> &'static str {
         LimboError::InternalError(_) => "InternalError",
         LimboError::Conflict(_) => "Conflict",
         LimboError::CheckpointFailed(_) => "CheckpointFailed",
+        LimboError::OutOfMemory => "OutOfMemory",
         LimboError::ParseError(_) => "ParseError",
         LimboError::TxError(_) => "TxError",
         LimboError::DatabaseFull(_) => "DatabaseFull",
@@ -168,6 +169,7 @@ fn error_kind_to_limbo_error(kind: &str, message: &str) -> LimboError {
         "InternalError" => LimboError::InternalError(message.to_string()),
         "Conflict" => LimboError::Conflict(message.to_string()),
         "CheckpointFailed" => LimboError::CheckpointFailed(message.to_string()),
+        "OutOfMemory" => LimboError::OutOfMemory,
         "ParseError" => LimboError::ParseError(message.to_string()),
         "TxError" => LimboError::TxError(message.to_string()),
         "DatabaseFull" => LimboError::DatabaseFull(message.to_string()),
@@ -204,6 +206,9 @@ mod tests {
                 LimboError::DatabaseFull("nextval: reached minimum value of sequence \"s\"".into()),
                 |e| matches!(e, LimboError::DatabaseFull(m) if m.starts_with("nextval: reached ")),
             ),
+            (LimboError::OutOfMemory, |e| {
+                matches!(e, LimboError::OutOfMemory)
+            }),
             (LimboError::Busy, |e| matches!(e, LimboError::Busy)),
             (LimboError::WriteWriteConflict, |e| {
                 matches!(e, LimboError::WriteWriteConflict)

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -114,6 +114,7 @@ fn create_multiprocess_whopper_with_shape_and_keep(
         restart_probability: 0.0,
         history_output: None,
         keep_files,
+        allocation_fault_probability: 0.0,
     })
     .expect("create multiprocess whopper")
 }

--- a/testing/concurrent-simulator/worker.rs
+++ b/testing/concurrent-simulator/worker.rs
@@ -29,6 +29,8 @@ pub fn run_worker(
     db_path: &str,
     enable_mvcc: bool,
     connections_per_process: usize,
+    allocation_fault_probability: f64,
+    allocation_fault_seed: u64,
 ) -> anyhow::Result<()> {
     // Install a panic hook that writes to stderr so panics don't pollute stdout JSON protocol.
     std::panic::set_hook(Box::new(|info| {
@@ -76,6 +78,7 @@ pub fn run_worker(
     }
 
     let telemetry = worker_startup_telemetry(&db)?;
+    crate::allocation_fault::install(allocation_fault_seed, allocation_fault_probability)?;
 
     // Signal ready
     send_response(&WorkerResponse::Ready { telemetry })?;


### PR DESCRIPTION
## Description
Just adds an additional fault where we can fail some allocation with some probability. In stable right now it won't do anything. When I add fallible allocations to Skiplist that will work on stable. We eventually will want to run this on nightly as well. 

## Motivation and context
Fallible allocation testing in CI


## Description of AI Usage
Codex helped me just put everything together
