### PR TITLE
fix: ALTER TABLE ADD COLUMN with explicit NULL constraint should not mark column as NOT NULL

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -5178,9 +5178,10 @@ impl TryFrom<&ColumnDefinition> for Column {
             match constraint {
                 ast::ColumnConstraint::PrimaryKey { .. } => primary_key = true,
                 ast::ColumnConstraint::NotNull {
+                    nullable,
                     conflict_clause, ..
                 } => {
-                    notnull = true;
+                    notnull = !nullable;
                     notnull_conflict_clause = *conflict_clause;
                 }
                 ast::ColumnConstraint::Unique(..) => unique = true,


### PR DESCRIPTION
Fixes #7511

## Description

ALTER TABLE ... ADD COLUMN with an explicit NULL constraint incorrectly marks the new column as NOT NULL. Any subsequent INSERT that leaves the column unset fails with `NOT NULL constraint failed`.

The same column definition is handled correctly in CREATE TABLE and ADD COLUMN with no nullability keyword — only explicit NULL on ADD COLUMN is mishandled.

## Root Cause

The ALTER TABLE ADD COLUMN path in core/schema.rs unconditionally set notnull=true for ColumnConstraint::NotNull, ignoring the nullable flag. The CREATE TABLE path correctly uses notnull=!nullable.

## Changes

- core/schema.rs: Added nullable field to ColumnConstraint::NotNull destructuring and changed notnull=true to notnull=!nullable in the TryFrom implementation, matching the CREATE TABLE path behavior.

## Impact

Fixes a critical issue for Diesel ORM migrations and any SQL migration that explicitly writes ADD COLUMN with NULL constraint.