### PR TITLE
Fix .NET SQLite facade compatibility

### DIFF
--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteCommand.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteCommand.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 using Turso.Raw.Public;
 using Turso.Raw.Public.Handles;
 
@@ -139,6 +140,7 @@ public class SqliteCommand : DbCommand
         {
         }
 
+        reader.Close();
         if (IsTransactionControlCommand(CommandText))
             Connection?.Transaction?.MarkCompletedExternally(IsRollbackCommand(CommandText));
 
@@ -187,6 +189,24 @@ public class SqliteCommand : DbCommand
     public new SqliteDataReader ExecuteReader(CommandBehavior behavior) => Execute("ExecuteReader", behavior);
 
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => Execute("ExecuteReader", behavior);
+
+    public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(ExecuteNonQuery());
+    }
+
+    public override Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(ExecuteScalar());
+    }
+
+    protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<DbDataReader>(Execute("ExecuteReader", behavior));
+    }
 
     protected override void Dispose(bool disposing)
     {
@@ -382,12 +402,11 @@ public class SqliteCommand : DbCommand
     }
 
     private static bool IsWriteCommand(string commandText)
-    {
-        var firstStatement = SplitStatements(commandText).FirstOrDefault();
-        if (firstStatement is null)
-            return false;
+        => SplitStatements(commandText).Any(IsWriteStatement);
 
-        var trimmed = firstStatement.TrimStart();
+    private static bool IsWriteStatement(string statement)
+    {
+        var trimmed = statement.TrimStart();
         return trimmed.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase)
                || trimmed.StartsWith("DROP", StringComparison.OrdinalIgnoreCase)
                || trimmed.StartsWith("ALTER", StringComparison.OrdinalIgnoreCase)
@@ -395,7 +414,8 @@ public class SqliteCommand : DbCommand
                || trimmed.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase)
                || trimmed.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase)
                || trimmed.StartsWith("REPLACE", StringComparison.OrdinalIgnoreCase)
-                || trimmed.StartsWith("VACUUM", StringComparison.OrdinalIgnoreCase);
+               || trimmed.StartsWith("VACUUM", StringComparison.OrdinalIgnoreCase)
+               || IsWithDmlStatement(trimmed);
     }
 
     internal bool TryHandleFacadeStatement(string sql, out string rewrittenSql)
@@ -482,8 +502,13 @@ public class SqliteCommand : DbCommand
         return trimmed.StartsWith("INSERT", StringComparison.OrdinalIgnoreCase)
                || trimmed.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase)
                || trimmed.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase)
-               || trimmed.StartsWith("REPLACE", StringComparison.OrdinalIgnoreCase);
+               || trimmed.StartsWith("REPLACE", StringComparison.OrdinalIgnoreCase)
+               || IsWithDmlStatement(trimmed);
     }
+
+    private static bool IsWithDmlStatement(string trimmedStatement)
+        => trimmedStatement.StartsWith("WITH", StringComparison.OrdinalIgnoreCase)
+           && Regex.IsMatch(trimmedStatement, @"\)\s*(INSERT|UPDATE|DELETE|REPLACE)\b", RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
     private static List<string> SplitStatements(string commandText)
     {

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Functions.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Functions.cs
@@ -188,7 +188,7 @@ public partial class SqliteConnection
             long longValue => CreateInteger(longValue),
             float floatValue => CreateReal(floatValue),
             double doubleValue => CreateReal(doubleValue),
-            decimal decimalValue => CreateReal((double)decimalValue),
+            decimal decimalValue => CreateText(decimalValue.ToString(CultureInfo.InvariantCulture)),
             byte[] bytes => CreateBlob(bytes),
             _ => CreateText(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty),
         };

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
@@ -123,6 +123,13 @@ public partial class SqliteConnection : DbConnection
         }
     }
 
+    public override Task OpenAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Open();
+        return Task.CompletedTask;
+    }
+
     public override void Close()
     {
         if (_database is null)
@@ -166,6 +173,8 @@ public partial class SqliteConnection : DbConnection
             table.Columns.Add(DbMetaDataColumnNames.NumberOfIdentifierParts, typeof(int));
             table.Rows.Add(DbMetaDataCollectionNames.MetaDataCollections, 0, 0);
             table.Rows.Add(DbMetaDataCollectionNames.ReservedWords, 0, 0);
+            table.Rows.Add("Tables", 4, 4);
+            table.Rows.Add("Columns", 4, 4);
             return table;
         }
 
@@ -179,6 +188,12 @@ public partial class SqliteConnection : DbConnection
 
             return table;
         }
+
+        if (string.Equals(collectionName, "Tables", StringComparison.OrdinalIgnoreCase))
+            return GetTablesSchema(collectionName, restrictionValues);
+
+        if (string.Equals(collectionName, "Columns", StringComparison.OrdinalIgnoreCase))
+            return GetColumnsSchema(collectionName, restrictionValues);
 
         throw new ArgumentException(Properties.Resources.UnknownCollection(collectionName));
     }
@@ -414,6 +429,84 @@ public partial class SqliteConnection : DbConnection
         return tables;
     }
 
+    private DataTable GetTablesSchema(string collectionName, string?[]? restrictionValues)
+    {
+        EnsureOpen();
+        ValidateRestrictions(collectionName, restrictionValues, 4);
+        var table = new DataTable("Tables");
+        table.Columns.Add("TABLE_CATALOG", typeof(string));
+        table.Columns.Add("TABLE_SCHEMA", typeof(string));
+        table.Columns.Add("TABLE_NAME", typeof(string));
+        table.Columns.Add("TABLE_TYPE", typeof(string));
+
+        var tableNameRestriction = GetRestriction(restrictionValues, 2);
+        using var command = CreateCommand();
+        command.CommandText = "SELECT name, type, sql FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'"
+                              + (tableNameRestriction is null ? "" : " AND name COLLATE NOCASE = $table")
+                              + " ORDER BY name;";
+        if (tableNameRestriction is not null)
+            command.Parameters.AddWithValue("$table", tableNameRestriction);
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var type = reader.GetString(1).Equals("view", StringComparison.OrdinalIgnoreCase) ? "VIEW" : "BASE TABLE";
+            var tableName = GetDeclaredSchemaObjectName(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.IsDBNull(2) ? null : reader.GetString(2));
+            table.Rows.Add("main", DBNull.Value, tableName, type);
+        }
+
+        return table;
+    }
+
+    private DataTable GetColumnsSchema(string collectionName, string?[]? restrictionValues)
+    {
+        EnsureOpen();
+        ValidateRestrictions(collectionName, restrictionValues, 4);
+        var table = new DataTable("Columns");
+        table.Columns.Add("TABLE_CATALOG", typeof(string));
+        table.Columns.Add("TABLE_SCHEMA", typeof(string));
+        table.Columns.Add("TABLE_NAME", typeof(string));
+        table.Columns.Add("COLUMN_NAME", typeof(string));
+        table.Columns.Add("ORDINAL_POSITION", typeof(int));
+        table.Columns.Add("COLUMN_DEFAULT", typeof(string));
+        table.Columns.Add("IS_NULLABLE", typeof(bool));
+        table.Columns.Add("DATA_TYPE", typeof(string));
+
+        var tableNameRestriction = GetRestriction(restrictionValues, 2);
+        var columnNameRestriction = GetRestriction(restrictionValues, 3);
+        var tableNames = tableNameRestriction is null ? GetUserTableNames() : [tableNameRestriction];
+        foreach (var tableName in tableNames)
+        {
+            using var command = CreateCommand();
+            command.CommandText = $"PRAGMA table_info({QuoteIdentifier(tableName)});";
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                var columnName = reader.GetString(1);
+                if (columnNameRestriction is not null
+                    && !string.Equals(columnNameRestriction, columnName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                table.Rows.Add(
+                    "main",
+                    DBNull.Value,
+                    tableName,
+                    columnName,
+                    reader.GetInt32(0),
+                    reader.IsDBNull(4) ? DBNull.Value : reader.GetValue(4),
+                    reader.GetInt64(3) == 0,
+                    reader.GetString(2));
+            }
+        }
+
+        return table;
+    }
+
     private void CopyTableRows(SqliteConnection destination, string tableName)
     {
         using var select = new SqliteCommand("SELECT * FROM " + QuoteIdentifier(tableName) + ";", this);
@@ -486,6 +579,149 @@ public partial class SqliteConnection : DbConnection
         if (restrictionValues is not null && restrictionValues.Length > maxRestrictions)
             throw new ArgumentException(Properties.Resources.TooManyRestrictions(collectionName));
     }
+
+    private static string? GetRestriction(string?[]? restrictionValues, int index)
+        => restrictionValues is not null && restrictionValues.Length > index && !string.IsNullOrEmpty(restrictionValues[index])
+            ? restrictionValues[index]
+            : null;
+
+    private static string GetDeclaredSchemaObjectName(string storedName, string type, string? createSql)
+    {
+        if (string.IsNullOrWhiteSpace(createSql))
+            return storedName;
+
+        var index = 0;
+        if (!TryReadKeyword(createSql, ref index, "CREATE"))
+            return storedName;
+
+        _ = TryReadKeyword(createSql, ref index, "TEMP")
+            || TryReadKeyword(createSql, ref index, "TEMPORARY");
+
+        var expectedType = type.Equals("view", StringComparison.OrdinalIgnoreCase) ? "VIEW" : "TABLE";
+        if (!TryReadKeyword(createSql, ref index, expectedType))
+            return storedName;
+
+        var beforeIf = index;
+        if (TryReadKeyword(createSql, ref index, "IF"))
+        {
+            if (!TryReadKeyword(createSql, ref index, "NOT")
+                || !TryReadKeyword(createSql, ref index, "EXISTS"))
+            {
+                index = beforeIf;
+            }
+        }
+
+        return TryReadSchemaObjectName(createSql, ref index, out var objectName)
+            ? objectName
+            : storedName;
+    }
+
+    private static bool TryReadKeyword(string sql, ref int index, string keyword)
+    {
+        SkipSqlWhitespace(sql, ref index);
+        if (sql.Length - index < keyword.Length
+            || !sql.AsSpan(index, keyword.Length).Equals(keyword, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var end = index + keyword.Length;
+        if (end < sql.Length && IsSqlIdentifierPart(sql[end]))
+            return false;
+
+        index = end;
+        return true;
+    }
+
+    private static bool TryReadSchemaObjectName(string sql, ref int index, [NotNullWhen(true)] out string? objectName)
+    {
+        objectName = null;
+        do
+        {
+            if (!TryReadIdentifier(sql, ref index, out var part))
+                return objectName is not null;
+
+            objectName = part;
+            SkipSqlWhitespace(sql, ref index);
+            if (index >= sql.Length || sql[index] != '.')
+                return true;
+
+            index++;
+        }
+        while (true);
+    }
+
+    private static bool TryReadIdentifier(string sql, ref int index, [NotNullWhen(true)] out string? identifier)
+    {
+        identifier = null;
+        SkipSqlWhitespace(sql, ref index);
+        if (index >= sql.Length)
+            return false;
+
+        var quote = sql[index];
+        if (quote is '"' or '\'' or '`')
+        {
+            index++;
+            var start = index;
+            var builder = new System.Text.StringBuilder();
+            while (index < sql.Length)
+            {
+                if (sql[index] == quote)
+                {
+                    if (index + 1 < sql.Length && sql[index + 1] == quote)
+                    {
+                        builder.Append(sql.AsSpan(start, index - start));
+                        builder.Append(quote);
+                        index += 2;
+                        start = index;
+                        continue;
+                    }
+
+                    builder.Append(sql.AsSpan(start, index - start));
+                    index++;
+                    identifier = builder.ToString();
+                    return true;
+                }
+
+                index++;
+            }
+
+            return false;
+        }
+
+        if (quote == '[')
+        {
+            index++;
+            var start = index;
+            while (index < sql.Length && sql[index] != ']')
+                index++;
+            if (index >= sql.Length)
+                return false;
+
+            identifier = sql[start..index];
+            index++;
+            return true;
+        }
+
+        var tokenStart = index;
+        while (index < sql.Length && IsSqlIdentifierPart(sql[index]))
+            index++;
+
+        if (index == tokenStart)
+            return false;
+
+        identifier = sql[tokenStart..index];
+        return true;
+    }
+
+    private static void SkipSqlWhitespace(string sql, ref int index)
+    {
+        while (index < sql.Length && char.IsWhiteSpace(sql[index]))
+            index++;
+    }
+
+    private static bool IsSqlIdentifierPart(char value)
+        => char.IsLetterOrDigit(value) || value == '_' || value == '$';
 
     private static string NormalizeDataSource(SqliteConnectionStringBuilder options)
     {

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteDataReader.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteDataReader.cs
@@ -25,6 +25,7 @@ public class SqliteDataReader : DbDataReader
     private bool _hasCurrentRow;
     private bool _hasPrefetchedRow;
     private bool _hadResultSet;
+    private bool _currentStatementRowsAffectedCounted;
 
     internal SqliteDataReader(SqliteCommand command, TursoStatementHandle statement, string currentSql, List<string> remainingSql, int recordsAffected, CommandBehavior behavior, Action closeCallback)
     {
@@ -86,6 +87,10 @@ public class SqliteDataReader : DbDataReader
     public override bool GetBoolean(int ordinal)
     {
         EnsureOpen();
+        var value = GetTypedValue(ordinal);
+        if (value.ValueType == TursoValueType.Text && bool.TryParse(value.StringValue, out var boolValue))
+            return boolValue;
+
         return GetInt64(ordinal) != 0;
     }
 
@@ -310,9 +315,14 @@ public class SqliteDataReader : DbDataReader
     public override long GetInt64(int ordinal)
     {
         EnsureOpen();
-        var statement = GetStatement();
         var value = GetTypedValue(ordinal);
-        return value.ValueType == TursoValueType.Real ? (long)value.RealValue : value.IntValue;
+        return value.ValueType switch
+        {
+            TursoValueType.Integer => value.IntValue,
+            TursoValueType.Real => (long)value.RealValue,
+            TursoValueType.Text => long.Parse(value.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture),
+            _ => Convert.ToInt64(GetValue(ordinal), CultureInfo.InvariantCulture)
+        };
     }
 
     public override string GetName(int ordinal)
@@ -458,8 +468,15 @@ public class SqliteDataReader : DbDataReader
     public override string GetString(int ordinal)
     {
         EnsureOpen();
-        var statement = GetStatement();
-        return GetTypedValue(ordinal).StringValue;
+        var value = GetTypedValue(ordinal);
+        return value.ValueType switch
+        {
+            TursoValueType.Text => value.StringValue,
+            TursoValueType.Integer => value.IntValue.ToString(CultureInfo.InvariantCulture),
+            TursoValueType.Real => value.RealValue.ToString(CultureInfo.InvariantCulture),
+            TursoValueType.Blob => Encoding.UTF8.GetString(value.BlobValue),
+            _ => Convert.ToString(GetValue(ordinal), CultureInfo.InvariantCulture) ?? string.Empty
+        };
     }
 
     public virtual TimeSpan GetTimeSpan(int ordinal)
@@ -528,13 +545,13 @@ public class SqliteDataReader : DbDataReader
         {
         }
 
-        if (SqliteCommand.CountsRowsAffected(_currentSql))
-            _recordsAffected += TursoBindings.RowsAffected(_statement);
+        CountCurrentStatementRowsAffected();
 
         _hasCurrentRow = false;
         _hasPrefetchedRow = false;
         _statement.Dispose();
         _statement = null;
+        _currentStatementRowsAffectedCounted = false;
 
         try
         {
@@ -551,6 +568,7 @@ public class SqliteDataReader : DbDataReader
                     _statement = statement;
                     _currentSql = rewrittenSql;
                     _hadResultSet = true;
+                    _currentStatementRowsAffectedCounted = false;
                     _hasPrefetchedRow = TursoBindings.Read(statement);
                     return true;
                 }
@@ -591,12 +609,38 @@ public class SqliteDataReader : DbDataReader
         try
         {
             _hasCurrentRow = TursoBindings.Read(_statement);
+            if (!_hasCurrentRow)
+                CountCurrentStatementRowsAffected();
             return _hasCurrentRow;
         }
         catch (TursoException ex)
         {
             throw SqliteCommand.ToSqliteException(ex);
         }
+    }
+
+    public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(Read());
+    }
+
+    public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(NextResult());
+    }
+
+    public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(IsDBNull(ordinal));
+    }
+
+    public override Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(GetFieldValue<T>(ordinal));
     }
 
     protected override void Dispose(bool disposing)
@@ -622,12 +666,12 @@ public class SqliteDataReader : DbDataReader
                 {
                 }
 
-                if (SqliteCommand.CountsRowsAffected(_currentSql))
-                    _recordsAffected += TursoBindings.RowsAffected(_statement);
+                CountCurrentStatementRowsAffected();
 
                 _statement.Dispose();
                 _statement = null;
                 _hasPrefetchedRow = false;
+                _currentStatementRowsAffectedCounted = false;
             }
 
             DrainRemainingStatements();
@@ -697,6 +741,17 @@ public class SqliteDataReader : DbDataReader
     {
         if (!_hasCurrentRow)
             throw new InvalidOperationException(Properties.Resources.NoData);
+    }
+
+    private void CountCurrentStatementRowsAffected()
+    {
+        if (_statement is not null
+            && !_currentStatementRowsAffectedCounted
+            && SqliteCommand.CountsRowsAffected(_currentSql))
+        {
+            _recordsAffected += TursoBindings.RowsAffected(_statement);
+            _currentStatementRowsAffectedCounted = true;
+        }
     }
 
     private string GetDeclaredTypeName(int ordinal)

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteParameter.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteParameter.cs
@@ -55,7 +55,7 @@ public class SqliteParameter : DbParameter
                 DbType.Binary => SqliteType.Blob,
                 DbType.Byte or DbType.Boolean or DbType.Int16 or DbType.Int32 or DbType.Int64 or DbType.SByte
                     or DbType.UInt16 or DbType.UInt32 or DbType.UInt64 => SqliteType.Integer,
-                DbType.Decimal or DbType.Double or DbType.Single => SqliteType.Real,
+                DbType.Double or DbType.Single => SqliteType.Real,
                 _ => SqliteType.Text,
             };
         }

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteTransaction.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteTransaction.cs
@@ -43,6 +43,13 @@ public class SqliteTransaction : DbTransaction
         Complete();
     }
 
+    public override Task CommitAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Commit();
+        return Task.CompletedTask;
+    }
+
     public override void Rollback()
     {
         ThrowIfCompleted();
@@ -57,11 +64,25 @@ public class SqliteTransaction : DbTransaction
         }
     }
 
+    public override Task RollbackAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Rollback();
+        return Task.CompletedTask;
+    }
+
     public override void Save(string savepointName)
     {
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
         Execute("SAVEPOINT " + QuoteIdentifier(savepointName) + ";");
+    }
+
+    public override Task SaveAsync(string savepointName, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Save(savepointName);
+        return Task.CompletedTask;
     }
 
     public override void Rollback(string savepointName)
@@ -71,11 +92,25 @@ public class SqliteTransaction : DbTransaction
         Execute("ROLLBACK TO SAVEPOINT " + QuoteIdentifier(savepointName) + ";");
     }
 
+    public override Task RollbackAsync(string savepointName, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Rollback(savepointName);
+        return Task.CompletedTask;
+    }
+
     public override void Release(string savepointName)
     {
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
         Execute("RELEASE SAVEPOINT " + QuoteIdentifier(savepointName) + ";");
+    }
+
+    public override Task ReleaseAsync(string savepointName, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Release(savepointName);
+        return Task.CompletedTask;
     }
 
     protected override void Dispose(bool disposing)

--- a/bindings/dotnet/src/Turso.Tests/SqliteFacadeTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/SqliteFacadeTests.cs
@@ -64,6 +64,121 @@ public class SqliteFacadeTests
     }
 
     [Test]
+    public async Task AsyncMethodsHonorPreCanceledToken()
+    {
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+        using var connection = new SqliteConnection("Data Source=:memory:");
+
+        Assert.ThrowsAsync<OperationCanceledException>(() => connection.OpenAsync(cancellation.Token))!
+            .CancellationToken.Should().Be(cancellation.Token);
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1;";
+
+        Assert.ThrowsAsync<OperationCanceledException>(() => command.ExecuteScalarAsync(cancellation.Token))!
+            .CancellationToken.Should().Be(cancellation.Token);
+    }
+
+    [Test]
+    public void SchemaCollectionsReportTablesAndColumns()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        connection.ExecuteNonQuery("""
+            CREATE TABLE Customers(
+                Id INTEGER PRIMARY KEY,
+                Name TEXT NOT NULL DEFAULT ''
+            );
+            CREATE VIEW CustomerNames AS SELECT Name FROM Customers;
+            """);
+
+        var collections = connection.GetSchema();
+        collections.Rows.Cast<DataRow>().Select(row => row[DbMetaDataColumnNames.CollectionName])
+            .Should().Contain(["Tables", "Columns"]);
+
+        var tables = connection.GetSchema("Tables");
+        tables.Rows.Cast<DataRow>().Select(row => row["TABLE_NAME"])
+            .Should().Contain(["Customers", "CustomerNames"]);
+
+        var columns = connection.GetSchema("Columns", [null, null, "Customers"]);
+        columns.Rows.Cast<DataRow>().Select(row => row["COLUMN_NAME"])
+            .Should().Equal("Id", "Name");
+        columns.Rows.Cast<DataRow>().Single(row => (string)row["COLUMN_NAME"] == "Name")["IS_NULLABLE"]
+            .Should().Be(false);
+    }
+
+    [Test]
+    public void TypedGettersConvertTextBackedValues()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        using var reader = connection.ExecuteReader("SELECT '42', '1', 'true', 42, 3.5;");
+        reader.Read().Should().BeTrue();
+        reader.GetInt64(0).Should().Be(42);
+        reader.GetBoolean(1).Should().BeTrue();
+        reader.GetBoolean(2).Should().BeTrue();
+        reader.GetString(3).Should().Be("42");
+        reader.GetString(4).Should().Be("3.5");
+    }
+
+    [Test]
+    public void ExecuteNonQueryReportsRowsAffectedForCteDmlAndReturning()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        connection.ExecuteNonQuery("CREATE TABLE Data(Id INTEGER PRIMARY KEY, Value TEXT); INSERT INTO Data VALUES (1, 'a');");
+
+        connection.ExecuteNonQuery("WITH Target AS (SELECT 1 AS Id) UPDATE Data SET Value = 'b' WHERE Id = (SELECT Id FROM Target);")
+            .Should().Be(1);
+        connection.ExecuteNonQuery("UPDATE Data SET Value = 'c' WHERE Id = 1 RETURNING Id;")
+            .Should().Be(1);
+    }
+
+    [Test]
+    public void ReadOnlyConnectionRejectsCteDml()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = Path.Combine(directory.Path, "readonly-cte.db");
+        using (var connection = new SqliteConnection($"Data Source={path}"))
+        {
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE Data(Id INTEGER PRIMARY KEY, Value TEXT); INSERT INTO Data VALUES (1, 'a');");
+        }
+
+        using var readOnly = new SqliteConnection($"Data Source={path};Mode=ReadOnly");
+        readOnly.Open();
+
+        var exception = Assert.Throws<SqliteException>(() => readOnly.ExecuteNonQuery("""
+            WITH Target AS (SELECT 1 AS Id)
+            UPDATE Data SET Value = 'b' WHERE Id = (SELECT Id FROM Target);
+            """));
+        exception!.SqliteErrorCode.Should().Be(8);
+    }
+
+    [Test]
+    public void ReadOnlyConnectionRejectsWriteAfterReadInBatch()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = Path.Combine(directory.Path, "readonly-batch.db");
+        using (var connection = new SqliteConnection($"Data Source={path}"))
+        {
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE Data(Value TEXT);");
+        }
+
+        using var readOnly = new SqliteConnection($"Data Source={path};Mode=ReadOnly");
+        readOnly.Open();
+
+        var exception = Assert.Throws<SqliteException>(() => readOnly.ExecuteNonQuery("""
+            SELECT 1;
+            INSERT INTO Data VALUES ('blocked');
+            """));
+        exception!.SqliteErrorCode.Should().Be(8);
+    }
+
+    [Test]
     public void StateChangeFiresForOpenAndClose()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -420,6 +535,44 @@ public class SqliteFacadeTests
 
         exception.SqliteErrorCode.Should().Be(1);
         exception.Message.Should().Be(Data.Sqlite.Properties.Resources.SqliteNativeError(1, Data.Sqlite.Properties.Resources.UDFCalledWithNull("test", 0)));
+    }
+
+    [Test]
+    public void ScalarFunctionPreservesDecimalPrecision()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        const decimal expected = 1234567890123456789012345678m;
+
+        connection.CreateFunction("test", () => expected);
+
+        using var reader = connection.ExecuteReader("SELECT test();");
+        reader.Read().Should().BeTrue();
+        reader.GetDecimal(0).Should().Be(expected);
+    }
+
+    [Test]
+    public void DbTypeDecimalParametersPreservePrecision()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        connection.ExecuteNonQuery("CREATE TABLE Data(Value TEXT);");
+        const decimal expected = 1234567890123456789012345678m;
+
+        using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO Data VALUES ($value);";
+            var parameter = insert.CreateParameter();
+            parameter.ParameterName = "$value";
+            parameter.DbType = DbType.Decimal;
+            parameter.Value = expected;
+            insert.Parameters.Add(parameter);
+            insert.ExecuteNonQuery();
+        }
+
+        using var reader = connection.ExecuteReader("SELECT Value FROM Data;");
+        reader.Read().Should().BeTrue();
+        reader.GetDecimal(0).Should().Be(expected);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Add local Turso.Data.Sqlite facade compatibility fixes for EF-style consumers
- Implement schema metadata for Tables/Columns with declared object casing helpers
- Add async ADO.NET overrides, DML/result-set draining, typed conversions, decimal precision preservation, and transaction/savepoint async methods

## Validation
- dotnet build bindings\dotnet\src\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj -f net9.0 --nologo -v minimal
- dotnet build bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --nologo -v minimal
- C:\Users\mamoreau\.cargo\bin\cargo.exe build -p turso_sdk_kit --target-dir .\bindings\dotnet\rs_compiled --target x86_64-pc-windows-msvc
- dotnet test bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --no-build --nologo -v minimal --filter FullyQualifiedName~SqliteFacadeTests