### PR TITLE
core: preserve type parameters in PRAGMA table_info

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4910,6 +4910,29 @@ impl Column {
             self.affinity()
         }
     }
+
+    /// The column's declared type as reported by `PRAGMA table_info`/`table_xinfo`.
+    ///
+    /// SQLite reports the declared type including any parenthesized parameters
+    /// (e.g. `VARCHAR(100)`, `DECIMAL(10,2)`). The base type name and its
+    /// parameters are stored separately (`ty_str` and `ty_params`), so this
+    /// reconstructs the full declared type string.
+    pub fn declared_type(&self) -> String {
+        if self.ty_params.is_empty() {
+            return self.ty_str.clone();
+        }
+        let mut declared = self.ty_str.clone();
+        declared.push('(');
+        for (i, param) in self.ty_params.iter().enumerate() {
+            if i > 0 {
+                declared.push(',');
+            }
+            declared.push_str(&param.to_string());
+        }
+        declared.push(')');
+        declared
+    }
+
     pub fn new_default_text(
         name: Option<String>,
         ty_str: String,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1712,7 +1712,7 @@ fn emit_columns_for_table_info(
         program.emit_string8(column.name.clone().unwrap_or_default(), base_reg + 1);
 
         // type
-        program.emit_string8(column.ty_str.clone(), base_reg + 2);
+        program.emit_string8(column.declared_type(), base_reg + 2);
 
         // notnull
         program.emit_bool(column.notnull(), base_reg + 3);

--- a/testing/sqltests/tests/pragma/table_info.sqltest
+++ b/testing/sqltests/tests/pragma/table_info.sqltest
@@ -1,0 +1,43 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/5762
+# PRAGMA table_info / table_xinfo must report the declared column type including
+# its parenthesized parameters (e.g. VARCHAR(100), DECIMAL(10,2)), matching SQLite.
+
+@cross-check-integrity
+test pragma-table-info-preserves-type-params {
+    CREATE TABLE t(
+        a VARCHAR(100),
+        b CHAR(50),
+        c DECIMAL(10,2),
+        d NUMERIC(5,3),
+        e FLOAT(24),
+        f NVARCHAR(200),
+        g INTEGER,
+        h TEXT,
+        i
+    );
+    SELECT cid, name, type FROM pragma_table_info('t');
+}
+expect {
+    0|a|VARCHAR(100)
+    1|b|CHAR(50)
+    2|c|DECIMAL(10,2)
+    3|d|NUMERIC(5,3)
+    4|e|FLOAT(24)
+    5|f|NVARCHAR(200)
+    6|g|INTEGER
+    7|h|TEXT
+    8|i|
+}
+
+@cross-check-integrity
+test pragma-table-xinfo-preserves-type-params {
+    CREATE TABLE t(a VARCHAR(100), c DECIMAL(10,2), g INTEGER);
+    SELECT cid, name, type FROM pragma_table_xinfo('t');
+}
+expect {
+    0|a|VARCHAR(100)
+    1|c|DECIMAL(10,2)
+    2|g|INTEGER
+}


### PR DESCRIPTION
## Description

`PRAGMA table_info` and `PRAGMA table_xinfo` reported only the base type name and stripped parenthesized type parameters. A column declared as `VARCHAR(100)` was reported as `VARCHAR`, `DECIMAL(10,2)` as `DECIMAL`, and so on. SQLite reports the declared type exactly, including its parameters.

The base type name and its parameters are already parsed and stored separately on `Column` (`ty_str` and `ty_params`), but the `type` column emitted only `ty_str`. This adds `Column::declared_type()`, which reconstructs the full declared type from `ty_str` and `ty_params`, and uses it in `emit_columns_for_table_info`, the path shared by both `table_info` and `table_xinfo`.

Before:

```
turso> CREATE TABLE t(a VARCHAR(100), c DECIMAL(10,2));
turso> SELECT name, type FROM pragma_table_info('t');
a|VARCHAR
c|DECIMAL
```

After (matches SQLite):

```
a|VARCHAR(100)
c|DECIMAL(10,2)
```

## Motivation and context

Fixes #5762. This improves SQLite compatibility for `PRAGMA table_info` and `PRAGMA table_xinfo`.

A regression test was added at `testing/sqltests/tests/pragma/table_info.sqltest` covering single parameter types, two parameter types, parameterless types, and an untyped column. It was verified to fail before the change and pass after, and the full `tests/pragma` suite passes.

## Description of AI Usage

This change was developed with the assistance of Claude Code. The agent was directed to investigate the issue, reproduce it against SQLite, locate the root cause, and implement the fix together with the regression test. I reviewed the diff, the reproduction against SQLite 3.50.6, and the test results. I understand the change and take responsibility for it. The change is intentionally small: a helper that reconstructs the declared type, plus a one line change at the emission site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
