### PR TITLE
Add mobile NuGet native targets

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -50,6 +50,26 @@ jobs:
           target: aarch64-unknown-linux-gnu
           docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
 
+        - os: ubuntu-latest
+          make-target: build-rust-androidarm64
+          artifact-name: native-android-arm64
+          target: aarch64-linux-android
+
+        - os: ubuntu-latest
+          make-target: build-rust-androidarm
+          artifact-name: native-android-arm
+          target: armv7-linux-androideabi
+
+        - os: ubuntu-latest
+          make-target: build-rust-androidx64
+          artifact-name: native-android-x64
+          target: x86_64-linux-android
+
+        - os: ubuntu-latest
+          make-target: build-rust-androidx86
+          artifact-name: native-android-x86
+          target: i686-linux-android
+
         - os: macos-latest
           make-target: build-rust-macos64
           artifact-name: native-osx-x64
@@ -61,6 +81,18 @@ jobs:
           target: aarch64-apple-darwin
           artifact-name: native-osx-arm64
           macos-deployment-target: "11.0"
+
+        - os: macos-latest
+          make-target: build-rust-iosarm64
+          target: aarch64-apple-ios
+          artifact-name: native-ios-arm64
+          ios-deployment-target: "12.2"
+
+        - os: macos-latest
+          make-target: build-rust-iossimulatorarm64
+          target: aarch64-apple-ios-sim
+          artifact-name: native-iossimulator-arm64
+          ios-deployment-target: "12.2"
 
         - os: windows-2025
           make-target: build-rust-windows64
@@ -98,6 +130,22 @@ jobs:
           prefix-key: "v1-rust-dotnet-publish"
           cache-on-failure: true
 
+      - name: Set up Android SDK
+        if: contains(matrix.target, 'linux-android')
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android NDK
+        if: contains(matrix.target, 'linux-android')
+        shell: bash
+        run: |
+          sdkmanager --install "ndk;27.2.12479018"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.2.12479018" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$ANDROID_HOME/ndk/27.2.12479018" >> "$GITHUB_ENV"
+
+      - name: Install cargo-ndk
+        if: contains(matrix.target, 'linux-android')
+        run: cargo install cargo-ndk --locked
+
       - name: Build rust native library (Linux in Docker)
         if: contains(matrix.target, 'unknown-linux-gnu')
         shell: bash
@@ -131,8 +179,14 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-deployment-target }}
         run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official'
 
+      - name: Build rust native library (iOS)
+        if: contains(matrix.target, 'apple-ios')
+        env:
+          IPHONEOS_DEPLOYMENT_TARGET: ${{ matrix.ios-deployment-target }}
+        run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official'
+
       - name: Build rust native library
-        if: ${{ !contains(matrix.target, 'unknown-linux-gnu') && !contains(matrix.target, 'apple-darwin') }}
+        if: ${{ !contains(matrix.target, 'unknown-linux-gnu') && !contains(matrix.target, 'apple-darwin') && !contains(matrix.target, 'apple-ios') }}
         run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official'
       
       - name: Upload rust native library
@@ -146,9 +200,40 @@ jobs:
 
           retention-days: 1
 
+  package-ios-framework:
+    needs: build-natives
+    runs-on: macos-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: ${{ env.working-directory }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download iOS native libraries
+        uses: actions/download-artifact@v7
+        with:
+          pattern: native-ios*
+          path: ${{ env.working-directory }}/rs_compiled
+          merge-multiple: true
+
+      - name: Package iOS XCFramework
+        run: make package-rust-iosframework RUST_PROFILE_DIR=release-official
+
+      - name: Upload iOS XCFramework
+        uses: actions/upload-artifact@v6
+        with:
+          name: native-ios-universal
+          path: ${{ env.working-directory }}/rs_compiled/**/libturso_sdk_kit.xcframework/**
+          retention-days: 1
+
   # Create NuGet packages; publish is opt-in
   publish:
-    needs: build-natives
+    needs: [build-natives, package-ios-framework]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -180,6 +265,33 @@ jobs:
       - name: Build and pack 
         run:
           make pack
+
+      - name: Verify mobile NuGet native assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          package=$(find src/Turso.Data.Sqlite/bin/Release -maxdepth 1 -name 'Turso.Data.Sqlite.*.nupkg' | head -n 1)
+          if [ -z "$package" ]; then
+            echo "No Turso.Data.Sqlite NuGet package found"
+            exit 1
+          fi
+          unzip -Z1 "$package" > package-files.txt
+          required_files=(
+            "buildTransitive/Turso.Data.Sqlite.targets"
+            "runtimes/android-arm64/native/libturso_sdk_kit.so"
+            "runtimes/android-arm/native/libturso_sdk_kit.so"
+            "runtimes/android-x64/native/libturso_sdk_kit.so"
+            "runtimes/android-x86/native/libturso_sdk_kit.so"
+            "runtimes/ios-universal/native/libturso_sdk_kit.xcframework/Info.plist"
+            "runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64/libturso_sdk_kit.framework/libturso_sdk_kit"
+            "runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64-simulator/libturso_sdk_kit.framework/libturso_sdk_kit"
+          )
+          for required_file in "${required_files[@]}"; do
+            if ! grep -Fxq "$required_file" package-files.txt; then
+              echo "Missing $required_file in $package"
+              exit 1
+            fi
+          done
 
       - name: Collect NuGet packages
         run: |

--- a/bindings/dotnet/Makefile
+++ b/bindings/dotnet/Makefile
@@ -16,7 +16,12 @@ else
 endif
 
 RUST_RELEASE_OPT ?= 
+RUST_PROFILE_DIR ?= debug
 DOTNET_RELEASE_OPT ?=
+IOS_FRAMEWORK_NAME = libturso_sdk_kit
+IOS_DYLIB_FILE = libturso_sdk_kit.dylib
+IOS_FRAMEWORK_BUILD_DIR = ./rs_compiled/ios-frameworks
+IOS_XCFRAMEWORK_DIR = ./rs_compiled/ios-universal/native/$(IOS_FRAMEWORK_NAME).xcframework
 
 all:
 	echo "make [build|test|benchmark|build-production]"
@@ -38,6 +43,63 @@ build-rust-macos64:
 
 build-rust-macosarm64:
 	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target aarch64-apple-darwin $(RUST_RELEASE_OPT)
+
+build-rust-androidarm64:
+	cargo ndk --target aarch64-linux-android --platform 31 build -p turso_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+
+build-rust-androidarm:
+	cargo ndk --target armv7-linux-androideabi --platform 31 build -p turso_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+
+build-rust-androidx64:
+	cargo ndk --target x86_64-linux-android --platform 31 build -p turso_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+
+build-rust-androidx86:
+	cargo ndk --target i686-linux-android --platform 31 build -p turso_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+
+build-rust-android: build-rust-androidarm64 build-rust-androidarm build-rust-androidx64 build-rust-androidx86
+
+build-rust-iosarm64:
+	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target aarch64-apple-ios $(RUST_RELEASE_OPT)
+
+build-rust-iossimulatorarm64:
+	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target aarch64-apple-ios-sim $(RUST_RELEASE_OPT)
+
+build-rust-ios: build-rust-iosarm64 build-rust-iossimulatorarm64
+
+package-rust-iosframework:
+	rm -rf "$(IOS_FRAMEWORK_BUILD_DIR)" "$(IOS_XCFRAMEWORK_DIR)"
+	mkdir -p "$(IOS_FRAMEWORK_BUILD_DIR)/device/$(IOS_FRAMEWORK_NAME).framework" "$(IOS_FRAMEWORK_BUILD_DIR)/simulator/$(IOS_FRAMEWORK_NAME).framework" ./rs_compiled/ios-universal/native
+	cp ./rs_compiled/aarch64-apple-ios/$(RUST_PROFILE_DIR)/$(IOS_DYLIB_FILE) "$(IOS_FRAMEWORK_BUILD_DIR)/device/$(IOS_FRAMEWORK_NAME).framework/$(IOS_FRAMEWORK_NAME)"
+	install_name_tool -id @rpath/$(IOS_FRAMEWORK_NAME).framework/$(IOS_FRAMEWORK_NAME) "$(IOS_FRAMEWORK_BUILD_DIR)/device/$(IOS_FRAMEWORK_NAME).framework/$(IOS_FRAMEWORK_NAME)"
+	cp ./rs_compiled/aarch64-apple-ios-sim/$(RUST_PROFILE_DIR)/$(IOS_DYLIB_FILE) "$(IOS_FRAMEWORK_BUILD_DIR)/simulator/$(IOS_FRAMEWORK_NAME).framework/$(IOS_FRAMEWORK_NAME)"
+	install_name_tool -id @rpath/$(IOS_FRAMEWORK_NAME).framework/$(IOS_FRAMEWORK_NAME) "$(IOS_FRAMEWORK_BUILD_DIR)/simulator/$(IOS_FRAMEWORK_NAME).framework/$(IOS_FRAMEWORK_NAME)"
+	printf '%s\n' \
+	'<?xml version="1.0" encoding="UTF-8"?>' \
+	'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
+	'<plist version="1.0">' \
+	'<dict>' \
+	'  <key>CFBundleDevelopmentRegion</key>' \
+	'  <string>en</string>' \
+	'  <key>CFBundleExecutable</key>' \
+	'  <string>$(IOS_FRAMEWORK_NAME)</string>' \
+	'  <key>CFBundleIdentifier</key>' \
+	'  <string>com.turso.turso-sdk-kit</string>' \
+	'  <key>CFBundleInfoDictionaryVersion</key>' \
+	'  <string>6.0</string>' \
+	'  <key>CFBundlePackageType</key>' \
+	'  <string>FMWK</string>' \
+	'  <key>CFBundleSignature</key>' \
+	'  <string>????</string>' \
+	'  <key>CFBundleVersion</key>' \
+	'  <string>1.0.0</string>' \
+	'  <key>CFBundleShortVersionString</key>' \
+	'  <string>1.0.0</string>' \
+	'  <key>MinimumOSVersion</key>' \
+	'  <string>12.2</string>' \
+	'</dict>' \
+	'</plist>' > "$(IOS_FRAMEWORK_BUILD_DIR)/device/$(IOS_FRAMEWORK_NAME).framework/Info.plist"
+	cp "$(IOS_FRAMEWORK_BUILD_DIR)/device/$(IOS_FRAMEWORK_NAME).framework/Info.plist" "$(IOS_FRAMEWORK_BUILD_DIR)/simulator/$(IOS_FRAMEWORK_NAME).framework/Info.plist"
+	xcodebuild -create-xcframework -framework "$(IOS_FRAMEWORK_BUILD_DIR)/device/$(IOS_FRAMEWORK_NAME).framework" -framework "$(IOS_FRAMEWORK_BUILD_DIR)/simulator/$(IOS_FRAMEWORK_NAME).framework" -output "$(IOS_XCFRAMEWORK_DIR)"
 
 build-rust: 
 	echo "Building for $(OS_TARGET)"

--- a/bindings/dotnet/Readme.md
+++ b/bindings/dotnet/Readme.md
@@ -12,7 +12,7 @@ dotnet add package Turso.Data.Sqlite
 
 Application code only needs to reference `Turso.Data.Sqlite`.
 
-The package targets `net8.0`, `net9.0`, and `net10.0`.
+The package targets `net8.0`, `net9.0`, and `net10.0`. It includes native runtime assets for Windows, Linux, macOS, Android (`android-arm64`, `android-arm`, `android-x64`, and `android-x86`), and iOS as an XCFramework with device and simulator slices.
 
 ## Getting started
 

--- a/bindings/dotnet/src/Turso.Data.Sqlite/Turso.Data.Sqlite.csproj
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/Turso.Data.Sqlite.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <None Include="..\..\Readme.md" Pack="true" PackagePath="README.md" />
+    <None Include="buildTransitive\Turso.Data.Sqlite.targets" Pack="true" PackagePath="buildTransitive\Turso.Data.Sqlite.targets" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Release'">
@@ -98,6 +99,70 @@
       <Pack>true</Pack>
       <PackagePath>runtimes\linux-arm64\native\libturso_sdk_kit.so</PackagePath>
     </None>
+    <None Include="..\..\rs_compiled\aarch64-linux-android\release-official\libturso_sdk_kit.so"
+          Visible="false"
+          Condition="Exists('..\..\rs_compiled\aarch64-linux-android\release-official\libturso_sdk_kit.so')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>runtimes\android-arm64\native\libturso_sdk_kit.so</TargetPath>
+      <Pack>true</Pack>
+      <PackagePath>runtimes\android-arm64\native\libturso_sdk_kit.so</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\aarch64-linux-android\release\libturso_sdk_kit.so"
+          Visible="false"
+          Condition="!Exists('..\..\rs_compiled\aarch64-linux-android\release-official\libturso_sdk_kit.so') and Exists('..\..\rs_compiled\aarch64-linux-android\release\libturso_sdk_kit.so')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>runtimes\android-arm64\native\libturso_sdk_kit.so</TargetPath>
+      <Pack>true</Pack>
+      <PackagePath>runtimes\android-arm64\native\libturso_sdk_kit.so</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\armv7-linux-androideabi\release-official\libturso_sdk_kit.so"
+          Visible="false"
+          Condition="Exists('..\..\rs_compiled\armv7-linux-androideabi\release-official\libturso_sdk_kit.so')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>runtimes\android-arm\native\libturso_sdk_kit.so</TargetPath>
+      <Pack>true</Pack>
+      <PackagePath>runtimes\android-arm\native\libturso_sdk_kit.so</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\armv7-linux-androideabi\release\libturso_sdk_kit.so"
+          Visible="false"
+          Condition="!Exists('..\..\rs_compiled\armv7-linux-androideabi\release-official\libturso_sdk_kit.so') and Exists('..\..\rs_compiled\armv7-linux-androideabi\release\libturso_sdk_kit.so')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>runtimes\android-arm\native\libturso_sdk_kit.so</TargetPath>
+      <Pack>true</Pack>
+      <PackagePath>runtimes\android-arm\native\libturso_sdk_kit.so</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\x86_64-linux-android\release-official\libturso_sdk_kit.so"
+          Visible="false"
+          Condition="Exists('..\..\rs_compiled\x86_64-linux-android\release-official\libturso_sdk_kit.so')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>runtimes\android-x64\native\libturso_sdk_kit.so</TargetPath>
+      <Pack>true</Pack>
+      <PackagePath>runtimes\android-x64\native\libturso_sdk_kit.so</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\x86_64-linux-android\release\libturso_sdk_kit.so"
+          Visible="false"
+          Condition="!Exists('..\..\rs_compiled\x86_64-linux-android\release-official\libturso_sdk_kit.so') and Exists('..\..\rs_compiled\x86_64-linux-android\release\libturso_sdk_kit.so')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>runtimes\android-x64\native\libturso_sdk_kit.so</TargetPath>
+      <Pack>true</Pack>
+      <PackagePath>runtimes\android-x64\native\libturso_sdk_kit.so</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\i686-linux-android\release-official\libturso_sdk_kit.so"
+          Visible="false"
+          Condition="Exists('..\..\rs_compiled\i686-linux-android\release-official\libturso_sdk_kit.so')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>runtimes\android-x86\native\libturso_sdk_kit.so</TargetPath>
+      <Pack>true</Pack>
+      <PackagePath>runtimes\android-x86\native\libturso_sdk_kit.so</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\i686-linux-android\release\libturso_sdk_kit.so"
+          Visible="false"
+          Condition="!Exists('..\..\rs_compiled\i686-linux-android\release-official\libturso_sdk_kit.so') and Exists('..\..\rs_compiled\i686-linux-android\release\libturso_sdk_kit.so')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>runtimes\android-x86\native\libturso_sdk_kit.so</TargetPath>
+      <Pack>true</Pack>
+      <PackagePath>runtimes\android-x86\native\libturso_sdk_kit.so</PackagePath>
+    </None>
     <None Include="..\..\rs_compiled\x86_64-apple-darwin\release-official\libturso_sdk_kit.dylib"
           Visible="false"
           Condition="Exists('..\..\rs_compiled\x86_64-apple-darwin\release-official\libturso_sdk_kit.dylib')">
@@ -130,6 +195,41 @@
       <Pack>true</Pack>
       <PackagePath>runtimes\osx-arm64\native\libturso_sdk_kit.dylib</PackagePath>
     </None>
+    <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\Info.plist"
+          Visible="false"
+          Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\Info.plist')">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\Info.plist"
+          Visible="false"
+          Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\Info.plist')">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64/libturso_sdk_kit.framework/</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\libturso_sdk_kit"
+          Visible="false"
+          Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\libturso_sdk_kit')">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64/libturso_sdk_kit.framework/</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\Info.plist"
+          Visible="false"
+          Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\Info.plist')">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64-simulator/libturso_sdk_kit.framework/</PackagePath>
+    </None>
+    <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\libturso_sdk_kit"
+          Visible="false"
+          Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\libturso_sdk_kit')">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64-simulator/libturso_sdk_kit.framework/</PackagePath>
+    </None>
   </ItemGroup>
 
   <Target Name="AddProjectReferencesToPackage">
@@ -155,9 +255,19 @@
            Text="Missing linux-x64 native asset. Build libturso_sdk_kit.so before packing Turso.Data.Sqlite." />
     <Error Condition="!Exists('..\..\rs_compiled\aarch64-unknown-linux-gnu\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\aarch64-unknown-linux-gnu\release-official\libturso_sdk_kit.so')"
            Text="Missing linux-arm64 native asset. Build libturso_sdk_kit.so before packing Turso.Data.Sqlite." />
+    <Error Condition="!Exists('..\..\rs_compiled\aarch64-linux-android\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\aarch64-linux-android\release-official\libturso_sdk_kit.so')"
+           Text="Missing android-arm64 native asset. Build libturso_sdk_kit.so before packing Turso.Data.Sqlite." />
+    <Error Condition="!Exists('..\..\rs_compiled\armv7-linux-androideabi\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\armv7-linux-androideabi\release-official\libturso_sdk_kit.so')"
+           Text="Missing android-arm native asset. Build libturso_sdk_kit.so before packing Turso.Data.Sqlite." />
+    <Error Condition="!Exists('..\..\rs_compiled\x86_64-linux-android\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\x86_64-linux-android\release-official\libturso_sdk_kit.so')"
+           Text="Missing android-x64 native asset. Build libturso_sdk_kit.so before packing Turso.Data.Sqlite." />
+    <Error Condition="!Exists('..\..\rs_compiled\i686-linux-android\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\i686-linux-android\release-official\libturso_sdk_kit.so')"
+           Text="Missing android-x86 native asset. Build libturso_sdk_kit.so before packing Turso.Data.Sqlite." />
     <Error Condition="!Exists('..\..\rs_compiled\x86_64-apple-darwin\release\libturso_sdk_kit.dylib') and !Exists('..\..\rs_compiled\x86_64-apple-darwin\release-official\libturso_sdk_kit.dylib')"
            Text="Missing osx-x64 native asset. Build libturso_sdk_kit.dylib before packing Turso.Data.Sqlite." />
     <Error Condition="!Exists('..\..\rs_compiled\aarch64-apple-darwin\release\libturso_sdk_kit.dylib') and !Exists('..\..\rs_compiled\aarch64-apple-darwin\release-official\libturso_sdk_kit.dylib')"
            Text="Missing osx-arm64 native asset. Build libturso_sdk_kit.dylib before packing Turso.Data.Sqlite." />
+    <Error Condition="!Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\Info.plist')"
+           Text="Missing iOS framework asset. Build libturso_sdk_kit.xcframework before packing Turso.Data.Sqlite." />
   </Target>
 </Project>

--- a/bindings/dotnet/src/Turso.Data.Sqlite/buildTransitive/Turso.Data.Sqlite.targets
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/buildTransitive/Turso.Data.Sqlite.targets
@@ -1,0 +1,44 @@
+<Project>
+  <PropertyGroup>
+    <_TursoDataSqlitePackageRoot>$(MSBuildThisFileDirectory)..\</_TursoDataSqlitePackageRoot>
+    <_TursoDataSqliteTargetPlatform>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</_TursoDataSqliteTargetPlatform>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_TursoDataSqliteTargetPlatform)' == 'android' and ($(AndroidSupportedAbis.Contains('armeabi-v7a')) or $(RuntimeIdentifiers.Contains('android-arm')) or '$(RuntimeIdentifier)' == 'android-arm')">
+    <AndroidNativeLibrary Include="$(_TursoDataSqlitePackageRoot)runtimes\android-arm\native\libturso_sdk_kit.so"
+                          Condition="Exists('$(_TursoDataSqlitePackageRoot)runtimes\android-arm\native\libturso_sdk_kit.so')">
+      <Link>%(Filename)%(Extension)</Link>
+      <Abi>armeabi-v7a</Abi>
+    </AndroidNativeLibrary>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(_TursoDataSqliteTargetPlatform)' == 'android' and ($(AndroidSupportedAbis.Contains('arm64-v8a')) or $(RuntimeIdentifiers.Contains('android-arm64')) or '$(RuntimeIdentifier)' == 'android-arm64')">
+    <AndroidNativeLibrary Include="$(_TursoDataSqlitePackageRoot)runtimes\android-arm64\native\libturso_sdk_kit.so"
+                          Condition="Exists('$(_TursoDataSqlitePackageRoot)runtimes\android-arm64\native\libturso_sdk_kit.so')">
+      <Link>%(Filename)%(Extension)</Link>
+      <Abi>arm64-v8a</Abi>
+    </AndroidNativeLibrary>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(_TursoDataSqliteTargetPlatform)' == 'android' and ($(AndroidSupportedAbis.Contains('x86')) or $(RuntimeIdentifiers.Contains('android-x86')) or '$(RuntimeIdentifier)' == 'android-x86')">
+    <AndroidNativeLibrary Include="$(_TursoDataSqlitePackageRoot)runtimes\android-x86\native\libturso_sdk_kit.so"
+                          Condition="Exists('$(_TursoDataSqlitePackageRoot)runtimes\android-x86\native\libturso_sdk_kit.so')">
+      <Link>%(Filename)%(Extension)</Link>
+      <Abi>x86</Abi>
+    </AndroidNativeLibrary>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(_TursoDataSqliteTargetPlatform)' == 'android' and ($(AndroidSupportedAbis.Contains('x86_64')) or $(RuntimeIdentifiers.Contains('android-x64')) or '$(RuntimeIdentifier)' == 'android-x64')">
+    <AndroidNativeLibrary Include="$(_TursoDataSqlitePackageRoot)runtimes\android-x64\native\libturso_sdk_kit.so"
+                          Condition="Exists('$(_TursoDataSqlitePackageRoot)runtimes\android-x64\native\libturso_sdk_kit.so')">
+      <Link>%(Filename)%(Extension)</Link>
+      <Abi>x86_64</Abi>
+    </AndroidNativeLibrary>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(_TursoDataSqliteTargetPlatform)' == 'ios'">
+    <NativeReference Include="$(_TursoDataSqlitePackageRoot)runtimes\ios-universal\native\libturso_sdk_kit.xcframework"
+                     Condition="Exists('$(_TursoDataSqlitePackageRoot)runtimes\ios-universal\native\libturso_sdk_kit.xcframework')"
+                     Kind="Framework" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/src/Turso.Raw/Turso.Raw.csproj
+++ b/bindings/dotnet/src/Turso.Raw/Turso.Raw.csproj
@@ -53,6 +53,38 @@
             <Pack>true</Pack>
             <PackagePath>runtimes\linux-arm64\native\libturso_sdk_kit.so</PackagePath>
         </None>
+        <None Include="..\..\rs_compiled\aarch64-linux-android\debug\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\aarch64-linux-android\debug\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-arm64\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-arm64\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\armv7-linux-androideabi\debug\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\armv7-linux-androideabi\debug\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-arm\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-arm\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\x86_64-linux-android\debug\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\x86_64-linux-android\debug\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-x64\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-x64\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\i686-linux-android\debug\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\i686-linux-android\debug\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-x86\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-x86\native\libturso_sdk_kit.so</PackagePath>
+        </None>
         <None Include="..\..\rs_compiled\x86_64-apple-darwin\debug\libturso_sdk_kit.dylib"
               Visible="false"
               Condition="Exists('..\..\rs_compiled\x86_64-apple-darwin\debug\libturso_sdk_kit.dylib')">
@@ -68,6 +100,41 @@
             <TargetPath>runtimes\osx-arm64\native\libturso_sdk_kit.dylib</TargetPath>
             <Pack>true</Pack>
             <PackagePath>runtimes\osx-arm64\native\libturso_sdk_kit.dylib</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\Info.plist"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\Info.plist')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\Info.plist"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\Info.plist')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64/libturso_sdk_kit.framework/</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\libturso_sdk_kit"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\libturso_sdk_kit')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64/libturso_sdk_kit.framework/</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\Info.plist"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\Info.plist')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64-simulator/libturso_sdk_kit.framework/</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\libturso_sdk_kit"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\libturso_sdk_kit')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64-simulator/libturso_sdk_kit.framework/</PackagePath>
         </None>
     </ItemGroup>
     <ItemGroup Condition="'$(Configuration)'=='Release'">
@@ -135,6 +202,70 @@
             <Pack>true</Pack>
             <PackagePath>runtimes\linux-arm64\native\libturso_sdk_kit.so</PackagePath>
         </None>
+        <None Include="..\..\rs_compiled\aarch64-linux-android\release-official\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\aarch64-linux-android\release-official\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-arm64\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-arm64\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\aarch64-linux-android\release\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\aarch64-linux-android\release\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-arm64\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-arm64\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\armv7-linux-androideabi\release-official\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\armv7-linux-androideabi\release-official\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-arm\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-arm\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\armv7-linux-androideabi\release\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\armv7-linux-androideabi\release\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-arm\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-arm\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\x86_64-linux-android\release-official\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\x86_64-linux-android\release-official\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-x64\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-x64\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\x86_64-linux-android\release\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\x86_64-linux-android\release\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-x64\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-x64\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\i686-linux-android\release-official\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\i686-linux-android\release-official\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-x86\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-x86\native\libturso_sdk_kit.so</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\i686-linux-android\release\libturso_sdk_kit.so"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\i686-linux-android\release\libturso_sdk_kit.so')">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <TargetPath>runtimes\android-x86\native\libturso_sdk_kit.so</TargetPath>
+            <Pack>true</Pack>
+            <PackagePath>runtimes\android-x86\native\libturso_sdk_kit.so</PackagePath>
+        </None>
         <None Include="..\..\rs_compiled\x86_64-apple-darwin\release-official\libturso_sdk_kit.dylib"
               Visible="false"
               Condition="Exists('..\..\rs_compiled\x86_64-apple-darwin\release-official\libturso_sdk_kit.dylib')">
@@ -167,6 +298,41 @@
             <Pack>true</Pack>
             <PackagePath>runtimes\osx-arm64\native\libturso_sdk_kit.dylib</PackagePath>
         </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\Info.plist"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\Info.plist')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\Info.plist"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\Info.plist')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64/libturso_sdk_kit.framework/</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\libturso_sdk_kit"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64\libturso_sdk_kit.framework\libturso_sdk_kit')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64/libturso_sdk_kit.framework/</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\Info.plist"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\Info.plist')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64-simulator/libturso_sdk_kit.framework/</PackagePath>
+        </None>
+        <None Include="..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\libturso_sdk_kit"
+              Visible="false"
+              Condition="Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\ios-arm64-simulator\libturso_sdk_kit.framework\libturso_sdk_kit')">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>runtimes/ios-universal/native/libturso_sdk_kit.xcframework/ios-arm64-simulator/libturso_sdk_kit.framework/</PackagePath>
+        </None>
     </ItemGroup>
 
     <Target Name="ValidateNativeAssetsForPack" BeforeTargets="Pack"
@@ -179,9 +345,19 @@
                Text="Missing linux-x64 native asset. Build libturso_sdk_kit.so before packing Turso.Raw." />
         <Error Condition="!Exists('..\..\rs_compiled\aarch64-unknown-linux-gnu\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\aarch64-unknown-linux-gnu\release-official\libturso_sdk_kit.so')"
                Text="Missing linux-arm64 native asset. Build libturso_sdk_kit.so before packing Turso.Raw." />
+        <Error Condition="!Exists('..\..\rs_compiled\aarch64-linux-android\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\aarch64-linux-android\release-official\libturso_sdk_kit.so')"
+               Text="Missing android-arm64 native asset. Build libturso_sdk_kit.so before packing Turso.Raw." />
+        <Error Condition="!Exists('..\..\rs_compiled\armv7-linux-androideabi\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\armv7-linux-androideabi\release-official\libturso_sdk_kit.so')"
+               Text="Missing android-arm native asset. Build libturso_sdk_kit.so before packing Turso.Raw." />
+        <Error Condition="!Exists('..\..\rs_compiled\x86_64-linux-android\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\x86_64-linux-android\release-official\libturso_sdk_kit.so')"
+               Text="Missing android-x64 native asset. Build libturso_sdk_kit.so before packing Turso.Raw." />
+        <Error Condition="!Exists('..\..\rs_compiled\i686-linux-android\release\libturso_sdk_kit.so') and !Exists('..\..\rs_compiled\i686-linux-android\release-official\libturso_sdk_kit.so')"
+               Text="Missing android-x86 native asset. Build libturso_sdk_kit.so before packing Turso.Raw." />
         <Error Condition="!Exists('..\..\rs_compiled\x86_64-apple-darwin\release\libturso_sdk_kit.dylib') and !Exists('..\..\rs_compiled\x86_64-apple-darwin\release-official\libturso_sdk_kit.dylib')"
                Text="Missing osx-x64 native asset. Build libturso_sdk_kit.dylib before packing Turso.Raw." />
         <Error Condition="!Exists('..\..\rs_compiled\aarch64-apple-darwin\release\libturso_sdk_kit.dylib') and !Exists('..\..\rs_compiled\aarch64-apple-darwin\release-official\libturso_sdk_kit.dylib')"
                Text="Missing osx-arm64 native asset. Build libturso_sdk_kit.dylib before packing Turso.Raw." />
+        <Error Condition="!Exists('..\..\rs_compiled\ios-universal\native\libturso_sdk_kit.xcframework\Info.plist')"
+               Text="Missing iOS framework asset. Build libturso_sdk_kit.xcframework before packing Turso.Raw." />
     </Target>
 </Project>

--- a/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Turso.Raw.Public;
 using Turso.Raw.Public.Handles;
@@ -47,6 +48,24 @@ internal struct TursoDatabaseConfig
 internal static class TursoInterop
 {
     private const string DllName = "turso_sdk_kit";
+
+    static TursoInterop()
+    {
+        if (OperatingSystem.IsIOS())
+        {
+            NativeLibrary.SetDllImportResolver(typeof(TursoInterop).Assembly, ResolveDllImport);
+        }
+    }
+
+    private static IntPtr ResolveDllImport(
+        string libraryName,
+        Assembly assembly,
+        DllImportSearchPath? searchPath)
+    {
+        return libraryName == DllName
+            ? NativeLibrary.Load($"Frameworks/lib{libraryName}.framework/lib{libraryName}", assembly, searchPath)
+            : IntPtr.Zero;
+    }
 
     [DllImport(DllName, EntryPoint = "turso_database_new", CallingConvention = CallingConvention.Cdecl)]
     public static extern TursoStatusCode DatabaseNew(


### PR DESCRIPTION
## Summary
- add Android native assets for android-arm64, android-arm, android-x64, and android-x86
- package iOS as libturso_sdk_kit.xcframework with device and simulator slices
- wire AndroidNativeLibrary and iOS framework NativeReference metadata through buildTransitive

## Validation
- dotnet build .\bindings\dotnet\Turso.slnx
- Dotnet Publish passed before squashing with the same changes and verified the NuGet package contents