### PR TITLE
core/mvcc: use per-MvStore skiplist collectors

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -48,6 +48,7 @@ use crate::{
     turso_assert, turso_assert_eq, turso_assert_less_than, turso_assert_reachable, Numeric,
 };
 use crate::{Connection, Pager, SyncMode};
+use crossbeam_epoch as epoch;
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 use std::collections::{BTreeSet, HashMap as StdHashMap};
@@ -3740,6 +3741,10 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// Allocator backing every skiplist in this store, including lazily
     /// created per-index maps in `index_rows`.
     alloc: A,
+    /// Collector backing every skiplist in this store. Embedders that need
+    /// store-scoped deferred destruction can inject a dedicated collector with
+    /// `new_in_with_collector`.
+    skiplist_collector: epoch::Collector,
     tx_ids: AtomicU64,
     version_id_counter: AtomicU64,
     next_rowid: AtomicU64,
@@ -3857,7 +3862,17 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         clock: Clock,
         storage: Arc<dyn crate::mvcc::persistent_storage::DurableStorage>,
     ) -> Result<Self> {
-        Self::new_in(clock, storage, TursoAllocator)
+        Self::new_with_collector(clock, storage, epoch::default_collector().clone())
+    }
+
+    /// Creates a new database backed by the default [`TursoAllocator`] whose
+    /// skiplists use `collector`.
+    pub fn new_with_collector(
+        clock: Clock,
+        storage: Arc<dyn crate::mvcc::persistent_storage::DurableStorage>,
+        collector: epoch::Collector,
+    ) -> Result<Self> {
+        Self::new_in_with_collector(clock, storage, TursoAllocator, collector)
     }
 }
 
@@ -3914,16 +3929,28 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         storage: Arc<dyn crate::mvcc::persistent_storage::DurableStorage>,
         alloc: A,
     ) -> Result<Self> {
-        let table_id_to_rootpage = SkipMap::new_in(alloc.clone());
+        Self::new_in_with_collector(clock, storage, alloc, epoch::default_collector().clone())
+    }
+
+    /// Creates a new database whose skiplists allocate through `alloc` and use
+    /// `collector` for epoch reclamation.
+    pub fn new_in_with_collector(
+        clock: Clock,
+        storage: Arc<dyn crate::mvcc::persistent_storage::DurableStorage>,
+        alloc: A,
+        collector: epoch::Collector,
+    ) -> Result<Self> {
+        let table_id_to_rootpage = SkipMap::with_collector_in(collector.clone(), alloc.clone());
         // table id 1 / root page 1 is always sqlite_schema.
         Self::insert_initial_rootpage_mapping(&table_id_to_rootpage)?;
         Ok(Self {
-            rows: SkipMap::new_in(alloc.clone()),
+            rows: SkipMap::with_collector_in(collector.clone(), alloc.clone()),
             table_id_to_rootpage,
-            index_rows: SkipMap::new_in(alloc.clone()),
-            txs: SkipMap::new_in(alloc.clone()),
-            finalized_tx_states: SkipMap::new_in(alloc.clone()),
+            index_rows: SkipMap::with_collector_in(collector.clone(), alloc.clone()),
+            txs: SkipMap::with_collector_in(collector.clone(), alloc.clone()),
+            finalized_tx_states: SkipMap::with_collector_in(collector.clone(), alloc.clone()),
             alloc,
+            skiplist_collector: collector,
             tx_ids: AtomicU64::new(1), // let's reserve transaction 0 for special purposes
             version_id_counter: AtomicU64::new(1), // Reserve 0 for special purposes
             next_rowid: AtomicU64::new(0), // TODO: determine this from B-Tree
@@ -6904,9 +6931,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         index_id: MVTableId,
     ) -> Result<IndexRowsEntry<'_, A>, TryReserveError> {
         let alloc = self.alloc.clone();
-        let index = self
-            .index_rows
-            .try_get_or_insert_with(index_id, move || SkipMap::new_in(alloc))?;
+        let collector = self.skiplist_collector.clone();
+        let index = self.index_rows.try_get_or_insert_with(index_id, move || {
+            SkipMap::with_collector_in(collector, alloc)
+        })?;
         Ok(index)
     }
 

--- a/core/skiplist/base.rs
+++ b/core/skiplist/base.rs
@@ -589,6 +589,11 @@ impl<K, V, C, A: SkiplistAllocator> SkipList<K, V, C, A> {
             assert!(c == &self.collector);
         }
     }
+
+    /// Pins the current thread in this skip list's collector.
+    pub(crate) fn pin(&self) -> Guard {
+        crate::skiplist::collector::pin(&self.collector)
+    }
 }
 
 impl<K, V, C, A: SkiplistAllocator> SkipList<K, V, C, A>
@@ -2053,6 +2058,13 @@ where
     }
 }
 
+impl<'a, K: 'a, V: 'a, C, A: SkiplistAllocator> RefIter<'a, K, V, C, A> {
+    /// Returns the parent skip list.
+    pub(crate) fn skiplist(&self) -> &'a SkipList<K, V, C, A> {
+        self.parent
+    }
+}
+
 impl<'a, K: 'a, V: 'a, C, A: SkiplistAllocator> RefIter<'a, K, V, C, A>
 where
     C: Comparator<K>,
@@ -2291,6 +2303,18 @@ where
             .field("head", &self.head)
             .field("tail", &self.tail)
             .finish()
+    }
+}
+
+impl<'a, Q, R, K: 'a, V: 'a, C, A: SkiplistAllocator> RefRange<'a, Q, R, K, V, C, A>
+where
+    C: Comparator<K> + Comparator<K, Q>,
+    R: RangeBounds<Q>,
+    Q: ?Sized,
+{
+    /// Returns the parent skip list.
+    pub(crate) fn skiplist(&self) -> &'a SkipList<K, V, C, A> {
+        self.parent
     }
 }
 

--- a/core/skiplist/collector.rs
+++ b/core/skiplist/collector.rs
@@ -1,0 +1,50 @@
+//! Collector selection and pinning for skiplist epoch reclamation.
+
+use std::cell::RefCell;
+
+use crossbeam_epoch::{Collector, Guard, LocalHandle};
+
+// TODO: to avoid allocations in the future we can use an intrusive linked list
+thread_local! {
+    static LOCAL_HANDLES: RefCell<Vec<CachedHandle>> = const { RefCell::new(Vec::new()) };
+}
+
+struct CachedHandle {
+    collector: Collector,
+    handle: LocalHandle,
+}
+
+#[inline]
+pub(crate) fn pin(collector: &Collector) -> Guard {
+    if collector == crossbeam_epoch::default_collector() {
+        crossbeam_epoch::pin()
+    } else {
+        with_handle(collector, |handle| handle.pin())
+    }
+}
+
+#[inline]
+fn with_handle<F, R>(collector: &Collector, mut f: F) -> R
+where
+    F: FnMut(&LocalHandle) -> R,
+{
+    LOCAL_HANDLES
+        .try_with(|handles| {
+            let Ok(mut handles) = handles.try_borrow_mut() else {
+                return f(&collector.register());
+            };
+
+            let index = handles
+                .iter()
+                .position(|handle| handle.collector == *collector)
+                .unwrap_or_else(|| {
+                    handles.push(CachedHandle {
+                        collector: collector.clone(),
+                        handle: collector.register(),
+                    });
+                    handles.len() - 1
+                });
+            f(&handles[index].handle)
+        })
+        .unwrap_or_else(|_| f(&collector.register()))
+}

--- a/core/skiplist/map.rs
+++ b/core/skiplist/map.rs
@@ -41,8 +41,13 @@ impl<K, V> SkipMap<K, V> {
     /// let map: SkipMap<i32, &str> = SkipMap::new();
     /// ```
     pub fn new() -> Self {
+        Self::with_collector(epoch::default_collector().clone())
+    }
+
+    /// Returns a new, empty map with the default comparator and `collector`.
+    pub fn with_collector(collector: epoch::Collector) -> Self {
         Self {
-            inner: base::SkipList::new(epoch::default_collector().clone()),
+            inner: base::SkipList::new(collector),
         }
     }
 }
@@ -60,8 +65,14 @@ impl<K, V, A: SkiplistAllocator> SkipMap<K, V, BasicComparator, A> {
     /// let map: SkipMap<i32, &str, _, TursoAllocator> = SkipMap::new_in(TursoAllocator);
     /// ```
     pub fn new_in(alloc: A) -> Self {
+        Self::with_collector_in(epoch::default_collector().clone(), alloc)
+    }
+
+    /// Returns a new, empty map with the default comparator and `collector`
+    /// that allocates its nodes in `alloc`.
+    pub fn with_collector_in(collector: epoch::Collector, alloc: A) -> Self {
         Self {
-            inner: base::SkipList::new_in(epoch::default_collector().clone(), alloc),
+            inner: base::SkipList::new_in(collector, alloc),
         }
     }
 }
@@ -77,8 +88,13 @@ impl<K, V, C> SkipMap<K, V, C> {
     /// let map: SkipMap<i32, &str> = SkipMap::with_comparator(BasicComparator);
     /// ```
     pub fn with_comparator(comparator: C) -> Self {
+        Self::with_collector_and_comparator(epoch::default_collector().clone(), comparator)
+    }
+
+    /// Returns a new, empty map with `collector` and the given comparator.
+    pub fn with_collector_and_comparator(collector: epoch::Collector, comparator: C) -> Self {
         Self {
-            inner: base::SkipList::with_comparator(epoch::default_collector().clone(), comparator),
+            inner: base::SkipList::with_comparator(collector, comparator),
         }
     }
 }
@@ -97,12 +113,18 @@ impl<K, V, C, A: SkiplistAllocator> SkipMap<K, V, C, A> {
     ///     SkipMap::with_comparator_in(BasicComparator, TursoAllocator);
     /// ```
     pub fn with_comparator_in(comparator: C, alloc: A) -> Self {
+        Self::with_collector_comparator_in(epoch::default_collector().clone(), comparator, alloc)
+    }
+
+    /// Returns a new, empty map with `collector` and the given comparator that
+    /// allocates its nodes in `alloc`.
+    pub fn with_collector_comparator_in(
+        collector: epoch::Collector,
+        comparator: C,
+        alloc: A,
+    ) -> Self {
         Self {
-            inner: base::SkipList::with_comparator_in(
-                epoch::default_collector().clone(),
-                comparator,
-                alloc,
-            ),
+            inner: base::SkipList::with_comparator_in(collector, comparator, alloc),
         }
     }
 
@@ -166,7 +188,7 @@ where
     /// assert_eq!(*numbers.front().unwrap().value(), "five");
     /// ```
     pub fn front(&self) -> Option<Entry<'_, K, V, C, A>> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         try_pin_loop(|| self.inner.front(guard)).map(Entry::new)
     }
 
@@ -186,7 +208,7 @@ where
     /// assert_eq!(*numbers.back().unwrap().value(), "six");
     /// ```
     pub fn back(&self) -> Option<Entry<'_, K, V, C, A>> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         try_pin_loop(|| self.inner.back(guard)).map(Entry::new)
     }
 
@@ -208,7 +230,7 @@ where
     /// assert_eq!(*jobs_age.value(), 65);
     /// ```
     pub fn get_or_insert(&self, key: K, value: V) -> Entry<'_, K, V, C, A> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         Entry::new(self.inner.get_or_insert(key, value, guard))
     }
 
@@ -230,7 +252,7 @@ where
         key: K,
         value: V,
     ) -> Result<Entry<'_, K, V, C, A>, TryReserveError> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         self.inner
             .try_get_or_insert(key, value, guard)
             .map(Entry::new)
@@ -263,7 +285,7 @@ where
     where
         F: FnOnce() -> V,
     {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         Entry::new(self.inner.get_or_insert_with(key, value_fn, guard))
     }
 
@@ -289,7 +311,7 @@ where
     where
         F: FnOnce() -> V,
     {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         self.inner
             .try_get_or_insert_with(key, value_fn, guard)
             .map(Entry::new)
@@ -345,7 +367,7 @@ where
         C: Comparator<K, Q>,
         Q: ?Sized,
     {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         self.inner.contains_key(key, guard)
     }
 
@@ -369,7 +391,7 @@ where
         C: Comparator<K, Q>,
         Q: ?Sized,
     {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         try_pin_loop(|| self.inner.get(key, guard)).map(Entry::new)
     }
 
@@ -404,7 +426,7 @@ where
         C: Comparator<K, Q>,
         Q: ?Sized,
     {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         try_pin_loop(|| self.inner.lower_bound(bound, guard)).map(Entry::new)
     }
 
@@ -436,7 +458,7 @@ where
         C: Comparator<K, Q>,
         Q: ?Sized,
     {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         try_pin_loop(|| self.inner.upper_bound(bound, guard)).map(Entry::new)
     }
 
@@ -497,7 +519,7 @@ where
     /// assert_eq!(*map.get("key").unwrap().value(), "value");
     /// ```
     pub fn insert(&self, key: K, value: V) -> Entry<'_, K, V, C, A> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         Entry::new(self.inner.insert(key, value, guard))
     }
 
@@ -516,7 +538,7 @@ where
     /// assert_eq!(*map.get("key").unwrap().value(), "value");
     /// ```
     pub fn try_insert(&self, key: K, value: V) -> Result<Entry<'_, K, V, C, A>, TryReserveError> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         self.inner.try_insert(key, value, guard).map(Entry::new)
     }
 
@@ -546,7 +568,7 @@ where
     where
         F: Fn(&V) -> bool,
     {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         Entry::new(self.inner.compare_insert(key, value, compare_fn, guard))
     }
 
@@ -573,7 +595,7 @@ where
     where
         F: Fn(&V) -> bool,
     {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         self.inner
             .try_compare_insert(key, value, compare_fn, guard)
             .map(Entry::new)
@@ -602,7 +624,7 @@ where
         C: Comparator<K, Q>,
         Q: ?Sized,
     {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         self.inner.remove(key, guard).map(Entry::new)
     }
 
@@ -629,7 +651,7 @@ where
     /// assert!(numbers.is_empty());
     /// ```
     pub fn pop_front(&self) -> Option<Entry<'_, K, V, C, A>> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         self.inner.pop_front(guard).map(Entry::new)
     }
 
@@ -656,7 +678,7 @@ where
     /// assert!(numbers.is_empty());
     /// ```
     pub fn pop_back(&self) -> Option<Entry<'_, K, V, C, A>> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.pin();
         self.inner.pop_back(guard).map(Entry::new)
     }
 
@@ -674,7 +696,7 @@ where
     /// assert!(people.is_empty());
     /// ```
     pub fn clear(&self) {
-        let guard = &mut epoch::pin();
+        let guard = &mut self.inner.pin();
         self.inner.clear(guard);
     }
 }
@@ -768,7 +790,9 @@ impl<'a, K, V, C, A: SkiplistAllocator> Entry<'a, K, V, C, A> {
 impl<K, V, C, A: SkiplistAllocator> Drop for Entry<'_, K, V, C, A> {
     fn drop(&mut self) {
         unsafe {
-            ManuallyDrop::into_inner(ptr::read(&self.inner)).release_with_pin(epoch::pin);
+            let entry = ManuallyDrop::into_inner(ptr::read(&self.inner));
+            let skiplist = entry.skiplist();
+            entry.release_with_pin(|| skiplist.pin());
         }
     }
 }
@@ -779,25 +803,25 @@ where
 {
     /// Moves to the next entry in the map.
     pub fn move_next(&mut self) -> bool {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.move_next(guard)
     }
 
     /// Moves to the previous entry in the map.
     pub fn move_prev(&mut self) -> bool {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.move_prev(guard)
     }
 
     /// Returns the next entry in the map.
     pub fn next(&self) -> Option<Self> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.next(guard).map(Entry::new)
     }
 
     /// Returns the previous entry in the map.
     pub fn prev(&self) -> Option<Self> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.prev(guard).map(Entry::new)
     }
 }
@@ -812,7 +836,7 @@ where
     ///
     /// Returns `true` if this call removed the entry and `false` if it was already removed.
     pub fn remove(&self) -> bool {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.remove(guard)
     }
 }
@@ -869,7 +893,7 @@ where
     type Item = Entry<'a, K, V, C, A>;
 
     fn next(&mut self) -> Option<Entry<'a, K, V, C, A>> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.next(guard).map(Entry::new)
     }
 }
@@ -879,7 +903,7 @@ where
     C: Comparator<K>,
 {
     fn next_back(&mut self) -> Option<Entry<'a, K, V, C, A>> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.next_back(guard).map(Entry::new)
     }
 }
@@ -892,7 +916,7 @@ impl<K, V, C, A: SkiplistAllocator> fmt::Debug for Iter<'_, K, V, C, A> {
 
 impl<K, V, C, A: SkiplistAllocator> Drop for Iter<'_, K, V, C, A> {
     fn drop(&mut self) {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.drop_impl(guard);
     }
 }
@@ -916,7 +940,7 @@ where
     type Item = Entry<'a, K, V, C, A>;
 
     fn next(&mut self) -> Option<Entry<'a, K, V, C, A>> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.next(guard).map(Entry::new)
     }
 }
@@ -928,7 +952,7 @@ where
     Q: ?Sized,
 {
     fn next_back(&mut self) -> Option<Entry<'a, K, V, C, A>> {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.next_back(guard).map(Entry::new)
     }
 }
@@ -957,7 +981,7 @@ where
     Q: ?Sized,
 {
     fn drop(&mut self) {
-        let guard = &epoch::pin();
+        let guard = &self.inner.skiplist().pin();
         self.inner.drop_impl(guard);
     }
 }

--- a/core/skiplist/map_tests.rs
+++ b/core/skiplist/map_tests.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use crate::skiplist::SkipMap;
+use crossbeam_epoch as epoch;
 use crossbeam_utils::thread;
 
 #[test]
@@ -14,6 +15,35 @@ fn smoke() {
     m.insert(1, 10);
     m.insert(5, 50);
     m.insert(7, 70);
+}
+
+#[test]
+fn custom_collector() {
+    let collector = epoch::Collector::new();
+    let m = SkipMap::with_collector(collector);
+
+    let first = m.insert(1, 10);
+    assert_eq!(*first.value(), 10);
+    drop(first);
+
+    m.insert(2, 20);
+    assert_eq!(*m.get(&1).unwrap().value(), 10);
+
+    let mut entry = m.front().unwrap();
+    assert!(entry.move_next());
+    assert_eq!(*entry.key(), 2);
+
+    let mut iter = m.iter();
+    assert_eq!(*iter.next().unwrap().key(), 1);
+    drop(iter);
+
+    let mut range = m.range(1..=2);
+    assert_eq!(*range.next_back().unwrap().key(), 2);
+    drop(range);
+
+    assert_eq!(*m.remove(&1).unwrap().value(), 10);
+    m.clear();
+    assert!(m.is_empty());
 }
 
 #[test]

--- a/core/skiplist/mod.rs
+++ b/core/skiplist/mod.rs
@@ -242,6 +242,7 @@
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 
 pub mod base;
+pub mod collector;
 
 #[doc(inline)]
 pub use base::{SkipList, SkiplistAllocator};

--- a/core/skiplist/set.rs
+++ b/core/skiplist/set.rs
@@ -5,6 +5,8 @@ use core::{
     ops::{Bound, Deref, RangeBounds},
 };
 
+use crossbeam_epoch as epoch;
+
 use super::{
     base::SkiplistAllocator,
     comparator::{BasicComparator, Comparator},
@@ -42,6 +44,13 @@ impl<T> SkipSet<T> {
             inner: map::SkipMap::new(),
         }
     }
+
+    /// Returns a new, empty set with the default comparator and `collector`.
+    pub fn with_collector(collector: epoch::Collector) -> Self {
+        Self {
+            inner: map::SkipMap::with_collector(collector),
+        }
+    }
 }
 
 impl<T, A: SkiplistAllocator> SkipSet<T, BasicComparator, A> {
@@ -61,6 +70,14 @@ impl<T, A: SkiplistAllocator> SkipSet<T, BasicComparator, A> {
             inner: map::SkipMap::new_in(alloc),
         }
     }
+
+    /// Returns a new, empty set with the default comparator and `collector`
+    /// that allocates its nodes in `alloc`.
+    pub fn with_collector_in(collector: epoch::Collector, alloc: A) -> Self {
+        Self {
+            inner: map::SkipMap::with_collector_in(collector, alloc),
+        }
+    }
 }
 
 impl<T, C> SkipSet<T, C> {
@@ -76,6 +93,13 @@ impl<T, C> SkipSet<T, C> {
     pub fn with_comparator(comparator: C) -> Self {
         Self {
             inner: map::SkipMap::with_comparator(comparator),
+        }
+    }
+
+    /// Returns a new, empty set with `collector` and the given comparator.
+    pub fn with_collector_and_comparator(collector: epoch::Collector, comparator: C) -> Self {
+        Self {
+            inner: map::SkipMap::with_collector_and_comparator(collector, comparator),
         }
     }
 }
@@ -96,6 +120,18 @@ impl<T, C, A: SkiplistAllocator> SkipSet<T, C, A> {
     pub fn with_comparator_in(comparator: C, alloc: A) -> Self {
         Self {
             inner: map::SkipMap::with_comparator_in(comparator, alloc),
+        }
+    }
+
+    /// Returns a new, empty set with `collector` and the given comparator that
+    /// allocates its nodes in `alloc`.
+    pub fn with_collector_comparator_in(
+        collector: epoch::Collector,
+        comparator: C,
+        alloc: A,
+    ) -> Self {
+        Self {
+            inner: map::SkipMap::with_collector_comparator_in(collector, comparator, alloc),
         }
     }
 

--- a/core/skiplist/set_tests.rs
+++ b/core/skiplist/set_tests.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::skiplist::SkipSet;
+use crossbeam_epoch as epoch;
 use crossbeam_utils::thread;
 
 #[test]
@@ -13,6 +14,31 @@ fn smoke() {
     m.insert(1);
     m.insert(5);
     m.insert(7);
+}
+
+#[test]
+fn custom_collector() {
+    let collector = epoch::Collector::new();
+    let set = SkipSet::with_collector(collector);
+
+    let entry = set.insert(1);
+    assert_eq!(*entry, 1);
+    drop(entry);
+
+    set.insert(2);
+    assert!(set.contains(&1));
+
+    let mut iter = set.iter();
+    assert_eq!(*iter.next().unwrap(), 1);
+    drop(iter);
+
+    let mut range = set.range(1..=2);
+    assert_eq!(*range.next_back().unwrap(), 2);
+    drop(range);
+
+    assert_eq!(*set.remove(&1).unwrap(), 1);
+    set.clear();
+    assert!(set.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This adds explicit collector injection to the skiplist wrappers and `MvStore`, while keeping the default `MvStore` constructors on Crossbeam's default collector fast path.

The public skiplist wrappers now support explicit collector injection for tests and embedding, and wrapper operations pin against the collector stored in the underlying `SkipList`. `MvStore::new_with_collector` and `MvStore::new_in_with_collector` let embedders opt into a store-scoped collector, including for lazily-created per-index maps.

`Entry` drops now release through `release_with_pin`, so deferred skiplist cleanup uses the entry's own skiplist collector.

## Why

Crossbeam epoch reclamation can drain deferred work during a later `pin()` on the same thread. When tenant-scoped allocator leases need reclamation to happen under a specific store/tenant context, embedders can now inject a collector tied to that store.

The normal core path still uses `crossbeam_epoch::pin()` via the default collector, which avoids paying `collector.register().pin()` on every hidden skiplist pin.
