### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/bindings/python/SQLALCHEMY_DIALECT.md
+++ b/bindings/python/SQLALCHEMY_DIALECT.md
@@ -12,7 +12,7 @@ The SQLAlchemy dialect is fully implemented with three dialects:
 ## Installation
 
 ```bash
-pip install pyturso[sqlalchemy]
+pip install 'pyturso[sqlalchemy]'
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `bindings/python/SQLALCHEMY_DIALECT.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`