### PR TITLE
Fix ROUND() to round half away from zero

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -797,11 +797,11 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        let f: f64 = crate::numeric::str_to_f64(format!("{f:.precision$}"))
-            .expect("formatted float should always parse successfully")
-            .into();
-
-        Value::from_f64(f)
+        // SQLite rounds half away from zero (the printf "%!.*f" flag), but Rust
+        // formatting rounds half to even, so ROUND(2.25, 1) returned 2.2.
+        // Scale, round away from zero, then scale back to match SQLite.
+        let scale = 10f64.powi(precision as i32);
+        Value::from_f64((f * scale).round() / scale)
     }
 
     fn _exec_trim(&self, pattern: Option<&Value>, trim_type: TrimType) -> Value {


### PR DESCRIPTION
## Description

ROUND(x, d) was using banker's rounding (round half to even) when d > 0, because it went through Rust's `format!("{:.*}")`. SQLite rounds half away from zero, so the two disagreed on exact .5 boundaries.

```sql
SELECT ROUND(2.25, 1);
-- was 2.2, sqlite gives 2.3
```

Changed the d > 0 path in `exec_round` to scale, round with `f64::round` (which rounds half away from zero), then scale back. The d == 0 path already rounded away from zero, so I left it alone.

Closes #5748

## Motivation and context

Found this going through the good first issues. ROUND not matching SQLite is a correctness/compat problem and #5748 has a clear reproducer.

## Description of AI Usage

I used an AI assistant to help find the relevant code and draft the fix. I reviewed the change myself and I'm responsible for it.
