### PR TITLE
alloc: add specialization in nightly for Vec

### DIFF
--- a/core/alloc/collections/mod.rs
+++ b/core/alloc/collections/mod.rs
@@ -12,6 +12,8 @@ mod traits;
 mod vec;
 mod vec_deque;
 
+#[cfg(nightly)]
+pub use traits::TursoFromIteratorIn;
 pub use traits::{
     TryClone, TursoAllocExt, TursoBinaryHeapExt, TursoBoxExt, TursoFromIterator, TursoHashMapExt,
     TursoHashSetExt, TursoIteratorExt, TursoNewExt, TursoSliceExt, TursoTryNewExt,

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -61,6 +61,13 @@ pub trait TursoFromIterator<T>: Sized {
         I: IntoIterator<Item = T>;
 }
 
+#[cfg(nightly)]
+pub trait TursoFromIteratorIn<T, A>: Sized {
+    fn try_from_iter_in<I>(iter: I, alloc: A) -> Result<Self, TryReserveError>
+    where
+        I: IntoIterator<Item = T>;
+}
+
 pub trait TursoIteratorExt: Iterator + Sized {
     #[inline]
     fn try_collect<C>(self) -> Result<C, TryReserveError>
@@ -77,6 +84,15 @@ pub trait TursoIteratorExt: Iterator + Sized {
         Self: Iterator<Item = (A, B)>,
     {
         <(FromA, FromB) as TursoFromIterator<(A, B)>>::try_from_iter(self)
+    }
+
+    #[cfg(nightly)]
+    #[inline]
+    fn try_collect_in<C, A>(self, alloc: A) -> Result<C, TryReserveError>
+    where
+        C: TursoFromIteratorIn<Self::Item, A>,
+    {
+        C::try_from_iter_in(self, alloc)
     }
 }
 

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -69,7 +69,7 @@ pub trait TursoFromIteratorIn<T, A>: Sized {
 }
 
 pub trait TursoIteratorExt: Iterator + Sized {
-    #[inline]
+    #[inline(always)]
     fn try_collect<C>(self) -> Result<C, TryReserveError>
     where
         C: TursoFromIterator<Self::Item>,
@@ -87,7 +87,7 @@ pub trait TursoIteratorExt: Iterator + Sized {
     }
 
     #[cfg(nightly)]
-    #[inline]
+    #[inline(always)]
     fn try_collect_in<C, A>(self, alloc: A) -> Result<C, TryReserveError>
     where
         C: TursoFromIteratorIn<Self::Item, A>,

--- a/core/alloc/collections/vec/mod.rs
+++ b/core/alloc/collections/vec/mod.rs
@@ -1,8 +1,11 @@
+#[cfg(nightly)]
+mod nightly;
+
+#[cfg(not(nightly))]
 use super::{
     TryClone, TursoAllocExt, TursoFromIterator, TursoSliceExt, TursoTryWithCapacityExt, TursoVecExt,
 };
-#[cfg(nightly)]
-use crate::alloc::TursoAllocator;
+#[cfg(not(nightly))]
 use crate::alloc::{TryReserveError, Vec};
 
 #[cfg(not(nightly))]
@@ -10,21 +13,12 @@ pub(super) const fn vec<T>() -> Vec<T> {
     Vec::new()
 }
 
-#[cfg(nightly)]
-pub(super) const fn vec<T>() -> Vec<T> {
-    Vec::new_in(TursoAllocator)
-}
-
 #[cfg(not(nightly))]
 fn vec_with_capacity<T>(capacity: usize) -> Vec<T> {
     Vec::with_capacity(capacity)
 }
 
-#[cfg(nightly)]
-fn vec_with_capacity<T>(capacity: usize) -> Vec<T> {
-    Vec::with_capacity_in(capacity, TursoAllocator)
-}
-
+#[cfg(not(nightly))]
 impl<T> TursoAllocExt for Vec<T> {
     #[inline(always)]
     fn new() -> Self {
@@ -32,6 +26,7 @@ impl<T> TursoAllocExt for Vec<T> {
     }
 }
 
+#[cfg(not(nightly))]
 impl<T> TursoVecExt<T> for Vec<T> {
     #[inline(always)]
     fn with_capacity(capacity: usize) -> Self {
@@ -45,6 +40,7 @@ impl<T> TursoVecExt<T> for Vec<T> {
     }
 }
 
+#[cfg(not(nightly))]
 impl<T> TursoTryWithCapacityExt for Vec<T> {
     #[inline(always)]
     fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
@@ -52,22 +48,14 @@ impl<T> TursoTryWithCapacityExt for Vec<T> {
     }
 }
 
+#[cfg(not(nightly))]
 impl<T> TursoFromIterator<T> for Vec<T> {
     #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        #[cfg(not(nightly))]
-        {
-            Ok(iter.into_iter().collect())
-        }
-        #[cfg(nightly)]
-        {
-            let mut values = vec();
-            values.extend(iter);
-            Ok(values)
-        }
+        Ok(iter.into_iter().collect())
     }
 
     #[inline(always)]
@@ -80,6 +68,7 @@ impl<T> TursoFromIterator<T> for Vec<T> {
     }
 }
 
+#[cfg(not(nightly))]
 impl<T: Clone> TursoSliceExt<T> for [T] {
     #[inline(always)]
     fn try_to_vec(&self) -> Result<Vec<T>, TryReserveError> {
@@ -89,18 +78,13 @@ impl<T: Clone> TursoSliceExt<T> for [T] {
     }
 }
 
+#[cfg(not(nightly))]
 impl<T: Clone> TryClone for Vec<T> {
     type Error = TryReserveError;
 
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
-        #[cfg(not(nightly))]
         let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
-        #[cfg(nightly)]
-        let mut cloned = {
-            let alloc = self.allocator().clone();
-            Self::try_with_capacity_in(self.len(), alloc).map_err(TryReserveError::from)?
-        };
         cloned.extend(self.iter().cloned());
         Ok(cloned)
     }

--- a/core/alloc/collections/vec/nightly.rs
+++ b/core/alloc/collections/vec/nightly.rs
@@ -70,7 +70,7 @@ impl<T, A> TursoFromIteratorIn<T, A> for Vec<T, A>
 where
     A: Allocator,
 {
-    #[inline]
+    #[inline(always)]
     fn try_from_iter_in<I>(iter: I, alloc: A) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
@@ -120,7 +120,7 @@ where
     I: Iterator<Item = T>,
     A: Allocator,
 {
-    #[inline]
+    #[inline(always)]
     default fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError> {
         self.try_extend_desugared(iter, true)
     }
@@ -131,7 +131,7 @@ where
     I: TrustedLen<Item = T>,
     A: Allocator,
 {
-    #[inline]
+    #[inline(always)]
     default fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError> {
         self.try_extend_trusted(iter)
     }
@@ -152,7 +152,7 @@ where
     I: Iterator<Item = &'a T>,
     A: Allocator,
 {
-    #[inline]
+    #[inline(always)]
     default fn try_spec_extend_ref(&mut self, iter: I) -> Result<(), TryReserveError> {
         self.try_spec_extend(iter.cloned())
     }
@@ -163,7 +163,7 @@ where
     T: Copy + 'a,
     A: Allocator,
 {
-    #[inline]
+    #[inline(always)]
     fn try_spec_extend_ref(&mut self, iter: slice::Iter<'a, T>) -> Result<(), TryReserveError> {
         self.try_copy_from_slice(iter.as_slice())
     }
@@ -186,15 +186,15 @@ where
     I: Iterator<Item = T>,
     A: Allocator,
 {
-    #[inline]
+    #[inline(always)]
     default fn try_from_iter_in(mut iter: I, alloc: A) -> Result<Self, TryReserveError> {
         let Some(first) = iter.next() else {
             return Ok(Vec::new_in(alloc));
         };
 
         let mut values = Vec::new_in(alloc);
-        let (lower, upper) = iter.size_hint();
-        let initial = upper.unwrap_or(lower).saturating_add(1);
+        let (lower, _) = iter.size_hint();
+        let initial = lower.saturating_add(1);
         values.try_reserve(initial).map_err(TryReserveError::from)?;
 
         unsafe {
@@ -202,6 +202,11 @@ where
             values.set_len(1);
         }
 
+        if lower != 0 {
+            unsafe {
+                extend_reserved_lower_bound(&mut values, &mut iter, lower);
+            }
+        }
         values.try_extend_desugared(iter, false)?;
         Ok(values)
     }
@@ -212,7 +217,7 @@ where
     I: TrustedLen<Item = T>,
     A: Allocator,
 {
-    #[inline]
+    #[inline(always)]
     fn try_from_iter_in(iter: I, alloc: A) -> Result<Self, TryReserveError> {
         let additional = trusted_len(iter.size_hint())?;
         if additional == 0 {
@@ -255,7 +260,7 @@ impl<T, A> TryVecInternal<T> for Vec<T, A>
 where
     A: Allocator,
 {
-    #[inline]
+    #[inline(always)]
     fn try_extend_desugared<I>(
         &mut self,
         mut iter: I,
@@ -273,9 +278,7 @@ where
         while let Some(element) = iter.next() {
             let len = self.len();
             if len == self.capacity() {
-                let (lower, _) = iter.size_hint();
-                self.try_reserve(lower.saturating_add(1))
-                    .map_err(TryReserveError::from)?;
+                try_reserve_for_extend(self, &iter)?;
             }
 
             unsafe {
@@ -287,7 +290,7 @@ where
         Ok(())
     }
 
-    #[inline]
+    #[inline(always)]
     fn try_extend_trusted<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: TrustedLen<Item = T>,
@@ -303,7 +306,7 @@ where
         Ok(())
     }
 
-    #[inline]
+    #[inline(always)]
     unsafe fn extend_trusted_unchecked<I>(&mut self, iter: I)
     where
         I: TrustedLen<Item = T>,
@@ -318,7 +321,7 @@ where
         });
     }
 
-    #[inline]
+    #[inline(always)]
     fn try_copy_from_slice(&mut self, slice: &[T]) -> Result<(), TryReserveError>
     where
         T: Copy,
@@ -346,6 +349,41 @@ fn trusted_len(size_hint: (usize, Option<usize>)) -> Result<usize, TryReserveErr
     };
     debug_assert_eq!(lower, additional);
     Ok(additional)
+}
+
+#[cold]
+#[inline(never)]
+fn try_reserve_for_extend<T, A, I>(values: &mut Vec<T, A>, iter: &I) -> Result<(), TryReserveError>
+where
+    A: Allocator,
+    I: Iterator<Item = T>,
+{
+    let (lower, _) = iter.size_hint();
+    values
+        .try_reserve(lower.saturating_add(1))
+        .map_err(TryReserveError::from)
+}
+
+#[inline(always)]
+unsafe fn extend_reserved_lower_bound<T, A, I>(
+    values: &mut Vec<T, A>,
+    iter: &mut I,
+    additional: usize,
+) where
+    A: Allocator,
+    I: Iterator<Item = T>,
+{
+    let ptr = values.as_mut_ptr();
+    let mut guard = SetLenOnDrop::new(values);
+    for _ in 0..additional {
+        let Some(element) = iter.next() else {
+            return;
+        };
+        unsafe {
+            ptr::write(ptr.add(guard.current_len()), element);
+        }
+        guard.increment_len();
+    }
 }
 
 /// Publishes the vector length for direct writes, including during unwinding.

--- a/core/alloc/collections/vec/nightly.rs
+++ b/core/alloc/collections/vec/nightly.rs
@@ -1,16 +1,13 @@
-use std::{iter::TrustedLen, ptr, slice};
+use std::{alloc::Allocator, iter::TrustedLen, ptr, slice};
 
 use super::super::{
-    TryClone, TursoAllocExt, TursoFromIterator, TursoSliceExt, TursoTryWithCapacityExt, TursoVecExt,
+    TryClone, TursoAllocExt, TursoFromIterator, TursoFromIteratorIn, TursoSliceExt,
+    TursoTryWithCapacityExt, TursoVecExt,
 };
 use crate::alloc::{TryReserveError, TursoAllocator, Vec};
 
 pub(super) const fn vec<T>() -> Vec<T> {
     Vec::new_in(TursoAllocator)
-}
-
-fn vec_with_capacity<T>(capacity: usize) -> Vec<T> {
-    Vec::with_capacity_in(capacity, TursoAllocator)
 }
 
 impl<T> TursoAllocExt for Vec<T> {
@@ -23,7 +20,7 @@ impl<T> TursoAllocExt for Vec<T> {
 impl<T> TursoVecExt<T> for Vec<T> {
     #[inline(always)]
     fn with_capacity(capacity: usize) -> Self {
-        vec_with_capacity(capacity)
+        Vec::with_capacity_in(capacity, TursoAllocator)
     }
 
     #[inline(always)]
@@ -48,13 +45,16 @@ impl<T> TursoTryWithCapacityExt for Vec<T> {
     }
 }
 
-impl<T> TursoFromIterator<T> for Vec<T> {
+impl<T, A> TursoFromIterator<T> for Vec<T, A>
+where
+    A: Allocator + Default,
+{
     #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        <Self as TrySpecFromIter<T, I::IntoIter>>::try_from_iter(iter.into_iter())
+        <Self as TursoFromIteratorIn<T, A>>::try_from_iter_in(iter, A::default())
     }
 
     #[inline(always)]
@@ -63,6 +63,19 @@ impl<T> TursoFromIterator<T> for Vec<T> {
         I: IntoIterator<Item = T>,
     {
         self.try_spec_extend(iter.into_iter())
+    }
+}
+
+impl<T, A> TursoFromIteratorIn<T, A> for Vec<T, A>
+where
+    A: Allocator,
+{
+    #[inline]
+    fn try_from_iter_in<I>(iter: I, alloc: A) -> Result<Self, TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        <Self as TrySpecFromIter<T, I::IntoIter, A>>::try_from_iter_in(iter.into_iter(), alloc)
     }
 }
 
@@ -75,7 +88,11 @@ impl<T: Clone> TursoSliceExt<T> for [T] {
     }
 }
 
-impl<T: Clone> TryClone for Vec<T> {
+impl<T, A> TryClone for Vec<T, A>
+where
+    T: Clone,
+    A: Allocator + Clone,
+{
     type Error = TryReserveError;
 
     #[inline(always)]
@@ -98,9 +115,10 @@ trait TrySpecExtend<T, I> {
     fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError>;
 }
 
-impl<T, I> TrySpecExtend<T, I> for Vec<T>
+impl<T, I, A> TrySpecExtend<T, I> for Vec<T, A>
 where
     I: Iterator<Item = T>,
+    A: Allocator,
 {
     #[inline]
     default fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError> {
@@ -108,9 +126,10 @@ where
     }
 }
 
-impl<T, I> TrySpecExtend<T, I> for Vec<T>
+impl<T, I, A> TrySpecExtend<T, I> for Vec<T, A>
 where
     I: TrustedLen<Item = T>,
+    A: Allocator,
 {
     #[inline]
     default fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError> {
@@ -127,10 +146,11 @@ trait TrySpecExtendRef<'a, T, I> {
     fn try_spec_extend_ref(&mut self, iter: I) -> Result<(), TryReserveError>;
 }
 
-impl<'a, T, I> TrySpecExtendRef<'a, T, I> for Vec<T>
+impl<'a, T, I, A> TrySpecExtendRef<'a, T, I> for Vec<T, A>
 where
     T: Clone + 'a,
     I: Iterator<Item = &'a T>,
+    A: Allocator,
 {
     #[inline]
     default fn try_spec_extend_ref(&mut self, iter: I) -> Result<(), TryReserveError> {
@@ -138,9 +158,10 @@ where
     }
 }
 
-impl<'a, T> TrySpecExtendRef<'a, T, slice::Iter<'a, T>> for Vec<T>
+impl<'a, T, A> TrySpecExtendRef<'a, T, slice::Iter<'a, T>> for Vec<T, A>
 where
     T: Copy + 'a,
+    A: Allocator,
 {
     #[inline]
     fn try_spec_extend_ref(&mut self, iter: slice::Iter<'a, T>) -> Result<(), TryReserveError> {
@@ -153,21 +174,25 @@ where
 /// Collection has different fast paths from extension, most notably the
 /// empty-iterator case and exact preallocation for `TrustedLen`, so route it
 /// through its own trait.
-trait TrySpecFromIter<T, I>: Sized {
-    fn try_from_iter(iter: I) -> Result<Self, TryReserveError>;
+trait TrySpecFromIter<T, I, A>: Sized
+where
+    A: Allocator,
+{
+    fn try_from_iter_in(iter: I, alloc: A) -> Result<Self, TryReserveError>;
 }
 
-impl<T, I> TrySpecFromIter<T, I> for Vec<T>
+impl<T, I, A> TrySpecFromIter<T, I, A> for Vec<T, A>
 where
     I: Iterator<Item = T>,
+    A: Allocator,
 {
     #[inline]
-    default fn try_from_iter(mut iter: I) -> Result<Self, TryReserveError> {
+    default fn try_from_iter_in(mut iter: I, alloc: A) -> Result<Self, TryReserveError> {
         let Some(first) = iter.next() else {
-            return Ok(vec());
+            return Ok(Vec::new_in(alloc));
         };
 
-        let mut values = vec();
+        let mut values = Vec::new_in(alloc);
         let (lower, upper) = iter.size_hint();
         let initial = upper.unwrap_or(lower).saturating_add(1);
         values.try_reserve(initial).map_err(TryReserveError::from)?;
@@ -182,19 +207,20 @@ where
     }
 }
 
-impl<T, I> TrySpecFromIter<T, I> for Vec<T>
+impl<T, I, A> TrySpecFromIter<T, I, A> for Vec<T, A>
 where
     I: TrustedLen<Item = T>,
+    A: Allocator,
 {
     #[inline]
-    fn try_from_iter(iter: I) -> Result<Self, TryReserveError> {
+    fn try_from_iter_in(iter: I, alloc: A) -> Result<Self, TryReserveError> {
         let additional = trusted_len(iter.size_hint())?;
         if additional == 0 {
-            return Ok(vec());
+            return Ok(Vec::new_in(alloc));
         }
 
         let mut values =
-            Vec::try_with_capacity_in(additional, TursoAllocator).map_err(TryReserveError::from)?;
+            Vec::try_with_capacity_in(additional, alloc).map_err(TryReserveError::from)?;
         unsafe {
             values.extend_trusted_unchecked(iter);
         }
@@ -225,7 +251,10 @@ trait TryVecInternal<T> {
         T: Copy;
 }
 
-impl<T> TryVecInternal<T> for Vec<T> {
+impl<T, A> TryVecInternal<T> for Vec<T, A>
+where
+    A: Allocator,
+{
     #[inline]
     fn try_extend_desugared<I>(
         &mut self,
@@ -320,14 +349,17 @@ fn trusted_len(size_hint: (usize, Option<usize>)) -> Result<usize, TryReserveErr
 }
 
 /// Publishes the vector length for direct writes, including during unwinding.
-struct SetLenOnDrop<'a, T> {
-    vec: &'a mut Vec<T>,
+struct SetLenOnDrop<'a, T, A: Allocator> {
+    vec: &'a mut Vec<T, A>,
     len: usize,
 }
 
-impl<'a, T> SetLenOnDrop<'a, T> {
+impl<'a, T, A> SetLenOnDrop<'a, T, A>
+where
+    A: Allocator,
+{
     #[inline]
-    fn new(vec: &'a mut Vec<T>) -> Self {
+    fn new(vec: &'a mut Vec<T, A>) -> Self {
         Self {
             len: vec.len(),
             vec,
@@ -345,7 +377,10 @@ impl<'a, T> SetLenOnDrop<'a, T> {
     }
 }
 
-impl<T> Drop for SetLenOnDrop<'_, T> {
+impl<T, A> Drop for SetLenOnDrop<'_, T, A>
+where
+    A: Allocator,
+{
     #[inline]
     fn drop(&mut self) {
         unsafe {

--- a/core/alloc/collections/vec/nightly.rs
+++ b/core/alloc/collections/vec/nightly.rs
@@ -1,0 +1,355 @@
+use std::{iter::TrustedLen, ptr, slice};
+
+use super::super::{
+    TryClone, TursoAllocExt, TursoFromIterator, TursoSliceExt, TursoTryWithCapacityExt, TursoVecExt,
+};
+use crate::alloc::{TryReserveError, TursoAllocator, Vec};
+
+pub(super) const fn vec<T>() -> Vec<T> {
+    Vec::new_in(TursoAllocator)
+}
+
+fn vec_with_capacity<T>(capacity: usize) -> Vec<T> {
+    Vec::with_capacity_in(capacity, TursoAllocator)
+}
+
+impl<T> TursoAllocExt for Vec<T> {
+    #[inline(always)]
+    fn new() -> Self {
+        vec()
+    }
+}
+
+impl<T> TursoVecExt<T> for Vec<T> {
+    #[inline(always)]
+    fn with_capacity(capacity: usize) -> Self {
+        vec_with_capacity(capacity)
+    }
+
+    #[inline(always)]
+    fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
+        match self.push_within_capacity(value) {
+            Ok(_) => Ok(()),
+            Err(value) => {
+                self.try_reserve(1).map_err(TryReserveError::from)?;
+                match self.push_within_capacity(value) {
+                    Ok(_) => Ok(()),
+                    Err(_) => unreachable!("Vec::try_reserve(1) did not make room"),
+                }
+            }
+        }
+    }
+}
+
+impl<T> TursoTryWithCapacityExt for Vec<T> {
+    #[inline(always)]
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
+        Self::try_with_capacity_in(capacity, TursoAllocator).map_err(TryReserveError::from)
+    }
+}
+
+impl<T> TursoFromIterator<T> for Vec<T> {
+    #[inline(always)]
+    fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        <Self as TrySpecFromIter<T, I::IntoIter>>::try_from_iter(iter.into_iter())
+    }
+
+    #[inline(always)]
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.try_spec_extend(iter.into_iter())
+    }
+}
+
+impl<T: Clone> TursoSliceExt<T> for [T] {
+    #[inline(always)]
+    fn try_to_vec(&self) -> Result<Vec<T>, TryReserveError> {
+        let mut values = <Vec<T> as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
+        values.try_spec_extend_ref(self.iter())?;
+        Ok(values)
+    }
+}
+
+impl<T: Clone> TryClone for Vec<T> {
+    type Error = TryReserveError;
+
+    #[inline(always)]
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        let allocator = self.allocator().clone();
+        let mut cloned =
+            Self::try_with_capacity_in(self.len(), allocator).map_err(TryReserveError::from)?;
+        cloned.try_spec_extend_ref(self.iter())?;
+        Ok(cloned)
+    }
+}
+
+/// Vec specialization shim for `TursoFromIterator::try_extend`.
+///
+/// The default implementation handles any iterator and keeps a capacity check in
+/// the loop because ordinary `Iterator::size_hint` is only advisory. The
+/// `TrustedLen` specialization reserves once and writes directly into spare
+/// capacity because the iterator promises the exact remaining length.
+trait TrySpecExtend<T, I> {
+    fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError>;
+}
+
+impl<T, I> TrySpecExtend<T, I> for Vec<T>
+where
+    I: Iterator<Item = T>,
+{
+    #[inline]
+    default fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError> {
+        self.try_extend_desugared(iter, true)
+    }
+}
+
+impl<T, I> TrySpecExtend<T, I> for Vec<T>
+where
+    I: TrustedLen<Item = T>,
+{
+    #[inline]
+    default fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError> {
+        self.try_extend_trusted(iter)
+    }
+}
+
+/// Vec specialization shim for reference iterators.
+///
+/// The default path clones arbitrary reference iterators, then lets the owned
+/// specialization pick the best path. The concrete `slice::Iter` specialization
+/// for `Copy` values can bulk-copy after a single fallible reservation.
+trait TrySpecExtendRef<'a, T, I> {
+    fn try_spec_extend_ref(&mut self, iter: I) -> Result<(), TryReserveError>;
+}
+
+impl<'a, T, I> TrySpecExtendRef<'a, T, I> for Vec<T>
+where
+    T: Clone + 'a,
+    I: Iterator<Item = &'a T>,
+{
+    #[inline]
+    default fn try_spec_extend_ref(&mut self, iter: I) -> Result<(), TryReserveError> {
+        self.try_spec_extend(iter.cloned())
+    }
+}
+
+impl<'a, T> TrySpecExtendRef<'a, T, slice::Iter<'a, T>> for Vec<T>
+where
+    T: Copy + 'a,
+{
+    #[inline]
+    fn try_spec_extend_ref(&mut self, iter: slice::Iter<'a, T>) -> Result<(), TryReserveError> {
+        self.try_copy_from_slice(iter.as_slice())
+    }
+}
+
+/// Vec specialization shim for `TursoFromIterator::try_from_iter`.
+///
+/// Collection has different fast paths from extension, most notably the
+/// empty-iterator case and exact preallocation for `TrustedLen`, so route it
+/// through its own trait.
+trait TrySpecFromIter<T, I>: Sized {
+    fn try_from_iter(iter: I) -> Result<Self, TryReserveError>;
+}
+
+impl<T, I> TrySpecFromIter<T, I> for Vec<T>
+where
+    I: Iterator<Item = T>,
+{
+    #[inline]
+    default fn try_from_iter(mut iter: I) -> Result<Self, TryReserveError> {
+        let Some(first) = iter.next() else {
+            return Ok(vec());
+        };
+
+        let mut values = vec();
+        let (lower, upper) = iter.size_hint();
+        let initial = upper.unwrap_or(lower).saturating_add(1);
+        values.try_reserve(initial).map_err(TryReserveError::from)?;
+
+        unsafe {
+            ptr::write(values.as_mut_ptr(), first);
+            values.set_len(1);
+        }
+
+        values.try_extend_desugared(iter, false)?;
+        Ok(values)
+    }
+}
+
+impl<T, I> TrySpecFromIter<T, I> for Vec<T>
+where
+    I: TrustedLen<Item = T>,
+{
+    #[inline]
+    fn try_from_iter(iter: I) -> Result<Self, TryReserveError> {
+        let additional = trusted_len(iter.size_hint())?;
+        if additional == 0 {
+            return Ok(vec());
+        }
+
+        let mut values =
+            Vec::try_with_capacity_in(additional, TursoAllocator).map_err(TryReserveError::from)?;
+        unsafe {
+            values.extend_trusted_unchecked(iter);
+        }
+        Ok(values)
+    }
+}
+
+/// Shared implementation details for generic and exact-length Vec paths.
+trait TryVecInternal<T> {
+    fn try_extend_desugared<I>(
+        &mut self,
+        iter: I,
+        reserve_upper_bound: bool,
+    ) -> Result<(), TryReserveError>
+    where
+        I: Iterator<Item = T>;
+
+    fn try_extend_trusted<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: TrustedLen<Item = T>;
+
+    unsafe fn extend_trusted_unchecked<I>(&mut self, iter: I)
+    where
+        I: TrustedLen<Item = T>;
+
+    fn try_copy_from_slice(&mut self, slice: &[T]) -> Result<(), TryReserveError>
+    where
+        T: Copy;
+}
+
+impl<T> TryVecInternal<T> for Vec<T> {
+    #[inline]
+    fn try_extend_desugared<I>(
+        &mut self,
+        mut iter: I,
+        reserve_upper_bound: bool,
+    ) -> Result<(), TryReserveError>
+    where
+        I: Iterator<Item = T>,
+    {
+        if reserve_upper_bound {
+            if let (_, Some(upper)) = iter.size_hint() {
+                self.try_reserve(upper).map_err(TryReserveError::from)?;
+            }
+        }
+
+        while let Some(element) = iter.next() {
+            let len = self.len();
+            if len == self.capacity() {
+                let (lower, _) = iter.size_hint();
+                self.try_reserve(lower.saturating_add(1))
+                    .map_err(TryReserveError::from)?;
+            }
+
+            unsafe {
+                ptr::write(self.as_mut_ptr().add(len), element);
+                self.set_len(len + 1);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    fn try_extend_trusted<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: TrustedLen<Item = T>,
+    {
+        let additional = trusted_len(iter.size_hint())?;
+
+        self.try_reserve(additional)
+            .map_err(TryReserveError::from)?;
+        unsafe {
+            self.extend_trusted_unchecked(iter);
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    unsafe fn extend_trusted_unchecked<I>(&mut self, iter: I)
+    where
+        I: TrustedLen<Item = T>,
+    {
+        let ptr = self.as_mut_ptr();
+        let mut guard = SetLenOnDrop::new(self);
+        iter.for_each(move |element| {
+            unsafe {
+                ptr::write(ptr.add(guard.current_len()), element);
+            }
+            guard.increment_len();
+        });
+    }
+
+    #[inline]
+    fn try_copy_from_slice(&mut self, slice: &[T]) -> Result<(), TryReserveError>
+    where
+        T: Copy,
+    {
+        self.try_reserve(slice.len())
+            .map_err(TryReserveError::from)?;
+        unsafe {
+            let len = self.len();
+            ptr::copy_nonoverlapping(slice.as_ptr(), self.as_mut_ptr().add(len), slice.len());
+            self.set_len(len + slice.len());
+        }
+
+        Ok(())
+    }
+}
+
+#[inline]
+fn trusted_len(size_hint: (usize, Option<usize>)) -> Result<usize, TryReserveError> {
+    let (lower, upper) = size_hint;
+    let Some(additional) = upper else {
+        let Err(err) = std::vec::Vec::<u8>::new().try_reserve(usize::MAX) else {
+            unreachable!("reserving usize::MAX bytes must fail");
+        };
+        return Err(TryReserveError::from(err));
+    };
+    debug_assert_eq!(lower, additional);
+    Ok(additional)
+}
+
+/// Publishes the vector length for direct writes, including during unwinding.
+struct SetLenOnDrop<'a, T> {
+    vec: &'a mut Vec<T>,
+    len: usize,
+}
+
+impl<'a, T> SetLenOnDrop<'a, T> {
+    #[inline]
+    fn new(vec: &'a mut Vec<T>) -> Self {
+        Self {
+            len: vec.len(),
+            vec,
+        }
+    }
+
+    #[inline]
+    fn current_len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    fn increment_len(&mut self) {
+        self.len += 1;
+    }
+}
+
+impl<T> Drop for SetLenOnDrop<'_, T> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            self.vec.set_len(self.len);
+        }
+    }
+}

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -20,6 +20,8 @@ pub use allocation_site::{
 pub use api::ApiAllocator;
 pub use api::{AllocError, Global, Layout};
 pub use backend::{set_allocator, SetAllocatorError, TursoAllocBackend};
+#[cfg(nightly)]
+pub use collections::TursoFromIteratorIn;
 pub use collections::{
     TryClone, TursoAllocExt, TursoBinaryHeapExt, TursoBoxExt, TursoFromIterator, TursoHashMapExt,
     TursoHashSetExt, TursoIteratorExt, TursoNewExt, TursoSliceExt, TursoTryNewExt,
@@ -81,7 +83,7 @@ pub type BoxedSlice<T> = std::boxed::Box<[T], TursoAllocator>;
 #[cfg(not(nightly))]
 pub type Vec<T> = std::vec::Vec<T>;
 #[cfg(nightly)]
-pub type Vec<T> = std::vec::Vec<T, TursoAllocator>;
+pub type Vec<T, A = TursoAllocator> = std::vec::Vec<T, A>;
 
 pub use crate::{__turso_alloc_try_vec as try_vec, __turso_alloc_vec as vec};
 

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -18,7 +18,29 @@ impl Iterator for LowerBoundOnly {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, None)
+        (self.end - self.next, None)
+    }
+}
+
+struct UnderreportedLowerBound {
+    next: usize,
+    end: usize,
+}
+
+impl Iterator for UnderreportedLowerBound {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next == self.end {
+            return None;
+        }
+        let value = self.next;
+        self.next += 1;
+        Some(value)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        ((self.end - self.next).saturating_sub(1), None)
     }
 }
 
@@ -38,6 +60,24 @@ fn try_extend_accepts_iterators_without_upper_bounds() {
     values
         .try_extend(LowerBoundOnly { next: 0, end: 3 })
         .unwrap();
+
+    assert_eq!(values.as_slice(), &[0, 1, 2]);
+}
+
+#[test]
+fn try_extend_accepts_underreported_lower_bound_iterators() {
+    let mut values = <Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(4).unwrap();
+
+    values
+        .try_extend(UnderreportedLowerBound { next: 0, end: 4 })
+        .unwrap();
+
+    assert_eq!(values.as_slice(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn iterator_try_collect_accepts_iterators_without_upper_bounds() {
+    let values: Vec<_> = LowerBoundOnly { next: 0, end: 3 }.try_collect().unwrap();
 
     assert_eq!(values.as_slice(), &[0, 1, 2]);
 }

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -24,7 +24,7 @@ impl Iterator for LowerBoundOnly {
 
 #[test]
 fn try_extend_accepts_exact_size_iterators() {
-    let mut values = Vec::new();
+    let mut values: Vec<_> = TursoAllocExt::new();
 
     values.try_extend([1, 2, 3]).unwrap();
 
@@ -33,7 +33,7 @@ fn try_extend_accepts_exact_size_iterators() {
 
 #[test]
 fn try_extend_accepts_iterators_without_upper_bounds() {
-    let mut values = Vec::new();
+    let mut values: Vec<_> = TursoAllocExt::new();
 
     values
         .try_extend(LowerBoundOnly { next: 0, end: 3 })
@@ -97,6 +97,14 @@ fn binary_heap_try_push_and_extend_reserve_before_mutation() {
 #[test]
 fn iterator_try_collect_builds_turso_vec() {
     let values: Vec<_> = [1, 2, 3].into_iter().try_collect().unwrap();
+
+    assert_eq!(values.as_slice(), &[1, 2, 3]);
+}
+
+#[cfg(nightly)]
+#[test]
+fn iterator_try_collect_in_builds_global_vec() {
+    let values: Vec<_, Global> = [1, 2, 3].into_iter().try_collect_in(Global).unwrap();
 
     assert_eq!(values.as_slice(), &[1, 2, 3]);
 }
@@ -176,7 +184,7 @@ fn iterator_try_collect_converts_result_error() {
 
 #[test]
 fn tuple_try_extend_extends_both_collections() {
-    let mut values: (Vec<_>, VecDeque<_>) = (Vec::new(), VecDeque::new());
+    let mut values: (Vec<_>, VecDeque<_>) = (TursoAllocExt::new(), VecDeque::new());
 
     values
         .try_extend([(1, "one"), (2, "two"), (3, "three")])

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -42,6 +42,17 @@ fn try_extend_accepts_iterators_without_upper_bounds() {
     assert_eq!(values.as_slice(), &[0, 1, 2]);
 }
 
+#[cfg(nightly)]
+#[test]
+fn vec_try_extend_reserves_before_mutation() {
+    let mut values = self::vec![1];
+
+    let result = values.try_extend(std::iter::repeat(2).take(usize::MAX));
+
+    assert!(result.is_err());
+    assert_eq!(values.as_slice(), &[1]);
+}
+
 #[test]
 fn hash_set_try_insert_and_extend_reserve_before_mutation() {
     let mut values: HashSet<usize> = HashSet::default();

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(nightly, feature(allocator_api))]
+
 use divan::{black_box, AllocProfiler, Bencher};
 use mimalloc::MiMalloc;
 use rustc_hash::FxBuildHasher;
@@ -422,6 +424,17 @@ fn vec_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
     });
 }
 
+#[cfg(nightly)]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_collect_unknown_upper_global_turso_traits(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .try_collect_in::<alloc::Vec<_, alloc::Global>, _>(alloc::Global)
+            .unwrap();
+        black_box(values)
+    });
+}
+
 #[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_extend_unknown_upper_std(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
@@ -436,6 +449,17 @@ fn vec_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
             <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[cfg(nightly)]
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_extend_unknown_upper_global_turso_traits(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = alloc::Vec::with_capacity_in(len, alloc::Global);
         TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
             .unwrap();
         black_box(values)

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -49,6 +49,7 @@ struct LowerBoundOnly<I> {
 }
 
 impl<I> LowerBoundOnly<I> {
+    #[inline(always)]
     fn new(iter: I) -> Self {
         Self { iter }
     }
@@ -60,10 +61,12 @@ where
 {
     type Item = I::Item;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, _) = self.iter.size_hint();
         (lower, None)

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1,6 +1,14 @@
 #![cfg_attr(
     nightly,
-    feature(allocator_api, btreemap_alloc, clone_from_ref, try_with_capacity)
+    feature(
+        allocator_api,
+        btreemap_alloc,
+        clone_from_ref,
+        min_specialization,
+        try_with_capacity,
+        trusted_len,
+        vec_push_within_capacity
+    )
 )]
 #![recursion_limit = "256"]
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -618,7 +618,7 @@ impl MakeFromBtreeState {
             cursor: None,
             accumulators: None,
             read_tx_active: false,
-            sequence_sources: Vec::new(),
+            sequence_sources: vec![],
             sequence_cursor: None,
         }
     }
@@ -1004,7 +1004,7 @@ impl Schema {
         &self,
         type_name: &str,
     ) -> crate::Result<(String, Vec<Arc<TypeDef>>)> {
-        let mut chain = Vec::new();
+        let mut chain = vec![];
         let mut visited = std::collections::HashSet::new();
         let mut current = type_name.to_lowercase();
 
@@ -1214,7 +1214,7 @@ impl Schema {
     /// Get all materialized views that depend on a given table
     pub fn get_dependent_materialized_views(&self, table_name: &str) -> Vec<String> {
         if self.table_to_materialized_views.is_empty() {
-            return Vec::new();
+            return vec![];
         }
         let table_name = normalize_ident(table_name);
         self.table_to_materialized_views
@@ -1939,7 +1939,7 @@ impl Schema {
                 name: view_name.clone(),
                 root_page: main_root,
                 columns: cols,
-                primary_key_columns: Vec::new(),
+                primary_key_columns: vec![],
                 has_rowid: true,
                 is_strict: false,
                 has_autoincrement: false,
@@ -3283,8 +3283,8 @@ impl BTreeTable {
             return Ok(());
         }
         // Collect new constraints and notnull flags to avoid borrowing issues
-        let mut new_checks = Vec::new();
-        let mut notnull_cols = Vec::new();
+        let mut new_checks = vec![];
+        let mut notnull_cols = vec![];
 
         for (col_idx, col) in self.columns.iter().enumerate() {
             let Ok(Some(resolved)) = schema.resolve_type_unchecked(&col.ty_str) else {
@@ -4646,7 +4646,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
         check_constraints,
         rowid_alias_conflict_clause,
         has_virtual_columns: false,
-        logical_to_physical_map: Vec::new(),
+        logical_to_physical_map: vec![],
         column_dependencies: Default::default(),
     };
     table.prepare_generated_columns()?;
@@ -6471,7 +6471,7 @@ mod tests {
             2,
             Some("CREATE TABLE t1(a INTEGER, b AS (a*2))"),
             &SymbolTable::default(),
-            &mut Vec::new(),
+            &mut vec![],
             &mut HashMap::default(),
             &mut HashMap::default(),
             &mut HashMap::default(),

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -248,7 +248,7 @@ impl HashEntry {
             hash,
             key_values,
             rowid,
-            payload_values: Vec::new(),
+            payload_values: vec![],
         }
     }
 
@@ -590,9 +590,7 @@ pub struct HashBucket {
 
 impl HashBucket {
     fn new() -> Self {
-        Self {
-            entries: Vec::new(),
-        }
+        Self { entries: vec![] }
     }
 
     fn insert(&mut self, entry: HashEntry) -> Result<()> {
@@ -677,16 +675,16 @@ impl SpilledPartition {
     fn new(partition_idx: usize) -> Self {
         Self {
             partition_idx,
-            chunks: Vec::new(),
+            chunks: vec![],
             state: PartitionState::OnDisk,
             io_state: Arc::new(AtomicSpillIOState::new(SpillIOState::None)),
-            read_buffer: Arc::new(RwLock::new(Vec::new())),
+            read_buffer: Arc::new(RwLock::new(vec![])),
             buffer_len: Arc::new(atomic::AtomicUsize::new(0)),
-            buckets: Vec::new(),
+            buckets: vec![],
             current_chunk_idx: 0,
             resident_mem: 0,
-            matched_bits: Vec::new(),
-            partial_entry: Vec::new(),
+            matched_bits: vec![],
+            partial_entry: vec![],
             parsed_entries: 0,
         }
     }
@@ -746,7 +744,7 @@ struct PartitionBuffer {
 impl PartitionBuffer {
     fn new() -> Self {
         Self {
-            entries: Vec::new(),
+            entries: vec![],
             mem_used: 0,
         }
     }
@@ -824,7 +822,7 @@ impl SpillState {
             partition_buffers: (0..partitioning.count)
                 .map(|_| PartitionBuffer::new())
                 .try_collect()?,
-            partitions: Vec::new(),
+            partitions: vec![],
             next_spill_offset: 0,
             temp_file: TempFile::with_temp_store(io, temp_store)?,
             partitioning,
@@ -874,7 +872,7 @@ impl ProbeSpillState {
             partition_buffers: (0..partitioning.count)
                 .map(|_| PartitionBuffer::new())
                 .try_collect()?,
-            partitions: Vec::new(),
+            partitions: vec![],
             next_spill_offset: 0,
             temp_file: TempFile::with_temp_store(io, temp_store)?,
             partitioning,
@@ -1059,9 +1057,9 @@ impl HashTable {
         let num_buckets = config.initial_buckets;
         let buckets = (0..num_buckets).map(|_| HashBucket::new()).try_collect()?;
         let matched_bits = if config.track_matched {
-            (0..num_buckets).map(|_| Vec::new()).try_collect()?
+            (0..num_buckets).map(|_| vec![]).try_collect()?
         } else {
-            Vec::new()
+            vec![]
         };
         Ok(Self {
             initial_buckets: config.initial_buckets,
@@ -1081,7 +1079,7 @@ impl HashTable {
             current_spill_partition_idx: 0,
             loaded_partitions_lru: VecDeque::new().into(),
             loaded_partitions_mem: 0,
-            non_empty_buckets: Vec::new(),
+            non_empty_buckets: vec![],
             temp_store: config.temp_store,
             track_matched: config.track_matched,
             matched_bits,
@@ -1726,7 +1724,7 @@ impl HashTable {
         }
 
         // Collect all partitions that need to be spilled
-        let mut partitions_to_spill = Vec::new();
+        let mut partitions_to_spill = vec![];
         let mut projected_mem_used = self.mem_used;
 
         let spill_state = self.spill_state.as_ref().expect("spill state must exist");
@@ -1786,7 +1784,7 @@ impl HashTable {
                 .map(|b| vec![false; b.entries.len()])
                 .try_collect()?
         } else {
-            Vec::new()
+            vec![]
         };
         let mut partition = SpilledPartition::new(partition_idx);
         partition.state = PartitionState::InMemory;
@@ -1822,8 +1820,8 @@ impl HashTable {
             }
             // Determine which partitions need to spill vs stay in memory without holding
             // a mutable borrow across the spill/materialize calls.
-            let mut spill_targets = Vec::new();
-            let mut materialize_targets = Vec::new();
+            let mut spill_targets = vec![];
+            let mut materialize_targets = vec![];
             {
                 let spill_state = self.spill_state.as_ref().expect("spill state must exist");
                 for partition_idx in 0..spill_state.partitioning.count {
@@ -2861,7 +2859,7 @@ impl HashTable {
 
         // Collect partition indices that need flushing
         let partition_count = probe_state.partitioning.count;
-        let mut flush_targets = Vec::new();
+        let mut flush_targets = vec![];
         for partition_idx in 0..partition_count {
             if probe_state.partition_buffers[partition_idx].is_empty() {
                 continue;
@@ -2913,7 +2911,7 @@ impl HashTable {
         self.free_in_memory_build_partitions();
 
         self.grace_state = Some(GraceState {
-            probe_entries: Vec::new(),
+            probe_entries: vec![],
             probe_entry_cursor: 0,
             partitions_to_process,
             partition_list_idx: 0,
@@ -3509,7 +3507,7 @@ mod hashtests {
             100,
         );
 
-        let mut buf = Vec::new();
+        let mut buf = vec![];
         entry.serialize(&mut buf).unwrap();
 
         let (deserialized, consumed) = HashEntry::deserialize(&buf).unwrap();
@@ -3549,7 +3547,7 @@ mod hashtests {
         );
 
         // Serialize using the Vec-based method
-        let mut vec_buf = Vec::new();
+        let mut vec_buf = vec![];
         entry.serialize(&mut vec_buf).unwrap();
 
         // Serialize using the slice-based method
@@ -3777,7 +3775,7 @@ mod hashtests {
         let mut ht = HashTable::new(config, io.clone()).unwrap();
 
         let entry = HashEntry::new(1, vec![Value::from_i64(1)], 7);
-        let mut buf = Vec::new();
+        let mut buf = vec![];
         entry.serialize(&mut buf).unwrap();
         let truncated = &buf[..buf.len() - 1];
 
@@ -3925,7 +3923,7 @@ mod hashtests {
     fn test_hash_entry_deserialization_truncated() {
         let entry = HashEntry::new(123, vec![Value::from_i64(1), Value::Text("abc".into())], 42);
 
-        let mut buf = Vec::new();
+        let mut buf = vec![];
         entry.serialize(&mut buf).unwrap();
 
         // Cut off the buffer mid-entry
@@ -3941,7 +3939,7 @@ mod hashtests {
     #[test]
     fn test_hash_entry_deserialization_garbage_type_tag() {
         let entry = HashEntry::new(1, vec![Value::from_i64(10)], 7);
-        let mut buf = Vec::new();
+        let mut buf = vec![];
         entry.serialize(&mut buf).unwrap();
 
         // Compute the exact offset of the *first* type tag.
@@ -4348,7 +4346,7 @@ mod hashtests {
             ],
         );
 
-        let mut buf = Vec::new();
+        let mut buf = vec![];
         entry.serialize(&mut buf).unwrap();
 
         let (deserialized, bytes_consumed) = HashEntry::deserialize(&buf).unwrap();
@@ -4388,7 +4386,7 @@ mod hashtests {
         assert!(entry.payload_values.is_empty());
 
         // Serialization should still work
-        let mut buf = Vec::new();
+        let mut buf = vec![];
         entry.serialize(&mut buf).unwrap();
 
         let (deserialized, _) = HashEntry::deserialize(&buf).unwrap();
@@ -4449,7 +4447,7 @@ mod hashtests {
     /// Returns (build_rowid, probe_rowid) pairs for all matches found.
     fn run_grace_processing(ht: &mut HashTable) -> Vec<(i64, i64)> {
         let _ = ht.finalize_probe_spill(None).unwrap();
-        let mut matches = Vec::new();
+        let mut matches = vec![];
 
         if !ht.grace_begin().unwrap() {
             return matches;
@@ -4576,7 +4574,7 @@ mod hashtests {
     fn test_grace_duplicate_keys() {
         let io = Arc::new(MemoryIO::new());
         // Insert multiple build rows with same key
-        let mut build_keys: Vec<(i64, Vec<Value>)> = Vec::new();
+        let mut build_keys: Vec<(i64, Vec<Value>)> = vec![];
         for i in 0..100 {
             // 3 build rows per key value
             build_keys.push((i * 3, vec![Value::from_i64(i)]));
@@ -4587,7 +4585,7 @@ mod hashtests {
         assert!(ht.has_spilled());
 
         // Buffer probe rows
-        let mut buffered_keys = Vec::new();
+        let mut buffered_keys = vec![];
         for i in 0..100 {
             let key = vec![Value::from_i64(i)];
             let partition_idx = ht.partition_for_keys(&key).unwrap();

--- a/core/vdbe/rowset.rs
+++ b/core/vdbe/rowset.rs
@@ -69,7 +69,7 @@ impl RowSet {
     /// Creates a new empty RowSet.
     pub fn new() -> Self {
         Self {
-            fresh: Vec::new(),
+            fresh: vec![],
             mode: RowSetMode::Unset,
         }
     }
@@ -474,7 +474,7 @@ mod tests {
         let attempts = 10;
         for _ in 0..attempts {
             let mut rowset = RowSet::new();
-            let mut batches: Vec<(i32, Vec<i64>)> = Vec::new();
+            let mut batches: Vec<(i32, Vec<i64>)> = crate::alloc::vec![];
 
             // Create multiple batches: batch 0 (first), intermediate batches (>0), and batch -1 (final)
             let num_batches = 5 + (rng.next_u64() % 10) as usize;
@@ -488,7 +488,7 @@ mod tests {
                 };
 
                 // Insert values for this batch
-                let mut batch_values = Vec::new();
+                let mut batch_values = crate::alloc::vec![];
                 let num_values = 10 + (rng.next_u64() % 90) as usize;
 
                 for _ in 0..num_values {
@@ -588,7 +588,7 @@ mod tests {
         for attempt in 0..attempts {
             let mut rowset = RowSet::new();
             let mut reference = std::collections::BTreeSet::new();
-            let mut batches: Vec<(i32, Vec<i64>)> = Vec::new();
+            let mut batches: Vec<(i32, Vec<i64>)> = crate::alloc::vec![];
 
             // Generate random number of batches and total inserts
             let num_batches = 10 + (rng.next_u64() % 40) as usize;
@@ -608,7 +608,7 @@ mod tests {
 
                 // Calculate how many values to insert in this batch
                 // (distribute total_inserts across batches with some randomness)
-                let mut batch_values = Vec::new();
+                let mut batch_values = crate::alloc::vec![];
                 let already_inserted = batches.iter().map(|(_, v)| v.len()).sum::<usize>();
                 let batch_inserts = if batch_idx == num_batches - 1 {
                     // Last batch gets remaining values

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -9,6 +9,7 @@ use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd, Reverse};
 use std::ptr::NonNull;
 use std::rc::Rc;
 
+use crate::alloc::vec;
 use crate::alloc::*;
 use crate::io::TempFile;
 use crate::types::{IOCompletions, ValueIterator};
@@ -120,12 +121,12 @@ impl Sorter {
             .try_collect()?;
         let this = Self {
             arena: Bump::new(),
-            records: Vec::new(),
+            records: vec![],
             current: None,
             key_len: order.len(),
             index_key_info: Rc::new(index_key_info),
             comparators: Rc::new(comparators),
-            chunks: Vec::new(),
+            chunks: vec![],
             chunk_heap: TursoAllocExt::new(),
             max_buffer_size: max_buffer_size_bytes,
             current_buffer_size: 0,
@@ -534,7 +535,7 @@ impl SortedChunk {
             chunk_size: 0,
             buffer: Arc::new(RwLock::new(try_vec![0; buffer_size]?)),
             buffer_len: Arc::new(atomic::AtomicUsize::new(0)),
-            records: Vec::new(),
+            records: vec![],
             io_state: Arc::new(RwLock::new(SortedChunkIOState::None)),
             total_bytes_read: Arc::new(atomic::AtomicUsize::new(0)),
             next_state: NextState::Start,
@@ -1086,7 +1087,7 @@ mod tests {
     }
 
     fn generate_value_types<R: RngCore>(rng: &mut R, num_values: usize) -> Vec<ValueType> {
-        let mut value_types = Vec::with_capacity(num_values);
+        let mut value_types = <Vec<ValueType> as TursoVecExt<ValueType>>::with_capacity(num_values);
 
         for _ in 0..num_values {
             let value_type: ValueType = match rng.next_u64() % 4 {
@@ -1103,7 +1104,7 @@ mod tests {
     }
 
     fn generate_values<R: RngCore>(rng: &mut R, value_types: &[ValueType]) -> Vec<Value> {
-        let mut values = Vec::with_capacity(value_types.len());
+        let mut values = <Vec<Value> as TursoVecExt<Value>>::with_capacity(value_types.len());
         for value_type in value_types {
             let value = match value_type {
                 ValueType::Integer => Value::from_i64(rng.next_u64() as i64),


### PR DESCRIPTION
## Description
Adds specialization in Nightly like we have in std, but for our fallible trait methods. 

## Motivation and context
Fallible allocations in nightly for Vec


## Description of AI Usage
Copied the code from std and made it fallible.
