### PR TITLE
Fix use-after-free when an extension aggregate is used as a window function

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -450,6 +450,20 @@ fn link_with_window(
     filter_clause: Option<&Expr>,
     distinctness: Distinctness,
 ) -> Result<()> {
+    // Extension (external) aggregates only expose a destructive `finalize` through the FFI —
+    // there is no non-destructive value callback (xValue) or inverse (xInverse). The window
+    // evaluator reads a running accumulator once per peer-group flush via `AggValue` and keeps
+    // stepping the same accumulator for later rows (RANGE UNBOUNDED PRECEDING .. CURRENT ROW).
+    // Finalizing an external aggregate frees its FFI state, so the next `AggStep`/`AggValue`
+    // dereferences a dangling pointer (use-after-free, see issue #7411). Reject the combination
+    // here instead of emitting bytecode that crashes.
+    if let AccumulatorFunc::Agg(AggFunc::External(_)) = &func {
+        let name = match expr {
+            Expr::FunctionCall { name, .. } | Expr::FunctionCallStar { name, .. } => name.as_str(),
+            _ => "extension function",
+        };
+        crate::bail_parse_error!("{} may not be used as a window function", name);
+    }
     if distinctness.is_distinct() {
         crate::bail_parse_error!("DISTINCT is not supported for window functions");
     }

--- a/testing/sqltests/tests/window/default.sqltest
+++ b/testing/sqltests/tests/window/default.sqltest
@@ -437,6 +437,7 @@ expect error {
     no such function
 }
 
+@skip-if sqlite "median/stddev are turso extension aggregates; rejecting them as window functions is turso-only behavior (SQLite has no such functions)"
 test window-external-aggregate-order-by-rejected {
     SELECT
     median(price) OVER (ORDER BY price)
@@ -446,6 +447,7 @@ expect error {
     may not be used as a window function
 }
 
+@skip-if sqlite "median/stddev are turso extension aggregates; rejecting them as window functions is turso-only behavior (SQLite has no such functions)"
 test window-external-aggregate-partition-rejected {
     SELECT
     stddev(price) OVER (PARTITION BY name)

--- a/testing/sqltests/tests/window/default.sqltest
+++ b/testing/sqltests/tests/window/default.sqltest
@@ -437,6 +437,24 @@ expect error {
     no such function
 }
 
+test window-external-aggregate-order-by-rejected {
+    SELECT
+    median(price) OVER (ORDER BY price)
+    FROM products;
+}
+expect error {
+    may not be used as a window function
+}
+
+test window-external-aggregate-partition-rejected {
+    SELECT
+    stddev(price) OVER (PARTITION BY name)
+    FROM products;
+}
+expect error {
+    may not be used as a window function
+}
+
 test window-aggregate-in-partition-by {
     SELECT
     max(price) OVER (PARTITION BY count(*))


### PR DESCRIPTION
sorry for the slop, i've learned from my ways