### PR TITLE
core/mvcc: retain ended btree_resident row versions till checkpoint

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2586,19 +2586,89 @@ mod tests {
     }
 
     fn committed_table_row_version(table_id: MVTableId, rowid: i64) -> RowVersion {
+        table_row_version(table_id, rowid, 1, Some(5), None, false)
+    }
+
+    fn table_row_version(
+        table_id: MVTableId,
+        rowid: i64,
+        version_id: u64,
+        begin: Option<u64>,
+        end: Option<u64>,
+        btree_resident: bool,
+    ) -> RowVersion {
         let record = ImmutableRecord::from_values(&[Value::from_i64(rowid)], 1).unwrap();
         RowVersion {
-            id: 1,
-            begin: crate::mvcc::database::PackedTs::pack(Some(TxTimestampOrID::Timestamp(5))),
-            end: crate::mvcc::database::PackedTs::pack(None),
+            id: version_id,
+            begin: crate::mvcc::database::PackedTs::pack(begin.map(TxTimestampOrID::Timestamp)),
+            end: crate::mvcc::database::PackedTs::pack(end.map(TxTimestampOrID::Timestamp)),
             row: Row::new_table_row(
                 RowID::new(table_id, RowKey::Int(rowid)),
                 record.as_blob(),
                 1,
             )
             .unwrap(),
-            btree_resident: false,
+            btree_resident,
         }
+    }
+
+    fn checkpoint_for_collect_tests() -> CheckpointStateMachine<crate::mvcc::clock::MvccClock> {
+        let db = MvccTestDbNoConn::new();
+        let conn = db.connect();
+        let mvstore = db.get_mvcc_store();
+        let pager = conn.pager.load().clone();
+        let mut checkpoint = CheckpointStateMachine::new(
+            pager,
+            mvstore,
+            conn.clone(),
+            true,
+            conn.get_sync_mode(),
+            crate::MAIN_DB_ID,
+        );
+        checkpoint.durable_txid_max_old = NonZeroU64::new(2);
+        checkpoint
+    }
+
+    #[test]
+    fn checkpoint_collection_uses_btree_marker_for_existence_but_writes_surviving_replacement() {
+        let checkpoint = checkpoint_for_collect_tests();
+        let table_id = MVTableId::from(-2);
+        let btree_tombstone = table_row_version(table_id, 1, 1, None, Some(5), true);
+        let replacement = table_row_version(table_id, 1, 2, Some(5), None, false);
+
+        let checkpointable =
+            checkpoint.maybe_get_checkpointable_versions(&[btree_tombstone, replacement], table_id);
+
+        assert_eq!(checkpointable.len(), 1);
+        assert_eq!(checkpointable[0].id, 2);
+        assert_eq!(checkpointable[0].end(), None);
+    }
+
+    #[test]
+    fn checkpoint_collection_uses_btree_marker_for_later_delete_of_replacement() {
+        let checkpoint = checkpoint_for_collect_tests();
+        let table_id = MVTableId::from(-2);
+        let btree_tombstone = table_row_version(table_id, 1, 1, None, Some(5), true);
+        let deleted_replacement = table_row_version(table_id, 1, 2, Some(5), Some(6), false);
+
+        let checkpointable = checkpoint
+            .maybe_get_checkpointable_versions(&[btree_tombstone, deleted_replacement], table_id);
+
+        assert_eq!(checkpointable.len(), 1);
+        assert_eq!(checkpointable[0].id, 2);
+        assert_eq!(checkpointable[0].end(), Some(TxTimestampOrID::Timestamp(6)));
+    }
+
+    #[test]
+    fn checkpoint_collection_skips_delete_of_never_checkpointed_replacement_without_btree_marker() {
+        let checkpoint = checkpoint_for_collect_tests();
+        let table_id = MVTableId::from(-2);
+        let deleted_replacement = table_row_version(table_id, 1, 2, Some(5), Some(6), false);
+
+        let checkpointable =
+            checkpoint.maybe_get_checkpointable_versions(&[deleted_replacement], table_id);
+
+        assert!(checkpointable.is_empty());
     }
 
     #[test]

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -6752,7 +6752,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Rule 1: Aborted garbage (begin=None, end=None) — always remove.
     /// Rule 2: Superseded (end=Timestamp(e), e <= lwm) — remove unless it's a
     ///         tombstone (no committed current version) whose deletion hasn't
-    ///         been checkpointed (e > ckpt_max).
+    ///         been checkpointed (e > ckpt_max), or a B-tree-resident version
+    ///         whose physical delete/overwrite hasn't been checkpointed.
     /// Rule 3: Current checkpointed sole-survivor (end=None, b <= ckpt_max,
     ///         b < lwm, no other versions remain) — remove.
     ///
@@ -6767,7 +6768,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         // removable — UNLESS it's a tombstone (sole version, no committed
         // current version) whose deletion hasn't been checkpointed to B-tree
         // yet. In that case removing it would let the dual cursor fall through
-        // to a stale B-tree row.
+        // to a stale B-tree row. A B-tree-resident version needs the same guard
+        // even with a committed current replacement: that replacement can be
+        // deleted before checkpoint, leaving this as the only evidence that
+        // checkpoint must remove or overwrite the physical row.
         //
         // has_current only counts committed current versions (begin=Timestamp).
         // Pending inserts (begin=TxID) don't count — they might roll back,
@@ -6777,8 +6781,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         });
         versions.retain(|rv| match &rv.end() {
             Some(TxTimestampOrID::Timestamp(e)) if *e <= lwm => {
-                // Retain only if this is a tombstone AND not yet checkpointed.
-                !has_current && *e > ckpt_max
+                // Also retain B-tree-resident versions until checkpoint makes the physical change durable.
+                *e > ckpt_max && (rv.btree_resident || !has_current)
             }
             _ => true,
         });

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7277,6 +7277,91 @@ fn test_sql_checkpoint_reinsert_existing_interior_index_key_keeps_sqlite_integri
     assert_eq!(integrity, "ok");
 }
 
+fn assert_integrity_ok(conn: &Arc<Connection>) {
+    let rows = get_rows(conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1, "integrity_check rows: {rows:?}");
+    assert_eq!(rows[0][0].to_string(), "ok");
+}
+
+fn setup_mvcc_checkpointed_indexed_table(conn: &Arc<Connection>, with_b_index: bool) {
+    conn.execute("PRAGMA mvcc_gc_threshold = 1").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a, b)")
+        .unwrap();
+    conn.execute("CREATE INDEX t_a ON t(a)").unwrap();
+    if with_b_index {
+        conn.execute("CREATE INDEX t_b ON t(b)").unwrap();
+    }
+    conn.execute(
+        "INSERT INTO t VALUES
+            (1,10,100),(2,20,200),(3,30,300),(4,40,400),(5,50,500)",
+    )
+    .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+}
+
+fn assert_checkpointed_replace_delete_result(conn: &Arc<Connection>) {
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    assert_integrity_ok(conn);
+
+    let rows = get_rows(conn, "SELECT id,a,b FROM t ORDER BY id");
+    assert_eq!(rows.len(), 4);
+    for (idx, row) in rows.iter().enumerate() {
+        let id = (idx as i64) + 1;
+        assert_eq!(
+            row,
+            &vec![
+                Value::from_i64(id),
+                Value::from_i64(id * 10),
+                Value::from_i64(id * 100)
+            ]
+        );
+    }
+}
+
+#[test]
+fn test_mvcc_checkpoint_insert_or_replace_then_delete_removes_checkpointed_index_entries() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    setup_mvcc_checkpointed_indexed_table(&conn, false);
+
+    conn.execute("INSERT OR REPLACE INTO t(id,a,b) VALUES(5,25,325)")
+        .unwrap();
+    conn.execute("DELETE FROM t WHERE id=5").unwrap();
+
+    assert_checkpointed_replace_delete_result(&conn);
+}
+
+#[test]
+fn test_mvcc_checkpoint_update_or_replace_then_delete_removes_checkpointed_index_entries() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    setup_mvcc_checkpointed_indexed_table(&conn, true);
+
+    conn.execute("UPDATE OR REPLACE t SET a=25,b=325 WHERE id=5")
+        .unwrap();
+    conn.execute("DELETE FROM t WHERE id=5").unwrap();
+
+    assert_checkpointed_replace_delete_result(&conn);
+}
+
+#[test]
+fn test_mvcc_repeated_delete_after_replace_delete_checkpoint_is_noop() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    setup_mvcc_checkpointed_indexed_table(&conn, false);
+
+    conn.execute("INSERT OR REPLACE INTO t(id,a,b) VALUES(5,25,325)")
+        .unwrap();
+    conn.execute("DELETE FROM t WHERE id=5").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    conn.execute("DELETE FROM t WHERE id=5").unwrap();
+
+    assert_integrity_ok(&conn);
+    let rows = get_rows(&conn, "SELECT id,a,b FROM t ORDER BY id");
+    assert_eq!(rows.len(), 4);
+}
+
 #[test]
 fn test_mvcc_checkpoint_integrity_after_upsert_with_secondary_indexes() {
     let db = MvccTestDbNoConn::new_with_random_db();
@@ -7913,9 +7998,9 @@ fn test_gc_rule2_pending_insert_does_not_disable_tombstone_guard() {
 /// Why this matters: GC mistakes can either lose data (over-collection) or retain stale history forever (under-collection).
 #[test]
 /// When a committed current version exists (begin=Timestamp, end=None), it takes
-/// over B-tree invalidation from the superseded version. The tombstone guard is
-/// no longer needed, so the superseded version can be safely removed.
-fn test_gc_rule2_committed_current_disables_tombstone_guard() {
+/// over MVCC visibility from a non-B-tree superseded version. The tombstone guard
+/// is no longer needed, so the superseded version can be safely removed.
+fn test_gc_rule2_committed_current_disables_non_btree_tombstone_guard() {
     // A committed current version (begin=Timestamp, end=None) means the row
     // has a live successor — the tombstone can safely be removed.
     let mut versions = crate::alloc::vec![
@@ -7927,6 +8012,40 @@ fn test_gc_rule2_committed_current_disables_tombstone_guard() {
     assert_eq!(dropped, 1);
     assert_eq!(versions.len(), 1);
     assert!(versions[0].end().is_none());
+}
+
+/// A B-tree-resident version whose ending timestamp has not been checkpointed
+/// still records a required physical B-tree delete or overwrite. A committed
+/// replacement can hide it from readers but cannot make it GC-eligible until
+/// checkpoint makes that physical change durable.
+#[test]
+fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() {
+    let mut tombstone = make_rv(None, ts(5));
+    tombstone.btree_resident = true;
+    let current = make_rv(ts(5), None);
+    let mut versions = crate::alloc::vec![tombstone, current.clone()];
+
+    let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 2);
+    assert_eq!(dropped, 0);
+    assert_eq!(versions.len(), 2);
+    assert!(versions[0].btree_resident);
+
+    let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 5);
+    assert_eq!(dropped, 2);
+    assert!(versions.is_empty());
+
+    let mut rewritten_btree_row = make_rv(ts(3), ts(5));
+    rewritten_btree_row.btree_resident = true;
+    let mut versions = crate::alloc::vec![rewritten_btree_row, current];
+
+    let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 2);
+    assert_eq!(dropped, 0);
+    assert_eq!(versions.len(), 2);
+    assert!(versions[0].btree_resident);
+
+    let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 5);
+    assert_eq!(dropped, 2);
+    assert!(versions.is_empty());
 }
 
 /// What this test checks: Garbage collection removes only versions that are provably unreachable and keeps versions still required for visibility and safety.

--- a/testing/sqltests/turso-tests/mvcc_checkpoint_replace_delete.sqltest
+++ b/testing/sqltests/turso-tests/mvcc_checkpoint_replace_delete.sqltest
@@ -1,0 +1,94 @@
+@database :memory:
+
+test mvcc-checkpoint-insert-or-replace-then-delete-indexed-row {
+    PRAGMA journal_mode=mvcc;
+    PRAGMA mvcc_gc_threshold=1;
+
+    CREATE TABLE t_insert_replace(id INTEGER PRIMARY KEY, a, b);
+    CREATE INDEX t_insert_replace_a ON t_insert_replace(a);
+
+    INSERT INTO t_insert_replace VALUES
+        (1,10,100),(2,20,200),(3,30,300),(4,40,400),(5,50,500);
+
+    PRAGMA wal_checkpoint(TRUNCATE);
+
+    INSERT OR REPLACE INTO t_insert_replace(id,a,b) VALUES(5,25,325);
+    DELETE FROM t_insert_replace WHERE id=5;
+
+    PRAGMA wal_checkpoint(TRUNCATE);
+    PRAGMA integrity_check;
+    SELECT id,a,b FROM t_insert_replace ORDER BY id;
+}
+expect {
+    mvcc
+    0|0|0
+    0|0|0
+    ok
+    1|10|100
+    2|20|200
+    3|30|300
+    4|40|400
+}
+
+test mvcc-checkpoint-update-or-replace-then-delete-multi-index-row {
+    PRAGMA journal_mode=mvcc;
+    PRAGMA mvcc_gc_threshold=1;
+
+    CREATE TABLE t_update_replace(id INTEGER PRIMARY KEY, a, b);
+    CREATE INDEX t_update_replace_a ON t_update_replace(a);
+    CREATE INDEX t_update_replace_b ON t_update_replace(b);
+
+    INSERT INTO t_update_replace VALUES
+        (1,10,100),(2,20,200),(3,30,300),(4,40,400),(5,50,500);
+
+    PRAGMA wal_checkpoint(TRUNCATE);
+
+    UPDATE OR REPLACE t_update_replace SET a=25,b=325 WHERE id=5;
+    DELETE FROM t_update_replace WHERE id=5;
+
+    PRAGMA wal_checkpoint(TRUNCATE);
+    PRAGMA integrity_check;
+    SELECT id,a,b FROM t_update_replace ORDER BY id;
+}
+expect {
+    mvcc
+    0|0|0
+    0|0|0
+    ok
+    1|10|100
+    2|20|200
+    3|30|300
+    4|40|400
+}
+
+test mvcc-delete-after-replace-delete-checkpoint-is-noop {
+    PRAGMA journal_mode=mvcc;
+    PRAGMA mvcc_gc_threshold=1;
+
+    CREATE TABLE t_repeated_delete(id INTEGER PRIMARY KEY, a, b);
+    CREATE INDEX t_repeated_delete_a ON t_repeated_delete(a);
+
+    INSERT INTO t_repeated_delete VALUES
+        (1,10,100),(2,20,200),(3,30,300),(4,40,400),(5,50,500);
+
+    PRAGMA wal_checkpoint(TRUNCATE);
+
+    INSERT OR REPLACE INTO t_repeated_delete(id,a,b) VALUES(5,25,325);
+    DELETE FROM t_repeated_delete WHERE id=5;
+
+    PRAGMA wal_checkpoint(TRUNCATE);
+
+    DELETE FROM t_repeated_delete WHERE id=5;
+    PRAGMA integrity_check;
+    SELECT id,a,b FROM t_repeated_delete ORDER BY id;
+}
+expect {
+    mvcc
+    0|0|0
+    0|0|0
+    ok
+    1|10|100
+    2|20|200
+    3|30|300
+    4|40|400
+}


### PR DESCRIPTION
## Motivation and context

### Prerequisites

MVCC is built top of SQLite's WAL. Internally, MVCC has a 'store' which keeps the row versions as they are changed. The checkpoint OP, folds these in-memory delta to SQLite's B Tree.

A RowVersion has:

```text
begin_ts           when this version becomes visible
end_ts             when this version stops being visible
btree_resident     this row/index entry already exists physically in the B-tree
```

btree_resident is quite important. It signals the checkpoint that something for this table row / index key exists on B tree file. If this version ended, then we need to update / delete the physcial entry.

So, if we are modifying (including deletion) a row which exists on b tree, then we keep a simple marker to help checkpointer make a decision.

Checkpointer:

1. if its a new row, then during checkpoint it MUST insert that row in the B tree
2. if its an existing row (on b tree), then during checkpoint, it must update / delete existing row on the b tree
3. if its a new row which got inserted and then also got deleted, then checkpointer does not need to do anything on btree, because this row never existed on b tree.

### The bug

Consider this regression test:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, name, iq, year);
CREATE INDEX t_iq ON t(iq);

INSERT INTO t VALUES
  (1, 'v', 100, 2024),
  (2, 'einstein', 150, 1950),
  (3, 'newton', 140, 1850);

PRAGMA wal_checkpoint(TRUNCATE); --- first checkpoint

INSERT OR REPLACE INTO t(id,name,iq,year) VALUES(1, 'v', 120, 2025);
DELETE FROM t WHERE id=1;

PRAGMA wal_checkpoint(TRUNCATE); --- second checkpoint
PRAGMA integrity_check;
```


After the first checkpoint, all these rows become 'durable' in b tree. Lets consider one record:

```text
table t B-tree:
  id=1 -> (name='v', iq=100, year=2024)

index t_iq B-tree:
  (iq=100, id=1)
```

The MVCC store records for this are empty. Then we have INSERT or REPLace statement. Since we are modifying an existing b tree row (remmeber, we checkpointed earlier), MVCC store will keep an marker as well:

```text
table chain for id=1:
  old B-tree row marker:
    row=(id=1, name='v', iq=100, year=2024), end=R, btree_resident=true

  replacement row:
    row=(id=1, name='v', iq=120, year=2025), begin=R, end=None
```

For the index, the old and new entries are different chains because the index key changed (notice my IQ increased from 100 to 120):

```text
index chain for (iq=100, id=1):
  old B-tree index marker:
    end=R, btree_resident=true

index chain for (iq=120, id=1):
  replacement index entry:
    begin=R, end=None
```

The bug happened during garbage collection. Notice there are two versions for it. So, GC looked at the marker which is now ended and saw there is a replacement. So it deleted the marker. This caused the bug.

Why? now if we delete the row, now MVCC store would have:

```text
replacement row (id=1, name='v', iq=120, year=2025):
  begin=R, end=D, btree_resident=false
```

Now checkpointer saw this as some row which got inserted and deleted which never reached B tree, so it skipped deleting the physical row on the B tree!

The original physical table row was still there:

```text
table t B-tree:
  id=1 -> (name='v', iq=100, year=2024)
```

The marker proving that fact had already been GC’d.

Meanwhile the old index marker for (iq=100, id=1) could still survive, so checkpoint could delete the old physical index entry:

```text
index t_iq B-tree:
  missing (iq=100, id=1)
```

Final broken state:

```text
table t B-tree:
  id=1 -> (name='v', iq=100, year=2024)     stale row remains

index t_iq B-tree:
  missing (iq=100, id=1)                    matching index entry removed
```

Then integrity_check scans the table, sees row id=1, name='v', iq=100, and expects index t_iq to contain (100,1). It does not, so it reports index corruption.

### Fix

The fix is simple, we must retain markers during GC. So:

1. if a version has only reader history, GC may remove it once no reader needs it
2. If a version is btree_resident and ended, it may also be checkpoint evidence. Keep it until checkpoint has caught up.

The key rule is:

```text
retain while:
  end timestamp > durable checkpoint timestamp
  and this version is btree_resident
```

After checkpoint advances past that end timestamp, the marker is no longer needed and can be collected.

Comes with regression tests which beautifully fail on teh CI:

```rust
thread 'mvcc::database::tests::test_mvcc_checkpoint_insert_or_replace_then_delete_removes_checkpointed_index_entries' panicked at core/mvcc/database/tests.rs:7282:5:
    assertion `left == right` failed: integrity_check rows: [[Text(Text { value: "row 5 missing from index t_a", subtype: Text })], [Text(Text { value: "wrong # of entries in index t_a", subtype: Text })]]
      left: 2
     right: 1

FAIL [   0.022s] (2558/3926) turso_core mvcc::database::tests::test_mvcc_checkpoint_update_or_replace_then_delete_removes_checkpointed_index_entries


thread 'mvcc::database::tests::test_mvcc_checkpoint_update_or_replace_then_delete_removes_checkpointed_index_entries' panicked at core/mvcc/database/tests.rs:7282:5:
assertion `left == right` failed: integrity_check rows: [[Text(Text { value: "row 5 missing from index t_b", subtype: Text })], [Text(Text { value: "row 5 missing from index t_a", subtype: Text })], [Text(Text { value: "wrong # of entries in index t_b", subtype: Text })], [Text(Text { value: "wrong # of entries in index t_a", subtype: Text })]]
  left: 4
 right: 1

FAIL [   0.021s] (2590/3926) turso_core mvcc::database::tests::test_mvcc_repeated_delete_after_replace_delete_checkpoint_is_noop


mvcc::database::tests::test_mvcc_repeated_delete_after_replace_delete_checkpoint_is_noop

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2068 filtered out; finished in 0.01s

thread 'mvcc::database::tests::test_mvcc_repeated_delete_after_replace_delete_checkpoint_is_noop' panicked at core/mvcc/database/tests.rs:7358:46:
called `Result::unwrap()` on an `Err` value: Corrupt("IdxDelete: no matching index entry found for key [Value(Numeric(Integer(50))), Value(Numeric(Integer(5)))] while seeking")
```
[rust](https://github.com/tursodatabase/turso/actions/runs/28154365678/job/83379250488?pr=7620) and [sqltests](https://github.com/tursodatabase/turso/actions/runs/28154365678/job/83379250464?pr=7620)