### PR TITLE
ci: shard CodSpeed benchmarks by toolchain and benchmark

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -15,24 +15,74 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  CODSPEED_STICKY_DISK_KEY: ${{ github.repository }}-codspeed-${{ github.run_id }}-${{ github.run_attempt }}
+
 jobs:
-  benchmarks:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 60
-    # Allow this job to fail without failing the entire CI run
-    continue-on-error: true
+  discover:
+    name: Discover benchmark shards
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    outputs:
+      benchmarks: ${{ steps.benchmarks.outputs.benchmarks }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@1.88.0
 
+      - name: Resolve benchmark shards
+        id: benchmarks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t benchmarks < <(make codspeed-benchmarks-exclude-tpc-h)
+          if [ "${#benchmarks[@]}" -eq 0 ]; then
+            echo "No benchmarks found (excluding tpc_h_benchmark)." >&2
+            exit 1
+          fi
+
+          printf 'Benchmark shards:\n'
+          printf '  %s\n' "${benchmarks[@]}"
+
+          json=$(printf '%s\n' "${benchmarks[@]}" | jq -R . | jq -cs .)
+          echo "benchmarks=$json" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: "Build benchmarks (${{ matrix.toolchain.label }})"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: discover
+    timeout-minutes: 60
+    # Allow this job to fail without failing the entire CI run
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - label: stable
+            version: "1.88.0"
+            rustflags: ""
+          - label: nightly
+            version: "nightly-2025-12-17"
+            rustflags: "--cfg nightly"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain.version }}
+
       - name: Setup mold linker
         uses: rui314/setup-mold@v1
 
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-rust-codspeed"
+          prefix-key: "v1-rust-codspeed-${{ matrix.toolchain.label }}"
           cache-on-failure: true
 
       - uses: "./.github/shared/setup-sccache"
@@ -42,6 +92,12 @@ jobs:
         with:
           tool: cargo-codspeed
 
+      - name: Mount benchmark sticky disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ matrix.toolchain.label }}
+          path: target/codspeed
+
       - name: Generate graph-queries DBs
         run: |
           python3 perf/graph-queries/generate_seed.py | sqlite3 perf/graph-queries/graph-queries.db
@@ -49,13 +105,91 @@ jobs:
           sqlite3 perf/graph-queries/graph-queries-analyzed.db "ANALYZE;"
 
       - name: Build benchmarks (excluding TPC-H)
-        run: make codspeed-build-bench-exclude-tpc-h
+        env:
+          BENCHMARKS_JSON: ${{ needs.discover.outputs.benchmarks }}
+          RUSTFLAGS: ${{ matrix.toolchain.rustflags }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          bench_args=$(jq -r '.[] | "--bench " + .' <<< "$BENCHMARKS_JSON" | tr '\n' ' ')
+          cargo +${{ matrix.toolchain.version }} codspeed build $bench_args --features codspeed
+
+  benchmarks:
+    name: "Run benchmark (${{ matrix.toolchain.label }}, ${{ matrix.benchmark }})"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - discover
+      - build
+    timeout-minutes: 30
+    # Allow this job to fail without failing the entire CI run
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - label: stable
+            version: "1.88.0"
+            rustflags: ""
+          - label: nightly
+            version: "nightly-2025-12-17"
+            rustflags: "--cfg nightly"
+        benchmark: ${{ fromJson(needs.discover.outputs.benchmarks) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain.version }}
+
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed
+
+      - name: Mount benchmark sticky disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ matrix.toolchain.label }}
+          path: target/codspeed
+
+      - name: Restore binary permissions
+        run: find target/codspeed -type f -exec chmod +x {} +
+
+      - name: Generate graph-queries DBs
+        if: matrix.benchmark == 'graph_queries_benchmark'
+        run: |
+          python3 perf/graph-queries/generate_seed.py | sqlite3 perf/graph-queries/graph-queries.db
+          cp perf/graph-queries/graph-queries.db perf/graph-queries/graph-queries-analyzed.db
+          sqlite3 perf/graph-queries/graph-queries-analyzed.db "ANALYZE;"
 
       - name: Run benchmarks (excluding TPC-H)
-        uses: CodSpeedHQ/action@v4.5.2
+        uses: CodSpeedHQ/action@v4.17.0
+        env:
+          RUSTFLAGS: ${{ matrix.toolchain.rustflags }}
         with:
           mode: simulation
-          run: cargo codspeed run
+          run: cargo +${{ matrix.toolchain.version }} codspeed run --bench ${{ matrix.benchmark }}
+
+  cleanup:
+    name: "Delete benchmark sticky disk (${{ matrix.toolchain }})"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - build
+      - benchmarks
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable
+          - nightly
+    steps:
+      - name: Delete benchmark sticky disk
+        uses: useblacksmith/stickydisk-delete@v1
+        with:
+          delete-key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ matrix.toolchain }}
 
   # tpc-h:
   #   runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed"
-version = "4.2.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0d98d97fd75ca4489a1a0997820a6521531085e7c8a98941bd0e1264d567dd"
+checksum = "d7ce4a32373a5c84f4fa785099b300b9b1796311abc122b9eb62c65fa615145d"
 dependencies = [
  "anyhow",
  "cc",
@@ -862,7 +862,7 @@ dependencies = [
  "getrandom 0.2.15",
  "glob",
  "libc",
- "nix 0.30.1",
+ "nix 0.31.3",
  "serde",
  "serde_json",
  "statrs",
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "4.2.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16fe2db207123f7b3a3b5cfff0c22f99469f7534145f3573f57f4c8a5653c2c"
+checksum = "f5557c4e023f427ba208b849193c51c2ebd40534828490cd3f5f7f7fc0284ce5"
 dependencies = [
  "clap",
  "codspeed",
@@ -884,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat-walltime"
-version = "4.2.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b035c7f9846b143aeabb3833f5b584023eb97b43ecbff3d997db74c4372df2bd"
+checksum = "43ac19f0a5c3542301e9d011d658f93c3f550698ec8ba7d7c072692e7924c401"
 dependencies = [
  "anes",
  "cast",
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat"
-version = "4.2.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4179ec5518e79efcd02ed50aa483ff807902e43c85146e87fff58b9cffc06078"
+checksum = "9fd4b79be5d5be3dd4ab2c2067759dedbfb65df01faba452f6b9f549acf30c9b"
 dependencies = [
  "clap",
  "codspeed",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-macros"
-version = "4.2.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15eaee97aa5bceb32cc683fe25cd6373b7fc48baee5c12471996b58b6ddf0d7c"
+checksum = "9726dee335c75f77ad4a01e1b637bd11e2e520204835efe95c6548961ad1fcb0"
 dependencies = [
  "divan-macros",
  "itertools 0.14.0",
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-walltime"
-version = "4.2.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38671153aa73be075d6019cab5ab1e6b31d36644067c1ac4cef73bf9723ce33"
+checksum = "32522981b494ec2422499ea1c62cf04e432ac8caaa6cee8a71f074f144db43e3"
 dependencies = [
  "cfg-if",
  "clap",
@@ -965,7 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1889,7 +1889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1964,7 +1964,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3013,7 +3013,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3182,9 +3182,9 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -3193,7 +3193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3764,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -4566,7 +4566,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.0",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4994,7 +4994,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5007,7 +5007,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5624,6 +5624,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5987,7 +5988,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7356,7 +7357,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,6 @@ either = { version = "1.15" }
 loom = { version = "0.7" }
 shuttle = { version = "0.8.1" }
 
-
 [profile.dev.package.similar]
 opt-level = 3
 

--- a/Makefile
+++ b/Makefile
@@ -179,8 +179,12 @@ bench-exclude-tpc-h:
 	fi
 .PHONY: bench-exclude-tpc-h
 
+codspeed-benchmarks-exclude-tpc-h:
+	@cargo bench --bench 2>&1 | awk '/^Available bench targets:/{list=1; next} list && NF {print $$1}' | grep -vx 'tpc_h_benchmark'
+.PHONY: codspeed-benchmarks-exclude-tpc-h
+
 codspeed-build-bench-exclude-tpc-h:
-	@benchmarks=$$(cargo bench --bench 2>&1 | grep -A 1000 '^Available bench targets:' | grep -v '^Available bench targets:' | grep -v '^ *$$' | grep -v 'tpc_h_benchmark' | xargs -I {} printf -- "--bench %s " {}); \
+	@benchmarks=$$($(MAKE) --no-print-directory codspeed-benchmarks-exclude-tpc-h | xargs -I {} printf -- "--bench %s " {}); \
 	if [ -z "$$benchmarks" ]; then \
 		echo "No benchmarks found (excluding tpc_h_benchmark)."; \
 		exit 1; \

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -68,7 +68,7 @@ where
     }
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_push_turso(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| {
@@ -82,7 +82,7 @@ fn vec_push_turso(bencher: Bencher, len: usize) {
         });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_push_std(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| std::vec::Vec::with_capacity(len))
@@ -94,7 +94,7 @@ fn vec_push_std(bencher: Bencher, len: usize) {
         });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -105,7 +105,7 @@ fn vec_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len).map(black_box).collect::<std::vec::Vec<_>>();
@@ -113,7 +113,7 @@ fn vec_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -123,7 +123,7 @@ fn vec_extend_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::vec::Vec::with_capacity(len);
@@ -132,7 +132,7 @@ fn vec_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_push_back_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -145,7 +145,7 @@ fn vec_deque_push_back_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_push_back_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::VecDeque::with_capacity(len);
@@ -156,7 +156,7 @@ fn vec_deque_push_back_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -167,7 +167,7 @@ fn vec_deque_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -177,7 +177,7 @@ fn vec_deque_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -188,7 +188,7 @@ fn vec_deque_extend_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::VecDeque::with_capacity(len);
@@ -197,7 +197,7 @@ fn vec_deque_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_push_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -210,7 +210,7 @@ fn binary_heap_push_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_push_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::BinaryHeap::with_capacity(len);
@@ -221,7 +221,7 @@ fn binary_heap_push_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -232,7 +232,7 @@ fn binary_heap_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -242,7 +242,7 @@ fn binary_heap_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -253,7 +253,7 @@ fn binary_heap_extend_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::BinaryHeap::with_capacity(len);
@@ -262,7 +262,7 @@ fn binary_heap_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -277,7 +277,7 @@ fn hash_set_insert_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_insert_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
@@ -288,7 +288,7 @@ fn hash_set_insert_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -299,7 +299,7 @@ fn hash_set_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -309,7 +309,7 @@ fn hash_set_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -322,7 +322,7 @@ fn hash_set_extend_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
@@ -331,7 +331,7 @@ fn hash_set_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -346,7 +346,7 @@ fn hash_map_insert_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -357,7 +357,7 @@ fn hash_map_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -367,7 +367,7 @@ fn hash_map_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -384,7 +384,7 @@ fn hash_map_extend_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
@@ -393,7 +393,7 @@ fn hash_map_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_insert_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
@@ -404,7 +404,7 @@ fn hash_map_insert_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = LowerBoundOnly::new((0..len).map(black_box)).collect::<std::vec::Vec<_>>();
@@ -412,7 +412,7 @@ fn vec_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = LowerBoundOnly::new((0..len).map(black_box))
@@ -422,7 +422,7 @@ fn vec_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::vec::Vec::with_capacity(len);
@@ -431,7 +431,7 @@ fn vec_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -442,7 +442,7 @@ fn vec_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values =
@@ -451,7 +451,7 @@ fn vec_deque_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = LowerBoundOnly::new((0..len).map(black_box))
@@ -461,7 +461,7 @@ fn vec_deque_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::VecDeque::with_capacity(len);
@@ -470,7 +470,7 @@ fn vec_deque_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -482,7 +482,7 @@ fn vec_deque_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = LowerBoundOnly::new((0..len).map(black_box))
@@ -491,7 +491,7 @@ fn binary_heap_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = LowerBoundOnly::new((0..len).map(black_box))
@@ -501,7 +501,7 @@ fn binary_heap_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::BinaryHeap::with_capacity(len);
@@ -510,7 +510,7 @@ fn binary_heap_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -522,7 +522,7 @@ fn binary_heap_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = LowerBoundOnly::new((0..len).map(black_box))
@@ -531,7 +531,7 @@ fn hash_set_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = LowerBoundOnly::new((0..len).map(black_box))
@@ -541,7 +541,7 @@ fn hash_set_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
@@ -550,7 +550,7 @@ fn hash_set_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -564,7 +564,7 @@ fn hash_set_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values =
@@ -574,7 +574,7 @@ fn hash_map_collect_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values =
@@ -585,7 +585,7 @@ fn hash_map_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
@@ -596,7 +596,7 @@ fn hash_map_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -613,7 +613,7 @@ fn hash_map_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_non_copy_push_std(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| std::vec::Vec::with_capacity(len))
@@ -625,7 +625,7 @@ fn vec_non_copy_push_std(bencher: Bencher, len: usize) {
         });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_non_copy_push_turso(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| {
@@ -642,7 +642,7 @@ fn vec_non_copy_push_turso(bencher: Bencher, len: usize) {
         });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_non_copy_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -652,7 +652,7 @@ fn vec_non_copy_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_non_copy_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -663,7 +663,7 @@ fn vec_non_copy_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_non_copy_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::vec::Vec::with_capacity(len);
@@ -672,7 +672,7 @@ fn vec_non_copy_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -687,7 +687,7 @@ fn vec_non_copy_extend_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_non_copy_push_back_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::VecDeque::with_capacity(len);
@@ -698,7 +698,7 @@ fn vec_deque_non_copy_push_back_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_non_copy_push_back_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -713,7 +713,7 @@ fn vec_deque_non_copy_push_back_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_non_copy_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -723,7 +723,7 @@ fn vec_deque_non_copy_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_non_copy_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -734,7 +734,7 @@ fn vec_deque_non_copy_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_non_copy_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::VecDeque::with_capacity(len);
@@ -743,7 +743,7 @@ fn vec_deque_non_copy_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_deque_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -758,7 +758,7 @@ fn vec_deque_non_copy_extend_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_non_copy_push_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::BinaryHeap::with_capacity(len);
@@ -769,7 +769,7 @@ fn binary_heap_non_copy_push_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_non_copy_push_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -786,7 +786,7 @@ fn binary_heap_non_copy_push_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_non_copy_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -796,7 +796,7 @@ fn binary_heap_non_copy_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_non_copy_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -807,7 +807,7 @@ fn binary_heap_non_copy_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_non_copy_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::BinaryHeap::with_capacity(len);
@@ -816,7 +816,7 @@ fn binary_heap_non_copy_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn binary_heap_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -833,7 +833,7 @@ fn binary_heap_non_copy_extend_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_non_copy_insert_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
@@ -844,7 +844,7 @@ fn hash_set_non_copy_insert_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_non_copy_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -859,7 +859,7 @@ fn hash_set_non_copy_insert_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_non_copy_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -869,7 +869,7 @@ fn hash_set_non_copy_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_non_copy_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -880,7 +880,7 @@ fn hash_set_non_copy_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_non_copy_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
@@ -889,7 +889,7 @@ fn hash_set_non_copy_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_set_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -906,7 +906,7 @@ fn hash_set_non_copy_extend_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_non_copy_insert_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
@@ -920,7 +920,7 @@ fn hash_map_non_copy_insert_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_non_copy_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
@@ -940,7 +940,7 @@ fn hash_map_non_copy_insert_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_non_copy_collect_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -955,7 +955,7 @@ fn hash_map_non_copy_collect_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_non_copy_collect_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let values = (0..len)
@@ -971,7 +971,7 @@ fn hash_map_non_copy_collect_turso(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_non_copy_extend_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
@@ -985,7 +985,7 @@ fn hash_map_non_copy_extend_std(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(args = [64, 1_024, 16_384])]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn hash_map_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -74,6 +74,7 @@ fn setup_rusqlite(temp_dir: &TempDir, query: &str) -> rusqlite::Connection {
     sqlite_conn
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_open(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/turso/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
@@ -116,6 +117,7 @@ fn bench_open(criterion: &mut Criterion) {
     group.finish();
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_alter(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/turso/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
@@ -316,6 +318,7 @@ fn bench_alter(criterion: &mut Criterion) {
     group.finish();
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_prepare_query(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/turso/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
@@ -398,6 +401,7 @@ fn bench_prepare_query(criterion: &mut Criterion) {
     }
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_execute_select_rows(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/turso/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
@@ -466,6 +470,7 @@ fn bench_execute_select_rows(criterion: &mut Criterion) {
     group.finish();
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_execute_select_1(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/turso/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
@@ -518,6 +523,7 @@ fn bench_execute_select_1(criterion: &mut Criterion) {
     group.finish();
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_execute_select_count(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/turso/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
@@ -570,6 +576,7 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
     group.finish();
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_insert_rows(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
@@ -987,6 +994,7 @@ fn generate_batch_insert(start: i64, num: usize) -> String {
     inserts
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_concurrent_writes(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("Concurrent writes");
 
@@ -1042,6 +1050,7 @@ fn bench_concurrent_writes(criterion: &mut Criterion) {
     });
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_insert_randomblob(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();

--- a/core/benches/create_index_benchmark.rs
+++ b/core/benches/create_index_benchmark.rs
@@ -189,6 +189,7 @@ fn should_bench_create_index_turso(row_count: usize) -> bool {
 ///
 /// Indexes the non-monotonic `val` column to force a real sort + B-tree build
 /// rather than the fast-append path that monotonic keys can take.
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_create_index(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -303,6 +304,7 @@ fn bench_create_index(criterion: &mut Criterion) {
 /// Benchmark CREATE INDEX inside an explicit BEGIN/COMMIT, isolating the
 /// commit cost the user is hitting in production.
 #[cfg(feature = "codspeed")]
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_create_index_commit(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");

--- a/core/benches/fts_benchmark.rs
+++ b/core/benches/fts_benchmark.rs
@@ -147,6 +147,7 @@ fn setup_fts_db(temp_dir: &TempDir, row_count: usize) -> Arc<Database> {
 /// load hot files, create the Tantivy Index, build a Reader+Searcher,
 /// parse the query, and execute the search. Each iteration uses a fresh
 /// connection to avoid directory cache hits.
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_fts_cold_query(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Cold Query");
     group.sample_size(20); // Cold queries are slow; reduce samples
@@ -188,6 +189,7 @@ fn bench_fts_cold_query(criterion: &mut Criterion) {
 /// skip the catalog scan and PreloadingEssentials entirely. This measures
 /// the pure query execution path: Index::open (from cached directory),
 /// Reader+Searcher creation, query parsing, and search.
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_fts_warm_query(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Warm Query");
 
@@ -233,6 +235,7 @@ fn bench_fts_warm_query(criterion: &mut Criterion) {
 /// Measures how the number of matching documents affects query time.
 /// "database" matches ~1/7 of docs, "performance" matches ~1/7,
 /// "database performance" (AND) matches fewer.
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_fts_query_selectivity(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Query Selectivity");
 
@@ -280,6 +283,7 @@ fn bench_fts_query_selectivity(criterion: &mut Criterion) {
 /// Measures the cost of inserting new rows, committing, and then querying.
 /// This exercises the full write path (IndexWriter, segment creation, BTree flush)
 /// followed by directory cache invalidation and a cold re-query.
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_fts_insert_then_query(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Insert+Query Lifecycle");
     group.sample_size(20);

--- a/core/benches/graph_queries_benchmark.rs
+++ b/core/benches/graph_queries_benchmark.rs
@@ -31,6 +31,7 @@ fn rusqlite_open(path: &str) -> rusqlite::Connection {
     conn
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_graph_queries(criterion: &mut Criterion) {
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 

--- a/core/benches/hash_spill_benchmark.rs
+++ b/core/benches/hash_spill_benchmark.rs
@@ -25,7 +25,7 @@ fn create_hash_table(mem_budget: usize) -> HashTable {
         initial_buckets: 64,
         mem_budget,
         num_keys: 1,
-        collations: vec![CollationSeq::Binary],
+        collations: turso_core::alloc::vec![CollationSeq::Binary],
         temp_store: turso_core::TempStore::Default,
         track_matched: false,
         partition_count: None,
@@ -36,8 +36,8 @@ fn create_hash_table(mem_budget: usize) -> HashTable {
 /// Insert entries with integer keys and no payload
 fn insert_integer_entries(ht: &mut HashTable, count: usize) {
     for i in 0..count {
-        let key = vec![Value::from_i64(i as i64)];
-        let _ = ht.insert(key, i as i64, vec![], None);
+        let key = turso_core::alloc::vec![Value::from_i64(i as i64)];
+        let _ = ht.insert(key, i as i64, turso_core::alloc::vec![], None);
     }
 }
 
@@ -45,8 +45,8 @@ fn insert_integer_entries(ht: &mut HashTable, count: usize) {
 fn insert_entries_with_text_payload(ht: &mut HashTable, count: usize, text_size: usize) {
     let payload_text: String = "x".repeat(text_size);
     for i in 0..count {
-        let key = vec![Value::from_i64(i as i64)];
-        let payload = vec![Value::Text(payload_text.clone().into())];
+        let key = turso_core::alloc::vec![Value::from_i64(i as i64)];
+        let payload = turso_core::alloc::vec![Value::Text(payload_text.clone().into())];
         let _ = ht.insert(key, i as i64, payload, None);
     }
 }
@@ -54,12 +54,13 @@ fn insert_entries_with_text_payload(ht: &mut HashTable, count: usize, text_size:
 /// Insert entries with text keys (for NOCASE hash testing)
 fn insert_text_key_entries(ht: &mut HashTable, count: usize) {
     for i in 0..count {
-        let key = vec![Value::Text(format!("key_{i}").into())];
-        let _ = ht.insert(key, i as i64, vec![], None);
+        let key = turso_core::alloc::vec![Value::Text(format!("key_{i}").into())];
+        let _ = ht.insert(key, i as i64, turso_core::alloc::vec![], None);
     }
 }
 
 /// Benchmark: Build phase with tight memory budget (forces frequent spilling)
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_build_tight_budget(c: &mut Criterion) {
     let mut group = c.benchmark_group("HashTable Build (Tight Budget)");
 
@@ -99,6 +100,7 @@ fn bench_build_tight_budget(c: &mut Criterion) {
 }
 
 /// Benchmark: Build phase with relaxed memory budget (occasional spilling)
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_build_relaxed_budget(c: &mut Criterion) {
     let mut group = c.benchmark_group("HashTable Build (Relaxed Budget)");
 
@@ -138,6 +140,7 @@ fn bench_build_relaxed_budget(c: &mut Criterion) {
 }
 
 /// Benchmark: Build + Probe with spilling
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_build_and_probe(c: &mut Criterion) {
     let mut group = c.benchmark_group("HashTable Build+Probe");
 
@@ -157,7 +160,8 @@ fn bench_build_and_probe(c: &mut Criterion) {
                     // Probe phase - look up every key
                     let mut found = 0;
                     for i in 0..count {
-                        let key = vec![Value::Numeric(Numeric::Integer(i as i64))];
+                        let key =
+                            turso_core::alloc::vec![Value::Numeric(Numeric::Integer(i as i64))];
                         if ht.has_spilled() {
                             let partition_idx = ht.partition_for_keys(&key).unwrap();
                             if !ht.is_partition_loaded(partition_idx) {
@@ -195,7 +199,7 @@ fn bench_build_and_probe(c: &mut Criterion) {
                     // Probe phase
                     let mut found = 0;
                     for i in 0..count {
-                        let key = vec![Value::from_i64(i as i64)];
+                        let key = turso_core::alloc::vec![Value::from_i64(i as i64)];
                         if ht.has_spilled() {
                             let partition_idx = ht.partition_for_keys(&key).unwrap();
                             if !ht.is_partition_loaded(partition_idx) {
@@ -225,6 +229,7 @@ fn bench_build_and_probe(c: &mut Criterion) {
 }
 
 /// Benchmark: Text key hashing (tests NOCASE optimization)
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_text_key_hashing(c: &mut Criterion) {
     let mut group = c.benchmark_group("HashTable Text Keys");
 
@@ -242,7 +247,7 @@ fn bench_text_key_hashing(c: &mut Criterion) {
                         initial_buckets: 64,
                         mem_budget: 64 * 1024,
                         num_keys: 1,
-                        collations: vec![CollationSeq::Binary],
+                        collations: turso_core::alloc::vec![CollationSeq::Binary],
                         temp_store: turso_core::TempStore::Default,
                         track_matched: false,
                         partition_count: None,
@@ -266,7 +271,7 @@ fn bench_text_key_hashing(c: &mut Criterion) {
                         initial_buckets: 64,
                         mem_budget: 64 * 1024,
                         num_keys: 1,
-                        collations: vec![CollationSeq::NoCase],
+                        collations: turso_core::alloc::vec![CollationSeq::NoCase],
                         temp_store: turso_core::TempStore::Default,
                         track_matched: false,
                         partition_count: None,
@@ -284,6 +289,7 @@ fn bench_text_key_hashing(c: &mut Criterion) {
 }
 
 /// Benchmark: Large payload serialization
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_large_payload_spill(c: &mut Criterion) {
     let mut group = c.benchmark_group("HashTable Large Payload Spill");
 

--- a/core/benches/json_benchmark.rs
+++ b/core/benches/json_benchmark.rs
@@ -21,6 +21,7 @@ fn rusqlite_open() -> rusqlite::Connection {
     sqlite_conn
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench(criterion: &mut Criterion) {
     // Flag to disable rusqlite benchmarks if needed
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
@@ -489,6 +490,7 @@ fn bench(criterion: &mut Criterion) {
     }
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_sequential_jsonb(criterion: &mut Criterion) {
     // Flag to disable rusqlite benchmarks if needed
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
@@ -646,6 +648,7 @@ fn bench_sequential_jsonb(criterion: &mut Criterion) {
     group.finish();
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_json_patch(criterion: &mut Criterion) {
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 

--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -39,6 +39,7 @@ fn bench_db() -> BenchDb {
     }
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("mvcc-ops-throughput");
     group.throughput(Throughput::Elements(1));
@@ -356,6 +357,7 @@ fn run_to_completion(db: &Arc<Database>, stmt: &mut Statement) {
     }
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_huge_multi_write(c: &mut Criterion) {
     let idx1 = NonZeroUsize::new(1).unwrap();
     let sql = build_huge_multi_write(HUGE_WRITE_ROWS_PER_BATCH);

--- a/core/benches/mvcc_recovery_benchmark.rs
+++ b/core/benches/mvcc_recovery_benchmark.rs
@@ -116,6 +116,7 @@ fn single_frame_with_num_ops(num_ops: u64) -> RecoveryFixture {
     })
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_recovery(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("mvcc-recovery/small-frames");

--- a/core/benches/sql_functions/datetime.rs
+++ b/core/benches/sql_functions/datetime.rs
@@ -10,56 +10,56 @@ use turso_core::types::Value;
 // These formats use the optimized custom parser (no chrono overhead)
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn fast_path_date_only(bencher: Bencher) {
     // YYYY-MM-DD (10 chars) - fast path
     let args = [Value::build_text("2024-07-21")];
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn fast_path_datetime_hhmm(bencher: Bencher) {
     // YYYY-MM-DD HH:MM (16 chars) - fast path
     let args = [Value::build_text("2024-07-21 14:30")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn fast_path_datetime_hhmmss(bencher: Bencher) {
     // YYYY-MM-DD HH:MM:SS (19 chars) - fast path
     let args = [Value::build_text("2024-07-21 14:30:45")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn fast_path_datetime_with_frac(bencher: Bencher) {
     // YYYY-MM-DD HH:MM:SS.fff (23 chars) - fast path
     let args = [Value::build_text("2024-07-21 14:30:45.123")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn fast_path_datetime_t_separator(bencher: Bencher) {
     // YYYY-MM-DDTHH:MM:SS - fast path with T separator
     let args = [Value::build_text("2024-07-21T14:30:45")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn fast_path_time_hhmm(bencher: Bencher) {
     // HH:MM (5 chars) - fast path
     let args = [Value::build_text("14:30")];
     bencher.bench_local(|| black_box(exec_time(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn fast_path_time_hhmmss(bencher: Bencher) {
     // HH:MM:SS (8 chars) - fast path
     let args = [Value::build_text("14:30:45")];
     bencher.bench_local(|| black_box(exec_time(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn fast_path_time_with_frac(bencher: Bencher) {
     // HH:MM:SS.fff - fast path
     let args = [Value::build_text("14:30:45.123")];
@@ -71,28 +71,28 @@ fn fast_path_time_with_frac(bencher: Bencher) {
 // These formats require chrono's parser (timezone handling)
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn slow_path_datetime_utc_z(bencher: Bencher) {
     // Ends with Z - triggers slow path for timezone
     let args = [Value::build_text("2024-07-21 14:30:45Z")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn slow_path_datetime_tz_offset(bencher: Bencher) {
     // Has timezone offset - slow path
     let args = [Value::build_text("2024-07-21 14:30:45+02:00")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn slow_path_datetime_negative_tz(bencher: Bencher) {
     // Negative timezone offset - slow path
     let args = [Value::build_text("2024-07-21 14:30:45-05:00")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn slow_path_time_with_tz(bencher: Bencher) {
     // Time with timezone - slow path
     let args = [Value::build_text("14:30:45+02:00")];
@@ -103,21 +103,21 @@ fn slow_path_time_with_tz(bencher: Bencher) {
 // Numeric Input Benchmarks (Julian Day)
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn julian_day_float_input(bencher: Bencher) {
     // Float julian day value
     let args = [Value::from_f64(2460512.5)];
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn julian_day_integer_input(bencher: Bencher) {
     // Integer julian day value
     let args = [Value::from_i64(2460513)];
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn julian_day_string_numeric(bencher: Bencher) {
     // Numeric string that parses as julian day
     let args = [Value::build_text("2460512.5")];
@@ -128,31 +128,31 @@ fn julian_day_string_numeric(bencher: Bencher) {
 // Output Type Benchmarks
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn output_date(bencher: Bencher) {
     let args = [Value::build_text("2024-07-21 14:30:45")];
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn output_time(bencher: Bencher) {
     let args = [Value::build_text("2024-07-21 14:30:45")];
     bencher.bench_local(|| black_box(exec_time(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn output_datetime(bencher: Bencher) {
     let args = [Value::build_text("2024-07-21 14:30:45")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn output_julianday(bencher: Bencher) {
     let args = [Value::build_text("2024-07-21 14:30:45")];
     bencher.bench_local(|| black_box(exec_julianday(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn output_unixepoch(bencher: Bencher) {
     let args = [Value::build_text("2024-07-21 14:30:45")];
     bencher.bench_local(|| black_box(exec_unixepoch(black_box(&args))));
@@ -162,7 +162,7 @@ fn output_unixepoch(bencher: Bencher) {
 // strftime Benchmarks
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn strftime_simple_format(bencher: Bencher) {
     let args = [
         Value::build_text("%Y-%m-%d"),
@@ -171,7 +171,7 @@ fn strftime_simple_format(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_strftime(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn strftime_complex_format(bencher: Bencher) {
     let args = [
         Value::build_text("%Y-%m-%d %H:%M:%S"),
@@ -180,7 +180,7 @@ fn strftime_complex_format(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_strftime(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn strftime_with_julian(bencher: Bencher) {
     // %J is SQLite-specific julian day format
     let args = [
@@ -190,7 +190,7 @@ fn strftime_with_julian(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_strftime(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn strftime_weekday_format(bencher: Bencher) {
     let args = [
         Value::build_text("%w %W"),
@@ -203,7 +203,7 @@ fn strftime_weekday_format(bencher: Bencher) {
 // Modifier Benchmarks
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_add_days(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-21"),
@@ -212,7 +212,7 @@ fn modifier_add_days(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_add_fractional_days(bencher: Bencher) {
     // Fractional modifier (new feature from PR)
     let args = [
@@ -222,7 +222,7 @@ fn modifier_add_fractional_days(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_add_months(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-21"),
@@ -231,7 +231,7 @@ fn modifier_add_months(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_start_of_month(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-21 14:30:45"),
@@ -240,7 +240,7 @@ fn modifier_start_of_month(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_start_of_year(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-21 14:30:45"),
@@ -249,7 +249,7 @@ fn modifier_start_of_year(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_weekday(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-21"),
@@ -258,28 +258,28 @@ fn modifier_weekday(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_unixepoch(bencher: Bencher) {
     // unixepoch modifier for numeric input
     let args = [Value::from_i64(1721577045), Value::build_text("unixepoch")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_auto_unixepoch(bencher: Bencher) {
     // auto modifier detecting unix epoch
     let args = [Value::from_i64(1721577045), Value::build_text("auto")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_auto_julianday(bencher: Bencher) {
     // auto modifier detecting julian day
     let args = [Value::from_f64(2460512.5), Value::build_text("auto")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_localtime(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-21 14:30:45"),
@@ -288,7 +288,7 @@ fn modifier_localtime(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn modifier_chain_multiple(bencher: Bencher) {
     // Multiple modifiers chained
     let args = [
@@ -304,7 +304,7 @@ fn modifier_chain_multiple(bencher: Bencher) {
 // timediff Benchmarks
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn timediff_same_day(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-21 14:30:45"),
@@ -313,7 +313,7 @@ fn timediff_same_day(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_timediff(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn timediff_different_days(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-25 14:30:45"),
@@ -322,7 +322,7 @@ fn timediff_different_days(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_timediff(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn timediff_different_years(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-21 14:30:45"),
@@ -335,20 +335,20 @@ fn timediff_different_years(bencher: Bencher) {
 // Special Cases
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn special_now(bencher: Bencher) {
     let args = [Value::build_text("now")];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn special_no_args_current_time(bencher: Bencher) {
     // No arguments - returns current time
     let args: [Value; 0] = [];
     bencher.bench_local(|| black_box(exec_datetime_full(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn special_subsec_modifier(bencher: Bencher) {
     let args = [
         Value::build_text("2024-07-21 14:30:45.123456"),
@@ -357,14 +357,14 @@ fn special_subsec_modifier(bencher: Bencher) {
     bencher.bench_local(|| black_box(exec_time(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn special_date_overflow(bencher: Bencher) {
     // Invalid date that overflows (Feb 30 -> Mar 2)
     let args = [Value::build_text("2024-02-30")];
     bencher.bench_local(|| black_box(exec_date(black_box(&args))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn special_negative_year(bencher: Bencher) {
     // Negative year (BCE dates)
     let args = [Value::build_text("-0044-03-15")];

--- a/core/benches/sql_functions/likeop.rs
+++ b/core/benches/sql_functions/likeop.rs
@@ -6,7 +6,7 @@ use turso_core::types::Value;
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_simple_exact_match(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_like(
@@ -19,7 +19,7 @@ fn like_simple_exact_match(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_simple_no_match(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_like(
@@ -32,7 +32,7 @@ fn like_simple_no_match(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_percent_prefix(bencher: Bencher) {
     // Pattern: %world - matches anything ending with "world"
     bencher.bench_local(|| {
@@ -46,7 +46,7 @@ fn like_percent_prefix(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_percent_suffix(bencher: Bencher) {
     // Pattern: hello% - matches anything starting with "hello"
     bencher.bench_local(|| {
@@ -59,7 +59,7 @@ fn like_percent_suffix(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_percent_both(bencher: Bencher) {
     // Pattern: %llo wor% - matches anything containing "llo wor"
     bencher.bench_local(|| {
@@ -72,7 +72,7 @@ fn like_percent_both(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_underscore_single(bencher: Bencher) {
     // Pattern: h_llo - matches "hello", "hallo", etc.
     bencher.bench_local(|| {
@@ -85,7 +85,7 @@ fn like_underscore_single(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_underscore_multiple(bencher: Bencher) {
     // Pattern: h___o - matches 5 character words starting with h, ending with o
     bencher.bench_local(|| {
@@ -98,7 +98,7 @@ fn like_underscore_multiple(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_mixed_wildcards(bencher: Bencher) {
     // Pattern: %h_llo% - complex pattern
     bencher.bench_local(|| {
@@ -111,7 +111,7 @@ fn like_mixed_wildcards(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_escape_percent(bencher: Bencher) {
     // Testing escaped percent sign
     bencher.bench_local(|| {
@@ -124,7 +124,7 @@ fn like_escape_percent(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_escape_underscore(bencher: Bencher) {
     // Testing escaped underscore
     bencher.bench_local(|| {
@@ -138,7 +138,7 @@ fn like_escape_underscore(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_case_insensitive(bencher: Bencher) {
     // LIKE is case-insensitive by default
     bencher.bench_local(|| {
@@ -152,7 +152,7 @@ fn like_case_insensitive(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_long_pattern(bencher: Bencher) {
     let pattern = "The quick brown fox %";
     let text = "The quick brown fox jumps over the lazy dog";
@@ -167,7 +167,7 @@ fn like_long_pattern(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_long_text_short_pattern(bencher: Bencher) {
     let pattern = "%dog";
     let text = "The quick brown fox jumps over the lazy dog";
@@ -181,7 +181,7 @@ fn like_long_text_short_pattern(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_many_percent_wildcards(bencher: Bencher) {
     // Pattern with multiple % wildcards - can be expensive
     let pattern = "%quick%fox%lazy%";
@@ -201,19 +201,19 @@ fn like_many_percent_wildcards(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_simple_exact_match(bencher: Bencher) {
     bencher.bench_local(|| black_box(Value::exec_glob(black_box("hello"), black_box("hello"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_simple_no_match(bencher: Bencher) {
     bencher.bench_local(|| black_box(Value::exec_glob(black_box("hello"), black_box("world"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_star_prefix(bencher: Bencher) {
     // Pattern: *world - matches anything ending with "world"
     bencher.bench_local(|| {
@@ -225,7 +225,7 @@ fn glob_star_prefix(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_star_suffix(bencher: Bencher) {
     // Pattern: hello* - matches anything starting with "hello"
     bencher.bench_local(|| {
@@ -236,7 +236,7 @@ fn glob_star_suffix(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_star_both(bencher: Bencher) {
     // Pattern: *llo wor* - matches anything containing "llo wor"
     bencher.bench_local(|| {
@@ -247,37 +247,37 @@ fn glob_star_both(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_question_single(bencher: Bencher) {
     // Pattern: h?llo - matches "hello", "hallo", etc.
     bencher.bench_local(|| black_box(Value::exec_glob(black_box("h?llo"), black_box("hello"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_question_multiple(bencher: Bencher) {
     // Pattern: h???o - matches 5 character words starting with h, ending with o
     bencher.bench_local(|| black_box(Value::exec_glob(black_box("h???o"), black_box("hello"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_character_class(bencher: Bencher) {
     // Pattern: [abc]* - matches words starting with a, b, or c
     bencher.bench_local(|| black_box(Value::exec_glob(black_box("[abc]*"), black_box("apple"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_character_class_range(bencher: Bencher) {
     // Pattern: [a-z]* - matches words starting with lowercase letter
     bencher.bench_local(|| black_box(Value::exec_glob(black_box("[a-z]*"), black_box("hello"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_character_class_negation(bencher: Bencher) {
     // Pattern: [^0-9]* - matches words not starting with digit
     bencher.bench_local(|| black_box(Value::exec_glob(black_box("[^0-9]*"), black_box("hello"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_mixed_wildcards(bencher: Bencher) {
     // Complex pattern with multiple wildcard types
     bencher.bench_local(|| {
@@ -288,7 +288,7 @@ fn glob_mixed_wildcards(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_file_path_pattern(bencher: Bencher) {
     // Common use case: file path matching
     bencher.bench_local(|| {
@@ -300,14 +300,14 @@ fn glob_file_path_pattern(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_long_pattern(bencher: Bencher) {
     let pattern = "The quick brown fox *";
     let text = "The quick brown fox jumps over the lazy dog";
     bencher.bench_local(|| black_box(Value::exec_glob(black_box(pattern), black_box(text))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_many_star_wildcards(bencher: Bencher) {
     // Pattern with multiple * wildcards
     let pattern = "*quick*fox*lazy*";
@@ -320,7 +320,7 @@ fn glob_many_star_wildcards(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_with_cache_first_call(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_glob(
@@ -331,7 +331,7 @@ fn glob_with_cache_first_call(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_with_cache_cached_hit(bencher: Bencher) {
     // Warm up the cache
 
@@ -343,7 +343,7 @@ fn glob_with_cache_cached_hit(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_complex_pattern_cached(bencher: Bencher) {
     let pattern = "*quick*fox*lazy*";
     let text = "The quick brown fox jumps over the lazy dog";
@@ -357,7 +357,7 @@ fn glob_complex_pattern_cached(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_empty_pattern(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_like(black_box(""), black_box(""), Some('\\'))).unwrap()
@@ -365,7 +365,7 @@ fn like_empty_pattern(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_only_percent(bencher: Bencher) {
     // % matches everything
     bencher.bench_local(|| {
@@ -379,7 +379,7 @@ fn like_only_percent(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_only_star(bencher: Bencher) {
     // * matches everything
     bencher.bench_local(|| {
@@ -391,7 +391,7 @@ fn glob_only_star(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_special_regex_chars(bencher: Bencher) {
     // Pattern with characters that are special in regex (checking for regression/bugs)
     bencher.bench_local(|| {
@@ -404,14 +404,14 @@ fn like_special_regex_chars(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_bracket_special_cases(bencher: Bencher) {
     // Test bracket edge cases
     bencher.bench_local(|| black_box(Value::exec_glob(black_box("a[]]b"), black_box("a]b"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn like_unicode_pattern(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_like(
@@ -424,7 +424,7 @@ fn like_unicode_pattern(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn glob_unicode_pattern(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_glob(

--- a/core/benches/sql_functions/numeric.rs
+++ b/core/benches/sql_functions/numeric.rs
@@ -9,68 +9,68 @@ use turso_core::types::Value;
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_simple_positive(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_i64(black_box("12345"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_simple_negative(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_i64(black_box("-12345"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_with_plus_sign(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_i64(black_box("+12345"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_max_value(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_i64(black_box("9223372036854775807"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_min_value(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_i64(black_box("-9223372036854775808"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_overflow(bencher: Bencher) {
     // Should return i64::MAX
     bencher.bench_local(|| black_box(str_to_i64(black_box("99999999999999999999999"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_with_whitespace(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_i64(black_box("  12345  "))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_zero(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_i64(black_box("0"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_empty(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_i64(black_box(""))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_non_numeric(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_i64(black_box("abc"))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_i64_mixed_content(bencher: Bencher) {
     // Should parse leading digits
     bencher.bench_local(|| black_box(str_to_i64(black_box("123abc456"))));
@@ -80,72 +80,72 @@ fn str_to_i64_mixed_content(bencher: Bencher) {
 // str_to_f64 Benchmarks - Float String Parsing
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_simple_integer(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("12345"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_simple_decimal(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("123.456"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_negative_decimal(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("-123.456"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_scientific_positive_exp(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("1.23e10"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_scientific_negative_exp(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("1.23e-10"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_scientific_uppercase(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("1.23E10"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_very_small(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("0.000000000001"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_very_large(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("999999999999999999999"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_leading_decimal(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box(".456"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_trailing_decimal(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("123."))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_with_whitespace(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("  123.456  "))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_zero(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("0.0"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_many_decimal_places(bencher: Bencher) {
     bencher.bench_local(|| black_box(str_to_f64(black_box("3.141592653589793238462643383279"))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn str_to_f64_prefix_only(bencher: Bencher) {
     // Should parse leading number
     bencher.bench_local(|| black_box(str_to_f64(black_box("123.456abc"))));
@@ -155,59 +155,59 @@ fn str_to_f64_prefix_only(bencher: Bencher) {
 // format_float Benchmarks - Float to String Formatting
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_simple(bencher: Bencher) {
     bencher.bench_local(|| black_box(format_float(black_box(123.456))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_integer(bencher: Bencher) {
     bencher.bench_local(|| black_box(format_float(black_box(12345.0))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_negative(bencher: Bencher) {
     bencher.bench_local(|| black_box(format_float(black_box(-123.456))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_zero(bencher: Bencher) {
     bencher.bench_local(|| black_box(format_float(black_box(0.0))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_very_small(bencher: Bencher) {
     bencher.bench_local(|| black_box(format_float(black_box(1e-100))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_very_large(bencher: Bencher) {
     bencher.bench_local(|| black_box(format_float(black_box(1e100))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_scientific_needed(bencher: Bencher) {
     // Should trigger scientific notation
     bencher.bench_local(|| black_box(format_float(black_box(9.93e-322))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_nan(bencher: Bencher) {
     bencher.bench_local(|| black_box(format_float(black_box(f64::NAN))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_infinity(bencher: Bencher) {
     bencher.bench_local(|| black_box(format_float(black_box(f64::INFINITY))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_neg_infinity(bencher: Bencher) {
     bencher.bench_local(|| black_box(format_float(black_box(f64::NEG_INFINITY))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn format_float_precision_edge(bencher: Bencher) {
     // Test precision handling
     bencher.bench_local(|| black_box(format_float(black_box(0.1 + 0.2))));
@@ -218,51 +218,51 @@ fn format_float_precision_edge(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_from_integer_value(bencher: Bencher) {
     let value = Value::from_i64(12345);
     bencher.bench_local(|| black_box(Numeric::from_value(black_box(&value))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_from_float_value(bencher: Bencher) {
     let value = Value::from_f64(123.456);
     bencher.bench_local(|| black_box(Numeric::from_value(black_box(&value))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_from_text_integer(bencher: Bencher) {
     let value = Value::build_text("12345");
     bencher.bench_local(|| black_box(Numeric::from_value(black_box(&value))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_from_text_float(bencher: Bencher) {
     let value = Value::build_text("123.456");
     bencher.bench_local(|| black_box(Numeric::from_value(black_box(&value))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_from_text_scientific(bencher: Bencher) {
     let value = Value::build_text("1.23e10");
     bencher.bench_local(|| black_box(Numeric::from_value(black_box(&value))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_from_null(bencher: Bencher) {
     let value = Value::Null;
     bencher.bench_local(|| black_box(Numeric::from_value(black_box(&value))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_from_blob(bencher: Bencher) {
     let value = Value::Blob(b"12345".to_vec());
     bencher.bench_local(|| black_box(Numeric::from_value(black_box(&value))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_from_string_ref(bencher: Bencher) {
     bencher.bench_local(|| black_box(Numeric::from(black_box("123.456"))));
 }
@@ -272,7 +272,7 @@ fn numeric_from_string_ref(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_add_integers(bencher: Bencher) {
     let a = Numeric::Integer(1000);
     let b = Numeric::Integer(2000);
@@ -280,7 +280,7 @@ fn numeric_add_integers(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_add_floats(bencher: Bencher) {
     let a = Numeric::from("100.5");
     let b = Numeric::from("200.5");
@@ -288,7 +288,7 @@ fn numeric_add_floats(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_add_mixed(bencher: Bencher) {
     let a = Numeric::Integer(100);
     let b = Numeric::from("200.5");
@@ -296,7 +296,7 @@ fn numeric_add_mixed(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_sub_integers(bencher: Bencher) {
     let a = Numeric::Integer(2000);
     let b = Numeric::Integer(1000);
@@ -304,7 +304,7 @@ fn numeric_sub_integers(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_mul_integers(bencher: Bencher) {
     let a = Numeric::Integer(100);
     let b = Numeric::Integer(200);
@@ -312,7 +312,7 @@ fn numeric_mul_integers(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_div_integers(bencher: Bencher) {
     let a = Numeric::Integer(1000);
     let b = Numeric::Integer(10);
@@ -320,14 +320,14 @@ fn numeric_div_integers(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_neg_integer(bencher: Bencher) {
     let a = Numeric::Integer(12345);
     bencher.bench_local(|| black_box(-black_box(a)));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_add_overflow(bencher: Bencher) {
     // Should overflow to float
     let a = Numeric::Integer(i64::MAX);
@@ -340,26 +340,26 @@ fn numeric_add_overflow(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_strict_from_integer(bencher: Bencher) {
     let value = Value::from_i64(12345);
     bencher.bench_local(|| black_box(Numeric::from_value_strict(black_box(&value))));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_strict_from_float(bencher: Bencher) {
     let value = Value::from_f64(123.456);
     bencher.bench_local(|| black_box(Numeric::from_value_strict(black_box(&value))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_strict_from_text_valid(bencher: Bencher) {
     let value = Value::build_text("123.456");
     bencher.bench_local(|| black_box(Numeric::from_value_strict(black_box(&value))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_strict_from_text_invalid_prefix(bencher: Bencher) {
     // Should return Null in strict mode
     let value = Value::build_text("123abc");
@@ -367,7 +367,7 @@ fn numeric_strict_from_text_invalid_prefix(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn numeric_strict_from_blob(bencher: Bencher) {
     // Blob is always Null in strict mode
     let value = Value::Blob(b"12345".to_vec());

--- a/core/benches/sql_functions/value.rs
+++ b/core/benches/sql_functions/value.rs
@@ -5,37 +5,37 @@ use turso_core::types::Value;
 // String Case Functions
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn lower_short_string(bencher: Bencher) {
     let value = Value::build_text("HELLO");
     bencher.bench_local(|| black_box(black_box(&value).exec_lower()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn lower_long_string(bencher: Bencher) {
     let value = Value::build_text("THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG");
     bencher.bench_local(|| black_box(black_box(&value).exec_lower()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn lower_integer(bencher: Bencher) {
     let value = Value::from_i64(12345);
     bencher.bench_local(|| black_box(black_box(&value).exec_lower()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn upper_short_string(bencher: Bencher) {
     let value = Value::build_text("hello");
     bencher.bench_local(|| black_box(black_box(&value).exec_upper()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn upper_long_string(bencher: Bencher) {
     let value = Value::build_text("the quick brown fox jumps over the lazy dog");
     bencher.bench_local(|| black_box(black_box(&value).exec_upper()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn upper_integer(bencher: Bencher) {
     let value = Value::from_i64(12345);
     bencher.bench_local(|| black_box(black_box(&value).exec_upper()));
@@ -46,52 +46,52 @@ fn upper_integer(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn length_short_text(bencher: Bencher) {
     let value = Value::build_text("hello");
     bencher.bench_local(|| black_box(black_box(&value).exec_length()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn length_long_text(bencher: Bencher) {
     let value = Value::build_text("the quick brown fox jumps over the lazy dog");
     bencher.bench_local(|| black_box(black_box(&value).exec_length()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn length_unicode_text(bencher: Bencher) {
     let value = Value::build_text("héllo wörld 你好世界");
     bencher.bench_local(|| black_box(black_box(&value).exec_length()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn length_integer(bencher: Bencher) {
     let value = Value::from_i64(123456789);
     bencher.bench_local(|| black_box(black_box(&value).exec_length()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn length_float(bencher: Bencher) {
     let value = Value::from_f64(123.456789);
     bencher.bench_local(|| black_box(black_box(&value).exec_length()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn length_blob(bencher: Bencher) {
     let value = Value::Blob(vec![0u8; 100]);
     bencher.bench_local(|| black_box(black_box(&value).exec_length()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn octet_length_text(bencher: Bencher) {
     let value = Value::build_text("héllo wörld");
     bencher.bench_local(|| black_box(black_box(&value).exec_octet_length()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn octet_length_unicode(bencher: Bencher) {
     let value = Value::build_text("你好世界");
     bencher.bench_local(|| black_box(black_box(&value).exec_octet_length()));
@@ -101,39 +101,39 @@ fn octet_length_unicode(bencher: Bencher) {
 // Trim Functions
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn trim_spaces(bencher: Bencher) {
     let value = Value::build_text("     hello world     ");
     bencher.bench_local(|| black_box(black_box(&value).exec_trim(None)));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn trim_with_pattern(bencher: Bencher) {
     let value = Value::build_text("xxxhello worldxxx");
     let pattern = Value::build_text("x");
     bencher.bench_local(|| black_box(black_box(&value).exec_trim(Some(black_box(&pattern)))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn ltrim_spaces(bencher: Bencher) {
     let value = Value::build_text("     hello world");
     bencher.bench_local(|| black_box(black_box(&value).exec_ltrim(None)));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn ltrim_with_pattern(bencher: Bencher) {
     let value = Value::build_text("xxxhello world");
     let pattern = Value::build_text("x");
     bencher.bench_local(|| black_box(black_box(&value).exec_ltrim(Some(black_box(&pattern)))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn rtrim_spaces(bencher: Bencher) {
     let value = Value::build_text("hello world     ");
     bencher.bench_local(|| black_box(black_box(&value).exec_rtrim(None)));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn rtrim_with_pattern(bencher: Bencher) {
     let value = Value::build_text("hello worldxxx");
     let pattern = Value::build_text("x");
@@ -144,7 +144,7 @@ fn rtrim_with_pattern(bencher: Bencher) {
 // Substring Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn substring_simple(bencher: Bencher) {
     let value = Value::build_text("hello world");
     let start = Value::from_i64(1);
@@ -158,7 +158,7 @@ fn substring_simple(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn substring_long_text(bencher: Bencher) {
     let value = Value::build_text("the quick brown fox jumps over the lazy dog");
     let start = Value::from_i64(5);
@@ -172,7 +172,7 @@ fn substring_long_text(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn substring_unicode(bencher: Bencher) {
     let value = Value::build_text("héllo wörld 你好");
     let start = Value::from_i64(1);
@@ -186,7 +186,7 @@ fn substring_unicode(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn substring_negative_start(bencher: Bencher) {
     let value = Value::build_text("hello world");
     let start = Value::from_i64(-5);
@@ -200,7 +200,7 @@ fn substring_negative_start(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn substring_blob(bencher: Bencher) {
     let value = Value::Blob(b"hello world".to_vec());
     let start = Value::from_i64(1);
@@ -218,21 +218,21 @@ fn substring_blob(bencher: Bencher) {
 // Instr Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn instr_found_early(bencher: Bencher) {
     let value = Value::build_text("hello world");
     let pattern = Value::build_text("ell");
     bencher.bench_local(|| black_box(black_box(&value).exec_instr(black_box(&pattern))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn instr_found_late(bencher: Bencher) {
     let value = Value::build_text("the quick brown fox jumps over the lazy dog");
     let pattern = Value::build_text("dog");
     bencher.bench_local(|| black_box(black_box(&value).exec_instr(black_box(&pattern))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn instr_not_found(bencher: Bencher) {
     let value = Value::build_text("hello world");
     let pattern = Value::build_text("xyz");
@@ -240,7 +240,7 @@ fn instr_not_found(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn instr_blob(bencher: Bencher) {
     let value = Value::Blob(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     let pattern = Value::Blob(vec![5, 6, 7]);
@@ -251,7 +251,7 @@ fn instr_blob(bencher: Bencher) {
 // Replace Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn replace_single_occurrence(bencher: Bencher) {
     let source = Value::build_text("hello world");
     let pattern = Value::build_text("world");
@@ -265,7 +265,7 @@ fn replace_single_occurrence(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn replace_multiple_occurrences(bencher: Bencher) {
     let source = Value::build_text("banana banana banana");
     let pattern = Value::build_text("banana");
@@ -279,7 +279,7 @@ fn replace_multiple_occurrences(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn replace_empty_pattern(bencher: Bencher) {
     let source = Value::build_text("hello world");
     let pattern = Value::build_text("");
@@ -297,32 +297,32 @@ fn replace_empty_pattern(bencher: Bencher) {
 // Quote Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn quote_text(bencher: Bencher) {
     let value = Value::build_text("hello world");
     bencher.bench_local(|| black_box(black_box(&value).exec_quote()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn quote_text_with_quotes(bencher: Bencher) {
     let value = Value::build_text("hello'world");
     bencher.bench_local(|| black_box(black_box(&value).exec_quote()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn quote_integer(bencher: Bencher) {
     let value = Value::from_i64(12345);
     bencher.bench_local(|| black_box(black_box(&value).exec_quote()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn quote_blob(bencher: Bencher) {
     let value = Value::Blob(vec![0x01, 0x02, 0xAB, 0xCD, 0xEF]);
     bencher.bench_local(|| black_box(black_box(&value).exec_quote()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn quote_null(bencher: Bencher) {
     let value = Value::Null;
     bencher.bench_local(|| black_box(black_box(&value).exec_quote()));
@@ -332,20 +332,20 @@ fn quote_null(bencher: Bencher) {
 // Soundex Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn soundex_simple(bencher: Bencher) {
     let value = Value::build_text("Robert");
     bencher.bench_local(|| black_box(black_box(&value).exec_soundex()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn soundex_complex(bencher: Bencher) {
     let value = Value::build_text("Ashcraft");
     bencher.bench_local(|| black_box(black_box(&value).exec_soundex()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn soundex_non_ascii(bencher: Bencher) {
     let value = Value::build_text("闪电五连鞭");
     bencher.bench_local(|| black_box(black_box(&value).exec_soundex()));
@@ -356,35 +356,35 @@ fn soundex_non_ascii(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn typeof_integer(bencher: Bencher) {
     let value = Value::from_i64(12345);
     bencher.bench_local(|| black_box(black_box(&value).exec_typeof()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn typeof_float(bencher: Bencher) {
     let value = Value::from_f64(123.456);
     bencher.bench_local(|| black_box(black_box(&value).exec_typeof()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn typeof_text(bencher: Bencher) {
     let value = Value::build_text("hello");
     bencher.bench_local(|| black_box(black_box(&value).exec_typeof()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn typeof_blob(bencher: Bencher) {
     let value = Value::Blob(vec![1, 2, 3]);
     bencher.bench_local(|| black_box(black_box(&value).exec_typeof()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn typeof_null(bencher: Bencher) {
     let value = Value::Null;
     bencher.bench_local(|| black_box(black_box(&value).exec_typeof()));
@@ -394,37 +394,37 @@ fn typeof_null(bencher: Bencher) {
 // Cast Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn cast_integer_to_text(bencher: Bencher) {
     let value = Value::from_i64(12345);
     bencher.bench_local(|| black_box(black_box(&value).exec_cast("TEXT")));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn cast_float_to_integer(bencher: Bencher) {
     let value = Value::from_f64(123.456);
     bencher.bench_local(|| black_box(black_box(&value).exec_cast("INT")));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn cast_text_to_integer(bencher: Bencher) {
     let value = Value::build_text("12345");
     bencher.bench_local(|| black_box(black_box(&value).exec_cast("INT")));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn cast_text_to_real(bencher: Bencher) {
     let value = Value::build_text("123.456");
     bencher.bench_local(|| black_box(black_box(&value).exec_cast("REAL")));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn cast_text_to_blob(bencher: Bencher) {
     let value = Value::build_text("hello world");
     bencher.bench_local(|| black_box(black_box(&value).exec_cast("BLOB")));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn cast_text_to_numeric(bencher: Bencher) {
     let value = Value::build_text("123.456");
     bencher.bench_local(|| black_box(black_box(&value).exec_cast("NUMERIC")));
@@ -434,31 +434,31 @@ fn cast_text_to_numeric(bencher: Bencher) {
 // Hex/Unhex Functions
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn hex_text(bencher: Bencher) {
     let value = Value::build_text("hello");
     bencher.bench_local(|| black_box(black_box(&value).exec_hex()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn hex_blob(bencher: Bencher) {
     let value = Value::Blob(vec![0x01, 0x02, 0xAB, 0xCD, 0xEF]);
     bencher.bench_local(|| black_box(black_box(&value).exec_hex()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn hex_integer(bencher: Bencher) {
     let value = Value::from_i64(255);
     bencher.bench_local(|| black_box(black_box(&value).exec_hex()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn unhex_valid(bencher: Bencher) {
     let value = Value::build_text("48656C6C6F");
     bencher.bench_local(|| black_box(black_box(&value).exec_unhex(None)));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn unhex_with_ignored(bencher: Bencher) {
     let value = Value::build_text("  48656C6C6F  ");
     let ignore = Value::build_text(" ");
@@ -469,19 +469,19 @@ fn unhex_with_ignored(bencher: Bencher) {
 // Unicode Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn unicode_ascii(bencher: Bencher) {
     let value = Value::build_text("A");
     bencher.bench_local(|| black_box(black_box(&value).exec_unicode()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn unicode_emoji(bencher: Bencher) {
     let value = Value::build_text("😊");
     bencher.bench_local(|| black_box(black_box(&value).exec_unicode()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn unicode_cjk(bencher: Bencher) {
     let value = Value::build_text("你");
     bencher.bench_local(|| black_box(black_box(&value).exec_unicode()));
@@ -492,55 +492,55 @@ fn unicode_cjk(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn abs_positive_integer(bencher: Bencher) {
     let value = Value::from_i64(12345);
     bencher.bench_local(|| black_box(black_box(&value).exec_abs()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn abs_negative_integer(bencher: Bencher) {
     let value = Value::from_i64(-12345);
     bencher.bench_local(|| black_box(black_box(&value).exec_abs()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn abs_float(bencher: Bencher) {
     let value = Value::from_f64(-123.456);
     bencher.bench_local(|| black_box(black_box(&value).exec_abs()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn abs_text_numeric(bencher: Bencher) {
     let value = Value::build_text("-123.456");
     bencher.bench_local(|| black_box(black_box(&value).exec_abs()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn sign_positive(bencher: Bencher) {
     let value = Value::from_i64(42);
     bencher.bench_local(|| black_box(black_box(&value).exec_sign()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn sign_negative(bencher: Bencher) {
     let value = Value::from_i64(-42);
     bencher.bench_local(|| black_box(black_box(&value).exec_sign()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn sign_zero(bencher: Bencher) {
     let value = Value::from_i64(0);
     bencher.bench_local(|| black_box(black_box(&value).exec_sign()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn sign_float(bencher: Bencher) {
     let value = Value::from_f64(-42.5);
     bencher.bench_local(|| black_box(black_box(&value).exec_sign()));
@@ -551,20 +551,20 @@ fn sign_float(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn round_no_precision(bencher: Bencher) {
     let value = Value::from_f64(123.456);
     bencher.bench_local(|| black_box(black_box(&value).exec_round(None)));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn round_with_precision(bencher: Bencher) {
     let value = Value::from_f64(123.456789);
     let precision = Value::from_i64(2);
     bencher.bench_local(|| black_box(black_box(&value).exec_round(Some(black_box(&precision)))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn round_high_precision(bencher: Bencher) {
     let value = Value::from_f64(std::f64::consts::PI);
     let precision = Value::from_i64(10);
@@ -575,20 +575,20 @@ fn round_high_precision(bencher: Bencher) {
 // Log Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn log_base_10(bencher: Bencher) {
     let value = Value::from_f64(100.0);
     bencher.bench_local(|| black_box(black_box(&value).exec_math_log(None)));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn log_base_2(bencher: Bencher) {
     let value = Value::from_f64(8.0);
     let base = Value::from_f64(2.0);
     bencher.bench_local(|| black_box(black_box(&value).exec_math_log(Some(black_box(&base)))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn log_arbitrary_base(bencher: Bencher) {
     let value = Value::from_f64(100.0);
     let base = Value::from_f64(7.0);
@@ -600,7 +600,7 @@ fn log_arbitrary_base(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn add_integers(bencher: Bencher) {
     let a = Value::from_i64(1000);
     let b = Value::from_i64(2000);
@@ -608,7 +608,7 @@ fn add_integers(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn add_floats(bencher: Bencher) {
     let a = Value::from_f64(100.5);
     let b = Value::from_f64(200.5);
@@ -616,7 +616,7 @@ fn add_floats(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn add_mixed(bencher: Bencher) {
     let a = Value::from_i64(100);
     let b = Value::from_f64(200.5);
@@ -624,7 +624,7 @@ fn add_mixed(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn subtract_integers(bencher: Bencher) {
     let a = Value::from_i64(2000);
     let b = Value::from_i64(1000);
@@ -632,7 +632,7 @@ fn subtract_integers(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn multiply_integers(bencher: Bencher) {
     let a = Value::from_i64(100);
     let b = Value::from_i64(200);
@@ -640,7 +640,7 @@ fn multiply_integers(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn divide_integers(bencher: Bencher) {
     let a = Value::from_i64(1000);
     let b = Value::from_i64(10);
@@ -648,7 +648,7 @@ fn divide_integers(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn remainder_integers(bencher: Bencher) {
     let a = Value::from_i64(17);
     let b = Value::from_i64(5);
@@ -660,7 +660,7 @@ fn remainder_integers(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn bit_and(bencher: Bencher) {
     let a = Value::from_i64(0b11110000);
     let b = Value::from_i64(0b10101010);
@@ -668,7 +668,7 @@ fn bit_and(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn bit_or(bencher: Bencher) {
     let a = Value::from_i64(0b11110000);
     let b = Value::from_i64(0b00001111);
@@ -676,14 +676,14 @@ fn bit_or(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn bit_not(bencher: Bencher) {
     let a = Value::from_i64(0b11110000);
     bencher.bench_local(|| black_box(black_box(&a).exec_bit_not()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn shift_left(bencher: Bencher) {
     let a = Value::from_i64(1);
     let b = Value::from_i64(8);
@@ -691,7 +691,7 @@ fn shift_left(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn shift_right(bencher: Bencher) {
     let a = Value::from_i64(256);
     let b = Value::from_i64(4);
@@ -703,21 +703,21 @@ fn shift_right(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn boolean_not_true(bencher: Bencher) {
     let value = Value::from_i64(1);
     bencher.bench_local(|| black_box(black_box(&value).exec_boolean_not()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn boolean_not_false(bencher: Bencher) {
     let value = Value::from_i64(0);
     bencher.bench_local(|| black_box(black_box(&value).exec_boolean_not()));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn and_true_true(bencher: Bencher) {
     let a = Value::from_i64(1);
     let b = Value::from_i64(1);
@@ -725,7 +725,7 @@ fn and_true_true(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn and_true_false(bencher: Bencher) {
     let a = Value::from_i64(1);
     let b = Value::from_i64(0);
@@ -733,7 +733,7 @@ fn and_true_false(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn or_false_false(bencher: Bencher) {
     let a = Value::from_i64(0);
     let b = Value::from_i64(0);
@@ -741,7 +741,7 @@ fn or_false_false(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn or_true_false(bencher: Bencher) {
     let a = Value::from_i64(1);
     let b = Value::from_i64(0);
@@ -752,28 +752,28 @@ fn or_true_false(bencher: Bencher) {
 // Concat Functions
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn concat_two_strings(bencher: Bencher) {
     let a = Value::build_text("hello ");
     let b = Value::build_text("world");
     bencher.bench_local(|| black_box(black_box(&a).exec_concat(black_box(&b))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn concat_string_integer(bencher: Bencher) {
     let a = Value::build_text("count: ");
     let b = Value::from_i64(42);
     bencher.bench_local(|| black_box(black_box(&a).exec_concat(black_box(&b))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn concat_blobs(bencher: Bencher) {
     let a = Value::Blob(b"hello ".to_vec());
     let b = Value::Blob(b"world".to_vec());
     bencher.bench_local(|| black_box(black_box(&a).exec_concat(black_box(&b))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn concat_strings_multiple(bencher: Bencher) {
     let values = [
         Value::build_text("the "),
@@ -784,7 +784,7 @@ fn concat_strings_multiple(bencher: Bencher) {
     bencher.bench_local(|| black_box(Value::exec_concat_strings(black_box(values.iter()))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn concat_ws_strings(bencher: Bencher) {
     let values = [
         Value::build_text(", "),
@@ -799,13 +799,13 @@ fn concat_ws_strings(bencher: Bencher) {
 // Char Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn char_single(bencher: Bencher) {
     let values = [Value::from_i64(65)];
     bencher.bench_local(|| black_box(Value::exec_char(black_box(values.iter()))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn char_multiple(bencher: Bencher) {
     let values = [
         Value::from_i64(72),
@@ -822,7 +822,7 @@ fn char_multiple(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn min_integers(bencher: Bencher) {
     let values = [
         Value::from_i64(5),
@@ -835,7 +835,7 @@ fn min_integers(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn max_integers(bencher: Bencher) {
     let values = [
         Value::from_i64(5),
@@ -847,7 +847,7 @@ fn max_integers(bencher: Bencher) {
     bencher.bench_local(|| black_box(Value::exec_max(black_box(values.iter()))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn min_strings(bencher: Bencher) {
     let values = [
         Value::build_text("banana"),
@@ -857,7 +857,7 @@ fn min_strings(bencher: Bencher) {
     bencher.bench_local(|| black_box(Value::exec_min(black_box(values.iter()))));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn max_strings(bencher: Bencher) {
     let values = [
         Value::build_text("banana"),
@@ -872,7 +872,7 @@ fn max_strings(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn nullif_equal(bencher: Bencher) {
     let a = Value::from_i64(42);
     let b = Value::from_i64(42);
@@ -880,7 +880,7 @@ fn nullif_equal(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn nullif_not_equal(bencher: Bencher) {
     let a = Value::from_i64(42);
     let b = Value::from_i64(100);
@@ -888,7 +888,7 @@ fn nullif_not_equal(bencher: Bencher) {
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn nullif_strings(bencher: Bencher) {
     let a = Value::build_text("hello");
     let b = Value::build_text("hello");
@@ -899,19 +899,19 @@ fn nullif_strings(bencher: Bencher) {
 // Zeroblob Function
 // =============================================================================
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn zeroblob_small(bencher: Bencher) {
     let value = Value::from_i64(10);
     bencher.bench_local(|| black_box(black_box(&value).exec_zeroblob().unwrap()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn zeroblob_medium(bencher: Bencher) {
     let value = Value::from_i64(1000);
     bencher.bench_local(|| black_box(black_box(&value).exec_zeroblob().unwrap()));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn zeroblob_large(bencher: Bencher) {
     let value = Value::from_i64(10000);
     bencher.bench_local(|| black_box(black_box(&value).exec_zeroblob().unwrap()));
@@ -922,28 +922,28 @@ fn zeroblob_large(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn exec_if_true(bencher: Bencher) {
     let value = Value::from_i64(1);
     bencher.bench_local(|| black_box(black_box(&value).exec_if(false, false)));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn exec_if_false(bencher: Bencher) {
     let value = Value::from_i64(0);
     bencher.bench_local(|| black_box(black_box(&value).exec_if(false, false)));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn exec_if_null(bencher: Bencher) {
     let value = Value::Null;
     bencher.bench_local(|| black_box(black_box(&value).exec_if(true, false)));
 }
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn exec_if_not(bencher: Bencher) {
     let value = Value::from_i64(1);
     bencher.bench_local(|| black_box(black_box(&value).exec_if(false, true)));
@@ -954,7 +954,7 @@ fn exec_if_not(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn construct_like_exact(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_like(
@@ -966,7 +966,7 @@ fn construct_like_exact(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn construct_like_contains(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_like(
@@ -978,7 +978,7 @@ fn construct_like_contains(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn construct_like_with_single_wildcard(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_like(
@@ -990,7 +990,7 @@ fn construct_like_with_single_wildcard(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn construct_like_complex(bencher: Bencher) {
     bencher.bench_local(|| {
         black_box(Value::exec_like(
@@ -1007,12 +1007,12 @@ fn construct_like_complex(bencher: Bencher) {
 // =============================================================================
 
 #[cfg(feature = "nanosecond-bench")]
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn exec_random(bencher: Bencher) {
     bencher.bench_local(|| black_box(Value::exec_random(|| 42)));
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn exec_randomblob_small(bencher: Bencher) {
     let length = Value::from_i64(10);
     bencher.bench_local(|| {
@@ -1024,7 +1024,7 @@ fn exec_randomblob_small(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn exec_randomblob_medium(bencher: Bencher) {
     let length = Value::from_i64(100);
     bencher.bench_local(|| {
@@ -1036,7 +1036,7 @@ fn exec_randomblob_medium(bencher: Bencher) {
     });
 }
 
-#[divan::bench]
+#[turso_macros::divan_bench]
 fn exec_randomblob_large(bencher: Bencher) {
     let length = Value::from_i64(1000);
     bencher.bench_local(|| {

--- a/core/benches/struct_union_benchmark.rs
+++ b/core/benches/struct_union_benchmark.rs
@@ -71,6 +71,7 @@ fn run_to_completion(db: &Database, stmt: &mut turso_core::Statement) {
 // flat:   SELECT x FROM t          (read integer directly from record)
 // struct: SELECT val.x FROM t      (read blob, deserialize, extract field)
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_select_one_field(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("select_one_field");
 
@@ -119,6 +120,7 @@ fn bench_select_one_field(criterion: &mut Criterion) {
 // flat:   SELECT x, y FROM t
 // struct: SELECT val.x, val.y FROM t
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_select_two_fields(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("select_two_fields");
 
@@ -166,6 +168,7 @@ fn bench_select_two_fields(criterion: &mut Criterion) {
 // struct: SELECT val.x FROM t WHERE val.x > 5000
 // Same data, same selectivity (~50%), isolates deserialization cost in the filter path.
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_where_filter(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("where_filter");
 
@@ -214,6 +217,7 @@ fn bench_where_filter(criterion: &mut Criterion) {
 // flat:   INSERT INTO t VALUES (id, x, y)
 // struct: INSERT INTO t VALUES (id, struct_pack(x, y))
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_insert(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("insert");
 
@@ -273,6 +277,7 @@ fn bench_insert(criterion: &mut Criterion) {
 // union:  SELECT val.i FROM t             (read blob, check tag, extract value)
 // All rows have the same tag so every extract succeeds.
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_union_extract(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("union_extract");
 
@@ -311,6 +316,7 @@ fn bench_union_extract(criterion: &mut Criterion) {
 // flat:   SELECT typeof(x) FROM t         (return type string for a column)
 // union:  SELECT union_tag(val) FROM t    (read blob, extract tag name)
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_union_tag(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("union_tag");
 

--- a/core/benches/tpc_h_benchmark.rs
+++ b/core/benches/tpc_h_benchmark.rs
@@ -31,6 +31,7 @@ fn rusqlite_open_tpc_h() -> rusqlite::Connection {
     sqlite_conn
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_tpc_h_queries(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/turso/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features

--- a/core/benches/triggers.rs
+++ b/core/benches/triggers.rs
@@ -82,6 +82,7 @@ fn setup_rusqlite(temp_dir: &TempDir, schema: &str) -> rusqlite::Connection {
 }
 
 /// Multi-row INSERT with AFTER INSERT trigger (tests statement caching + step_subprogram)
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_multirow_insert_with_trigger(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -168,6 +169,7 @@ fn bench_multirow_insert_with_trigger(criterion: &mut Criterion) {
 }
 
 /// Wide table where trigger references only a few columns (tests sparse parameter allocation)
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_wide_table_sparse_trigger(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -267,6 +269,7 @@ fn bench_wide_table_sparse_trigger(criterion: &mut Criterion) {
 }
 
 /// Multiple triggers on the same table (tests pre-trigger affinity emission)
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_multiple_triggers(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -394,6 +397,7 @@ fn bench_multiple_triggers(criterion: &mut Criterion) {
 }
 
 /// Baseline: INSERT with vs without triggers to isolate trigger overhead
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_trigger_overhead(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -488,6 +492,7 @@ fn bench_trigger_overhead(criterion: &mut Criterion) {
 }
 
 /// BEFORE INSERT trigger that modifies NEW values
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_before_trigger(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");

--- a/core/benches/write_perf_benchmark.rs
+++ b/core/benches/write_perf_benchmark.rs
@@ -112,6 +112,7 @@ fn setup_rusqlite(temp_dir: &TempDir, schema: &str) -> rusqlite::Connection {
 /// 1. Seek operations for uniqueness checks
 /// 2. Additional B-tree insertions
 /// 3. Page splits on index pages
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_index_impact(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -209,6 +210,7 @@ fn bench_index_impact(criterion: &mut Criterion) {
 ///
 /// Measures how the number of rows per transaction affects throughput.
 /// Larger transactions amortize commit overhead but increase memory pressure.
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_transaction_size(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -298,6 +300,7 @@ fn bench_transaction_size(criterion: &mut Criterion) {
 /// 1. Balance quick path can be used (appending to rightmost leaf)
 /// 2. Better cache locality
 /// 3. Fewer page splits
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_key_pattern(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -437,6 +440,7 @@ fn bench_key_pattern(criterion: &mut Criterion) {
 /// 1. Required seek to find existing row
 /// 2. Potential in-place update vs delete+insert
 /// 3. Index maintenance on modified columns
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_update_performance(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -514,6 +518,7 @@ fn bench_update_performance(criterion: &mut Criterion) {
 /// Benchmark: DELETE performance
 ///
 /// Measures DELETE throughput with different patterns
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_delete_performance(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -603,6 +608,7 @@ fn bench_delete_performance(criterion: &mut Criterion) {
 /// Benchmark: Large transaction commit (many dirty pages)
 ///
 /// Specifically targets the commit_dirty_pages path with many pages
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_large_transaction_commit(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");
@@ -703,6 +709,7 @@ fn bench_large_transaction_commit(criterion: &mut Criterion) {
 /// Benchmark: Fsync overhead isolation
 ///
 /// Compares INSERT performance with sync=FULL vs sync=OFF to isolate fsync cost
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_fsync_overhead(criterion: &mut Criterion) {
     let enable_rusqlite =
         std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err() && !cfg!(feature = "codspeed");

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -692,7 +692,7 @@ impl HybridBTreeDirectory {
         cursor.index_info = Some(Arc::new(IndexInfo {
             has_rowid: false,
             num_cols: Self::CHUNK_LEN,
-            key_info: vec![key_info(), key_info(), key_info()],
+            key_info: crate::alloc::vec![key_info(), key_info(), key_info()],
             is_unique: false,
         }));
 
@@ -1871,7 +1871,7 @@ impl FtsCursor {
         cursor.index_info = Some(Arc::new(IndexInfo {
             has_rowid: false,
             num_cols: 3,
-            key_info: vec![key_info(), key_info(), key_info()],
+            key_info: crate::alloc::vec![key_info(), key_info(), key_info()],
             is_unique: false,
         }));
         self.fts_dir_cursor = Some(cursor);
@@ -2462,7 +2462,10 @@ impl Drop for FtsCursor {
         );
 
         if is_flushing {
-            turso_assert!(conn.is_in_write_tx(), "FTS Drop: in-progress flush abandoned (transaction already committed). pre_commit should have completed the flush.");
+            turso_assert!(
+                conn.is_in_write_tx(),
+                "FTS Drop: in-progress flush abandoned (transaction already committed). pre_commit should have completed the flush."
+            );
 
             tracing::debug!("FTS Drop: completing in-progress flush");
             loop {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,4 +17,4 @@ proc-macro = true
 [dependencies]
 quote = "1.0.38"
 proc-macro2 = "1.0.93"
-syn = { version = "2.0.96", features = ["full", "clone-impls"] }
+syn = { version = "2.0.96", features = ["full", "clone-impls", "visit-mut"] }

--- a/macros/src/codspeed.rs
+++ b/macros/src/codspeed.rs
@@ -1,0 +1,120 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::visit_mut::{self, VisitMut};
+use syn::{parse_macro_input, Expr, ExprCall, ExprMethodCall, ItemFn, LitStr};
+
+pub(crate) fn divan_bench_attribute(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attr = proc_macro2::TokenStream::from(attr);
+    let function = parse_macro_input!(input as ItemFn);
+    let nightly_name = LitStr::new(
+        &format!("{} nightly", function.sig.ident),
+        function.sig.ident.span(),
+    );
+
+    let stable_attr = if attr.is_empty() {
+        quote! { #[cfg_attr(not(nightly), divan::bench)] }
+    } else {
+        quote! { #[cfg_attr(not(nightly), divan::bench(#attr))] }
+    };
+
+    let nightly_attr = if attr.is_empty() {
+        quote! { #[cfg_attr(nightly, divan::bench(name = #nightly_name))] }
+    } else {
+        quote! { #[cfg_attr(nightly, divan::bench(name = #nightly_name, #attr))] }
+    };
+
+    quote! {
+        #nightly_attr
+        #stable_attr
+        #function
+    }
+    .into()
+}
+
+pub(crate) fn criterion_benchmark_attribute(attr: TokenStream, input: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "codspeed_criterion_benchmark does not accept arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let mut function = parse_macro_input!(input as ItemFn);
+    CriterionBenchmarkIds.visit_block_mut(&mut function.block);
+
+    quote! { #function }.into()
+}
+
+struct CriterionBenchmarkIds;
+
+impl VisitMut for CriterionBenchmarkIds {
+    fn visit_expr_method_call_mut(&mut self, expr: &mut ExprMethodCall) {
+        visit_mut::visit_expr_method_call_mut(self, expr);
+
+        if expr.method != "bench_function" && expr.method != "bench_with_input" {
+            return;
+        }
+
+        let Some(first_arg) = expr.args.first_mut() else {
+            return;
+        };
+        let original = first_arg.clone();
+        let nightly = nightly_criterion_id(original.clone());
+        *first_arg = syn::parse_quote!({
+            #[cfg(nightly)]
+            {
+                #nightly
+            }
+            #[cfg(not(nightly))]
+            {
+                #original
+            }
+        });
+    }
+}
+
+fn nightly_criterion_id(expr: Expr) -> Expr {
+    if let Expr::Call(call) = &expr {
+        if let Some(id) = nightly_benchmark_id_call(call) {
+            return id;
+        }
+    }
+
+    syn::parse_quote! {
+        format!("{} nightly", #expr)
+    }
+}
+
+fn nightly_benchmark_id_call(call: &ExprCall) -> Option<Expr> {
+    let Expr::Path(func_path) = call.func.as_ref() else {
+        return None;
+    };
+
+    let mut segments = func_path.path.segments.iter().rev();
+    let method = segments.next()?;
+    let ty = segments.next()?;
+    if ty.ident != "BenchmarkId" {
+        return None;
+    }
+
+    let func = &call.func;
+    match (method.ident.to_string().as_str(), call.args.len()) {
+        ("new", 2) => {
+            let mut args = call.args.iter();
+            let function_name = args.next()?;
+            let parameter = args.next()?;
+            Some(syn::parse_quote! {
+                #func(#function_name, format!("{} nightly", #parameter))
+            })
+        }
+        ("from_parameter", 1) => {
+            let parameter = call.args.first()?;
+            Some(syn::parse_quote! {
+                #func(format!("{} nightly", #parameter))
+            })
+        }
+        _ => None,
+    }
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -82,6 +82,7 @@
 
 extern crate proc_macro;
 mod atomic_enum;
+mod codspeed;
 mod ext;
 mod test;
 
@@ -185,6 +186,16 @@ pub fn derive_description_from_doc(item: TokenStream) -> TokenStream {
         }
     }
     generate_get_description(enum_name, &variant_description_map, enum_variants)
+}
+
+#[proc_macro_attribute]
+pub fn codspeed_criterion_benchmark(attr: TokenStream, input: TokenStream) -> TokenStream {
+    codspeed::criterion_benchmark_attribute(attr, input)
+}
+
+#[proc_macro_attribute]
+pub fn divan_bench(attr: TokenStream, input: TokenStream) -> TokenStream {
+    codspeed::divan_bench_attribute(attr, input)
 }
 
 /// Processes a Rust docs to extract the description string.

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 description = "The Turso parser library"
 
+[lints]
+workspace = true
+
 [lib]
 name = "turso_parser"
 

--- a/parser/benches/parser_benchmark.rs
+++ b/parser/benches/parser_benchmark.rs
@@ -10,6 +10,7 @@ use codspeed_criterion_compat::{
 
 use turso_parser::{lexer::Lexer, parser::Parser};
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_parser(criterion: &mut Criterion) {
     let queries = [
         "SELECT 1",
@@ -29,6 +30,7 @@ fn bench_parser(criterion: &mut Criterion) {
     }
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_parser_insert_batch(criterion: &mut Criterion) {
     for batch_size in [1, 10, 100] {
         let mut values = String::from("INSERT INTO test VALUES ");
@@ -50,6 +52,7 @@ fn bench_parser_insert_batch(criterion: &mut Criterion) {
     }
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_lexer(criterion: &mut Criterion) {
     let queries = [
         "SELECT 1",

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -287,7 +287,7 @@ impl<'a> Parser<'a> {
                             parsed_offset: (offset, 1).into(),
                             expected: &[TK_SEMI],
                             got: tt,
-                            token_text: token_text.clone(),
+                            token_text,
                             offset,
                             expected_display: crate::token::TokenType::format_expected_tokens(&[
                                 TK_SEMI,
@@ -1827,7 +1827,7 @@ impl<'a> Parser<'a> {
                                 parsed_offset: (self.offset() - name.len(), name.len()).into(),
                                 got: TK_STRING,
                                 expected: &[TK_ID, TK_INDEXED, TK_JOIN_KW],
-                                token_text: token_text.clone(),
+                                token_text,
                                 offset,
                                 expected_display: crate::token::TokenType::format_expected_tokens(
                                     &[TK_ID, TK_INDEXED, TK_JOIN_KW],
@@ -5222,6 +5222,7 @@ mod tests {
         }
     }
 
+    #[expect(clippy::large_stack_frames)]
     #[test]
     fn test_parser() {
         let test_cases = vec![


### PR DESCRIPTION
## Summary

- Discover non-TPC-H CodSpeed benchmark targets dynamically so newly added benches are sharded automatically.
- Build benchmark binaries once per toolchain and share them with sharded run jobs through per-run Blacksmith sticky disks.
- Run CodSpeed on both Rust 1.88.0 and pinned nightly with `--cfg nightly`, using separate sticky disks for stable and nightly artifacts.

## AI USAGE
Done with codex, nobody likes editing workflow yaml by hand. 