### PR TITLE
Fix various typos across the codebase

### DIFF
--- a/bindings/go/go-bindings-db-tests.mdx
+++ b/bindings/go/go-bindings-db-tests.mdx
@@ -29,7 +29,7 @@ Generate tests which will cover generic use of SQL.
 - Subqueries
 - INSERT ... RETURNING ...
     * Make additional test case for scenario, where multiple values were inserted, but only one row were fetch
-    * Make sure that in this case transaction will be properly commited even when not all rows were consumed
+    * Make sure that in this case transaction will be properly committed even when not all rows were consumed
 - CONFLICT clauses (and how driver inform caller about conflict)
 - Basic DDL statements (CREATE/DELETE)
 - More complex DDL statements (ALTER TABLE)

--- a/bindings/python/py-bindings-db-aio.mdx
+++ b/bindings/python/py-bindings-db-aio.mdx
@@ -100,7 +100,7 @@ Pay additional attention to the following aspects:
     - MAKE SURE this logic implemented properly
 * Implement .rowcount property correctly, be careful with `executemany(...)` methods as it must return rowcount of all executed statements (not just last statement)
 * Convert exceptions from rust layer to appropriate exceptions documented in the sqlite3 db-api2 docs
-* BE CAREFUL with implementation of transaction control. Make sure that in LEGACY_TRANSACTION_CONTROL mode implicit transaction will be properly commited in case of cursor close
+* BE CAREFUL with implementation of transaction control. Make sure that in LEGACY_TRANSACTION_CONTROL mode implicit transaction will be properly committed in case of cursor close
 
 Also, make types and API compatible with aiosqlite (note, that aiosqlite implements some other methods, which can be omitted now, like interrupt)
 

--- a/bindings/python/py-bindings-db.mdx
+++ b/bindings/python/py-bindings-db.mdx
@@ -106,7 +106,7 @@ Pay additional attention to the following aspects:
     - MAKE SURE this logic implemented properly
 * Implement .rowcount property correctly, be careful with `executemany(...)` methods as it must return rowcount of all executed statements (not just last statement)
 * Convert exceptions from rust layer to appropriate exceptions documented in the sqlite3 db-api2 docs
-* BE CAREFUL with implementation of transaction control. Make sure that in LEGACY_TRANSACTION_CONTROL mode implicit transaction will be properly commited in case of cursor close
+* BE CAREFUL with implementation of transaction control. Make sure that in LEGACY_TRANSACTION_CONTROL mode implicit transaction will be properly committed in case of cursor close
 
 <Shell 
     cmd="curl https://docs.python.org/3/library/sqlite3.html | pandoc --from html --to markdown" 

--- a/bindings/python/py-bindings-tests-aio.mdx
+++ b/bindings/python/py-bindings-tests-aio.mdx
@@ -37,7 +37,7 @@ Generate tests which will cover generic use of SQL.
 - Subqueries
 - INSERT ... RETURNING ...
     * Make additional test case for scenario, where multiple values were inserted, but only one row were fetch
-    * Make sure that in this case transaction will be properly commited even when not all rows were consumed
+    * Make sure that in this case transaction will be properly committed even when not all rows were consumed
 - CONFLICT clauses (and how driver inform caller about conflict)
 - Basic DDL statements (CREATE/DELETE)
 - More complex DDL statements (ALTER TABLE)

--- a/bindings/python/py-bindings-tests.mdx
+++ b/bindings/python/py-bindings-tests.mdx
@@ -34,7 +34,7 @@ Generate tests which will cover generic use of SQL.
 - Subqueries
 - INSERT ... RETURNING ...
     * Make additional test case for scenario, where multiple values were inserted, but only one row were fetch
-    * Make sure that in this case transaction will be properly commited even when not all rows were consumed
+    * Make sure that in this case transaction will be properly committed even when not all rows were consumed
 - CONFLICT clauses (and how driver inform caller about conflict)
 - Basic DDL statements (CREATE/DELETE)
 - More complex DDL statements (ALTER TABLE)

--- a/cli/sync_server.mdx
+++ b/cli/sync_server.mdx
@@ -134,7 +134,7 @@ The main database API is in the lib.rs:
     * pub const WAL_FRAME_HEADER_SIZE: usize = 24;
     * Do not forget to cut this meta to get page content
 - sync server must work only with page_size = 4096 (4kb)
-- If server_revision is not set - take latest commited frame offset
+- If server_revision is not set - take latest committed frame offset
 - If client_revision is not set - use zero for this
 - Pull updates logic should take all frames between [client_revision..server_revision] and send latest versions of unique pages changed in this range
     * Iterates backward and maintain HashSet of changes pages in memory during request execution

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2055,7 +2055,7 @@ impl Connection {
             wal.end_read_tx();
 
             if !force_commit {
-                // remove all non-commited changes in case if WAL session left some suffix without commit frame
+                // remove all non-committed changes in case if WAL session left some suffix without commit frame
                 if let Some(mv_store) = self.mv_store().as_ref() {
                     if let Some(tx_id) = self.get_mv_tx_id() {
                         mv_store.rollback_tx(tx_id, pager.clone(), self, MAIN_DB_ID);

--- a/core/mvcc/database/hermitage_tests.rs
+++ b/core/mvcc/database/hermitage_tests.rs
@@ -140,7 +140,7 @@ fn test_hermitage_g0_write_cycles_prevented() {
 /// If a transaction T1 updates a row but then aborts, another transaction T2 should never see
 /// T1's uncommitted changes, even if T2 reads the same row before T1 aborts.
 ///
-/// Since we don't allow reading uncommited data ever, we prevent g1a and also dirty update phenomena
+/// Since we don't allow reading uncommitted data ever, we prevent g1a and also dirty update phenomena
 /// (mentioned in the jepsen page)
 ///
 /// Turso: T2 never sees T1's uncommitted write

--- a/core/storage/buffer_pool.rs
+++ b/core/storage/buffer_pool.rs
@@ -220,7 +220,7 @@ impl BufferPool {
         // Tries to atomically (guarenteed by the OnceLock) initialize the page size for the inner pool.
         // If it succeeds, we now have to initialize the arenas.
         // If the initialization fails, this means the arenas have already been initialized by a previous thread
-        // This avoids a potential TOCTOU race, where 2 threads could try to initalize the arena at the same time
+        // This avoids a potential TOCTOU race, where 2 threads could try to initialize the arena at the same time
         // after checking the `db_page_size`
         if inner.db_page_size.set(page_size).is_ok() {
             inner.init_arenas()?;

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -354,7 +354,7 @@ impl TursoRwLock {
 
     /// upgrade read lock to the write lock
     /// only possible if there is exactly single reader at the moment
-    /// return true if lock was upgraded succesfully - and false otherwise
+    /// return true if lock was upgraded successfully - and false otherwise
     #[inline]
     pub fn upgrade(&self) -> bool {
         let cur = self.0.load(Ordering::Acquire);

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -900,8 +900,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         let mut main_session = WalSession::new(main_conn.clone());
         main_session.begin()?;
 
-        // we need to make sure that updates from the session will not be commited accidentally in the middle of the pull process
-        // in order to achieve that we mark current session as "nested program" which eliminates possibility that data will be actually commited without our explicit command
+        // we need to make sure that updates from the session will not be committed accidentally in the middle of the pull process
+        // in order to achieve that we mark current session as "nested program" which eliminates possibility that data will be actually committed without our explicit command
         //
         // the reason to not use auto-commit is because it has its own rules which resets the flag in case of statement reset - which we do under the hood sometimes
         // that's why nested executed was chosen instead of auto-commit=false mode
@@ -988,7 +988,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
         // Phase 5: collect local changes
         // note, that collecting chanages from main_conn will yield zero rows as we already rolled back everything from it
-        // but since we didn't commited these changes yet - we can just collect changes from another connection
+        // but since we didn't committed these changes yet - we can just collect changes from another connection
         let iterate_opts = DatabaseChangesIteratorOpts {
             first_change_id: last_change_id.map(|x| x + 1),
             mode: DatabaseChangesIteratorMode::Apply,

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -589,7 +589,7 @@ pub async fn wal_pull_to_file_legacy<IO: SyncEngineIo, Ctx>(
     };
 
     tracing::info!(
-        "wal_pull: generation={generation}, frame={start_frame}, last_offset={last_offset}, commited_len={committed_len}"
+        "wal_pull: generation={generation}, frame={start_frame}, last_offset={last_offset}, committed_len={committed_len}"
     );
     let c = Completion::new_trunc(move |result| {
         let Ok(rc) = result else {

--- a/testing/antithesis/README.md
+++ b/testing/antithesis/README.md
@@ -58,7 +58,7 @@ using [sqlite-viz](https://github.com/LeMikaelF/sqlite-viz). SQLite (and possibl
 can also dump information about certain pages in a human-readable form (see the `dump` command and the `-p` flag for
 pages, or `-t` for trees), so that you can either reason better about them, or pass them to an LLM.
 
-You might also try binary-searching for the time that the corruption occured. The resolution of `rewind()` is
+You might also try binary-searching for the time that the corruption occurred. The resolution of `rewind()` is
 only one millisecond, but that will at least give you an idea:
 
 ```js

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -75,8 +75,8 @@ pub struct SimpleKeysDoNotDisappear {
     pub txn_started_at: HashMap<u64, u64>,
     /// map of simple keys addition moment: TxnId -> (Table, Key) -> AdditionMoment
     /// For every transaction we put information about key addition moment which equals to end of successful INSERT operation
-    /// We use None key to represent "commited" state of the database
-    /// The "commited" state modified by operations in auto-commit mode (txn_id is None) or after successful COMMIT operation
+    /// We use None key to represent "committed" state of the database
+    /// The "committed" state modified by operations in auto-commit mode (txn_id is None) or after successful COMMIT operation
     pub simple_keys_added_at: HashMap<Option<u64>, HashMap<(String, String), u64>>,
 }
 
@@ -119,7 +119,7 @@ impl Property for SimpleKeysDoNotDisappear {
             self.simple_keys_added_at.remove(&txn_id);
         }
 
-        // on successful COMMIT we move information about current transaction keys to the "commited" state (None key in the map)
+        // on successful COMMIT we move information about current transaction keys to the "committed" state (None key in the map)
         // note, that we use end_exec_id of current COMMIT operation as AdditionMoment of moved keys
         if let Operation::Commit = &op {
             if let Some(keys) = self.simple_keys_added_at.remove(&txn_id) {
@@ -183,9 +183,9 @@ impl Property for SimpleKeysDoNotDisappear {
             }
         }
 
-        // on successful SELECT get information about the key AdditionMoment from the "commited" state: key_exec_id
+        // on successful SELECT get information about the key AdditionMoment from the "committed" state: key_exec_id
         // calculate our current ViewMoment as start_exec_id (in auto-commit mode) or start moment of the current transaction: view_exec_id
-        // if we have information about key in the "commited" state and key_exec_id < view_exec_id -> then key MUST be visible
+        // if we have information about key in the "committed" state and key_exec_id < view_exec_id -> then key MUST be visible
         if let Operation::SimpleSelect { table_name, key } = &op {
             let search_key = (table_name.clone(), key.clone());
             let key_exec_id = self

--- a/testing/conformance/sqlite3/alter2.test
+++ b/testing/conformance/sqlite3/alter2.test
@@ -375,7 +375,7 @@ do_test alter2-7.5 {
 
 #-----------------------------------------------------------------------
 # Test that UPDATE trigger tables work with default values, and that when
-# a row is updated the default values are correctly transfered to the 
+# a row is updated the default values are correctly transferred to the 
 # new row.
 # 
 ifcapable trigger {
@@ -406,7 +406,7 @@ ifcapable trigger {
 
 #-----------------------------------------------------------------------
 # Test that DELETE trigger tables work with default values, and that when
-# a row is updated the default values are correctly transfered to the 
+# a row is updated the default values are correctly transferred to the 
 # new row.
 # 
 ifcapable trigger {

--- a/testing/conformance/sqlite3/insert4.test
+++ b/testing/conformance/sqlite3/insert4.test
@@ -132,7 +132,7 @@ xferopt_test insert4-2.4.4 0
 # The TESTID argument is the symbolic name for this test.  The XFER-USED
 # argument is true if the transfer optimization should be employed and
 # false if not.  INIT-DATA is a single row of data that is to be 
-# transfered.  DEST-SCHEMA and SRC-SCHEMA are table declarations for
+# transferred.  DEST-SCHEMA and SRC-SCHEMA are table declarations for
 # the destination and source tables.
 #
 proc xfer_check {testid xferused initdata destschema srcschema} {

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -330,7 +330,7 @@ impl Property {
                         let sim_table = conn_tables
                             .iter()
                             .find(|t| t.name == table)
-                            .expect("table should be in enviroment");
+                            .expect("table should be in environment");
                         let expected: Vec<Vec<SimValue>> = sim_table
                             .rows
                             .iter()
@@ -987,7 +987,7 @@ impl Property {
                 // then when IO is called the fault triggers. It may happen that a fault is injected
                 // but no IO happens right after it
                 let assert = Assertion::new(
-                    "fault occured".to_string(),
+                    "fault occurred".to_string(),
                     move |stack, env: &mut SimulatorEnv| {
                         let last = stack.last().unwrap();
                         match last {

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -162,7 +162,7 @@ pub enum Property {
     /// implementation in the database. It relies on the fact that `SELECT * FROM <t
     /// > WHERE <predicate> UNION ALL SELECT * FROM <t> WHERE <predicate>`
     /// should return the same number of rows as `SELECT <predicate> FROM <t> WHERE <predicate>`.
-    /// > The property is succesfull when the UNION ALL of 2 select queries returns the same number of rows
+    /// > The property is successful when the UNION ALL of 2 select queries returns the same number of rows
     /// > as the sum of the two select queries.
     UnionAllPreservesCardinality {
         select: Select,

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1063,7 +1063,7 @@ pub(crate) struct SimulatorEnv {
     ///
     /// E.g Select, Insert, Create
     /// and not Begin, Commit, Rollback \
-    /// Has max size of 64 to accomodate 64 connections
+    /// Has max size of 64 to accommodate 64 connections
     connection_last_query: Bitmap<64>,
     // Table data that is committed into the database or wal
     pub committed_tables: Vec<Table>,

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -8,7 +8,7 @@ use crate::common::{assert_checkpoint_preserves_content, ExecRows, TempDatabase}
 // Test a scenario where there are two concurrent deferred transactions:
 //
 // 1. Both transactions T1 and T2 start at the same time.
-// 2. T1 writes to the database succesfully, but does not commit.
+// 2. T1 writes to the database successfully, but does not commit.
 // 3. T2 attempts to write to the database, but gets busy error.
 // 4. T1 commits
 // 5. T2 attempts to write again and succeeds. This is because the transaction

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1407,7 +1407,7 @@ pub fn test_reopen_database_wal_restart() {
 /// Test for a bug found by whopper
 /// It is slightly fragile and can be removed if it will be unclear how to maintain it
 ///
-/// Here, we simulate BusySnapshot condition when during IO in between of begin_read_tx and begin_write_tx, another connection commited some change
+/// Here, we simulate BusySnapshot condition when during IO in between of begin_read_tx and begin_write_tx, another connection committed some change
 pub fn test_busy_snapshot_immediate() {
     let _ = env_logger::try_init();
     let db_path = tempfile::NamedTempFile::new().unwrap();
@@ -1460,7 +1460,7 @@ pub fn test_busy_snapshot_immediate() {
 /// Test for a bug found by whopper
 /// It is slightly fragile and can be removed if it will be unclear how to maintain it
 ///
-/// Here, we simulate BusySnapshot condition when transaction upgraded in the middle, but since its started another connection commited changes
+/// Here, we simulate BusySnapshot condition when transaction upgraded in the middle, but since its started another connection committed changes
 pub fn test_busy_snapshot_txn_upgrade() {
     let _ = env_logger::try_init();
     let db_path = tempfile::NamedTempFile::new().unwrap();


### PR DESCRIPTION
Fixes a handful of typos I noticed while reading through the code. Nothing major, just cleaning up small typos in comments and strings.

Happy to split these up if preferred — just let me know.