### PR TITLE
mvcc: Add fallible MVCC row payload allocation sites

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -334,10 +334,19 @@ jobs:
         run: make test
 
   concurrent-simulator:
+    name: "Concurrent simulator (${{ matrix.toolchain.label }}, ${{ matrix.profile.name }})"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 40
     strategy:
+      fail-fast: false
       matrix:
+        toolchain:
+          - label: stable
+            version: "1.88.0"
+            rustflags: ""
+          - label: nightly
+            version: "nightly-2025-12-17"
+            rustflags: "--cfg nightly"
         profile:
           - name: in-process
             iterations: 100
@@ -353,21 +362,28 @@ jobs:
             args: "--mode fast --multiprocess --connections-per-process 4 --processes 4 --kill-probability 0.01"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain.version }}
       - name: Setup mold linker
         uses: "./.github/shared/setup-mold"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-rust"
+          prefix-key: "v1-rust-whopper-${{ matrix.toolchain.label }}"
           cache-on-failure: true
       - uses: "./.github/shared/setup-sccache"
       - name: Run turso_whopper regression tests
         if: matrix.profile.name == 'in-process'
-        run: cargo test -p turso_whopper --test regression_tests
+        env:
+          RUSTFLAGS: ${{ matrix.toolchain.rustflags }}
+        run: cargo +${{ matrix.toolchain.version }} test -p turso_whopper --test regression_tests
         timeout-minutes: 15
-      - name: Run turso_whopper (${{ matrix.profile.name }})
+      - name: Run turso_whopper (${{ matrix.toolchain.label }}, ${{ matrix.profile.name }})
+        env:
+          RUSTFLAGS: ${{ matrix.toolchain.rustflags }}
         run: |
-          cargo build -p turso_whopper --release
+          cargo +${{ matrix.toolchain.version }} build -p turso_whopper --release
           for i in $(seq 1 ${{ matrix.profile.iterations }}); do
             ./target/release/turso_whopper ${{ matrix.profile.args }} || exit 1
           done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -353,7 +353,7 @@ jobs:
             args: "--mode fast --reopen-probability 0.001"
           - name: in-process-mvcc
             iterations: 25
-            args: "--mode fast --reopen-probability 0.01 --enable-mvcc"
+            args: "--mode fast --reopen-probability 0.01 --enable-mvcc --allocation-fault-probability 0.01"
           - name: multiprocess
             iterations: 10
             args: "--mode fast --multiprocess --connections-per-process 4 --processes 4"

--- a/core/alloc/allocation_site.rs
+++ b/core/alloc/allocation_site.rs
@@ -16,6 +16,8 @@ pub enum MvStoreAllocationSite {
     IndexRowsEntry,
     IndexKeyEntry,
     RowVersionReserve,
+    RowPayload,
+    SchemaRowPayload,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -77,6 +79,16 @@ macro_rules! without_allocation_faults {
         #[cfg(feature = "allocation_metric")]
         let _turso_allocation_site_guard =
             $crate::alloc::enter_allocation_site($crate::alloc::AllocationSite::NoFaultInjection);
+        $expr
+    }};
+}
+
+#[macro_export]
+macro_rules! with_mv_store_allocation_site {
+    ($site:ident, $expr:expr) => {{
+        #[cfg(feature = "allocation_metric")]
+        let _turso_allocation_site_guard =
+            $crate::alloc::enter_allocation_site($crate::alloc::MvStoreAllocationSite::$site);
         $expr
     }};
 }

--- a/core/alloc/arc.rs
+++ b/core/alloc/arc.rs
@@ -1,0 +1,9 @@
+#[cfg(nightly)]
+#[path = "arc/nightly.rs"]
+mod imp;
+
+#[cfg(not(nightly))]
+#[path = "arc/stable.rs"]
+mod imp;
+
+pub use imp::{try_arc_slice_from_slice, ArcSlice};

--- a/core/alloc/arc/nightly.rs
+++ b/core/alloc/arc/nightly.rs
@@ -1,0 +1,8 @@
+use crate::alloc::{TryReserveError, TursoAllocator};
+
+pub type ArcSlice<T> = std::sync::Arc<[T], TursoAllocator>;
+
+pub fn try_arc_slice_from_slice<T: Clone>(slice: &[T]) -> Result<ArcSlice<T>, TryReserveError> {
+    std::sync::Arc::<[T], TursoAllocator>::try_clone_from_ref_in(slice, TursoAllocator)
+        .map_err(|_| TryReserveError)
+}

--- a/core/alloc/arc/stable.rs
+++ b/core/alloc/arc/stable.rs
@@ -1,0 +1,7 @@
+use crate::alloc::TryReserveError;
+
+pub type ArcSlice<T> = crate::sync::Arc<[T]>;
+
+pub fn try_arc_slice_from_slice<T: Clone>(slice: &[T]) -> Result<ArcSlice<T>, TryReserveError> {
+    Ok(crate::sync::Arc::from(slice))
+}

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -8,6 +8,7 @@ use std::fmt;
 
 mod allocation_site;
 mod api;
+mod arc;
 mod backend;
 mod collections;
 
@@ -19,6 +20,7 @@ pub use allocation_site::{
 /// stable, `std::alloc::Allocator` on `--cfg nightly` builds.
 pub use api::ApiAllocator;
 pub use api::{AllocError, Global, Layout};
+pub use arc::{try_arc_slice_from_slice, ArcSlice};
 pub use backend::{set_allocator, SetAllocatorError, TursoAllocBackend};
 #[cfg(nightly)]
 pub use collections::TursoFromIteratorIn;

--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -113,11 +113,8 @@ fn bench(c: &mut Criterion) {
             db.mvcc_store
                 .update(
                     tx_id,
-                    Row::new_table_row(
-                        RowID::new((-2).into(), RowKey::Int(1)),
-                        record_data.clone(),
-                        1,
-                    ),
+                    Row::new_table_row(RowID::new((-2).into(), RowKey::Int(1)), record_data, 1)
+                        .unwrap(),
                 )
                 .unwrap();
             let mv_store = &db.mvcc_store;
@@ -140,11 +137,7 @@ fn bench(c: &mut Criterion) {
     db.mvcc_store
         .insert(
             tx_id,
-            Row::new_table_row(
-                RowID::new((-2).into(), RowKey::Int(1)),
-                record_data.clone(),
-                1,
-            ),
+            Row::new_table_row(RowID::new((-2).into(), RowKey::Int(1)), record_data, 1).unwrap(),
         )
         .unwrap();
     group.bench_function("read", |b| {
@@ -166,11 +159,7 @@ fn bench(c: &mut Criterion) {
     db.mvcc_store
         .insert(
             tx_id,
-            Row::new_table_row(
-                RowID::new((-2).into(), RowKey::Int(1)),
-                record_data.clone(),
-                1,
-            ),
+            Row::new_table_row(RowID::new((-2).into(), RowKey::Int(1)), record_data, 1).unwrap(),
         )
         .unwrap();
     group.bench_function("update", |b| {
@@ -178,11 +167,8 @@ fn bench(c: &mut Criterion) {
             db.mvcc_store
                 .update(
                     tx_id,
-                    Row::new_table_row(
-                        RowID::new((-2).into(), RowKey::Int(1)),
-                        record_data.clone(),
-                        1,
-                    ),
+                    Row::new_table_row(RowID::new((-2).into(), RowKey::Int(1)), record_data, 1)
+                        .unwrap(),
                 )
                 .unwrap();
         })

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1668,25 +1668,19 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
         };
         let row = match &self.mv_cursor_type {
             MvccCursorType::Table => {
-                let record_buf = key
-                    .get_record()
-                    .ok_or_else(|| {
-                        LimboError::InternalError("BTreeKey should have a record".to_string())
-                    })?
-                    .get_payload()
-                    .to_vec();
                 let BTreeKey::TableRowId((_, record)) = key else {
                     return Err(LimboError::InternalError(
                         "Table cursor requires a TableRowId key".to_string(),
                     ));
                 };
-                let num_columns = record
-                    .as_ref()
-                    .ok_or_else(|| {
-                        LimboError::InternalError("TableRowId should have a record".to_string())
-                    })?
-                    .column_count();
-                Row::new_table_row(row_id, record_buf, num_columns)
+                let record = record.as_ref().ok_or_else(|| {
+                    LimboError::InternalError("TableRowId should have a record".to_string())
+                })?;
+                let num_columns = record.column_count();
+                crate::with_mv_store_allocation_site!(
+                    RowPayload,
+                    Row::new_table_row(row_id, record.get_payload(), num_columns)
+                )
             }
             MvccCursorType::Index(_) => {
                 let BTreeKey::IndexKey(record) = key else {
@@ -1694,9 +1688,9 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                         "Index cursor requires an IndexKey".to_string(),
                     ));
                 };
-                Row::new_index_row(row_id, record.column_count())
+                Ok(Row::new_index_row(row_id, record.column_count()))
             }
-        };
+        }?;
 
         // Check if the cursor is currently positioned at a B-tree row that matches
         // the row we're inserting. This indicates we're updating a B-tree-resident row
@@ -1800,11 +1794,12 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
             let record = record.clone();
             let column_count = record.column_count();
             let row = match &self.mv_cursor_type {
-                MvccCursorType::Table => {
-                    Row::new_table_row(rowid.clone(), record.into_payload(), column_count)
-                }
-                MvccCursorType::Index(_) => Row::new_index_row(rowid.clone(), column_count),
-            };
+                MvccCursorType::Table => crate::with_mv_store_allocation_site!(
+                    RowPayload,
+                    Row::new_table_row(rowid.clone(), record.get_payload(), column_count)
+                ),
+                MvccCursorType::Index(_) => Ok(Row::new_index_row(rowid.clone(), column_count)),
+            }?;
             self.db
                 .insert_tombstone_to_table_or_index(self.tx_id, rowid, row, maybe_index_id)?;
         }

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1,4 +1,6 @@
-use crate::alloc::{ConcurrentAllocator, TryReserveError, TursoAllocator};
+use crate::alloc::{
+    ConcurrentAllocator, TryReserveError, TursoAllocator, TursoIteratorExt, TursoVecExt, Vec,
+};
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
     DeleteRowStateMachine, MVTableId, MvStore, Row, RowID, RowKey, RowVersion, SortableIndexKey,
@@ -558,7 +560,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     /// when the schema still carries the uncheckpointed-negative
     /// sentinel; tables that have no real root yet (created and
     /// immediately dropped in this checkpoint) are filtered out.
-    fn pending_sequence_compactions(&self) -> Vec<SeqCompaction> {
+    fn pending_sequence_compactions(&self) -> Result<Vec<SeqCompaction>> {
         let resolve_root = |schema_root: i64| -> Option<i64> {
             if schema_root > 0 {
                 return Some(schema_root);
@@ -573,7 +575,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 .and_then(|entry| entry.value().map(|rp| rp as i64))
         };
         let db_id = crate::MAIN_DB_ID;
-        self.connection.with_schema(db_id, |schema| {
+        Ok(self.connection.with_schema(db_id, |schema| {
             with_mvcc_checkpoint_allocation_site!(
                 CheckpointSequenceCompactions,
                 schema
@@ -599,9 +601,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                             increment_positive: seq.increment_by >= 0,
                         })
                     })
-                    .collect()
+                    .try_collect()
             )
-        })
+        })?)
     }
 
     fn refresh_checkpoint_bounds(&mut self) {
@@ -666,14 +668,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             #[cfg(any(test, injected_yields))]
             yield_instance_id,
             checkpoint_lock,
-            write_set: Vec::new(),
+            write_set: crate::alloc::vec![],
             write_row_state_machine: None,
             delete_row_state_machine: None,
             cursors: HashMap::default(),
             created_btrees: HashMap::default(),
             destroyed_tables: HashSet::default(),
             destroyed_indexes: HashSet::default(),
-            index_write_set: Vec::new(),
+            index_write_set: crate::alloc::vec![],
             index_id_to_index,
             checkpoint_result: None,
             update_transaction_state,
@@ -846,7 +848,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     ///    * The row is not a delete (we inserted or changed an existing row), OR
     ///    * The row is a delete AND it exists in the database file already.
     ///      If the row didn't exist in the database file and was deleted, we can simply not write it.
-    fn collect_table_rows(&mut self) -> Option<IOCompletions> {
+    fn collect_table_rows(&mut self) -> Result<Option<IOCompletions>> {
         // Invariant: RowID ordering is (table_id, row_id) with table_id ascending.
         // Since MV table IDs are negative and sqlite_schema is table_id=-1, iterating
         // in reverse visits sqlite_schema first so CREATE/DROP metadata is applied
@@ -1005,15 +1007,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 }
                 if !skip_write {
                     tracing::trace!("adding to write_set {:?}", (&version, &special_write));
-                    with_mvcc_checkpoint_allocation_site!(
-                        CheckpointWriteSet,
-                        self.write_set.push((version, special_write))
-                    );
+                    with_mvcc_checkpoint_allocation_site!(CheckpointWriteSet, {
+                        self.write_set.try_push((version, special_write))?;
+                    });
                 }
             }
             processed += 1;
             if processed >= COLLECT_PREEMPTION_THRESHOLD {
-                return Some(IOCompletions::Single(Completion::new_yield()));
+                return Ok(Some(IOCompletions::Single(Completion::new_yield())));
             }
         }
         // Writing in ascending order of rowid gives us a better chance of using balance-quick algorithm
@@ -1026,7 +1027,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 version.0.row.id.row_id.clone(),
             )
         });
-        None
+        Ok(None)
     }
 
     /// Collect all committed index row versions that need to be written to the B-tree.
@@ -1036,7 +1037,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     /// 2. Either:
     ///    * The row is not a delete (we inserted or changed an existing row), OR
     ///    * The row is a delete AND it exists in the database file already.
-    fn collect_index_rows(&mut self) -> Option<IOCompletions> {
+    fn collect_index_rows(&mut self) -> Result<Option<IOCompletions>> {
         let outer_bounds: (Bound<MVTableId>, Bound<MVTableId>) =
             match self.collect_index_tableid_cursor {
                 None => (Bound::Unbounded, Bound::Unbounded),
@@ -1072,20 +1073,20 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
                     // Only write the row to the B-tree if it is not a delete, or if it is a delete and it exists in
                     // the database file.
-                    with_mvcc_checkpoint_allocation_site!(
-                        CheckpointIndexWriteSet,
-                        self.index_write_set.push((index_id, version, is_delete))
-                    );
+                    with_mvcc_checkpoint_allocation_site!(CheckpointIndexWriteSet, {
+                        self.index_write_set
+                            .try_push((index_id, version, is_delete))?;
+                    });
                 }
                 processed += 1;
                 if processed >= COLLECT_PREEMPTION_THRESHOLD {
-                    return Some(IOCompletions::Single(Completion::new_yield()));
+                    return Ok(Some(IOCompletions::Single(Completion::new_yield())));
                 }
             }
             self.collect_index_tableid_cursor = Some(index_id);
             self.collect_index_key_cursor = None;
         }
-        None
+        Ok(None)
     }
 
     #[cfg(any(test, debug_assertions))]
@@ -1436,23 +1437,26 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         let new_i64 = i64::try_from(new).map_err(|_| {
             LimboError::Corrupt(format!("MVCC checkpoint timestamp does not fit i64: {new}"))
         })?;
-        let record = ImmutableRecord::from_values(
-            &[
-                Value::build_text(MVCC_META_KEY_PERSISTENT_TX_TS_MAX),
-                Value::from_i64(new_i64),
-            ],
-            2,
-        )?;
-        // TODO eleminate this allocation here by just returing the underlying vec in ImmutableRecord.
-        // this can only be done when ImmutableRecord starts using Vec<u8, TursoAllocator>
-        let payload = with_mvcc_checkpoint_allocation_site!(
+        let record = with_mvcc_checkpoint_allocation_site!(
             CheckpointMetadataPayload,
-            record.get_payload().to_vec()
+            ImmutableRecord::from_values(
+                &[
+                    Value::build_text(MVCC_META_KEY_PERSISTENT_TX_TS_MAX),
+                    Value::from_i64(new_i64),
+                ],
+                2,
+            )?
         );
-        let row = Row::new_table_row(RowID::new(table_id, RowKey::Int(1)), payload, num_columns);
-        with_mvcc_checkpoint_allocation_site!(
-            CheckpointWriteSet,
-            self.write_set.push((
+        let row = with_mvcc_checkpoint_allocation_site!(
+            CheckpointMetadataPayload,
+            Row::new_table_row(
+                RowID::new(table_id, RowKey::Int(1)),
+                record.get_payload(),
+                num_columns,
+            )?
+        );
+        with_mvcc_checkpoint_allocation_site!(CheckpointWriteSet, {
+            self.write_set.try_push((
                 RowVersion {
                     id: 0,
                     begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(
@@ -1463,8 +1467,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     btree_resident: true,
                 },
                 None,
-            ))
-        );
+            ))?;
+        });
         Ok(())
     }
 
@@ -1488,7 +1492,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 Ok(TransitionResult::Continue)
             }
             CheckpointState::CollectTableRows => {
-                if let Some(io) = self.collect_table_rows() {
+                if let Some(io) = self.collect_table_rows()? {
                     return Ok(TransitionResult::Io(io));
                 }
                 tracing::debug!("Collected {} committed versions", self.write_set.len());
@@ -1496,7 +1500,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 Ok(TransitionResult::Continue)
             }
             CheckpointState::CollectIndexRows => {
-                if let Some(io) = self.collect_index_rows() {
+                if let Some(io) = self.collect_index_rows()? {
                     return Ok(TransitionResult::Io(io));
                 }
                 tracing::debug!("Collected {} index row changes", self.index_write_set.len());
@@ -1782,7 +1786,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         let mut values = record.get_values_owned()?;
                         values[3] = Value::from_i64(root_page as i64);
                         let record = ImmutableRecord::from_values(&values, values.len())?;
-                        row_version.row.data = Some(Arc::from(record.get_payload()));
+                        // Btree creation has already happened by this point; an injected fault
+                        // while publishing the sqlite_schema root page can leave retry state with
+                        // a durable btree and a stale rootpage=0 schema row.
+                        // TODO: make this rewrite resumable before re-enabling fault injection.
+                        row_version.row.data = Some(crate::without_allocation_faults!(
+                            crate::alloc::try_arc_slice_from_slice(record.get_payload())?
+                        ));
                         row_version.clone()
                     };
                     self.created_btrees
@@ -1815,7 +1825,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         let mut values = record.get_values_owned()?;
                         values[3] = Value::from_i64(root_page as i64);
                         let record = ImmutableRecord::from_values(&values, values.len())?;
-                        row_version.row.data = Some(Arc::from(record.get_payload()));
+                        // Btree creation has already happened by this point; an injected fault
+                        // while publishing the sqlite_schema root page can leave retry state with
+                        // a durable btree and a stale rootpage=0 schema row.
+                        // TODO: make this rewrite resumable before re-enabling fault injection.
+                        row_version.row.data = Some(crate::without_allocation_faults!(
+                            crate::alloc::try_arc_slice_from_slice(record.get_payload())?
+                        ));
                         row_version.clone()
                     };
 
@@ -2060,7 +2076,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
             CheckpointState::CompactSequences => {
                 if self.seq_compact.is_none() {
-                    let pending = self.pending_sequence_compactions();
+                    let pending = self.pending_sequence_compactions()?;
                     if pending.is_empty() {
                         self.state = CheckpointState::CommitPagerTxn;
                         return Ok(TransitionResult::Continue);
@@ -2378,9 +2394,10 @@ mod tests {
             end: crate::mvcc::database::PackedTs::pack(end.map(TxTimestampOrID::Timestamp)),
             row: Row::new_table_row(
                 RowID::new(SQLITE_SCHEMA_MVCC_TABLE_ID, RowKey::Int(rowid)),
-                record.as_blob().to_vec(),
+                record.as_blob(),
                 5,
-            ),
+            )
+            .unwrap(),
             btree_resident: false,
         }
     }
@@ -2451,9 +2468,10 @@ mod tests {
             end: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(2))),
             row: Row::new_table_row(
                 RowID::new(SQLITE_SCHEMA_MVCC_TABLE_ID, RowKey::Int(9)),
-                Vec::new(),
+                &[],
                 0,
-            ),
+            )
+            .unwrap(),
             btree_resident: false,
         };
 
@@ -2551,7 +2569,7 @@ mod tests {
             .insert_index_version(index_id, tombstone_key, tombstone_version)
             .unwrap();
 
-        while checkpoint.collect_index_rows().is_some() {}
+        while checkpoint.collect_index_rows().unwrap().is_some() {}
 
         assert!(
             checkpoint.index_write_set.is_empty(),
@@ -2567,9 +2585,10 @@ mod tests {
             end: crate::mvcc::database::PackedTs::pack(None),
             row: Row::new_table_row(
                 RowID::new(table_id, RowKey::Int(rowid)),
-                record.as_blob().to_vec(),
+                record.as_blob(),
                 1,
-            ),
+            )
+            .unwrap(),
             btree_resident: false,
         }
     }
@@ -2596,12 +2615,12 @@ mod tests {
             let version = committed_table_row_version(table_id, i);
             mvstore.rows.insert(
                 RowID::new(table_id, RowKey::Int(i)),
-                Arc::new(RwLock::new(std::vec![version])),
+                Arc::new(RwLock::new(crate::alloc::vec![version])),
             );
         }
 
         // The first chunk fills up before the scan finishes, so it must yield.
-        let first = checkpoint.collect_table_rows();
+        let first = checkpoint.collect_table_rows().unwrap();
         assert!(
             first.is_some_and(|io| io.is_explicit_yield()),
             "scanning more than COLLECT_PREEMPTION_THRESHOLD rows must preempt with an explicit yield"
@@ -2609,7 +2628,7 @@ mod tests {
 
         // Resume from the cursor until the scan finishes; every row must still
         // be collected exactly once across the chunks.
-        while checkpoint.collect_table_rows().is_some() {}
+        while checkpoint.collect_table_rows().unwrap().is_some() {}
         assert_eq!(checkpoint.write_set.len(), row_count);
     }
 
@@ -2637,13 +2656,13 @@ mod tests {
                 .unwrap();
         }
 
-        let first = checkpoint.collect_index_rows();
+        let first = checkpoint.collect_index_rows().unwrap();
         assert!(
             first.is_some_and(|io| io.is_explicit_yield()),
             "scanning more than COLLECT_PREEMPTION_THRESHOLD index rows must preempt with an explicit yield"
         );
 
-        while checkpoint.collect_index_rows().is_some() {}
+        while checkpoint.collect_index_rows().unwrap().is_some() {}
         assert_eq!(checkpoint.index_write_set.len(), row_count);
     }
 
@@ -2669,9 +2688,10 @@ mod tests {
         for i in 0..row_count as i64 {
             let version = committed_table_row_version(table_id, i);
             let row_id = RowID::new(table_id, RowKey::Int(i));
-            mvstore
-                .rows
-                .insert(row_id, Arc::new(RwLock::new(std::vec![version.clone()])));
+            mvstore.rows.insert(
+                row_id,
+                Arc::new(RwLock::new(crate::alloc::vec![version.clone()])),
+            );
             checkpoint.write_set.push((version, None));
         }
         checkpoint.state = CheckpointState::GcTableRows {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1,5 +1,6 @@
 use crate::alloc::{
     ConcurrentAllocator, TryReserveError, TursoAllocator, TursoIteratorExt, TursoVecExt, Vec,
+    ALLOC_ERR_MSG,
 };
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
@@ -575,35 +576,42 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 .and_then(|entry| entry.value().map(|rp| rp as i64))
         };
         let db_id = crate::MAIN_DB_ID;
-        Ok(self.connection.with_schema(db_id, |schema| {
-            with_mvcc_checkpoint_allocation_site!(
-                CheckpointSequenceCompactions,
-                schema
-                    .sequences
-                    .values()
-                    .filter(|seq| !seq.cycle)
-                    .filter_map(|seq| {
-                        let backing_name =
-                            crate::translate::sequence::sequence_backing_table_name(&seq.name);
-                        let bt = schema.get_btree_table(&backing_name)?;
-                        let backing_root = resolve_root(bt.root_page)?;
-                        // Resolve the MVCC table_id once per sequence so the
-                        // per-row purge in `ScanDelete` doesn't re-scan
-                        // `table_id_to_rootpage` on every deletion. Uses the
-                        // schema-side root (pre-resolve) because
-                        // `get_table_id_from_root_page` already understands
-                        // the negative uncheckpointed-sentinel encoding.
-                        let table_id = self.mvstore.get_table_id_from_root_page(bt.root_page);
-                        Some(SeqCompaction {
-                            backing_root,
-                            backing_num_cols: bt.columns().len(),
-                            table_id,
-                            increment_positive: seq.increment_by >= 0,
+        Ok(self
+            .connection
+            .with_schema(db_id, |schema| {
+                crate::without_allocation_faults!(
+                    // Checkpoint has already written table/index rows by the time sequence
+                    // compaction setup runs. An injected fault here can abort before the
+                    // checkpoint reaches its normal pager cleanup/retry path.
+                    // TODO: make sequence compaction setup resumable before re-enabling
+                    // fault injection for this collection.
+                    schema
+                        .sequences
+                        .values()
+                        .filter(|seq| !seq.cycle)
+                        .filter_map(|seq| {
+                            let backing_name =
+                                crate::translate::sequence::sequence_backing_table_name(&seq.name);
+                            let bt = schema.get_btree_table(&backing_name)?;
+                            let backing_root = resolve_root(bt.root_page)?;
+                            // Resolve the MVCC table_id once per sequence so the
+                            // per-row purge in `ScanDelete` doesn't re-scan
+                            // `table_id_to_rootpage` on every deletion. Uses the
+                            // schema-side root (pre-resolve) because
+                            // `get_table_id_from_root_page` already understands
+                            // the negative uncheckpointed-sentinel encoding.
+                            let table_id = self.mvstore.get_table_id_from_root_page(bt.root_page);
+                            Some(SeqCompaction {
+                                backing_root,
+                                backing_num_cols: bt.columns().len(),
+                                table_id,
+                                increment_positive: seq.increment_by >= 0,
+                            })
                         })
-                    })
-                    .try_collect()
-            )
-        })?)
+                        .try_collect()
+                )
+            })
+            .expect(ALLOC_ERR_MSG))
     }
 
     fn refresh_checkpoint_bounds(&mut self) {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -111,8 +111,9 @@ struct YieldContext;
 #[repr(transparent)]
 pub struct MVTableId(i64);
 
-/// The versions of a single row
-pub type RowVersions = Arc<RwLock<Vec<RowVersion>>>;
+/// The versions of a single row.
+pub type RowVersionChain = crate::alloc::Vec<RowVersion>;
+pub type RowVersions = Arc<RwLock<RowVersionChain>>;
 type TableRowEntry<'a, A = TursoAllocator> = Entry<'a, RowID, RowVersions, BasicComparator, A>;
 type IndexRowEntry<'a, A = TursoAllocator> =
     Entry<'a, Arc<SortableIndexKey>, RowVersions, BasicComparator, A>;
@@ -328,17 +329,21 @@ impl RowID {
 pub struct Row {
     pub id: RowID,
     /// Data is None for index rows because the key holds all the data.
-    pub data: Option<Arc<[u8]>>,
+    pub data: Option<crate::alloc::ArcSlice<u8>>,
     pub column_count: usize,
 }
 
 impl Row {
-    pub fn new_table_row(id: RowID, data: Vec<u8>, column_count: usize) -> Self {
-        Self {
+    pub fn new_table_row(
+        id: RowID,
+        data: &[u8],
+        column_count: usize,
+    ) -> Result<Self, TryReserveError> {
+        Ok(Self {
             id,
-            data: Some(Arc::from(data)),
+            data: Some(crate::alloc::try_arc_slice_from_slice(data)?),
             column_count,
-        }
+        })
     }
 
     pub fn new_index_row(id: RowID, column_count: usize) -> Self {
@@ -651,7 +656,8 @@ fn portable_delete_op_extension_for_row_version<Clock: LogicalClock, A: Concurre
         let values = match &record_values {
             Some(values) => values,
             None => record_values.insert(
-                ImmutableRecordRef::from_bin_record(row_version.row.payload()).get_values_owned()?,
+                ImmutableRecordRef::from_bin_record(row_version.row.payload())
+                    .get_values_owned()?,
             ),
         };
         let physical_column = table.logical_to_physical_column(logical_column);
@@ -1990,7 +1996,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             }
         };
 
-        let collect_versions = |row_versions: &Arc<RwLock<Vec<RowVersion>>>,
+        let collect_versions = |row_versions: &RowVersions,
                                 log_record: &mut LogRecord|
          -> Result<()> {
             // `log_record.row_versions` is the logical transaction log. Recovery
@@ -3710,7 +3716,7 @@ pub struct RecoverCtx {
 /// A multi-version concurrency control database.
 #[derive(Debug)]
 pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator> {
-    pub rows: SkipMap<RowID, Arc<RwLock<Vec<RowVersion>>>, BasicComparator, A>,
+    pub rows: SkipMap<RowID, RowVersions, BasicComparator, A>,
     /// Table ID is an opaque identifier that is only meaningful to the MV store.
     /// Each checkpointed MVCC table corresponds to a single B-tree on the pager,
     /// which naturally has a root page.
@@ -5094,7 +5100,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// (O(log N)) per scanned row with an amortized-O(1) merge step.
     pub(crate) fn index_chain_invalidates_btree(
         &self,
-        versions: &RwLock<Vec<RowVersion>>,
+        versions: &RwLock<RowVersionChain>,
         tx_id: TxID,
     ) -> bool {
         let tx = self
@@ -6750,7 +6756,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Rule 3: Current checkpointed sole-survivor (end=None, b <= ckpt_max,
     ///         b < lwm, no other versions remain) — remove.
     ///
-    fn gc_version_chain(versions: &mut Vec<RowVersion>, lwm: u64, ckpt_max: u64) -> usize {
+    fn gc_version_chain(versions: &mut RowVersionChain, lwm: u64, ckpt_max: u64) -> usize {
         let before = versions.len();
 
         // Rule 1: aborted garbage
@@ -6806,7 +6812,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// peak allocation forever. Capacity drops to a quarter of its current
     /// value — deliberately not to fit — when the survivors occupy less than
     /// a quarter of it, so steady-state chains keep slack for new versions.
-    fn shrink_version_chain_allocation(versions: &mut Vec<RowVersion>) {
+    fn shrink_version_chain_allocation(versions: &mut RowVersionChain) {
         let capacity = versions.capacity();
         if capacity > Self::CHAIN_SHRINK_MIN_CAPACITY && versions.len() < capacity / 4 {
             versions.shrink_to(capacity / 4);
@@ -6854,7 +6860,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     fn get_or_create_table_row_versions(&self, id: RowID) -> Result<RowVersions, TryReserveError> {
         let versions = self
             .rows
-            .try_get_or_insert_with(id, || Arc::new(RwLock::new(Vec::new())))?;
+            .try_get_or_insert_with(id, || Arc::new(RwLock::new(crate::alloc::vec![])))?;
         Ok(versions.value().clone())
     }
 
@@ -6910,7 +6916,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         index: &'a IndexRowsMap<A>,
         key: Arc<SortableIndexKey>,
     ) -> Result<IndexRowEntry<'a, A>, TryReserveError> {
-        let entry = index.try_get_or_insert_with(key, || Arc::new(RwLock::new(Vec::new())))?;
+        let entry =
+            index.try_get_or_insert_with(key, || Arc::new(RwLock::new(crate::alloc::vec![])))?;
         Ok(entry)
     }
 
@@ -6919,7 +6926,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::RowVersionReserve)]
     pub fn insert_version_raw(
         &self,
-        versions: &mut Vec<RowVersion>,
+        versions: &mut RowVersionChain,
         row_version: RowVersion,
     ) -> Result<(), TryReserveError> {
         // NOTICE: this is an insert a'la insertion sort, with pessimistic linear complexity.
@@ -7700,10 +7707,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 "sqlite_schema row must have at least 5 columns, got {column_count}",
                             )));
                         }
-                        schema_rows_after.insert(
-                            rowid.row_id.to_int_or_panic(),
-                            ImmutableRecord::from_bin_record(record_bytes.clone()),
-                        );
+                        crate::with_mv_store_allocation_site!(SchemaRowPayload, {
+                            schema_rows_after.insert(
+                                rowid.row_id.to_int_or_panic(),
+                                ImmutableRecord::from_bin_record(record_bytes.clone()),
+                            );
+                        });
                     }
                     ParsedOp::DeleteTable { rowid, .. }
                         if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID =>
@@ -7850,6 +7859,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 if column_count < 5 {
                                     return Err(LimboError::Corrupt(format!(
                                         "sqlite_schema row must have at least 5 columns, got {column_count}",
+
                                     )));
                                 }
                                 let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
@@ -7928,10 +7938,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     )));
                                 }
                                 let rowid_int = rowid.row_id.to_int_or_panic();
-                                schema_rows.insert(
-                                    rowid_int,
-                                    ImmutableRecord::from_bin_record(row.payload().to_vec()),
-                                );
+                                crate::with_mv_store_allocation_site!(SchemaRowPayload, {
+                                    schema_rows.insert(
+                                        rowid_int,
+                                        ImmutableRecord::from_bin_record(row.payload().to_vec()),
+                                    );
+                                });
                             } else if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
                                 // Data row references a table_id not yet in the map. This can happen
                                 // with logs written before the schema-first serialization fix: in a
@@ -7975,22 +7987,25 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 // serialized before the schema INSERT that registers the table_id.
                                 self.insert_table_id_to_rootpage(rowid.table_id, None)?;
                             }
-                            let tombstone_row = if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                                let rowid_int = rowid.row_id.to_int_or_panic();
-                                if let Some(record) = schema_rows.get(&rowid_int) {
-                                    // Preserve the pre-delete sqlite_schema record in recovered
-                                    // tombstones so checkpoint can still recover B-tree identity.
-                                    Row::new_table_row(
-                                        rowid.clone(),
-                                        record.as_blob().clone(),
-                                        record.column_count(),
-                                    )
+                            let tombstone_row = crate::with_mv_store_allocation_site!(
+                                RowPayload,
+                                if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                                    let rowid_int = rowid.row_id.to_int_or_panic();
+                                    if let Some(record) = schema_rows.get(&rowid_int) {
+                                        // Preserve the pre-delete sqlite_schema record in recovered
+                                        // tombstones so checkpoint can still recover B-tree identity.
+                                        Row::new_table_row(
+                                            rowid.clone(),
+                                            record.as_blob(),
+                                            record.column_count(),
+                                        )?
+                                    } else {
+                                        Row::new_table_row(rowid.clone(), &[], 0)?
+                                    }
                                 } else {
-                                    Row::new_table_row(rowid.clone(), Vec::new(), 0)
+                                    Row::new_table_row(rowid.clone(), &[], 0)?
                                 }
-                            } else {
-                                Row::new_table_row(rowid.clone(), Vec::new(), 0)
-                            };
+                            );
                             if let Some(versions) = self.rows.get(&rowid) {
                                 // Row exists in memory — try to find the current (non-ended) version
                                 // that was committed before this delete, and mark it as ended. If no

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -29,6 +29,7 @@ use crate::types::compare_immutable;
 use crate::types::IOCompletions;
 use crate::types::IOResult;
 use crate::types::ImmutableRecord;
+use crate::types::ImmutableRecordRef;
 use crate::types::IndexInfo;
 use crate::types::SeekResult;
 use crate::File;
@@ -650,8 +651,7 @@ fn portable_delete_op_extension_for_row_version<Clock: LogicalClock, A: Concurre
         let values = match &record_values {
             Some(values) => values,
             None => record_values.insert(
-                ImmutableRecord::from_bin_record(row_version.row.payload().to_vec())
-                    .get_values_owned()?,
+                ImmutableRecordRef::from_bin_record(row_version.row.payload()).get_values_owned()?,
             ),
         };
         let physical_column = table.logical_to_physical_column(logical_column);
@@ -7693,14 +7693,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     } if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID => {
                         let schema_rows_after =
                             schema_rows_after.get_or_insert_with(|| schema_rows.clone());
-                        let record = ImmutableRecord::from_bin_record(record_bytes.clone());
-                        if record.column_count() < 5 {
+                        let record = ImmutableRecordRef::from_bin_record(record_bytes);
+                        let column_count = record.column_count();
+                        if column_count < 5 {
                             return Err(LimboError::Corrupt(format!(
-                                "sqlite_schema row must have at least 5 columns, got {}",
-                                record.column_count()
+                                "sqlite_schema row must have at least 5 columns, got {column_count}",
                             )));
                         }
-                        schema_rows_after.insert(rowid.row_id.to_int_or_panic(), record);
+                        schema_rows_after.insert(
+                            rowid.row_id.to_int_or_panic(),
+                            ImmutableRecord::from_bin_record(record_bytes.clone()),
+                        );
                     }
                     ParsedOp::DeleteTable { rowid, .. }
                         if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID =>
@@ -7842,12 +7845,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             }
                             let is_schema_row = rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID;
                             if is_schema_row {
-                                let row_data = row.payload().to_vec();
-                                let record = ImmutableRecord::from_bin_record(row_data);
-                                if record.column_count() < 5 {
+                                let record = ImmutableRecordRef::from_bin_record(row.payload());
+                                let column_count = record.column_count();
+                                if column_count < 5 {
                                     return Err(LimboError::Corrupt(format!(
-                                        "sqlite_schema row must have at least 5 columns, got {}",
-                                        record.column_count()
+                                        "sqlite_schema row must have at least 5 columns, got {column_count}",
                                     )));
                                 }
                                 let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
@@ -7926,7 +7928,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     )));
                                 }
                                 let rowid_int = rowid.row_id.to_int_or_panic();
-                                schema_rows.insert(rowid_int, record);
+                                schema_rows.insert(
+                                    rowid_int,
+                                    ImmutableRecord::from_bin_record(row.payload().to_vec()),
+                                );
                             } else if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
                                 // Data row references a table_id not yet in the map. This can happen
                                 // with logs written before the schema-first serialization fix: in a

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9855,6 +9855,48 @@ fn test_checkpoint_drop_table_removes_stale_rootpage_mapping() {
     );
 }
 
+#[test]
+fn test_checkpoint_post_durable_drop_failure_retry_removes_stale_rootpage_mapping() {
+    let db = MvccTestDb::new();
+
+    db.conn
+        .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    db.conn
+        .execute("CREATE TABLE stale_root(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO stale_root VALUES(1, 'old')")
+        .unwrap();
+    db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(
+        &db.conn,
+        "SELECT rootpage FROM sqlite_schema WHERE type = 'table' AND name = 'stale_root'",
+    );
+    let rootpage = rows[0][0].as_int().unwrap();
+    let table_id = db.mvcc_store.get_table_id_from_root_page(rootpage);
+    assert!(db.mvcc_store.table_id_to_rootpage.get(&table_id).is_some());
+
+    db.conn.execute("DROP TABLE stale_root").unwrap();
+    db.conn
+        .set_failure_injector(Some(FixedFailureInjector::new([(
+            CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
+            LimboError::TxError("synthetic checkpoint failure after pager commit".to_string()),
+        )])));
+    db.conn
+        .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        .expect_err("checkpoint should fail after pager commit");
+    db.conn.set_failure_injector(None);
+
+    db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    assert!(
+        db.mvcc_store.table_id_to_rootpage.get(&table_id).is_none(),
+        "dropped checkpointed table mapping must be removed after retry"
+    );
+}
+
 /// Test that inserting a duplicate primary key fails when the existing row
 /// was committed before this transaction started (and thus is visible).
 #[test]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashSet as HashSet;
 
 use super::*;
+use crate::alloc::{TursoIteratorExt, TursoTryWithCapacityExt};
 use crate::io::{PlatformIO, IO};
 use crate::mvcc::clock::MvccClock;
 use crate::mvcc::cursor::{CursorYieldPoint, MvccCursorType};
@@ -226,7 +227,7 @@ fn mv_store_skiplist_allocations_are_fallible() {
         id: 1,
         begin: PackedTs::pack(Some(TxTimestampOrID::TxID(1))),
         end: PackedTs::pack(None),
-        row: Row::new_table_row(row_id.clone(), Vec::new(), 0),
+        row: Row::new_table_row(row_id.clone(), &[], 0).unwrap(),
         btree_resident: false,
     };
     let result = store.insert_version(row_id, row_version);
@@ -251,7 +252,7 @@ fn mv_store_insert_allocation_failure_leaves_tx_state_untouched() {
 
     let table_id = MVTableId::from(-2);
     let row_id = RowID::new(table_id, RowKey::Int(42));
-    let row = Row::new_table_row(row_id.clone(), Vec::new(), 0);
+    let row = Row::new_table_row(row_id.clone(), &[], 0).unwrap();
     let allocator = store.get_rowid_allocator(&table_id);
 
     alloc.fail_allocations(true);
@@ -720,11 +721,7 @@ impl MvccTestDbNoConn {
 pub(crate) fn generate_simple_string_row(table_id: MVTableId, id: i64, data: &str) -> Row {
     let record =
         ImmutableRecord::from_values(&[Value::Text(Text::new(data.to_string()))], 1).unwrap();
-    Row::new_table_row(
-        RowID::new(table_id, RowKey::Int(id)),
-        record.as_blob().to_vec(),
-        1,
-    )
+    Row::new_table_row(RowID::new(table_id, RowKey::Int(id)), record.as_blob(), 1).unwrap()
 }
 
 pub(crate) fn generate_simple_string_record(data: &str) -> ImmutableRecord {
@@ -1365,9 +1362,10 @@ fn test_recovery_replays_schema_op_after_data_op_in_frame() {
         end: crate::mvcc::database::PackedTs::pack(None),
         row: Row::new_table_row(
             RowID::new(SQLITE_SCHEMA_MVCC_TABLE_ID, RowKey::Int(2)),
-            schema_record.as_blob().to_vec(),
+            schema_record.as_blob(),
             5,
-        ),
+        )
+        .unwrap(),
         btree_resident: false,
     };
     let tx = LogRecord::for_test(commit_ts, &[data_version, schema_version], None);
@@ -4104,7 +4102,7 @@ fn setup_test_db() -> (MvccTestDb, u64, MVTableId, i64) {
         let id = RowID::new(table_id, RowKey::Int(*row_id));
         let record =
             ImmutableRecord::from_values(&[Value::Text(Text::new(data.to_string()))], 1).unwrap();
-        let row = Row::new_table_row(id, record.as_blob().to_vec(), 1);
+        let row = Row::new_table_row(id, record.as_blob(), 1).unwrap();
         db.mvcc_store.insert(tx_id, row).unwrap();
     }
 
@@ -4140,7 +4138,7 @@ fn setup_lazy_db(initial_keys: &[i64]) -> (MvccTestDb, u64, MVTableId, i64) {
         let id = RowID::new(table_id, RowKey::Int(*i));
         let data = format!("row{i}");
         let record = ImmutableRecord::from_values(&[Value::Text(Text::new(data))], 1).unwrap();
-        let row = Row::new_table_row(id, record.as_blob().to_vec(), 1);
+        let row = Row::new_table_row(id, record.as_blob(), 1).unwrap();
         db.mvcc_store.insert(tx_id, row).unwrap();
     }
 
@@ -5249,7 +5247,7 @@ fn test_index_finger_no_spurious_dep_on_stepped_over_key() {
         .index_rows
         .get_or_insert_with(table_id, SkipMap::new)
         .value()
-        .insert(key20, Arc::new(RwLock::new(vec![tombstone])));
+        .insert(key20, Arc::new(RwLock::new(crate::alloc::vec![tombstone])));
 
     let mut finger = IndexShadowFinger::default();
     // B-tree key 10: finger seeds at the first index key >= 10 (key 20), which is
@@ -6147,9 +6145,10 @@ fn write_synthetic_row(db: &MvccTestDbNoConn, value: &str) {
             tx_id,
             Row::new_table_row(
                 RowID::new((-1).into(), RowKey::Int(next_schema_rowid)),
-                data.as_blob().to_vec(),
+                data.as_blob(),
                 5,
-            ),
+            )
+            .unwrap(),
         )
         .unwrap();
     let row = generate_simple_string_row(synthetic_table_id, 1, value);
@@ -6496,7 +6495,7 @@ fn transaction_display() {
     let tx_id = 42;
     let begin_ts = 20250914;
 
-    let empty_versions = || Arc::new(RwLock::new(Vec::new()));
+    let empty_versions = || Arc::new(RwLock::new(crate::alloc::vec![]));
     let write_set = Mutex::new({
         let mut write_set = WriteSet::new();
         write_set.insert(RowID::new((-2).into(), RowKey::Int(11)), empty_versions());
@@ -7695,7 +7694,7 @@ fn txid(v: u64) -> Option<TxTimestampOrID> {
 /// Rolled-back transactions leave versions with begin=None, end=None. These are
 /// invisible to every transaction and must be removed unconditionally by Rule 1.
 fn test_gc_rule1_aborted_garbage_removed() {
-    let mut versions = vec![make_rv(None, None)];
+    let mut versions = crate::alloc::vec![make_rv(None, None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, u64::MAX, 0);
     assert_eq!(dropped, 1);
     assert!(versions.is_empty());
@@ -7706,7 +7705,7 @@ fn test_gc_rule1_aborted_garbage_removed() {
 #[test]
 /// Rule 1 removes only aborted garbage, leaving live and superseded versions intact.
 fn test_gc_rule1_aborted_among_live_versions() {
-    let mut versions = vec![
+    let mut versions = crate::alloc::vec![
         make_rv(ts(5), None),  // current
         make_rv(None, None),   // aborted
         make_rv(ts(3), ts(5)), // superseded
@@ -7728,7 +7727,7 @@ fn test_gc_rule1_aborted_among_live_versions() {
 /// take over B-tree invalidation, the superseded version is safely removable.
 fn test_gc_rule2_superseded_below_lwm_with_current() {
     // Superseded version (end=Timestamp(3)) below LWM=10, and there's a current version.
-    let mut versions = vec![
+    let mut versions = crate::alloc::vec![
         make_rv(ts(3), ts(5)), // superseded, e=5 <= lwm=10
         make_rv(ts(5), None),  // current
     ];
@@ -7745,7 +7744,7 @@ fn test_gc_rule2_superseded_below_lwm_with_current() {
 /// to an active reader. It must be retained regardless of other conditions.
 fn test_gc_rule2_superseded_above_lwm_retained() {
     // Superseded version (end=Timestamp(15)) above LWM=10 — must be retained.
-    let mut versions = vec![make_rv(ts(3), ts(15)), make_rv(ts(15), None)];
+    let mut versions = crate::alloc::vec![make_rv(ts(3), ts(15)), make_rv(ts(15), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 0);
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 2);
@@ -7760,7 +7759,7 @@ fn test_gc_rule2_superseded_above_lwm_retained() {
 fn test_gc_rule2_tombstone_guard_uncheckpointed() {
     // Tombstone: end is set, no current version, and e > ckpt_max.
     // Must be retained to prevent row resurrection via dual cursor.
-    let mut versions = vec![
+    let mut versions = crate::alloc::vec![
         make_rv(ts(3), ts(5)), // tombstone (sole version, no current)
     ];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 2);
@@ -7776,7 +7775,7 @@ fn test_gc_rule2_tombstone_guard_uncheckpointed() {
 /// contains the row, so the tombstone is safe to remove.
 fn test_gc_rule2_tombstone_guard_checkpointed() {
     // Tombstone with e <= ckpt_max — deletion is checkpointed, safe to remove.
-    let mut versions = vec![make_rv(ts(3), ts(5))];
+    let mut versions = crate::alloc::vec![make_rv(ts(3), ts(5))];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 5);
     // e=5 <= ckpt_max=5, e=5 <= lwm=10 → removable
     assert_eq!(dropped, 1);
@@ -7791,7 +7790,7 @@ fn test_gc_rule2_tombstone_guard_checkpointed() {
 /// fall through to the B-tree which has identical data. Safe to remove.
 fn test_gc_rule3_checkpointed_sole_survivor_removed() {
     // Single current version with b <= ckpt_max and b < lwm.
-    let mut versions = vec![make_rv(ts(5), None)];
+    let mut versions = crate::alloc::vec![make_rv(ts(5), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 5);
     assert_eq!(dropped, 1);
     assert!(versions.is_empty());
@@ -7804,7 +7803,7 @@ fn test_gc_rule3_checkpointed_sole_survivor_removed() {
 /// the B-tree doesn't have the data, so fallthrough would return stale results.
 fn test_gc_rule3_not_checkpointed_retained() {
     // Single current version with b > ckpt_max — B-tree doesn't have it yet.
-    let mut versions = vec![make_rv(ts(5), None)];
+    let mut versions = crate::alloc::vec![make_rv(ts(5), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 3);
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 1);
@@ -7817,7 +7816,7 @@ fn test_gc_rule3_not_checkpointed_retained() {
 /// by the oldest active reader. Rule 3 requires strict b < lwm, so it's retained.
 fn test_gc_rule3_visible_to_active_tx_retained() {
     // Single current version with b >= lwm — some active tx might need it.
-    let mut versions = vec![make_rv(ts(5), None)];
+    let mut versions = crate::alloc::vec![make_rv(ts(5), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 5, 10);
     // b=5 is NOT < lwm=5 (strict <), so retained
     assert_eq!(dropped, 0);
@@ -7829,7 +7828,7 @@ fn test_gc_rule3_visible_to_active_tx_retained() {
 #[test]
 /// A current version cannot be removed before checkpoint has persisted it.
 fn test_gc_rule3_current_retained_before_first_checkpoint() {
-    let mut versions = vec![make_rv(ts(1), None)];
+    let mut versions = crate::alloc::vec![make_rv(ts(1), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 0);
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 1);
@@ -7840,7 +7839,7 @@ fn test_gc_rule3_current_retained_before_first_checkpoint() {
 #[test]
 /// Once checkpoint has persisted a sole current version, it becomes GC-eligible.
 fn test_gc_rule3_current_collected_after_checkpoint() {
-    let mut versions = vec![make_rv(ts(1), None)];
+    let mut versions = crate::alloc::vec![make_rv(ts(1), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 5);
     assert_eq!(dropped, 1);
     assert_eq!(versions.len(), 0);
@@ -7854,7 +7853,7 @@ fn test_gc_rule3_current_collected_after_checkpoint() {
 /// fire on the remaining sole survivor — both rules compose correctly.
 fn test_gc_rule3_not_sole_survivor() {
     // Rule 3 only fires when exactly one version remains after rules 1 & 2.
-    let mut versions = vec![make_rv(ts(3), ts(5)), make_rv(ts(5), None)];
+    let mut versions = crate::alloc::vec![make_rv(ts(3), ts(5)), make_rv(ts(5), None)];
     // Both b <= ckpt_max and b < lwm, but there are 2 versions.
     // Rule 2 removes the superseded one (has_current=true), then rule 3 fires
     // on the remaining sole survivor.
@@ -7870,7 +7869,7 @@ fn test_gc_rule3_not_sole_survivor() {
 /// inserts. They don't match any removal rule and must always be retained.
 fn test_gc_txid_refs_retained() {
     // Versions with TxID (uncommitted) references are never collected.
-    let mut versions = vec![make_rv(txid(99), None)];
+    let mut versions = crate::alloc::vec![make_rv(txid(99), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, u64::MAX, u64::MAX);
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 1);
@@ -7883,7 +7882,7 @@ fn test_gc_txid_refs_retained() {
 /// end=Timestamp, so these are never collected until the deleting tx resolves.
 fn test_gc_txid_end_retained() {
     // end=TxID means the deletion is uncommitted; rule 2 only matches Timestamp.
-    let mut versions = vec![make_rv(ts(3), txid(50))];
+    let mut versions = crate::alloc::vec![make_rv(ts(3), txid(50))];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, u64::MAX, u64::MAX);
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 1);
@@ -7899,7 +7898,7 @@ fn test_gc_rule2_pending_insert_does_not_disable_tombstone_guard() {
     // A pending insert (begin=TxID, end=None) coexists with a tombstone.
     // has_current must NOT count the pending insert — if it rolls back,
     // the tombstone is the only thing hiding the B-tree row.
-    let mut versions = vec![
+    let mut versions = crate::alloc::vec![
         make_rv(ts(3), ts(5)), // tombstone: deletion at e=5, not checkpointed (ckpt_max=2)
         make_rv(txid(99), None), // pending insert (uncommitted)
     ];
@@ -7919,7 +7918,7 @@ fn test_gc_rule2_pending_insert_does_not_disable_tombstone_guard() {
 fn test_gc_rule2_committed_current_disables_tombstone_guard() {
     // A committed current version (begin=Timestamp, end=None) means the row
     // has a live successor — the tombstone can safely be removed.
-    let mut versions = vec![
+    let mut versions = crate::alloc::vec![
         make_rv(ts(3), ts(5)), // superseded, e=5 <= lwm=10
         make_rv(ts(5), None),  // committed current
     ];
@@ -7941,7 +7940,7 @@ fn test_gc_rule2_btree_tombstone_lifecycle() {
     // B-tree tombstone: begin=None, end=Timestamp(e) where e > 0.
     // Represents a row deleted in MVCC that existed in B-tree before MVCC.
     // Before checkpoint (ckpt_max < e): tombstone must be retained.
-    let mut versions = vec![make_rv(None, ts(5))];
+    let mut versions = crate::alloc::vec![make_rv(None, ts(5))];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, u64::MAX, 3);
     assert_eq!(dropped, 0, "tombstone retained: e=5 > ckpt_max=3");
     assert_eq!(versions.len(), 1);
@@ -7962,7 +7961,7 @@ fn test_gc_rule3_not_firing_with_unremovable_superseded() {
     // Two versions: superseded with e > lwm (can't remove), and current.
     // Rule 2 can't remove the superseded one, so 2 versions remain.
     // Rule 3 requires sole-survivor, so it must NOT fire.
-    let mut versions = vec![
+    let mut versions = crate::alloc::vec![
         make_rv(ts(3), ts(15)), // e=15 > lwm=10 — retained
         make_rv(ts(15), None),  // current
     ];
@@ -7976,7 +7975,7 @@ fn test_gc_rule3_not_firing_with_unremovable_superseded() {
 #[test]
 /// GC on an empty version chain is a no-op. Verifies no panics or off-by-one errors.
 fn test_gc_noop_on_empty() {
-    let mut versions: Vec<RowVersion> = vec![];
+    let mut versions: RowVersionChain = crate::alloc::vec![];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 5);
     assert_eq!(dropped, 0);
 }
@@ -7990,7 +7989,7 @@ fn test_gc_noop_on_empty() {
 fn test_gc_combined_rules() {
     // Mix of all cases: aborted, superseded below LWM, current checkpointed,
     // and one above LWM that must be retained.
-    let mut versions = vec![
+    let mut versions = crate::alloc::vec![
         make_rv(None, None),   // aborted → rule 1
         make_rv(ts(1), ts(3)), // superseded, e=3 <= lwm=10 → rule 2 (has_current=true)
         make_rv(ts(3), ts(5)), // superseded, e=5 <= lwm=10 → rule 2
@@ -8095,11 +8094,11 @@ fn test_gc_shrinks_version_chain_capacity() {
 
     // One committed current version that survives GC (b=1 > ckpt_max=0, so
     // rule 3 doesn't fire), plus a burst of aborted garbage (always removed).
-    let mut versions: Vec<RowVersion> = Vec::new();
-    versions.push(make_version(Some(TxTimestampOrID::Timestamp(1)), None));
-    for _ in 0..1023 {
-        versions.push(make_version(None, None));
-    }
+    let mut versions: RowVersionChain =
+        std::iter::once(make_version(Some(TxTimestampOrID::Timestamp(1)), None))
+            .chain((0..1023).map(|_| make_version(None, None)))
+            .try_collect()
+            .unwrap();
     let capacity_before = versions.capacity();
     assert!(capacity_before >= 1024);
 
@@ -8113,7 +8112,10 @@ fn test_gc_shrinks_version_chain_capacity() {
     );
 
     // A chain emptied entirely also releases its allocation.
-    let mut versions: Vec<RowVersion> = (0..1024).map(|_| make_version(None, None)).collect();
+    let mut versions: RowVersionChain = (0..1024)
+        .map(|_| make_version(None, None))
+        .try_collect()
+        .unwrap();
     let capacity_before = versions.capacity();
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 0, 0);
     assert_eq!(dropped, 1024);
@@ -8126,7 +8128,7 @@ fn test_gc_shrinks_version_chain_capacity() {
 
     // Small chains are not worth a realloc: capacity at or below the minimum
     // threshold is left untouched even when fully emptied.
-    let mut small: Vec<RowVersion> = Vec::with_capacity(16);
+    let mut small: RowVersionChain = RowVersionChain::try_with_capacity_ext(16).unwrap();
     small.push(make_version(None, None));
     let capacity_before = small.capacity();
     MvStore::<MvccClock>::gc_version_chain(&mut small, 0, 0);
@@ -8858,7 +8860,7 @@ fn test_gc_e2e_index_rows_collected_after_checkpoint() {
 /// Represents a version chain entry for quickcheck.
 #[derive(Debug, Clone)]
 struct ArbitraryVersionChain {
-    versions: Vec<RowVersion>,
+    versions: RowVersionChain,
     lwm: u64,
     ckpt_max: u64,
 }
@@ -8925,7 +8927,10 @@ impl Arbitrary for ArbitraryVersionChain {
     fn arbitrary(g: &mut Gen) -> Self {
         // 1..8 versions (no empty chains — they trivially pass all properties)
         let len = usize::arbitrary(g) % 8 + 1;
-        let versions: Vec<RowVersion> = (0..len).map(|_| arbitrary_row_version(g)).collect();
+        let versions: RowVersionChain = (0..len)
+            .map(|_| arbitrary_row_version(g))
+            .try_collect()
+            .unwrap();
         // Include boundary values with ~20% probability each.
         let lwm = match u8::arbitrary(g) % 5 {
             0 => 0,

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -3481,6 +3481,7 @@ impl StreamingLogicalLogReader {
             } => {
                 // Compute column_count from the serialized record so recovered rows keep
                 // the same shape metadata as non-recovered rows.
+                // Decode shape metadata by reference; ownership is only needed for the row payload.
                 let column_count =
                     crate::types::ImmutableRecordRef::from_bin_record(&record_bytes).column_count();
                 let row = Row::new_table_row(

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -3484,10 +3484,13 @@ impl StreamingLogicalLogReader {
                 // Decode shape metadata by reference; ownership is only needed for the row payload.
                 let column_count =
                     crate::types::ImmutableRecordRef::from_bin_record(&record_bytes).column_count();
-                let row = Row::new_table_row(
-                    RowID::new(table_id, rowid.row_id.clone()),
-                    record_bytes,
-                    column_count,
+                let row = crate::with_mv_store_allocation_site!(
+                    RowPayload,
+                    Row::new_table_row(
+                        RowID::new(table_id, rowid.row_id.clone()),
+                        &record_bytes,
+                        column_count,
+                    )?
                 );
                 Ok(StreamingResult::UpsertTableRow {
                     row,
@@ -4418,9 +4421,10 @@ mod tests {
                     tx_id,
                     Row::new_table_row(
                         RowID::new((-1).into(), RowKey::Int(1000)),
-                        data.as_blob().to_vec(),
+                        data.as_blob(),
                         5,
-                    ),
+                    )
+                    .unwrap(),
                 )
                 .unwrap();
             // now insert a row into table -2
@@ -4490,9 +4494,10 @@ mod tests {
                     tx_id,
                     Row::new_table_row(
                         RowID::new((-1).into(), RowKey::Int(1000)),
-                        data.as_blob().to_vec(),
+                        data.as_blob(),
                         5,
-                    ),
+                    )
+                    .unwrap(),
                 )
                 .unwrap();
             commit_tx(mvcc_store.clone(), &conn, tx_id).unwrap();
@@ -4604,9 +4609,10 @@ mod tests {
                     tx_id,
                     Row::new_table_row(
                         RowID::new((-1).into(), RowKey::Int(1000)),
-                        data.as_blob().to_vec(),
+                        data.as_blob(),
                         5,
-                    ),
+                    )
+                    .unwrap(),
                 )
                 .unwrap();
             commit_tx(mvcc_store.clone(), &conn, tx_id).unwrap();
@@ -5666,9 +5672,10 @@ mod tests {
                         )),
                         row: Row::new_table_row(
                             RowID::new((-2).into(), RowKey::Int(rowid)),
-                            Vec::new(),
+                            &[],
                             0,
-                        ),
+                        )
+                        .unwrap(),
                         btree_resident,
                     });
                     expected.push(ExpectedTableOp::Delete {
@@ -6278,7 +6285,8 @@ mod tests {
         commit_ts: u64,
         is_delete: bool,
     ) -> crate::mvcc::database::RowVersion {
-        let row = Row::new_table_row(RowID::new(table_id, RowKey::Int(rowid)), record_bytes, 1);
+        let row =
+            Row::new_table_row(RowID::new(table_id, RowKey::Int(rowid)), &record_bytes, 1).unwrap();
         crate::mvcc::database::RowVersion {
             id: rowid as u64,
             begin: crate::mvcc::database::PackedTs::pack(if is_delete {

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -1,4 +1,4 @@
-use crate::types::{ImmutableRecord, Value};
+use crate::types::{ImmutableRecordRef, ValueRef};
 use crate::{LimboError, Numeric, Result};
 use std::collections::{HashMap, HashSet};
 
@@ -72,33 +72,41 @@ pub(crate) struct PortableSchemaRow {
 }
 
 pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<PortableSchemaRow> {
-    let values = ImmutableRecord::from_bin_record(record_bytes.to_vec()).get_values_owned()?;
-    if values.len() < 5 {
+    let record = ImmutableRecordRef::from_bin_record(record_bytes);
+    let column_count = record.column_count();
+    if column_count < 5 {
         return Err(LimboError::Corrupt(format!(
-            "sqlite_schema record must have at least 5 columns, got {}",
-            values.len()
+            "sqlite_schema record must have at least 5 columns, got {column_count}",
         )));
     }
-    let text = |value: &Value, field: &str| -> Result<String> {
+    let value = |idx: usize, field: &str| -> Result<ValueRef<'_>> {
+        record.get_value_opt(idx).ok_or_else(|| {
+            LimboError::Corrupt(format!("sqlite_schema record missing {field} column"))
+        })
+    };
+    let text = |value: ValueRef<'_>, field: &str| -> Result<String> {
         match value {
-            Value::Text(text) => Ok(text.as_str().to_string()),
+            ValueRef::Text(text) => Ok(text.as_str().to_string()),
             other => Err(LimboError::Corrupt(format!(
                 "{field} must be text in sqlite_schema record, got {other:?}"
             ))),
         }
     };
-    let integer = |value: &Value, field: &str| -> Result<i64> {
+    let integer = |value: ValueRef<'_>, field: &str| -> Result<i64> {
         match value {
-            Value::Numeric(Numeric::Integer(value)) => Ok(*value),
+            ValueRef::Numeric(Numeric::Integer(value)) => Ok(value),
             other => Err(LimboError::Corrupt(format!(
                 "{field} must be integer in sqlite_schema record, got {other:?}"
             ))),
         }
     };
     Ok(PortableSchemaRow {
-        row_type: text(&values[0], "sqlite_schema.type")?,
-        name: text(&values[1], "sqlite_schema.name")?,
-        rootpage: integer(&values[3], "sqlite_schema.rootpage")?,
+        row_type: text(value(0, "sqlite_schema.type")?, "sqlite_schema.type")?,
+        name: text(value(1, "sqlite_schema.name")?, "sqlite_schema.name")?,
+        rootpage: integer(
+            value(3, "sqlite_schema.rootpage")?,
+            "sqlite_schema.rootpage",
+        )?,
     })
 }
 

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -79,11 +79,7 @@ pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<Por
             "sqlite_schema record must have at least 5 columns, got {column_count}",
         )));
     }
-    let value = |idx: usize, field: &str| -> Result<ValueRef<'_>> {
-        record.get_value_opt(idx).ok_or_else(|| {
-            LimboError::Corrupt(format!("sqlite_schema record missing {field} column"))
-        })
-    };
+
     let text = |value: ValueRef<'_>, field: &str| -> Result<String> {
         match value {
             ValueRef::Text(text) => Ok(text.as_str().to_string()),
@@ -100,13 +96,16 @@ pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<Por
             ))),
         }
     };
+    let (row_type, name, rootpage) = record.get_three_values(0, 1, 3)?;
+    let (row_type, name, rootpage) = (
+        text(row_type, "sqlite_schema.type")?,
+        text(name, "sqlite_schema.name")?,
+        integer(rootpage, "sqlite_schema.rootpage")?,
+    );
     Ok(PortableSchemaRow {
-        row_type: text(value(0, "sqlite_schema.type")?, "sqlite_schema.type")?,
-        name: text(value(1, "sqlite_schema.name")?, "sqlite_schema.name")?,
-        rootpage: integer(
-            value(3, "sqlite_schema.rootpage")?,
-            "sqlite_schema.rootpage",
-        )?,
+        row_type,
+        name,
+        rootpage,
     })
 }
 

--- a/core/types.rs
+++ b/core/types.rs
@@ -1368,6 +1368,15 @@ mod immutable_record {
             two_values(self.payload, idx1, idx2)
         }
 
+        pub fn get_three_values(
+            &self,
+            idx1: usize,
+            idx2: usize,
+            idx3: usize,
+        ) -> Result<(ValueRef<'_>, ValueRef<'_>, ValueRef<'_>)> {
+            three_values(self.get_payload(), idx1, idx2, idx3)
+        }
+
         pub fn get_values_owned(&self) -> Result<Vec<Value>> {
             values_owned(self.payload)
         }

--- a/testing/concurrent-simulator/Cargo.toml
+++ b/testing/concurrent-simulator/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 description = "The Turso deterministic simulator"
 publish = false
 
+[lints]
+workspace = true
+
 [lib]
 name = "turso_whopper"
 path = "lib.rs"

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -208,6 +208,8 @@ fn allocation_site_id(site: AllocationSite) -> u64 {
             MvStoreAllocationSite::IndexRowsEntry => 5,
             MvStoreAllocationSite::IndexKeyEntry => 6,
             MvStoreAllocationSite::RowVersionReserve => 7,
+            MvStoreAllocationSite::RowPayload => 12,
+            MvStoreAllocationSite::SchemaRowPayload => 13,
         },
         AllocationSite::MvccCheckpoint(site) => match site {
             MvccCheckpointAllocationSite::CheckpointWriteSet => 8,

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(nightly, feature(allocator_api))]
+
 /// Whopper is a deterministic simulator for testing the Turso database.
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;


### PR DESCRIPTION
## Summary

- add MVCC allocation-site annotations for checkpoint and MvStore row payload paths
- make MVCC row payload construction fallible via allocator-aware `Arc<[u8]>` helpers
- use `ImmutableRecordRef` when inspecting existing row payloads so recovery/checkpoint paths avoid copying records just to read column metadata or schema fields
- only materialize owned `ImmutableRecord` payloads at the allocation sites where we actually need to store rewritten schema rows
- defer checkpoint root-page publication/removal until pager commit/finalize so allocation faults cannot leave stale MVStore root mappings
- wire the new allocation sites into Whopper allocation-fault injection
- run the Whopper concurrent-simulator workflow across stable and pinned nightly toolchains

## Testing

- `cargo fmt`
- `cargo fmt --check`
- `cargo check -p turso_core --all-targets`
- `RUSTFLAGS="--cfg nightly" cargo +nightly-2025-12-17 check -p turso_core --all-targets`
- `RUSTFLAGS="--cfg nightly" cargo +nightly-2025-12-17 check -p turso_core --all-targets --features allocation_metric --locked`
- `RUSTFLAGS="--cfg nightly" cargo +nightly-2025-12-17 build -p turso_whopper`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust.yml"); puts "ok"'`
- `SEED=2140438362277322441 RUST_BACKTRACE=1 ./target/release/turso_whopper --mode fast --reopen-probability 0.01 --enable-mvcc`
