### PR TITLE
Linear better than quadratic

### DIFF
--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -195,19 +195,34 @@ fn bench(c: &mut Criterion) {
 // Models the shape of a workload that hit a pathological MVCC slowdown: a single
 // batch `INSERT ... SELECT` that joins a `VALUES` list of new rows against a
 // one-row `metadata` table and inserts them into a table with a UNIQUE index,
-// with `RETURNING`. The hot path is the per-row eq-only index probe (NoConflict).
+// with `RETURNING`. The hot path is a per-row eq-only probe (`NoConflict` on the
+// UNIQUE `seq` index, and `NotExists` on the INTEGER PRIMARY KEY rowid).
 //
 // The `pending_invisible` parameter opens a second connection that holds an
-// uncommitted `BEGIN CONCURRENT` transaction full of index entries that are
-// invisible to the measured connection — reproducing concurrent in-flight batch
-// inserts. Before the eq-only seek bound was added, each probe scanned O(pending)
-// invisible skiplist entries, so this benchmark's time grew with `pending`; after
-// the fix it should stay roughly flat.
+// uncommitted `BEGIN CONCURRENT` transaction full of entries that are invisible
+// to the measured connection — reproducing concurrent in-flight batch inserts.
+// Before the eq-only seek bound was added, each probe scanned O(pending) invisible
+// skiplist entries, so the benchmark's time grew with `pending`; after the fix it
+// should stay roughly flat.
 //
-// To isolate the *index* (`seq`) seek path that the fix touches, the ghost rows'
-// rowids sit *below* every measured rowid (so the separate table-rowid seek never
-// walks into them) while their `seq` values sit *above* (so the index probe does).
+// Two variants isolate the two seek paths via `GhostPlacement`:
+// - `IndexProbe`  (`mvcc-huge-multi-write`): ghost rows have LOW rowids and HIGH
+//   `seq`, so only the eq-only *index* probe (`seek_index`) walks toward them.
+// - `RowidProbe`  (`mvcc-huge-multi-write-rowid`): ghost rows have HIGH rowids and
+//   LOW `seq`, so only the eq-only *table-rowid* probe (`seek_rowid`) walks toward
+//   them.
 // ---------------------------------------------------------------------------
+
+/// Selects which per-row eq-only probe the invisible ghost rows force to scan,
+/// by placing the ghosts in that probe's forward seek path (and out of the
+/// other's).
+#[derive(Clone, Copy)]
+enum GhostPlacement {
+    /// Low rowid, high `seq`: exercises `seek_index` (the UNIQUE-index probe).
+    IndexProbe,
+    /// High rowid, low `seq`: exercises `seek_rowid` (the INTEGER PRIMARY KEY probe).
+    RowidProbe,
+}
 
 /// Number of anonymized payload (TEXT) columns on `core`, mirroring wide rows
 /// without reproducing any real schema.
@@ -222,6 +237,11 @@ const HUGE_WRITE_SEQ_BASE: i64 = 1_000_000;
 /// anything the measured batch inserts, so every measured eq-only index probe
 /// scans toward them (pre-fix) rather than stopping at a visible neighbor.
 const GHOST_SEQ_BASE: i64 = 100_000_000;
+/// For `GhostPlacement::RowidProbe`, the ghost rows' *rowids* sit far above any
+/// rowid the measured batch reaches (which climbs from `HUGE_WRITE_SEQ_BASE` over
+/// a run), so every measured table-rowid probe scans toward them (pre-fix) rather
+/// than stopping at a visible neighbor.
+const GHOST_ROWID_BASE: i64 = 1_000_000_000;
 /// Rebuild the database (and ghost) every this many measured batches to keep the
 /// committed-row footprint bounded over a long Criterion run.
 const HUGE_WRITE_RESET_EVERY: u64 = 2_000;
@@ -271,7 +291,7 @@ fn build_huge_multi_write(rows: usize) -> String {
     )
 }
 
-fn ghost_insert_sql(pending: i64) -> String {
+fn ghost_insert_sql(pending: i64, placement: GhostPlacement) -> String {
     let col_list = payload_columns();
     let payload = (0..HUGE_WRITE_PAYLOAD_COLS)
         .map(|_| "'ghost'")
@@ -282,10 +302,14 @@ fn ghost_insert_sql(pending: i64) -> String {
         if j > 0 {
             values.push(',');
         }
-        // Low rowid (out of the measured rowid seek's forward path), high seq
-        // (in the measured index probe's forward path).
-        let rowid = j + 1;
-        let seq = GHOST_SEQ_BASE + j;
+        let (rowid, seq) = match placement {
+            // Low rowid (out of the measured rowid seek's forward path), high seq
+            // (in the measured index probe's forward path).
+            GhostPlacement::IndexProbe => (j + 1, GHOST_SEQ_BASE + j),
+            // High rowid (in the measured rowid seek's forward path), low seq
+            // (out of the measured index probe's forward path).
+            GhostPlacement::RowidProbe => (GHOST_ROWID_BASE + j, j + 1),
+        };
         values.push_str(&format!("({rowid}, {seq}, {payload}, 0, {seq}, 0, 0)"));
     }
     format!(
@@ -305,7 +329,7 @@ struct HugeMultiWriteHarness {
 }
 
 impl HugeMultiWriteHarness {
-    fn new(pending: i64) -> Self {
+    fn new(pending: i64, placement: GhostPlacement) -> Self {
         // In-memory IO: no fsync per commit, so the measurement reflects the
         // CPU-bound index-probe path the eq-only seek bound affects.
         let io = Arc::new(MemoryIO::new());
@@ -329,7 +353,7 @@ impl HugeMultiWriteHarness {
             let ghost = db.connect().unwrap();
             ghost.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
             ghost.execute("BEGIN CONCURRENT").unwrap();
-            ghost.execute(ghost_insert_sql(pending)).unwrap();
+            ghost.execute(ghost_insert_sql(pending, placement)).unwrap();
             // Intentionally not committed: these rows stay invisible to `conn`.
             ghost
         });
@@ -357,12 +381,11 @@ fn run_to_completion(db: &Arc<Database>, stmt: &mut Statement) {
     }
 }
 
-#[turso_macros::codspeed_criterion_benchmark]
-fn bench_huge_multi_write(c: &mut Criterion) {
+fn run_huge_multi_write(c: &mut Criterion, group_name: &str, placement: GhostPlacement) {
     let idx1 = NonZeroUsize::new(1).unwrap();
     let sql = build_huge_multi_write(HUGE_WRITE_ROWS_PER_BATCH);
 
-    let mut group = c.benchmark_group("mvcc-huge-multi-write");
+    let mut group = c.benchmark_group(group_name);
     group.sample_size(10);
     group.throughput(Throughput::Elements(HUGE_WRITE_ROWS_PER_BATCH as u64));
 
@@ -378,7 +401,7 @@ fn bench_huge_multi_write(c: &mut Criterion) {
                     for i in 0..iters {
                         if i % HUGE_WRITE_RESET_EVERY == 0 {
                             // Rebuild from scratch (setup time is excluded from `total`).
-                            let h = HugeMultiWriteHarness::new(pending);
+                            let h = HugeMultiWriteHarness::new(pending, placement);
                             stmt = Some(h.conn.prepare(&sql).unwrap());
                             harness = Some(h);
                             base = HUGE_WRITE_SEQ_BASE;
@@ -400,18 +423,35 @@ fn bench_huge_multi_write(c: &mut Criterion) {
     group.finish();
 }
 
+/// Guards the eq-only bound on the UNIQUE-index probe (`seek_index`): the ghost
+/// rows' `seq` values sit above the measured batch, so each per-row `NoConflict`
+/// probe would scan O(pending) invisible entries without the bound.
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_huge_multi_write(c: &mut Criterion) {
+    run_huge_multi_write(c, "mvcc-huge-multi-write", GhostPlacement::IndexProbe);
+}
+
+/// Guards the eq-only bound on the table-rowid probe (`seek_rowid`): the ghost
+/// rows' rowids sit above the measured batch, so each per-row `NotExists` probe
+/// would scan O(pending) invisible entries without the bound. Time should stay
+/// flat across `pending`; pre-fix it grew ~linearly (O(rows * pending)).
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_huge_multi_write_rowid(c: &mut Criterion) {
+    run_huge_multi_write(c, "mvcc-huge-multi-write-rowid", GhostPlacement::RowidProbe);
+}
+
 #[cfg(not(feature = "codspeed"))]
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench, bench_huge_multi_write
+    targets = bench, bench_huge_multi_write, bench_huge_multi_write_rowid
 }
 
 #[cfg(feature = "codspeed")]
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = bench, bench_huge_multi_write
+    targets = bench, bench_huge_multi_write, bench_huge_multi_write_rowid
 }
 
 criterion_main!(benches);

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1511,6 +1511,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                             let mvcc_rowid = self.db.seek_rowid(
                                 rowid.clone(),
                                 inclusive,
+                                op.eq_only(),
                                 direction,
                                 self.tx_id,
                                 &mut self.table_iterator,
@@ -1828,13 +1829,16 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
             };
             let inclusive = true;
 
-            // Check MVCC first
+            // Check MVCC first. This is a point existence probe, so it is
+            // eq-only: bound the skiplist walk to the single rowid instead of
+            // scanning forward over invisible concurrent rows.
             let rowid = self.db.seek_rowid(
                 RowID {
                     table_id: self.table_id,
                     row_id: RowKey::Int(*int_key),
                 },
                 inclusive,
+                true,
                 IterationDirection::Forwards,
                 self.tx_id,
                 &mut self.table_iterator,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5227,18 +5227,33 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         start: RowID,
         inclusive: bool,
+        eq_only: bool,
         direction: IterationDirection,
         tx_id: TxID,
         table_iterator: &mut Option<MvccIterator<'static, RowID, A>>,
     ) -> Option<RowID> {
         let table_id = start.table_id;
         let iter_box = {
-            let start = if inclusive {
-                Bound::Included(start)
+            let range = if eq_only {
+                // An eq-only rowid seek (point lookup, NotExists / rowid-uniqueness
+                // probe) only cares about the single key `start`. Bound BOTH ends of
+                // the range to that key so the skiplist walk stops immediately instead
+                // of scanning forward over every invisible neighbor until it happens to
+                // find the next visible row. Without this bound a single probe costs
+                // O(pending invisible versions), which compounds into quadratic work
+                // when each row of a concurrent batch insert pays it. This mirrors the
+                // eq-only bound in `seek_index`. The cursor's final position is still
+                // decided by `PickWinner` from the merged MVCC/B-tree peeks, so bounding
+                // the range here does not change where the cursor lands.
+                (Bound::Included(start.clone()), Bound::Included(start))
             } else {
-                Bound::Excluded(start)
+                let start = if inclusive {
+                    Bound::Included(start)
+                } else {
+                    Bound::Excluded(start)
+                };
+                create_seek_range(start, direction)
             };
-            let range = create_seek_range(start, direction);
             match direction {
                 IterationDirection::Forwards => {
                     Box::new(self.rows.range(range)) as TableRowIterator<'_, A>


### PR DESCRIPTION
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/ef0391fe-9e5f-4c81-83ae-394ae4b5b960" />


```
mvcc-huge-multi-write-rowid/rows=32/pending_invisible=0
                        time:   [177.25 µs 180.22 µs 184.25 µs]
                        thrpt:  [173.68 Kelem/s 177.56 Kelem/s 180.54 Kelem/s]
                 change:
                        time:   [-1.2426% +0.9051% +2.9260%] (p = 0.43 > 0.05)
                        thrpt:  [-2.8428% -0.8970% +1.2582%]
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
mvcc-huge-multi-write-rowid/rows=32/pending_invisible=1000
                        time:   [183.27 µs 187.19 µs 190.17 µs]
                        thrpt:  [168.27 Kelem/s 170.95 Kelem/s 174.61 Kelem/s]
                 change:
                        time:   [-90.903% -90.773% -90.636%] (p = 0.00 < 0.05)
                        thrpt:  [+967.92% +983.76% +999.25%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
mvcc-huge-multi-write-rowid/rows=32/pending_invisible=4000
                        time:   [186.49 µs 187.18 µs 188.25 µs]
                        thrpt:  [169.99 Kelem/s 170.96 Kelem/s 171.59 Kelem/s]
                 change:
                        time:   [-97.531% -97.504% -97.480%] (p = 0.00 < 0.05)
                        thrpt:  [+3868.8% +3907.0% +3951.0%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
```