### PR TITLE
Drizzle Studio error - Received integer which is too large to be safely represented as a JavaScript number

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -14,7 +14,7 @@ use super::integrity_check::{
 };
 use crate::function::Func;
 use crate::pragma::pragma_for;
-use crate::schema::Schema;
+use crate::schema::{Schema, TURSO_INTERNAL_PREFIX};
 use crate::storage::encryption::{CipherMode, EncryptionKey};
 use crate::storage::pager::AutoVacuumMode;
 use crate::storage::pager::Pager;
@@ -62,6 +62,10 @@ fn visible_database_ids_for_table_list(connection: &crate::Connection) -> crate:
             .copied(),
     )?;
     Ok(ids)
+}
+
+fn is_turso_internal_name(name: &str) -> bool {
+    name.starts_with(TURSO_INTERNAL_PREFIX)
 }
 
 fn display_table_list_name(database_id: usize, name: &str) -> String {
@@ -158,6 +162,9 @@ fn emit_table_list_rows_for_schema(
 
     if let Some(filter_name) = filter_name {
         let lookup_name = normalize_table_pragma_lookup_name(database_id, filter_name);
+        if is_turso_internal_name(&lookup_name) {
+            return;
+        }
         if let Some(table) = schema.get_table(&lookup_name) {
             let (wr, strict) = match table.btree() {
                 Some(bt) => (!bt.has_rowid, bt.is_strict),
@@ -188,6 +195,9 @@ fn emit_table_list_rows_for_schema(
         let Some(bt) = table.btree() else {
             continue;
         };
+        if is_turso_internal_name(&bt.name) {
+            continue;
+        }
         emit_table_row(
             program,
             &bt.name,
@@ -198,6 +208,9 @@ fn emit_table_list_rows_for_schema(
         );
     }
     for view in schema.views.values() {
+        if is_turso_internal_name(&view.name) {
+            continue;
+        }
         emit_table_row(
             program,
             &view.name,
@@ -1120,6 +1133,13 @@ fn query_pragma(
             program.alloc_registers(4);
 
             if let Some(table_name) = table_name {
+                if is_turso_internal_name(&table_name) {
+                    let pragma_meta = pragma_for(&pragma);
+                    for col_name in pragma_meta.columns.iter() {
+                        program.add_pragma_result_column(col_name.to_string());
+                    }
+                    return Ok(TransactionMode::None);
+                }
                 let table_database_id = resolve_table_pragma_database_id(
                     resolver,
                     database_id,
@@ -1285,6 +1305,13 @@ fn query_pragma(
             // we need 6 registers, but first register was allocated at the beginning  of the "query_pragma" function
             program.alloc_registers(5);
             if let Some(name) = name {
+                if is_turso_internal_name(&name) {
+                    let col_names = ["cid", "name", "type", "notnull", "dflt_value", "pk"];
+                    for name in col_names {
+                        program.add_pragma_result_column(name.into());
+                    }
+                    return Ok(TransactionMode::None);
+                }
                 let table_database_id = resolve_table_pragma_database_id(
                     resolver,
                     database_id,
@@ -1320,6 +1347,21 @@ fn query_pragma(
             // we need 7 registers, but first register was allocated at the beginning  of the "query_pragma" function
             program.alloc_registers(6);
             if let Some(name) = name {
+                if is_turso_internal_name(&name) {
+                    let col_names = [
+                        "cid",
+                        "name",
+                        "type",
+                        "notnull",
+                        "dflt_value",
+                        "pk",
+                        "hidden",
+                    ];
+                    for name in col_names {
+                        program.add_pragma_result_column(name.into());
+                    }
+                    return Ok(TransactionMode::None);
+                }
                 let table_database_id = resolve_table_pragma_database_id(
                     resolver,
                     database_id,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -3,7 +3,7 @@ use super::plan::{
     select_star, Distinctness, InSeekSource, JoinOrderMember, Operation, OuterQueryReference,
     QueryDestination, Search, TableReferences, Window,
 };
-use crate::schema::Table;
+use crate::schema::{Table, SCHEMA_TABLE_NAME};
 use crate::stack::trace_stack;
 use crate::sync::Arc;
 use crate::translate::emitter::{OperationMode, Resolver};
@@ -12,7 +12,9 @@ use crate::translate::expr::{
 };
 use crate::translate::group_by::compute_group_by_sort_order;
 use crate::translate::optimizer::optimize_plan;
-use crate::translate::plan::{GroupBy, Plan, ResultSetColumn, SelectPlan, SubqueryState};
+use crate::translate::plan::{
+    GroupBy, Plan, ResultSetColumn, SelectPlan, SubqueryState, WhereTerm,
+};
 use crate::translate::planner::{
     append_vtab_predicates_to_where_clause, break_predicate_at_and_boundaries, parse_from,
     parse_limit, parse_where, plan_ctes_as_outer_refs, resolve_window_and_aggregate_functions,
@@ -26,7 +28,7 @@ use crate::vdbe::insn::Insn;
 use crate::{vdbe::builder::ProgramBuilder, Result};
 use std::borrow::Cow;
 use turso_parser::ast::ResultColumn;
-use turso_parser::ast::{self, CompoundSelect, Expr};
+use turso_parser::ast::{self, CompoundSelect, Expr, LikeOperator, Literal};
 
 /// Maximum number of columns in a result set.
 /// SQLite's default SQLITE_MAX_COLUMN is 2000, with a hard upper limit of 32767.
@@ -54,6 +56,41 @@ pub fn translate_select(
         }
     }
     emit_select_plan(plan, resolver, program, connection)
+}
+
+fn append_internal_schema_visibility_filters(plan: &mut SelectPlan) {
+    for joined_table in plan.table_references.joined_tables() {
+        if !joined_table
+            .table
+            .get_name()
+            .eq_ignore_ascii_case(SCHEMA_TABLE_NAME)
+        {
+            continue;
+        }
+        let Some((name_col_idx, _)) = joined_table.table.get_column_by_name("name") else {
+            continue;
+        };
+        let from_outer_join = joined_table
+            .join_info
+            .as_ref()
+            .and_then(|join_info| join_info.is_outer().then_some(joined_table.internal_id));
+        let mut term = WhereTerm::from(Expr::Like {
+            lhs: Box::new(Expr::Column {
+                database: Some(joined_table.database_id),
+                table: joined_table.internal_id,
+                column: name_col_idx,
+                is_rowid_alias: false,
+            }),
+            not: true,
+            op: LikeOperator::Like,
+            rhs: Box::new(Expr::Literal(Literal::String(
+                "'\\_\\_turso\\_internal\\_%'".to_string(),
+            ))),
+            escape: Some(Box::new(Expr::Literal(Literal::String("'\\'".to_string())))),
+        });
+        term.from_outer_join = from_outer_join;
+        plan.where_clause.push(term);
+    }
 }
 
 /// Optimize and emit bytecode for an already-prepared select plan.
@@ -543,6 +580,7 @@ fn prepare_one_select_plan(
                     &mut plan.where_clause,
                     resolver,
                 )?;
+                append_internal_schema_visibility_filters(&mut plan);
             }
 
             {

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -1,24 +1,47 @@
 @database :memory:
 @skip-file-if mvcc "AUTOINCREMENT is not supported in MVCC mode"
 
-# Test: Create an AUTOINCREMENT table and verify sqlite_sequence is also created.
-#
-# Turso-only: SQLite does not maintain the internal
-# `__turso_internal_seq___turso_internal_autoincrement_*` backing table
-# (Turso's disk-only sequence allocator) so the schema listing differs.
-# The `sqlite_sequence` row creation is exercised by every other
-# AUTOINCREMENT test in this file, so the SQLite cross-check coverage
-# is preserved.
-@skip-if sqlite "Turso-specific internal backing table not present in SQLite"
+# Test: Create an AUTOINCREMENT table and verify public schema introspection
+# exposes sqlite_sequence but hides Turso's internal sequence backing table.
 @cross-check-integrity
 test autoinc-create-sequence-table {
     CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y);
     SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;
 }
 expect {
-    __turso_internal_seq___turso_internal_autoincrement_t1
     sqlite_sequence
     t1
+}
+
+@cross-check-integrity
+test autoinc-create-sequence-table-sqlite-schema {
+    CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y);
+    SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name;
+}
+expect {
+    sqlite_sequence
+    t1
+}
+
+@skip-if sqlite "Turso internal namespace is not present in SQLite"
+test autoinc-pragma-table-list-hides-internal-sequence {
+    CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y);
+    SELECT name FROM pragma_table_list
+     WHERE name LIKE '__turso_internal_%' OR name IN ('t1', 'sqlite_sequence')
+     ORDER BY name;
+}
+expect {
+    sqlite_sequence
+    t1
+}
+
+@skip-if sqlite "Turso internal namespace is not present in SQLite"
+test autoinc-pragma-table-info-hides-internal-sequence {
+    CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y);
+    SELECT name FROM pragma_table_info('__turso_internal_seq___turso_internal_autoincrement_t1')
+     ORDER BY cid;
+}
+expect {
 }
 
 # Test: The sqlite_sequence table is initially empty after table creation.


### PR DESCRIPTION
## Final Report

Committed and pushed the fix for the Drizzle Studio/tursodb introspection issue.

### Commit

### Branch
- `berserk/db792cd8-69c3-4cf7-af88-9cc38543105b`
- Pushed to `origin`

### What changed
- Hid Turso internal schema objects whose names start with `__turso_internal_` from public `sqlite_schema` / `sqlite_master` SELECT introspection by adding a synthetic `name NOT LIKE '\_\_turso\_internal\_%' ESCAPE '\'` filter during SELECT planning for schema-table reads.
- Hid the same internal objects from PRAGMA-based introspection paths, including:
  - `pragma_table_list`
  - `pragma_table_info`
  - `pragma_table_xinfo`
  - related filtered table lookup handling
- Preserved visibility and compatibility for `sqlite_sequence`, which remains user-visible for SQLite compatibility.
- Updated AUTOINCREMENT sqltests so public schema introspection now expects only user tables plus `sqlite_sequence`, not Turso's private sequence backing table.
- Added regression coverage for both `sqlite_master`/`sqlite_schema` and PRAGMA introspection behavior.

### Why
Drizzle Studio introspects database schemas through SQLite-compatible schema and PRAGMA APIs. Turso's private sequence backing tables could appear there and expose descriptor metadata containing `9223372036854775807` (`i64::MAX`). JavaScript clients using number-mode integer decoding cannot safely represent that value, causing Studio to fail even though application data is unaffected.

The fix keeps internal sequence persistence and recovery intact while preventing public schema introspection from surfacing Turso-only private tables.

### Verification
The previous verification phase passed:
- `cargo +1.88.0 fmt`
- `cargo check -p turso_core`
- Full AUTOINCREMENT sqltest run: `cargo run -p test-runner --bin test-runner -- run testing/sqltests/tests/autoincr.sqltest --jobs 1 --snapshot-mode no` — 41 passed

### Repository status
- Working tree clean after commit and push.

## Commit

c901b7af2d14df5cb960bd2275294a9dce71adb7

## Branch

berserk/db792cd8-69c3-4cf7-af88-9cc38543105b

Fixes #7556
