### PR TITLE
sync: Use core allocator Vec in sync engine for compile reasons

### DIFF
--- a/sync/engine/src/alloc.rs
+++ b/sync/engine/src/alloc.rs
@@ -1,0 +1,1 @@
+pub use turso_core::alloc::*;

--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use turso_parser::parser::Parser;
 
 use crate::{
+    alloc::{TursoAllocExt, TursoVecExt},
     database_tape::{run_stmt_once, DatabaseReplaySessionOpts},
     errors::Error,
     types::{
@@ -112,18 +113,18 @@ impl DatabaseReplayGenerator {
         info: &ReplayInfo,
         change: DatabaseChangeType,
         id: i64,
-        mut record: Vec<turso_core::Value>,
-        updates: Option<Vec<turso_core::Value>>,
-    ) -> Vec<turso_core::Value> {
+        mut record: crate::alloc::Vec<turso_core::Value>,
+        updates: Option<crate::alloc::Vec<turso_core::Value>>,
+    ) -> crate::alloc::Vec<turso_core::Value> {
         if info.is_ddl_replay {
-            return Vec::new();
+            return <crate::alloc::Vec<turso_core::Value> as TursoAllocExt>::new();
         }
         match change {
             DatabaseChangeType::Delete => {
                 if self.opts.use_implicit_rowid || info.pk_column_indices.is_none() {
-                    vec![turso_core::Value::from_i64(id)]
+                    crate::alloc::vec![turso_core::Value::from_i64(id)]
                 } else {
-                    let mut values = Vec::new();
+                    let mut values = <crate::alloc::Vec<turso_core::Value> as TursoAllocExt>::new();
                     let pk_column_indices = info.pk_column_indices.as_ref().unwrap();
                     for pk in pk_column_indices {
                         let value = std::mem::replace(&mut record[*pk], turso_core::Value::Null);
@@ -142,7 +143,10 @@ impl DatabaseReplayGenerator {
                 let mut updates = updates.unwrap();
                 assert!(updates.len() % 2 == 0);
                 let columns_cnt = updates.len() / 2;
-                let mut values = Vec::with_capacity(columns_cnt + 1);
+                let mut values =
+                    <crate::alloc::Vec<turso_core::Value> as TursoVecExt<_>>::with_capacity(
+                        columns_cnt + 1,
+                    );
                 for i in 0..columns_cnt {
                     let changed = match updates[i] {
                         turso_core::Value::Numeric(turso_core::Numeric::Integer(x @ (1 | 0))) => {
@@ -172,7 +176,7 @@ impl DatabaseReplayGenerator {
             }
             DatabaseChangeType::Commit => {
                 // COMMIT records are handled at the tape level, not here
-                Vec::new()
+                <crate::alloc::Vec<turso_core::Value> as TursoAllocExt>::new()
             }
         }
     }

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -677,7 +677,9 @@ pub const TURSO_SYNC_UPDATE_LAST_CHANGE_ID: &str =
 const TURSO_SYNC_SELECT_LAST_CHANGE_ID: &str =
     "SELECT pull_gen, change_id FROM turso_sync_last_change_id WHERE client_id = ?";
 
-fn convert_to_args(values: Vec<turso_core::Value>) -> Vec<server_proto::Value> {
+fn convert_to_args(
+    values: impl IntoIterator<Item = turso_core::Value>,
+) -> Vec<server_proto::Value> {
     values
         .into_iter()
         .map(|value| match value {

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -543,7 +543,7 @@ pub struct DatabaseReplaySession {
 async fn replay_stmt<Ctx>(
     coro: &Coro<Ctx>,
     stmt: &mut turso_core::Statement,
-    values: Vec<turso_core::Value>,
+    values: impl IntoIterator<Item = turso_core::Value>,
 ) -> Result<()> {
     stmt.reset()?;
     for (i, value) in values.into_iter().enumerate() {

--- a/sync/engine/src/lib.rs
+++ b/sync/engine/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alloc;
 pub mod database_replay_generator;
 pub mod database_sync_engine;
 pub mod database_sync_engine_io;

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -461,15 +461,15 @@ pub enum DatabaseRowTransformResult {
 #[derive(Clone)]
 pub enum DatabaseTapeRowChangeType {
     Delete {
-        before: Vec<turso_core::Value>,
+        before: crate::alloc::Vec<turso_core::Value>,
     },
     Update {
-        before: Vec<turso_core::Value>,
-        after: Vec<turso_core::Value>,
-        updates: Option<Vec<turso_core::Value>>,
+        before: crate::alloc::Vec<turso_core::Value>,
+        after: crate::alloc::Vec<turso_core::Value>,
+        updates: Option<crate::alloc::Vec<turso_core::Value>>,
     },
     Insert {
-        after: Vec<turso_core::Value>,
+        after: crate::alloc::Vec<turso_core::Value>,
     },
 }
 
@@ -582,7 +582,9 @@ pub enum SyncEngineIoResult {
     IO,
 }
 
-pub fn parse_bin_record(bin_record: impl AsRef<[u8]>) -> Result<Vec<turso_core::Value>> {
+pub fn parse_bin_record(
+    bin_record: impl AsRef<[u8]>,
+) -> Result<crate::alloc::Vec<turso_core::Value>> {
     match turso_core::types::ImmutableRecordRef::from_bin_record(bin_record.as_ref())
         .get_values_owned()
     {


### PR DESCRIPTION
## Summary
- re-export `turso_core::alloc` from `turso_sync_engine` as `crate::alloc`
- use `crate::alloc::Vec<turso_core::Value>` for decoded CDC row-change value records
- keep replay/HTTP helpers generic over owned value iterators so existing std `Vec` rewrite paths continue to work

## Root cause
The nightly allocator-aware build makes `ImmutableRecordRef::get_values_owned()` return a `Vec<Value, TursoAllocator>`, while the sync engine decoded record path expected a standard `Vec<Value>`.

## Validation
- `cargo fmt --check`
- `cargo +nightly-2025-12-16 check -p turso_sync_engine --all-features`