### PR TITLE
Drizzle Studio error - Received integer which is too large to be safely represented as a JavaScript number

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3548,7 +3548,11 @@ impl Connection {
         use crate::types::IOResult;
         if stmt.is_none() {
             let escaped = backing_table_name.replace('"', "\"\"");
-            let sql = format!("SELECT start, inc, min, max, cycle FROM \"{escaped}\" LIMIT 1");
+            let sql = format!(
+                "SELECT CAST(start AS INTEGER), CAST(inc AS INTEGER), \
+                 CAST(min AS INTEGER), CAST(max AS INTEGER), cycle \
+                 FROM \"{escaped}\" LIMIT 1"
+            );
             let prepared = self.prepare_internal(sql).map_err(|err| {
                 LimboError::Corrupt(format!(
                     "internal sequence backing table \"{backing_table_name}\" for sequence \

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -15616,6 +15616,52 @@ fn test_checkpoint_after_create_and_drop_sequence() {
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
 
+/// Sequence descriptor bounds are stored as text in backing tables so generic
+/// JavaScript clients can introspect these internal tables without receiving
+/// i64::MAX as an unsafe number. Runtime nextval/autoincrement behavior still
+/// uses parsed integer descriptors.
+#[test]
+fn test_internal_sequence_descriptor_bounds_are_text_for_js_introspection() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+
+    conn.execute("CREATE TABLE autoinc_js(id INTEGER PRIMARY KEY AUTOINCREMENT)")
+        .unwrap();
+    conn.execute("INSERT INTO autoinc_js DEFAULT VALUES").unwrap();
+    conn.execute("CREATE SEQUENCE user_js_seq").unwrap();
+
+    let autoinc_rows = get_rows(
+        &conn,
+        "SELECT typeof(start), start, typeof(inc), inc, typeof(min), min, typeof(max), max \
+         FROM __turso_internal_seq___turso_internal_autoincrement_autoinc_js",
+    );
+    assert_eq!(autoinc_rows.len(), 1);
+    assert_eq!(autoinc_rows[0][0].to_string(), "text");
+    assert_eq!(autoinc_rows[0][1].to_string(), "1");
+    assert_eq!(autoinc_rows[0][2].to_string(), "text");
+    assert_eq!(autoinc_rows[0][3].to_string(), "1");
+    assert_eq!(autoinc_rows[0][4].to_string(), "text");
+    assert_eq!(autoinc_rows[0][5].to_string(), "1");
+    assert_eq!(autoinc_rows[0][6].to_string(), "text");
+    assert_eq!(autoinc_rows[0][7].to_string(), i64::MAX.to_string());
+    assert!(
+        autoinc_rows[0][7].as_int().is_none(),
+        "default AUTOINCREMENT max must not be exposed as an INTEGER value"
+    );
+
+    let user_seq_rows = get_rows(
+        &conn,
+        "SELECT typeof(max), max FROM __turso_internal_seq_user_js_seq",
+    );
+    assert_eq!(user_seq_rows.len(), 1);
+    assert_eq!(user_seq_rows[0][0].to_string(), "text");
+    assert_eq!(user_seq_rows[0][1].to_string(), i64::MAX.to_string());
+    assert!(user_seq_rows[0][1].as_int().is_none());
+
+    let nextval = get_rows(&conn, "SELECT nextval('user_js_seq')");
+    assert_eq!(nextval[0][0].as_int().unwrap(), 1);
+}
+
 /// Descending sequence compaction must keep the most-advanced (lowest) value.
 ///
 /// A descending sequence (INCREMENT BY -1, START WITH 100) produces values 100, 99, 98...
@@ -15632,6 +15678,21 @@ fn test_descending_sequence_compaction() {
         .unwrap();
     conn.execute("CREATE SEQUENCE desc_seq START WITH 100 INCREMENT BY -1 MINVALUE 1 MAXVALUE 100")
         .unwrap();
+
+    let descriptor = get_rows(
+        &conn,
+        "SELECT typeof(start), start, typeof(inc), inc, typeof(min), min, typeof(max), max \
+         FROM __turso_internal_seq_desc_seq",
+    );
+    assert_eq!(descriptor.len(), 1);
+    assert_eq!(descriptor[0][0].to_string(), "text");
+    assert_eq!(descriptor[0][1].to_string(), "100");
+    assert_eq!(descriptor[0][2].to_string(), "text");
+    assert_eq!(descriptor[0][3].to_string(), "-1");
+    assert_eq!(descriptor[0][4].to_string(), "text");
+    assert_eq!(descriptor[0][5].to_string(), "1");
+    assert_eq!(descriptor[0][6].to_string(), "text");
+    assert_eq!(descriptor[0][7].to_string(), "100");
 
     // Call nextval 5 times across separate transactions.
     // Descending: produces 100, 99, 98, 97, 96

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -662,9 +662,12 @@ pub fn allow_user_dml(table_name: &str) -> bool {
 // Every sequence — user-created (CREATE SEQUENCE) and implicit
 // (AUTOINCREMENT) — is backed by a B-tree table
 // `__turso_internal_seq_<name>` with schema (value INTEGER PRIMARY KEY,
-// is_called, start, inc, min, max, cycle). The runtime watermark IS the
-// disk state: there is no in-memory counter. Every nextval/setval reads
-// the current watermark row inside the executing transaction, computes
+// is_called, start TEXT, inc TEXT, min TEXT, max TEXT, cycle). Descriptor
+// bounds are text to keep i64::MAX/i64::MIN from surfacing as unsafe numbers
+// through JavaScript clients that introspect these internal tables; runtime
+// arithmetic uses the parsed in-memory `Sequence` descriptor. The runtime
+// watermark IS the disk state: there is no in-memory counter. Every
+// nextval/setval reads the current watermark row inside the executing transaction, computes
 // the new value, and writes it back — nextval INSERTs a new row;
 // setval DELETEs every row then INSERTs one at the requested value.
 //
@@ -1996,16 +1999,14 @@ impl Schema {
     }
 
     fn read_sequence_metadata(record: &ImmutableRecord) -> Option<SequenceMetadata> {
-        let mut values = [0i64; 6];
-        for (i, value) in values.iter_mut().enumerate() {
-            match record.get_value(i + 1) {
-                Ok(ValueRef::Numeric(crate::numeric::Numeric::Integer(v))) => {
-                    *value = v;
-                }
-                _ => return None,
-            }
-        }
-        let [_is_called, start, increment, min, max, cycle] = values;
+        let start = Self::read_sequence_i64_metadata_value(record, 2)?;
+        let increment = Self::read_sequence_i64_metadata_value(record, 3)?;
+        let min = Self::read_sequence_i64_metadata_value(record, 4)?;
+        let max = Self::read_sequence_i64_metadata_value(record, 5)?;
+        let cycle = match record.get_value(6) {
+            Ok(ValueRef::Numeric(crate::numeric::Numeric::Integer(v))) => v,
+            _ => return None,
+        };
         Some(SequenceMetadata {
             start,
             increment,
@@ -2013,6 +2014,14 @@ impl Schema {
             max,
             cycle: cycle != 0,
         })
+    }
+
+    fn read_sequence_i64_metadata_value(record: &ImmutableRecord, idx: usize) -> Option<i64> {
+        match record.get_value(idx).ok()? {
+            ValueRef::Numeric(crate::numeric::Numeric::Integer(v)) => Some(v),
+            ValueRef::Text(text) => text.as_str().parse::<i64>().ok(),
+            _ => None,
+        }
     }
 
     fn install_sequence_descriptor(

--- a/core/translate/sequence.rs
+++ b/core/translate/sequence.rs
@@ -41,10 +41,10 @@ pub fn sequence_backing_table_sql(seq_name: &str) -> String {
         "CREATE TABLE \"{table_name}\"(\
          value INTEGER PRIMARY KEY,\
          is_called INTEGER,\
-         start INTEGER,\
-         inc INTEGER,\
-         min INTEGER,\
-         max INTEGER,\
+         start TEXT,\
+         inc TEXT,\
+         min TEXT,\
+         max TEXT,\
          cycle INTEGER)"
     )
 }
@@ -105,22 +105,10 @@ pub fn emit_sequence_backing_table(
         dest: base_reg + 1,
         value: 0, // is_called = false
     });
-    program.emit_insn(Insn::Integer {
-        dest: base_reg + 2,
-        value: start,
-    });
-    program.emit_insn(Insn::Integer {
-        dest: base_reg + 3,
-        value: increment,
-    });
-    program.emit_insn(Insn::Integer {
-        dest: base_reg + 4,
-        value: min_value,
-    });
-    program.emit_insn(Insn::Integer {
-        dest: base_reg + 5,
-        value: max_value,
-    });
+    program.emit_string8(start.to_string(), base_reg + 2);
+    program.emit_string8(increment.to_string(), base_reg + 3);
+    program.emit_string8(min_value.to_string(), base_reg + 4);
+    program.emit_string8(max_value.to_string(), base_reg + 5);
     program.emit_insn(Insn::Integer {
         dest: base_reg + 6,
         value: if cycle { 1 } else { 0 },
@@ -763,31 +751,21 @@ pub(crate) fn emit_autoincrement_sqlite_sequence_sync(
     Ok(())
 }
 
-/// Emit five `Insn::Integer` literals — start, increment, min, max, cycle —
-/// to populate the immutable suffix of a backing-table row. Shared between
-/// `emit_disk_read_nextval`, `emit_disk_advance_past`, and the setval
-/// emitter in `translate/expr/functions.rs`.
+/// Emit five descriptor literals — start, increment, min, max, cycle —
+/// to populate the immutable suffix of a backing-table row. Numeric bounds are
+/// stored as TEXT so Drizzle/libSQL-style introspection of internal sequence
+/// tables cannot surface i64::MAX/i64::MIN as unsafe JavaScript numbers.
+/// Runtime sequence arithmetic uses the in-memory `Sequence` descriptor, and
+/// schema bootstrap parses these text descriptors back into i64.
 pub(crate) fn emit_sequence_descriptor_literals(
     program: &mut ProgramBuilder,
     seq: &Sequence,
     dest_base: usize,
 ) {
-    program.emit_insn(Insn::Integer {
-        dest: dest_base,
-        value: seq.start_value,
-    });
-    program.emit_insn(Insn::Integer {
-        dest: dest_base + 1,
-        value: seq.increment_by,
-    });
-    program.emit_insn(Insn::Integer {
-        dest: dest_base + 2,
-        value: seq.min_value,
-    });
-    program.emit_insn(Insn::Integer {
-        dest: dest_base + 3,
-        value: seq.max_value,
-    });
+    program.emit_string8(seq.start_value.to_string(), dest_base);
+    program.emit_string8(seq.increment_by.to_string(), dest_base + 1);
+    program.emit_string8(seq.min_value.to_string(), dest_base + 2);
+    program.emit_string8(seq.max_value.to_string(), dest_base + 3);
     program.emit_insn(Insn::Integer {
         dest: dest_base + 4,
         value: if seq.cycle { 1 } else { 0 },


### PR DESCRIPTION
Fixed the Drizzle Studio/libSQL JavaScript number-mode failure caused by tursodb internal sequence backing tables exposing default sequence bounds such as `9223372036854775807` as SQLite INTEGER values.

## What changed

- Updated sequence backing table schema generation so immutable descriptor bounds are stored as `TEXT`:
  - `start TEXT`
  - `inc TEXT`
  - `min TEXT`
  - `max TEXT`
- Updated sequence descriptor emission paths to write those bounds as string values while leaving runtime sequence watermark state (`value INTEGER PRIMARY KEY`) unchanged.
- Updated schema bootstrap and sequence descriptor loading to parse descriptor bounds from either `TEXT` or legacy `INTEGER` values, preserving compatibility with existing databases.
- Updated internal sequence descriptor reads in connection code to cast text descriptors back to integers for runtime use.
- Added regression tests covering:
  - AUTOINCREMENT internal sequence tables no longer expose default `max = i64::MAX` as an INTEGER.
  - User-created `CREATE SEQUENCE` backing tables store default max as text.
  - Sequence operations such as `nextval` continue to work.
  - Descending sequence descriptor bounds are text and compaction behavior remains covered.

## Why

Drizzle Studio introspection can encounter tursodb internal `__turso_internal_seq_*` tables. Those tables previously stored default sequence metadata such as `max = i64::MAX` as INTEGER values. The libSQL client default `intMode: "number"` cannot safely represent that value as a JavaScript number, so it throws `Received integer which is too large to be safely represented as a JavaScript number` and Studio becomes unusable.

Storing immutable descriptor bounds as text prevents generic introspection from receiving unsafe JavaScript numbers, while sequence arithmetic still uses parsed `i64` descriptors internally.

## Verification

- Ran `. $HOME/.cargo/env && cargo test -p turso_core` successfully.
- Result: full `turso_core` suite passed, including 2001 unit tests and 53 doc tests.
- Note: the direct foreground run exceeded the 120s tool timeout, so the same command was run to completion in the background with captured output and exit status `0`.

## Commit / push

- Commit: `6c92adbbcb44888dc2e70a327376e4c8cdb2b100`
- Branch: `berserk/436be1ee-2b91-4f1c-ba85-b65f4516855a`
- Pushed to `origin`.

## Commit

6c92adbbcb44888dc2e70a327376e4c8cdb2b100

## Branch

berserk/436be1ee-2b91-4f1c-ba85-b65f4516855a

Fixes #7556
