### PR TITLE
Added Regression Testing for SQLite Compatibility in datetime.rs

### DIFF
--- a/VOUCHED.td
+++ b/VOUCHED.td
@@ -29,4 +29,3 @@
 + travenin
 + github-actions[bot]
 + awakecoding
-+ SaisakthiM

--- a/VOUCHED.td
+++ b/VOUCHED.td
@@ -29,3 +29,4 @@
 + travenin
 + github-actions[bot]
 + awakecoding
++ SaisakthiM

--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -1712,8 +1712,7 @@ mod tests {
                     Value::build_text(modifier),
                 ]),
                 Value::Null,
-                "modifier: {}",
-                modifier
+                "modifier: {modifier}"
             );
         }
     }
@@ -1873,8 +1872,7 @@ mod tests {
                     Value::build_text(modifier),
                 ]),
                 Value::Null,
-                "modifier: {}",
-                modifier
+                "modifier: {modifier}"
             );
         }
 
@@ -1892,8 +1890,7 @@ mod tests {
                     Value::build_text(modifier),
                 ]),
                 Value::Null,
-                "modifier: {}",
-                modifier
+                "modifier: {modifier}"
             );
         }
     }
@@ -1938,8 +1935,7 @@ mod tests {
             assert_eq!(
                 result,
                 Value::Null,
-                "modifier: {}",
-                modifier
+                "modifier: {modifier}"
             );
         }
     }

--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -1668,11 +1668,53 @@ mod tests {
             Value::build_text("2024-07-21T12:00:00+Z"),        // Invalid timezone format
             Value::build_text("2024-07-21T12:00:00+00:00Z"),   // Mixing offset and Z
             Value::build_text("2024-07-21T12:00:00UTC"),       // Named timezone (not supported)
+            // Unsupported date format tests
+            Value::build_text("2024/07/21"),
+            Value::build_text("2024.07.21"),
+            Value::build_text("07/21/2024"),
+            Value::build_text("21/07/2024"),
+
         ];
 
         for case in invalid_cases {
             let result = exec_time(&[case.clone()]);
             assert_eq!(result, Value::Null);
+        }
+    }
+
+    #[test]
+    fn test_parse_modifier_overflow() {
+        let modifiers = [
+            "1e308 days",
+            "1e308 hours",
+            "1e308 minutes",
+            "1e308 seconds",
+            "1e308 months",
+            "1e308 years",
+            "-1e308 days",
+            "-1e308 hours",
+            "-1e308 minutes",
+            "-1e308 seconds",
+            "-1e308 months",
+            "-1e308 years",
+            "1e309 days",
+            "1e309 hours",
+            "1e309 minutes",
+            "1e309 seconds",
+            "1e309 months",
+            "1e309 years"
+        ];
+
+        for modifier in modifiers {
+            assert_eq!(
+                exec_datetime_full(&[
+                    Value::build_text("now"),
+                    Value::build_text(modifier),
+                ]),
+                Value::Null,
+                "modifier: {}",
+                modifier
+            );
         }
     }
 
@@ -1821,6 +1863,40 @@ mod tests {
         assert_eq!(run("+2023-05-15 14:30"), "4023-06-16 14:30:00");
         assert_eq!(run("-0001-05-15 14:30"), "1998-07-16 09:30:00");
     }
+    #[test]
+    fn test_time_offset_boundaries() {
+        let valid = ["+24:59", "-24:59"];
+
+        for modifier in valid {
+            assert_ne!(exec_datetime_full(&[
+                    Value::build_text("now"),
+                    Value::build_text(modifier),
+                ]),
+                Value::Null,
+                "modifier: {}",
+                modifier
+            );
+        }
+
+        let invalid = [
+            "+25:00",
+            "+25:01",
+            "-25:00",
+            "-25:01",
+        ];
+
+        for modifier in invalid {
+            assert_eq!(
+                exec_datetime_full(&[
+                    Value::build_text("now"),
+                    Value::build_text(modifier),
+                ]),
+                Value::Null,
+                "modifier: {}",
+                modifier
+            );
+        }
+    }
 
     #[test]
     fn test_parse_start_of() {
@@ -1840,6 +1916,32 @@ mod tests {
         assert_eq!(run(base, "START OF YEAR"), "2023-01-01 00:00:00");
         assert_eq!(run(base, "start of day"), "2023-06-15 00:00:00");
         assert_eq!(run(base, "START OF DAY"), "2023-06-15 00:00:00");
+    }
+
+    #[test]
+    fn test_invalid_end_of_modifiers() {
+        let modifiers = [
+            "end of month",
+            "END OF MONTH",
+            "end of year",
+            "END OF YEAR",
+            "end of day",
+            "END OF DAY",
+        ];
+
+        for modifier in modifiers {
+            let result = exec_datetime_full(&[
+                Value::build_text("2023-06-15"),
+                Value::build_text(modifier),
+            ]);
+
+            assert_eq!(
+                result,
+                Value::Null,
+                "modifier: {}",
+                modifier
+            );
+        }
     }
 
     #[test]
@@ -1963,6 +2065,74 @@ mod tests {
 
         assert_eq!(run("30 seconds"), "2023-06-15 12:31:15");
         assert_eq!(run("-20 seconds"), "2023-06-15 12:30:25");
+    }
+    #[test]
+    fn test_datetime_boundary_arithmetic() {
+        assert_eq!(
+            exec_datetime_full(&[
+                Value::build_text("9999-12-31 23:59:59"),
+                Value::build_text("+1 second"),
+            ]),
+            Value::Null
+        );
+
+        assert_eq!(
+            exec_datetime_full(&[
+                Value::build_text("9999-12-31 23:59:59"),
+                Value::build_text("+1 day"),
+            ]),
+            Value::Null
+        );
+
+        assert_eq!(
+            exec_datetime_full(&[
+                Value::build_text("9999-12-31 23:59:59"),
+                Value::build_text("+1 month"),
+            ]),
+            Value::Null
+        );
+
+        assert_eq!(
+            exec_datetime_full(&[
+                Value::build_text("9999-12-31 23:59:59"),
+                Value::build_text("+1 year"),
+            ]),
+            Value::Null
+        );
+
+        assert_eq!(
+            exec_datetime_full(&[
+                Value::build_text("0000-01-01 00:00:00"),
+                Value::build_text("-1 second"),
+            ]),
+            Value::build_text("-0001-12-31 23:59:59")
+        );
+
+        
+
+        assert_eq!(
+            exec_datetime_full(&[
+                Value::build_text("0000-01-01 00:00:00"),
+                Value::build_text("-1 day"),
+            ]),
+            Value::build_text("-0001-12-31 00:00:00")
+        );
+
+        assert_eq!(
+            exec_datetime_full(&[
+                Value::build_text("0000-01-01 00:00:00"),
+                Value::build_text("-1 month"),
+            ]),
+            Value::build_text("-0001-12-01 00:00:00")
+        );
+        
+        assert_eq!(
+            exec_datetime_full(&[
+                Value::build_text("0000-01-01 00:00:00"),
+                Value::build_text("-1 year"),
+            ]),
+            Value::build_text("-0001-01-01 00:00:00")
+        );
     }
 
     #[test]

--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -1673,7 +1673,6 @@ mod tests {
             Value::build_text("2024.07.21"),
             Value::build_text("07/21/2024"),
             Value::build_text("21/07/2024"),
-
         ];
 
         for case in invalid_cases {
@@ -1702,15 +1701,12 @@ mod tests {
             "1e309 minutes",
             "1e309 seconds",
             "1e309 months",
-            "1e309 years"
+            "1e309 years",
         ];
 
         for modifier in modifiers {
             assert_eq!(
-                exec_datetime_full(&[
-                    Value::build_text("now"),
-                    Value::build_text(modifier),
-                ]),
+                exec_datetime_full(&[Value::build_text("now"), Value::build_text(modifier),]),
                 Value::Null,
                 "modifier: {modifier}"
             );
@@ -1867,28 +1863,18 @@ mod tests {
         let valid = ["+24:59", "-24:59"];
 
         for modifier in valid {
-            assert_ne!(exec_datetime_full(&[
-                    Value::build_text("now"),
-                    Value::build_text(modifier),
-                ]),
+            assert_ne!(
+                exec_datetime_full(&[Value::build_text("now"), Value::build_text(modifier),]),
                 Value::Null,
                 "modifier: {modifier}"
             );
         }
 
-        let invalid = [
-            "+25:00",
-            "+25:01",
-            "-25:00",
-            "-25:01",
-        ];
+        let invalid = ["+25:00", "+25:01", "-25:00", "-25:01"];
 
         for modifier in invalid {
             assert_eq!(
-                exec_datetime_full(&[
-                    Value::build_text("now"),
-                    Value::build_text(modifier),
-                ]),
+                exec_datetime_full(&[Value::build_text("now"), Value::build_text(modifier),]),
                 Value::Null,
                 "modifier: {modifier}"
             );
@@ -1927,16 +1913,10 @@ mod tests {
         ];
 
         for modifier in modifiers {
-            let result = exec_datetime_full(&[
-                Value::build_text("2023-06-15"),
-                Value::build_text(modifier),
-            ]);
+            let result =
+                exec_datetime_full(&[Value::build_text("2023-06-15"), Value::build_text(modifier)]);
 
-            assert_eq!(
-                result,
-                Value::Null,
-                "modifier: {modifier}"
-            );
+            assert_eq!(result, Value::Null, "modifier: {modifier}");
         }
     }
 
@@ -2104,8 +2084,6 @@ mod tests {
             Value::build_text("-0001-12-31 23:59:59")
         );
 
-        
-
         assert_eq!(
             exec_datetime_full(&[
                 Value::build_text("0000-01-01 00:00:00"),
@@ -2121,7 +2099,7 @@ mod tests {
             ]),
             Value::build_text("-0001-12-01 00:00:00")
         );
-        
+
         assert_eq!(
             exec_datetime_full(&[
                 Value::build_text("0000-01-01 00:00:00"),


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->

## Description

Added regression tests for datetime parsing and modifier edge cases.

The new tests cover:

- Invalid datetime inputs returning NULL
- Modifier overflow handling (`days`, `hours`, `minutes`, `seconds`, `months`, `years`)
- Large numeric modifier values (`1e308`, `1e309`, etc.)
- Time offset boundary validation
- Datetime arithmetic near supported date boundaries
- Unsupported modifiers such as `end of month`, `end of year`, and `end of day`

The tests were verified against SQLite behavior and help prevent regressions in datetime parsing and arithmetic.

## Motivation and context

While investigating datetime behavior and SQLite compatibility, several edge cases were identified around modifier overflow, invalid inputs, timezone offsets, and date boundary arithmetic.

This PR adds regression tests covering those scenarios to ensure behavior remains consistent with SQLite and to improve confidence when modifying datetime-related code in the future.

## Description of AI Usage

AI was used as an assistant during test development and review.

Usage included:
- Brainstorming edge cases for datetime parsing and arithmetic
- Suggesting additional SQLite compatibility checks
- Reviewing test coverage for overflow, boundary, and invalid-input scenarios
- Discussing expected behavior before verifying results directly against SQLite

All proposed test cases were manually reviewed, executed, and validated against SQLite behavior before being included in this PR. The implementation and final verification were performed by the author.

### SQLite verification queries

The following queries were used to verify behavior against SQLite:

```sql
-- Modifier overflow
SELECT datetime('now', '1e308 days');
SELECT datetime('now', '-1e308 days');
SELECT datetime('now', '1e309 days');

SELECT datetime('now', '1e308 hours');
SELECT datetime('now', '-1e308 hours');

SELECT datetime('now', '1e308 minutes');
SELECT datetime('now', '-1e308 minutes');

SELECT datetime('now', '1e308 seconds');
SELECT datetime('now', '-1e308 seconds');

SELECT datetime('now', '1e308 months');
SELECT datetime('now', '1e308 years');

-- Time offset boundaries
SELECT datetime('now', '+24:59');
SELECT datetime('now', '+25:00');
SELECT datetime('now', '+25:01');

SELECT datetime('now', '-24:59');
SELECT datetime('now', '-25:00');
SELECT datetime('now', '-25:01');

SELECT datetime('now', '+999999999:00');
SELECT datetime('now', '-999999999:00');
SELECT datetime('now', '+2147483648:00');

-- Unsupported modifiers
SELECT datetime('2023-06-15', 'end of month');
SELECT datetime('2023-06-15', 'end of year');
SELECT datetime('2023-06-15', 'end of day');

-- Boundary arithmetic
SELECT datetime('2023-06-15 12:30:45', '+100000000 days');
SELECT datetime('2023-06-15 12:30:45', '-100000000 days');

SELECT datetime('9999-12-31 23:59:59', '+1 second');
SELECT datetime('9999-12-31 23:59:59', '+1 day');
SELECT datetime('9999-12-31 23:59:59', '+1 month');
SELECT datetime('9999-12-31 23:59:59', '+1 year');

SELECT datetime('0000-01-01 00:00:00', '-1 second');
SELECT datetime('0000-01-01 00:00:00', '-1 day');
SELECT datetime('0000-01-01 00:00:00', '-1 month');
SELECT datetime('0000-01-01 00:00:00', '-1 year');

-- Existing supported behavior
SELECT datetime('now', '+14:00');
SELECT datetime('now', '-14:00');
SELECT datetime('now', '+14:01');
SELECT datetime('now', '-14:01');

SELECT datetime(
    '2023-06-15',
    'start of year',
    '+1 year',
    '-1 day'
);
```
### SQLite verification results

The following behaviors were verified directly against SQLite 3.53.2.

#### Modifier overflow

```sql
SELECT datetime('now', '1e308 days');
SELECT datetime('now', '-1e308 days');
SELECT datetime('now', '1e309 days');

SELECT datetime('now', '1e308 hours');
SELECT datetime('now', '-1e308 hours');

SELECT datetime('now', '1e308 minutes');
SELECT datetime('now', '-1e308 minutes');

SELECT datetime('now', '1e308 seconds');
SELECT datetime('now', '-1e308 seconds');

SELECT datetime('now', '1e308 months');
SELECT datetime('now', '1e308 years');
```

**Result:** All return `NULL`.

---

#### Time offset boundaries

```sql
SELECT datetime('now', '+24:59');
SELECT datetime('now', '+25:00');
SELECT datetime('now', '+25:01');

SELECT datetime('now', '-24:59');
SELECT datetime('now', '-25:00');
SELECT datetime('now', '-25:01');
```

**Results:**

| Expression | SQLite Result |
|------------|---------------|
| `+24:59` | Valid datetime |
| `+25:00` | NULL |
| `+25:01` | NULL |
| `-24:59` | Valid datetime |
| `-25:00` | NULL |
| `-25:01` | NULL |

This confirms that SQLite accepts offsets up to `±24:59` and rejects values beyond that range.

---

#### Large offset values

```sql
SELECT datetime('now', '+999999999:00');
SELECT datetime('now', '-999999999:00');
SELECT datetime('now', '+2147483648:00');
```

**Result:** All return `NULL`.

---

#### Unsupported modifiers

```sql
SELECT datetime('2023-06-15', 'end of month');
SELECT datetime('2023-06-15', 'end of year');
SELECT datetime('2023-06-15', 'end of day');
```

**Result:** All return `NULL`.

---

#### Arithmetic overflow and date boundaries

```sql
SELECT datetime('2023-06-15 12:30:45', '+100000000 days');
SELECT datetime('2023-06-15 12:30:45', '-100000000 days');
```

**Result:** Both return `NULL`.

---

#### Upper date boundary

```sql
SELECT datetime('9999-12-31 23:59:59', '+1 second');
SELECT datetime('9999-12-31 23:59:59', '+1 day');
SELECT datetime('9999-12-31 23:59:59', '+1 month');
SELECT datetime('9999-12-31 23:59:59', '+1 year');
```

**Result:** All return `NULL`.

---

#### Lower date boundary

```sql
SELECT datetime('0000-01-01 00:00:00', '-1 second');
SELECT datetime('0000-01-01 00:00:00', '-1 day');
SELECT datetime('0000-01-01 00:00:00', '-1 month');
SELECT datetime('0000-01-01 00:00:00', '-1 year');
```

**Results:**

| Expression | SQLite Result |
|------------|---------------|
| `-1 second` | `-0001-12-31 23:59:59` |
| `-1 day` | `-0001-12-31 00:00:00` |
| `-1 month` | `-0001-12-01 00:00:00` |
| `-1 year` | `-0001-01-01 00:00:00` |

---

#### Existing supported behavior

```sql
SELECT datetime('now', '+14:00');
SELECT datetime('now', '-14:00');
SELECT datetime('now', '+14:01');
SELECT datetime('now', '-14:01');
```

**Result:** All return valid datetimes.

```sql
SELECT datetime(
    '2023-06-15',
    'start of year',
    '+1 year',
    '-1 day'
);
```

**Result:**

```text
2023-12-31 00:00:00
```