### PR TITLE
fix(schema): store bare trigger target table name on schema reload

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2317,7 +2317,11 @@ impl Schema {
                     Trigger::new(
                         trigger_name,
                         sql.to_string(),
-                        tbl_name.name.to_string(),
+                        // Store the bare (unquoted) table name. `Name::to_string()`
+                        // renders the quoted form (`"t1"`), which then fails every
+                        // schema lookup since `normalize_ident` does not strip quotes.
+                        // This must match the bucket key used in `add_trigger` below.
+                        tbl_name.name.as_str().to_string(),
                         time,
                         event,
                         for_each_row,

--- a/testing/sqltests/tests/alter-table-quoted-trigger-target.sqltest
+++ b/testing/sqltests/tests/alter-table-quoted-trigger-target.sqltest
@@ -1,0 +1,66 @@
+@database :memory:
+
+# Regression tests for https://github.com/tursodatabase/turso/issues/7516
+#
+# ALTER TABLE re-validates every trigger in the schema. A trigger whose target
+# table is written with a quoted identifier (`ON "t1"`) must resolve to the bare
+# table name `t1` during that re-validation. Otherwise an unrelated ALTER on
+# another table fails with `no such table: "t1"` even though the trigger and its
+# target table are perfectly valid.
+
+setup quoted-target-trigger {
+    CREATE TABLE t1 (id INTEGER PRIMARY KEY, updated_at REAL);
+    CREATE TRIGGER trg AFTER UPDATE ON "t1" FOR EACH ROW
+        WHEN NEW.updated_at = OLD.updated_at
+        BEGIN
+            UPDATE t1 SET updated_at = julianday('now') WHERE id = NEW.id;
+        END;
+}
+
+@setup quoted-target-trigger
+test drop-column-with-unrelated-quoted-trigger-target {
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, drop_me TEXT, keep_col TEXT);
+    ALTER TABLE t2 DROP COLUMN drop_me;
+    SELECT sql FROM sqlite_schema WHERE name = 't2';
+}
+expect {
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, keep_col TEXT)
+}
+
+@setup quoted-target-trigger
+test rename-column-with-unrelated-quoted-trigger-target {
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, c TEXT);
+    ALTER TABLE t2 RENAME COLUMN c TO d;
+    SELECT sql FROM sqlite_schema WHERE name = 't2';
+}
+expect {
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, d TEXT)
+}
+
+@setup quoted-target-trigger
+test rename-table-with-unrelated-quoted-trigger-target {
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, c TEXT);
+    ALTER TABLE t2 RENAME TO t3;
+    SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name;
+}
+expect {
+    t1
+    t3
+}
+
+# The quoted-target trigger must still actually fire after all of this: the
+# bare-name normalization that fixes ALTER must not break trigger dispatch.
+test quoted-target-trigger-still-fires {
+    CREATE TABLE "tq" (id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE audit (id INTEGER);
+    CREATE TRIGGER trg_fire AFTER UPDATE ON "tq" FOR EACH ROW
+        BEGIN
+            INSERT INTO audit VALUES (NEW.id);
+        END;
+    INSERT INTO tq VALUES (1, 10);
+    UPDATE tq SET v = 20 WHERE id = 1;
+    SELECT * FROM audit;
+}
+expect {
+    1
+}


### PR DESCRIPTION
## Problem

Fixes #7516.

`ALTER TABLE ... DROP COLUMN` (and the `RENAME` variants) fail when an **unrelated** trigger in the schema targets a table written with a quoted identifier:

```sql
CREATE TABLE t1 (id INTEGER PRIMARY KEY, updated_at REAL);
CREATE TRIGGER trg AFTER UPDATE ON "t1" FOR EACH ROW
  WHEN NEW.updated_at = OLD.updated_at
  BEGIN UPDATE t1 SET updated_at = julianday('now') WHERE id = NEW.id; END;
CREATE TABLE t2 (id INTEGER PRIMARY KEY, drop_me TEXT, keep_col TEXT);
ALTER TABLE t2 DROP COLUMN drop_me;
-- Turso: error in trigger trg: no such table: "t1"
-- SQLite: succeeds
```

## Root cause

When the schema is loaded from `sqlite_schema`, each `CREATE TRIGGER` DDL is re-parsed and a `Trigger` struct is built. The target table name was stored with `Name::to_string()`, which renders the **quoted** form (`"t1"`) via `as_ident()`. The trigger-bucket key on the next line used `as_str()` (bare `t1`), so the two diverged.

`ALTER TABLE` re-validates every trigger and looks the target table up through `normalize_ident`, which only case-folds and does **not** strip quotes. The leaked quotes made the lookup miss, surfacing as `no such table: "t1"`.

## Fix

Store the bare name with `as_str()` so it matches the bucket key and every downstream schema lookup — a one-line change in `core/schema.rs`.

## Tests

New `testing/sqltests/tests/alter-table-quoted-trigger-target.sqltest` (runs against both SQLite and Turso):
- DROP COLUMN, RENAME COLUMN, RENAME TABLE with a quoted unrelated trigger target — each fails without the fix, passes with it
- a guard that a quoted-target trigger still actually fires

Verified: original repro fixed, 397 related sqltests pass, 9 trigger Rust unit tests pass, `cargo fmt` + `clippy --deny=warnings` clean. No DB fixture needed — the on-disk DDL is correct and unchanged; the bug was purely in the in-memory reparse (confirmed a file DB reopens and ALTERs cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)