### PR TITLE
parser: preserve blob literal prefix case

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -1693,7 +1693,7 @@ impl DbspCompiler {
                         let escaped = t.to_string().replace('\'', "''");
                         ast::Literal::String(format!("'{escaped}'"))
                     }
-                    Value::Blob(b) => ast::Literal::Blob(format!("{b:?}")),
+                    Value::Blob(b) => ast::Literal::Blob(format!("X'{}'", hex::encode(b))),
                     Value::Null => ast::Literal::Null,
                 };
                 Ok(ast::Expr::Literal(lit))

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -415,7 +415,8 @@ pub(crate) fn literal_default_value(literal: &ast::Literal) -> Result<Value> {
         ast::Literal::Numeric(val) => parse_numeric_literal(val),
         ast::Literal::String(s) => Ok(Value::from_text(crate::translate::expr::sanitize_string(s))),
         ast::Literal::Blob(s) => Ok(Value::Blob(
-            s.as_bytes()
+            ast::blob_literal_hex(s)
+                .as_bytes()
                 .chunks_exact(2)
                 .map(|pair| {
                     let hex_byte = std::str::from_utf8(pair).expect("parser validated hex string");

--- a/core/translate/expr/emission.rs
+++ b/core/translate/expr/emission.rs
@@ -34,7 +34,7 @@ pub fn emit_literal(
             Ok(target_register)
         }
         ast::Literal::Blob(s) => {
-            let bytes = s
+            let bytes = ast::blob_literal_hex(s)
                 .as_bytes()
                 .chunks_exact(2)
                 .map(|pair| {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1167,7 +1167,8 @@ pub fn resolve_index_method_parameters(
                 ast::Literal::Null => crate::Value::Null,
                 ast::Literal::String(s) => crate::Value::Text(s.into()),
                 ast::Literal::Blob(b) => crate::Value::Blob(
-                    b.as_bytes()
+                    ast::blob_literal_hex(&b)
+                        .as_bytes()
                         .chunks_exact(2)
                         .map(|pair| {
                             // We assume that sqlite3-parser has already validated that

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -1931,7 +1931,7 @@ impl<'a> LogicalPlanBuilder<'a> {
                 };
                 Ok(Value::Text(unquoted.to_string().into()))
             }
-            ast::Literal::Blob(b) => Ok(Value::from_slice(b.as_bytes())?),
+            ast::Literal::Blob(b) => Ok(Value::from_slice(ast::blob_literal_hex(b).as_bytes())?),
             ast::Literal::CurrentDate
             | ast::Literal::CurrentTime
             | ast::Literal::CurrentTimestamp => Err(LimboError::ParseError(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3794,10 +3794,10 @@ mod tests {
                 Expr::InList {
                     lhs: Box::new(fn_call(
                         "hex",
-                        vec![Expr::Literal(ast::Literal::Blob("01".into()))],
+                        vec![Expr::Literal(ast::Literal::Blob("X'01'".into()))],
                     )),
                     not: false,
-                    rhs: vec![Box::new(Expr::Literal(ast::Literal::Blob("02".into())))],
+                    rhs: vec![Box::new(Expr::Literal(ast::Literal::Blob("X'02'".into())))],
                 },
             ],
         );

--- a/core/util.rs
+++ b/core/util.rs
@@ -410,7 +410,9 @@ pub fn check_literal_equivalency(lhs: &Literal, rhs: &Literal) -> bool {
     match (lhs, rhs) {
         (Literal::Numeric(n1), Literal::Numeric(n2)) => cmp_numeric_strings(n1, n2),
         (Literal::String(s1), Literal::String(s2)) => s1 == s2,
-        (Literal::Blob(b1), Literal::Blob(b2)) => b1 == b2,
+        (Literal::Blob(b1), Literal::Blob(b2)) => {
+            ast::blob_literal_hex(b1).eq_ignore_ascii_case(ast::blob_literal_hex(b2))
+        }
         (Literal::Keyword(k1), Literal::Keyword(k2)) => check_ident_equivalency(k1, k2),
         (Literal::Null, Literal::Null) => true,
         (Literal::True, Literal::True) => true,

--- a/sql_generation/generation/expr.rs
+++ b/sql_generation/generation/expr.rs
@@ -275,7 +275,10 @@ impl Arbitrary for ast::Literal {
                     }
                 }),
                 1 => ast::Literal::String(format!("'{}'", gen_random_text(rng))),
-                2 => ast::Literal::Blob(hex::encode(gen_random_text(rng).as_bytes())),
+                2 => ast::Literal::Blob(format!(
+                    "X'{}'",
+                    hex::encode(gen_random_text(rng).as_bytes())
+                )),
                 // TODO: skip Keyword
                 3 => continue,
                 4 => ast::Literal::Null,

--- a/sql_generation/generation/generated_expr.rs
+++ b/sql_generation/generation/generated_expr.rs
@@ -178,7 +178,7 @@ fn generate_literal<R: Rng + ?Sized>(rng: &mut R, target_type: &ColumnType) -> E
         ColumnType::Blob => {
             // Generate a simple blob literal
             let bytes: Vec<u8> = (0..4).map(|_| rng.random()).collect();
-            Expr::Literal(ast::Literal::Blob(hex::encode(bytes)))
+            Expr::Literal(ast::Literal::Blob(format!("X'{}'", hex::encode(bytes))))
         }
     }
 }

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -455,7 +455,8 @@ impl From<&ast::Literal> for SimValue {
             ast::Literal::Numeric(number) => Numeric::from(number).into(),
             ast::Literal::String(string) => types::Value::build_text(unescape_singlequotes(string)),
             ast::Literal::Blob(blob) => types::Value::Blob(
-                blob.as_bytes()
+                ast::blob_literal_hex(blob)
+                    .as_bytes()
                     .chunks_exact(2)
                     .map(|pair| {
                         // We assume that sqlite3-parser has already validated that
@@ -491,7 +492,7 @@ impl From<&SimValue> for ast::Literal {
             types::Value::Numeric(Numeric::Integer(i)) => Self::Numeric(i.to_string()),
             types::Value::Numeric(Numeric::Float(f)) => Self::Numeric(f.to_string()),
             text @ types::Value::Text(..) => Self::String(escape_singlequotes(&text.to_string())),
-            types::Value::Blob(blob) => Self::Blob(hex::encode(blob)),
+            types::Value::Blob(blob) => Self::Blob(format!("X'{}'", hex::encode(blob))),
         }
     }
 }

--- a/sqlite/conformance/sqlite-sqltests/default_value.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/default_value.sqltest
@@ -31,6 +31,17 @@ expect {
     3.14
 }
 
+test default-value-blob-preserves-prefix-case {
+    CREATE TABLE t_blob (a INTEGER);
+    ALTER TABLE t_blob ADD COLUMN lower_blob BLOB NOT NULL DEFAULT x'00';
+    ALTER TABLE t_blob ADD COLUMN upper_blob BLOB NOT NULL DEFAULT X'AB';
+    SELECT name, dflt_value FROM pragma_table_info('t_blob') WHERE name LIKE '%_blob' ORDER BY cid;
+}
+expect {
+    lower_blob|x'00'
+    upper_blob|X'AB'
+}
+
 @cross-check-integrity
 test default-value-null {
     CREATE TABLE t5 (x INTEGER PRIMARY KEY, y TEXT DEFAULT NULL);

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -785,6 +785,14 @@ pub enum Literal {
     CurrentTimestamp,
 }
 
+pub fn blob_literal_hex(blob: &str) -> &str {
+    debug_assert!(blob.len() >= 3);
+    debug_assert!(matches!(blob.as_bytes()[0], b'x' | b'X'));
+    debug_assert_eq!(blob.as_bytes()[1], b'\'');
+    debug_assert_eq!(blob.as_bytes()[blob.len() - 1], b'\'');
+    &blob[2..blob.len() - 1]
+}
+
 /// Textual comparison operator in an expression
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/sqlite/parser/src/ast/fmt.rs
+++ b/sqlite/parser/src/ast/fmt.rs
@@ -79,12 +79,11 @@ impl<T: Write> TokenStream for WriteTokenStream<'_, T> {
 
         match (ty, ty.as_str(), value) {
             (TK_BLOB, None, value) => {
-                self.write.write_char('X')?;
-                self.write.write_char('\'')?;
                 if let Some(str) = value {
                     self.write.write_str(str)?;
+                } else {
+                    self.write.write_str("X''")?;
                 }
-                self.write.write_char('\'')?;
                 Ok(())
             }
             (_, ty_str, value) => {

--- a/sqlite/parser/src/lexer.rs
+++ b/sqlite/parser/src/lexer.rs
@@ -895,9 +895,8 @@ impl<'a> Lexer<'a> {
                                 offset: start,
                             });
                         }
-                        // do not include 'x' or 'X' and the last '
                         Ok(Token::new(
-                            &self.input[start + 2..self.offset - 1],
+                            &self.input[start..self.offset],
                             TokenType::TK_BLOB,
                         ))
                     }
@@ -1066,14 +1065,14 @@ mod tests {
             ),
             (
                 b"x'1234567890abcdef'".as_slice(),
-                Token::new(b"1234567890abcdef", TokenType::TK_BLOB), // hex payload only
+                Token::new(b"x'1234567890abcdef'", TokenType::TK_BLOB),
             ),
             (
                 b"X'1234567890abcdef'".as_slice(),
-                Token::new(b"1234567890abcdef", TokenType::TK_BLOB), // hex payload only
+                Token::new(b"X'1234567890abcdef'", TokenType::TK_BLOB),
             ),
-            (b"x''".as_slice(), Token::new(b"", TokenType::TK_BLOB)),
-            (b"X''".as_slice(), Token::new(b"", TokenType::TK_BLOB)),
+            (b"x''".as_slice(), Token::new(b"x''", TokenType::TK_BLOB)),
+            (b"X''".as_slice(), Token::new(b"X''", TokenType::TK_BLOB)),
             (
                 b"wHeRe".as_slice(),
                 Token::new(b"wHeRe", TokenType::TK_WHERE),

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -5686,7 +5686,7 @@ mod tests {
                         select: OneSelect::Select {
                             distinctness: None,
                             columns: vec![ResultColumn::Expr(
-                                Box::new(Expr::Literal(Literal::Blob("ab".to_owned()))),
+                                Box::new(Expr::Literal(Literal::Blob("X'ab'".to_owned()))),
                                 None,
                             )],
                             from: None,
@@ -12883,7 +12883,7 @@ mod tests {
                     with_clause: vec![
                         (Name::exact("a".to_string()), Box::new(Expr::Literal(Literal::Numeric("1".to_string())))),
                         (Name::exact("b".to_string()), Box::new(Expr::Literal(Literal::String("'test'".to_string())))),
-                        (Name::exact("c".to_string()), Box::new(Expr::Literal(Literal::Blob("deadbeef".to_string())))),
+                        (Name::exact("c".to_string()), Box::new(Expr::Literal(Literal::Blob("x'deadbeef'".to_string())))),
                         (Name::exact("d".to_string()), Box::new(Expr::Literal(Literal::Null))),
                     ],
                 })],


### PR DESCRIPTION
## Description

`pragma_table_info`'s `dflt_value` rendered a blob-literal column default in fixed uppercase, so a default of `x'00'` was reported as `X'00'`. SQLite preserves the literal's as-typed case (`x'00'` stays `x'00'`, `X'AB'` stays `X'AB'`).

The lexer dropped the `x`/`X` prefix and quotes, keeping only the hex payload, and the formatter re-emitted a hardcoded uppercase `X'...'`. This keeps the full literal text (prefix and quotes included) in `Literal::Blob`, adds a `blob_literal_hex` helper to recover the hex payload where the bytes are needed, and emits the stored text verbatim.

Before:

```
turso> ALTER TABLE t ADD COLUMN c BLOB NOT NULL DEFAULT x'00';
turso> SELECT dflt_value FROM pragma_table_info('t') WHERE name='c';
X'00'
```

After (matches SQLite):

```
x'00'
```

## Motivation and context

Fixes #7554. Improves SQLite compatibility for blob-literal rendering.

A regression test was added to `testing/sqltests/tests/default_value.sqltest` covering both lowercase and uppercase prefixes. Blob values still round-trip correctly (`hex(x'00ab')` and `x'00ab' = X'00AB'`), and case-insensitive blob equality is preserved.

## Description of AI Usage

This change was developed with the assistance of Claude Code. The agent was directed to investigate the issue, reproduce it against SQLite, locate the root cause, and implement the fix and regression test. I reviewed the diff, the reproduction against SQLite 3.50.6, and the test results, and I understand and take responsibility for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
