### PR TITLE
core: register additional virtual tables into the catalog

### DIFF
--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -1,0 +1,11 @@
+//! Per-dialect built-in catalog tables.
+//!
+//! The single [`sqlite`] module here owns the set of catalog tables that ship
+//! with every Turso build (`pragma_*`, `json_each`/`json_tree`,
+//! `sqlite_dbpage`, `btree_dump`, `sqlite_turso_types`). `Schema::with_options`
+//! reaches them through this module rather than touching the implementations
+//! directly, so an alternative catalog set can be substituted — by a
+//! downstream crate or a future feature gate — without churning the shared
+//! schema-construction path.
+
+pub mod sqlite;

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -1,0 +1,63 @@
+//! Built-in SQLite-style catalog tables.
+//!
+//! `pragma_*` table-valued functions, `json_each`/`json_tree`,
+//! `sqlite_dbpage`, `btree_dump`, and `sqlite_turso_types`. Registered into
+//! every fresh schema by [`crate::schema::Schema::with_options`] through
+//! [`register_builtin_catalog`].
+
+use crate::pragma::PragmaVirtualTable;
+use crate::schema::{Schema, Table};
+use crate::sync::Arc;
+use crate::vtab::{VirtualTable, VirtualTableType};
+use turso_ext::VTabKind;
+
+/// Insert the standard SQLite-style catalog tables into `schema`.
+///
+/// `pragma_*` virtual tables use the dedicated [`VirtualTableType::Pragma`]
+/// variant (they aren't `InternalVirtualTable`), so they are inserted
+/// directly. The rest go through [`Schema::register_internal_vtab`] — the
+/// same path external callers use via [`crate::Database::register_internal_vtab`].
+pub fn register_builtin_catalog(
+    schema: &mut Schema,
+    enable_custom_types: bool,
+) -> crate::Result<()> {
+    for vtab in pragma_vtabs() {
+        schema.tables.insert(
+            vtab.name.to_owned(),
+            Arc::new(Table::Virtual(Arc::new((*vtab).clone()))),
+        );
+    }
+
+    #[cfg(feature = "json")]
+    {
+        schema.register_internal_vtab(crate::json::vtab::JsonVirtualTable::json_each())?;
+        schema.register_internal_vtab(crate::json::vtab::JsonVirtualTable::json_tree())?;
+    }
+    #[cfg(feature = "cli_only")]
+    {
+        schema.register_internal_vtab(crate::dbpage::DbPageTable::new())?;
+        schema.register_internal_vtab(crate::btree_dump::BtreeDumpTable::new())?;
+    }
+    if enable_custom_types {
+        schema.register_internal_vtab(crate::turso_types_vtab::TursoTypesTable::new())?;
+    }
+    Ok(())
+}
+
+/// Build a `VirtualTable` for each PRAGMA table-valued function.
+fn pragma_vtabs() -> Vec<Arc<VirtualTable>> {
+    PragmaVirtualTable::functions()
+        .into_iter()
+        .map(|(tab, schema_sql)| {
+            Arc::new(VirtualTable {
+                name: format!("pragma_{}", tab.pragma_name),
+                columns: VirtualTable::resolve_columns(schema_sql)
+                    .expect("pragma table-valued function schema resolution should not fail"),
+                kind: VTabKind::TableValuedFunction,
+                vtab_type: VirtualTableType::Pragma(tab),
+                vtab_id: 0,
+                innocuous: true,
+            })
+        })
+        .collect()
+}

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -48,6 +48,7 @@ pub(crate) mod thread;
 
 mod assert;
 mod connection;
+mod dialect;
 mod error;
 mod ext;
 mod fast_lock;
@@ -182,6 +183,7 @@ pub use vdbe::{
     builder::QueryMode, explain::EXPLAIN_COLUMNS, explain::EXPLAIN_QUERY_PLAN_COLUMNS,
     FromValueRow, PrepareContext, PreparedProgram, Program, Register,
 };
+pub use vtab::{InternalVirtualTable, InternalVirtualTableCursor};
 
 /// Database index for the main database (always 0 in SQLite).
 pub const MAIN_DB_ID: usize = 0;
@@ -2672,6 +2674,24 @@ impl Database {
         let mut schema_ref = self.schema.lock();
         let schema = Arc::make_mut(&mut *schema_ref);
         f(schema)
+    }
+
+    /// Register an `InternalVirtualTable` into this database's catalog. The
+    /// table is visible to connections opened after this call and is queryable
+    /// like any other table.
+    ///
+    /// Intended for callers that want to surface state as a queryable table
+    /// without going through `CREATE VIRTUAL TABLE` — for example, extensions
+    /// contributing metadata tables or alternative-dialect catalogs.
+    ///
+    /// Call before opening connections. Connections that already exist will
+    /// not pick up the new table unless they re-read the shared schema (e.g.
+    /// via the usual schema-change path).
+    pub fn register_internal_vtab<T>(&self, table: T) -> Result<String>
+    where
+        T: InternalVirtualTable + 'static,
+    {
+        self.with_schema_mut(|schema| schema.register_internal_vtab(table))
     }
     pub(crate) fn clone_schema(&self) -> Arc<Schema> {
         let schema = self.schema.lock();

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -910,12 +910,6 @@ impl Schema {
         );
         #[cfg(feature = "conn_raw_api")]
         table_names_by_root_page.insert(1, SCHEMA_TABLE_NAME.to_string());
-        for function in VirtualTable::builtin_functions(enable_custom_types) {
-            tables.insert(
-                function.name.to_owned(),
-                Arc::new(Table::Virtual(Arc::new((*function).clone()))),
-            );
-        }
         let materialized_view_names = HashSet::default();
         let materialized_view_sql = HashMap::default();
         let incremental_views = HashMap::default();
@@ -927,7 +921,7 @@ impl Schema {
         if enable_custom_types {
             bootstrap_builtin_types(&mut type_registry)?;
         }
-        Ok(Self {
+        let mut schema = Self {
             tables,
             #[cfg(feature = "conn_raw_api")]
             table_names_by_root_page,
@@ -947,7 +941,30 @@ impl Schema {
             type_registry,
             generated_columns_enabled: false,
             sequences: HashMap::default(),
-        })
+        };
+        crate::dialect::sqlite::register_builtin_catalog(&mut schema, enable_custom_types)?;
+        Ok(schema)
+    }
+
+    /// Add an `InternalVirtualTable` to the schema's catalog. The wrapped
+    /// table appears under the name returned by its `name()` method and is
+    /// queryable like any other table. Returns the name actually inserted.
+    ///
+    /// Intended for callers that want to surface state as a queryable table
+    /// without going through `CREATE VIRTUAL TABLE` — for example, extensions
+    /// that contribute metadata tables or alternative-dialect catalogs.
+    pub fn register_internal_vtab<T>(&mut self, table: T) -> crate::Result<String>
+    where
+        T: crate::vtab::InternalVirtualTable + 'static,
+    {
+        let vtab = crate::vtab::VirtualTable::wrap_internal_table(table)?;
+        let name = vtab.name.clone();
+        let lookup_name = normalize_ident(&name);
+        self.tables.insert(
+            lookup_name,
+            Arc::new(Table::Virtual(Arc::new((*vtab).clone()))),
+        );
+        Ok(name)
     }
 
     /// Look up a custom type definition by name.

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -21,9 +21,9 @@ pub struct VirtualTable {
     pub(crate) name: String,
     pub(crate) columns: Vec<Column>,
     pub(crate) kind: VTabKind,
-    vtab_type: VirtualTableType,
+    pub(crate) vtab_type: VirtualTableType,
     // identifier to tie a cursor to a specific instantiated virtual table instance
-    vtab_id: u64,
+    pub(crate) vtab_id: u64,
     // Whether this virtual table is safe to use from within triggers and views.
     // Corresponds to SQLite's SQLITE_VTAB_INNOCUOUS flag.
     pub(crate) innocuous: bool,
@@ -41,115 +41,25 @@ impl VirtualTable {
         }
     }
 
-    #[cfg(feature = "cli_only")]
-    fn dbpage_virtual_table() -> Arc<VirtualTable> {
-        let dbpage_table = crate::dbpage::DbPageTable::new();
-        let dbpage_vtab = VirtualTable {
-            name: dbpage_table.name(),
-            columns: Self::resolve_columns(dbpage_table.sql())
-                .expect("sqlite_dbpage schema resolution should not fail"),
-            kind: VTabKind::TableValuedFunction,
-            vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(dbpage_table))),
-            vtab_id: 0,
-            innocuous: true,
-        };
-        Arc::new(dbpage_vtab)
-    }
-
-    #[cfg(feature = "cli_only")]
-    fn btree_dump_virtual_table() -> Arc<VirtualTable> {
-        let btree_dump_table = crate::btree_dump::BtreeDumpTable::new();
-        let vtab = VirtualTable {
-            name: btree_dump_table.name(),
-            columns: Self::resolve_columns(btree_dump_table.sql())
-                .expect("btree_dump schema resolution should not fail"),
-            kind: VTabKind::TableValuedFunction,
-            vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(btree_dump_table))),
-            vtab_id: 0,
-            innocuous: true,
-        };
-        Arc::new(vtab)
-    }
-
-    fn turso_types_virtual_table() -> Arc<VirtualTable> {
-        let table = crate::turso_types_vtab::TursoTypesTable::new();
-        let vtab = VirtualTable {
-            name: table.name(),
-            columns: Self::resolve_columns(table.sql())
-                .expect("sqlite_turso_types schema resolution should not fail"),
+    /// Wrap an `InternalVirtualTable` implementation so it can appear in a
+    /// `Schema`'s catalog. The table's `name()` becomes the catalog name and
+    /// its `sql()` is parsed to derive the column metadata. Returns an error
+    /// if the SQL string is not a valid `CREATE TABLE` statement.
+    pub(crate) fn wrap_internal_table<T>(table: T) -> crate::Result<Arc<VirtualTable>>
+    where
+        T: InternalVirtualTable + 'static,
+    {
+        let name = table.name();
+        let sql = table.sql();
+        let columns = Self::resolve_columns(sql)?;
+        Ok(Arc::new(VirtualTable {
+            name,
+            columns,
             kind: VTabKind::TableValuedFunction,
             vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(table))),
             vtab_id: 0,
             innocuous: true,
-        };
-        Arc::new(vtab)
-    }
-
-    pub(crate) fn builtin_functions(enable_custom_types: bool) -> Vec<Arc<VirtualTable>> {
-        let mut vtables: Vec<Arc<VirtualTable>> = PragmaVirtualTable::functions()
-            .into_iter()
-            .map(|(tab, schema)| {
-                let vtab = VirtualTable {
-                    name: format!("pragma_{}", tab.pragma_name),
-                    columns: Self::resolve_columns(schema)
-                        .expect("pragma table-valued function schema resolution should not fail"),
-                    kind: VTabKind::TableValuedFunction,
-                    vtab_type: VirtualTableType::Pragma(tab),
-                    vtab_id: 0,
-                    innocuous: true,
-                };
-                Arc::new(vtab)
-            })
-            .collect();
-
-        #[cfg(feature = "json")]
-        vtables.extend(Self::json_virtual_tables());
-
-        #[cfg(feature = "cli_only")]
-        vtables.push(Self::dbpage_virtual_table());
-
-        #[cfg(feature = "cli_only")]
-        vtables.push(Self::btree_dump_virtual_table());
-
-        if enable_custom_types {
-            vtables.push(Self::turso_types_virtual_table());
-        }
-
-        vtables
-    }
-
-    #[cfg(feature = "json")]
-    fn json_virtual_tables() -> Vec<Arc<VirtualTable>> {
-        use crate::json::vtab::JsonVirtualTable;
-
-        let json_each = JsonVirtualTable::json_each();
-
-        let json_each_virtual_table = VirtualTable {
-            name: json_each.name(),
-            columns: Self::resolve_columns(json_each.sql())
-                .expect("internal table-valued function schema resolution should not fail"),
-            kind: VTabKind::TableValuedFunction,
-            vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(json_each))),
-            vtab_id: 0,
-            innocuous: true,
-        };
-
-        let json_tree = JsonVirtualTable::json_tree();
-
-        let json_tree_virtual_table = VirtualTable {
-            name: json_tree.name(),
-            columns: Self::resolve_columns(json_tree.sql())
-                .expect("internal table-valued function schema resolution should not fail"),
-            kind: VTabKind::TableValuedFunction,
-            vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(json_tree))),
-            vtab_id: 0,
-            innocuous: true,
-        };
-
-        vec![
-            Arc::new(json_each_virtual_table),
-            Arc::new(json_tree_virtual_table),
-        ]
+        }))
     }
 
     pub(crate) fn function(name: &str, syms: &SymbolTable) -> crate::Result<Arc<VirtualTable>> {
@@ -194,7 +104,7 @@ impl VirtualTable {
         Ok(Arc::new(vtab))
     }
 
-    fn resolve_columns(schema: String) -> crate::Result<Vec<Column>> {
+    pub(crate) fn resolve_columns(schema: String) -> crate::Result<Vec<Column>> {
         let mut parser = Parser::new(schema.as_bytes());
         if let ast::Cmd::Stmt(ast::Stmt::CreateTable { body, .. }) =
             parser.next_cmd()?.ok_or_else(|| {
@@ -686,4 +596,159 @@ pub trait InternalVirtualTableCursor: Send + Sync {
         idx_str: Option<String>,
         idx_num: i32,
     ) -> Result<bool, LimboError>;
+}
+
+#[cfg(all(test, feature = "fs"))]
+mod tests {
+    use super::*;
+    use crate::{Database, DatabaseOpts, MemoryIO, OpenFlags};
+
+    /// Minimal `InternalVirtualTable` that exposes a fixed two-row table. Used
+    /// to verify that callers can register an arbitrary catalog table at
+    /// database open time and query it like any other table.
+    #[derive(Debug)]
+    struct StaticTable {
+        name: &'static str,
+    }
+
+    impl InternalVirtualTable for StaticTable {
+        fn name(&self) -> String {
+            self.name.to_string()
+        }
+        fn sql(&self) -> String {
+            format!("CREATE TABLE {}(key TEXT, value INTEGER)", self.name)
+        }
+        fn open(
+            &self,
+            _conn: Arc<Connection>,
+        ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
+            Ok(Arc::new(RwLock::new(StaticCursor {
+                rows: vec![("alpha".to_string(), 1), ("beta".to_string(), 2)],
+                position: -1,
+            })))
+        }
+        fn best_index(
+            &self,
+            constraints: &[turso_ext::ConstraintInfo],
+            _order_by: &[turso_ext::OrderByInfo],
+        ) -> std::result::Result<turso_ext::IndexInfo, ResultCode> {
+            Ok(turso_ext::IndexInfo {
+                idx_num: 0,
+                idx_str: None,
+                order_by_consumed: false,
+                estimated_cost: 1.0,
+                estimated_rows: 2,
+                constraint_usages: constraints
+                    .iter()
+                    .map(|_| turso_ext::ConstraintUsage {
+                        argv_index: None,
+                        omit: false,
+                    })
+                    .collect(),
+            })
+        }
+    }
+
+    struct StaticCursor {
+        rows: Vec<(String, i64)>,
+        position: i64,
+    }
+
+    impl InternalVirtualTableCursor for StaticCursor {
+        fn next(&mut self) -> Result<bool, LimboError> {
+            self.position += 1;
+            Ok((self.position as usize) < self.rows.len())
+        }
+        fn rowid(&self) -> i64 {
+            self.position
+        }
+        fn column(&self, column: usize) -> Result<Value, LimboError> {
+            let (key, value) = &self.rows[self.position as usize];
+            match column {
+                0 => Ok(Value::build_text(key.clone())),
+                1 => Ok(Value::from_i64(*value)),
+                _ => Err(LimboError::InternalError(format!(
+                    "column index {column} out of range"
+                ))),
+            }
+        }
+        fn filter(
+            &mut self,
+            _args: &[Value],
+            _idx_str: Option<String>,
+            _idx_num: i32,
+        ) -> Result<bool, LimboError> {
+            self.position = -1;
+            self.next()
+        }
+    }
+
+    #[test]
+    fn registered_internal_vtab_is_visible_to_connections() {
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            crate::util::MEMORY_PATH,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let name = db
+            .register_internal_vtab(StaticTable {
+                name: "external_metadata",
+            })
+            .unwrap();
+        assert_eq!(name, "external_metadata");
+
+        let conn = db.connect().unwrap();
+        let mut stmt = conn
+            .prepare("SELECT key, value FROM external_metadata")
+            .unwrap();
+        let rows = stmt.run_collect_rows().unwrap();
+        let mapped: Vec<(String, i64)> = rows
+            .into_iter()
+            .map(|cols| {
+                let key = match &cols[0] {
+                    Value::Text(t) => t.as_str().to_string(),
+                    other => panic!("unexpected key type {other:?}"),
+                };
+                let value = match &cols[1] {
+                    Value::Numeric(crate::Numeric::Integer(i)) => *i,
+                    other => panic!("unexpected value type {other:?}"),
+                };
+                (key, value)
+            })
+            .collect();
+        assert_eq!(
+            mapped,
+            vec![("alpha".to_string(), 1), ("beta".to_string(), 2)]
+        );
+    }
+
+    #[test]
+    fn registered_internal_vtab_lookup_folds_ascii_only() {
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            crate::util::MEMORY_PATH,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let name = db
+            .register_internal_vtab(StaticTable {
+                name: "External_ΔΥΣ",
+            })
+            .unwrap();
+        assert_eq!(name, "External_ΔΥΣ");
+
+        let conn = db.connect().unwrap();
+        let mut stmt = conn.prepare("SELECT key, value FROM external_ΔΥΣ").unwrap();
+        let rows = stmt.run_collect_rows().unwrap();
+        assert_eq!(rows.len(), 2);
+
+        assert!(conn.prepare("SELECT key, value FROM external_δυσ").is_err());
+    }
 }


### PR DESCRIPTION
Summary:
- add public Database/Schema registration for internal virtual tables
- register built-in SQLite catalog virtual tables through the same path
- normalize internal vtab catalog lookup keys while preserving SQLite ASCII-only identifier folding
- keep VirtualTable::wrap_internal_table crate-private

Tests:
- cargo test -p turso_core registered_internal_vtab
- cargo test was attempted; workspace build failed in turso_sqlite3 compat linking because libturso_sqlite3 was not found on the linker search path