### PR TITLE
core: fix blob literal handling in materialized views

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -1692,7 +1692,7 @@ impl DbspCompiler {
                         let escaped = t.to_string().replace('\'', "''");
                         ast::Literal::String(format!("'{escaped}'"))
                     }
-                    Value::Blob(b) => ast::Literal::Blob(format!("{b:?}")),
+                    Value::Blob(b) => ast::Literal::Blob(hex::encode_upper(b)),
                     Value::Null => ast::Literal::Null,
                 };
                 Ok(ast::Expr::Literal(lit))

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -1931,7 +1931,13 @@ impl<'a> LogicalPlanBuilder<'a> {
                 };
                 Ok(Value::Text(unquoted.to_string().into()))
             }
-            ast::Literal::Blob(b) => Ok(Value::Blob(b.clone().into())),
+            // The lexer guarantees a valid even-length hex string; decode it to the
+            // actual bytes instead of storing the hex text's UTF-8.
+            ast::Literal::Blob(b) => {
+                Ok(Value::Blob(hex::decode(b).map_err(|_| {
+                    LimboError::ParseError(format!("invalid blob literal: {b}"))
+                })?))
+            }
             ast::Literal::CurrentDate
             | ast::Literal::CurrentTime
             | ast::Literal::CurrentTimestamp => Err(LimboError::ParseError(

--- a/testing/sqltests/turso-tests/materialized_views.sqltest
+++ b/testing/sqltests/turso-tests/materialized_views.sqltest
@@ -2508,3 +2508,25 @@ test matview-reserved-prefix-sqlite {
 expect error {
     object name reserved for internal use: sqlite_matview
 }
+
+# A hex blob literal in a materialized view definition must round-trip to the
+# correct bytes (not panic, and not the UTF-8 of the hex text). See issue #7355.
+test matview-blob-literal {
+    CREATE TABLE t_blob(id INTEGER);
+    INSERT INTO t_blob VALUES (1);
+    CREATE MATERIALIZED VIEW mv_blob AS SELECT x'FF' AS b FROM t_blob;
+    SELECT typeof(b), quote(b), hex(b) FROM mv_blob;
+}
+expect {
+    blob|X'FF'|FF
+}
+
+test matview-blob-literal-multibyte-and-empty {
+    CREATE TABLE t_blob2(id INTEGER);
+    INSERT INTO t_blob2 VALUES (1);
+    CREATE MATERIALIZED VIEW mv_blob2 AS SELECT x'DEADBEEF' AS b, x'' AS e FROM t_blob2;
+    SELECT hex(b), length(b), quote(e), length(e) FROM mv_blob2;
+}
+expect {
+    DEADBEEF|4|X''|0
+}


### PR DESCRIPTION
## Summary
A hex blob literal in a materialized view definition, e.g.

    CREATE MATERIALIZED VIEW mv AS SELECT x'FF' FROM t;

panicked when the view was queried (#7355). The blob is mishandled on the
incremental-view path in two places:

- `build_literal` (`core/translate/logical.rs`) stored the UTF-8 bytes of
  the hex text (`x'FF'` became `[0x46, 0x46]`) instead of decoding it, so
  the view held the wrong blob value.
- `logical_to_ast_expr_with_schema` (`core/incremental/compiler.rs`) then
  re-serialized the blob with `format!("{b:?}")` (`"[255]"`), which
  `emit_literal` reparses as hex via `from_str_radix(..).unwrap()` and
  panicked.

Fixing only the panic would turn it into silent corruption (the view
would return `[0x46, 0x46]`), so both sites are fixed: decode the hex
literal to real bytes, and encode the bytes back to a valid hex string for
the round-trip. Both use the `hex` crate already used in the engine
(e.g. `core/incremental/dbsp.rs`). Ordinary SQL is unaffected; only
materialized views build literals through this path.

## Validation
- new regression tests in
  `testing/sqltests/turso-tests/materialized_views.sqltest`
  (`matview-blob-literal`, `matview-blob-literal-multibyte-and-empty`)
- `materialized_views.sqltest`: 112 passed on both rust and cli backends
- `cargo fmt`; `cargo clippy --workspace --all-features --all-targets -- --deny=warnings`

Closes #7355