### PR TITLE
core/storage: bound-check table-leaf cell pointer array on read

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10559,6 +10559,31 @@ mod tests {
         assert_eq!(final_count, n as usize);
     }
 
+    /// An oversized on-disk cell count must not panic the rowid binary search:
+    /// indexing the cell-pointer array off the page should surface `Corrupt`.
+    /// Regression test for https://github.com/tursodatabase/turso/issues/7473.
+    #[test]
+    fn table_leaf_oversized_cell_count_reads_corrupt_not_panic() {
+        let (pager, root_page, _db, _conn) = empty_btree();
+
+        let (root, _c) = pager.io.block(|| pager.read_page(root_page)).unwrap();
+        while root.is_locked() {
+            pager.io.step().unwrap();
+        }
+
+        // Forge an oversized cell count, as a corrupt file would.
+        let contents = root.get_contents();
+        contents.write_cell_count(0xFFFF);
+
+        // In range per the forged count, but its array entry lies off the page.
+        let oob_idx = pager.usable_space() / CELL_PTR_SIZE_BYTES;
+        let result = contents.cell_table_leaf_read_rowid(oob_idx);
+        assert!(
+            matches!(result, Err(LimboError::Corrupt(_))),
+            "expected Corrupt error, got {result:?}"
+        );
+    }
+
     #[test]
     pub fn test_clear_overflow_pages_no_overflow() -> Result<()> {
         let pager = setup_test_env(5);

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -435,6 +435,13 @@ impl PageInner {
         let buf = self.as_ptr();
         let cell_pointer_array_start = self.header_size();
         let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
+        // Bound-check the array entry: `idx` is the untrusted on-disk cell count.
+        crate::assert_or_bail_corrupt!(
+            self.offset() + cell_pointer + CELL_PTR_SIZE_BYTES <= buf.len(),
+            "cell pointer array index {} out of bounds for page size {}",
+            idx,
+            buf.len()
+        );
         let cell_pointer = self.read_u16(cell_pointer) as usize;
         let mut pos = cell_pointer;
         let (_, nr) = read_varint(crate::slice_in_bounds_or_corrupt!(buf, pos..))?;


### PR DESCRIPTION
## Summary

`cell_table_leaf_read_rowid` indexes a table-leaf page's cell-pointer array
with `idx`, and the rowid binary search derives `idx` from the page's on-disk
cell count. That count is read verbatim from the file, so a crafted page with
an oversized count (e.g. `0xFFFF`) pushes `idx` past the page buffer and
`read_u16` panics on an out-of-bounds slice index, crashing the process
(release builds too). The interior sibling `cell_interior_read_left_child_page`
already guards this; the table-leaf reader didn't.

It now bounds-checks the entry and bails with `Corrupt` instead, matching the
sibling. The check adds `self.offset()` because `read_u16` applies the page
content offset, so a plain `cell_pointer + 2 <= buf.len()` would under-protect
page 1.

Closes: #7473

## Testing

Added a regression test `table_leaf_oversized_cell_count_reads_corrupt_not_panic`
that forges an oversized cell count; it panicked before this change and now
returns `Corrupt`. The issue's repro (flip a table-leaf page's cell count to
`0xFFFF`, then seek by rowid) no longer panics:

    Error: Corrupt database: cell pointer array index 32767 out of bounds for page size 4096

`storage::btree` (63 tests, incl. fuzz) and `storage::pager` pass.
`fmt` + `clippy --all-targets --all-features` clean.

---

I'm Korean, so sorry if any wording reads a little awkward.
