### PR TITLE
core/btree: prevent leaking pinned pages in page stack

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6327,10 +6327,7 @@ impl CursorTrait for BTreeCursor {
     /// valid_state stays Valid — only rewind/seek-style entry points are safe
     /// next; next/prev land on `current_page == -1` and return Done(false).
     fn invalidate_btree_cache(&mut self) {
-        for slot in self.stack.stack.iter_mut() {
-            *slot = None;
-        }
-        self.stack.current_page = -1;
+        self.stack.clear();
         self.has_record = false;
         self.move_to_right_state.1 = None;
         self.invalidate_count_cache();


### PR DESCRIPTION
The following simulator run:
`target/debug/limbo_sim --maximum-tests 1000 --min-tick 10 --max-tick 50 --profile write_heavy_spill --io-backend=memory --seed 9227228821763364487`

results in:

```console
Error: failed with error: 'CacheError(Pinned { pgno: 29 })'
```
This is due to `invalidate_btree_cache` not unpinning the pages when clearing the page stack.

the seed now completes on this branch