### PR TITLE
feat: Add into_* for owned Value to T conversion

### DIFF
--- a/bindings/rust/src/value.rs
+++ b/bindings/rust/src/value.rs
@@ -45,14 +45,6 @@ impl Value {
         matches!(self, Self::Null)
     }
 
-    /// Returns `true` if the value is [`Integer`].
-    ///
-    /// [`Integer`]: Value::Integer
-    #[must_use]
-    pub fn is_integer(&self) -> bool {
-        matches!(self, Self::Integer(..))
-    }
-
     /// Returns `true` if the value is [`Real`].
     ///
     /// [`Real`]: Value::Real
@@ -62,6 +54,14 @@ impl Value {
     }
 
     pub fn as_real(&self) -> Option<&f64> {
+        if let Self::Real(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_real(self) -> Option<f64> {
         if let Self::Real(v) = self {
             Some(v)
         } else {
@@ -85,7 +85,31 @@ impl Value {
         }
     }
 
+    pub fn into_text(self) -> Option<String> {
+        if let Self::Text(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if the value is [`Integer`].
+    ///
+    /// [`Integer`]: Value::Integer
+    #[must_use]
+    pub fn is_integer(&self) -> bool {
+        matches!(self, Self::Integer(..))
+    }
+
     pub fn as_integer(&self) -> Option<&i64> {
+        if let Self::Integer(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_integer(self) -> Option<i64> {
         if let Self::Integer(v) = self {
             Some(v)
         } else {
@@ -102,6 +126,14 @@ impl Value {
     }
 
     pub fn as_blob(&self) -> Option<&Vec<u8>> {
+        if let Self::Blob(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_blob(self) -> Option<Vec<u8>> {
         if let Self::Blob(v) = self {
             Some(v)
         } else {


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

adds `into_{*}` helper fns (that mirror the `as_{*}` helpers) so that users dont have to `match` in their application code. 

(also moves the `is_integer` fn to live closer to the `as_integer` and `into_integer` fns)

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

quality of life improvement

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

No AI used.