### PR TITLE
Fix sqlite_sequence NULL name handling

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -315,7 +315,7 @@ fn emit_rename_sqlite_sequence_entry(
             lhs: sequence_name_reg,
             rhs: row_name_to_replace_reg,
             target_pc: continue_loop_label,
-            flags: CmpInsFlags::default(),
+            flags: CmpInsFlags::default().jump_if_null(),
             collation: None,
         });
 
@@ -395,7 +395,7 @@ fn emit_delete_sqlite_sequence_entry(
             lhs: sequence_name_reg,
             rhs: row_name_to_delete_reg,
             target_pc: continue_loop_label,
-            flags: CmpInsFlags::default(),
+            flags: CmpInsFlags::default().jump_if_null(),
             collation: None,
         });
 

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1719,7 +1719,7 @@ fn reload_autoincrement_state(program: &mut ProgramBuilder, meta: AutoincMeta) {
         lhs: table_name_reg,
         rhs: name_col_reg,
         target_pc: found_label,
-        flags: Default::default(),
+        flags: CmpInsFlags::default().jump_if_null(),
         collation: None,
     });
 

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -2312,7 +2312,7 @@ pub fn translate_drop_table(
             lhs: seq_table_name_reg,
             rhs: dropped_table_name_reg,
             target_pc: continue_loop_label,
-            flags: CmpInsFlags::default(),
+            flags: CmpInsFlags::default().jump_if_null(),
             collation: None,
         });
 

--- a/core/translate/sequence.rs
+++ b/core/translate/sequence.rs
@@ -689,7 +689,7 @@ pub(crate) fn emit_sqlite_sequence_sync(
         lhs: col_name_reg,
         rhs: name_reg,
         target_pc: skip_delete_label,
-        flags: CmpInsFlags::default(),
+        flags: CmpInsFlags::default().jump_if_null(),
         collation: program.curr_collation(),
     });
     program.emit_insn(Insn::Delete {

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -171,6 +171,25 @@ expect {
     t3|1
 }
 
+# Test: A NULL sqlite_sequence.name row does not match a later AUTOINCREMENT update.
+@cross-check-integrity
+test autoinc-null-sequence-name-skipped-on-insert {
+    CREATE TABLE t1(i INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t2(i INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t3(i INTEGER PRIMARY KEY AUTOINCREMENT);
+    INSERT INTO t1 VALUES(NULL);
+    INSERT INTO t2 VALUES(NULL);
+    INSERT INTO t3 VALUES(NULL);
+    UPDATE sqlite_sequence SET name=NULL WHERE name='t2';
+    INSERT INTO t3 VALUES(NULL);
+    SELECT rowid, name, seq FROM sqlite_sequence ORDER BY rowid;
+}
+expect {
+    1|t1|1
+    2||1
+    3|t3|2
+}
+
 # Test: Dropping an AUTOINCREMENT table removes its entry from sqlite_sequence.
 @cross-check-integrity
 test autoinc-drop-table-removes-sequence-entry {
@@ -183,6 +202,21 @@ test autoinc-drop-table-removes-sequence-entry {
 }
 expect {
     t2
+}
+
+# Test: DROP TABLE skips unrelated NULL sqlite_sequence.name rows.
+@cross-check-integrity
+test autoinc-drop-table-skips-null-sequence-name {
+    CREATE TABLE t1(i INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t2(i INTEGER PRIMARY KEY AUTOINCREMENT);
+    INSERT INTO t1 VALUES(NULL);
+    INSERT INTO t2 VALUES(NULL);
+    UPDATE sqlite_sequence SET name=NULL WHERE name='t1';
+    DROP TABLE t2;
+    SELECT rowid, name, seq FROM sqlite_sequence ORDER BY rowid;
+}
+expect {
+    1||1
 }
 
 # Test: When the last AUTOINCREMENT table is dropped, the sequence table remains but is empty.
@@ -227,6 +261,22 @@ expect {
     t2|2
 }
 
+# Test: ALTER TABLE RENAME skips unrelated NULL sqlite_sequence.name rows.
+@cross-check-integrity
+test autoinc-rename-table-skips-null-sequence-name {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY AUTOINCREMENT);
+    INSERT INTO t1 VALUES(NULL);
+    INSERT INTO t2 VALUES(NULL);
+    UPDATE sqlite_sequence SET name=NULL WHERE name='t1';
+    ALTER TABLE t2 RENAME TO t3;
+    SELECT rowid, name, seq FROM sqlite_sequence ORDER BY rowid;
+}
+expect {
+    1||1
+    2|t3|1
+}
+
 # Regression test for https://github.com/tursodatabase/turso/issues/6769
 @skip-if sqlite "ALTER COLUMN is a Turso extension"
 test autoinc-alter-column-clears-sequence-row {
@@ -246,6 +296,21 @@ expect {
     1|x
     2|y
     |z
+}
+
+# ALTER COLUMN cleanup skips unrelated NULL sqlite_sequence.name rows.
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
+test autoinc-alter-column-skips-null-sequence-name {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY AUTOINCREMENT);
+    INSERT INTO t1 VALUES(NULL);
+    INSERT INTO t2 VALUES(NULL);
+    UPDATE sqlite_sequence SET name=NULL WHERE name='t1';
+    ALTER TABLE t2 ALTER COLUMN id TO id2 TEXT;
+    SELECT rowid, name, seq FROM sqlite_sequence ORDER BY rowid;
+}
+expect {
+    1||1
 }
 
 # Test: AUTOINCREMENT fails if the maximum rowid is reached. (Assumes 64-bit rowid)


### PR DESCRIPTION
## Description

Treat `sqlite_sequence` rows with a `NULL` `name` as non-matches when scanning
for AUTOINCREMENT metadata during insert, table drop, table rename, ALTER COLUMN
cleanup, and MVCC sequence sync.

## Motivation and context

SQLite allows direct writes to `sqlite_sequence`, including setting `name` to
`NULL`. Those rows should not be treated as matching another AUTOINCREMENT table
name during internal sequence maintenance.

Fixes #6966.

Validation:
- `cargo fmt`
- `git diff --check`
- `make -C testing/sqltests run-rust ARGS='--filter null-sequence-name --snapshot-filter __never__'`
- `cd testing/sqltests && cargo run --bin test-runner run tests/autoincr.sqltest --backend rust --snapshot-filter __never__`
- `cargo run -q --bin tursodb -- :memory: "CREATE TABLE t1(i INTEGER PRIMARY KEY AUTOINCREMENT); CREATE TABLE t2(i INTEGER PRIMARY KEY AUTOINCREMENT); CREATE TABLE t3(i INTEGER PRIMARY KEY AUTOINCREMENT); INSERT INTO t1 VALUES(NULL); INSERT INTO t2 VALUES(NULL); INSERT INTO t3 VALUES(NULL); UPDATE sqlite_sequence SET name=NULL WHERE name='t2'; INSERT INTO t3 VALUES(NULL); SELECT rowid, name, seq FROM sqlite_sequence ORDER BY rowid;" --output-mode list`
