### PR TITLE
ci: Gate CodSpeed shards on matching build

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -52,37 +52,33 @@ jobs:
           json=$(printf '%s\n' "${benchmarks[@]}" | jq -R . | jq -cs .)
           echo "benchmarks=$json" >> "$GITHUB_OUTPUT"
 
-  build:
-    name: "Build benchmarks (${{ matrix.toolchain.label }})"
+  build-stable:
+    name: "Build benchmarks (stable)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: discover
     timeout-minutes: 60
     # Allow this job to fail without failing the entire CI run
     continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain:
-          - label: stable
-            version: "1.88.0"
-            rustflags: ""
-          - label: nightly
-            version: "nightly-2025-12-17"
-            rustflags: "--cfg nightly"
+    outputs:
+      built: ${{ steps.build_status.outputs.built }}
+    env:
+      TOOLCHAIN_LABEL: stable
+      TOOLCHAIN_VERSION: "1.88.0"
+      TOOLCHAIN_RUSTFLAGS: ""
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.toolchain.version }}
+          toolchain: ${{ env.TOOLCHAIN_VERSION }}
 
       - name: Setup mold linker
         uses: rui314/setup-mold@v1
 
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-rust-codspeed-${{ matrix.toolchain.label }}"
+          prefix-key: "v1-rust-codspeed-${{ env.TOOLCHAIN_LABEL }}"
           cache-on-failure: true
 
       - uses: "./.github/shared/setup-sccache"
@@ -95,7 +91,7 @@ jobs:
       - name: Mount benchmark sticky disk
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ matrix.toolchain.label }}
+          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ env.TOOLCHAIN_LABEL }}
           path: target/codspeed
 
       - name: Generate graph-queries DBs
@@ -105,43 +101,52 @@ jobs:
           sqlite3 perf/graph-queries/graph-queries-analyzed.db "ANALYZE;"
 
       - name: Build benchmarks (excluding TPC-H)
+        id: build_benchmarks
         env:
           BENCHMARKS_JSON: ${{ needs.discover.outputs.benchmarks }}
-          RUSTFLAGS: ${{ matrix.toolchain.rustflags }}
+          RUSTFLAGS: ${{ env.TOOLCHAIN_RUSTFLAGS }}
         shell: bash
         run: |
           set -euo pipefail
 
           bench_args=$(jq -r '.[] | "--bench " + .' <<< "$BENCHMARKS_JSON" | tr '\n' ' ')
-          cargo +${{ matrix.toolchain.version }} codspeed build $bench_args --features codspeed
+          cargo +${{ env.TOOLCHAIN_VERSION }} codspeed build $bench_args --features codspeed
 
-  benchmarks:
-    name: "Run benchmark (${{ matrix.toolchain.label }}, ${{ matrix.benchmark }})"
+      - name: Record build status
+        id: build_status
+        if: always()
+        run: echo "built=${{ steps.build_benchmarks.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
+
+  build-nightly:
+    name: "Build benchmarks (nightly)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs:
-      - discover
-      - build
-    timeout-minutes: 30
+    needs: discover
+    timeout-minutes: 60
     # Allow this job to fail without failing the entire CI run
     continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain:
-          - label: stable
-            version: "1.88.0"
-            rustflags: ""
-          - label: nightly
-            version: "nightly-2025-12-17"
-            rustflags: "--cfg nightly"
-        benchmark: ${{ fromJson(needs.discover.outputs.benchmarks) }}
+    outputs:
+      built: ${{ steps.build_status.outputs.built }}
+    env:
+      TOOLCHAIN_LABEL: nightly
+      TOOLCHAIN_VERSION: "nightly-2025-12-17"
+      TOOLCHAIN_RUSTFLAGS: "--cfg nightly"
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.toolchain.version }}
+          toolchain: ${{ env.TOOLCHAIN_VERSION }}
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-codspeed-${{ env.TOOLCHAIN_LABEL }}"
+          cache-on-failure: true
+
+      - uses: "./.github/shared/setup-sccache"
 
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2
@@ -151,7 +156,67 @@ jobs:
       - name: Mount benchmark sticky disk
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ matrix.toolchain.label }}
+          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ env.TOOLCHAIN_LABEL }}
+          path: target/codspeed
+
+      - name: Generate graph-queries DBs
+        run: |
+          python3 perf/graph-queries/generate_seed.py | sqlite3 perf/graph-queries/graph-queries.db
+          cp perf/graph-queries/graph-queries.db perf/graph-queries/graph-queries-analyzed.db
+          sqlite3 perf/graph-queries/graph-queries-analyzed.db "ANALYZE;"
+
+      - name: Build benchmarks (excluding TPC-H)
+        id: build_benchmarks
+        env:
+          BENCHMARKS_JSON: ${{ needs.discover.outputs.benchmarks }}
+          RUSTFLAGS: ${{ env.TOOLCHAIN_RUSTFLAGS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          bench_args=$(jq -r '.[] | "--bench " + .' <<< "$BENCHMARKS_JSON" | tr '\n' ' ')
+          cargo +${{ env.TOOLCHAIN_VERSION }} codspeed build $bench_args --features codspeed
+
+      - name: Record build status
+        id: build_status
+        if: always()
+        run: echo "built=${{ steps.build_benchmarks.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
+
+  benchmarks-stable:
+    name: "Run benchmark (stable, ${{ matrix.benchmark }})"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - discover
+      - build-stable
+    if: needs.build-stable.outputs.built == 'true'
+    timeout-minutes: 30
+    # Allow this job to fail without failing the entire CI run
+    continue-on-error: true
+    env:
+      TOOLCHAIN_VERSION: "1.88.0"
+      TOOLCHAIN_LABEL: stable
+      TOOLCHAIN_RUSTFLAGS: ""
+    strategy:
+      fail-fast: false
+      matrix:
+        benchmark: ${{ fromJson(needs.discover.outputs.benchmarks) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.TOOLCHAIN_VERSION }}
+
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed
+
+      - name: Mount benchmark sticky disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ env.TOOLCHAIN_LABEL }}
           path: target/codspeed
 
       - name: Restore binary permissions
@@ -167,17 +232,74 @@ jobs:
       - name: Run benchmarks (excluding TPC-H)
         uses: CodSpeedHQ/action@v4.17.0
         env:
-          RUSTFLAGS: ${{ matrix.toolchain.rustflags }}
+          RUSTFLAGS: ${{ env.TOOLCHAIN_RUSTFLAGS }}
         with:
           mode: simulation
-          run: cargo +${{ matrix.toolchain.version }} codspeed run --bench ${{ matrix.benchmark }}
+          run: cargo +${{ env.TOOLCHAIN_VERSION }} codspeed run --bench ${{ matrix.benchmark }}
+
+  benchmarks-nightly:
+    name: "Run benchmark (nightly, ${{ matrix.benchmark }})"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - discover
+      - build-nightly
+    if: needs.build-nightly.outputs.built == 'true'
+    timeout-minutes: 30
+    # Allow this job to fail without failing the entire CI run
+    continue-on-error: true
+    env:
+      TOOLCHAIN_VERSION: "nightly-2025-12-17"
+      TOOLCHAIN_LABEL: nightly
+      TOOLCHAIN_RUSTFLAGS: "--cfg nightly"
+    strategy:
+      fail-fast: false
+      matrix:
+        benchmark: ${{ fromJson(needs.discover.outputs.benchmarks) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.TOOLCHAIN_VERSION }}
+
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed
+
+      - name: Mount benchmark sticky disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ env.TOOLCHAIN_LABEL }}
+          path: target/codspeed
+
+      - name: Restore binary permissions
+        run: find target/codspeed -type f -exec chmod +x {} +
+
+      - name: Generate graph-queries DBs
+        if: matrix.benchmark == 'graph_queries_benchmark'
+        run: |
+          python3 perf/graph-queries/generate_seed.py | sqlite3 perf/graph-queries/graph-queries.db
+          cp perf/graph-queries/graph-queries.db perf/graph-queries/graph-queries-analyzed.db
+          sqlite3 perf/graph-queries/graph-queries-analyzed.db "ANALYZE;"
+
+      - name: Run benchmarks (excluding TPC-H)
+        uses: CodSpeedHQ/action@v4.17.0
+        env:
+          RUSTFLAGS: ${{ env.TOOLCHAIN_RUSTFLAGS }}
+        with:
+          mode: simulation
+          run: cargo +${{ env.TOOLCHAIN_VERSION }} codspeed run --bench ${{ matrix.benchmark }}
 
   cleanup:
     name: "Delete benchmark sticky disk (${{ matrix.toolchain }})"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
-      - build
-      - benchmarks
+      - build-stable
+      - build-nightly
+      - benchmarks-stable
+      - benchmarks-nightly
     if: always()
     strategy:
       fail-fast: false

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -19,7 +19,6 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
-  CODSPEED_STICKY_DISK_KEY: ${{ github.repository }}-codspeed-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   discover:
@@ -88,12 +87,6 @@ jobs:
         with:
           tool: cargo-codspeed
 
-      - name: Mount benchmark sticky disk
-        uses: useblacksmith/stickydisk@v1
-        with:
-          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ env.TOOLCHAIN_LABEL }}
-          path: target/codspeed
-
       - name: Generate graph-queries DBs
         run: |
           python3 perf/graph-queries/generate_seed.py | sqlite3 perf/graph-queries/graph-queries.db
@@ -110,12 +103,22 @@ jobs:
           set -euo pipefail
 
           bench_args=$(jq -r '.[] | "--bench " + .' <<< "$BENCHMARKS_JSON" | tr '\n' ' ')
-          cargo +${{ env.TOOLCHAIN_VERSION }} codspeed build $bench_args --features codspeed
+          cargo +${{ env.TOOLCHAIN_VERSION }} codspeed build -m simulation $bench_args --features codspeed
+
+      - name: Upload benchmark binaries
+        id: upload_artifact
+        if: steps.build_benchmarks.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: codspeed-benchmarks-${{ env.TOOLCHAIN_LABEL }}
+          path: target/codspeed
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Record build status
         id: build_status
         if: always()
-        run: echo "built=${{ steps.build_benchmarks.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
+        run: echo "built=${{ steps.build_benchmarks.outcome == 'success' && steps.upload_artifact.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
 
   build-nightly:
     name: "Build benchmarks (nightly)"
@@ -153,12 +156,6 @@ jobs:
         with:
           tool: cargo-codspeed
 
-      - name: Mount benchmark sticky disk
-        uses: useblacksmith/stickydisk@v1
-        with:
-          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ env.TOOLCHAIN_LABEL }}
-          path: target/codspeed
-
       - name: Generate graph-queries DBs
         run: |
           python3 perf/graph-queries/generate_seed.py | sqlite3 perf/graph-queries/graph-queries.db
@@ -175,12 +172,22 @@ jobs:
           set -euo pipefail
 
           bench_args=$(jq -r '.[] | "--bench " + .' <<< "$BENCHMARKS_JSON" | tr '\n' ' ')
-          cargo +${{ env.TOOLCHAIN_VERSION }} codspeed build $bench_args --features codspeed
+          cargo +${{ env.TOOLCHAIN_VERSION }} codspeed build -m simulation $bench_args --features codspeed
+
+      - name: Upload benchmark binaries
+        id: upload_artifact
+        if: steps.build_benchmarks.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: codspeed-benchmarks-${{ env.TOOLCHAIN_LABEL }}
+          path: target/codspeed
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Record build status
         id: build_status
         if: always()
-        run: echo "built=${{ steps.build_benchmarks.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
+        run: echo "built=${{ steps.build_benchmarks.outcome == 'success' && steps.upload_artifact.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
 
   benchmarks-stable:
     name: "Run benchmark (stable, ${{ matrix.benchmark }})"
@@ -213,10 +220,10 @@ jobs:
         with:
           tool: cargo-codspeed
 
-      - name: Mount benchmark sticky disk
-        uses: useblacksmith/stickydisk@v1
+      - name: Download benchmark binaries
+        uses: actions/download-artifact@v4
         with:
-          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ env.TOOLCHAIN_LABEL }}
+          name: codspeed-benchmarks-${{ env.TOOLCHAIN_LABEL }}
           path: target/codspeed
 
       - name: Restore binary permissions
@@ -268,10 +275,10 @@ jobs:
         with:
           tool: cargo-codspeed
 
-      - name: Mount benchmark sticky disk
-        uses: useblacksmith/stickydisk@v1
+      - name: Download benchmark binaries
+        uses: actions/download-artifact@v4
         with:
-          key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ env.TOOLCHAIN_LABEL }}
+          name: codspeed-benchmarks-${{ env.TOOLCHAIN_LABEL }}
           path: target/codspeed
 
       - name: Restore binary permissions
@@ -291,27 +298,6 @@ jobs:
         with:
           mode: simulation
           run: cargo +${{ env.TOOLCHAIN_VERSION }} codspeed run --bench ${{ matrix.benchmark }}
-
-  cleanup:
-    name: "Delete benchmark sticky disk (${{ matrix.toolchain }})"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs:
-      - build-stable
-      - build-nightly
-      - benchmarks-stable
-      - benchmarks-nightly
-    if: always()
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain:
-          - stable
-          - nightly
-    steps:
-      - name: Delete benchmark sticky disk
-        uses: useblacksmith/stickydisk-delete@v1
-        with:
-          delete-key: ${{ env.CODSPEED_STICKY_DISK_KEY }}-${{ matrix.toolchain }}
 
   # tpc-h:
   #   runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,11 @@ limbo/
 - **[Async I/O Model](docs/agent-guides/async-io-model.md)** - IOResult, state machines, re-entrancy
 - **[MVCC](docs/agent-guides/mvcc.md)** - experimental multi-version concurrency (WIP)
 
+## Benchmark Naming
+
+- Criterion benchmark functions must use `#[turso_macros::codspeed_criterion_benchmark]` so stable and nightly CodSpeed runs get distinct benchmark names.
+- Divan benchmark functions must use `#[turso_macros::divan_bench]` for the same stable/nightly naming behavior.
+
 ## Core Principles
 
 1. **Correctness paramount.** Production DB, not a toy. Crash > corrupt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,6 +3568,7 @@ dependencies = [
  "criterion",
  "memory-benchmark",
  "tokio",
+ "turso_macros",
 ]
 
 [[package]]
@@ -4467,6 +4468,7 @@ dependencies = [
  "rusqlite",
  "tokio",
  "turso",
+ "turso_macros",
 ]
 
 [[package]]

--- a/core/benches/prepare_params_benchmark.rs
+++ b/core/benches/prepare_params_benchmark.rs
@@ -79,6 +79,7 @@ fn build_insert(rows: usize) -> String {
     sql
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_prepare_params(c: &mut Criterion) {
     let mut group = c.benchmark_group("prepare_multirow_insert");
 

--- a/perf/memory/codspeed/Cargo.toml
+++ b/perf/memory/codspeed/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2024"
 license.workspace = true
 publish = false
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }
+
 [features]
 codspeed = []
 
@@ -18,6 +21,7 @@ memory-benchmark = { path = ".." }
 tokio = { workspace = true, default-features = true, features = ["full"] }
 criterion = { workspace = true }
 codspeed-criterion-compat = { workspace = true }
+turso_macros = { workspace = true }
 
 [[bench]]
 name = "memory_profiles"

--- a/perf/memory/codspeed/benches/memory_profiles.rs
+++ b/perf/memory/codspeed/benches/memory_profiles.rs
@@ -63,6 +63,7 @@ fn base_workload_size(workload: WorkloadProfile) -> (usize, usize) {
     }
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_memory_profiles(c: &mut Criterion) {
     let work_dir = std::env::temp_dir().join(format!("turso-memory-bench-{}", std::process::id()));
     std::fs::create_dir_all(&work_dir).expect("failed to create bench work dir");
@@ -89,6 +90,7 @@ fn bench_memory_profiles(c: &mut Criterion) {
     }
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_workload(
     c: &mut Criterion,
     work_dir: &std::path::Path,

--- a/perf/query-batch/Cargo.toml
+++ b/perf/query-batch/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license.workspace = true
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }
+
 [dependencies]
 turso = { workspace = true }
 rusqlite = { workspace = true }
@@ -11,6 +14,7 @@ tokio = { workspace = true, default-features = true, features = ["full"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
+turso_macros = { workspace = true }
 
 [[bench]]
 name = "query_batch"

--- a/perf/query-batch/benches/query_batch.rs
+++ b/perf/query-batch/benches/query_batch.rs
@@ -121,6 +121,7 @@ fn text_value(row: &turso::Row, idx: usize) -> String {
     }
 }
 
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group("query_batch");


### PR DESCRIPTION
## Summary

- split CodSpeed stable/nightly builds and benchmark shards so each shard group depends on its matching build
- record build success as a job output and skip shards when that toolchain build fails
- apply CodSpeed benchmark naming macros to remaining Criterion benchmark code and document the requirement in `AGENTS.md`

