### PR TITLE
Add core page codec hooks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -475,8 +475,20 @@ jobs:
           cache-on-failure: true
       - name: Run Windows concurrent simulator multiprocess regressions
         run: cargo test -q -p turso_whopper --test regression_tests
+      - name: Reclaim Windows runner disk space
+        shell: pwsh
+        run: |
+          Get-PSDrive -PSProvider FileSystem
+          if (Get-Command docker -ErrorAction SilentlyContinue) {
+            docker system prune --all --force
+          }
+          Get-ChildItem -LiteralPath ([System.IO.Path]::GetTempPath()) -Force -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+          Get-PSDrive -PSProvider FileSystem
       - name: Run Windows concurrent simulator cross-platform regression
-        run: cargo test -q -p turso_whopper --test regression_tests_cross_platform
+        # Each test preallocates 8 GiB backing files. Run serially to stay below
+        # the Windows runner's per-job allocation limit.
+        run: cargo test -q -p turso_whopper --test regression_tests_cross_platform -- --test-threads=1
       - name: Run Windows CLI multiprocess VFS regression
         run: cargo test -q -p turso_cli input::tests::experimental_win_iocp_backend_is_available_for_path_databases -- --exact
       - name: Run Windows core multiprocess regressions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7547,7 +7547,6 @@ dependencies = [
  "anyhow",
  "clap",
  "hex",
- "memmap2",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "serde",

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -622,7 +622,7 @@ impl Connection {
                 None,
                 self.db.dialect(),
             )?;
-            let pager = Arc::new(db._init(None)?);
+            let pager = Arc::new(db._init(None, None)?);
             pager.set_initial_page_size(page_size)?;
             return Ok(TempDatabase {
                 db,
@@ -653,7 +653,7 @@ impl Connection {
                 None,
                 self.db.dialect(),
             )?;
-            let pager = Arc::new(db._init(None)?);
+            let pager = Arc::new(db._init(None, None)?);
             pager.set_initial_page_size(page_size)?;
             Ok(TempDatabase {
                 db,
@@ -673,7 +673,7 @@ impl Connection {
                 None,
                 self.db.dialect(),
             )?;
-            let pager = Arc::new(db._init(None)?);
+            let pager = Arc::new(db._init(None, None)?);
             pager.set_initial_page_size(page_size)?;
             Ok(TempDatabase { db, pager })
         }
@@ -690,7 +690,7 @@ impl Connection {
             None,
             self.db.dialect(),
         )?;
-        let pager = Arc::new(db._init(None)?);
+        let pager = Arc::new(db._init(None, None)?);
         pager.set_initial_page_size(self.get_page_size())?;
         Ok(TempDatabase {
             db,
@@ -3358,6 +3358,12 @@ impl Connection {
                             "reserved name {alias} is already in use"
                         )));
                     }
+                    if self.pager.load().has_page_codec() {
+                        return Err(LimboError::InvalidArgument(
+                            "ATTACH is unsupported for connections using an external page codec"
+                                .to_string(),
+                        ));
+                    }
 
                     let db_opts = DatabaseOpts::new()
                         .with_views(self.db.experimental_views_enabled())
@@ -3408,9 +3414,11 @@ impl Connection {
                     }));
                 }
                 AttachDatabaseState::Init(init) => {
-                    let mut pager = Arc::new(crate::return_if_io!(init
-                        .db
-                        ._init_nonblock(&mut init.init_st, init.encryption_key.as_ref(),)));
+                    let mut pager = Arc::new(crate::return_if_io!(init.db._init_nonblock(
+                        &mut init.init_st,
+                        init.encryption_key.as_ref(),
+                        None,
+                    )));
 
                     if !init.attached_is_fresh {
                         self.reject_initialized_attach_mismatches(&init.alias, &init.db, &pager)?;
@@ -4493,6 +4501,20 @@ impl Connection {
 
     pub fn set_reserved_bytes(&self, reserved_bytes: u8) -> Result<()> {
         let pager = self.pager.load();
+        if let Some(required_reserved_bytes) = pager.encryption_reserved_space() {
+            if reserved_bytes != required_reserved_bytes {
+                return Err(LimboError::InvalidArgument(format!(
+                    "built-in encryption requires exactly {required_reserved_bytes} reserved bytes"
+                )));
+            }
+        } else if let Some(codec) = pager.page_codec() {
+            let required_reserved_bytes = codec.required_reserved_bytes();
+            if reserved_bytes != required_reserved_bytes {
+                return Err(LimboError::InvalidArgument(format!(
+                    "page codec requires exactly {required_reserved_bytes} reserved bytes"
+                )));
+            }
+        }
         pager.set_reserved_space_bytes(reserved_bytes);
         Ok(())
     }
@@ -4513,9 +4535,16 @@ impl Connection {
 
     fn ensure_can_change_encryption_settings(&self) -> Result<()> {
         let pager = self.pager.load();
-        if pager.is_encryption_ctx_set() {
+        if pager.has_encryption() {
             return Err(LimboError::InvalidArgument(
-                "cannot reset encryption attributes if already set in the session".to_string(),
+                "cannot change encryption settings after built-in encryption is configured"
+                    .to_string(),
+            ));
+        }
+        if pager.has_page_codec() {
+            return Err(LimboError::InvalidArgument(
+                "cannot configure built-in encryption while an external page codec is installed"
+                    .to_string(),
             ));
         }
         if self.db.get_mv_store().is_some() {

--- a/core/error.rs
+++ b/core/error.rs
@@ -185,6 +185,8 @@ pub enum CompletionError {
     Aborted,
     #[error("Decryption failed for page={page_idx}")]
     DecryptionError { page_idx: usize },
+    #[error("Page codec failed for page={page_idx}")]
+    PageCodecError { page_idx: usize },
     #[error("I/O error: partial write")]
     ShortWrite,
     #[error("I/O error: short read on page {page_idx}: expected {expected} bytes, got {actual}")]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -164,7 +164,9 @@ pub use numeric::{nonnan::NonNan, Numeric};
 pub use statement::{ColumnTypeInfo, ColumnTypeKind, Statement, StatementStatusCounter};
 pub use storage::{
     buffer_pool::BufferPool,
-    database::{DatabaseStorage, IOContext},
+    database::{
+        DatabaseStorage, IOContext, PageCodec, PageCodecHeaderInfo, PageCodecId, PageCodecLocation,
+    },
     encryption::{CipherMode, EncryptionContext, EncryptionKey},
     pager::{Page, PageRef, Pager},
     wal::{CheckpointMode, CheckpointResult, Wal, WalAutoActions, WalFile, WalFileShared},
@@ -372,6 +374,7 @@ pub struct OpenOptions {
     flags: OpenFlags,
     db_opts: DatabaseOpts,
     encryption: Option<EncryptionOpts>,
+    page_codec: Option<Arc<dyn PageCodec>>,
     durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
     allocator: alloc::DynAllocator,
     /// SQL dialect the database is opened with. The dialect is fixed at open
@@ -390,6 +393,7 @@ impl OpenOptions {
             flags: OpenFlags::default(),
             db_opts: DatabaseOpts::default(),
             encryption: None,
+            page_codec: None,
             durable_storage: None,
             allocator: alloc::DynAllocator::default(),
             dialect,
@@ -421,6 +425,11 @@ impl OpenOptions {
 
     pub fn encryption(mut self, encryption: impl Into<Option<EncryptionOpts>>) -> Self {
         self.encryption = encryption.into();
+        self
+    }
+
+    pub fn page_codec(mut self, page_codec: impl Into<Option<Arc<dyn PageCodec>>>) -> Self {
+        self.page_codec = page_codec.into();
         self
     }
 
@@ -727,6 +736,8 @@ pub struct Database<A: alloc::ConcurrentAllocator = alloc::DynAllocator> {
 
     // Encryption
     encryption_cipher_mode: AtomicCipherMode,
+    requires_page_codec: bool,
+    page_codec_id: Option<PageCodecId>,
 }
 
 // SAFETY: This needs to be audited for thread safety.
@@ -786,26 +797,42 @@ impl fmt::Debug for Database {
     }
 }
 
+struct DatabaseNewArgs<'a> {
+    opts: DatabaseOpts,
+    flags: OpenFlags,
+    path: &'a str,
+    wal_path: &'a str,
+    io: &'a Arc<dyn IO>,
+    db_file: Arc<dyn DatabaseStorage>,
+    encryption_opts: Option<EncryptionOpts>,
+    mv_store_allocator: alloc::DynAllocator,
+    requires_page_codec: bool,
+    page_codec_id: Option<PageCodecId>,
+    dialect: Arc<dyn Dialect>,
+}
+
 impl Database {
     /// Returns true if this database is backed by MemoryIO.
     pub fn is_in_memory_db(&self) -> bool {
         is_memory_like(&self.path)
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        opts: DatabaseOpts,
-        flags: OpenFlags,
-        path: impl Into<String>,
-        wal_path: impl Into<String>,
-        io: &Arc<dyn IO>,
-        db_file: Arc<dyn DatabaseStorage>,
-        encryption_opts: Option<EncryptionOpts>,
-        mv_store_allocator: alloc::DynAllocator,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<Self> {
-        let path = path.into();
-        let wal_path = wal_path.into();
+    fn new(args: DatabaseNewArgs<'_>) -> Result<Self> {
+        let DatabaseNewArgs {
+            opts,
+            flags,
+            path,
+            wal_path,
+            io,
+            db_file,
+            encryption_opts,
+            mv_store_allocator,
+            requires_page_codec,
+            page_codec_id,
+            dialect,
+        } = args;
+        let path = path.to_string();
+        let wal_path = wal_path.to_string();
         let shared_wal = WalFileShared::new_noop();
         let mv_store = ArcSwapOption::empty();
 
@@ -864,6 +891,8 @@ impl Database {
             encryption_cipher_mode: AtomicCipherMode::new(
                 encryption_cipher_mode.unwrap_or(CipherMode::None),
             ),
+            requires_page_codec,
+            page_codec_id,
 
             durable_storage: None,
         };
@@ -964,6 +993,29 @@ impl Database {
         // cross-platform helpers/tests can request multiprocess WAL without
         // breaking legacy single-process behavior.
         Ok(flags)
+    }
+
+    fn validate_external_page_codec_options(
+        opts: DatabaseOpts,
+        has_external_page_codec: bool,
+    ) -> Result<()> {
+        if has_external_page_codec && opts.enable_multiprocess_wal {
+            return Err(LimboError::InvalidArgument(
+                "external page codecs are not supported with experimental multiprocess WAL"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_open_options(options: &OpenOptions) -> Result<()> {
+        Self::validate_external_page_codec_options(options.db_opts, options.page_codec.is_some())?;
+        if options.encryption.is_some() && options.page_codec.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
+        Ok(())
     }
 
     #[cfg(feature = "fs")]
@@ -1075,6 +1127,7 @@ impl Database {
         path: &str,
         encryption_opts: &Option<EncryptionOpts>,
         dialect: &dyn Dialect,
+        page_codec: Option<&dyn PageCodec>,
     ) -> Result<Option<Arc<Database>>> {
         if is_memory_like(path) {
             return Ok(None);
@@ -1101,10 +1154,29 @@ impl Database {
                 "Database is encrypted but no encryption options provided".to_string(),
             ));
         }
+        db.validate_page_codec(page_codec)?;
 
         Self::check_registry_dialect(&db, dialect)?;
 
         Ok(Some(db))
+    }
+
+    fn validate_page_codec(&self, page_codec: Option<&dyn PageCodec>) -> Result<()> {
+        match (self.page_codec_id, page_codec) {
+            (Some(_), None) => Err(LimboError::InvalidArgument(
+                "Database was opened with an external page codec; reopen with a page codec"
+                    .to_string(),
+            )),
+            (None, Some(_)) => Err(LimboError::InvalidArgument(
+                "Database is already open without an external page codec".to_string(),
+            )),
+            (Some(expected), Some(codec)) if expected != codec.codec_id() => {
+                Err(LimboError::InvalidArgument(
+                    "page codec identity does not match the existing database".to_string(),
+                ))
+            }
+            _ => Ok(()),
+        }
     }
 
     /// Deprecated convenience shim: prefer [`Database::open`] with
@@ -1130,6 +1202,31 @@ impl Database {
         )
     }
 
+    /// Open a file-backed database with an external page codec.
+    #[cfg(feature = "fs")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_file_with_flags_and_page_codec(
+        io: Arc<dyn IO>,
+        path: &str,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Arc<dyn PageCodec>,
+        dialect: Arc<dyn Dialect>,
+    ) -> Result<Arc<Database>> {
+        Self::open(
+            io,
+            path,
+            OpenOptions::new(dialect)
+                .flags(flags)
+                .db_opts(opts)
+                .encryption(encryption_opts)
+                .durable_storage(durable_storage)
+                .page_codec(page_codec),
+        )
+    }
+
     /// Resolve `OpenOptions::storage` for a file-backed open when the caller
     /// did not supply pre-opened storage: optionally consult the registry, run
     /// the legacy/multiprocess WAL probes, open the file, and fill in
@@ -1146,9 +1243,12 @@ impl Database {
         // Check the registry before opening the file to avoid acquiring a file
         // lock that would conflict with an already-open Database in this process.
         if use_registry {
-            if let Some(db) =
-                Self::lookup_in_registry(path, &options.encryption, options.dialect.as_ref())?
-            {
+            if let Some(db) = Self::lookup_in_registry(
+                path,
+                &options.encryption,
+                options.dialect.as_ref(),
+                options.page_codec.as_deref(),
+            )? {
                 if options.durable_storage.is_some() && db.durable_storage.is_none() {
                     return Err(LimboError::InvalidArgument(
                         "database already open without custom durable storage; \
@@ -1233,6 +1333,7 @@ impl Database {
         // otherwise return the cached default-WAL instance and silently ignore
         // the custom wal_path before open_async runs its own check.
         Self::reject_wal_path_for_registry_open(&options)?;
+        Self::validate_open_options(&options)?;
         if options.storage.is_none() {
             if let Some(db) = Self::resolve_default_storage(&io, path, &mut options, true)? {
                 return Ok(db);
@@ -1271,6 +1372,7 @@ impl Database {
         options: &OpenOptions,
     ) -> Result<IOResult<Arc<Database>>> {
         Self::reject_wal_path_for_registry_open(options)?;
+        Self::validate_open_options(options)?;
         let Some(storage) = options.storage.clone() else {
             return Err(LimboError::InvalidArgument(
                 "OpenOptions::storage is required for Database::open_async".to_string(),
@@ -1310,6 +1412,7 @@ impl Database {
                                         .to_string(),
                                 ));
                             }
+                            db.validate_page_codec(options.page_codec.as_deref())?;
                             Self::check_registry_dialect(&db, options.dialect.as_ref())?;
                             return Ok(IOResult::Done(db));
                         }
@@ -1345,6 +1448,7 @@ impl Database {
             options.db_opts,
             options.encryption.clone(),
             options.durable_storage.clone(),
+            options.page_codec.clone(),
             options.allocator.clone(),
             options.dialect.clone(),
         );
@@ -1376,6 +1480,7 @@ impl Database {
     /// production code uses the registry-aware [`Database::open`].
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
     pub fn do_open(io: Arc<dyn IO>, path: &str, mut options: OpenOptions) -> Result<Arc<Database>> {
+        Self::validate_open_options(&options)?;
         if options.storage.is_none() {
             // `use_registry = false`: the raw path never consults the registry,
             // so this only opens the file and never returns a cached Database.
@@ -1403,6 +1508,7 @@ impl Database {
         path: &str,
         options: &OpenOptions,
     ) -> Result<IOResult<Arc<Database>>> {
+        Self::validate_open_options(options)?;
         let Some(storage) = options.storage.clone() else {
             return Err(LimboError::InvalidArgument(
                 "OpenOptions::storage is required for Database::do_open_async".to_string(),
@@ -1418,6 +1524,7 @@ impl Database {
             options.db_opts,
             options.encryption.clone(),
             options.durable_storage.clone(),
+            options.page_codec.clone(),
             options.allocator.clone(),
             options.dialect.clone(),
         )
@@ -1437,9 +1544,16 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Option<Arc<dyn PageCodec>>,
         allocator: alloc::DynAllocator,
         dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
+        Self::validate_external_page_codec_options(opts, page_codec.is_some())?;
+        if encryption_opts.is_some() && page_codec.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
         let result = Self::do_open_async_internal(
             state,
             io,
@@ -1450,6 +1564,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
+            page_codec,
             allocator,
             dialect,
         );
@@ -1457,6 +1572,38 @@ impl Database {
             let _ = state.schema_guard.take();
         }
         result
+    }
+
+    /// Async version of database opening with an external page codec.
+    /// Caller must drive the IO loop and pass state between calls.
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_with_flags_bypass_registry_and_page_codec_async(
+        state: &mut OpenDbAsyncState,
+        io: Arc<dyn IO>,
+        path: &str,
+        wal_path: Option<&str>,
+        db_file: Arc<dyn DatabaseStorage>,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Arc<dyn PageCodec>,
+        dialect: Arc<dyn Dialect>,
+    ) -> Result<IOResult<Arc<Database>>> {
+        Self::do_open_async_guarded(
+            state,
+            io,
+            path,
+            wal_path,
+            db_file,
+            flags,
+            opts,
+            encryption_opts,
+            durable_storage,
+            Some(page_codec),
+            alloc::DynAllocator::default(),
+            dialect,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1470,6 +1617,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Option<Arc<dyn PageCodec>>,
         allocator: alloc::DynAllocator,
         dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
@@ -1489,17 +1637,19 @@ impl Database {
                     } else {
                         &format!("{path}-wal")
                     };
-                    let mut db = Self::new(
+                    let mut db = Self::new(DatabaseNewArgs {
                         opts,
                         flags,
                         path,
                         wal_path,
-                        &io,
-                        db_file.clone(),
-                        encryption_opts.clone(),
-                        allocator.clone(),
-                        dialect.clone(),
-                    )?;
+                        io: &io,
+                        db_file: db_file.clone(),
+                        encryption_opts: encryption_opts.clone(),
+                        mv_store_allocator: allocator.clone(),
+                        requires_page_codec: page_codec.is_some(),
+                        page_codec_id: page_codec.as_deref().map(PageCodec::codec_id),
+                        dialect: dialect.clone(),
+                    })?;
                     db.durable_storage.clone_from(&durable_storage);
 
                     // Header validation + WAL recovery runs as a sub state
@@ -1518,7 +1668,11 @@ impl Database {
                         .as_mut()
                         .expect("building_db must be set in Init phase");
                     let mut hv_state = std::mem::take(&mut state.header_validation_state);
-                    let result = db.header_validation(&mut hv_state, state.encryption_key.as_ref());
+                    let result = db.header_validation(
+                        &mut hv_state,
+                        state.encryption_key.as_ref(),
+                        page_codec.as_ref(),
+                    );
                     state.header_validation_state = hv_state;
                     let pager = return_if_io!(result);
 
@@ -1543,8 +1697,12 @@ impl Database {
                     let db = Arc::new(db);
 
                     // Check: https://github.com/tursodatabase/turso/pull/1761#discussion_r2154013123
-                    let conn =
-                        db._connect(false, Some(pager.clone()), state.encryption_key.clone())?;
+                    let conn = db._connect(
+                        false,
+                        Some(pager.clone()),
+                        state.encryption_key.clone(),
+                        page_codec.clone(),
+                    )?;
 
                     // Acquire schema lock and hold it through ReadingHeader and LoadingSchema phases
                     // to ensure schema_version and make_from_btree are atomic
@@ -1681,6 +1839,7 @@ impl Database {
                                 true,
                                 Some(pager.clone()),
                                 state.encryption_key.clone(),
+                                page_codec.clone(),
                             )?);
                         }
                         let conn = state.mvcc_bootstrap_conn.as_ref().expect("created above");
@@ -1712,10 +1871,14 @@ impl Database {
     /// Blocking shim over [`Database::_init_nonblock`], retained for the
     /// synchronous callers (connection setup paths). The open state machine
     /// uses `_init_nonblock` directly so a fresh open never blocks here.
-    pub(crate) fn _init(&self, encryption_key: Option<&EncryptionKey>) -> Result<Pager> {
+    pub(crate) fn _init(
+        &self,
+        encryption_key: Option<&EncryptionKey>,
+        page_codec: Option<Arc<dyn PageCodec>>,
+    ) -> Result<Pager> {
         let mut st = InitState::default();
         self.io
-            .block(|| self._init_nonblock(&mut st, encryption_key))
+            .block(|| self._init_nonblock(&mut st, encryption_key, page_codec.as_ref()))
     }
 
     /// Necessary Pager initialization, so that we are prepared to read from
@@ -1726,14 +1889,20 @@ impl Database {
         &self,
         st: &mut InitState,
         encryption_key: Option<&EncryptionKey>,
+        page_codec: Option<&Arc<dyn PageCodec>>,
     ) -> Result<IOResult<Pager>> {
+        if encryption_key.is_some() && page_codec.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
         loop {
             match st {
                 InitState::Start => {
                     *st = InitState::InitPager(DbHeaderReadState::default());
                 }
                 InitState::InitPager(hdr_st) => {
-                    let pager = return_if_io!(self.init_pager(None, hdr_st));
+                    let pager = return_if_io!(self.init_pager(None, hdr_st, page_codec));
                     pager.enable_encryption(self.opts.enable_encryption);
 
                     // Set up encryption context BEFORE reading the header page.
@@ -1745,6 +1914,8 @@ impl Database {
                     if let Some(key) = encryption_key {
                         let cipher_mode = self.encryption_cipher_mode.get();
                         pager.set_encryption_context(cipher_mode, key)?;
+                    } else if let Some(codec) = page_codec {
+                        pager.set_page_codec(codec.clone())?;
                     }
 
                     // Start a read transaction before reading page 1 to prevent a concurrent
@@ -1821,6 +1992,7 @@ impl Database {
         &mut self,
         st: &mut HeaderValidationState,
         encryption_key: Option<&EncryptionKey>,
+        page_codec: Option<&Arc<dyn PageCodec>>,
     ) -> Result<IOResult<Arc<Pager>>> {
         loop {
             match st {
@@ -1828,7 +2000,8 @@ impl Database {
                     // `_init` does not modify `open_flags` (the autovacuum
                     // override happens later in `Validate`), so capturing
                     // `is_readonly` across the `_init` yields is stable.
-                    let pager = return_if_io!(self._init_nonblock(init, encryption_key));
+                    let pager =
+                        return_if_io!(self._init_nonblock(init, encryption_key, page_codec));
                     let log_exists =
                         journal_mode::logical_log_exists(std::path::Path::new(&self.path));
                     let is_readonly = self.open_flags.contains(OpenFlags::ReadOnly);
@@ -1960,6 +2133,12 @@ impl Database {
                     // Determine if we should open in MVCC mode based on the database header version
                     // MVCC is controlled only by the database header (set via PRAGMA journal_mode)
                     let open_mv_store = matches!(read_version, Version::Mvcc);
+                    if open_mv_store && page_codec.is_some() {
+                        return Err(LimboError::InvalidArgument(
+                            "external page codecs are not supported with MVCC databases"
+                                .to_string(),
+                        ));
+                    }
 
                     // MVCC has no cross-process coordination: commit
                     // serialization, the logical-log append offset, and
@@ -2059,7 +2238,7 @@ impl Database {
                 HeaderValidationState::OpenWal {
                     open_mv_store,
                     driver,
-                    ..
+                    pager,
                 } => {
                     // Always open shared WAL and set it in the Database and Pager.
                     // MVCC currently requires a WAL open to function.
@@ -2085,12 +2264,14 @@ impl Database {
                             let shared_authority = self.open_shared_wal_coordination_for_open()?;
                             if let Some(authority) = shared_authority.as_ref() {
                                 if !authority.frame_index_overflowed() {
+                                    let io_ctx = pager.io_ctx.read();
                                     WalFileShared::open_shared_from_authority_if_exists(
                                         &self.io,
                                         &self.wal_path,
                                         flags,
                                         authority,
                                         &self.db_file,
+                                        Some(&io_ctx),
                                     )?
                                 } else {
                                     WalFileShared::open_shared_if_exists(
@@ -2166,6 +2347,12 @@ impl Database {
     /// Rebuild the process-local shared WAL view after a caller restores the
     /// database and WAL files outside the pager.
     pub fn reload_wal_after_external_restore(self: &Arc<Self>) -> Result<()> {
+        if self.requires_page_codec {
+            return Err(LimboError::InvalidArgument(
+                "reloading a WAL after external restore is not supported with an external page codec"
+                    .to_string(),
+            ));
+        }
         let flags = self.open_flags;
         #[cfg(host_shared_wal)]
         let shared_authority = self.open_shared_wal_coordination_for_open()?;
@@ -2183,6 +2370,7 @@ impl Database {
                             flags,
                             authority,
                             &self.db_file,
+                            None,
                         )?
                     } else {
                         WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
@@ -2216,7 +2404,7 @@ impl Database {
                 self.experimental_mvcc_passive_checkpoint_enabled(),
             )?;
             self.mv_store.store(Some(mv_store.clone()));
-            let mvcc_bootstrap_conn = self._connect(true, None, None)?;
+            let mvcc_bootstrap_conn = self._connect(true, None, None, None)?;
             match mv_store.bootstrap(mvcc_bootstrap_conn.clone()) {
                 Ok(()) => {}
                 Err(LimboError::SchemaUpdated) => {
@@ -2233,7 +2421,7 @@ impl Database {
 
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn connect(self: &Arc<Database>) -> Result<Arc<Connection>> {
-        self._connect(false, None, None)
+        self._connect(false, None, None, None)
     }
 
     /// Connect with an encryption key.
@@ -2243,7 +2431,19 @@ impl Database {
         self: &Arc<Database>,
         encryption_key: Option<EncryptionKey>,
     ) -> Result<Arc<Connection>> {
-        self._connect(false, None, encryption_key)
+        self._connect(false, None, encryption_key, None)
+    }
+
+    /// Connect with an external page codec.
+    ///
+    /// The codec may contain sensitive key material, so it is installed only on
+    /// the pager for this connection and is not cached on the shared `Database`.
+    #[instrument(skip_all, level = Level::DEBUG)]
+    pub fn connect_with_page_codec(
+        self: &Arc<Database>,
+        page_codec: Arc<dyn PageCodec>,
+    ) -> Result<Arc<Connection>> {
+        self._connect(false, None, None, Some(page_codec))
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
@@ -2252,13 +2452,27 @@ impl Database {
         is_mvcc_bootstrap_connection: bool,
         pager: Option<Arc<Pager>>,
         encryption_key: Option<EncryptionKey>,
+        page_codec: Option<Arc<dyn PageCodec>>,
     ) -> Result<Arc<Connection>> {
+        if self.requires_page_codec && page_codec.is_none() {
+            return Err(LimboError::InvalidArgument(
+                "database requires an external page codec".to_string(),
+            ));
+        }
+        if !self.requires_page_codec && page_codec.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "database was opened without an external page codec".to_string(),
+            ));
+        }
+        if let Some(page_codec) = page_codec.as_deref() {
+            self.validate_page_codec(Some(page_codec))?;
+        }
         let pager = if let Some(pager) = pager {
             pager
         } else {
             // Pass encryption key to _init so it can set up encryption context
             // before reading page 1. This is required for reopening encrypted databases.
-            Arc::new(self._init(encryption_key.as_ref())?)
+            Arc::new(self._init(encryption_key.as_ref(), page_codec.clone())?)
         };
         let default_cache_size = pager
             .io
@@ -2382,6 +2596,10 @@ impl Database {
                     *st = DbHeaderReadState::Reading { buf, completion: c };
                 }
                 DbHeaderReadState::Reading { buf, completion } => {
+                    if let Some(err) = completion.get_error() {
+                        *st = DbHeaderReadState::Start;
+                        return Err(err.into());
+                    }
                     if !completion.succeeded() {
                         let c = completion.clone();
                         io_yield_one!(c);
@@ -2834,6 +3052,7 @@ impl Database {
         &self,
         requested_page_size: Option<usize>,
         hdr_st: &mut DbHeaderReadState,
+        page_codec: Option<&Arc<dyn PageCodec>>,
     ) -> Result<IOResult<Pager>> {
         let cipher = self.encryption_cipher_mode.get();
 
@@ -2842,13 +3061,51 @@ impl Database {
         // on-disk page size from it.
         let (header_reserved_bytes, header_page_size) = if self.initialized() {
             let buf = return_if_io!(self.read_db_header_buf(hdr_st));
-            let reserved = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
-            let ps_raw = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
-            let page_size = PageSize::new_from_header_u16(ps_raw)?;
-            (Some(reserved), Some(page_size))
+            if let Some(codec) = page_codec {
+                if let Some(header_info) = codec.probe_header(buf.as_slice())? {
+                    let page_size_u32 = u32::try_from(header_info.page_size).map_err(|_| {
+                        LimboError::InvalidArgument(format!(
+                            "page codec reported invalid page size {}",
+                            header_info.page_size
+                        ))
+                    })?;
+                    let Some(page_size) = PageSize::new(page_size_u32) else {
+                        return Err(LimboError::InvalidArgument(format!(
+                            "page codec reported invalid page size {}",
+                            header_info.page_size
+                        )));
+                    };
+                    if !page_size.has_valid_reserved_space(header_info.reserved_space) {
+                        return Err(LimboError::InvalidArgument(format!(
+                            "page codec reported invalid reserved space {} for page size {}",
+                            header_info.reserved_space,
+                            page_size.get()
+                        )));
+                    }
+                    (Some(header_info.reserved_space), Some(page_size))
+                } else {
+                    return Err(LimboError::InvalidArgument(
+                        "page codec must implement probe_header to reopen an initialized database"
+                            .to_string(),
+                    ));
+                }
+            } else {
+                let reserved = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
+                let ps_raw = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
+                let page_size = PageSize::new_from_header_u16(ps_raw)?;
+                (Some(reserved), Some(page_size))
+            }
         } else {
             (None, None)
         };
+        if let (Some(codec), Some(reserved_bytes)) = (page_codec, header_reserved_bytes) {
+            let required_reserved_bytes = codec.required_reserved_bytes();
+            if reserved_bytes != required_reserved_bytes {
+                return Err(LimboError::InvalidArgument(format!(
+                    "page codec requires exactly {required_reserved_bytes} reserved bytes, but database provides {reserved_bytes}"
+                )));
+            }
+        }
 
         let reserved_bytes = header_reserved_bytes.or_else(|| {
             if !matches!(cipher, CipherMode::None) {
@@ -3402,7 +3659,18 @@ impl Iterator for QueryRunner<'_> {
 
 #[cfg(test)]
 mod database_tests {
-    use super::{is_memory_like, Database};
+    use std::sync::Arc;
+
+    use super::{is_memory_like, Database, InitState};
+    use crate::storage::encryption::{CipherMode, EncryptionKey};
+    use crate::storage::sqlite3_ondisk::DatabaseHeader;
+    use crate::{
+        storage::database::{
+            DatabaseFile, PageCodec, PageCodecHeaderInfo, PageCodecId, PageCodecLocation,
+        },
+        Connection, DatabaseOpts, DatabaseStorage, EncryptionOpts, IOResult, LimboError,
+        OpenDbAsyncState, OpenFlags, OpenOptions, PlatformIO, SqliteDialect, IO,
+    };
 
     #[test]
     fn memory_path_classifies_named_memory_databases() {
@@ -3424,5 +3692,1105 @@ mod database_tests {
 
         assert!(io.file_id(&path).is_ok());
         assert!(std::fs::metadata(&path).is_err());
+    }
+
+    #[derive(Debug)]
+    struct IdentityPageCodec;
+
+    impl PageCodec for IdentityPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            PageCodecId::new(*b"identity-codec--")
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            output.copy_from_slice(page);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            output.copy_from_slice(page);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct InvalidHeaderPageCodec {
+        page_size: usize,
+        reserved_space: u8,
+    }
+
+    impl PageCodec for InvalidHeaderPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            PageCodecId::new(*b"invalid-header-c")
+        }
+
+        fn probe_header(
+            &self,
+            _raw_page1_prefix: &[u8],
+        ) -> crate::Result<Option<PageCodecHeaderInfo>> {
+            Ok(Some(PageCodecHeaderInfo {
+                page_size: self.page_size,
+                reserved_space: self.reserved_space,
+            }))
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            output.copy_from_slice(page);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            output.copy_from_slice(page);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct XorPageCodec {
+        mask: u8,
+        reserved_bytes: u8,
+    }
+
+    impl XorPageCodec {
+        fn transform(&self, page: &[u8], output: &mut [u8]) {
+            for (input, output) in page.iter().zip(output) {
+                *output = input ^ self.mask;
+            }
+        }
+    }
+
+    impl PageCodec for XorPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"xor-page-codec--";
+            id[15] = self.mask;
+            id[14] = self.reserved_bytes;
+            PageCodecId::new(id)
+        }
+
+        fn probe_header(
+            &self,
+            raw_page1_prefix: &[u8],
+        ) -> crate::Result<Option<PageCodecHeaderInfo>> {
+            if raw_page1_prefix.len() < 21 {
+                return Ok(None);
+            }
+
+            let decoded_magic = raw_page1_prefix[..16]
+                .iter()
+                .map(|byte| byte ^ self.mask)
+                .collect::<Vec<_>>();
+            if decoded_magic.as_slice() != b"SQLite format 3\0" {
+                return Ok(None);
+            }
+
+            let ps_raw = u16::from_be_bytes([
+                raw_page1_prefix[16] ^ self.mask,
+                raw_page1_prefix[17] ^ self.mask,
+            ]);
+            let page_size = if ps_raw == 1 { 65536 } else { ps_raw as usize };
+            Ok(Some(PageCodecHeaderInfo {
+                page_size,
+                reserved_space: raw_page1_prefix[20] ^ self.mask,
+            }))
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            self.reserved_bytes
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct LocationPageCodec;
+
+    impl LocationPageCodec {
+        const MASK: u8 = 0x6d;
+
+        fn byte_key(page_idx: usize, location: PageCodecLocation, offset: usize) -> u8 {
+            // Persisted transforms must not depend on the host pointer width.
+            let page_id_byte = (page_idx as u64).to_le_bytes()[offset % std::mem::size_of::<u64>()];
+            let page_id_rotation =
+                ((offset / std::mem::size_of::<u64>()) % (u8::BITS as usize)) as u32;
+            Self::MASK
+                ^ page_id_byte.rotate_left(page_id_rotation)
+                ^ match location {
+                    PageCodecLocation::Database => 0,
+                    PageCodecLocation::Wal => 0xa5,
+                }
+        }
+
+        fn transform(page: &[u8], output: &mut [u8], page_idx: usize, location: PageCodecLocation) {
+            for (offset, (input, output)) in page.iter().zip(output).enumerate() {
+                *output = input ^ Self::byte_key(page_idx, location, offset);
+            }
+        }
+    }
+
+    impl PageCodec for LocationPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            PageCodecId::new(*b"location-page-co")
+        }
+
+        fn probe_header(
+            &self,
+            raw_page1_prefix: &[u8],
+        ) -> crate::Result<Option<PageCodecHeaderInfo>> {
+            if raw_page1_prefix.len() < 21 {
+                return Ok(None);
+            }
+            if !raw_page1_prefix[..16]
+                .iter()
+                .enumerate()
+                .zip(b"SQLite format 3\0")
+                .all(|((offset, encoded), expected)| {
+                    *encoded
+                        ^ Self::byte_key(
+                            DatabaseHeader::PAGE_ID,
+                            PageCodecLocation::Database,
+                            offset,
+                        )
+                        == *expected
+                })
+            {
+                return Ok(None);
+            }
+
+            let page_size = u16::from_be_bytes([
+                raw_page1_prefix[16]
+                    ^ Self::byte_key(DatabaseHeader::PAGE_ID, PageCodecLocation::Database, 16),
+                raw_page1_prefix[17]
+                    ^ Self::byte_key(DatabaseHeader::PAGE_ID, PageCodecLocation::Database, 17),
+            ]);
+            Ok(Some(PageCodecHeaderInfo {
+                page_size: if page_size == 1 {
+                    65_536
+                } else {
+                    page_size as usize
+                },
+                reserved_space: raw_page1_prefix[20]
+                    ^ Self::byte_key(DatabaseHeader::PAGE_ID, PageCodecLocation::Database, 20),
+            }))
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            1
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            page_idx: usize,
+            location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            Self::transform(page, output, page_idx, location);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            page_idx: usize,
+            location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            Self::transform(page, output, page_idx, location);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn location_page_codec_uses_full_page_id() {
+        let input = vec![0; 512];
+        let mut page_one = vec![0; input.len()];
+        let mut page_two_fifty_seven = vec![0; input.len()];
+        LocationPageCodec::transform(&input, &mut page_one, 1, PageCodecLocation::Database);
+        LocationPageCodec::transform(
+            &input,
+            &mut page_two_fifty_seven,
+            257,
+            PageCodecLocation::Database,
+        );
+
+        assert_ne!(page_one, page_two_fifty_seven);
+
+        let mut decoded = vec![0; input.len()];
+        LocationPageCodec::transform(
+            &page_two_fifty_seven,
+            &mut decoded,
+            257,
+            PageCodecLocation::Database,
+        );
+        assert_eq!(decoded, input);
+    }
+
+    #[derive(Debug)]
+    struct XorNoProbePageCodec {
+        mask: u8,
+        reserved_bytes: u8,
+    }
+
+    impl XorNoProbePageCodec {
+        fn transform(&self, page: &[u8], output: &mut [u8]) {
+            for (input, output) in page.iter().zip(output) {
+                *output = input ^ self.mask;
+            }
+        }
+    }
+
+    impl PageCodec for XorNoProbePageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"xor-no-probe----";
+            id[15] = self.mask;
+            id[14] = self.reserved_bytes;
+            PageCodecId::new(id)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            self.reserved_bytes
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+    }
+
+    #[cfg(feature = "fs")]
+    fn open_with_page_codec_result(
+        io: Arc<dyn IO>,
+        path: &str,
+        codec: Arc<dyn PageCodec>,
+    ) -> crate::Result<Arc<Database>> {
+        open_with_page_codec_with_opts_result(io, path, codec, DatabaseOpts::new())
+    }
+
+    #[cfg(feature = "fs")]
+    fn open_with_page_codec_with_opts_result(
+        io: Arc<dyn IO>,
+        path: &str,
+        codec: Arc<dyn PageCodec>,
+        opts: DatabaseOpts,
+    ) -> crate::Result<Arc<Database>> {
+        let file = io.open_file(path, OpenFlags::Create, true).unwrap();
+        let db_file: Arc<dyn DatabaseStorage> = Arc::new(DatabaseFile::new(file));
+        let mut state = OpenDbAsyncState::new();
+        let options = OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file)
+            .flags(OpenFlags::Create)
+            .db_opts(opts)
+            .page_codec(codec);
+
+        loop {
+            match Database::open_async(&mut state, io.clone(), path, &options)? {
+                IOResult::Done(db) => return Ok(db),
+                IOResult::IO(completion) => completion.wait(&*io).unwrap(),
+            }
+        }
+    }
+
+    #[cfg(feature = "fs")]
+    fn open_with_page_codec(
+        io: Arc<dyn IO>,
+        path: &str,
+        codec: Arc<dyn PageCodec>,
+    ) -> Arc<Database> {
+        open_with_page_codec_result(io, path, codec).unwrap()
+    }
+
+    #[cfg(feature = "fs")]
+    fn count_test_rows(conn: &Arc<Connection>) -> i64 {
+        let mut stmt = conn.prepare("select count(*) from test").unwrap();
+        let mut count = 0;
+        stmt.run_with_row_callback(|row| {
+            count = row.get(0).unwrap();
+            Ok(())
+        })
+        .unwrap();
+        count
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn registry_reuses_cached_database_without_retaining_page_codec() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-registry.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let first_codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let first_codec_weak = Arc::downgrade(&first_codec);
+        let second_codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+
+        let first = open_with_page_codec(io.clone(), path, first_codec);
+        assert!(
+            first_codec_weak.upgrade().is_none(),
+            "cached Database must not retain the page codec"
+        );
+        let second = open_with_page_codec(io, path, second_codec);
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_identity_must_match_cached_database() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-identity.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let first_codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 1,
+        });
+        let different_codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 1,
+        });
+
+        let db = open_with_page_codec(io.clone(), path, first_codec);
+
+        let err = match db.connect_with_page_codec(different_codec.clone()) {
+            Ok(_) => panic!("a cached codec-backed database must reject a different codec"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("page codec identity does not match the existing database"));
+
+        let err = open_with_page_codec_result(io, path, different_codec).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("page codec identity does not match the existing database"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cached_database_rejects_encryption_and_page_codec() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-encryption-cached.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let _db = open_with_page_codec(io.clone(), path, codec.clone());
+
+        let err = Database::open_file_with_flags_and_page_codec(
+            io,
+            path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            Some(EncryptionOpts {
+                cipher: "aes256gcm".to_string(),
+                hexkey: "00".repeat(32),
+            }),
+            None,
+            codec,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("built-in encryption cannot be combined with an external page codec"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn external_page_codec_rejects_multiprocess_wal_before_opening_file() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-multiprocess-wal.db");
+        let path_str = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let err = Database::open_file_with_flags_and_page_codec(
+            io,
+            path_str,
+            OpenFlags::Create,
+            DatabaseOpts::new().with_multiprocess_wal(true),
+            None,
+            None,
+            Arc::new(IdentityPageCodec),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            LimboError::InvalidArgument(ref message)
+                if message
+                    == "external page codecs are not supported with experimental multiprocess WAL"
+        ));
+        assert!(!path.exists());
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn bypass_registry_page_codec_open_rejects_multiprocess_wal() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-bypass-multiprocess-wal.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let file = io.open_file(path, OpenFlags::Create, true).unwrap();
+        let db_file: Arc<dyn DatabaseStorage> = Arc::new(DatabaseFile::new(file));
+        let mut state = OpenDbAsyncState::new();
+
+        let err = match Database::open_with_flags_bypass_registry_and_page_codec_async(
+            &mut state,
+            io,
+            path,
+            None,
+            db_file,
+            OpenFlags::Create,
+            DatabaseOpts::new().with_multiprocess_wal(true),
+            None,
+            None,
+            Arc::new(IdentityPageCodec),
+            Arc::new(SqliteDialect),
+        ) {
+            Err(err) => err,
+            Ok(_) => panic!("multiprocess WAL must reject an external page codec"),
+        };
+
+        assert!(matches!(
+            err,
+            LimboError::InvalidArgument(ref message)
+                if message
+                    == "external page codecs are not supported with experimental multiprocess WAL"
+        ));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cached_page_codec_database_requires_codec_at_connection_time() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-registry-no-codec.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 1,
+        });
+        let _db = open_with_page_codec(io.clone(), path, codec.clone());
+        let db = open_with_page_codec(io.clone(), path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+        conn.execute("create table test(id integer primary key)")
+            .unwrap();
+        drop(conn);
+
+        assert!(
+            Database::open_file_with_flags(
+                io,
+                path,
+                OpenFlags::Create,
+                DatabaseOpts::new(),
+                None,
+                Arc::new(SqliteDialect),
+            )
+            .is_err(),
+            "opening without the codec must not reuse a codec-required database"
+        );
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_round_trips_wal_and_checkpointed_database_with_probe_header() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-roundtrip.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 1,
+        });
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+            conn.execute(
+                "create table test(id integer primary key, value text);
+                 insert into test(value) values ('alpha'), ('bravo');",
+            )
+            .unwrap();
+            assert_eq!(count_test_rows(&conn), 2);
+            conn.set_sync_mode(crate::SyncMode::Full);
+            let passive = conn
+                .checkpoint(crate::storage::wal::CheckpointMode::Passive {
+                    upper_bound_inclusive: None,
+                })
+                .unwrap();
+            assert!(
+                passive.wal_checkpoint_backfilled > 0,
+                "PASSIVE checkpoint must backfill codec-transformed pages"
+            );
+            conn.execute("insert into test(value) values ('charlie')")
+                .unwrap();
+            let full = conn
+                .checkpoint(crate::storage::wal::CheckpointMode::Full)
+                .unwrap();
+            assert!(
+                full.wal_checkpoint_backfilled > 0,
+                "FULL checkpoint must backfill codec-transformed pages"
+            );
+            assert_eq!(count_test_rows(&conn), 3);
+        }
+
+        let raw_database = std::fs::read(path).unwrap();
+        assert_ne!(&raw_database[..16], b"SQLite format 3\0");
+
+        let reopened = open_with_page_codec(io, path, codec.clone());
+        let conn = reopened.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&conn), 3);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopens_live_wal_then_checkpointed_database() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-live-wal-recovery.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(LocationPageCodec);
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+            conn.execute(
+                "create table test(id integer primary key, value text);
+                 insert into test(value) values ('alpha'), ('bravo'), ('charlie');",
+            )
+            .unwrap();
+            assert_eq!(count_test_rows(&conn), 3);
+        }
+        let wal_path = format!("{path}-wal");
+        assert!(
+            std::fs::metadata(&wal_path).unwrap().len() > 0,
+            "the first reopen must recover committed codec-transformed WAL frames"
+        );
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            assert_eq!(count_test_rows(&conn), 3);
+            let checkpoint = conn
+                .checkpoint(crate::storage::wal::CheckpointMode::Full)
+                .unwrap();
+            assert!(
+                checkpoint.wal_checkpoint_backfilled > 0,
+                "the recovery checkpoint must backfill codec-transformed WAL frames"
+            );
+        }
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&conn), 3);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopen_requires_header_probe() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-no-probe-roundtrip.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorNoProbePageCodec {
+            mask: 0x3c,
+            reserved_bytes: 1,
+        });
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            conn.execute(
+                "create table test(id integer primary key, value text);
+                 insert into test(value) values ('alpha'), ('bravo');",
+            )
+            .unwrap();
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        }
+
+        let err = open_with_page_codec_result(io, path, codec).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("page codec must implement probe_header"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_rejects_mvcc_mode() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-mvcc.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+
+        let err = conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("external page codecs are not supported with MVCC"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn plaintext_database_rejects_page_codec_connection() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("plaintext-codec-connection.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io,
+            path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+
+        let err = match db.connect_with_page_codec(Arc::new(IdentityPageCodec)) {
+            Ok(_) => panic!("plaintext databases must reject external page codecs"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("database was opened without an external page codec"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_database_rejects_codecless_connection() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-requires-connection-codec.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db = open_with_page_codec(io, path, Arc::new(IdentityPageCodec));
+
+        let err = match db.connect() {
+            Ok(_) => panic!("codec-backed databases must reject codec-less connections"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("database requires an external page codec"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopen_rejects_mismatched_reserved_space() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-reserved-space.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let initial_codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 1,
+        });
+
+        {
+            let db = open_with_page_codec(io.clone(), path, initial_codec.clone());
+            let conn = db.connect_with_page_codec(initial_codec).unwrap();
+            conn.execute("create table test(id integer primary key)")
+                .unwrap();
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        }
+
+        for required_reserved_bytes in [0, 2] {
+            let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+                mask: 0x5a,
+                reserved_bytes: required_reserved_bytes,
+            });
+            let err = open_with_page_codec_result(io.clone(), path, codec).unwrap_err();
+            assert!(err.to_string().contains(&format!(
+                "page codec requires exactly {required_reserved_bytes} reserved bytes, but database provides 1"
+            )));
+        }
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopen_rejects_invalid_header_layout() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-invalid-header-layout.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        {
+            let db = open_with_page_codec(io.clone(), path, Arc::new(IdentityPageCodec));
+            let conn = db
+                .connect_with_page_codec(Arc::new(IdentityPageCodec))
+                .unwrap();
+            conn.execute("create table test(id integer primary key)")
+                .unwrap();
+        }
+
+        for (codec, expected_error) in [
+            (
+                InvalidHeaderPageCodec {
+                    page_size: 513,
+                    reserved_space: 0,
+                },
+                "page codec reported invalid page size 513",
+            ),
+            (
+                InvalidHeaderPageCodec {
+                    page_size: 512,
+                    reserved_space: 33,
+                },
+                "page codec reported invalid reserved space 33 for page size 512",
+            ),
+        ] {
+            let err = open_with_page_codec_result(io.clone(), path, Arc::new(codec)).unwrap_err();
+            assert!(err.to_string().contains(expected_error));
+        }
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopen_reports_short_header_read() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-short-header.db");
+        std::fs::write(&path, [0u8]).unwrap();
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let err = open_with_page_codec_result(io, path, Arc::new(IdentityPageCodec)).unwrap_err();
+        assert!(err.to_string().contains("short read on page 1"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_and_encryption_cannot_share_pager() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-encryption-conflict.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let db = open_with_page_codec(io, path, codec.clone());
+        let encryption_key = EncryptionKey::from_hex_string(&"00".repeat(32)).unwrap();
+        let mut state = InitState::default();
+
+        let err = match db._init_nonblock(&mut state, Some(&encryption_key), Some(&codec)) {
+            Ok(_) => panic!("encryption and an external page codec must not share a pager"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("built-in encryption cannot be combined with an external page codec"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_connection_rejects_builtin_encryption_settings() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-encryption-settings.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+
+        let err = conn
+            .set_encryption_key(EncryptionKey::from_hex_string(&"00".repeat(32)).unwrap())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            LimboError::InvalidArgument(message)
+                if message
+                    == "cannot configure built-in encryption while an external page codec is installed"
+        ));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_vacuum_preserves_encoded_database() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-vacuum.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x4d,
+            reserved_bytes: 1,
+        });
+        let db = open_with_page_codec_with_opts_result(
+            io.clone(),
+            path,
+            codec.clone(),
+            DatabaseOpts::new().with_vacuum(true),
+        )
+        .unwrap();
+        let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+        conn.execute(
+            "create table test(id integer primary key, value text);
+             insert into test(value) values ('alpha'), ('bravo');",
+        )
+        .unwrap();
+        conn.execute("VACUUM").unwrap();
+        assert_eq!(count_test_rows(&conn), 2);
+        drop(conn);
+        drop(db);
+
+        assert_ne!(&std::fs::read(path).unwrap()[..16], b"SQLite format 3\0");
+        let reopened = open_with_page_codec(io, path, codec.clone());
+        let conn = reopened.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&conn), 2);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_vacuum_into_preserves_encoded_database() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-vacuum-into.db");
+        let output_path = temp_dir.path().join("codec-vacuum-into-copy.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x4d,
+            reserved_bytes: 1,
+        });
+        let db = open_with_page_codec_with_opts_result(
+            io.clone(),
+            path,
+            codec.clone(),
+            DatabaseOpts::new().with_vacuum(true),
+        )
+        .unwrap();
+        let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+        conn.execute(
+            "create table test(id integer primary key, value text);
+             insert into test(value) values ('secret-value');",
+        )
+        .unwrap();
+        conn.execute(format!("VACUUM INTO '{}'", output_path.display()))
+            .unwrap();
+
+        let raw_output = std::fs::read(&output_path).unwrap();
+        assert_ne!(&raw_output[..16], b"SQLite format 3\0");
+        let output = open_with_page_codec(io, output_path.to_str().unwrap(), codec.clone());
+        let output_conn = output.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&output_conn), 1);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn location_page_codec_round_trips_wal_checkpoint_and_overflow_pages() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("location-codec.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(LocationPageCodec);
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            conn.execute(
+                "create table test(id integer primary key, value blob);
+                 insert into test(value) values (zeroblob(12000));
+                 delete from test where id = 1;
+                 insert into test(value)
+                 values (cast(replace(printf('%0*d', 16000, 0), '0', 'x') as blob));",
+            )
+            .unwrap();
+            let checkpoint = conn
+                .checkpoint(crate::storage::wal::CheckpointMode::Full)
+                .unwrap();
+            assert!(checkpoint.wal_checkpoint_backfilled > 0);
+        }
+
+        let raw_database = std::fs::read(path).unwrap();
+        assert_ne!(&raw_database[..16], b"SQLite format 3\0");
+        let reopened = open_with_page_codec(io, path, codec.clone());
+        let conn = reopened.connect_with_page_codec(codec).unwrap();
+        let mut values: Vec<(i64, String)> = Vec::new();
+        conn.prepare("select length(value), hex(substr(value, 1, 8)) from test order by id")
+            .unwrap()
+            .run_with_row_callback(|row| {
+                values.push((row.get(0).unwrap(), row.get(1).unwrap()));
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(values, vec![(16_000, "7878787878787878".to_string())]);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_attach_is_rejected() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let main_path = temp_dir.path().join("codec-main.db");
+        let aux_path = temp_dir.path().join("codec-aux.db");
+        let main_path = main_path.to_str().unwrap();
+        let aux_path = aux_path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x91,
+            reserved_bytes: 1,
+        });
+        let db = open_with_page_codec_with_opts_result(
+            io.clone(),
+            main_path,
+            codec.clone(),
+            DatabaseOpts::new().with_attach(true),
+        )
+        .unwrap();
+        let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+        let err = conn
+            .execute(format!("ATTACH '{aux_path}' AS aux"))
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("ATTACH is unsupported for connections using an external page codec"));
+        assert!(!std::path::Path::new(aux_path).exists());
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_rejects_reserved_space_mutation() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-reserved-space.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x91,
+            reserved_bytes: 1,
+        });
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+
+        let err = conn.set_reserved_bytes(0).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("page codec requires exactly 1 reserved bytes"));
+        assert_eq!(conn.get_reserved_bytes(), Some(1));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn encryption_rejects_reserved_space_mutation() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("encrypted-reserved-space.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io,
+            path,
+            OpenFlags::Create,
+            DatabaseOpts::new().with_encryption(true),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.set_encryption_cipher(CipherMode::Aes256Gcm).unwrap();
+        conn.set_encryption_key(EncryptionKey::from_hex_string(&"00".repeat(32)).unwrap())
+            .unwrap();
+        let reserved_before = conn.get_reserved_bytes();
+
+        let err = conn.set_reserved_bytes(0).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("built-in encryption requires exactly 28 reserved bytes"));
+        assert_eq!(conn.get_reserved_bytes(), reserved_before);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_rejects_page_size_incompatible_with_reserved_space() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-page-size.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 33,
+        });
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            // 512 - 33 = 479 usable bytes < 480: must be rejected up front,
+            // otherwise the engine creates a database it refuses to reopen.
+            let err = conn.execute("PRAGMA page_size = 512").unwrap_err();
+            assert!(err.to_string().contains("usable bytes"));
+            // The database must remain usable at a compatible page size.
+            conn.execute("create table test(id integer primary key, value text)")
+                .unwrap();
+            conn.execute("insert into test(value) values ('alpha')")
+                .unwrap();
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        }
+
+        let reopened = open_with_page_codec(io, path, codec.clone());
+        let conn = reopened.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&conn), 1);
     }
 }

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -9,56 +9,170 @@ use crate::{
 };
 use tracing::{instrument, Level};
 
-#[derive(Debug, Clone)]
-pub enum EncryptionOrChecksum {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageCodecHeaderInfo {
+    pub page_size: usize,
+    pub reserved_space: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageCodecLocation {
+    Database,
+    Wal,
+}
+
+/// A stable, non-secret identifier for a page codec configuration.
+///
+/// This identifies the transform configuration rather than the codec
+/// implementation. Callers must return the same value when reopening or
+/// sharing a database with an equivalent codec, and a different value for any
+/// codec that could transform pages differently. Do not include key material.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PageCodecId([u8; 16]);
+
+impl PageCodecId {
+    pub const fn new(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Converts complete SQLite page images between their on-disk and in-memory
+/// representations.
+///
+/// The engine supplies an output buffer exactly as large as the input page,
+/// enforcing SQLite's fixed page-size invariant without codec allocations.
+/// Codecs needing per-page metadata must store it in reserved bytes.
+///
+/// Codecs that support reopening initialized databases must implement
+/// [`Self::probe_header`]. The engine cannot safely decode an arbitrary
+/// full-page transform before it knows the physical page size.
+pub trait PageCodec: Send + Sync {
+    /// Returns a stable, non-secret identifier for this codec configuration.
+    ///
+    /// The identifier is retained by the shared [`crate::Database`] so every
+    /// connection and cached open for the same file uses an equivalent codec.
+    /// It must change whenever the codec could produce different on-disk bytes.
+    fn codec_id(&self) -> PageCodecId;
+
+    /// Reports page layout metadata from the raw prefix of page 1.
+    ///
+    /// Return `None` only when the codec cannot reopen initialized databases.
+    fn probe_header(&self, _raw_page1_prefix: &[u8]) -> Result<Option<PageCodecHeaderInfo>> {
+        Ok(None)
+    }
+
+    /// Returns the exact number of reserved bytes required in every page.
+    fn required_reserved_bytes(&self) -> u8;
+    fn encode_page(
+        &self,
+        page: &[u8],
+        output: &mut [u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> Result<()>;
+    fn decode_page(
+        &self,
+        page: &[u8],
+        output: &mut [u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> Result<()>;
+}
+
+#[derive(Clone)]
+/// Storage-layer operations applied to complete SQLite page images.
+///
+/// `Checksum` is separate because it only maintains and verifies bytes in the
+/// reserved page tail; it does not transform logical SQLite content.
+pub enum PageTransform {
     Encryption(EncryptionContext),
+    PageCodec(Arc<dyn PageCodec>),
     Checksum(ChecksumContext),
     None,
 }
 
+#[deprecated(note = "renamed to PageTransform")]
+pub type EncryptionOrChecksum = PageTransform;
+
+impl std::fmt::Debug for PageTransform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Encryption(_) => "Encryption",
+            Self::PageCodec(_) => "PageCodec",
+            Self::Checksum(_) => "Checksum",
+            Self::None => "None",
+        };
+        f.write_str(name)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct IOContext {
-    encryption_or_checksum: EncryptionOrChecksum,
+    page_transform: PageTransform,
 }
 
 impl IOContext {
     pub fn encryption_context(&self) -> Option<&EncryptionContext> {
-        match &self.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => Some(ctx),
+        match &self.page_transform {
+            PageTransform::Encryption(ctx) => Some(ctx),
             _ => None,
         }
     }
 
     pub fn get_reserved_space_bytes(&self) -> u8 {
-        match &self.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => ctx.required_reserved_bytes(),
-            EncryptionOrChecksum::Checksum(ctx) => ctx.required_reserved_bytes(),
-            EncryptionOrChecksum::None => Default::default(),
+        match &self.page_transform {
+            PageTransform::Encryption(ctx) => ctx.required_reserved_bytes(),
+            PageTransform::PageCodec(ctx) => ctx.required_reserved_bytes(),
+            PageTransform::Checksum(ctx) => ctx.required_reserved_bytes(),
+            PageTransform::None => Default::default(),
         }
     }
 
     pub fn set_encryption(&mut self, encryption_ctx: EncryptionContext) {
-        self.encryption_or_checksum = EncryptionOrChecksum::Encryption(encryption_ctx);
+        self.page_transform = PageTransform::Encryption(encryption_ctx);
     }
 
+    pub fn set_page_codec(&mut self, codec: Arc<dyn PageCodec>) {
+        self.page_transform = PageTransform::PageCodec(codec);
+    }
+
+    pub fn has_encryption(&self) -> bool {
+        matches!(self.page_transform, PageTransform::Encryption(_))
+    }
+
+    pub fn has_page_codec(&self) -> bool {
+        matches!(self.page_transform, PageTransform::PageCodec(_))
+    }
+
+    pub fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
+        match &self.page_transform {
+            PageTransform::PageCodec(codec) => Some(codec.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn page_transform(&self) -> &PageTransform {
+        &self.page_transform
+    }
+
+    #[deprecated(note = "renamed to page_transform")]
+    #[allow(deprecated)]
     pub fn encryption_or_checksum(&self) -> &EncryptionOrChecksum {
-        &self.encryption_or_checksum
+        self.page_transform()
     }
 
     pub fn reset_checksum(&mut self) {
-        self.encryption_or_checksum = EncryptionOrChecksum::None;
+        self.page_transform = PageTransform::None;
     }
 }
 
 impl Default for IOContext {
     fn default() -> Self {
         #[cfg(feature = "checksum")]
-        let encryption_or_checksum = EncryptionOrChecksum::Checksum(ChecksumContext::default());
+        let page_transform = PageTransform::Checksum(ChecksumContext::default());
         #[cfg(not(feature = "checksum"))]
-        let encryption_or_checksum = EncryptionOrChecksum::None;
-        Self {
-            encryption_or_checksum,
-        }
+        let page_transform = PageTransform::None;
+        Self { page_transform }
     }
 }
 
@@ -117,10 +231,10 @@ impl DatabaseStorage for DatabaseFile {
             return Err(LimboError::IntegerOverflow);
         };
 
-        match &io_ctx.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => {
+        match &io_ctx.page_transform {
+            PageTransform::Encryption(ctx) => {
                 let encryption_ctx = ctx.clone();
-                let read_buffer = r.buf_arc();
+                let read_buffer = Arc::new(Buffer::new_temporary(r.buf_arc().len()));
                 let original_c = c.clone();
                 let decrypt_complete =
                     Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
@@ -132,15 +246,26 @@ impl DatabaseStorage for DatabaseFile {
                                 return original_c.get_error();
                             }
                         };
+                        // A zero-byte read is the expected probe result for an
+                        // empty database; only complete page images are decryptable.
+                        if bytes_read == 0 {
+                            original_c.complete(bytes_read);
+                            return original_c.get_error();
+                        }
                         turso_assert_greater_than!(
-                            bytes_read, 0,
-                            "database: expected to read data on success for encrypted page",
+                            bytes_read,
+                            0,
+                            "database: expected positive bytes for encrypted page",
                             { "page_idx": page_idx }
                         );
+                        if bytes_read as usize != buf.len() {
+                            original_c.complete(bytes_read);
+                            return original_c.get_error();
+                        }
+                        let original_buf = original_c.as_read().buf();
                         match encryption_ctx.decrypt_page(buf.as_slice(), page_idx) {
-                            Ok(decrypted_data) => {
-                                let original_buf = original_c.as_read().buf();
-                                original_buf.as_mut_slice().copy_from_slice(&decrypted_data);
+                            Ok(decrypted) => {
+                                original_buf.as_mut_slice().copy_from_slice(&decrypted);
                                 original_c.complete(bytes_read);
                                 original_c.get_error()
                             }
@@ -160,7 +285,64 @@ impl DatabaseStorage for DatabaseFile {
                 let wrapped_completion = Completion::new_read(read_buffer, decrypt_complete);
                 self.file.pread(pos, wrapped_completion)
             }
-            EncryptionOrChecksum::Checksum(ctx) => {
+            PageTransform::PageCodec(ctx) => {
+                let page_codec = ctx.clone();
+                let read_buffer = Arc::new(Buffer::new_temporary(r.buf_arc().len()));
+                let original_c = c;
+                let decode_complete =
+                    Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                        let (buf, bytes_read) = match res {
+                            Ok((buf, bytes_read)) => (buf, bytes_read),
+                            Err(err) => {
+                                tracing::error!(err = ?err);
+                                original_c.error(err);
+                                return original_c.get_error();
+                            }
+                        };
+                        // A zero-byte read is the expected probe result for an
+                        // empty database; only complete page images are decodable.
+                        if bytes_read == 0 {
+                            original_c.complete(bytes_read);
+                            return original_c.get_error();
+                        }
+                        turso_assert_greater_than!(
+                            bytes_read,
+                            0,
+                            "database: expected positive bytes for page codec page",
+                            { "page_idx": page_idx }
+                        );
+                        if bytes_read as usize != buf.len() {
+                            original_c.complete(bytes_read);
+                            return original_c.get_error();
+                        }
+                        let original_buf = original_c.as_read().buf();
+                        match page_codec.decode_page(
+                            buf.as_slice(),
+                            original_buf.as_mut_slice(),
+                            page_idx,
+                            PageCodecLocation::Database,
+                        ) {
+                            Ok(()) => {
+                                original_c.complete(bytes_read);
+                                original_c.get_error()
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to decode page data for page_id={page_idx}: {e}"
+                                );
+                                turso_assert!(
+                                    !original_c.failed(),
+                                    "Original completion already has an error"
+                                );
+                                original_c.error(CompletionError::PageCodecError { page_idx });
+                                original_c.get_error()
+                            }
+                        }
+                    });
+                let wrapped_completion = Completion::new_read(read_buffer, decode_complete);
+                self.file.pread(pos, wrapped_completion)
+            }
+            PageTransform::Checksum(ctx) => {
                 let checksum_ctx = ctx.clone();
                 let read_buffer = r.buf_arc();
                 let original_c = c.clone();
@@ -201,7 +383,7 @@ impl DatabaseStorage for DatabaseFile {
                 let wrapped_completion = Completion::new_read(read_buffer, verify_complete);
                 self.file.pread(pos, wrapped_completion)
             }
-            EncryptionOrChecksum::None => self.file.pread(pos, c),
+            PageTransform::None => self.file.pread(pos, c),
         }
     }
 
@@ -221,10 +403,13 @@ impl DatabaseStorage for DatabaseFile {
         let Some(pos) = (page_idx as u64 - 1).checked_mul(buffer_size as u64) else {
             return Err(LimboError::IntegerOverflow);
         };
-        let buffer = match &io_ctx.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => encrypt_buffer(page_idx, buffer, ctx),
-            EncryptionOrChecksum::Checksum(ctx) => checksum_buffer(page_idx, buffer, ctx),
-            EncryptionOrChecksum::None => buffer,
+        let buffer = match &io_ctx.page_transform {
+            PageTransform::Encryption(ctx) => encrypt_buffer(page_idx, buffer, ctx)?,
+            PageTransform::PageCodec(ctx) => {
+                encode_buffer(page_idx, buffer, ctx.as_ref(), PageCodecLocation::Database)?
+            }
+            PageTransform::Checksum(ctx) => checksum_buffer(page_idx, buffer, ctx),
+            PageTransform::None => buffer,
         };
         self.file.pwrite(pos, buffer, c)
     }
@@ -245,18 +430,30 @@ impl DatabaseStorage for DatabaseFile {
         let Some(pos) = (first_page_idx as u64 - 1).checked_mul(page_size as u64) else {
             return Err(LimboError::IntegerOverflow);
         };
-        let buffers = match &io_ctx.encryption_or_checksum() {
-            EncryptionOrChecksum::Encryption(ctx) => buffers
+        let buffers = match &io_ctx.page_transform() {
+            PageTransform::Encryption(ctx) => buffers
                 .into_iter()
                 .enumerate()
                 .map(|(i, buffer)| encrypt_buffer(first_page_idx + i, buffer, ctx))
-                .collect::<Vec<_>>(),
-            EncryptionOrChecksum::Checksum(ctx) => buffers
+                .collect::<Result<Vec<_>>>()?,
+            PageTransform::PageCodec(ctx) => buffers
+                .into_iter()
+                .enumerate()
+                .map(|(i, buffer)| {
+                    encode_buffer(
+                        first_page_idx + i,
+                        buffer,
+                        ctx.as_ref(),
+                        PageCodecLocation::Database,
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?,
+            PageTransform::Checksum(ctx) => buffers
                 .into_iter()
                 .enumerate()
                 .map(|(i, buffer)| checksum_buffer(first_page_idx + i, buffer, ctx))
                 .collect::<Vec<_>>(),
-            EncryptionOrChecksum::None => buffers,
+            PageTransform::None => buffers,
         };
         let c = self.file.pwritev(pos, buffers, c)?;
         Ok(c)
@@ -286,15 +483,283 @@ impl DatabaseFile {
     }
 }
 
-fn encrypt_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &EncryptionContext) -> Arc<Buffer> {
-    let encrypted_data = ctx.encrypt_page(buffer.as_slice(), page_idx).unwrap();
-    Arc::new(Buffer::new(encrypted_data.to_vec()))
+fn encode_buffer(
+    page_idx: usize,
+    buffer: Arc<Buffer>,
+    ctx: &dyn PageCodec,
+    location: PageCodecLocation,
+) -> Result<Arc<Buffer>> {
+    let encoded = Arc::new(Buffer::new_temporary(buffer.len()));
+    ctx.encode_page(
+        buffer.as_slice(),
+        encoded.as_mut_slice(),
+        page_idx,
+        location,
+    )?;
+    Ok(encoded)
+}
+
+fn encrypt_buffer(
+    page_idx: usize,
+    buffer: Arc<Buffer>,
+    ctx: &EncryptionContext,
+) -> Result<Arc<Buffer>> {
+    Ok(Arc::new(Buffer::new(
+        ctx.encrypt_page(buffer.as_slice(), page_idx)?,
+    )))
 }
 
 fn checksum_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &ChecksumContext) -> Arc<Buffer> {
     ctx.add_checksum_to_page(buffer.as_mut_slice(), page_idx)
         .unwrap();
     buffer
+}
+
+#[cfg(test)]
+mod page_codec_tests {
+    use super::*;
+    use crate::File;
+    use crate::{io::IO, MemoryIO};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug)]
+    struct XorPageCodec(u8);
+
+    impl PageCodec for XorPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"xor-page-codec--";
+            id[15] = self.0;
+            PageCodecId::new(id)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            for (input, output) in page.iter().zip(output) {
+                *output = input ^ self.0;
+            }
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            self.encode_page(page, output, _page_idx, _location)
+        }
+    }
+
+    #[derive(Debug)]
+    enum FailingPageCodec {
+        Encode,
+        Decode,
+    }
+
+    impl PageCodec for FailingPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"failing-page-cod";
+            id[15] = match self {
+                Self::Encode => 1,
+                Self::Decode => 2,
+            };
+            PageCodecId::new(id)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            match self {
+                Self::Encode => Err(LimboError::InternalError("codec encode failed".into())),
+                Self::Decode => {
+                    output.copy_from_slice(page);
+                    Ok(())
+                }
+            }
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            match self {
+                Self::Encode => {
+                    output.copy_from_slice(page);
+                    Ok(())
+                }
+                Self::Decode => Err(LimboError::InternalError("codec decode failed".into())),
+            }
+        }
+    }
+
+    struct MockFile {
+        read_result: std::result::Result<i32, CompletionError>,
+        writes_submitted: Arc<AtomicUsize>,
+    }
+
+    impl File for MockFile {
+        fn lock_file(&self, _exclusive: bool) -> Result<()> {
+            Ok(())
+        }
+
+        fn unlock_file(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn pread(&self, _pos: u64, c: Completion) -> Result<Completion> {
+            match self.read_result {
+                Ok(bytes_read) => c.complete(bytes_read),
+                Err(err) => c.error(err),
+            }
+            Ok(c)
+        }
+
+        fn pwrite(&self, _pos: u64, _buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
+            self.writes_submitted.fetch_add(1, Ordering::Relaxed);
+            c.complete(0);
+            Ok(c)
+        }
+
+        fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
+            c.complete(0);
+            Ok(c)
+        }
+
+        fn size(&self) -> Result<u64> {
+            Ok(0)
+        }
+
+        fn truncate(&self, _len: u64, c: Completion) -> Result<Completion> {
+            c.complete(0);
+            Ok(c)
+        }
+    }
+
+    #[test]
+    fn page_codec_encodes_into_fixed_size_database_buffer() {
+        let buffer = Arc::new(Buffer::new(vec![1, 2, 3, 4]));
+        let encoded =
+            encode_buffer(7, buffer, &XorPageCodec(0xa5), PageCodecLocation::Database).unwrap();
+        assert_eq!(encoded.as_slice(), &[0xa4, 0xa7, 0xa6, 0xa1]);
+    }
+
+    #[test]
+    fn page_codec_read_decodes_into_original_database_buffer() {
+        let db_file = DatabaseFile {
+            file: Arc::new(MockFile {
+                read_result: Ok(4096),
+                writes_submitted: Arc::new(AtomicUsize::new(0)),
+            }),
+        };
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(Arc::new(XorPageCodec(0xa5)));
+        let page_idx = 9usize;
+        let original = Completion::new_read(Arc::new(Buffer::new_temporary(4096)), |_res| None);
+
+        let wrapped = db_file
+            .read_page(page_idx, &io_ctx, original.clone())
+            .unwrap();
+        MemoryIO::new().wait_for_completion(wrapped).unwrap();
+        assert!(original.succeeded());
+        assert!(original
+            .as_read()
+            .buf()
+            .as_slice()
+            .iter()
+            .all(|byte| *byte == 0xa5));
+    }
+
+    #[test]
+    fn page_codec_empty_database_read_completes_without_decoding() {
+        let db_file = DatabaseFile {
+            file: Arc::new(MockFile {
+                read_result: Ok(0),
+                writes_submitted: Arc::new(AtomicUsize::new(0)),
+            }),
+        };
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(Arc::new(XorPageCodec(0xa5)));
+        let original = Completion::new_read(Arc::new(Buffer::new_temporary(4096)), |_| None);
+
+        let wrapped = db_file.read_page(9, &io_ctx, original.clone()).unwrap();
+        MemoryIO::new().wait_for_completion(wrapped).unwrap();
+        assert!(original.succeeded());
+    }
+
+    #[test]
+    fn page_codec_database_write_error_does_not_submit_io() {
+        let writes_submitted = Arc::new(AtomicUsize::new(0));
+        let db_file = DatabaseFile {
+            file: Arc::new(MockFile {
+                read_result: Ok(0),
+                writes_submitted: writes_submitted.clone(),
+            }),
+        };
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(Arc::new(FailingPageCodec::Encode));
+
+        let err = db_file
+            .write_page(
+                1,
+                Arc::new(Buffer::new_temporary(512)),
+                &io_ctx,
+                Completion::new_write(|_| {}),
+            )
+            .unwrap_err();
+
+        assert!(err.to_string().contains("codec encode failed"));
+        assert_eq!(
+            writes_submitted.load(Ordering::Relaxed),
+            0,
+            "a codec error must prevent the database write from being submitted"
+        );
+    }
+
+    #[test]
+    fn page_codec_database_read_reports_decode_error() {
+        let db_file = DatabaseFile {
+            file: Arc::new(MockFile {
+                read_result: Ok(512),
+                writes_submitted: Arc::new(AtomicUsize::new(0)),
+            }),
+        };
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(Arc::new(FailingPageCodec::Decode));
+        let original = Completion::new_read(Arc::new(Buffer::new_temporary(512)), |_| None);
+
+        let wrapped = db_file.read_page(1, &io_ctx, original.clone()).unwrap();
+        let err = MemoryIO::new().wait_for_completion(wrapped).unwrap_err();
+
+        assert!(matches!(
+            err,
+            LimboError::CompletionError(CompletionError::PageCodecError { page_idx: 1 })
+        ));
+        assert!(matches!(
+            original.get_error(),
+            Some(CompletionError::PageCodecError { page_idx: 1 })
+        ));
+    }
 }
 
 #[cfg(all(test, feature = "checksum"))]

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -234,7 +234,7 @@ impl DatabaseStorage for DatabaseFile {
         match &io_ctx.page_transform {
             PageTransform::Encryption(ctx) => {
                 let encryption_ctx = ctx.clone();
-                let read_buffer = Arc::new(Buffer::new_temporary(r.buf_arc().len()));
+                let read_buffer = r.buf_arc();
                 let original_c = c.clone();
                 let decrypt_complete =
                     Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
@@ -246,10 +246,12 @@ impl DatabaseStorage for DatabaseFile {
                                 return original_c.get_error();
                             }
                         };
-                        // A zero-byte read is the expected probe result for an
-                        // empty database; only complete page images are decryptable.
                         if bytes_read == 0 {
-                            original_c.complete(bytes_read);
+                            original_c.error(CompletionError::ShortRead {
+                                page_idx,
+                                expected: buf.len(),
+                                actual: 0,
+                            });
                             return original_c.get_error();
                         }
                         turso_assert_greater_than!(
@@ -299,10 +301,12 @@ impl DatabaseStorage for DatabaseFile {
                                 return original_c.get_error();
                             }
                         };
-                        // A zero-byte read is the expected probe result for an
-                        // empty database; only complete page images are decodable.
                         if bytes_read == 0 {
-                            original_c.complete(bytes_read);
+                            original_c.error(CompletionError::ShortRead {
+                                page_idx,
+                                expected: buf.len(),
+                                actual: 0,
+                            });
                             return original_c.get_error();
                         }
                         turso_assert_greater_than!(
@@ -691,7 +695,7 @@ mod page_codec_tests {
     }
 
     #[test]
-    fn page_codec_empty_database_read_completes_without_decoding() {
+    fn page_codec_zero_byte_read_reports_short_read() {
         let db_file = DatabaseFile {
             file: Arc::new(MockFile {
                 read_result: Ok(0),
@@ -700,11 +704,31 @@ mod page_codec_tests {
         };
         let mut io_ctx = IOContext::default();
         io_ctx.set_page_codec(Arc::new(XorPageCodec(0xa5)));
+        let page_idx = 9usize;
         let original = Completion::new_read(Arc::new(Buffer::new_temporary(4096)), |_| None);
 
-        let wrapped = db_file.read_page(9, &io_ctx, original.clone()).unwrap();
-        MemoryIO::new().wait_for_completion(wrapped).unwrap();
-        assert!(original.succeeded());
+        let wrapped = db_file
+            .read_page(page_idx, &io_ctx, original.clone())
+            .unwrap();
+        let err = MemoryIO::new()
+            .wait_for_completion(wrapped)
+            .expect_err("a zero-byte transformed page read must fail");
+        assert!(matches!(
+            err,
+            LimboError::CompletionError(CompletionError::ShortRead {
+                page_idx: 9,
+                expected: 4096,
+                actual: 0,
+            })
+        ));
+        assert!(matches!(
+            original.get_error(),
+            Some(CompletionError::ShortRead {
+                page_idx: 9,
+                expected: 4096,
+                actual: 0,
+            })
+        ));
     }
 
     #[test]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -27,7 +27,7 @@ use crate::{
     io::CompletionGroup, return_if_io, types::WalFrameInfo, Completion, Connection, IOResult,
     LimboError, Result, TransactionState,
 };
-use crate::{io_yield_one, Buffer, CompletionError, IOContext, OpenFlags, SyncMode, IO};
+use crate::{io_yield_one, Buffer, CompletionError, IOContext, OpenFlags, PageCodec, SyncMode, IO};
 #[allow(unused_imports)]
 use crate::{
     turso_assert, turso_assert_eq, turso_assert_greater_than, turso_assert_greater_than_or_equal,
@@ -2768,6 +2768,17 @@ impl Pager {
     /// Set the initial page size for the database. Should only be called before the database is initialized
     pub fn set_initial_page_size(&self, size: PageSize) -> Result<()> {
         turso_assert!(!self.db_initialized());
+        let reserved_space = self
+            .get_reserved_space()
+            .unwrap_or_else(|| self.io_ctx.read().get_reserved_space_bytes());
+        if !size.has_valid_reserved_space(reserved_space) {
+            return Err(LimboError::InvalidArgument(format!(
+                "page size {} with reserved space {} leaves less than {} usable bytes",
+                size.get(),
+                reserved_space,
+                PageSize::MIN_USABLE_SPACE
+            )));
+        }
         let IOResult::Done(mut header) = self.with_header(|header| *header)? else {
             panic!("DB should not be initialized and should not do any IO");
         };
@@ -2845,7 +2856,7 @@ impl Pager {
     }
 
     /// Set the page size. Used internally when page size is determined.
-    pub fn set_page_size(&self, size: PageSize) {
+    pub(crate) fn set_page_size(&self, size: PageSize) {
         self.page_size.store(size.get(), Ordering::SeqCst);
     }
 
@@ -2860,7 +2871,7 @@ impl Pager {
     }
 
     /// Set the reserved space. Must fit in u8.
-    pub fn set_reserved_space(&self, space: u8) {
+    fn set_reserved_space(&self, space: u8) {
         self.reserved_space.store(space as u16, Ordering::SeqCst);
     }
 
@@ -3682,6 +3693,12 @@ impl Pager {
         completion: Completion,
     ) -> Result<CacheFlushStep> {
         if !completion.succeeded() {
+            if completion.finished() {
+                let err = completion
+                    .get_error()
+                    .expect("finished unsuccessful cacheflush read must have an error");
+                return Err(err.into());
+            }
             return Ok(CacheFlushStep::Yield(
                 CacheFlushState::WaitingForRead {
                     state,
@@ -4535,7 +4552,9 @@ impl Pager {
                 clear_page_cache,
                 read: PendingCheckpointDbIdentityRead {
                     max_frame: result.wal_total_backfilled,
-                    header_buf: Arc::new(Buffer::new_temporary(PageSize::MIN as usize)),
+                    header_buf: Arc::new(Buffer::new_temporary(
+                        self.get_page_size_unchecked().get() as usize,
+                    )),
                     bytes_read: Arc::new(AtomicUsize::new(usize::MAX)),
                     read_sent: false,
                 },
@@ -4766,14 +4785,19 @@ impl Pager {
                     if !read.read_sent {
                         let header_buf = read.header_buf.clone();
                         let bytes_read = read.bytes_read.clone();
-                        let c = self.db_file.read_header(Completion::new_read(header_buf, {
-                            Box::new(move |res| {
-                                if let Ok((_buf, count)) = res {
-                                    bytes_read.store(count as usize, Ordering::Release);
-                                }
-                                None
-                            })
-                        }))?;
+                        let io_ctx = self.io_ctx.read();
+                        let c = self.db_file.read_page(
+                            1,
+                            &io_ctx,
+                            Completion::new_read(header_buf, {
+                                Box::new(move |res| {
+                                    if let Ok((_buf, count)) = res {
+                                        bytes_read.store(count as usize, Ordering::Release);
+                                    }
+                                    None
+                                })
+                            }),
+                        )?;
                         read.read_sent = true;
                         self.checkpoint_state.write().phase = CheckpointPhase::ReadDbIdentity {
                             clear_page_cache,
@@ -5641,8 +5665,28 @@ impl Pager {
         Ok(IOResult::Done(result))
     }
 
+    pub fn has_encryption(&self) -> bool {
+        self.io_ctx.read().has_encryption()
+    }
+
+    pub fn encryption_reserved_space(&self) -> Option<u8> {
+        self.io_ctx
+            .read()
+            .encryption_context()
+            .map(EncryptionContext::required_reserved_bytes)
+    }
+
+    #[deprecated(note = "renamed to has_encryption")]
     pub fn is_encryption_ctx_set(&self) -> bool {
-        self.io_ctx.read().encryption_context().is_some()
+        self.has_encryption()
+    }
+
+    pub fn has_page_codec(&self) -> bool {
+        self.io_ctx.read().has_page_codec()
+    }
+
+    pub fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
+        self.io_ctx.read().page_codec()
     }
 
     pub fn is_encryption_enabled(&self) -> bool {
@@ -5658,6 +5702,12 @@ impl Pager {
         if !self.enable_encryption.load(Ordering::SeqCst) {
             return Err(LimboError::InvalidArgument(
                 "encryption is an opt in feature. enable it via passing `--experimental-encryption`"
+                    .into(),
+            ));
+        }
+        if self.has_page_codec() {
+            return Err(LimboError::InvalidArgument(
+                "cannot configure built-in encryption while an external page codec is installed"
                     .into(),
             ));
         }
@@ -5682,6 +5732,46 @@ impl Pager {
         Ok(())
     }
 
+    pub(crate) fn set_page_codec(&self, codec: Arc<dyn PageCodec>) -> Result<()> {
+        if self.has_encryption() {
+            return Err(LimboError::InvalidArgument(
+                "cannot install an external page codec while built-in encryption is configured"
+                    .into(),
+            ));
+        }
+        let required_reserved_space = codec.required_reserved_bytes();
+        if let Some(reserved_space) = self.get_reserved_space() {
+            if reserved_space != required_reserved_space {
+                return Err(LimboError::InvalidArgument(format!(
+                    "page codec requires exactly {required_reserved_space} reserved bytes, but database provides {reserved_space}"
+                )));
+            }
+        } else {
+            if let Some(page_size) = self.get_page_size() {
+                if !page_size.has_valid_reserved_space(required_reserved_space) {
+                    return Err(LimboError::InvalidArgument(format!(
+                        "page codec requires {} reserved bytes, which leaves less than {} usable bytes for page size {}",
+                        required_reserved_space,
+                        PageSize::MIN_USABLE_SPACE,
+                        page_size.get()
+                    )));
+                }
+            }
+            self.set_reserved_space(required_reserved_space);
+        }
+        {
+            let mut io_ctx = self.io_ctx.write();
+            io_ctx.set_page_codec(codec);
+        }
+        if let Some(wal) = self.wal.as_ref() {
+            let io_ctx = self.io_ctx.read().clone();
+            wal.set_io_context(io_ctx);
+        }
+        self.clear_page_cache(false);
+        self.set_schema_cookie(None);
+        Ok(())
+    }
+
     pub fn reset_checksum_context(&self) {
         {
             let mut io_ctx = self.io_ctx.write();
@@ -5691,7 +5781,7 @@ impl Pager {
         wal.set_io_context(self.io_ctx.read().clone())
     }
 
-    pub fn set_reserved_space_bytes(&self, value: u8) {
+    pub(crate) fn set_reserved_space_bytes(&self, value: u8) {
         self.set_reserved_space(value);
     }
 
@@ -5965,7 +6055,8 @@ mod tests {
     use crate::util::IOExt;
     use arc_swap::ArcSwapOption;
 
-    use super::{default_page1, Page, PageRef, Pager};
+    use super::{default_page1, CacheFlushState, CollectingState, Page, PageRef, Pager};
+    use crate::{Buffer, Completion, CompletionError, LimboError};
 
     fn pager_with_cache_capacity(cache_capacity: usize, database_pages: u32) -> Arc<Pager> {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
@@ -6074,6 +6165,32 @@ mod tests {
             pager.page_cache.read().len() > CAP,
             "page must have been admitted over capacity"
         );
+    }
+
+    #[test]
+    fn cacheflush_propagates_failed_page_codec_reread() {
+        let pager = pager_with_cache_capacity(5, 2);
+        let page = Arc::new(Page::new(2));
+        page.set_loaded();
+        let completion =
+            Completion::new_read(Arc::new(Buffer::new_temporary(4096)), Box::new(|_| None));
+        completion.error(CompletionError::PageCodecError { page_idx: 2 });
+        *pager.cacheflush_state.write() = CacheFlushState::WaitingForRead {
+            state: CollectingState::default(),
+            page_id: 2,
+            page,
+            completion,
+        };
+
+        let err = pager.cacheflush().unwrap_err();
+        assert!(matches!(
+            err,
+            LimboError::CompletionError(CompletionError::PageCodecError { page_idx: 2 })
+        ));
+        assert!(matches!(
+            *pager.cacheflush_state.read(),
+            CacheFlushState::Init
+        ));
     }
 
     #[test]
@@ -6504,7 +6621,9 @@ mod ptrmap_tests {
 #[cfg(all(test, feature = "fs", host_shared_wal))]
 mod checkpoint_phase_tests {
     use super::*;
-    use crate::io::{PlatformIO, IO};
+    #[cfg(not(all(target_os = "windows", feature = "experimental_win_iocp")))]
+    use crate::io::PlatformIO;
+    use crate::io::IO;
     use crate::storage::sqlite3_ondisk::DatabaseHeader;
     use crate::storage::wal::CheckpointMode;
     use crate::sync::atomic::Ordering;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -5676,11 +5676,6 @@ impl Pager {
             .map(EncryptionContext::required_reserved_bytes)
     }
 
-    #[deprecated(note = "renamed to has_encryption")]
-    pub fn is_encryption_ctx_set(&self) -> bool {
-        self.has_encryption()
-    }
-
     pub fn has_page_codec(&self) -> bool {
         self.io_ctx.read().has_page_codec()
     }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -62,7 +62,7 @@ use crate::io::{Buffer, Completion, FileSyncType, ReadComplete};
 use crate::numeric::Numeric;
 use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_threshold_min};
 use crate::storage::buffer_pool::BufferPool;
-use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum};
+use crate::storage::database::{DatabaseStorage, PageCodecLocation, PageTransform};
 use crate::storage::pager::Pager;
 use crate::storage::wal::READMARK_NOT_USED;
 use crate::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
@@ -101,6 +101,7 @@ impl PageSize {
     pub const MIN: u32 = 512;
     pub const MAX: u32 = 65536;
     pub const DEFAULT: u16 = 4096;
+    pub const MIN_USABLE_SPACE: u32 = 480;
 
     /// Interpret a user-provided u32 as either a valid page size or None.
     pub const fn new(size: u32) -> Option<Self> {
@@ -141,6 +142,10 @@ impl PageSize {
             1 => Self::MAX,
             v => v as u32,
         }
+    }
+
+    pub const fn has_valid_reserved_space(self, reserved_space: u8) -> bool {
+        self.get().saturating_sub(reserved_space as u32) >= Self::MIN_USABLE_SPACE
     }
 
     /// Get the raw u16 value stored internally
@@ -1965,8 +1970,8 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
     let buf = buffer_pool.get_page();
     let buf = Arc::new(buf);
 
-    match io_ctx.encryption_or_checksum() {
-        EncryptionOrChecksum::Encryption(ctx) => {
+    match io_ctx.page_transform() {
+        PageTransform::Encryption(ctx) => {
             let encryption_ctx = ctx.clone();
             let original_complete = complete;
 
@@ -1976,10 +1981,14 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
                         return original_complete(res);
                     };
                     turso_assert_greater_than!(
-                        bytes_read, 0,
+                        bytes_read,
+                        0,
                         "expected to read data for encrypted page",
                         { "page_idx": page_idx }
                     );
+                    if bytes_read as usize != encrypted_buf.len() {
+                        return original_complete(Ok((encrypted_buf, bytes_read)));
+                    }
                     match encryption_ctx.decrypt_page(encrypted_buf.as_slice(), page_idx) {
                         Ok(decrypted_data) => {
                             encrypted_buf
@@ -2001,7 +2010,47 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
             let new_completion = Completion::new_read(buf, decrypt_complete);
             io.pread(offset, new_completion)
         }
-        EncryptionOrChecksum::Checksum(ctx) => {
+        PageTransform::PageCodec(ctx) => {
+            let page_codec = ctx.clone();
+            let original_complete = complete;
+            let decoded_buf = Arc::new(buffer_pool.get_page());
+
+            let decode_complete =
+                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                    let Ok((encoded_buf, bytes_read)) = res else {
+                        return original_complete(res);
+                    };
+                    turso_assert_greater_than!(
+                        bytes_read,
+                        0,
+                        "expected to read data for page codec page",
+                        { "page_idx": page_idx }
+                    );
+                    if bytes_read as usize != encoded_buf.len() {
+                        return original_complete(Ok((encoded_buf, bytes_read)));
+                    }
+                    match page_codec.decode_page(
+                        encoded_buf.as_slice(),
+                        decoded_buf.as_mut_slice(),
+                        page_idx,
+                        PageCodecLocation::Wal,
+                    ) {
+                        Ok(()) => original_complete(Ok((decoded_buf.clone(), bytes_read))),
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to decode WAL frame data for page_idx={page_idx}: {e}"
+                            );
+                            let err = CompletionError::PageCodecError { page_idx };
+                            original_complete(Err(err));
+                            Some(err)
+                        }
+                    }
+                });
+
+            let new_completion = Completion::new_read(buf, decode_complete);
+            io.pread(offset, new_completion)
+        }
+        PageTransform::Checksum(ctx) => {
             let checksum_ctx = ctx.clone();
             let original_c = complete;
             let verify_complete =
@@ -2029,7 +2078,7 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
             let c = Completion::new_read(buf, verify_complete);
             io.pread(offset, c)
         }
-        EncryptionOrChecksum::None => {
+        PageTransform::None => {
             let c = Completion::new_read(buf, complete);
             io.pread(offset, c)
         }
@@ -2059,37 +2108,60 @@ pub fn prepare_wal_frame(
     buffer_pool: &Arc<BufferPool>,
     wal_header: &WalHeader,
     prev_checksums: (u32, u32),
-    page_size: u32,
+    _page_size: u32,
     page_number: u32,
     db_size: u32,
     page: &[u8],
 ) -> ((u32, u32), Arc<Buffer>) {
     tracing::trace!(page_number);
 
-    let buffer = buffer_pool.get_wal_frame();
+    let buffer = prepare_wal_frame_header(buffer_pool, wal_header, page_number, db_size);
     let frame = buffer.as_mut_slice();
     frame[WAL_FRAME_HEADER_SIZE..].copy_from_slice(page);
 
+    let final_checksum = recompute_wal_frame_checksum(frame, wal_header, prev_checksums);
+
+    (final_checksum, buffer)
+}
+
+/// Prepares a WAL frame header while leaving the page body for a transform to fill.
+///
+/// The caller must write every byte after [`WAL_FRAME_HEADER_SIZE`] before computing
+/// the frame checksum or submitting the frame to storage.
+pub fn prepare_wal_frame_header(
+    buffer_pool: &Arc<BufferPool>,
+    wal_header: &WalHeader,
+    page_number: u32,
+    db_size: u32,
+) -> Arc<Buffer> {
+    let buffer = Arc::new(buffer_pool.get_wal_frame());
+    let frame = buffer.as_mut_slice();
     frame[0..4].copy_from_slice(&page_number.to_be_bytes());
     frame[4..8].copy_from_slice(&db_size.to_be_bytes());
     frame[8..12].copy_from_slice(&wal_header.salt_1.to_be_bytes());
     frame[12..16].copy_from_slice(&wal_header.salt_2.to_be_bytes());
+    buffer
+}
 
+/// Recompute a frame checksum after transforming its page body in place.
+pub fn recompute_wal_frame_checksum(
+    frame: &mut [u8],
+    wal_header: &WalHeader,
+    prev_checksums: (u32, u32),
+) -> (u32, u32) {
     let expects_be = wal_header.magic & 1;
     let use_native_endian = cfg!(target_endian = "big") as u32 == expects_be;
     let header_checksum = checksum_wal(&frame[0..8], wal_header, prev_checksums, use_native_endian);
     let final_checksum = checksum_wal(
-        &frame[WAL_FRAME_HEADER_SIZE..WAL_FRAME_HEADER_SIZE + page_size as usize],
+        &frame[WAL_FRAME_HEADER_SIZE..],
         wal_header,
         header_checksum,
         use_native_endian,
     );
     frame[16..20].copy_from_slice(&final_checksum.0.to_be_bytes());
     frame[20..24].copy_from_slice(&final_checksum.1.to_be_bytes());
-
-    (final_checksum, Arc::new(buffer))
+    final_checksum
 }
-
 pub fn begin_write_wal_header<F: File + ?Sized>(io: &F, header: &WalHeader) -> Result<Completion> {
     tracing::trace!("begin_write_wal_header");
     let buffer = {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -7,7 +7,6 @@ use crate::{turso_assert, turso_assert_greater_than, turso_debug_assert};
 use branches::mark_unlikely;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::array;
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use strum::EnumString;
@@ -28,7 +27,7 @@ use crate::fast_lock::SpinLock;
 use crate::io::clock::MonotonicInstant;
 use crate::io::CompletionGroup;
 use crate::io::{File, IO};
-use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum};
+use crate::storage::database::{DatabaseStorage, PageCodecLocation, PageTransform};
 #[cfg(host_shared_wal)]
 use crate::storage::shared_wal_coordination::SharedWalCoordinationOpenMode;
 #[cfg(host_shared_wal)]
@@ -37,7 +36,8 @@ use crate::storage::shared_wal_coordination::{
 };
 use crate::storage::sqlite3_ondisk::{
     begin_read_wal_frame, begin_read_wal_frame_raw, finish_read_page, prepare_wal_frame,
-    write_pages_vectored, PageSize, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
+    prepare_wal_frame_header, recompute_wal_frame_checksum, write_pages_vectored, PageSize,
+    WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
 };
 use crate::types::{IOCompletions, IOResult};
 use crate::util::IOExt as _;
@@ -677,11 +677,14 @@ pub trait Wal: Debug + Send + Sync {
         scratch_buf: Option<Arc<Buffer>>,
     ) -> Result<Completion>;
 
-    /// Read a raw frame (header included) from the WAL.
+    /// Read a raw WAL frame with its on-disk header and page body decoded by
+    /// the configured encryption context or external page codec.
     fn read_frame_raw(&self, frame_id: u64, frame: &mut [u8]) -> Result<Completion>;
 
-    /// Write a raw frame (header included) from the WAL.
-    /// Note, that turso-db will use page_no and size_after fields from the header, but will overwrite checksum with proper value
+    /// Write an in-memory page as a WAL frame.
+    ///
+    /// TursoDB uses `page_no` and `size_after` from the supplied header, applies
+    /// any configured page transform to the body, and overwrites the checksum.
     fn write_frame_raw(
         &self,
         buffer_pool: Arc<BufferPool>,
@@ -3513,13 +3516,14 @@ impl Wal for WalFile {
         // important not to hold shared state locks beyond this point to avoid deadlock with
         // completions that re-enter WAL state while a writer is waiting.
         let file = self.coordination.wal_file()?;
+        let io_ctx = self.io_ctx.read();
         begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
             buffer_pool,
             complete,
             page_idx,
-            &self.io_ctx.read(),
+            &io_ctx,
         )
     }
 
@@ -3574,7 +3578,7 @@ impl Wal for WalFile {
         }
 
         let epoch = self.coordination.checkpoint_epoch();
-        let enc_or_csum = self.io_ctx.read().encryption_or_checksum().clone();
+        let page_transform = self.io_ctx.read().page_transform().clone();
         let raw_buf = scratch_buf.unwrap_or_else(|| Arc::new(Buffer::new_temporary(total)));
 
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
@@ -3629,10 +3633,9 @@ impl Wal for WalFile {
                     "read_frames_batch buffer size must match WAL page size",
                     { "buffer_len": body_slice.len(), "page_size": page_size }
                 );
-                body_slice.copy_from_slice(page_body);
-
-                match &enc_or_csum {
-                    EncryptionOrChecksum::Encryption(ctx) => {
+                match &page_transform {
+                    PageTransform::Encryption(ctx) => {
+                        body_slice.copy_from_slice(page_body);
                         match ctx.decrypt_page(body_slice, expected_page_id) {
                             Ok(decrypted) => body_slice.copy_from_slice(&decrypted),
                             Err(e) => {
@@ -3647,7 +3650,28 @@ impl Wal for WalFile {
                             }
                         }
                     }
-                    EncryptionOrChecksum::Checksum(ctx) => {
+                    PageTransform::PageCodec(ctx) => {
+                        match ctx.decode_page(
+                            page_body,
+                            body_slice,
+                            expected_page_id,
+                            PageCodecLocation::Wal,
+                        ) {
+                            Ok(()) => {}
+                            Err(e) => {
+                                mark_unlikely();
+                                tracing::error!(
+                                    "Failed to decode WAL batch frame for page_idx={expected_page_id}: {e}"
+                                );
+                                clear_slots_on_err(&slots);
+                                return Some(CompletionError::PageCodecError {
+                                    page_idx: expected_page_id,
+                                });
+                            }
+                        }
+                    }
+                    PageTransform::Checksum(ctx) => {
+                        body_slice.copy_from_slice(page_body);
                         if let Err(e) = ctx.verify_checksum(body_slice, expected_page_id) {
                             mark_unlikely();
                             tracing::error!(
@@ -3657,7 +3681,7 @@ impl Wal for WalFile {
                             return Some(e);
                         }
                     }
-                    EncryptionOrChecksum::None => {}
+                    PageTransform::None => body_slice.copy_from_slice(page_body),
                 }
             }
 
@@ -3689,6 +3713,13 @@ impl Wal for WalFile {
             let io_ctx = self.io_ctx.read();
             io_ctx.encryption_context().cloned()
         };
+        let page_codec = {
+            let io_ctx = self.io_ctx.read();
+            match io_ctx.page_transform() {
+                PageTransform::PageCodec(ctx) => Some(ctx.clone()),
+                _ => None,
+            }
+        };
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 return None; // IO error already captured in completion
@@ -3704,20 +3735,15 @@ impl Wal for WalFile {
                     actual: bytes_read as usize,
                 });
             }
-            let buf_ptr = buf.as_ptr();
             let frame_ptr = frame_ptr as *mut u8;
             let frame_ref: &mut [u8] =
                 unsafe { std::slice::from_raw_parts_mut(frame_ptr, frame_len) };
 
-            // Copy the just-read WAL frame into the destination buffer
-            unsafe {
-                std::ptr::copy_nonoverlapping(buf_ptr, frame_ptr, frame_len);
-            }
+            frame_ref[..WAL_FRAME_HEADER_SIZE]
+                .copy_from_slice(&buf.as_slice()[..WAL_FRAME_HEADER_SIZE]);
+            let (header, raw_page) = sqlite3_ondisk::parse_wal_frame_header(buf.as_slice());
 
-            // Now parse the header from the freshly-copied data
-            let (header, raw_page) = sqlite3_ondisk::parse_wal_frame_header(frame_ref);
-
-            if let Some(ctx) = encryption_ctx.clone() {
+            if let Some(ctx) = encryption_ctx.as_ref() {
                 match ctx.decrypt_page(raw_page, header.page_number as usize) {
                     Ok(decrypted_data) => {
                         turso_assert!(
@@ -3729,8 +3755,28 @@ impl Wal for WalFile {
                     }
                     Err(_) => {
                         tracing::debug!("Failed to decrypt page data for frame_id={frame_id}");
+                        return Some(CompletionError::DecryptionError {
+                            page_idx: header.page_number as usize,
+                        });
                     }
                 }
+            } else if let Some(ctx) = page_codec.as_ref() {
+                match ctx.decode_page(
+                    raw_page,
+                    &mut frame_ref[WAL_FRAME_HEADER_SIZE..],
+                    header.page_number as usize,
+                    PageCodecLocation::Wal,
+                ) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        tracing::debug!("Failed to decode page data for frame_id={frame_id}: {e}");
+                        return Some(CompletionError::PageCodecError {
+                            page_idx: header.page_number as usize,
+                        });
+                    }
+                }
+            } else {
+                frame_ref[WAL_FRAME_HEADER_SIZE..].copy_from_slice(raw_page);
             }
             None
         });
@@ -3806,13 +3852,14 @@ impl Wal for WalFile {
                 }
             });
             let file = self.coordination.wal_file()?;
+            let io_ctx = self.io_ctx.read();
             let c = begin_read_wal_frame(
                 file.as_ref(),
                 offset + WAL_FRAME_HEADER_SIZE as u64,
                 buffer_pool,
                 complete,
                 page_id as usize,
-                &self.io_ctx.read(),
+                &io_ctx,
             )?;
             self.io.wait_for_completion(c)?;
             return if *conflict.lock() {
@@ -3828,16 +3875,55 @@ impl Wal for WalFile {
         let offset = self.frame_offset(frame_id);
         let header = self.coordination.wal_header();
         let file = self.coordination.wal_file()?;
-        let checksums = *self.last_checksum.read();
-        let (checksums, frame_bytes) = prepare_wal_frame(
-            &self.buffer_pool,
-            &header,
-            checksums,
-            header.page_size,
-            page_id as u32,
-            db_size as u32,
-            page,
-        );
+        let previous_checksums = *self.last_checksum.read();
+        let (checksums, frame_bytes) = match self.io_ctx.read().page_transform() {
+            PageTransform::Encryption(ctx) => {
+                let encrypted_page = ctx.encrypt_page(page, page_id as usize)?;
+                let frame_bytes = prepare_wal_frame_header(
+                    &self.buffer_pool,
+                    &header,
+                    page_id as u32,
+                    db_size as u32,
+                );
+                frame_bytes.as_mut_slice()[WAL_FRAME_HEADER_SIZE..]
+                    .copy_from_slice(&encrypted_page);
+                let checksums = recompute_wal_frame_checksum(
+                    frame_bytes.as_mut_slice(),
+                    &header,
+                    previous_checksums,
+                );
+                (checksums, frame_bytes)
+            }
+            PageTransform::PageCodec(ctx) => {
+                let frame_bytes = prepare_wal_frame_header(
+                    &self.buffer_pool,
+                    &header,
+                    page_id as u32,
+                    db_size as u32,
+                );
+                ctx.encode_page(
+                    page,
+                    &mut frame_bytes.as_mut_slice()[WAL_FRAME_HEADER_SIZE..],
+                    page_id as usize,
+                    PageCodecLocation::Wal,
+                )?;
+                let checksums = recompute_wal_frame_checksum(
+                    frame_bytes.as_mut_slice(),
+                    &header,
+                    previous_checksums,
+                );
+                (checksums, frame_bytes)
+            }
+            PageTransform::Checksum(_) | PageTransform::None => prepare_wal_frame(
+                &self.buffer_pool,
+                &header,
+                previous_checksums,
+                header.page_size,
+                page_id as u32,
+                db_size as u32,
+                page,
+            ),
+        };
         let c = Completion::new_write(|_| {});
         let c = file.pwrite(offset, frame_bytes, c)?;
         self.io.wait_for_completion(c)?;
@@ -4320,24 +4406,11 @@ impl Wal for WalFile {
 
         let mut bufs: Vec<Arc<Buffer>> = Vec::with_capacity(pages.len());
         let mut metadata = Vec::with_capacity(pages.len());
+        let page_transform = self.io_ctx.read().page_transform().clone();
 
         for (idx, page) in pages.iter().enumerate() {
             let page_id = page.get().id;
             let plain = page.get_contents().as_ptr();
-
-            let data: Cow<[u8]> = {
-                let io_ctx = self.io_ctx.read();
-                match io_ctx.encryption_or_checksum() {
-                    EncryptionOrChecksum::Encryption(ctx) => {
-                        Cow::Owned(ctx.encrypt_page(plain, page_id)?)
-                    }
-                    EncryptionOrChecksum::Checksum(ctx) => {
-                        ctx.add_checksum_to_page(plain, page_id)?;
-                        Cow::Borrowed(plain)
-                    }
-                    EncryptionOrChecksum::None => Cow::Borrowed(plain),
-                }
-            };
 
             // if DB size is included for commit frame, it will need to be included only in the last frame of the batch.
             // however it might not be present in this batch so we cannot assert its presence
@@ -4346,15 +4419,61 @@ impl Wal for WalFile {
             } else {
                 0
             };
-            let (checksum, frame_buf) = prepare_wal_frame(
-                &self.buffer_pool,
-                &header,
-                rolling_checksum,
-                header.page_size,
-                page_id as u32,
-                frame_db_size,
-                &data,
-            );
+            let (checksum, frame_buf) = match &page_transform {
+                PageTransform::PageCodec(ctx) => {
+                    let frame_buf = prepare_wal_frame_header(
+                        &self.buffer_pool,
+                        &header,
+                        page_id as u32,
+                        frame_db_size,
+                    );
+                    ctx.encode_page(
+                        plain,
+                        &mut frame_buf.as_mut_slice()[WAL_FRAME_HEADER_SIZE..],
+                        page_id,
+                        PageCodecLocation::Wal,
+                    )?;
+                    let checksum = recompute_wal_frame_checksum(
+                        frame_buf.as_mut_slice(),
+                        &header,
+                        rolling_checksum,
+                    );
+                    (checksum, frame_buf)
+                }
+                PageTransform::Encryption(ctx) => {
+                    let data = ctx.encrypt_page(plain, page_id)?;
+                    prepare_wal_frame(
+                        &self.buffer_pool,
+                        &header,
+                        rolling_checksum,
+                        header.page_size,
+                        page_id as u32,
+                        frame_db_size,
+                        &data,
+                    )
+                }
+                PageTransform::Checksum(ctx) => {
+                    ctx.add_checksum_to_page(plain, page_id)?;
+                    prepare_wal_frame(
+                        &self.buffer_pool,
+                        &header,
+                        rolling_checksum,
+                        header.page_size,
+                        page_id as u32,
+                        frame_db_size,
+                        plain,
+                    )
+                }
+                PageTransform::None => prepare_wal_frame(
+                    &self.buffer_pool,
+                    &header,
+                    rolling_checksum,
+                    header.page_size,
+                    page_id as u32,
+                    frame_db_size,
+                    plain,
+                ),
+            };
             bufs.push(frame_buf);
             metadata.push((page.clone(), next_frame_id, checksum));
             rolling_checksum = checksum;
@@ -4431,6 +4550,7 @@ impl Wal for WalFile {
         let mut iovecs: Vec<Arc<Buffer>> = Vec::with_capacity(pages.len());
         let mut page_frame_and_checksum: Vec<(PageRef, u64, (u32, u32))> =
             Vec::with_capacity(pages.len());
+        let page_transform = self.io_ctx.read().page_transform().clone();
 
         // Rolling checksum input to each frame build
         let mut rolling_checksum: (u32, u32) = *self.last_checksum.read();
@@ -4442,30 +4562,62 @@ impl Wal for WalFile {
             let page_id = page.get().id;
             let plain = page.get_contents().as_ptr();
 
-            let data_to_write: std::borrow::Cow<[u8]> = {
-                let io_ctx = self.io_ctx.read();
-                match &io_ctx.encryption_or_checksum() {
-                    EncryptionOrChecksum::Encryption(ctx) => {
-                        Cow::Owned(ctx.encrypt_page(plain, page_id)?)
-                    }
-                    EncryptionOrChecksum::Checksum(ctx) => {
-                        ctx.add_checksum_to_page(plain, page_id)?;
-                        Cow::Borrowed(plain)
-                    }
-                    EncryptionOrChecksum::None => Cow::Borrowed(plain),
-                }
-            };
-
             let frame_db_size = 0; // this method is not used for the commit path
-            let (new_checksum, frame_bytes) = prepare_wal_frame(
-                &self.buffer_pool,
-                &header,
-                rolling_checksum,
-                shared_page_size,
-                page_id as u32,
-                frame_db_size,
-                &data_to_write,
-            );
+            let (new_checksum, frame_bytes) = match &page_transform {
+                PageTransform::PageCodec(ctx) => {
+                    let frame_bytes = prepare_wal_frame_header(
+                        &self.buffer_pool,
+                        &header,
+                        page_id as u32,
+                        frame_db_size,
+                    );
+                    ctx.encode_page(
+                        plain,
+                        &mut frame_bytes.as_mut_slice()[WAL_FRAME_HEADER_SIZE..],
+                        page_id,
+                        PageCodecLocation::Wal,
+                    )?;
+                    let checksum = recompute_wal_frame_checksum(
+                        frame_bytes.as_mut_slice(),
+                        &header,
+                        rolling_checksum,
+                    );
+                    (checksum, frame_bytes)
+                }
+                PageTransform::Encryption(ctx) => {
+                    let data = ctx.encrypt_page(plain, page_id)?;
+                    prepare_wal_frame(
+                        &self.buffer_pool,
+                        &header,
+                        rolling_checksum,
+                        shared_page_size,
+                        page_id as u32,
+                        frame_db_size,
+                        &data,
+                    )
+                }
+                PageTransform::Checksum(ctx) => {
+                    ctx.add_checksum_to_page(plain, page_id)?;
+                    prepare_wal_frame(
+                        &self.buffer_pool,
+                        &header,
+                        rolling_checksum,
+                        shared_page_size,
+                        page_id as u32,
+                        frame_db_size,
+                        plain,
+                    )
+                }
+                PageTransform::None => prepare_wal_frame(
+                    &self.buffer_pool,
+                    &header,
+                    rolling_checksum,
+                    shared_page_size,
+                    page_id as u32,
+                    frame_db_size,
+                    plain,
+                ),
+            };
             iovecs.push(frame_bytes);
 
             // (page, assigned_frame_id, cumulative_checksum_at_this_frame)
@@ -5208,13 +5360,14 @@ impl WalFile {
         };
         // schedule read of the page payload
         let file = self.coordination.wal_file()?;
+        let io_ctx = self.io_ctx.read();
         let c = begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
             self.buffer_pool.clone(),
             complete,
             page_id,
-            &self.io_ctx.read(),
+            &io_ctx,
         )?;
 
         Ok(InflightRead {
@@ -5337,10 +5490,14 @@ pub(crate) fn database_identity_from_header_bytes(header_bytes: &[u8]) -> Result
 fn read_database_identity_from_storage(
     io: &Arc<dyn IO>,
     db_file: &Arc<dyn DatabaseStorage>,
+    io_ctx: Option<&IOContext>,
+    page_size: usize,
 ) -> Result<Option<(u32, u32)>> {
-    let read_buf = Arc::new(Buffer::new_temporary(PageSize::MIN as usize));
+    let read_buf = Arc::new(Buffer::new_temporary(
+        io_ctx.map_or(PageSize::MIN as usize, |_| page_size),
+    ));
     let bytes_read = Arc::new(AtomicUsize::new(usize::MAX));
-    let c = db_file.read_header(Completion::new_read(read_buf.clone(), {
+    let completion = Completion::new_read(read_buf.clone(), {
         let bytes_read = bytes_read.clone();
         Box::new(move |res| {
             if let Ok((_buf, count)) = res {
@@ -5348,7 +5505,11 @@ fn read_database_identity_from_storage(
             }
             None
         })
-    }))?;
+    });
+    let c = match io_ctx {
+        Some(io_ctx) => db_file.read_page(1, io_ctx, completion)?,
+        None => db_file.read_header(completion)?,
+    };
     io.wait_for_completion(c)?;
     if bytes_read.load(Ordering::Acquire) < DatabaseHeader::SIZE {
         return Ok(None);
@@ -5502,6 +5663,7 @@ impl WalFileShared {
         flags: crate::OpenFlags,
         authority: &Arc<MappedSharedWalCoordination>,
         db_file: &Arc<dyn DatabaseStorage>,
+        io_ctx: Option<&IOContext>,
     ) -> Result<Arc<RwLock<WalFileShared>>> {
         let snapshot = authority.snapshot();
         let file = match io.open_file(path, flags, false) {
@@ -5555,8 +5717,12 @@ impl WalFileShared {
             return sqlite3_ondisk::build_shared_wal(&file, io);
         }
         if snapshot.nbackfills != 0 {
-            let Some((db_size_pages, db_header_crc32c)) =
-                read_database_identity_from_storage(io, db_file)?
+            let Some((db_size_pages, db_header_crc32c)) = read_database_identity_from_storage(
+                io,
+                db_file,
+                io_ctx,
+                snapshot.page_size as usize,
+            )?
             else {
                 tracing::debug!(
                     nbackfills = snapshot.nbackfills,
@@ -5830,15 +5996,19 @@ pub mod test {
         io::FileSyncType,
         storage::{
             buffer_pool::BufferPool,
-            database::{DatabaseFile, DatabaseStorage},
+            database::{
+                DatabaseFile, DatabaseStorage, IOContext, PageCodec, PageCodecId, PageCodecLocation,
+            },
+            encryption::{CipherMode, EncryptionContext, EncryptionKey},
             pager::{allocate_new_page, PageRef},
-            sqlite3_ondisk::{self, PageSize, WAL_HEADER_SIZE},
+            sqlite3_ondisk::{self, PageSize, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE},
             wal::READMARK_NOT_USED,
         },
         types::IOResult,
         util::IOExt,
         Buffer, CheckpointMode, CheckpointResult, Completion, CompletionError, Connection,
-        Database, File, LimboError, MemoryIO, OpenFlags, PlatformIO, SyncMode, WalFileShared, IO,
+        Database, File, LimboError, MemoryIO, OpenFlags, PlatformIO, Result, SyncMode,
+        WalFileShared, IO,
     };
     use std::num::NonZeroUsize;
     #[cfg(unix)]
@@ -6309,6 +6479,83 @@ pub mod test {
         page
     }
 
+    #[derive(Debug)]
+    enum TestPageCodec {
+        Xor(u8),
+        ErrorEncode,
+        ErrorDecode,
+    }
+
+    impl PageCodec for TestPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"wal-test-codec--";
+            id[15] = match self {
+                Self::Xor(mask) => *mask,
+                Self::ErrorEncode => 1,
+                Self::ErrorDecode => 2,
+            };
+            PageCodecId::new(id)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            match self {
+                Self::Xor(mask) => {
+                    for (input, output) in page.iter().zip(output) {
+                        *output = input ^ mask;
+                    }
+                    Ok(())
+                }
+                Self::ErrorEncode => Err(LimboError::InternalError("codec encode failed".into())),
+                Self::ErrorDecode => {
+                    output.copy_from_slice(page);
+                    Ok(())
+                }
+            }
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            match self {
+                Self::Xor(_) => self.encode_page(page, output, _page_idx, _location),
+                Self::ErrorEncode => {
+                    output.copy_from_slice(page);
+                    Ok(())
+                }
+                Self::ErrorDecode => Err(LimboError::InternalError("codec decode failed".into())),
+            }
+        }
+    }
+
+    fn set_test_page_codec(wal: &WalFile, codec: Arc<dyn PageCodec>) {
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(codec);
+        wal.set_io_context(io_ctx);
+    }
+
+    fn set_test_encryption(wal: &WalFile, page_size: usize) {
+        let key = EncryptionKey::from_hex_string("000102030405060708090a0b0c0d0e0f").unwrap();
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_encryption(
+            EncryptionContext::new(CipherMode::Aes128Gcm, &key, page_size).unwrap(),
+        );
+        wal.set_io_context(io_ctx);
+    }
+
     fn append_test_pages(
         io: &Arc<dyn IO>,
         wal: &WalFile,
@@ -6403,6 +6650,142 @@ pub mod test {
             assert_eq!(page.wal_tag_pair(), ((idx + 1) as u64, 0));
             assert_eq!(page.get_contents().as_ptr(), expected[idx].as_slice());
         }
+    }
+
+    #[test]
+    fn page_codec_round_trips_wal_batch_reads() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::Xor(0xa5)));
+        let source_pages = vec![
+            page_with_pattern(32, 0x10, &buffer_pool),
+            page_with_pattern(33, 0x20, &buffer_pool),
+        ];
+        let expected = append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(32)),
+            Arc::new(crate::Page::new(33)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        for (idx, page) in target_pages.iter().enumerate() {
+            assert_eq!(page.get_contents().as_ptr(), expected[idx].as_slice());
+        }
+    }
+
+    #[test]
+    fn page_codec_round_trips_vectored_wal_spill_frames() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::Xor(0xa5)));
+        let source_page = page_with_pattern(32, 0x10, &buffer_pool);
+        let expected = source_page.get_contents().as_ptr().to_vec();
+
+        let completion = wal
+            .append_frames_vectored(vec![source_page], PageSize::new(page_size).unwrap())
+            .unwrap();
+        io.wait_for_completion(completion).unwrap();
+
+        let target_page = Arc::new(crate::Page::new(32));
+        let completion = wal
+            .read_frames_batch(1, &[target_page.clone()], buffer_pool, None)
+            .unwrap();
+        io.wait_for_completion(completion).unwrap();
+        assert_eq!(target_page.get_contents().as_ptr(), expected.as_slice());
+    }
+
+    #[test]
+    fn page_codec_round_trips_raw_wal_frames() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::Xor(0xa5)));
+        let expected = (0..page_size).map(|i| i as u8).collect::<Vec<_>>();
+
+        wal.write_frame_raw(buffer_pool, 1, 44, 0, &expected, FileSyncType::Fsync)
+            .unwrap();
+
+        let mut frame = vec![0; WAL_FRAME_HEADER_SIZE + page_size as usize];
+        let completion = wal.read_frame_raw(1, &mut frame).unwrap();
+        io.wait_for_completion(completion).unwrap();
+        assert_eq!(&frame[WAL_FRAME_HEADER_SIZE..], expected.as_slice());
+    }
+
+    #[test]
+    fn page_codec_encode_error_does_not_publish_wal_frames() {
+        let page_size = 512;
+        let (_io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::ErrorEncode));
+        let source_page = page_with_pattern(43, 0x43, &buffer_pool);
+
+        assert!(wal
+            .prepare_frames(
+                &[source_page],
+                PageSize::new(page_size).unwrap(),
+                Some(1),
+                None,
+            )
+            .is_err());
+        assert_eq!(wal.get_max_frame(), 0);
+        assert_eq!(wal.find_frame(43, None).unwrap(), None);
+    }
+
+    #[test]
+    fn encryption_round_trips_raw_wal_frames() {
+        let page_size = 4096;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_encryption(&wal, page_size as usize);
+        let mut expected = (0..page_size).map(|i| i as u8).collect::<Vec<_>>();
+        expected[page_size as usize - 64..].fill(0);
+
+        wal.write_frame_raw(buffer_pool, 1, 44, 0, &expected, FileSyncType::Fsync)
+            .unwrap();
+
+        let mut frame = vec![0; WAL_FRAME_HEADER_SIZE + page_size as usize];
+        let completion = wal.read_frame_raw(1, &mut frame).unwrap();
+        io.wait_for_completion(completion).unwrap();
+        assert_eq!(&frame[WAL_FRAME_HEADER_SIZE..], expected.as_slice());
+    }
+
+    #[test]
+    fn page_codec_raw_wal_read_propagates_decode_error() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::ErrorDecode));
+        let source_pages = vec![page_with_pattern(43, 0x43, &buffer_pool)];
+        append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let mut frame = vec![0; WAL_FRAME_HEADER_SIZE + page_size as usize];
+        let c = wal.read_frame_raw(1, &mut frame).unwrap();
+        let err = wait_for_completion_error(&io, c);
+
+        assert!(matches!(
+            err,
+            CompletionError::PageCodecError { page_idx: 43 }
+        ));
+    }
+
+    #[test]
+    fn page_codec_wal_batch_read_reports_codec_error() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::ErrorDecode));
+        let source_pages = vec![page_with_pattern(43, 0x43, &buffer_pool)];
+        append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_page = Arc::new(crate::Page::new(43));
+        let c = wal
+            .read_frames_batch(1, &[target_page], buffer_pool, None)
+            .unwrap();
+        let err = wait_for_completion_error(&io, c);
+
+        assert!(matches!(
+            err,
+            CompletionError::PageCodecError { page_idx: 43 }
+        ));
     }
 
     #[test]
@@ -7587,6 +7970,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 
@@ -7634,6 +8018,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
         assert!(shared.read().runtime.frame_cache.lock().is_empty());
@@ -7702,6 +8087,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 
@@ -7790,6 +8176,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 
@@ -7827,6 +8214,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
         assert!(exclusive
@@ -7859,6 +8247,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
         assert!(!reopened_shared
@@ -7903,6 +8292,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
         assert!(shared
@@ -7964,6 +8354,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 
@@ -8271,6 +8662,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -16660,6 +16660,11 @@ fn op_journal_mode_inner(
                             .to_string(),
                     ));
                 }
+                if matches!(new_mode, journal_mode::JournalMode::Mvcc) && pager.has_page_codec() {
+                    return Err(LimboError::InvalidArgument(
+                        "external page codecs are not supported with MVCC databases".to_string(),
+                    ));
+                }
 
                 state.active_op_state.journal_mode().new_mode = Some(new_mode);
                 state.active_op_state.journal_mode().sub_state = OpJournalModeSubState::Checkpoint;
@@ -17184,15 +17189,31 @@ fn op_vacuum_into_inner(
                 // Always use PlatformIO for the output file, even if source
                 // is in-memory. This ensures VACUUM INTO writes to disk.
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
-                let output_db = crate::Database::open_file_with_flags(
-                    io,
-                    dest_path,
-                    OpenFlags::Create,
-                    output_opts,
-                    None,
-                    source_db.dialect(),
-                )?;
-                let output_conn = output_db.connect()?;
+                let page_codec = source_pager.page_codec();
+                let output_db = match &page_codec {
+                    Some(codec) => crate::Database::open_file_with_flags_and_page_codec(
+                        io,
+                        dest_path,
+                        OpenFlags::Create,
+                        output_opts,
+                        None,
+                        None,
+                        codec.clone(),
+                        source_db.dialect(),
+                    )?,
+                    None => crate::Database::open_file_with_flags(
+                        io,
+                        dest_path,
+                        OpenFlags::Create,
+                        output_opts,
+                        None,
+                        source_db.dialect(),
+                    )?,
+                };
+                let output_conn = match page_codec {
+                    Some(codec) => output_db.connect_with_page_codec(codec)?,
+                    None => output_db.connect()?,
+                };
                 output_conn.reset_page_size(page_size)?;
                 // set reserved_space on output to match source
                 // this is important for databases using encryption or checksums

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -292,15 +292,31 @@ pub(crate) fn open_vacuum_temp_db(
     let test_path = path.clone();
 
     let (encryption_opts, encryption_key) = vacuum_temp_db_encryption(source_conn)?;
-    let db = Database::open_file_with_flags(
-        source_db.io.clone(),
-        &path,
-        OpenFlags::Create,
-        vacuum_target_opts_from_source(source_db),
-        encryption_opts,
-        source_db.dialect(),
-    )?;
-    let conn = db.connect_with_encryption(encryption_key)?;
+    let page_codec = source_conn.pager.load().page_codec();
+    let db = match &page_codec {
+        Some(codec) => Database::open_file_with_flags_and_page_codec(
+            source_db.io.clone(),
+            &path,
+            OpenFlags::Create,
+            vacuum_target_opts_from_source(source_db),
+            encryption_opts,
+            None,
+            codec.clone(),
+            source_db.dialect(),
+        )?,
+        None => Database::open_file_with_flags(
+            source_db.io.clone(),
+            &path,
+            OpenFlags::Create,
+            vacuum_target_opts_from_source(source_db),
+            encryption_opts,
+            source_db.dialect(),
+        )?,
+    };
+    let conn = match page_codec {
+        Some(codec) => db.connect_with_page_codec(codec)?,
+        None => db.connect_with_encryption(encryption_key)?,
+    };
     conn.reset_page_size(page_size)?;
     conn.set_reserved_bytes(reserved_space)?;
     conn.wal_auto_actions_disable();

--- a/testing/concurrent-simulator/Cargo.toml
+++ b/testing/concurrent-simulator/Cargo.toml
@@ -32,7 +32,6 @@ path = "regression_tests_cross_platform.rs"
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
-memmap2 = "0.9"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 sql_generation = { workspace = true }

--- a/testing/concurrent-simulator/io.rs
+++ b/testing/concurrent-simulator/io.rs
@@ -1,6 +1,6 @@
-use memmap2::{MmapMut, MmapOptions};
 use rand::{Rng, RngCore};
 use rand_chacha::ChaCha8Rng;
+use std::collections::BTreeMap;
 use std::collections::{HashMap, HashSet};
 use std::fs::{File as StdFile, OpenOptions};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -59,6 +59,30 @@ impl SimulatorIO {
         self.file_sizes.clone()
     }
 
+    /// Number of submitted I/O operations whose completion callbacks have not run.
+    pub fn pending_completion_count(&self) -> usize {
+        self.pending.lock().unwrap().len()
+    }
+
+    /// Abort queued completion notifications after a simulated process crash.
+    ///
+    /// `SimulatorFile` applies submitted bytes before queuing the completion, so
+    /// this models losing process state after storage accepted an I/O request but
+    /// before the issuing state machine observed completion. Completing the
+    /// callbacks as aborted releases their process-local waiters before the
+    /// test drops the simulated process.
+    pub fn abort_pending_completions(&self) -> usize {
+        let pending = {
+            let mut pending = self.pending.lock().unwrap();
+            std::mem::take(&mut *pending)
+        };
+        let discarded = pending.len();
+        for completion in pending {
+            completion.completion.abort();
+        }
+        discarded
+    }
+
     /// Dump all database files to the specified output directory.
     /// Only copies the actual file content, not the full mmap size.
     pub fn dump_files(&self, out_dir: &std::path::Path) -> anyhow::Result<()> {
@@ -77,8 +101,8 @@ impl SimulatorIO {
                     .unwrap_or_else(|| path.clone());
 
                 let dest_path = out_dir.join(&filename);
-                let mmap = file.mmap.lock().unwrap();
-                std::fs::write(&dest_path, &mmap[..actual_size])?;
+                let contents = file.read_to_vec(0, actual_size);
+                std::fs::write(&dest_path, &contents)?;
                 println!(
                     "Dumped {} ({} bytes) to {}",
                     path,
@@ -202,12 +226,22 @@ impl IO for SimulatorIO {
                         let byte_offset = rng.random_range(0..file_size);
                         let bit_idx = rng.random_range(0..8);
 
-                        let mut mmap = file.mmap.lock().unwrap();
-                        let old_byte = mmap[byte_offset];
-                        mmap[byte_offset] ^= 1 << bit_idx;
+                        let mut byte = [0];
+                        let result = file.read_at(byte_offset, &mut byte);
+                        assert_eq!(
+                            result, 1,
+                            "cosmic ray offset is selected from a valid simulator file size"
+                        );
+                        let old_byte = byte[0];
+                        byte[0] ^= 1 << bit_idx;
+                        let result = file.write_at(byte_offset, &byte);
+                        assert_eq!(
+                            result, 1,
+                            "cosmic ray offset is selected from a valid simulator file size"
+                        );
                         println!(
                             "Cosmic ray! File: {} - Flipped bit {} at offset {} (0x{:02x} -> 0x{:02x})",
-                            path, bit_idx, byte_offset, old_byte, mmap[byte_offset]
+                            path, bit_idx, byte_offset, old_byte, byte[0]
                         );
                     }
                 }
@@ -235,9 +269,11 @@ type PendingQueue = Arc<Mutex<Vec<PendingCompletion>>>;
 
 const MAX_FILE_SIZE: usize = 1 << 33; // 8 GiB
 pub(crate) const FILE_SIZE_SOFT_LIMIT: u64 = 6 * (1 << 30); // 6 GiB (75% of MAX_FILE_SIZE)
+const SIMULATOR_FILE_BLOCK_SIZE: usize = 4096;
+type SimulatorFileBlock = Box<[u8; SIMULATOR_FILE_BLOCK_SIZE]>;
 
 struct SimulatorFile {
-    mmap: Mutex<MmapMut>,
+    blocks: Mutex<BTreeMap<usize, SimulatorFileBlock>>,
     size: Mutex<usize>,
     file_sizes: Arc<Mutex<HashMap<String, u64>>>,
     path: String,
@@ -259,29 +295,87 @@ impl SimulatorFile {
             .open(file_path)
             .unwrap_or_else(|e| panic!("Failed to create file {file_path}: {e}"));
 
-        file.set_len(MAX_FILE_SIZE as u64)
-            .unwrap_or_else(|e| panic!("Failed to truncate file {file_path}: {e}"));
-
-        let mmap = unsafe {
-            MmapOptions::new()
-                .len(MAX_FILE_SIZE)
-                .map_mut(&file)
-                .unwrap_or_else(|e| panic!("mmap failed for file {file_path}: {e}"))
-        };
-
         {
             let mut sizes = file_sizes.lock().unwrap();
             sizes.insert(file_path.to_string(), 0);
         }
 
         Self {
-            mmap: Mutex::new(mmap),
+            blocks: Mutex::new(BTreeMap::new()),
             size: Mutex::new(0),
             file_sizes,
             path: file_path.to_string(),
             _file: file,
             pending,
         }
+    }
+
+    fn read_at(&self, pos: usize, dest: &mut [u8]) -> i32 {
+        let Some(end) = pos.checked_add(dest.len()) else {
+            return 0;
+        };
+        if end > MAX_FILE_SIZE {
+            return 0;
+        }
+
+        dest.fill(0);
+        let blocks = self.blocks.lock().unwrap();
+        let mut copied = 0;
+        while copied < dest.len() {
+            let absolute = pos + copied;
+            let block_idx = absolute / SIMULATOR_FILE_BLOCK_SIZE;
+            let block_offset = absolute % SIMULATOR_FILE_BLOCK_SIZE;
+            let chunk_len = (SIMULATOR_FILE_BLOCK_SIZE - block_offset).min(dest.len() - copied);
+            if let Some(block) = blocks.get(&block_idx) {
+                dest[copied..copied + chunk_len]
+                    .copy_from_slice(&block[block_offset..block_offset + chunk_len]);
+            }
+            copied += chunk_len;
+        }
+        dest.len() as i32
+    }
+
+    fn read_to_vec(&self, pos: usize, len: usize) -> Vec<u8> {
+        let mut contents = vec![0; len];
+        let result = self.read_at(pos, &mut contents);
+        assert_eq!(
+            result as usize, len,
+            "dumped simulator files must stay within MAX_FILE_SIZE"
+        );
+        contents
+    }
+
+    fn write_at(&self, pos: usize, src: &[u8]) -> i32 {
+        let Some(end) = pos.checked_add(src.len()) else {
+            return 0;
+        };
+        if end > MAX_FILE_SIZE {
+            return 0;
+        }
+
+        let mut blocks = self.blocks.lock().unwrap();
+        let mut written = 0;
+        while written < src.len() {
+            let absolute = pos + written;
+            let block_idx = absolute / SIMULATOR_FILE_BLOCK_SIZE;
+            let block_offset = absolute % SIMULATOR_FILE_BLOCK_SIZE;
+            let chunk_len = (SIMULATOR_FILE_BLOCK_SIZE - block_offset).min(src.len() - written);
+            let block = blocks
+                .entry(block_idx)
+                .or_insert_with(|| Box::new([0; SIMULATOR_FILE_BLOCK_SIZE]));
+            block[block_offset..block_offset + chunk_len]
+                .copy_from_slice(&src[written..written + chunk_len]);
+            written += chunk_len;
+        }
+        drop(blocks);
+
+        let mut size = self.size.lock().unwrap();
+        if end > *size {
+            *size = end;
+            let mut sizes = self.file_sizes.lock().unwrap();
+            sizes.insert(self.path.clone(), *size as u64);
+        }
+        src.len() as i32
     }
 }
 
@@ -297,15 +391,8 @@ impl File for SimulatorFile {
         let pos = pos as usize;
         let read_completion = c.as_read();
         let buffer = read_completion.buf_arc();
-        let len = buffer.len();
 
-        let result = if pos + len <= MAX_FILE_SIZE {
-            let mmap = self.mmap.lock().unwrap();
-            buffer.as_mut_slice().copy_from_slice(&mmap[pos..pos + len]);
-            len as i32
-        } else {
-            0
-        };
+        let result = self.read_at(pos, buffer.as_mut_slice());
         self.pending.lock().unwrap().push(PendingCompletion {
             completion: c.clone(),
             result,
@@ -320,23 +407,7 @@ impl File for SimulatorFile {
         c: Completion,
     ) -> Result<Completion> {
         let pos = pos as usize;
-        let len = buffer.len();
-
-        let result = if pos + len <= MAX_FILE_SIZE {
-            let mut mmap = self.mmap.lock().unwrap();
-            mmap[pos..pos + len].copy_from_slice(buffer.as_slice());
-            let mut size = self.size.lock().unwrap();
-            if pos + len > *size {
-                *size = pos + len;
-                {
-                    let mut sizes = self.file_sizes.lock().unwrap();
-                    sizes.insert(self.path.clone(), *size as u64);
-                }
-            }
-            len as i32
-        } else {
-            0
-        };
+        let result = self.write_at(pos, buffer.as_slice());
         self.pending.lock().unwrap().push(PendingCompletion {
             completion: c.clone(),
             result,
@@ -353,31 +424,14 @@ impl File for SimulatorFile {
         let mut offset = pos as usize;
         let mut total_written = 0;
 
-        {
-            let mut mmap = self.mmap.lock().unwrap();
-            for buffer in buffers {
-                let len = buffer.len();
-                if offset + len <= MAX_FILE_SIZE {
-                    mmap[offset..offset + len].copy_from_slice(buffer.as_slice());
-                    offset += len;
-                    total_written += len;
-                } else {
-                    break;
-                }
+        for buffer in buffers {
+            let len = buffer.len();
+            let result = self.write_at(offset, buffer.as_slice());
+            if result != len as i32 {
+                break;
             }
-        }
-
-        // Update the file size if we wrote beyond the current size
-        if total_written > 0 {
-            let mut size = self.size.lock().unwrap();
-            let end_pos = (pos as usize) + total_written;
-            if end_pos > *size {
-                *size = end_pos;
-                {
-                    let mut sizes = self.file_sizes.lock().unwrap();
-                    sizes.insert(self.path.clone(), *size as u64);
-                }
-            }
+            offset += len;
+            total_written += len;
         }
 
         self.pending.lock().unwrap().push(PendingCompletion {
@@ -420,5 +474,44 @@ impl File for SimulatorFile {
 
     fn size(&self) -> Result<u64> {
         Ok(*self.size.lock().unwrap() as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TempFile {
+        path: String,
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    #[test]
+    fn simulator_file_does_not_preallocate_max_size() {
+        let path =
+            std::env::temp_dir().join(format!("turso-whopper-blocks-{}.db", std::process::id()));
+        let path = path.to_string_lossy().into_owned();
+        let _cleanup = TempFile { path: path.clone() };
+        let file = SimulatorFile::new(
+            &path,
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(Vec::new())),
+        );
+
+        assert_eq!(file._file.metadata().unwrap().len(), 0);
+
+        let pos = MAX_FILE_SIZE - 2;
+        assert_eq!(file.write_at(pos, &[1, 2]), 2);
+        assert_eq!(file._file.metadata().unwrap().len(), 0);
+        assert_eq!(file.size().unwrap(), MAX_FILE_SIZE as u64);
+
+        let mut read = [0; 3];
+        assert_eq!(file.read_at(pos - 1, &mut read), 3);
+        assert_eq!(read, [0, 1, 2]);
     }
 }

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -21,7 +21,8 @@ use turso_core::SqliteDialect;
 use turso_core::WindowsIOCP;
 use turso_core::schema::SEQ_BACKING_TABLE_PREFIX;
 use turso_core::{
-    CipherMode, Connection, Database, DatabaseOpts, EncryptionOpts, IO, OpenFlags, Statement, Value,
+    CipherMode, Connection, Database, DatabaseOpts, EncryptionOpts, IO, OpenFlags, PageCodec,
+    PageCodecHeaderInfo, PageCodecId, PageCodecLocation, Statement, Value,
 };
 use turso_parser::ast::{ColumnConstraint, SortOrder};
 
@@ -42,6 +43,141 @@ pub mod worker;
 pub mod workloads;
 mod yield_injection;
 
+// The simulator codec is keyed by both page id and transform location so that a
+// bug threading the wrong `page_idx` or `PageCodecLocation` through any DB read,
+// WAL read, WAL write, or checkpoint path corrupts the decoded page rather than
+// silently producing correct bytes.
+struct SimulatorPageCodec;
+
+impl SimulatorPageCodec {
+    const MASK: u8 = 0x6d;
+
+    fn byte_key(page_idx: usize, location: PageCodecLocation, offset: usize) -> u8 {
+        // Persisted transforms must not depend on the host pointer width.
+        let page_id_byte = (page_idx as u64).to_le_bytes()[offset % std::mem::size_of::<u64>()];
+        let page_id_rotation = ((offset / std::mem::size_of::<u64>()) % (u8::BITS as usize)) as u32;
+        Self::MASK
+            ^ page_id_byte.rotate_left(page_id_rotation)
+            ^ match location {
+                PageCodecLocation::Database => 0,
+                PageCodecLocation::Wal => 0xa5,
+            }
+    }
+
+    fn transform(input: &[u8], output: &mut [u8], page_idx: usize, location: PageCodecLocation) {
+        for (offset, (input, output)) in input.iter().zip(output).enumerate() {
+            *output = input ^ Self::byte_key(page_idx, location, offset);
+        }
+    }
+}
+
+/// Page id of the database header, used to probe the encoded header prefix.
+const SIMULATOR_HEADER_PAGE_ID: usize = 1;
+
+impl PageCodec for SimulatorPageCodec {
+    fn codec_id(&self) -> PageCodecId {
+        PageCodecId::new(*b"simulator-codec-")
+    }
+
+    fn probe_header(
+        &self,
+        raw_page1_prefix: &[u8],
+    ) -> turso_core::Result<Option<PageCodecHeaderInfo>> {
+        if raw_page1_prefix.len() < 21 {
+            return Ok(None);
+        }
+        if !raw_page1_prefix[..16]
+            .iter()
+            .enumerate()
+            .zip(b"SQLite format 3\0")
+            .all(|((offset, encoded), expected)| {
+                *encoded
+                    ^ Self::byte_key(
+                        SIMULATOR_HEADER_PAGE_ID,
+                        PageCodecLocation::Database,
+                        offset,
+                    )
+                    == *expected
+            })
+        {
+            return Ok(None);
+        }
+
+        let raw_page_size = u16::from_be_bytes([
+            raw_page1_prefix[16]
+                ^ Self::byte_key(SIMULATOR_HEADER_PAGE_ID, PageCodecLocation::Database, 16),
+            raw_page1_prefix[17]
+                ^ Self::byte_key(SIMULATOR_HEADER_PAGE_ID, PageCodecLocation::Database, 17),
+        ]);
+        let page_size = if raw_page_size == 1 {
+            65_536
+        } else {
+            raw_page_size as usize
+        };
+        Ok(Some(PageCodecHeaderInfo {
+            page_size,
+            reserved_space: raw_page1_prefix[20]
+                ^ Self::byte_key(SIMULATOR_HEADER_PAGE_ID, PageCodecLocation::Database, 20),
+        }))
+    }
+
+    fn required_reserved_bytes(&self) -> u8 {
+        1
+    }
+
+    fn encode_page(
+        &self,
+        page: &[u8],
+        output: &mut [u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> turso_core::Result<()> {
+        Self::transform(page, output, page_idx, location);
+        Ok(())
+    }
+
+    fn decode_page(
+        &self,
+        page: &[u8],
+        output: &mut [u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> turso_core::Result<()> {
+        Self::transform(page, output, page_idx, location);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod simulator_page_codec_tests {
+    use super::*;
+
+    #[test]
+    fn simulator_page_codec_uses_full_page_id() {
+        let input = vec![0; 512];
+        let mut page_one = vec![0; input.len()];
+        let mut page_two_fifty_seven = vec![0; input.len()];
+        SimulatorPageCodec::transform(&input, &mut page_one, 1, PageCodecLocation::Database);
+        SimulatorPageCodec::transform(
+            &input,
+            &mut page_two_fifty_seven,
+            257,
+            PageCodecLocation::Database,
+        );
+
+        assert_ne!(page_one, page_two_fifty_seven);
+
+        let mut decoded = vec![0; input.len()];
+        SimulatorPageCodec::transform(
+            &page_two_fifty_seven,
+            &mut decoded,
+            257,
+            PageCodecLocation::Database,
+        );
+        assert_eq!(decoded, input);
+    }
+}
+
 use crate::{
     allocation_fault::{
         AllocationFaultConfig, AllocationFaultContext, SimulatorAllocationFaultInjector,
@@ -57,7 +193,7 @@ use crate::{
 pub fn multiprocess_platform_io() -> anyhow::Result<Arc<dyn IO>> {
     #[cfg(target_os = "windows")]
     {
-        return Ok(Arc::new(WindowsIOCP::new()?));
+        Ok(Arc::new(WindowsIOCP::new()?))
     }
 
     #[cfg(unix)]
@@ -282,6 +418,8 @@ pub struct WhopperOpts {
     pub experimental_mvcc_passive_checkpoint: bool,
     /// Enable database encryption with random cipher.
     pub enable_encryption: bool,
+    /// Enable a fixed external page codec for in-process simulator coverage.
+    pub enable_page_codec: bool,
     /// Elle tables to create: vec of (table_name, create_sql).
     pub elle_tables: Vec<(String, String)>,
     /// Workloads with weights: (weight, workload). Higher weight = more likely.
@@ -342,6 +480,7 @@ impl Default for WhopperOpts {
             enable_mvcc: false,
             experimental_mvcc_passive_checkpoint: false,
             enable_encryption: false,
+            enable_page_codec: false,
             elle_tables: vec![],
             workloads: vec![],
             properties: vec![],
@@ -468,6 +607,11 @@ impl WhopperOpts {
 
     pub fn with_enable_encryption(mut self, enable: bool) -> Self {
         self.enable_encryption = enable;
+        self
+    }
+
+    pub fn with_enable_page_codec(mut self, enable: bool) -> Self {
+        self.enable_page_codec = enable;
         self
     }
 
@@ -634,6 +778,7 @@ pub struct Whopper {
     db_path: String,
     wal_path: String,
     encryption_opts: Option<EncryptionOpts>,
+    page_codec: Option<Arc<dyn PageCodec>>,
     max_connections: usize,
     workloads: Vec<(u32, Box<dyn Workload>)>,
     properties: Vec<std::sync::Mutex<Box<dyn Property>>>,
@@ -659,6 +804,17 @@ pub struct Whopper {
 impl Whopper {
     /// Create a new Whopper simulator with the given options.
     pub fn new(opts: WhopperOpts) -> anyhow::Result<Self> {
+        if opts.enable_page_codec && opts.enable_encryption {
+            return Err(anyhow::anyhow!(
+                "page codec simulation cannot be combined with encryption"
+            ));
+        }
+        if opts.enable_page_codec && opts.enable_mvcc {
+            return Err(anyhow::anyhow!(
+                "page codec simulation cannot be combined with MVCC"
+            ));
+        }
+
         let seed = opts.seed.unwrap_or_else(|| {
             let mut rng = rand::rng();
             rng.next_u64()
@@ -698,6 +854,9 @@ impl Whopper {
         } else {
             None
         };
+        let page_codec = opts
+            .enable_page_codec
+            .then(|| Arc::new(SimulatorPageCodec) as Arc<dyn PageCodec>);
 
         let db = {
             let db_opts = DatabaseOpts::new()
@@ -706,14 +865,27 @@ impl Whopper {
                     opts.experimental_mvcc_passive_checkpoint,
                 );
 
-            match Database::open_file_with_flags(
-                io.clone(),
-                &db_path,
-                OpenFlags::default(),
-                db_opts,
-                encryption_opts.clone(),
-                Arc::new(SqliteDialect),
-            ) {
+            let result = match &page_codec {
+                Some(codec) => Database::open_file_with_flags_and_page_codec(
+                    io.clone(),
+                    &db_path,
+                    OpenFlags::default(),
+                    db_opts,
+                    encryption_opts.clone(),
+                    None,
+                    codec.clone(),
+                    Arc::new(SqliteDialect),
+                ),
+                None => Database::open_file_with_flags(
+                    io.clone(),
+                    &db_path,
+                    OpenFlags::default(),
+                    db_opts,
+                    encryption_opts.clone(),
+                    Arc::new(SqliteDialect),
+                ),
+            };
+            match result {
                 Ok(db) => db,
                 Err(e) => {
                     return Err(anyhow::anyhow!("Database open failed: {}", e));
@@ -721,7 +893,7 @@ impl Whopper {
             }
         };
 
-        let bootstrap_conn = match db.connect() {
+        let bootstrap_conn = match connect_with_optional_page_codec(&db, &page_codec) {
             Ok(conn) => may_be_set_encryption(conn, &encryption_opts)?,
             Err(e) => {
                 return Err(anyhow::anyhow!("Connection failed: {}", e));
@@ -793,6 +965,7 @@ impl Whopper {
             db_path,
             wal_path,
             encryption_opts,
+            page_codec,
             max_connections: opts.max_connections,
             workloads: opts.workloads,
             properties: opts
@@ -830,10 +1003,59 @@ impl Whopper {
             .unwrap_or(0)
     }
 
+    /// Number of submitted I/O operations whose completions are still pending.
+    pub fn pending_io_count(&self) -> usize {
+        self.io.pending_completion_count()
+    }
+
+    /// Run a direct integrity check after a controlled recovery boundary.
+    pub fn assert_integrity_check(&mut self) -> anyhow::Result<()> {
+        let conn = self
+            .context
+            .fibers
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("integrity check requires a live connection"))?
+            .connection
+            .clone();
+        let mut stmt = conn.prepare("PRAGMA integrity_check")?;
+        let mut rows = Vec::new();
+        loop {
+            match stmt.step()? {
+                turso_core::StepResult::Row => {
+                    let row = stmt
+                        .row()
+                        .ok_or_else(|| anyhow::anyhow!("integrity check returned no row"))?;
+                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                turso_core::StepResult::Done => break,
+                turso_core::StepResult::IO => self.io.step()?,
+                _ => {}
+            }
+        }
+
+        if rows.len() != 1 || rows[0].len() != 1 || rows[0][0].to_text() != Some("ok") {
+            anyhow::bail!("integrity_check returned unexpected rows: {rows:?}");
+        }
+        Ok(())
+    }
+
     /// Perform a single simulation step.
     /// Returns `StepResult::Ok` if the step completed normally,
     /// or `StepResult::WalSizeLimitExceeded` if the WAL file exceeded the soft limit.
     pub fn step(&mut self) -> anyhow::Result<StepResult> {
+        self.step_with_io_completion(true)
+    }
+
+    /// Perform one state-machine step without completing queued simulated I/O.
+    ///
+    /// This leaves the operation resumable at its next I/O boundary. It is
+    /// intended for deterministic crash tests, which must call
+    /// [`Self::crash_reopen`] before running another regular step.
+    pub fn step_without_completing_io(&mut self) -> anyhow::Result<StepResult> {
+        self.step_with_io_completion(false)
+    }
+
+    fn step_with_io_completion(&mut self, complete_io: bool) -> anyhow::Result<StepResult> {
         trace!("step={}", self.current_step);
         if self.current_step >= self.max_steps {
             return Ok(StepResult::Ok);
@@ -841,7 +1063,9 @@ impl Whopper {
 
         let fiber_idx = self.current_step % self.context.fibers.len();
         self.perform_work(fiber_idx)?;
-        self.io.step()?;
+        if complete_io {
+            self.io.step()?;
+        }
         self.current_step += 1;
 
         if file_size_soft_limit_exceeded(&self.wal_path, self.file_sizes.clone()) {
@@ -1358,25 +1582,67 @@ impl Whopper {
         );
 
         self.drain_active_statements("reopen")?;
-        // Close and drop all fiber connections to release database Arc references
-        {
-            let fibers = self.context.fibers.drain(..).collect::<Vec<_>>();
-            for fiber in fibers {
-                drop(fiber.statement.into_inner());
-                if self.close_connections_gracefully {
-                    if let Err(e) = fiber.connection.close() {
-                        debug!("Error closing connection during restart: {}", e);
-                    }
-                }
-                drop(fiber.connection);
+        self.drop_fiber_connections(self.close_connections_gracefully);
+        self.finish_reopen()?;
+
+        debug!(
+            "Database restarted with {} fibers",
+            self.context.fibers.len()
+        );
+        Ok(())
+    }
+
+    /// Restart after aborting active statements and their queued I/O completions.
+    ///
+    /// This models a process crash after submitted I/O reaches simulated storage
+    /// but before the state machine observes completion. It deliberately does not
+    /// drain statements or gracefully close connections.
+    pub fn crash_reopen(&mut self) -> anyhow::Result<()> {
+        let discarded = self.io.abort_pending_completions();
+        debug!(
+            "Crashing database with {} pending I/O completions and {} fibers",
+            discarded,
+            self.context.fibers.len()
+        );
+        self.abort_fiber_properties()?;
+        self.drop_fiber_connections(false);
+        self.finish_reopen()?;
+
+        debug!(
+            "Database crash-restarted with {} fibers",
+            self.context.fibers.len()
+        );
+        Ok(())
+    }
+
+    fn abort_fiber_properties(&self) -> anyhow::Result<()> {
+        for (fiber_id, fiber) in self.context.fibers.iter().enumerate() {
+            for property in &self.properties {
+                property
+                    .lock()
+                    .unwrap()
+                    .abort_fiber(fiber_id, fiber.txn_id)?;
             }
-            // All fibers are now dropped, database Arc should be released
         }
+        Ok(())
+    }
 
-        // Without this, the Database object is never dropped and recovery never happens
+    fn drop_fiber_connections(&mut self, close_gracefully: bool) {
+        let fibers = self.context.fibers.drain(..).collect::<Vec<_>>();
+        for fiber in fibers {
+            drop(fiber.statement.into_inner());
+            if close_gracefully {
+                if let Err(e) = fiber.connection.close() {
+                    debug!("Error closing connection during restart: {}", e);
+                }
+            }
+            drop(fiber.connection);
+        }
+    }
+
+    fn finish_reopen(&mut self) -> anyhow::Result<()> {
+        // Without this, the Database object is never dropped and recovery never happens.
         turso_core::clear_database_registry();
-
-        // Reopen connections (creates new Database instance)
         self.open_connections()?;
 
         // Query persisted user sequence state from backing tables after restart.
@@ -1395,11 +1661,6 @@ impl Whopper {
         if !self.context.fibers.is_empty() {
             self.rebuild_sequences_after_restart(&persisted_sequences);
         }
-
-        debug!(
-            "Database restarted with {} fibers",
-            self.context.fibers.len()
-        );
         Ok(())
     }
 
@@ -1523,14 +1784,26 @@ impl Whopper {
         let db_opts = DatabaseOpts::new()
             .with_encryption(self.encryption_opts.is_some())
             .with_experimental_mvcc_passive_checkpoint(self.experimental_mvcc_passive_checkpoint);
-        let db = Database::open_file_with_flags(
-            self.io.clone(),
-            &self.db_path,
-            OpenFlags::default(),
-            db_opts,
-            self.encryption_opts.clone(),
-            Arc::new(SqliteDialect),
-        )
+        let db = match &self.page_codec {
+            Some(codec) => Database::open_file_with_flags_and_page_codec(
+                self.io.clone(),
+                &self.db_path,
+                OpenFlags::default(),
+                db_opts,
+                self.encryption_opts.clone(),
+                None,
+                codec.clone(),
+                Arc::new(SqliteDialect),
+            ),
+            None => Database::open_file_with_flags(
+                self.io.clone(),
+                &self.db_path,
+                OpenFlags::default(),
+                db_opts,
+                self.encryption_opts.clone(),
+                Arc::new(SqliteDialect),
+            ),
+        }
         .map_err(|e| anyhow::anyhow!("Database open failed: {}", e))?;
 
         if self.disable_mvcc_auto_checkpoint {
@@ -1540,8 +1813,7 @@ impl Whopper {
         }
 
         for i in 0..self.max_connections {
-            let conn = db
-                .connect()
+            let conn = connect_with_optional_page_codec(&db, &self.page_codec)
                 .map_err(|e| anyhow::anyhow!("Failed to create fiber connection {}: {}", i, e))?;
             let conn = may_be_set_encryption(conn, &self.encryption_opts)?;
             self.context.fibers.push(SimulatorFiber {
@@ -1561,6 +1833,16 @@ impl Whopper {
         }
 
         Ok(())
+    }
+}
+
+fn connect_with_optional_page_codec(
+    db: &Arc<Database>,
+    page_codec: &Option<Arc<dyn PageCodec>>,
+) -> turso_core::Result<Arc<Connection>> {
+    match page_codec {
+        Some(codec) => db.connect_with_page_codec(codec.clone()),
+        None => db.connect(),
     }
 }
 

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -67,6 +67,9 @@ struct Args {
     /// Enable database encryption
     #[arg(long)]
     enable_encryption: bool,
+    /// Enable the external page codec simulation (in-process mode only)
+    #[arg(long)]
+    enable_page_codec: bool,
     /// Enable Elle consistency checking with specified model (uses only Elle workloads)
     #[arg(long, value_enum)]
     elle: Option<ElleModel>,
@@ -150,6 +153,11 @@ fn main() -> anyhow::Result<()> {
     if args.enable_experimental_mvcc_passive_checkpoint && !args.enable_mvcc {
         return Err(anyhow::anyhow!(
             "--enable-experimental-mvcc-passive-checkpoint requires --enable-mvcc"
+        ));
+    }
+    if args.multiprocess && args.enable_page_codec {
+        return Err(anyhow::anyhow!(
+            "--enable-page-codec is only supported in in-process simulator mode"
         ));
     }
 
@@ -508,6 +516,7 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         .with_enable_mvcc(args.enable_mvcc || is_schema_clone_fault_mode(&args.mode))
         .with_experimental_mvcc_passive_checkpoint(args.enable_experimental_mvcc_passive_checkpoint)
         .with_enable_encryption(args.enable_encryption)
+        .with_enable_page_codec(args.enable_page_codec)
         .with_elle_tables(elle_tables)
         .with_workloads(workloads)
         .with_properties(properties)

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -1,8 +1,20 @@
 use rand_chacha::ChaCha8Rng;
 use rand_chacha::rand_core::SeedableRng;
 use std::sync::Arc;
-use turso_core::{Database, DatabaseOpts, IO, OpenFlags, SqliteDialect, Statement};
-use turso_whopper::{IOFaultConfig, SimulatorIO};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use turso_core::{
+    Database, DatabaseOpts, IO, LimboError, OpenFlags, PageCodec, PageCodecHeaderInfo, PageCodecId,
+    PageCodecLocation, SqliteDialect, Statement,
+};
+use turso_whopper::{
+    IOFaultConfig, SimulatorIO, Whopper, WhopperOpts,
+    properties::{IntegrityCheckProperty, Property},
+    workloads::{
+        BeginWorkload, CommitWorkload, CreateSimpleTableWorkload, IntegrityCheckWorkload,
+        OverflowInsertWorkload, RollbackWorkload, SimpleInsertWorkload, SimpleSelectWorkload,
+        WalCheckpointWorkload,
+    },
+};
 
 fn run_to_done(stmt: &mut Statement, io: &SimulatorIO) {
     loop {
@@ -11,6 +23,109 @@ fn run_to_done(stmt: &mut Statement, io: &SimulatorIO) {
             turso_core::StepResult::IO => io.step().expect("io step"),
             _ => {}
         }
+    }
+}
+
+fn run_to_error(stmt: &mut Statement, io: &SimulatorIO) -> LimboError {
+    loop {
+        match stmt.step() {
+            Ok(turso_core::StepResult::Done) => {
+                panic!("statement unexpectedly completed without a codec error")
+            }
+            Ok(turso_core::StepResult::IO) => io.step().expect("io step"),
+            Ok(_) => {}
+            Err(err) => return err,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FailOnceCheckpointDecodeCodec {
+    armed: AtomicBool,
+}
+
+impl FailOnceCheckpointDecodeCodec {
+    fn arm(&self) {
+        self.armed.store(true, Ordering::Release);
+    }
+}
+
+impl PageCodec for FailOnceCheckpointDecodeCodec {
+    fn codec_id(&self) -> PageCodecId {
+        PageCodecId::new(*b"fail-once-codec-")
+    }
+
+    fn probe_header(
+        &self,
+        raw_page1_prefix: &[u8],
+    ) -> turso_core::Result<Option<PageCodecHeaderInfo>> {
+        if raw_page1_prefix.len() < 21 || raw_page1_prefix[..16] != *b"SQLite format 3\0" {
+            return Ok(None);
+        }
+        let raw_page_size = u16::from_be_bytes([raw_page1_prefix[16], raw_page1_prefix[17]]);
+        Ok(Some(PageCodecHeaderInfo {
+            page_size: if raw_page_size == 1 {
+                65_536
+            } else {
+                raw_page_size as usize
+            },
+            reserved_space: raw_page1_prefix[20],
+        }))
+    }
+
+    fn required_reserved_bytes(&self) -> u8 {
+        0
+    }
+
+    fn encode_page(
+        &self,
+        page: &[u8],
+        output: &mut [u8],
+        _page_idx: usize,
+        _location: PageCodecLocation,
+    ) -> turso_core::Result<()> {
+        output.copy_from_slice(page);
+        Ok(())
+    }
+
+    fn decode_page(
+        &self,
+        page: &[u8],
+        output: &mut [u8],
+        _page_idx: usize,
+        location: PageCodecLocation,
+    ) -> turso_core::Result<()> {
+        if location == PageCodecLocation::Wal && self.armed.swap(false, Ordering::AcqRel) {
+            return Err(LimboError::InternalError(
+                "simulated WAL codec decode failure".into(),
+            ));
+        }
+        output.copy_from_slice(page);
+        Ok(())
+    }
+}
+
+struct AbortRecorder {
+    aborts: Arc<AtomicUsize>,
+}
+
+impl Property for AbortRecorder {
+    fn finish_op(
+        &mut self,
+        _step: usize,
+        _fiber_id: usize,
+        _txn_id: Option<u64>,
+        _start_exec_id: u64,
+        _end_exec_id: u64,
+        _op: &turso_whopper::operations::Operation,
+        _result: &turso_whopper::operations::OpResult,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn abort_fiber(&mut self, _fiber_id: usize, _txn_id: Option<u64>) -> anyhow::Result<()> {
+        self.aborts.fetch_add(1, Ordering::Relaxed);
+        Ok(())
     }
 }
 
@@ -128,4 +243,230 @@ fn test_concurrent_commit_no_yield_spin() {
         }
     }
     assert_eq!(count, 2, "both inserts should be visible");
+}
+
+#[test]
+fn test_page_codec_simulator_checkpoint_and_reopen() {
+    let opts = WhopperOpts::fast()
+        .with_seed(0xface_feed)
+        .with_max_connections(3)
+        .with_max_steps(2_000)
+        .with_enable_page_codec(true)
+        .with_workloads(vec![
+            (
+                5,
+                Box::new(WalCheckpointWorkload {
+                    allow_passive: true,
+                }),
+            ),
+            (10, Box::new(IntegrityCheckWorkload)),
+            (10, Box::new(CreateSimpleTableWorkload)),
+            (25, Box::new(SimpleSelectWorkload)),
+            (25, Box::new(SimpleInsertWorkload)),
+            (30, Box::new(BeginWorkload)),
+            (15, Box::new(CommitWorkload)),
+            (10, Box::new(RollbackWorkload)),
+        ])
+        .with_properties(vec![Box::new(IntegrityCheckProperty)]);
+    let mut whopper = Whopper::new(opts).expect("create page codec simulator");
+
+    while !whopper.is_done() {
+        whopper.step().expect("simulator step");
+        if whopper.current_step % 127 == 0 {
+            whopper.reopen().expect("reopen codec database");
+        }
+    }
+
+    whopper
+        .finalize_properties()
+        .expect("finalize page codec simulator");
+}
+
+/// Exercise the page codec across multi-page overflow chains, WAL checkpoints,
+/// and repeated database reopen under concurrent transactions. The simulator
+/// codec is keyed by page id and transform location, so a mismatched page index
+/// or `PageCodecLocation` threaded through any overflow, WAL, or checkpoint path
+/// surfaces as a corrupted page rather than silent success.
+#[test]
+fn test_page_codec_simulator_overflow_checkpoint_and_reopen() {
+    let opts = WhopperOpts::fast()
+        .with_seed(0xc0de_c0ffee)
+        .with_max_connections(3)
+        .with_max_steps(4_000)
+        .with_enable_page_codec(true)
+        .with_workloads(vec![
+            (
+                5,
+                Box::new(WalCheckpointWorkload {
+                    allow_passive: false,
+                }),
+            ),
+            (10, Box::new(IntegrityCheckWorkload)),
+            (10, Box::new(CreateSimpleTableWorkload)),
+            (35, Box::new(OverflowInsertWorkload)),
+            (20, Box::new(SimpleSelectWorkload)),
+            (15, Box::new(SimpleInsertWorkload)),
+            (30, Box::new(BeginWorkload)),
+            (15, Box::new(CommitWorkload)),
+            (10, Box::new(RollbackWorkload)),
+        ])
+        .with_properties(vec![Box::new(IntegrityCheckProperty)]);
+    let mut whopper = Whopper::new(opts).expect("create overflow page codec simulator");
+
+    while !whopper.is_done() {
+        whopper.step().expect("simulator step");
+        if whopper.current_step % 97 == 0 {
+            whopper.reopen().expect("reopen overflow codec database");
+        }
+    }
+
+    whopper
+        .finalize_properties()
+        .expect("finalize overflow page codec simulator");
+}
+
+#[test]
+fn test_page_codec_simulator_checkpoint_decode_failure_recovers() {
+    let io_rng = ChaCha8Rng::seed_from_u64(0x5eed);
+    let io = Arc::new(SimulatorIO::new(
+        false,
+        io_rng,
+        IOFaultConfig {
+            cosmic_ray_probability: 0.0,
+        },
+    ));
+    let db_path = format!("test-codec-checkpoint-failure-{}.db", std::process::id());
+    let codec = Arc::new(FailOnceCheckpointDecodeCodec {
+        armed: AtomicBool::new(false),
+    });
+    let db = Database::open_file_with_flags_and_page_codec(
+        io.clone(),
+        &db_path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        None,
+        codec.clone(),
+        Arc::new(SqliteDialect),
+    )
+    .expect("open database");
+    let conn = db
+        .connect_with_page_codec(codec.clone())
+        .expect("open connection");
+
+    conn.execute("PRAGMA journal_mode = 'wal'")
+        .expect("enable WAL");
+    conn.execute(
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT);
+         INSERT INTO t(value) VALUES ('checkpoint failure recovery');",
+    )
+    .expect("create committed WAL content");
+    drop(conn);
+    drop(db);
+    turso_core::clear_database_registry();
+
+    let db = Database::open_file_with_flags_and_page_codec(
+        io.clone(),
+        &db_path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        None,
+        codec.clone(),
+        Arc::new(SqliteDialect),
+    )
+    .expect("reopen with live WAL");
+    let conn = db
+        .connect_with_page_codec(codec.clone())
+        .expect("reconnect with live WAL");
+
+    codec.arm();
+    let mut checkpoint = conn
+        .prepare("PRAGMA wal_checkpoint(FULL)")
+        .expect("prepare checkpoint");
+    let err = run_to_error(&mut checkpoint, &io);
+    assert!(
+        err.to_string()
+            .contains("Checkpoint failed: Page codec failed for page="),
+        "unexpected checkpoint error: {err}"
+    );
+    drop(checkpoint);
+
+    let mut retry = conn
+        .prepare("PRAGMA wal_checkpoint(FULL)")
+        .expect("prepare checkpoint retry");
+    run_to_done(&mut retry, &io);
+    drop(retry);
+    drop(conn);
+    drop(db);
+    turso_core::clear_database_registry();
+
+    let reopened = Database::open_file_with_flags_and_page_codec(
+        io.clone(),
+        &db_path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        None,
+        codec.clone(),
+        Arc::new(SqliteDialect),
+    )
+    .expect("reopen database after failed checkpoint");
+    let conn = reopened
+        .connect_with_page_codec(codec)
+        .expect("reconnect after failed checkpoint");
+    let mut stmt = conn.prepare("SELECT value FROM t").expect("prepare read");
+    let mut values = Vec::new();
+    loop {
+        match stmt.step().expect("step read after failed checkpoint") {
+            turso_core::StepResult::Row => {
+                values.push(stmt.row().expect("read row").get::<String>(0).unwrap());
+            }
+            turso_core::StepResult::Done => break,
+            turso_core::StepResult::IO => io.step().expect("io step"),
+            _ => {}
+        }
+    }
+    assert_eq!(values, ["checkpoint failure recovery"]);
+}
+
+#[test]
+fn test_page_codec_simulator_crash_reopens_checkpoint_io() {
+    let aborts = Arc::new(AtomicUsize::new(0));
+    let opts = WhopperOpts::fast()
+        .with_seed(0xc0de_cafe)
+        .with_max_connections(1)
+        .with_max_steps(32)
+        .with_enable_page_codec(true)
+        .with_workloads(vec![(
+            1,
+            Box::new(WalCheckpointWorkload {
+                allow_passive: false,
+            }),
+        )])
+        .with_properties(vec![Box::new(AbortRecorder {
+            aborts: Arc::clone(&aborts),
+        })]);
+    let mut whopper = Whopper::new(opts).expect("create page codec simulator");
+
+    for _ in 0..8 {
+        whopper
+            .step_without_completing_io()
+            .expect("step checkpoint before crash");
+        if whopper.pending_io_count() > 0 {
+            break;
+        }
+    }
+    assert!(
+        whopper.pending_io_count() > 0,
+        "checkpoint must have submitted codec-backed I/O before the crash"
+    );
+
+    whopper
+        .crash_reopen()
+        .expect("recover after interrupted checkpoint");
+    assert_eq!(aborts.load(Ordering::Relaxed), 1);
+    whopper
+        .assert_integrity_check()
+        .expect("verify integrity after checkpoint crash");
 }

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -146,6 +146,30 @@ impl Workload for SimpleInsertWorkload {
     }
 }
 
+/// Insert blobs large enough to force multi-page overflow chains, exercising the
+/// page-codec transform across page ids beyond the leaf cell.
+pub struct OverflowInsertWorkload;
+
+impl Workload for OverflowInsertWorkload {
+    fn generate(&self, ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        if ctx.sim_state.simple_tables.is_empty() {
+            return None;
+        }
+        let table_name = match ctx.sim_state.simple_tables.pick(rng) {
+            Some((name, _)) => name.clone(),
+            None => return None,
+        };
+        let key = format!("ovf_{}", rng.random_range(0..10000));
+        let value_length = rng.random_range(20 * 1024..64 * 1024);
+
+        Some(Operation::SimpleInsert {
+            table_name,
+            key,
+            value_length,
+        })
+    }
+}
+
 /// Execute a SELECT query (works in both Idle and InTx states).
 pub struct SelectWorkload;
 

--- a/testing/sqltest/src/main.rs
+++ b/testing/sqltest/src/main.rs
@@ -25,6 +25,7 @@ struct Cli {
     command: Commands,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 enum Commands {
     /// Run tests


### PR DESCRIPTION
Split from #7498.

This PR contains only the core engine/storage portion of external page codec support:

- Defines and exports the core page codec API.
- Wires optional page codecs through database open/init paths.
- Integrates page encode/decode hooks with database storage and WAL frame read/write/checkpoint paths.
- Adds pager support for installing a page codec and propagating it to WAL IO context.
- Adds regression coverage for page-codec registry/open behavior.

Kept out of scope for this stack slice: SDK-kit, C ABI, bindings, .NET, and examples; those are handled in follow-up PRs.

## Verified in this PR

Working behavior verified for the core/storage layer:

- A database can be opened with an external page codec installed in core.
- Repeated registry opens with the same page codec reuse the cached database instead of failing.
- Database page reads decode through the page codec before pages are exposed to the pager/btree layers.
- Database page writes encode through the page codec before bytes are written to disk.
- WAL frame reads decode through the page codec.
- WAL frame writes encode through the page codec.
- WAL checkpoint/truncate paths continue to work with a page codec installed.
- Encoded page 1 can be probed before normal reads so the codec can provide page size and reserved-space metadata.
- Page codec location is propagated so codecs can distinguish database pages from WAL frames.

Error paths verified for the core/storage layer:

- Codec probe/decode/encode failures are propagated as errors instead of being swallowed.
- Invalid transformed page lengths are rejected.
- Invalid page-size or reserved-space metadata from encoded page 1 is rejected.
- Registry/open mismatch cases involving page-codec requirements are rejected instead of silently reusing an incompatible database handle.

## Validation run

- `cargo fmt`
- `cargo fmt --check`
- `cargo check -p turso_core --features pure-rust-crypto`
- `cargo check -p core_tester --tests --features pure-rust-crypto`
- `cargo check -p test-runner`
- `cargo check -p turso_whopper --features turso_core/pure-rust-crypto`
- `cargo clippy -p turso_core --all-features --all-targets -- --deny=warnings`
- `cargo clippy -p turso_whopper --all-targets -- -D warnings`
- `cargo test -p turso_whopper`
- `cargo test -p turso_core --features pure-rust-crypto,experimental_win_iocp --lib page_codec -- --nocapture`
- `cargo test -p turso_core --features pure-rust-crypto,experimental_win_iocp --lib database_tests::registry_reuses_cached_database_when_page_codec_is_provided_again`
- `cargo test -p turso_core --features pure-rust-crypto,experimental_win_iocp --lib storage::wal::test::test_wal_truncate_checkpoint`
- `cargo test -p turso_core --features pure-rust-crypto,experimental_win_iocp --lib storage::pager::checkpoint_phase_tests::checkpoint_db_sync_completion_still_leaves_backfill_unpublished_until_proof_install`

Simulator-specific validation:

- Five local Windows page-codec fast seeds at 250k steps each passed (`--mode fast --enable-page-codec --max-steps 250000 --reopen-probability 0.01 --allocation-fault-probability 0.01`), for 1.25M total page-codec simulator steps.
- One local Windows multiprocess crash/reopen pass at 100k steps passed (`--mode fast --multiprocess --connections-per-process 4 --processes 4 --kill-probability 0.01 --max-steps 100000`), 10x the Windows CI smoke-test step budget.
- Four additional 500k-step page-codec fast seeds passed during the exhaustive sweep before seed `11355797357712538743` exposed Windows private-commit exhaustion in the simulator backing store.
- The original failing seed now passes: `SEED=11355797357712538743 cargo run -q -p turso_whopper -- --mode fast --enable-page-codec --max-steps 500000 --reopen-probability 0.02 --allocation-fault-probability 0.01`.
- A 100k-step smoke of that same seed also passed. The fixed 500k run stayed under ~170 MiB private memory, versus the prior ~50 GiB private-memory growth before replacing fixed 8 GiB mmap-backed simulator files with sparse 4 KiB blocks.

Note: default `cargo check -p turso_core` on this Windows machine requires the non-pure-Rust crypto toolchain setup; the pure-Rust crypto checks above were used for local validation.