### PR TITLE
Add macOS mold linker installation instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,11 +74,14 @@ sudo dnf install mold
 
 # Ubuntu/Debian
 sudo apt install mold
+
+# macOS
+brew install mold
 ```
 
 Then configure Cargo to use mold by creating `.cargo/config.toml`:
 
-**For Linux:**
+**For Linux / macOS:**
 
 ```toml
 [target.x86_64-unknown-linux-gnu]


### PR DESCRIPTION
Adds `brew install mold` instructions for macOS users next to the existing Fedora/RHEL and Ubuntu/Debian sections. Also updates the section heading from 'For Linux' to 'For Linux / macOS' since the linker config works the same way.