### PR TITLE
Update outdated 'Limbo' project references to 'Turso'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ cargo run -Zbuild-std --target x86_64-unknown-linux-gnu -p turso_stress -- --vfs
 
 ## Finding things to work on
 
-The issue tracker has issues tagged with [good first issue](https://github.com/tursodatabase/limbo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22),
+The issue tracker has issues tagged with [good first issue](https://github.com/tursodatabase/turso/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22),
 which are considered to be things to work on to get going. If you're interested in working on one of them, comment on the issue tracker, and we're happy to help you get going.
 
 You don't need to ask "can I work on this?" The answer is always yes. Pick something, work on it, and open a pull request. A few things to keep in mind:

--- a/docs/contributing/contributing_functions.md
+++ b/docs/contributing/contributing_functions.md
@@ -42,12 +42,12 @@ Result
 TODO for implementing the function:
 - analysis
   - read and try out how the function works in SQLite.
-  - compare `explain` output of SQLite and Limbo.
+  - compare `explain` output of SQLite and Turso.
 - add/ update the function definition in `functions.rs`.
 - add/ update how to function is translated from `definition` to `instruction` in virtual machine layer VDBE.
 - add/ update the function Rust execution code and tests in vdbe layer.
 - add/ update how the bytecode `Program` executes when steps into the function.
-- add/ update TCL tests for this function in limbo/testing.
+- add/ update TCL tests for this function in testing/.
 - update doc for function compatibility.
 
 ### Analysis
@@ -68,24 +68,24 @@ addr  opcode         p1    p2    p3    p4             p5  comment
 6     Goto           0     1     0                    0
 ```
 
-Comparing that with `Limbo`:
+Comparing that with `Turso`:
 ```bash
 # created a sqlite database file database.db
 # or cargo run to use the memory mode if it is already available.
 > cargo run database.db
 
 Enter ".help" for usage hints.
-limbo> explain select date('now');
+tursodb> explain select date('now');
 Parse error: unknown function date
 ```
 
 We can see that the function is not implemented yet so the Parser did not understand it and throw an error `Parse error: unknown function date`.
-- we only need to pay attention to opcode `Function` at addr 2. The rest is already set up in limbo.
+- we only need to pay attention to opcode `Function` at addr 2. The rest is already set up in Turso.
 - we have up to 5 registers p1 to p5 for each opcode.
 
 ### Function definition
 
-For limbo to understand the meaning of `date`, we need to define it as a Function somewhere.
+For Turso to understand the meaning of `date`, we need to define it as a Function somewhere.
 That place can be found currently in `core/functions.rs`. We need to edit 3 places
 1. add to ScalarFunc as `date` is a scalar function. 
 ```diff

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,12 +1,12 @@
-# Testing in Limbo
+# Testing in Turso
 
-Limbo supports a comprehensive testing system to ensure correctness, performance, and compatibility with SQLite.
+Turso supports a comprehensive testing system to ensure correctness, performance, and compatibility with SQLite.
 
 ## 1. Compatibility Tests
 
 The `make test` target is the main entry point.
 
-Most compatibility tests live in the testing/ directory and are written in SQLite’s TCL test format. These tests ensure that Limbo matches SQLite’s behavior exactly. The database used during these tests is located at testing/testing.db, which includes the following schema:
+Most compatibility tests live in the testing/ directory and are written in SQLite’s TCL test format. These tests ensure that Turso matches SQLite’s behavior exactly. The database used during these tests is located at testing/testing.db, which includes the following schema:
 
 ```sql
 CREATE TABLE users (
@@ -55,7 +55,7 @@ Use these Python-based tests for validating:
 
   - Shell commands and .dot interactions
 
-  - Limbo-specific extensions in `testing/cli_tests/extensions.py`
+  - Turso-specific extensions in `testing/cli_tests/extensions.py`
 
   - Any known divergence from SQLite behavior
 
@@ -74,7 +74,7 @@ This will enable trace-level logs for the turso_core crate and disable logs else
 
 ## Deterministic Simulation Testing (DST):
 
-Limbo simulator uses randomized deterministic simulations to test the Limbo database behaviors.
+The Turso simulator uses randomized deterministic simulations to test Turso database behaviors.
 
 Each simulation begins with a random configurations:
 
@@ -115,7 +115,7 @@ RUST_LOG=limbo_sim=debug cargo run --bin limbo_sim
 The simulator CLI has a few configuration options that you can explore via `--help` flag.
 
 ```txt
-The Limbo deterministic simulator
+The Turso deterministic simulator
 
 Usage: limbo_sim [OPTIONS]
 
@@ -127,7 +127,7 @@ Options:
   -t, --maximum-time <MAXIMUM_TIME>  change the maximum time of the simulation(in seconds) [default: 3600]
   -l, --load <LOAD>                  load plan from the bug base
   -w, --watch                        enable watch mode that reruns the simulation on file changes
-      --differential                 run differential testing between sqlite and Limbo
+      --differential                 run differential testing between sqlite and Turso
   -h, --help                         Print help
   -V, --version                      Print version
 ```


### PR DESCRIPTION
Updates outdated project name references across documentation:

- **CONTRIBUTING.md**: Fix GitHub issues link pointing to `tursodatabase/limbo` → `tursodatabase/turso`
- **docs/testing.md**: Update title and project name references from 'Limbo' → 'Turso'
- **docs/contributing/contributing_functions.md**: Update project name, shell prompt (`limbo>` → `tursodb>`), and testing path (`limbo/testing` → `testing/`)

Binary names (`limbo_sim`) and image filenames (`limbo_architecture.png`) are left unchanged — those still reflect the actual tooling.