### PR TITLE
core/translate: apply explicit COLLATE in compound SELECT ORDER BY

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -8,7 +8,7 @@ use crate::translate::emitter::{
 };
 use crate::translate::expr::translate_expr;
 use crate::translate::order_by::{custom_type_comparator, sorter_insert};
-use crate::translate::plan::{Plan, QueryDestination, SelectPlan};
+use crate::translate::plan::{CompoundOrderByKey, Plan, QueryDestination, SelectPlan};
 use crate::translate::result_row::emit_columns_to_destination;
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
 use crate::vdbe::insn::Insn;
@@ -828,7 +828,7 @@ fn create_collection_index(
 #[allow(clippy::too_many_arguments)]
 fn emit_compound_order_by(
     program: &mut ProgramBuilder,
-    order_by: &[(usize, SortOrder, Option<turso_parser::ast::NullsOrder>)],
+    order_by: &[CompoundOrderByKey],
     collection_cursor_id: usize,
     collection_index: &Index,
     num_result_cols: usize,
@@ -851,11 +851,13 @@ fn emit_compound_order_by(
         Option<turso_parser::ast::NullsOrder>,
     )> = order_by
         .iter()
-        .map(|(col_idx, order, nulls)| {
-            let collation = collection_index
-                .columns
-                .get(*col_idx)
-                .and_then(|c| c.collation);
+        .map(|(col_idx, order, nulls, explicit_collation)| {
+            let collation = (*explicit_collation).or_else(|| {
+                collection_index
+                    .columns
+                    .get(*col_idx)
+                    .and_then(|c| c.collation)
+            });
             (*order, collation, *nulls)
         })
         // Sequence tie-breaker: preserves insertion order for rows with equal ORDER BY keys
@@ -872,7 +874,7 @@ fn emit_compound_order_by(
             if let Some((sort_key_idx, _)) = order_by
                 .iter()
                 .enumerate()
-                .find(|(_, (ob_col, _, _))| *ob_col == col_idx)
+                .find(|(_, (ob_col, _, _, _))| *ob_col == col_idx)
             {
                 // This result column is also a sort key - deduplicate.
                 (sort_key_idx, true)
@@ -890,7 +892,7 @@ fn emit_compound_order_by(
     // NumericLt to sort correctly instead of default blob/text comparison).
     let comparators: crate::alloc::Vec<Option<crate::vdbe::insn::SortComparatorType>> = order_by
         .iter()
-        .map(|(col_idx, _, _)| {
+        .map(|(col_idx, _, _, _)| {
             program.result_columns.get(*col_idx).and_then(|rc| {
                 custom_type_comparator(
                     &rc.expr,
@@ -942,7 +944,7 @@ fn emit_compound_order_by(
     // Build sorter record: [sort_keys..., sequence, non-dedup result cols...]
     let sorter_regs = program.alloc_registers(sorter_column_count);
     // First emit sort keys
-    for (sort_key_idx, (col_idx, _, _)) in order_by.iter().enumerate() {
+    for (sort_key_idx, (col_idx, _, _, _)) in order_by.iter().enumerate() {
         program.emit_insn(Insn::Copy {
             src_reg: read_regs + col_idx,
             dst_reg: sorter_regs + sort_key_idx,

--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -222,7 +222,7 @@ impl Display for Plan {
                 }
                 if let Some(order_by) = order_by {
                     writeln!(f, "ORDER BY:")?;
-                    for (expr, dir, nulls) in order_by {
+                    for (expr, dir, nulls, _) in order_by {
                         fmt_order_by_item(f, expr, *dir, *nulls)?;
                     }
                 }
@@ -671,7 +671,7 @@ impl ToTokens for Plan {
                     s.comma(
                         order_by
                             .iter()
-                            .map(|(col_idx, order, nulls)| ast::SortedColumn {
+                            .map(|(col_idx, order, nulls, _)| ast::SortedColumn {
                                 expr: Box::new(ast::Expr::Literal(ast::Literal::Numeric(
                                     (col_idx + 1).to_string(),
                                 ))),

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -356,6 +356,18 @@ impl SubqueryOrigin {
     }
 }
 
+/// One ORDER BY key of a compound SELECT:
+/// `(result_column_index, sort_order, nulls_order, explicit_collation)`.
+/// The column index is 0-based into the result set. The explicit collation is
+/// set when the term carries a COLLATE override and otherwise the referenced
+/// column's own collation is used.
+pub(crate) type CompoundOrderByKey = (
+    usize,
+    SortOrder,
+    Option<ast::NullsOrder>,
+    Option<CollationSeq>,
+);
+
 /// A query plan is either a SELECT or a DELETE (for now)
 /// Variants are boxed so that moving a `Plan` around the prepare path
 /// (returns from plan builders, argument to emitters) costs a pointer
@@ -369,9 +381,8 @@ pub enum Plan {
         right_most: Box<SelectPlan>,
         limit: Option<Box<Expr>>,
         offset: Option<Box<Expr>>,
-        /// ORDER BY for compound selects. Each entry is (result_column_index, sort_order, nulls_order).
-        /// The column index is 0-based into the result set.
-        order_by: Option<Vec<(usize, SortOrder, Option<ast::NullsOrder>)>>,
+        /// ORDER BY for compound selects, or `None` when the query has none.
+        order_by: Option<Vec<CompoundOrderByKey>>,
     },
     Delete(Box<DeletePlan>),
     Update(Box<UpdatePlan>),

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -6,6 +6,7 @@ use super::plan::{
 use crate::schema::Table;
 use crate::stack::trace_stack;
 use crate::sync::Arc;
+use crate::translate::collate::CollationSeq;
 use crate::translate::emitter::{OperationMode, Resolver};
 use crate::translate::expr::{
     bind_and_rewrite_expr, expr_vector_size, walk_expr, BindingBehavior, WalkControl,
@@ -234,8 +235,14 @@ pub fn prepare_select_plan(
             } else {
                 let mut key = Vec::with_capacity(select.order_by.len());
                 for (i, o) in select.order_by.iter().enumerate() {
-                    let col_idx = resolve_compound_order_by_expr(&o.expr, &all_plans, i + 1)?;
-                    key.push((col_idx, o.order.unwrap_or(ast::SortOrder::Asc), o.nulls));
+                    let (col_idx, collation) =
+                        resolve_compound_order_by_expr(&o.expr, &all_plans, i + 1)?;
+                    key.push((
+                        col_idx,
+                        o.order.unwrap_or(ast::SortOrder::Asc),
+                        o.nulls,
+                        collation,
+                    ));
                 }
                 Some(key)
             };
@@ -1161,9 +1168,16 @@ fn resolve_compound_order_by_expr(
     expr: &ast::Expr,
     all_plans: &[&SelectPlan],
     term_number: usize,
-) -> Result<usize> {
+) -> Result<(usize, Option<CollationSeq>)> {
     let num_result_columns = all_plans[0].result_columns.len();
     match expr {
+        // An explicit COLLATE wraps the column reference. Resolve the inner
+        // reference and carry the collation so it overrides the referenced
+        // column's own collation when the compound result is sorted.
+        ast::Expr::Collate(inner, collation_name) => {
+            let (col_idx, _) = resolve_compound_order_by_expr(inner, all_plans, term_number)?;
+            Ok((col_idx, Some(CollationSeq::new(collation_name.as_str())?)))
+        }
         // Case 1: Numeric column reference (e.g., ORDER BY 1)
         ast::Expr::Literal(ast::Literal::Numeric(num)) => {
             if let Ok(column_number) = num.parse::<usize>() {
@@ -1174,7 +1188,7 @@ fn resolve_compound_order_by_expr(
                         num_result_columns
                     );
                 }
-                Ok(column_number - 1)
+                Ok((column_number - 1, None))
             } else {
                 crate::bail_parse_error!(
                     "{} ORDER BY term does not match any column in the result set",
@@ -1193,7 +1207,7 @@ fn resolve_compound_order_by_expr(
                 for (i, rc) in result_columns.iter().enumerate() {
                     if let Some(alias) = &rc.alias {
                         if normalize_ident(alias) == name_normalized {
-                            return Ok(i);
+                            return Ok((i, None));
                         }
                     }
                 }
@@ -1201,7 +1215,7 @@ fn resolve_compound_order_by_expr(
                 for (i, rc) in result_columns.iter().enumerate() {
                     if let Some(col_name) = rc.name(table_references) {
                         if normalize_ident(col_name) == name_normalized {
-                            return Ok(i);
+                            return Ok((i, None));
                         }
                     }
                 }

--- a/sqlite/conformance/sqlite-sqltests/compound-select-orderby.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/compound-select-orderby.sqltest
@@ -897,3 +897,32 @@ test union-order-by-expr-no-match {
 expect error {
     1st ORDER BY term does not match any column in the result set
 }
+
+# ===== ORDER BY with COLLATE =====
+
+@setup schema
+test union-all-order-by-collate-nocase {
+    SELECT 'a' AS x UNION ALL SELECT 'B' ORDER BY 1 COLLATE NOCASE;
+}
+expect {
+    a
+    B
+}
+
+@setup schema
+test union-all-order-by-collate-nocase-name {
+    SELECT 'b' AS x UNION ALL SELECT 'A' ORDER BY x COLLATE NOCASE;
+}
+expect {
+    A
+    b
+}
+
+@setup schema
+test union-all-order-by-collate-nocase-desc {
+    SELECT 'a' AS x UNION ALL SELECT 'B' ORDER BY 1 COLLATE NOCASE DESC;
+}
+expect {
+    B
+    a
+}


### PR DESCRIPTION
## Description

A compound SELECT (`UNION`, `UNION ALL`, `INTERSECT`, `EXCEPT`) whose `ORDER BY` term carried an explicit `COLLATE` was rejected:

```
turso> SELECT 'a' AS x UNION ALL SELECT 'B' ORDER BY 1 COLLATE NOCASE;
  x Parse error: 1st ORDER BY term does not match any column in the result set
```

SQLite accepts this and applies the collation when sorting.

`resolve_compound_order_by_expr` only handled bare numeric and identifier `ORDER BY` terms, so an `Expr::Collate` wrapping either fell through to the catch-all error. The compound `ORDER BY` key also had no slot to carry a per-term collation, so an explicit `COLLATE` had nowhere to live.

This accepts `Expr::Collate` by resolving the wrapped column reference and threading the collation through the compound `ORDER BY` key. When emitting the sorter, an explicit collation overrides the referenced column's own collation; without an explicit `COLLATE`, the column's own collation is used as before.

After (matches SQLite):

```
turso> SELECT 'a' AS x UNION ALL SELECT 'B' ORDER BY 1 COLLATE NOCASE;
a
B
```

The `GROUP BY n COLLATE` case also mentioned in the issue already works and is covered by `collate.sqltest`.

## Motivation and context

Fixes #6408. Improves SQLite compatibility for compound SELECT `ORDER BY`.

Regression tests were added to `testing/sqltests/tests/compound-select-orderby.sqltest` covering an explicit `COLLATE` on a numeric ordinal, on a column name, and combined with `DESC`. They fail before the change and pass after. The existing compound-select-orderby (54 tests) and collate (108 tests) suites pass.

## Description of AI Usage

This change was developed with the assistance of Claude Code. The agent was directed to investigate the issue, reproduce it against SQLite, locate the root cause, and implement the fix and regression tests. I reviewed the diff, the reproduction against SQLite 3.50.6, and the test results, and I understand and take responsibility for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
