### PR TITLE
Fix macOS build instructions for mold linker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,11 +74,14 @@ sudo dnf install mold
 
 # Ubuntu/Debian
 sudo apt install mold
+
+# macOS
+brew install mold
 ```
 
 Then configure Cargo to use mold by creating `.cargo/config.toml`:
 
-**For Linux:**
+**For Linux / macOS:**
 
 ```toml
 [target.x86_64-unknown-linux-gnu]


### PR DESCRIPTION
The macOS build instructions for using the mold linker were slightly off. This fixes the steps so they actually work on a fresh macOS setup.