### PR TITLE
core/wal: do not mark dirty pages clean during WAL cacheflush

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3343,8 +3343,12 @@ impl Pager {
         let mut dirty_pages = self.dirty_pages.write();
         dirty_pages.insert(page.get().id as u32);
         // Notify cache before marking dirty (page was evictable, now it won't be)
-        // Only notify if page wasn't already dirty
-        if !page.is_dirty() {
+        // Only notify if page wasn't already dirty, or if it was spilled
+        // State before set_dirty():
+        // - clean page: evictable -> set_dirty() makes it dirty and unevictable
+        // - dirty + spilled page: evictable -> set_dirty() clears spilled and makes it unevictable
+        // - dirty + not spilled page: already unevictable -> no cache accounting change
+        if !page.is_dirty() || page.is_spilled() {
             let key = PageCacheKey::new(page.get().id);
             self.page_cache.write().notify_page_dirty(key);
         }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4287,7 +4287,6 @@ impl Wal for WalFile {
             );
 
             for (page, fid, _csum) in &page_frame_for_cb {
-                page.clear_dirty();
                 page.set_wal_tag(*fid, epoch);
             }
         };

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -110,6 +110,84 @@ fn test_savepoint_rollback_after_cache_spill_preserves_wal_pages(
     Ok(())
 }
 
+#[allow(clippy::arc_with_non_send_sync)]
+#[turso_macros::test]
+fn test_wal_cacheflush_savepoint_rollback_preserves_pre_savepoint_indexed_rows(
+    tmp_db: TempDatabase,
+) -> Result<()> {
+    maybe_setup_tracing();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA page_size=512;")?;
+    conn.execute("PRAGMA journal_mode=WAL;")?;
+    conn.execute("PRAGMA cache_size=200;")?;
+    conn.execute("PRAGMA data_sync_retry=1;")?;
+
+    conn.execute(
+        "CREATE TABLE shy_rain_806 (
+            hot_cave_669 BLOB NOT NULL,
+            blue_wind_834 TEXT,
+            hard_star_751 NUMERIC UNIQUE,
+            angry_stone_202 INTEGER,
+            slow_sun_632 NUMERIC NOT NULL,
+            fast_fish_819 REAL PRIMARY KEY,
+            happy_lake_980 REAL NOT NULL,
+            brave_fish_935 NUMERIC NOT NULL
+        );",
+    )?;
+
+    for i in 0..260 {
+        conn.execute(format!(
+            "INSERT INTO shy_rain_806
+             (hot_cave_669, blue_wind_834, hard_star_751, angry_stone_202,
+              slow_sun_632, fast_fish_819, happy_lake_980, brave_fish_935)
+             VALUES (x'73656564', 'seed_{i}', {}, {}, {}, {:.2}, {:.2}, {});",
+            10_000 + i,
+            20_000 + i,
+            30_000 + i,
+            i as f64 + 0.25,
+            i as f64 + 0.75,
+            40_000 + i,
+        ))?;
+    }
+
+    conn.execute("BEGIN;")?;
+    conn.execute(
+        "UPDATE shy_rain_806
+         SET hot_cave_669 = x'75706461746564',
+             blue_wind_834 = 'updated',
+             hard_star_751 = hard_star_751 + 100000,
+             angry_stone_202 = angry_stone_202 + 1,
+             happy_lake_980 = happy_lake_980 + 1.0
+         WHERE fast_fish_819 BETWEEN 180.25 AND 240.25;",
+    )?;
+    conn.execute("SAVEPOINT sp_55;")?;
+    for completion in conn.cacheflush()? {
+        tmp_db.io.wait_for_completion(completion)?;
+    }
+    conn.execute(
+        "UPDATE shy_rain_806
+         SET blue_wind_834 = 'rolled_back',
+             hard_star_751 = hard_star_751 + 50000
+         WHERE fast_fish_819 = 204.25;",
+    )?;
+    conn.execute("ROLLBACK TO sp_55;")?;
+    conn.execute("RELEASE sp_55;")?;
+    conn.execute("COMMIT;")?;
+
+    let res = execute_and_get_strings(&conn, "PRAGMA integrity_check;")?;
+    assert_eq!(res, vec!["ok"]);
+    let count = execute_and_get_ints(&conn, "SELECT COUNT(*) FROM shy_rain_806;")?;
+    assert_eq!(count, vec![260]);
+    let updated = execute_and_get_ints(
+        &conn,
+        "SELECT COUNT(*) FROM shy_rain_806 WHERE hard_star_751 >= 110000;",
+    )?;
+    assert_eq!(updated, vec![61]);
+
+    Ok(())
+}
+
 #[test]
 #[ignore = "ignored for now because it's flaky"]
 fn test_wal_1_writer_1_reader() -> Result<()> {


### PR DESCRIPTION
## Motivation and context

## Prerequisites

It's important to understand (some phases of) page's lifecycle:

1. When a page is loaded into page cache and if modified, we set `PAGE_DIRTY`
2. During commit, we write this page to disk and clear the `PAGE_DIRTY` tag. We clear `PAGE_DIRTY` only during commit (or when txn is aborted, in that case we discard the page as well)
3. It is also possible that we 'spill' this page to disk when cache memory usage exceeds during a txn, in that case set `PAGE_SPILLED`

All these affect how we cache the pages and cache eviction policy:

```
evictable = clean OR spilled
```

i.e.

- clean page -> evictable: because no changes were made, and a copy of the page exists on disk already
- dirty page -> non evictable: because the copy of the page which exists on disk is different. if we evict, we will lose the only copy we have
- dirty + spilled page -> evictable: well, because the changes we made persist on disk. so even if we evict this dirty page, we can always reload from the disk

So the intended state transitions are:

```
UPDATE page:
  clean -> dirty
  spilled cleared

spill dirty page:
  dirty -> dirty (unchanged)
  set spilled

modify spilled page again:
  dirty + spilled -> dirty
  spilled cleared

commit:
  dirty pages are written as commit frames
  committed pages become clean
  dirty_pages is cleared

rollback/discard:
  dirty transaction state is discarded or restored from savepoint state
```

The bug happened we were marking a page as clean during cache flush

## The bug

Let's say this is the starting state:

```
Committed WAL max frame = 100

Page 20 = table leaf page
Page 31 = index leaf page
Page 44 = another index/table page
```

We have following sequence of ops:

```sql
BEGIN;

UPDATE t
SET indexed_col = indexed_col + 100000     --- first update
WHERE k BETWEEN 180 AND 240;

SAVEPOINT sp;

cacheflush();							   --- spilled due to memory pressure

UPDATE t
SET indexed_col = indexed_col + 50000      --- second update
WHERE k = 204;

ROLLBACK TO sp;
RELEASE sp;
COMMIT;
```

Now assume the first update changes those pages:

```
Page 20: modified in memory, dirty
Page 31: modified in memory, dirty
Page 44: modified in memory, dirty

dirty_pages = {20, 31, 44}

conn.wal.max_frame is still 100 (because there is no new commit yet nor we have written our changes to WAL)
```

Then:

```sql
SAVEPOINT sp;
```

The savepoint records the current connection-local WAL state.

```
sp.wal_max_frame = 100
```

The savepoint state is:

```
WAL/DB state up to frame 100
+
dirty in-memory pages {20, 31, 44}
```

Those dirty pages were changed before the savepoint, so they must survive ROLLBACK TO sp.

Then:

```sql
cacheflush();
```

cacheflush() writes dirty pages to non-commit WAL frames.

Example:

```
Page 20 -> WAL frame 101
Page 31 -> WAL frame 102
Page 44 -> WAL frame 103
```

These frames have db_size = 0, so they are not commit frames.

After cacheflush, the correct state should be:

```
Page 20: dirty, wal_tag = 101
Page 31: dirty, wal_tag = 102
Page 44: dirty, wal_tag = 103

dirty_pages = {20, 31, 44}
conn.wal.max_frame = 103
shared committed WAL max frame is still 100
```

The old bug incorrectly made the pages clean:

```
Page 20: clean, wal_tag = 101
Page 31: clean, wal_tag = 102
Page 44: clean, wal_tag = 103

dirty_pages = {20, 31, 44}
```

That is inconsistent: dirty_pages still says these page ids belong to the transaction, but the cached pages no longer look like protected transaction-local state.

Then:

```sql
UPDATE t
SET indexed_col = indexed_col + 50000
WHERE k = 204;
```

Assume this second update touches only pages 20 and 31.

Before changing each touched page, savepoint logic writes its current contents to the subjournal. That current content includes the first update’s +100000 change.

Example:

```
Subjournal stores:
Page 20 image as of savepoint sp
Page 31 image as of savepoint sp

Then second update modifies:
Page 20
Page 31
```

Page 44 is not touched after the savepoint, so it is not subjournaled. That is fine. Since page 44 did not change after the savepoint, rollback should not need to restore it.

Then:

```sql
ROLLBACK TO sp;
```

Rollback does two separate things.

First, it restores pages changed after the savepoint from the subjournal:

```
Page 20 restored from subjournal, dirty
Page 31 restored from subjournal, dirty
```

Now pages 20 and 31 again contain the +100000 state from before the savepoint, with the later +50000 change undone.

Second, rollback restores the connection-local WAL state:

```
conn.wal.max_frame = sp.wal_max_frame = 100
```

So frames 101, 102, and 103 are no longer in the valid WAL view for this connection. They still physically exist in the WAL file though.

Then rollback cleanup removes clean cached pages whose WAL tag is after the savepoint frame.

With the old bug, page 44 looks like this:

```
Page 44: clean, wal_tag = 103
```

Because it is clean and tagged after frame 100, rollback cleanup can delete it from the page cache.

Now the state is broken:

```
dirty_pages = {20, 31, 44}

Page 20: in cache, dirty, correct bytes
Page 31: in cache, dirty, correct bytes
Page 44: missing from cache

conn.wal.max_frame = 100
```

But page 44 was changed by the first update before the savepoint. The only valid copy was the cached dirty page, and it was deleted.

Then:

```sql
RELEASE sp;
```

This just removes the savepoint. It does not recover page 44.

Then:

```sql
COMMIT;
```

Commit scans dirty_pages:

```
dirty_pages = {20, 31, 44}
```

For pages 20 and 31, commit finds them in cache:

```
Page 20 -> commit correct dirty bytes
Page 31 -> commit correct dirty bytes
```

For page 44, commit does not find it in cache, so it reloads the page from the current storage view.

But the current WAL view stops at frame 100:

```
conn.wal.max_frame = 100
```

So commit cannot read frame 103, even though frame 103 physically exists on disk. Frame 103 is after the rollback target and is no longer part of the valid WAL view.

Commit reloads page 44 from frame <= 100 or from the DB file. That gives the old committed version of page 44, before the first update.

Then commit writes a final transaction with mixed page images:

```
Page 20: correct, includes +100000
Page 31: correct, includes +100000
Page 44: stale, missing +100000
```

This causes data loss / data corruption.

The important idea is:

```
A savepoint's state is:
WAL/DB up to savepoint.wal_max_frame
plus dirty in-memory pages that already existed at the savepoint.
```

A page changed before the savepoint may not have been written to WAL yet. It may only exist as a dirty cached page.

The correct invariant is:

```
cacheflush may write dirty page bytes to non-commit WAL frames but cacheflush must not clear the dirty flag.
```


Another smoll fix we do for cache accounting:

```rust
if !page.is_dirty() || page.is_spilled() {
  notify_page_dirty(...)
}
page.set_dirty();
```

This covers both cases where cache accounting changes:

```
clean -> dirty
dirty + spilled -> dirty + not spilled
```

It intentionally does nothing for:

```
dirty + not spilled -> dirty + not spilled
```

because that page was already unevictable, so the cache count does not change.


```
$ CARGO_INCREMENTAL=0 cargo test -p core_tester --test integration_tests test_wal_cacheflush_savepoint_rollback_preserves_pre_savepoint_indexed_rows -- --nocapture


thread 'wal::test_wal::test_wal_cacheflush_savepoint_rollback_preserves_pre_savepoint_indexed_rows' panicked at tests/integration/wal/test_wal.rs:179:5:
assertion `left == right` failed
  left: ["row 195 missing from index sqlite_autoindex_shy_rain_806_1", "row 196 missing from index sqlite_autoindex_shy_rain_806_1", "row 197 missing from index sqlite_autoindex_shy_rain_806_1", "row 198 missing from index sqlite_autoindex_shy_rain_806_1", "row 199 missing from index sqlite_autoindex_shy_rain_806_1", "row 200 missing from index sqlite_autoindex_shy_rain_806_1", "row 201 missing from index sqlite_autoindex_shy_rain_806_1", "row 202 missing from index sqlite_autoindex_shy_rain_806_1", "row 203 missing from index sqlite_autoindex_shy_rain_806_1", "row 204 missing from index sqlite_autoindex_shy_rain_806_1", "row 205 missing from index sqlite_autoindex_shy_rain_806_1", "row 206 missing from index sqlite_autoindex_shy_rain_806_1", "row 207 missing from index sqlite_autoindex_shy_rain_806_1", "row 208 missing from index sqlite_autoindex_shy_rain_806_1", "row 209 missing from index sqlite_autoindex_shy_rain_806_1", "row 212 missing from index sqlite_autoindex_shy_rain_806_1", "row 213 missing from index sqlite_autoindex_shy_rain_806_1", "row 214 missing from index sqlite_autoindex_shy_rain_806_1", "row 215 missing from index sqlite_autoindex_shy_rain_806_1", "row 216 missing from index sqlite_autoindex_shy_rain_806_1", "row 217 missing from index sqlite_autoindex_shy_rain_806_1", "row 218 missing from index sqlite_autoindex_shy_rain_806_1", "row 219 missing from index sqlite_autoindex_shy_rain_806_1", "row 220 missing from index sqlite_autoindex_shy_rain_806_1", "row 221 missing from index sqlite_autoindex_shy_rain_806_1", "row 222 missing from index sqlite_autoindex_shy_rain_806_1", "row 223 missing from index sqlite_autoindex_shy_rain_806_1", "row 224 missing from index sqlite_autoindex_shy_rain_806_1", "row 225 missing from index sqlite_autoindex_shy_rain_806_1", "row 226 missing from index sqlite_autoindex_shy_rain_806_1", "row 227 missing from index sqlite_autoindex_shy_rain_806_1", "row 228 missing from index sqlite_autoindex_shy_rain_806_1", "row 229 missing from index sqlite_autoindex_shy_rain_806_1", "row 230 missing from index sqlite_autoindex_shy_rain_806_1", "row 231 missing from index sqlite_autoindex_shy_rain_806_1", "row 233 missing from index sqlite_autoindex_shy_rain_806_1", "row 234 missing from index sqlite_autoindex_shy_rain_806_1", "row 235 missing from index sqlite_autoindex_shy_rain_806_1", "row 236 missing from index sqlite_autoindex_shy_rain_806_1", "row 237 missing from index sqlite_autoindex_shy_rain_806_1", "row 238 missing from index sqlite_autoindex_shy_rain_806_1", "row 239 missing from index sqlite_autoindex_shy_rain_806_1", "row 240 missing from index sqlite_autoindex_shy_rain_806_1", "row 241 missing from index sqlite_autoindex_shy_rain_806_1", "row 242 missing from index sqlite_autoindex_shy_rain_806_1", "row 243 missing from index sqlite_autoindex_shy_rain_806_1", "row 244 missing from index sqlite_autoindex_shy_rain_806_1", "row 245 missing from index sqlite_autoindex_shy_rain_806_1", "row 246 missing from index sqlite_autoindex_shy_rain_806_1", "row 247 missing from index sqlite_autoindex_shy_rain_806_1", "row 248 missing from index sqlite_autoindex_shy_rain_806_1", "row 249 missing from index sqlite_autoindex_shy_rain_806_1", "row 250 missing from index sqlite_autoindex_shy_rain_806_1", "row 251 missing from index sqlite_autoindex_shy_rain_806_1", "row 252 missing from index sqlite_autoindex_shy_rain_806_1", "row 253 missing from index sqlite_autoindex_shy_rain_806_1", "row 254 missing from index sqlite_autoindex_shy_rain_806_1", "row 255 missing from index sqlite_autoindex_shy_rain_806_1", "row 256 missing from index sqlite_autoindex_shy_rain_806_1", "row 257 missing from index sqlite_autoindex_shy_rain_806_1", "row 258 missing from index sqlite_autoindex_shy_rain_806_1", "row 259 missing from index sqlite_autoindex_shy_rain_806_1", "row 260 missing from index sqlite_autoindex_shy_rain_806_1", "wrong # of entries in index sqlite_autoindex_shy_rain_806_1"]
 right: ["ok"]

test wal::test_wal::test_wal_cacheflush_savepoint_rollback_preserves_pre_savepoint_indexed_rows ... FAILED
```

with patch:

```
running 1 test
test wal::test_wal::test_wal_cacheflush_savepoint_rollback_preserves_pre_savepoint_indexed_rows ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 960 filtered out; finished in 0.10s
```

## Description of AI Usage

I used everything: Claude, Fable, Codex and still it did not come up with a proper fix though it did identify the bug.