### PR TITLE
Exercise MVCC recovery in turso_stress (v2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6831,6 +6831,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "turso",
+ "turso_core",
  "turso_macros",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(shuttle)', 'c
 unstable_name_collisions = "allow"
 
 [workspace.lints.clippy]
+await_holding_lock = "deny"
 or_fun_call = "deny"
 clear_with_drain = "deny"
 collection_is_never_read = "deny"

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -7542,6 +7542,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     };
                 }
                 RecoverLogicalLogState::Replay { ctx } => {
+                    turso_assert_reachable!("MVCC recovery (replaying a frame)");
                     loop {
                         let Some(frame) = return_if_io!(ctx.reader.next_frame()) else {
                             let recovered_offset = ctx.reader.last_valid_offset() as u64;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1190,22 +1190,19 @@ pub fn turso_assert_all(input: TokenStream) -> TokenStream {
     emit_boolean_guidance(&file_path, input, BooleanCombinator::All).into()
 }
 
-/// Asserts that a code path is reached **at least once** during Antithesis testing.
-///
-/// # Behavior
-///
-/// **Currently a no-op in all builds.** This macro is disabled pending better SQL
-/// generation in `turso-stress`. When enabled, it will tell Antithesis that this code
-/// path should be exercised at least once across the entire test campaign.
+/// Asserts that a code path is reached **at least once** during Antithesis testing. No-op in
+/// non-antithesis builds.
 ///
 /// # Parameters
 ///
-/// - `"message"` — human-readable description of the code path.
+/// - `"message"` — human-readable description of the code path (required).
+/// - `{ "key": value, ... }` *(optional)* — structured details for Antithesis.
 ///
 /// # Usage
 ///
 /// ```ignore
 /// turso_assert_reachable!("opcode: Init");
+/// turso_assert_reachable!("checkpoint", { "frames": frame_count });
 /// ```
 ///
 /// # Examples
@@ -1218,11 +1215,26 @@ pub fn turso_assert_all(input: TokenStream) -> TokenStream {
 /// # When to use
 ///
 /// Place at code paths that should be exercised by the fuzzer.
-//TODO enable this when turso-stress has better SQL generation
 #[proc_macro]
-pub fn turso_assert_reachable(_input: TokenStream) -> TokenStream {
+pub fn turso_assert_reachable(input: TokenStream) -> TokenStream {
+    let file_path = get_caller_file(&input);
+    let input = parse_macro_input!(input as MessageAssertInput);
+    let prefixed = prefix_message(&file_path, &input.message);
+    let details = details_json(&input.details);
+    let debug_check = details_debug_check(&input.details);
+
+    let env_check = antithesis_env_check();
     quote! {
         {
+            #[cfg(antithesis)]
+            {
+                #env_check
+                antithesis_sdk::assert_reachable!(#prefixed, #details);
+            }
+            #[cfg(not(antithesis))]
+            {
+                #debug_check
+            }
         }
     }
     .into()

--- a/testing/stress/Cargo.toml
+++ b/testing/stress/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 turso = { workspace = true, features = ["io_memory_yield"] }
+turso_core = { workspace = true, features = ["simulator"] }
 turso_macros = { workspace = true }
 rusqlite = { workspace = true }
 

--- a/testing/stress/conn.rs
+++ b/testing/stress/conn.rs
@@ -1,7 +1,8 @@
 use crate::sql_logging::SqlLogger;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 use turso::{Builder, Connection, IntoParams, Row, Rows};
+use turso_stress::sync::Arc;
+use turso_stress::sync::AsyncMutex as Mutex;
+use turso_stress::ThreadId;
 
 /// A wrapper around `Database` that simplifies dropping the db.
 pub struct StressDb {
@@ -41,7 +42,7 @@ impl StressDb {
 
     pub async fn connect(
         this: &Arc<Mutex<Self>>,
-        thread: usize,
+        thread: ThreadId,
         busy_timeout: u64,
     ) -> turso::Result<StressConn> {
         let conn = {
@@ -57,13 +58,13 @@ impl StressDb {
 }
 
 pub struct StressConn {
-    thread: usize,
+    thread: ThreadId,
     sql_logger: Arc<SqlLogger>,
     conn: Connection,
 }
 
 impl StressConn {
-    fn new(sql_logger: Arc<SqlLogger>, thread: usize, conn: Connection) -> Self {
+    fn new(sql_logger: Arc<SqlLogger>, thread: ThreadId, conn: Connection) -> Self {
         Self {
             thread,
             sql_logger,
@@ -77,7 +78,7 @@ impl StressConn {
         params: impl IntoParams,
     ) -> turso::connection::Result<u64> {
         let result = self.conn.execute(sql, params).await;
-        self.sql_logger.log_result(self.thread, sql, &result);
+        self.sql_logger.log_result(&self.thread, sql, &result);
         result
     }
 

--- a/testing/stress/conn.rs
+++ b/testing/stress/conn.rs
@@ -1,6 +1,60 @@
 use crate::sql_logging::SqlLogger;
 use std::sync::Arc;
-use turso::{Connection, IntoParams, Row, Rows};
+use tokio::sync::Mutex;
+use turso::{Builder, Connection, IntoParams, Row, Rows};
+
+/// A wrapper around `Database` that simplifies dropping the db.
+pub struct StressDb {
+    db: Option<turso::Database>,
+    db_file: String,
+    vfs: Option<String>,
+    sql_logger: Arc<SqlLogger>,
+}
+
+impl StressDb {
+    pub(crate) fn new(db_file: String, sql_logger: Arc<SqlLogger>, vfs: Option<String>) -> Self {
+        Self {
+            db: None,
+            db_file,
+            sql_logger,
+            vfs,
+        }
+    }
+
+    async fn get_or_init(&mut self) -> turso::Result<&turso::Database> {
+        if self.db.is_none() {
+            let mut builder = Builder::new_local(&self.db_file);
+            if let Some(ref vfs) = self.vfs {
+                builder = builder.with_io(vfs.clone());
+            }
+            self.db = Some(builder.build().await?);
+        }
+        Ok(self.db.as_ref().unwrap())
+    }
+
+    pub fn reset(&mut self) {
+        let old = self.db.take();
+        if old.is_none() {
+            panic!("cannot reset uninitialized StressDb");
+        }
+    }
+
+    pub async fn connect(
+        this: &Arc<Mutex<Self>>,
+        thread: usize,
+        busy_timeout: u64,
+    ) -> turso::Result<StressConn> {
+        let conn = {
+            let mut db = this.lock().await;
+            let raw_conn = db.get_or_init().await?.connect()?;
+
+            StressConn::new(db.sql_logger.clone(), thread, raw_conn)
+        };
+        conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
+        conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
+        Ok(conn)
+    }
+}
 
 pub struct StressConn {
     thread: usize,
@@ -9,7 +63,7 @@ pub struct StressConn {
 }
 
 impl StressConn {
-    pub fn new(sql_logger: Arc<SqlLogger>, thread: usize, conn: Connection) -> Self {
+    fn new(sql_logger: Arc<SqlLogger>, thread: usize, conn: Connection) -> Self {
         Self {
             thread,
             sql_logger,

--- a/testing/stress/conn.rs
+++ b/testing/stress/conn.rs
@@ -1,0 +1,49 @@
+use crate::sql_logging::SqlLogger;
+use std::sync::Arc;
+use turso::{Connection, IntoParams, Row, Rows};
+
+pub struct StressConn {
+    thread: usize,
+    sql_logger: Arc<SqlLogger>,
+    conn: Connection,
+}
+
+impl StressConn {
+    pub fn new(sql_logger: Arc<SqlLogger>, thread: usize, conn: Connection) -> Self {
+        Self {
+            thread,
+            sql_logger,
+            conn,
+        }
+    }
+
+    pub async fn execute(
+        &self,
+        sql: &str,
+        params: impl IntoParams,
+    ) -> turso::connection::Result<u64> {
+        let result = self.conn.execute(sql, params).await;
+        self.sql_logger.log_result(self.thread, sql, &result);
+        result
+    }
+
+    pub async fn pragma_update<V: std::fmt::Display>(
+        &self,
+        pragma_name: &str,
+        pragma_value: V,
+    ) -> turso::connection::Result<Vec<Row>> {
+        self.conn.pragma_update(pragma_name, pragma_value).await
+    }
+
+    pub fn busy_timeout(&self, duration: std::time::Duration) -> turso::connection::Result<()> {
+        self.conn.busy_timeout(duration)
+    }
+
+    pub async fn query(
+        &self,
+        sql: impl AsRef<str>,
+        params: impl IntoParams,
+    ) -> turso::connection::Result<Rows> {
+        self.conn.query(sql, params).await
+    }
+}

--- a/testing/stress/counter.rs
+++ b/testing/stress/counter.rs
@@ -1,0 +1,58 @@
+use turso_stress::sync::{Arc, Mutex};
+
+/// StressCounter wraps an Arc, so even after being cloned it still refers to the same state.
+#[derive(Clone)]
+pub struct StressCounter {
+    inner: Arc<Mutex<Inner>>,
+}
+
+struct Inner {
+    iteration_counts: Vec<usize>,
+    completed_count: usize,
+    iteration_limit: usize,
+}
+
+impl StressCounter {
+    pub fn new(num_threads: usize, iteration_limit: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                iteration_counts: vec![0; num_threads],
+                completed_count: 0,
+                iteration_limit,
+            })),
+        }
+    }
+
+    pub fn register_iterations(&mut self, thread_idx: usize, iterations: usize) {
+        let mut inner = self.inner.lock().unwrap();
+
+        inner.iteration_counts[thread_idx] += iterations;
+        if inner.iteration_counts[thread_idx] >= inner.iteration_limit {
+            inner.completed_count += 1;
+        }
+    }
+
+    pub fn iteration_idx(&self, thread_idx: usize) -> usize {
+        let inner = self.inner.lock().unwrap();
+
+        inner.iteration_counts[thread_idx]
+    }
+
+    pub fn all_done(&self) -> bool {
+        let inner = self.inner.lock().unwrap();
+
+        inner.completed_count == inner.iteration_counts.len()
+    }
+
+    pub fn done(&self, thread_idx: usize) -> bool {
+        let inner = self.inner.lock().unwrap();
+
+        inner.iteration_counts[thread_idx] >= inner.iteration_limit
+    }
+
+    pub fn incomplete_threads(&self) -> usize {
+        let inner = self.inner.lock().unwrap();
+
+        inner.iteration_counts.len() - inner.completed_count
+    }
+}

--- a/testing/stress/lib.rs
+++ b/testing/stress/lib.rs
@@ -1,13 +1,109 @@
+use std::fmt::{Display, Formatter};
+
 #[cfg(shuttle)]
 pub mod sync {
+    pub use super::async_barrier::AsyncBarrier;
+    pub use super::async_mutex::{AsyncMutex, AsyncMutexGuard};
     pub use shuttle::sync::atomic;
-    pub use shuttle::sync::{Arc, Weak};
-    pub use std::sync::{LazyLock, OnceLock};
+    pub use shuttle::sync::{Arc, Mutex, Weak};
+    pub use std::sync::Mutex as StdMutex;
 }
 
 #[cfg(not(shuttle))]
 pub mod sync {
-    pub use std::sync::{atomic, Arc, LazyLock, OnceLock, Weak};
+    pub use super::async_barrier::AsyncBarrier;
+    pub use super::async_mutex::{AsyncMutex, AsyncMutexGuard};
+    pub use std::sync::{atomic, Arc, Mutex, Mutex as StdMutex, Weak};
+}
+
+#[cfg(shuttle)]
+mod async_mutex {
+    use shuttle::sync::Mutex;
+    pub use shuttle::sync::MutexGuard as AsyncMutexGuard;
+
+    pub struct AsyncMutex<T: ?Sized> {
+        inner: Mutex<T>,
+    }
+
+    impl<T> AsyncMutex<T> {
+        pub fn new(value: T) -> Self {
+            Self {
+                inner: Mutex::new(value),
+            }
+        }
+    }
+
+    impl<T: ?Sized> AsyncMutex<T> {
+        pub async fn lock(&self) -> AsyncMutexGuard<'_, T> {
+            self.inner.lock().unwrap()
+        }
+    }
+}
+
+#[cfg(not(shuttle))]
+mod async_mutex {
+    use tokio::sync::Mutex;
+    pub use tokio::sync::MutexGuard as AsyncMutexGuard;
+
+    pub struct AsyncMutex<T: ?Sized> {
+        inner: Mutex<T>,
+    }
+
+    impl<T> AsyncMutex<T> {
+        pub fn new(value: T) -> Self {
+            Self {
+                inner: Mutex::new(value),
+            }
+        }
+    }
+
+    impl<T: ?Sized> AsyncMutex<T> {
+        pub async fn lock(&self) -> AsyncMutexGuard<'_, T> {
+            self.inner.lock().await
+        }
+    }
+}
+
+#[cfg(shuttle)]
+mod async_barrier {
+    use shuttle::sync::Barrier;
+
+    pub struct AsyncBarrier {
+        inner: Barrier,
+    }
+
+    impl AsyncBarrier {
+        pub fn new(n: usize) -> Self {
+            Self {
+                inner: Barrier::new(n),
+            }
+        }
+
+        pub async fn wait(&self) {
+            self.inner.wait();
+        }
+    }
+}
+
+#[cfg(not(shuttle))]
+mod async_barrier {
+    use tokio::sync::Barrier;
+
+    pub struct AsyncBarrier {
+        inner: Barrier,
+    }
+
+    impl AsyncBarrier {
+        pub fn new(n: usize) -> Self {
+            Self {
+                inner: Barrier::new(n),
+            }
+        }
+
+        pub async fn wait(&self) {
+            self.inner.wait().await;
+        }
+    }
 }
 
 #[cfg(shuttle)]
@@ -24,15 +120,17 @@ pub mod thread {
 pub mod thread {
     pub use std::hint::spin_loop;
     pub use std::thread::{
-        current, panicking, park, scope, sleep, spawn, yield_now, Builder, JoinHandle, Scope,
-        ScopedJoinHandle, Thread, ThreadId,
+        current, panicking, park, scope, spawn, Builder, JoinHandle, Scope, ScopedJoinHandle,
+        Thread, ThreadId,
     };
     pub use std::thread_local;
+    pub use tokio::task::yield_now;
+    pub use tokio::time::sleep;
 }
 
 #[cfg(shuttle)]
 pub mod future {
-    pub use shuttle::future::{spawn, JoinHandle};
+    pub use shuttle::future::{spawn_local as spawn, JoinHandle};
 }
 
 #[cfg(not(shuttle))]
@@ -46,4 +144,19 @@ pub fn shuttle_config() -> shuttle::Config {
     config.stack_size *= 10;
     config.max_steps = shuttle::MaxSteps::FailAfter(10_000_000);
     config
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadId(String);
+
+impl ThreadId {
+    pub fn new(thread_id: usize) -> Self {
+        Self(format!("Thread {thread_id}"))
+    }
+}
+
+impl Display for ThreadId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0.as_str())
+    }
 }

--- a/testing/stress/logging.rs
+++ b/testing/stress/logging.rs
@@ -1,0 +1,78 @@
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{reload, EnvFilter};
+
+const LOG_LEVEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+const LOG_LEVEL_FILE: &str = "RUST_LOG";
+
+pub type LogLevelReloadHandle = reload::Handle<EnvFilter, tracing_subscriber::Registry>;
+
+pub struct Tracer {
+    _guard: WorkerGuard,
+}
+
+impl Tracer {
+    pub(crate) fn new(log_path: &str) -> Result<Self, std::io::Error> {
+        let log_file = std::fs::File::create(log_path)?;
+        let (non_blocking, guard) = tracing_appender::non_blocking(log_file);
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        let (filter_layer, reload_handle) = reload::Layer::new(filter);
+
+        if let Err(e) = tracing_subscriber::registry()
+            .with(filter_layer)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(non_blocking)
+                    .with_ansi(false)
+                    .with_line_number(true)
+                    .with_thread_ids(true)
+                    .json(),
+            )
+            .try_init()
+        {
+            println!("Unable to setup tracing appender: {e:?}");
+        }
+
+        Self::spawn_log_level_watcher(reload_handle);
+
+        Ok(Self { _guard: guard })
+    }
+
+    /// Spawns a background thread that watches for a RUST_LOG file and dynamically
+    /// updates the log level when the file contents change.
+    fn spawn_log_level_watcher(reload_handle: LogLevelReloadHandle) {
+        std::thread::spawn(move || {
+            let mut last_content: Option<String> = None;
+
+            loop {
+                std::thread::sleep(LOG_LEVEL_POLL_INTERVAL);
+
+                let content = match std::fs::read_to_string(LOG_LEVEL_FILE) {
+                    Ok(content) => content.trim().to_string(),
+                    Err(_) => {
+                        continue;
+                    }
+                };
+
+                if last_content.as_ref() == Some(&content) {
+                    continue;
+                }
+
+                match content.parse::<EnvFilter>() {
+                    Ok(new_filter) => {
+                        if let Err(e) = reload_handle.reload(new_filter) {
+                            eprintln!("Failed to reload log filter: {e}");
+                        } else {
+                            last_content = Some(content);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Invalid log filter in {LOG_LEVEL_FILE}: {e}");
+                        last_content = Some(content);
+                    }
+                }
+            }
+        });
+    }
+}

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -1,4 +1,5 @@
 mod conn;
+mod counter;
 mod logging;
 mod opts;
 mod progress;
@@ -14,14 +15,19 @@ use rand::{Rng, SeedableRng};
 use shuttle::scheduler::Scheduler;
 use std::collections::HashSet;
 use std::path::Path;
-use std::sync::Arc;
-use tokio::sync::Mutex;
-use turso::Builder;
+use turso_stress::sync::atomic::{AtomicBool, Ordering};
+use turso_stress::sync::Arc;
+use turso_stress::sync::AsyncBarrier as Barrier;
+use turso_stress::sync::AsyncMutex as Mutex;
 
 use crate::conn::StressDb;
+use crate::counter::StressCounter;
 use crate::logging::Tracer;
 use crate::progress::ProgressBars;
 use crate::sql_logging::SqlLogger;
+use turso::core::clear_database_registry;
+use turso::Builder;
+use turso_stress::ThreadId;
 
 /// Represents a column in a SQLite table
 #[derive(Debug, Clone)]
@@ -578,7 +584,6 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
     let ddl_statements = schema.to_sql();
     let schema = Arc::new(schema);
 
-    let mut handles = Vec::with_capacity(opts.nr_threads);
     let mut stop = false;
 
     let progress_bars = ProgressBars::new(opts.nr_iterations);
@@ -612,7 +617,19 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         vfs_option.clone(),
     )));
 
-    let conn = StressDb::connect(&db, usize::MAX, opts.busy_timeout).await?;
+    let mut stress_counter = StressCounter::new(opts.nr_threads, opts.nr_iterations);
+
+    let threads: Vec<_> = (0..opts.nr_threads)
+        .map(ThreadId::new)
+        .enumerate()
+        .collect();
+
+    let progress_bars: Vec<_> = threads
+        .iter()
+        .map(|(_, thread)| progress_bars.add(thread.to_string()))
+        .collect();
+
+    let conn = StressDb::connect(&db, ThreadId::new(usize::MAX), opts.busy_timeout).await?;
     'stmts: for stmt in &ddl_statements {
         let mut retry_counter = 0;
         while retry_counter < 10 {
@@ -653,139 +670,175 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         }
     };
 
-    for thread in 0..opts.nr_threads {
-        if stop {
-            break;
-        }
-        let nr_iterations = opts.nr_iterations;
-        let db = db.clone();
-        let schema_for_task = schema.clone();
-        let busy_timeout = opts.busy_timeout;
-        let tx_mode = opts.tx_mode;
-        let sql_logger = sql_logger.clone();
+    while !stop && !stress_counter.all_done() {
+        let mut handles = Vec::with_capacity(opts.nr_threads);
+        let reopen_requested = Arc::new(AtomicBool::new(false));
+        let all_threads_ready = Arc::new(Barrier::new(stress_counter.incomplete_threads()));
 
-        let mut progress_bar = progress_bars.add(format!("Thread {thread}"));
-
-        let handle = turso_stress::future::spawn(async move {
-            let mut conn = StressDb::connect(&db, thread, busy_timeout).await?;
-
-            let mut rng = ThreadRng::new(global_seed.wrapping_add(thread as u64));
-
-            for i in 0..nr_iterations {
-                if gen_bool(&mut rng, 0.01) {
-                    // Reopen the database
-                    db.lock().await.reset();
-                    conn = StressDb::connect(&db, thread, busy_timeout).await?;
-                } else if gen_bool(&mut rng, 0.02) {
-                    // Reconnect to the database
-                    conn = StressDb::connect(&db, thread, busy_timeout).await?;
-                }
-
-                let tx = if rng.get_random() % 2 == 0 {
-                    match tx_mode {
-                        TxMode::SQLite => Some("BEGIN;"),
-                        TxMode::Concurrent => Some("BEGIN CONCURRENT;"),
-                    }
-                } else {
-                    None
-                };
-
-                if let Some(tx_stmt) = tx {
-                    let _ = conn.execute(tx_stmt, ()).await;
-                }
-
-                let sql = generate_random_statement(&mut rng, &schema_for_task);
-
-                progress_bar.tick();
-                if let Err(turso::Error::Corrupt(e)) = conn.execute(&sql, ()).await {
-                    turso_macros::turso_assert_unreachable!("corrupt error executing query", { "thread": thread, "error": e, "sql": sql });
-                }
-
-                // When inside a transaction, 30% chance to exercise savepoints.
-                // This generates the pattern that exposed the pager rollback bug
-                // in tursodatabase/turso#6176: SAVEPOINT → DML (possibly with
-                // large blobs that allocate new pages) → ROLLBACK TO / RELEASE.
-                if tx.is_some() && rng.get_random() % 100 < 30 {
-                    let sp_name = format!("sp_{}", rng.get_random() % 100);
-                    let savepoint_sql = format!("SAVEPOINT {sp_name};");
-                    let _ = conn.execute(&savepoint_sql, ()).await;
-
-                    // Execute 1-3 DML statements inside the savepoint.
-                    let sp_stmts = 1 + (rng.get_random() % 3) as usize;
-                    for _ in 0..sp_stmts {
-                        let sp_sql = generate_random_statement(&mut rng, &schema_for_task);
-                        if let Err(turso::Error::Corrupt(e)) = conn.execute(&sp_sql, ()).await {
-                            turso_macros::turso_assert_unreachable!("corrupt error in savepoint", { "thread": thread, "error": e, "sql": sp_sql });
-                        }
-                    }
-
-                    // 50% ROLLBACK TO (partial undo), 50% RELEASE (keep changes).
-                    if rng.get_random() % 2 == 0 {
-                        let rollback_sql = format!("ROLLBACK TO {sp_name};");
-                        let _ = conn.execute(&rollback_sql, ()).await;
-                    }
-                    let release_sql = format!("RELEASE {sp_name};");
-                    let _ = conn.execute(&release_sql, ()).await;
-                }
-
-                if tx.is_some() {
-                    let end_tx = if rng.get_random() % 2 == 0 {
-                        "COMMIT;"
-                    } else {
-                        "ROLLBACK;"
-                    };
-                    let _ = conn.execute(end_tx, ()).await;
-                }
-
-                const INTEGRITY_CHECK_INTERVAL: usize = 100;
-                if i % INTEGRITY_CHECK_INTERVAL == 0 {
-                    let mut res = conn.query("PRAGMA integrity_check", ()).await.unwrap();
-                    match res.next().await {
-                        Ok(Some(row)) => {
-                            let value = row.get_value(0).unwrap();
-                            if value != "ok".into() {
-                                sql_logger.log(
-                                    thread,
-                                    "PRAGMA integrity_check",
-                                    &format!("ERROR: {value:?}"),
-                                );
-                                turso_macros::turso_assert_unreachable!("integrity check failed", { "thread": thread, "value": value });
-                            }
-                            sql_logger.log(thread, "PRAGMA integrity_check", "OK");
-                        }
-                        Ok(None) => {
-                            sql_logger.log(thread, "PRAGMA integrity_check", "ERROR: no rows");
-                            turso_macros::turso_assert_unreachable!("integrity check returned no rows", { "thread": thread });
-                        }
-                        Err(e) => {
-                            sql_logger.log(
-                                thread,
-                                "PRAGMA integrity_check",
-                                &format!("ERROR: {e}"),
-                            );
-                            println!("thread#{thread} Error performing integrity check: {e}");
-                        }
-                    }
-                    match res.next().await {
-                        Ok(Some(_)) => {
-                            turso_macros::turso_assert_unreachable!("integrity check returned more than 1 row", { "thread": thread });
-                        }
-                        Err(e) => println!("thread#{thread} Error performing integrity check: {e}"),
-                        _ => {}
-                    }
-                }
+        for (iteration_idx, ((thread_idx, thread), mut progress_bar)) in threads
+            .iter()
+            .cloned()
+            .zip(progress_bars.iter().cloned())
+            .enumerate()
+        {
+            if stress_counter.done(thread_idx) {
+                continue;
+            } else if stop {
+                break;
             }
-            // In case this thread is running an exclusive transaction, commit it so that it doesn't block other threads.
-            let _ = conn.execute("COMMIT", ()).await;
-            progress_bar.finish();
-            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
-        });
-        handles.push(handle);
+
+            let reopen_requested = reopen_requested.clone();
+            let db = db.clone();
+            let schema_for_task = schema.clone();
+            let sql_logger = sql_logger.clone();
+            let all_threads_ready = all_threads_ready.clone();
+            let stress_counter = stress_counter.clone();
+
+            let handle = turso_stress::future::spawn(async move {
+                let mut conn = StressDb::connect(&db, thread.clone(), opts.busy_timeout).await?;
+                let mut rng = ThreadRng::new(
+                    global_seed
+                        .wrapping_add(thread_idx as u64)
+                        .wrapping_add(iteration_idx as u64 * 1000),
+                );
+                let mut iteration_count_this_batch = 0;
+
+                all_threads_ready.wait().await;
+                for interaction_idx in stress_counter.iteration_idx(thread_idx)..opts.nr_iterations
+                {
+                    if gen_bool(&mut rng, 0.02) {
+                        // Reconnect to the database
+                        conn = StressDb::connect(&db, thread.clone(), opts.busy_timeout).await?;
+                    }
+
+                    let tx = match opts.tx_mode {
+                        TxMode::SQLite => gen_bool(&mut rng, 0.5).then_some("BEGIN;"),
+                        TxMode::Concurrent => {
+                            gen_bool(&mut rng, 0.9).then_some("BEGIN CONCURRENT;")
+                        }
+                    };
+
+                    if let Some(tx_stmt) = tx {
+                        let _ = conn.execute(tx_stmt, ()).await;
+                    }
+
+                    let sql = generate_random_statement(&mut rng, &schema_for_task);
+
+                    if let Err(turso::Error::Corrupt(e)) = conn.execute(&sql, ()).await {
+                        turso_macros::turso_assert_unreachable!("corrupt error executing query", { "thread": thread, "error": e, "sql": sql });
+                    }
+
+                    // When inside a transaction, 30% chance to exercise savepoints.
+                    // This generates the pattern that exposed the pager rollback bug
+                    // in tursodatabase/turso#6176: SAVEPOINT → DML (possibly with
+                    // large blobs that allocate new pages) → ROLLBACK TO / RELEASE.
+                    if tx.is_some() && rng.get_random() % 100 < 30 {
+                        let sp_name = format!("sp_{}", rng.get_random() % 100);
+                        let savepoint_sql = format!("SAVEPOINT {sp_name};");
+                        let _ = conn.execute(&savepoint_sql, ()).await;
+
+                        // Execute 1-3 DML statements inside the savepoint.
+                        let sp_stmts = 1 + (rng.get_random() % 3) as usize;
+                        for _ in 0..sp_stmts {
+                            let sp_sql = generate_random_statement(&mut rng, &schema_for_task);
+                            if let Err(turso::Error::Corrupt(e)) = conn.execute(&sp_sql, ()).await {
+                                turso_macros::turso_assert_unreachable!("corrupt error in savepoint", { "thread": thread, "error": e, "sql": sp_sql });
+                            }
+                        }
+
+                        // 50% ROLLBACK TO (partial undo), 50% RELEASE (keep changes).
+                        if rng.get_random() % 2 == 0 {
+                            let rollback_sql = format!("ROLLBACK TO {sp_name};");
+                            let _ = conn.execute(&rollback_sql, ()).await;
+                        }
+                        let release_sql = format!("RELEASE {sp_name};");
+                        let _ = conn.execute(&release_sql, ()).await;
+                    }
+
+                    if tx.is_some() {
+                        let end_tx = if rng.get_random() % 2 == 0 {
+                            "COMMIT;"
+                        } else {
+                            "ROLLBACK;"
+                        };
+                        let _ = conn.execute(end_tx, ()).await;
+                    }
+
+                    const INTEGRITY_CHECK_INTERVAL: usize = 100;
+                    if interaction_idx % INTEGRITY_CHECK_INTERVAL == 0 {
+                        let mut res = conn.query("PRAGMA integrity_check", ()).await.unwrap();
+                        match res.next().await {
+                            Ok(Some(row)) => {
+                                let value = row.get_value(0).unwrap();
+                                if value != "ok".into() {
+                                    sql_logger.log(
+                                        &thread,
+                                        "PRAGMA integrity_check",
+                                        &format!("ERROR: {value:?}"),
+                                    );
+                                    turso_macros::turso_assert_unreachable!("integrity check failed", { "thread": thread, "value": value });
+                                }
+                                sql_logger.log(&thread, "PRAGMA integrity_check", "OK");
+                            }
+                            Ok(None) => {
+                                sql_logger.log(&thread, "PRAGMA integrity_check", "ERROR: no rows");
+                                turso_macros::turso_assert_unreachable!("integrity check returned no rows", { "thread": thread });
+                            }
+                            Err(e) => {
+                                sql_logger.log(
+                                    &thread,
+                                    "PRAGMA integrity_check",
+                                    &format!("ERROR: {e}"),
+                                );
+                                println!("thread#{thread} Error performing integrity check: {e}");
+                            }
+                        }
+                        match res.next().await {
+                            Ok(Some(_)) => {
+                                turso_macros::turso_assert_unreachable!("integrity check returned more than 1 row", { "thread": thread });
+                            }
+                            Err(e) => {
+                                println!("thread#{thread} Error performing integrity check: {e}")
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    if gen_bool(&mut rng, 0.01 / stress_counter.incomplete_threads() as f64) {
+                        reopen_requested.store(true, Ordering::Release);
+                    }
+                    if reopen_requested.load(Ordering::Acquire) {
+                        break;
+                    }
+
+                    progress_bar.tick();
+                    iteration_count_this_batch += 1;
+                }
+
+                // In case this thread is running an exclusive transaction, commit it so that it doesn't block other threads.
+                let _ = conn.execute("COMMIT", ()).await;
+                Ok::<_, Box<dyn std::error::Error + Send + Sync>>((
+                    thread_idx,
+                    iteration_count_this_batch,
+                ))
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            let (thread_idx, completed_iteration_count) = handle.await??;
+            stress_counter.register_iterations(thread_idx, completed_iteration_count);
+        }
+
+        // This is what triggers MVCC recovery
+        db.lock().await.reset();
+        clear_database_registry();
     }
 
-    for handle in handles {
-        handle.await??;
-    }
+    progress_bars
+        .into_iter()
+        .for_each(|mut progress_bar| progress_bar.finish());
+
     println!("Database file: {db_file}");
 
     // Switch back to WAL mode before SQLite integrity check if we were in MVCC mode.

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -1,5 +1,6 @@
 mod logging;
 mod opts;
+mod sql_logging;
 
 use clap::Parser;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -11,25 +12,13 @@ use rand::{Rng, SeedableRng};
 #[cfg(shuttle)]
 use shuttle::scheduler::Scheduler;
 use std::collections::HashSet;
-use std::fs::File;
-use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-
-type SqlLog = Arc<std::sync::Mutex<BufWriter<File>>>;
-
-fn log_sql(log: &SqlLog, thread: usize, sql: &str, result: &str) {
-    let sql = sql.trim().trim_end_matches(';');
-    let mut w = log.lock().unwrap();
-    writeln!(w, "{sql}; -- [thread:{thread}] {result}").unwrap();
-    if result.starts_with("ERROR") {
-        w.flush().unwrap();
-    }
-}
 use turso::Builder;
 
 use crate::logging::Tracer;
+use crate::sql_logging::SqlLogger;
 
 /// Represents a column in a SQLite table
 #[derive(Debug, Clone)]
@@ -611,9 +600,8 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
     println!("db_file={db_file}");
 
     let sql_log_path = format!("{db_file}.sql");
-    let sql_log_file = File::create(&sql_log_path)?;
-    let sql_log: SqlLog = Arc::new(std::sync::Mutex::new(BufWriter::new(sql_log_file)));
     println!("sql_log={sql_log_path}");
+    let sql_logger = Arc::new(SqlLogger::new(&sql_log_path)?);
 
     let tracing_log_path = format!("{db_file}.jsonl");
     println!("tracing_log={tracing_log_path}");
@@ -651,54 +639,39 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
             while retry_counter < 10 {
                 match conn.execute(stmt, ()).await {
                     Ok(_) => {
-                        log_sql(&sql_log, thread, stmt, "OK");
+                        sql_logger.log(thread, stmt, "OK");
                         break;
                     }
                     Err(turso::Error::Busy(e)) => {
-                        log_sql(&sql_log, thread, stmt, &format!("ERROR(busy): {e}"));
+                        sql_logger.log(thread, stmt, &format!("ERROR(busy): {e}"));
                         println!("Error (busy) creating table: {e}");
                         retry_counter += 1;
                     }
                     Err(turso::Error::DatabaseFull(e)) => {
-                        log_sql(
-                            &sql_log,
-                            thread,
-                            stmt,
-                            &format!("ERROR(database_full): {e}"),
-                        );
+                        sql_logger.log(thread, stmt, &format!("ERROR(database_full): {e}"));
                         eprintln!("Database full, stopping: {e}");
                         stop = true;
                         break;
                     }
                     Err(turso::Error::IoError(std::io::ErrorKind::StorageFull, _)) => {
-                        log_sql(&sql_log, thread, stmt, "ERROR(io): StorageFull");
+                        sql_logger.log(thread, stmt, "ERROR(io): StorageFull");
                         eprintln!("No storage space, stopping");
                         stop = true;
                         break;
                     }
                     Err(turso::Error::BusySnapshot(e)) => {
-                        log_sql(
-                            &sql_log,
-                            thread,
-                            stmt,
-                            &format!("ERROR(busy_snapshot): {e}"),
-                        );
+                        sql_logger.log(thread, stmt, &format!("ERROR(busy_snapshot): {e}"));
                         println!("Error (busy snapshot): {e}");
                         retry_counter += 1;
                     }
                     Err(turso::Error::IoError(kind, op)) => {
-                        log_sql(
-                            &sql_log,
-                            thread,
-                            stmt,
-                            &format!("ERROR(io): {op}: {kind:?}"),
-                        );
+                        sql_logger.log(thread, stmt, &format!("ERROR(io): {op}: {kind:?}"));
                         eprintln!("I/O error ({op}: {kind:?}), stopping");
                         stop = true;
                         break;
                     }
                     Err(e) => {
-                        log_sql(&sql_log, thread, stmt, &format!("ERROR(fatal): {e}"));
+                        sql_logger.log(thread, stmt, &format!("ERROR(fatal): {e}"));
                         turso_macros::turso_assert_unreachable!("fatal error creating table", { "thread": thread, "stmt": stmt, "error": e });
                     }
                 }
@@ -719,7 +692,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         let schema_for_task = schema.clone();
         let busy_timeout = opts.busy_timeout;
         let tx_mode = opts.tx_mode;
-        let sql_log = sql_log.clone();
+        let sql_logger = sql_logger.clone();
 
         let progress_bar = multi_progress.add(ProgressBar::new(nr_iterations as u64));
         progress_bar.set_style(progress_style.clone());
@@ -765,8 +738,8 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
 
                 if let Some(tx_stmt) = tx {
                     match conn.execute(tx_stmt, ()).await {
-                        Ok(_) => log_sql(&sql_log, thread, tx_stmt, "OK"),
-                        Err(e) => log_sql(&sql_log, thread, tx_stmt, &format!("ERROR: {e}")),
+                        Ok(_) => sql_logger.log(thread, tx_stmt, "OK"),
+                        Err(e) => sql_logger.log(thread, tx_stmt, &format!("ERROR: {e}")),
                     }
                 }
 
@@ -775,52 +748,37 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                 progress_bar.set_position(i as u64);
                 match conn.execute(&sql, ()).await {
                     Ok(_) => {
-                        log_sql(&sql_log, thread, &sql, "OK");
+                        sql_logger.log(thread, &sql, "OK");
                     }
                     Err(e) => match e {
                         turso::Error::Corrupt(e) => {
-                            log_sql(&sql_log, thread, &sql, &format!("ERROR(corrupt): {e}"));
+                            sql_logger.log(thread, &sql, &format!("ERROR(corrupt): {e}"));
                             turso_macros::turso_assert_unreachable!("corrupt error executing query", { "thread": thread, "error": e, "sql": sql });
                         }
                         turso::Error::Constraint(e) => {
-                            log_sql(&sql_log, thread, &sql, &format!("ERROR(constraint): {e}"));
+                            sql_logger.log(thread, &sql, &format!("ERROR(constraint): {e}"));
                         }
                         turso::Error::Busy(e) => {
-                            log_sql(&sql_log, thread, &sql, &format!("ERROR(busy): {e}"));
+                            sql_logger.log(thread, &sql, &format!("ERROR(busy): {e}"));
                             println!("thread#{thread} Error[WARNING] executing query: {e}");
                         }
                         turso::Error::BusySnapshot(e) => {
-                            log_sql(
-                                &sql_log,
-                                thread,
-                                &sql,
-                                &format!("ERROR(busy_snapshot): {e}"),
-                            );
+                            sql_logger.log(thread, &sql, &format!("ERROR(busy_snapshot): {e}"));
                             println!("thread#{thread} Error[WARNING] busy snapshot: {e}");
                         }
                         turso::Error::Error(e) => {
-                            log_sql(&sql_log, thread, &sql, &format!("ERROR: {e}"));
+                            sql_logger.log(thread, &sql, &format!("ERROR: {e}"));
                         }
                         turso::Error::DatabaseFull(e) => {
-                            log_sql(
-                                &sql_log,
-                                thread,
-                                &sql,
-                                &format!("ERROR(database_full): {e}"),
-                            );
+                            sql_logger.log(thread, &sql, &format!("ERROR(database_full): {e}"));
                             eprintln!("thread#{thread} Database full: {e}");
                         }
                         turso::Error::IoError(kind, op) => {
-                            log_sql(
-                                &sql_log,
-                                thread,
-                                &sql,
-                                &format!("ERROR(io): {op}: {kind:?}"),
-                            );
+                            sql_logger.log(thread, &sql, &format!("ERROR(io): {op}: {kind:?}"));
                             eprintln!("thread#{thread} I/O error ({op}: {kind:?}), continuing...");
                         }
                         _ => {
-                            log_sql(&sql_log, thread, &sql, &format!("ERROR(fatal): {e}"));
+                            sql_logger.log(thread, &sql, &format!("ERROR(fatal): {e}"));
                             turso_macros::turso_assert_unreachable!("fatal error executing query", { "thread": thread, "error": e, "sql": sql });
                         }
                     },
@@ -834,8 +792,8 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                     let sp_name = format!("sp_{}", rng.get_random() % 100);
                     let savepoint_sql = format!("SAVEPOINT {sp_name};");
                     match conn.execute(&savepoint_sql, ()).await {
-                        Ok(_) => log_sql(&sql_log, thread, &savepoint_sql, "OK"),
-                        Err(e) => log_sql(&sql_log, thread, &savepoint_sql, &format!("ERROR: {e}")),
+                        Ok(_) => sql_logger.log(thread, &savepoint_sql, "OK"),
+                        Err(e) => sql_logger.log(thread, &savepoint_sql, &format!("ERROR: {e}")),
                     }
 
                     // Execute 1-3 DML statements inside the savepoint.
@@ -843,12 +801,12 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                     for _ in 0..sp_stmts {
                         let sp_sql = generate_random_statement(&mut rng, &schema_for_task);
                         match conn.execute(&sp_sql, ()).await {
-                            Ok(_) => log_sql(&sql_log, thread, &sp_sql, "OK"),
+                            Ok(_) => sql_logger.log(thread, &sp_sql, "OK"),
                             Err(turso::Error::Corrupt(e)) => {
-                                log_sql(&sql_log, thread, &sp_sql, &format!("ERROR(corrupt): {e}"));
+                                sql_logger.log(thread, &sp_sql, &format!("ERROR(corrupt): {e}"));
                                 turso_macros::turso_assert_unreachable!("corrupt error in savepoint", { "thread": thread, "error": e, "sql": sp_sql });
                             }
-                            Err(e) => log_sql(&sql_log, thread, &sp_sql, &format!("ERROR: {e}")),
+                            Err(e) => sql_logger.log(thread, &sp_sql, &format!("ERROR: {e}")),
                         }
                     }
 
@@ -856,16 +814,14 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                     if rng.get_random() % 2 == 0 {
                         let rollback_sql = format!("ROLLBACK TO {sp_name};");
                         match conn.execute(&rollback_sql, ()).await {
-                            Ok(_) => log_sql(&sql_log, thread, &rollback_sql, "OK"),
-                            Err(e) => {
-                                log_sql(&sql_log, thread, &rollback_sql, &format!("ERROR: {e}"))
-                            }
+                            Ok(_) => sql_logger.log(thread, &rollback_sql, "OK"),
+                            Err(e) => sql_logger.log(thread, &rollback_sql, &format!("ERROR: {e}")),
                         }
                     }
                     let release_sql = format!("RELEASE {sp_name};");
                     match conn.execute(&release_sql, ()).await {
-                        Ok(_) => log_sql(&sql_log, thread, &release_sql, "OK"),
-                        Err(e) => log_sql(&sql_log, thread, &release_sql, &format!("ERROR: {e}")),
+                        Ok(_) => sql_logger.log(thread, &release_sql, "OK"),
+                        Err(e) => sql_logger.log(thread, &release_sql, &format!("ERROR: {e}")),
                     }
                 }
 
@@ -876,8 +832,8 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                         "ROLLBACK;"
                     };
                     match conn.execute(end_tx, ()).await {
-                        Ok(_) => log_sql(&sql_log, thread, end_tx, "OK"),
-                        Err(e) => log_sql(&sql_log, thread, end_tx, &format!("ERROR: {e}")),
+                        Ok(_) => sql_logger.log(thread, end_tx, "OK"),
+                        Err(e) => sql_logger.log(thread, end_tx, &format!("ERROR: {e}")),
                     }
                 }
 
@@ -888,23 +844,21 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                         Ok(Some(row)) => {
                             let value = row.get_value(0).unwrap();
                             if value != "ok".into() {
-                                log_sql(
-                                    &sql_log,
+                                sql_logger.log(
                                     thread,
                                     "PRAGMA integrity_check",
                                     &format!("ERROR: {value:?}"),
                                 );
                                 turso_macros::turso_assert_unreachable!("integrity check failed", { "thread": thread, "value": value });
                             }
-                            log_sql(&sql_log, thread, "PRAGMA integrity_check", "OK");
+                            sql_logger.log(thread, "PRAGMA integrity_check", "OK");
                         }
                         Ok(None) => {
-                            log_sql(&sql_log, thread, "PRAGMA integrity_check", "ERROR: no rows");
+                            sql_logger.log(thread, "PRAGMA integrity_check", "ERROR: no rows");
                             turso_macros::turso_assert_unreachable!("integrity check returned no rows", { "thread": thread });
                         }
                         Err(e) => {
-                            log_sql(
-                                &sql_log,
+                            sql_logger.log(
                                 thread,
                                 "PRAGMA integrity_check",
                                 &format!("ERROR: {e}"),
@@ -923,8 +877,8 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
             }
             // In case this thread is running an exclusive transaction, commit it so that it doesn't block other threads.
             match conn.execute("COMMIT", ()).await {
-                Ok(_) => log_sql(&sql_log, thread, "COMMIT", "OK"),
-                Err(e) => log_sql(&sql_log, thread, "COMMIT", &format!("ERROR: {e}")),
+                Ok(_) => sql_logger.log(thread, "COMMIT", "OK"),
+                Err(e) => sql_logger.log(thread, "COMMIT", &format!("ERROR: {e}")),
             }
             progress_bar.finish_with_message("done");
             Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
@@ -935,8 +889,6 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
     for handle in handles {
         handle.await??;
     }
-    // Flush SQL log before exit
-    sql_log.lock().unwrap().flush().unwrap();
     println!("Database file: {db_file}");
 
     // Switch back to WAL mode before SQLite integrity check if we were in MVCC mode.

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -612,55 +612,51 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         vfs_option.clone(),
     )));
 
+    let conn = StressDb::connect(&db, usize::MAX, opts.busy_timeout).await?;
+    'stmts: for stmt in &ddl_statements {
+        let mut retry_counter = 0;
+        while retry_counter < 10 {
+            match conn.execute(stmt, ()).await {
+                Ok(_) => {
+                    break;
+                }
+                Err(turso::Error::Busy(_) | turso::Error::BusySnapshot(_)) => {
+                    retry_counter += 1;
+                }
+                Err(
+                    turso::Error::DatabaseFull(_)
+                    | turso::Error::IoError(std::io::ErrorKind::StorageFull, _)
+                    | turso::Error::IoError(_, _),
+                ) => {
+                    stop = true;
+                    break 'stmts;
+                }
+                Err(e) => {
+                    turso_macros::turso_assert_unreachable!("fatal error creating table", { "stmt": stmt, "error": e });
+                }
+            }
+        }
+        if retry_counter == 10 {
+            eprintln!(
+                "WARNING: Could not execute statement [{stmt}] after {retry_counter} attempts."
+            );
+        }
+    }
+
+    match opts.tx_mode {
+        TxMode::SQLite => {
+            conn.pragma_update("journal_mode", "WAL").await?;
+            conn.busy_timeout(std::time::Duration::from_millis(opts.busy_timeout))?;
+        }
+        TxMode::Concurrent => {
+            conn.pragma_update("journal_mode", "mvcc").await?;
+        }
+    };
+
     for thread in 0..opts.nr_threads {
         if stop {
             break;
         }
-        let conn = StressDb::connect(&db, thread, opts.busy_timeout).await?;
-
-        match opts.tx_mode {
-            TxMode::SQLite => {
-                conn.pragma_update("journal_mode", "WAL").await?;
-                conn.busy_timeout(std::time::Duration::from_millis(opts.busy_timeout))?;
-            }
-            TxMode::Concurrent => {
-                conn.pragma_update("journal_mode", "mvcc").await?;
-            }
-        };
-
-        for stmt in &ddl_statements {
-            let mut retry_counter = 0;
-            while retry_counter < 10 {
-                match conn.execute(stmt, ()).await {
-                    Ok(_) => {
-                        break;
-                    }
-                    Err(turso::Error::Busy(_) | turso::Error::BusySnapshot(_)) => {
-                        retry_counter += 1;
-                    }
-                    Err(
-                        turso::Error::DatabaseFull(_)
-                        | turso::Error::IoError(std::io::ErrorKind::StorageFull, _)
-                        | turso::Error::IoError(_, _),
-                    ) => {
-                        stop = true;
-                        break;
-                    }
-                    Err(e) => {
-                        turso_macros::turso_assert_unreachable!("fatal error creating table", { "thread": thread, "stmt": stmt, "error": e });
-                    }
-                }
-            }
-            if stop {
-                break;
-            }
-            if retry_counter == 10 {
-                eprintln!(
-                    "WARNING: Could not execute statement [{stmt}] after {retry_counter} attempts."
-                );
-            }
-        }
-
         let nr_iterations = opts.nr_iterations;
         let db = db.clone();
         let schema_for_task = schema.clone();

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use turso::Builder;
 
-use crate::conn::StressConn;
+use crate::conn::StressDb;
 use crate::logging::Tracer;
 use crate::progress::ProgressBars;
 use crate::sql_logging::SqlLogger;
@@ -606,18 +606,17 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
 
     let vfs_option = opts.vfs.clone();
 
-    let mut builder = Builder::new_local(&db_file);
-    if let Some(ref vfs) = vfs_option {
-        builder = builder.with_io(vfs.clone());
-    }
-    let db = Arc::new(Mutex::new(builder.build().await?));
+    let db = Arc::new(Mutex::new(StressDb::new(
+        db_file.clone(),
+        sql_logger.clone(),
+        vfs_option.clone(),
+    )));
 
     for thread in 0..opts.nr_threads {
         if stop {
             break;
         }
-        let db_file = db_file.clone();
-        let conn = StressConn::new(sql_logger.clone(), thread, db.lock().await.connect()?);
+        let conn = StressDb::connect(&db, thread, opts.busy_timeout).await?;
 
         match opts.tx_mode {
             TxMode::SQLite => {
@@ -628,8 +627,6 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                 conn.pragma_update("journal_mode", "mvcc").await?;
             }
         };
-
-        conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
 
         for stmt in &ddl_statements {
             let mut retry_counter = 0;
@@ -666,7 +663,6 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
 
         let nr_iterations = opts.nr_iterations;
         let db = db.clone();
-        let vfs_for_task = vfs_option.clone();
         let schema_for_task = schema.clone();
         let busy_timeout = opts.busy_timeout;
         let tx_mode = opts.tx_mode;
@@ -675,30 +671,18 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         let mut progress_bar = progress_bars.add(format!("Thread {thread}"));
 
         let handle = turso_stress::future::spawn(async move {
-            let mut conn = StressConn::new(sql_logger.clone(), thread, db.lock().await.connect()?);
-
-            conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
-
-            conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
+            let mut conn = StressDb::connect(&db, thread, busy_timeout).await?;
 
             let mut rng = ThreadRng::new(global_seed.wrapping_add(thread as u64));
 
             for i in 0..nr_iterations {
                 if gen_bool(&mut rng, 0.01) {
                     // Reopen the database
-                    let mut db_guard = db.lock().await;
-                    let mut builder = Builder::new_local(&db_file);
-                    if let Some(ref vfs) = vfs_for_task {
-                        builder = builder.with_io(vfs.clone());
-                    }
-                    *db_guard = builder.build().await?;
-                    conn = StressConn::new(sql_logger.clone(), thread, db_guard.connect()?);
-                    conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
+                    db.lock().await.reset();
+                    conn = StressDb::connect(&db, thread, busy_timeout).await?;
                 } else if gen_bool(&mut rng, 0.02) {
                     // Reconnect to the database
-                    let db_guard = db.lock().await;
-                    conn = StressConn::new(sql_logger.clone(), thread, db_guard.connect()?);
-                    conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
+                    conn = StressDb::connect(&db, thread, busy_timeout).await?;
                 }
 
                 let tx = if rng.get_random() % 2 == 0 {

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -1,9 +1,9 @@
 mod logging;
 mod opts;
+mod progress;
 mod sql_logging;
 
 use clap::Parser;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use opts::{Opts, TxMode};
 #[cfg(not(antithesis))]
 use rand::rngs::StdRng;
@@ -18,6 +18,7 @@ use tokio::sync::Mutex;
 use turso::Builder;
 
 use crate::logging::Tracer;
+use crate::progress::ProgressBars;
 use crate::sql_logging::SqlLogger;
 
 /// Represents a column in a SQLite table
@@ -578,13 +579,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
     let mut handles = Vec::with_capacity(opts.nr_threads);
     let mut stop = false;
 
-    let multi_progress = MultiProgress::new();
-    let progress_style = ProgressStyle::default_bar()
-        .template(
-            "[{elapsed_precise}] {prefix} {bar:40.cyan/blue} {pos:>7}/{len:7} ({percent}%) {msg}",
-        )
-        .unwrap()
-        .progress_chars("##-");
+    let progress_bars = ProgressBars::new(opts.nr_iterations);
 
     let tempfile = tempfile::NamedTempFile::new()?;
     let (_, path) = tempfile.keep().unwrap();
@@ -694,9 +689,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         let tx_mode = opts.tx_mode;
         let sql_logger = sql_logger.clone();
 
-        let progress_bar = multi_progress.add(ProgressBar::new(nr_iterations as u64));
-        progress_bar.set_style(progress_style.clone());
-        progress_bar.set_prefix(format!("Thread {thread}"));
+        let mut progress_bar = progress_bars.add(format!("Thread {thread}"));
 
         let handle = turso_stress::future::spawn(async move {
             let mut conn = db.lock().await.connect()?;
@@ -704,8 +697,6 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
             conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
 
             conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
-
-            progress_bar.set_message("executing queries...");
 
             let mut rng = ThreadRng::new(global_seed.wrapping_add(thread as u64));
 
@@ -745,7 +736,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
 
                 let sql = generate_random_statement(&mut rng, &schema_for_task);
 
-                progress_bar.set_position(i as u64);
+                progress_bar.tick();
                 match conn.execute(&sql, ()).await {
                     Ok(_) => {
                         sql_logger.log(thread, &sql, "OK");
@@ -880,7 +871,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                 Ok(_) => sql_logger.log(thread, "COMMIT", "OK"),
                 Err(e) => sql_logger.log(thread, "COMMIT", &format!("ERROR: {e}")),
             }
-            progress_bar.finish_with_message("done");
+            progress_bar.finish();
             Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
         });
         handles.push(handle);

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -1,3 +1,4 @@
+mod conn;
 mod logging;
 mod opts;
 mod progress;
@@ -17,6 +18,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use turso::Builder;
 
+use crate::conn::StressConn;
 use crate::logging::Tracer;
 use crate::progress::ProgressBars;
 use crate::sql_logging::SqlLogger;
@@ -615,7 +617,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
             break;
         }
         let db_file = db_file.clone();
-        let conn = db.lock().await.connect()?;
+        let conn = StressConn::new(sql_logger.clone(), thread, db.lock().await.connect()?);
 
         match opts.tx_mode {
             TxMode::SQLite => {
@@ -634,39 +636,20 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
             while retry_counter < 10 {
                 match conn.execute(stmt, ()).await {
                     Ok(_) => {
-                        sql_logger.log(thread, stmt, "OK");
                         break;
                     }
-                    Err(turso::Error::Busy(e)) => {
-                        sql_logger.log(thread, stmt, &format!("ERROR(busy): {e}"));
-                        println!("Error (busy) creating table: {e}");
+                    Err(turso::Error::Busy(_) | turso::Error::BusySnapshot(_)) => {
                         retry_counter += 1;
                     }
-                    Err(turso::Error::DatabaseFull(e)) => {
-                        sql_logger.log(thread, stmt, &format!("ERROR(database_full): {e}"));
-                        eprintln!("Database full, stopping: {e}");
-                        stop = true;
-                        break;
-                    }
-                    Err(turso::Error::IoError(std::io::ErrorKind::StorageFull, _)) => {
-                        sql_logger.log(thread, stmt, "ERROR(io): StorageFull");
-                        eprintln!("No storage space, stopping");
-                        stop = true;
-                        break;
-                    }
-                    Err(turso::Error::BusySnapshot(e)) => {
-                        sql_logger.log(thread, stmt, &format!("ERROR(busy_snapshot): {e}"));
-                        println!("Error (busy snapshot): {e}");
-                        retry_counter += 1;
-                    }
-                    Err(turso::Error::IoError(kind, op)) => {
-                        sql_logger.log(thread, stmt, &format!("ERROR(io): {op}: {kind:?}"));
-                        eprintln!("I/O error ({op}: {kind:?}), stopping");
+                    Err(
+                        turso::Error::DatabaseFull(_)
+                        | turso::Error::IoError(std::io::ErrorKind::StorageFull, _)
+                        | turso::Error::IoError(_, _),
+                    ) => {
                         stop = true;
                         break;
                     }
                     Err(e) => {
-                        sql_logger.log(thread, stmt, &format!("ERROR(fatal): {e}"));
                         turso_macros::turso_assert_unreachable!("fatal error creating table", { "thread": thread, "stmt": stmt, "error": e });
                     }
                 }
@@ -692,7 +675,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         let mut progress_bar = progress_bars.add(format!("Thread {thread}"));
 
         let handle = turso_stress::future::spawn(async move {
-            let mut conn = db.lock().await.connect()?;
+            let mut conn = StressConn::new(sql_logger.clone(), thread, db.lock().await.connect()?);
 
             conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
 
@@ -709,12 +692,12 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                         builder = builder.with_io(vfs.clone());
                     }
                     *db_guard = builder.build().await?;
-                    conn = db_guard.connect()?;
+                    conn = StressConn::new(sql_logger.clone(), thread, db_guard.connect()?);
                     conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
                 } else if gen_bool(&mut rng, 0.02) {
                     // Reconnect to the database
                     let db_guard = db.lock().await;
-                    conn = db_guard.connect()?;
+                    conn = StressConn::new(sql_logger.clone(), thread, db_guard.connect()?);
                     conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
                 }
 
@@ -728,51 +711,14 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                 };
 
                 if let Some(tx_stmt) = tx {
-                    match conn.execute(tx_stmt, ()).await {
-                        Ok(_) => sql_logger.log(thread, tx_stmt, "OK"),
-                        Err(e) => sql_logger.log(thread, tx_stmt, &format!("ERROR: {e}")),
-                    }
+                    let _ = conn.execute(tx_stmt, ()).await;
                 }
 
                 let sql = generate_random_statement(&mut rng, &schema_for_task);
 
                 progress_bar.tick();
-                match conn.execute(&sql, ()).await {
-                    Ok(_) => {
-                        sql_logger.log(thread, &sql, "OK");
-                    }
-                    Err(e) => match e {
-                        turso::Error::Corrupt(e) => {
-                            sql_logger.log(thread, &sql, &format!("ERROR(corrupt): {e}"));
-                            turso_macros::turso_assert_unreachable!("corrupt error executing query", { "thread": thread, "error": e, "sql": sql });
-                        }
-                        turso::Error::Constraint(e) => {
-                            sql_logger.log(thread, &sql, &format!("ERROR(constraint): {e}"));
-                        }
-                        turso::Error::Busy(e) => {
-                            sql_logger.log(thread, &sql, &format!("ERROR(busy): {e}"));
-                            println!("thread#{thread} Error[WARNING] executing query: {e}");
-                        }
-                        turso::Error::BusySnapshot(e) => {
-                            sql_logger.log(thread, &sql, &format!("ERROR(busy_snapshot): {e}"));
-                            println!("thread#{thread} Error[WARNING] busy snapshot: {e}");
-                        }
-                        turso::Error::Error(e) => {
-                            sql_logger.log(thread, &sql, &format!("ERROR: {e}"));
-                        }
-                        turso::Error::DatabaseFull(e) => {
-                            sql_logger.log(thread, &sql, &format!("ERROR(database_full): {e}"));
-                            eprintln!("thread#{thread} Database full: {e}");
-                        }
-                        turso::Error::IoError(kind, op) => {
-                            sql_logger.log(thread, &sql, &format!("ERROR(io): {op}: {kind:?}"));
-                            eprintln!("thread#{thread} I/O error ({op}: {kind:?}), continuing...");
-                        }
-                        _ => {
-                            sql_logger.log(thread, &sql, &format!("ERROR(fatal): {e}"));
-                            turso_macros::turso_assert_unreachable!("fatal error executing query", { "thread": thread, "error": e, "sql": sql });
-                        }
-                    },
+                if let Err(turso::Error::Corrupt(e)) = conn.execute(&sql, ()).await {
+                    turso_macros::turso_assert_unreachable!("corrupt error executing query", { "thread": thread, "error": e, "sql": sql });
                 }
 
                 // When inside a transaction, 30% chance to exercise savepoints.
@@ -782,38 +728,24 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                 if tx.is_some() && rng.get_random() % 100 < 30 {
                     let sp_name = format!("sp_{}", rng.get_random() % 100);
                     let savepoint_sql = format!("SAVEPOINT {sp_name};");
-                    match conn.execute(&savepoint_sql, ()).await {
-                        Ok(_) => sql_logger.log(thread, &savepoint_sql, "OK"),
-                        Err(e) => sql_logger.log(thread, &savepoint_sql, &format!("ERROR: {e}")),
-                    }
+                    let _ = conn.execute(&savepoint_sql, ()).await;
 
                     // Execute 1-3 DML statements inside the savepoint.
                     let sp_stmts = 1 + (rng.get_random() % 3) as usize;
                     for _ in 0..sp_stmts {
                         let sp_sql = generate_random_statement(&mut rng, &schema_for_task);
-                        match conn.execute(&sp_sql, ()).await {
-                            Ok(_) => sql_logger.log(thread, &sp_sql, "OK"),
-                            Err(turso::Error::Corrupt(e)) => {
-                                sql_logger.log(thread, &sp_sql, &format!("ERROR(corrupt): {e}"));
-                                turso_macros::turso_assert_unreachable!("corrupt error in savepoint", { "thread": thread, "error": e, "sql": sp_sql });
-                            }
-                            Err(e) => sql_logger.log(thread, &sp_sql, &format!("ERROR: {e}")),
+                        if let Err(turso::Error::Corrupt(e)) = conn.execute(&sp_sql, ()).await {
+                            turso_macros::turso_assert_unreachable!("corrupt error in savepoint", { "thread": thread, "error": e, "sql": sp_sql });
                         }
                     }
 
                     // 50% ROLLBACK TO (partial undo), 50% RELEASE (keep changes).
                     if rng.get_random() % 2 == 0 {
                         let rollback_sql = format!("ROLLBACK TO {sp_name};");
-                        match conn.execute(&rollback_sql, ()).await {
-                            Ok(_) => sql_logger.log(thread, &rollback_sql, "OK"),
-                            Err(e) => sql_logger.log(thread, &rollback_sql, &format!("ERROR: {e}")),
-                        }
+                        let _ = conn.execute(&rollback_sql, ()).await;
                     }
                     let release_sql = format!("RELEASE {sp_name};");
-                    match conn.execute(&release_sql, ()).await {
-                        Ok(_) => sql_logger.log(thread, &release_sql, "OK"),
-                        Err(e) => sql_logger.log(thread, &release_sql, &format!("ERROR: {e}")),
-                    }
+                    let _ = conn.execute(&release_sql, ()).await;
                 }
 
                 if tx.is_some() {
@@ -822,10 +754,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                     } else {
                         "ROLLBACK;"
                     };
-                    match conn.execute(end_tx, ()).await {
-                        Ok(_) => sql_logger.log(thread, end_tx, "OK"),
-                        Err(e) => sql_logger.log(thread, end_tx, &format!("ERROR: {e}")),
-                    }
+                    let _ = conn.execute(end_tx, ()).await;
                 }
 
                 const INTEGRITY_CHECK_INTERVAL: usize = 100;
@@ -867,10 +796,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                 }
             }
             // In case this thread is running an exclusive transaction, commit it so that it doesn't block other threads.
-            match conn.execute("COMMIT", ()).await {
-                Ok(_) => sql_logger.log(thread, "COMMIT", "OK"),
-                Err(e) => sql_logger.log(thread, "COMMIT", &format!("ERROR: {e}")),
-            }
+            let _ = conn.execute("COMMIT", ()).await;
             progress_bar.finish();
             Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
         });

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -1,3 +1,4 @@
+mod logging;
 mod opts;
 
 use clap::Parser;
@@ -26,12 +27,9 @@ fn log_sql(log: &SqlLog, thread: usize, sql: &str, result: &str) {
         w.flush().unwrap();
     }
 }
-use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::reload;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::EnvFilter;
 use turso::Builder;
+
+use crate::logging::Tracer;
 
 /// Represents a column in a SQLite table
 #[derive(Debug, Clone)]
@@ -497,72 +495,6 @@ pub fn load_schema(
     Ok(ArbitrarySchema { tables })
 }
 
-pub type LogLevelReloadHandle = reload::Handle<EnvFilter, tracing_subscriber::Registry>;
-
-pub fn init_tracing(log_path: &str) -> Result<(WorkerGuard, LogLevelReloadHandle), std::io::Error> {
-    let log_file = std::fs::File::create(log_path)?;
-    let (non_blocking, guard) = tracing_appender::non_blocking(log_file);
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let (filter_layer, reload_handle) = reload::Layer::new(filter);
-
-    if let Err(e) = tracing_subscriber::registry()
-        .with(filter_layer)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_writer(non_blocking)
-                .with_ansi(false)
-                .with_line_number(true)
-                .with_thread_ids(true)
-                .json(),
-        )
-        .try_init()
-    {
-        println!("Unable to setup tracing appender: {e:?}");
-    }
-    Ok((guard, reload_handle))
-}
-
-const LOG_LEVEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
-
-const LOG_LEVEL_FILE: &str = "RUST_LOG";
-
-/// Spawns a background thread that watches for a RUST_LOG file and dynamically
-/// updates the log level when the file contents change.
-pub fn spawn_log_level_watcher(reload_handle: LogLevelReloadHandle) {
-    std::thread::spawn(move || {
-        let mut last_content: Option<String> = None;
-
-        loop {
-            std::thread::sleep(LOG_LEVEL_POLL_INTERVAL);
-
-            let content = match std::fs::read_to_string(LOG_LEVEL_FILE) {
-                Ok(content) => content.trim().to_string(),
-                Err(_) => {
-                    continue;
-                }
-            };
-
-            if last_content.as_ref() == Some(&content) {
-                continue;
-            }
-
-            match content.parse::<EnvFilter>() {
-                Ok(new_filter) => {
-                    if let Err(e) = reload_handle.reload(new_filter) {
-                        eprintln!("Failed to reload log filter: {e}");
-                    } else {
-                        last_content = Some(content);
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Invalid log filter in {LOG_LEVEL_FILE}: {e}");
-                    last_content = Some(content);
-                }
-            }
-        }
-    });
-}
-
 fn sqlite_integrity_check(
     db_path: &std::path::Path,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -684,10 +616,8 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
     println!("sql_log={sql_log_path}");
 
     let tracing_log_path = format!("{db_file}.jsonl");
-    // This may cause torn writes if payloads are > 4KB, but for now let's ignore the issue.
-    let (_guard, reload_handle) = init_tracing(&tracing_log_path)?;
-    spawn_log_level_watcher(reload_handle);
     println!("tracing_log={tracing_log_path}");
+    let _tracer = Tracer::new(&tracing_log_path)?;
 
     let vfs_option = opts.vfs.clone();
 

--- a/testing/stress/progress.rs
+++ b/testing/stress/progress.rs
@@ -1,0 +1,56 @@
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+pub struct ProgressBars {
+    num_ticks: usize,
+    multi_progress: MultiProgress,
+}
+
+impl ProgressBars {
+    pub(crate) fn new(num_ticks: usize) -> Self {
+        Self {
+            multi_progress: MultiProgress::new(),
+            num_ticks,
+        }
+    }
+
+    pub(crate) fn add(&self, id: String) -> Progress {
+        let progress_bar = self
+            .multi_progress
+            .add(ProgressBar::new(self.num_ticks as u64));
+
+        progress_bar.set_style(Self::style());
+        progress_bar.set_prefix(id);
+
+        Progress::new(progress_bar)
+    }
+
+    fn style() -> ProgressStyle {
+        ProgressStyle::default_bar()
+            .template(
+                "[{elapsed_precise}] {prefix} {bar:40.cyan/blue} {pos:>7}/{len:7} ({percent}%) {msg}",
+            )
+            .unwrap()
+            .progress_chars("##-")
+    }
+}
+
+#[derive(Clone)]
+pub struct Progress {
+    progress_bar: ProgressBar,
+}
+
+impl Progress {
+    fn new(progress_bar: ProgressBar) -> Self {
+        progress_bar.set_message("executing queries...");
+
+        Self { progress_bar }
+    }
+
+    pub fn tick(&mut self) {
+        self.progress_bar.inc(1);
+    }
+
+    pub fn finish(&mut self) {
+        self.progress_bar.finish_with_message("done");
+    }
+}

--- a/testing/stress/sql_logging.rs
+++ b/testing/stress/sql_logging.rs
@@ -1,9 +1,13 @@
+use std::cell::RefCell;
 use std::fs::File;
 use std::io::BufWriter;
 use std::io::Write;
-use std::sync::{Arc, Mutex};
+use turso_stress::sync::{Arc, StdMutex};
+use turso_stress::ThreadId;
 
-type SqlLog = Arc<Mutex<BufWriter<File>>>;
+/// SqlLog uses [StdMutex] instead of [AsyncMutex] (shuttle-instrumented) because
+/// we don't care about Shuttle intercepting invocations on the logger.
+type SqlLog = Arc<StdMutex<RefCell<BufWriter<File>>>>;
 
 #[derive(Clone)]
 pub struct SqlLogger {
@@ -13,20 +17,21 @@ pub struct SqlLogger {
 impl SqlLogger {
     pub(crate) fn new(sql_log_path: &str) -> Result<Self, std::io::Error> {
         let file = File::create(sql_log_path)?;
-        let log: SqlLog = Arc::new(Mutex::new(BufWriter::new(file)));
+        let log: SqlLog = Arc::new(StdMutex::new(RefCell::new(BufWriter::new(file))));
         Ok(Self { log })
     }
 
-    pub fn log(&self, thread: usize, sql: &str, result: &str) {
+    pub fn log(&self, thread: &ThreadId, sql: &str, result: &str) {
         let sql = sql.trim().trim_end_matches(';');
-        let mut w = self.log.lock().unwrap();
+        let w = self.log.lock().unwrap();
+        let mut w = w.borrow_mut();
         writeln!(w, "{sql}; -- [thread:{thread}] {result}").unwrap();
         if result.starts_with("ERROR") {
             w.flush().unwrap();
         }
     }
 
-    pub fn log_result<T>(&self, thread: usize, sql: &str, result: &Result<T, turso::Error>) {
+    pub fn log_result<T>(&self, thread: &ThreadId, sql: &str, result: &Result<T, turso::Error>) {
         match result {
             Ok(_) => {
                 self.log(thread, sql, "OK");
@@ -66,7 +71,7 @@ impl SqlLogger {
 
 impl Drop for SqlLogger {
     fn drop(&mut self) {
-        let mut w = self.log.lock().unwrap();
-        w.flush().unwrap();
+        let log = self.log.lock().unwrap();
+        log.borrow_mut().flush().unwrap();
     }
 }

--- a/testing/stress/sql_logging.rs
+++ b/testing/stress/sql_logging.rs
@@ -1,0 +1,35 @@
+use std::fs::File;
+use std::io::BufWriter;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+type SqlLog = Arc<Mutex<BufWriter<File>>>;
+
+#[derive(Clone)]
+pub struct SqlLogger {
+    log: SqlLog,
+}
+
+impl SqlLogger {
+    pub(crate) fn new(sql_log_path: &str) -> Result<Self, std::io::Error> {
+        let file = File::create(sql_log_path)?;
+        let log: SqlLog = Arc::new(Mutex::new(BufWriter::new(file)));
+        Ok(Self { log })
+    }
+
+    pub fn log(&self, thread: usize, sql: &str, result: &str) {
+        let sql = sql.trim().trim_end_matches(';');
+        let mut w = self.log.lock().unwrap();
+        writeln!(w, "{sql}; -- [thread:{thread}] {result}").unwrap();
+        if result.starts_with("ERROR") {
+            w.flush().unwrap();
+        }
+    }
+}
+
+impl Drop for SqlLogger {
+    fn drop(&mut self) {
+        let mut w = self.log.lock().unwrap();
+        w.flush().unwrap();
+    }
+}

--- a/testing/stress/sql_logging.rs
+++ b/testing/stress/sql_logging.rs
@@ -25,6 +25,43 @@ impl SqlLogger {
             w.flush().unwrap();
         }
     }
+
+    pub fn log_result<T>(&self, thread: usize, sql: &str, result: &Result<T, turso::Error>) {
+        match result {
+            Ok(_) => {
+                self.log(thread, sql, "OK");
+            }
+            Err(turso::Error::Busy(e)) => {
+                self.log(thread, sql, &format!("ERROR(busy): {e}"));
+                println!("Error (busy): {e}");
+            }
+            Err(turso::Error::DatabaseFull(e)) => {
+                self.log(thread, sql, &format!("ERROR(database_full): {e}"));
+                eprintln!("Database full: {e}");
+            }
+            Err(turso::Error::IoError(std::io::ErrorKind::StorageFull, _)) => {
+                self.log(thread, sql, "ERROR(io): StorageFull");
+                eprintln!("No storage space, stopping");
+            }
+            Err(turso::Error::BusySnapshot(e)) => {
+                self.log(thread, sql, &format!("ERROR(busy_snapshot): {e}"));
+                println!("Error (busy snapshot): {e}");
+            }
+            Err(turso::Error::IoError(kind, op)) => {
+                self.log(thread, sql, &format!("ERROR(io): {op}: {kind:?}"));
+                eprintln!("I/O error ({op}: {kind:?})");
+            }
+            Err(turso::Error::Corrupt(e)) => {
+                self.log(thread, sql, &format!("ERROR(corrupt): {e}"));
+            }
+            Err(turso::Error::Constraint(e)) => {
+                self.log(thread, sql, &format!("ERROR(constraint): {e}"));
+            }
+            Err(e) => {
+                self.log(thread, sql, &format!("ERROR: {e}"));
+            }
+        }
+    }
 }
 
 impl Drop for SqlLogger {


### PR DESCRIPTION
## Description

This is a simple version of https://github.com/tursodatabase/turso/pull/7489

I did a bunch of refactoring to make `main.rs` in turso-stress have less responsibilities and be easier to work with. Unfortunately the commit history isn't as nice as I would have wanted, so the diff may be a bit messy.

Here's what's going on in this PR:
* extracted logging to a `Tracer` type
* extracted SQL logging (to a file) to a `SqlLogger` type
* extracted progress bars to a `Progress` type
* encapsulated post-statement SQL logging inside a `StressConn` type
* encapsulated closing/reopening in a `StressDb` type
* moved the ddl up so that it was performed only once (previously we performed the same DDL setup once per thread, which I think was a mistake). This was necessary because without this fix, threads with higher indexes barely got any attention, because by the time threads 0 or 1 requested a synchronization, they were still performing their initialization.
* restored `turso_assert_reachable!` (it was a no-op), and added one invocation to MVCC recovery, so that we'll know if we ever have a regression and it's not exercised in Antithesis anymore.
* changed how the loop is structured, so that all the DBs are dropped at the same time, thereby exercising MVCC recovery



## Description of AI Usage

Handwritten. I used Claude to figure out bugs (I had a few deadlocks and starvation issues while coding this).
