### PR TITLE
Add Turso EF Core SQLite provider

### DIFF
--- a/bindings/dotnet/Makefile
+++ b/bindings/dotnet/Makefile
@@ -108,6 +108,7 @@ build-rust:
 build-dotnet:
 	dotnet build $(DOTNET_RELEASE_OPT) ./src/Turso.Data/Turso.Data.csproj
 	dotnet build $(DOTNET_RELEASE_OPT) ./src/Turso.Data.Sqlite/Turso.Data.Sqlite.csproj
+	dotnet build $(DOTNET_RELEASE_OPT) ./src/Turso.EntityFrameworkCore.Sqlite/Turso.EntityFrameworkCore.Sqlite.csproj
 
 build: build-rust build-dotnet
 
@@ -122,3 +123,4 @@ benchmark: build-production
 
 pack:
 	dotnet pack -c Release ./src/Turso.Data.Sqlite/Turso.Data.Sqlite.csproj
+	dotnet pack -c Release ./src/Turso.EntityFrameworkCore.Sqlite/Turso.EntityFrameworkCore.Sqlite.csproj

--- a/bindings/dotnet/Readme.md
+++ b/bindings/dotnet/Readme.md
@@ -102,3 +102,39 @@ Supported common connection string keywords include:
 - `SqliteBlob` preserves fixed-length blob stream behavior through SQL reads and writes. It is not yet backed by a native incremental-blob storage handle.
 - SQLite virtual-table modules such as FTS3/FTS5 are not built in unless provided by a Turso extension/module.
 - Async methods currently use the base ADO.NET behavior rather than a dedicated async native path.
+
+## Entity Framework Core
+
+`Turso.EntityFrameworkCore.Sqlite` adds a `UseTurso` provider hook for local and embedded Turso databases. It reuses EF Core SQLite's LINQ translation pipeline and executes generated SQL through `Turso.Data.Sqlite`.
+
+```bash
+dotnet add package Turso.EntityFrameworkCore.Sqlite
+```
+
+```C#
+using Microsoft.EntityFrameworkCore;
+
+public sealed class AppDbContext : DbContext
+{
+    public DbSet<Customer> Customers => Set<Customer>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options.UseTurso("Data Source=app.db");
+}
+```
+
+You can also pass an existing Turso SQLite-compatible connection:
+
+```C#
+using Microsoft.EntityFrameworkCore;
+using Turso.Data.Sqlite;
+
+await using var connection = new SqliteConnection("Data Source=app.db");
+var options = new DbContextOptionsBuilder<AppDbContext>()
+    .UseTurso(connection)
+    .Options;
+```
+
+The local provider supports the normal EF Core SQLite query pipeline, including composed `IQueryable<T>` filters, navigation-property joins, ordering, paging, grouping, aggregates, async materialization, and `SaveChangesAsync`. Schema creation can use the standard EF Core SQLite mechanisms such as `EnsureCreated`, `EnsureCreatedAsync`, and migrations against local database files.
+
+Remote `libsql://`/auth-token EF Core support is not part of the local provider. Use the local/embedded provider for EF Core today; remote/serverless EF support needs a separate connection, batching, retry, and transaction design.

--- a/bindings/dotnet/Turso.slnx
+++ b/bindings/dotnet/Turso.slnx
@@ -17,6 +17,7 @@
     <Configuration Solution="Release|x86" Project="Release|Any CPU" />
   </Project>
   <Project Path="src\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj" />
+  <Project Path="src\Turso.EntityFrameworkCore.Sqlite\Turso.EntityFrameworkCore.Sqlite.csproj" />
   <Project Path="src\Turso.Data\Turso.Data.csproj" />
   <Project Path="src\Turso.Raw\Turso.Raw.csproj" Type="Classic C#" />
 </Solution>

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Query/Internal/TursoSqliteQuerySqlGenerator.cs
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Query/Internal/TursoSqliteQuerySqlGenerator.cs
@@ -1,0 +1,32 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+
+namespace Turso.EntityFrameworkCore.Sqlite.Query.Internal;
+
+public sealed class TursoSqliteQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : SqliteQuerySqlGenerator(dependencies)
+{
+    protected override Expression VisitOrdering(OrderingExpression orderingExpression)
+    {
+        if (ShouldUseDecimalCollation(orderingExpression.Expression))
+        {
+            var collatedExpression = new CollateExpression(orderingExpression.Expression, "EF_DECIMAL");
+            return base.VisitOrdering(new OrderingExpression(collatedExpression, orderingExpression.IsAscending));
+        }
+
+        return base.VisitOrdering(orderingExpression);
+    }
+
+    private static bool ShouldUseDecimalCollation(SqlExpression expression)
+    {
+        if (expression is CollateExpression)
+            return false;
+
+        return IsDecimalType(expression.Type)
+               || (expression.TypeMapping is not null && IsDecimalType(expression.TypeMapping.ClrType));
+    }
+
+    private static bool IsDecimalType(Type type)
+        => (Nullable.GetUnderlyingType(type) ?? type) == typeof(decimal);
+}

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Query/Internal/TursoSqliteQuerySqlGeneratorFactory.cs
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Query/Internal/TursoSqliteQuerySqlGeneratorFactory.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Turso.EntityFrameworkCore.Sqlite.Query.Internal;
+
+public sealed class TursoSqliteQuerySqlGeneratorFactory(QuerySqlGeneratorDependencies dependencies) : IQuerySqlGeneratorFactory
+{
+    public QuerySqlGenerator Create()
+        => new TursoSqliteQuerySqlGenerator(dependencies);
+}

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Query/Internal/TursoSqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Query/Internal/TursoSqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -1,0 +1,651 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Turso.EntityFrameworkCore.Sqlite.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public sealed class TursoSqliteQueryableMethodTranslatingExpressionVisitor : RelationalQueryableMethodTranslatingExpressionVisitor
+{
+    private readonly IRelationalTypeMappingSource _typeMappingSource;
+    private readonly SqliteSqlExpressionFactory _sqlExpressionFactory;
+    private readonly SqlAliasManager _sqlAliasManager;
+    private readonly bool _areJsonFunctionsSupported;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal] // https://www.sqlite.org/json1.html#jeach
+    public const string JsonEachKeyColumnName = "key";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal] // https://www.sqlite.org/json1.html#jeach
+    public const string JsonEachValueColumnName = "value";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public TursoSqliteQueryableMethodTranslatingExpressionVisitor(
+        QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
+        RelationalQueryableMethodTranslatingExpressionVisitorDependencies relationalDependencies,
+        RelationalQueryCompilationContext queryCompilationContext)
+        : base(dependencies, relationalDependencies, queryCompilationContext)
+    {
+        _typeMappingSource = relationalDependencies.TypeMappingSource;
+        _sqlExpressionFactory = (SqliteSqlExpressionFactory)relationalDependencies.SqlExpressionFactory;
+        _sqlAliasManager = queryCompilationContext.SqlAliasManager;
+
+        _areJsonFunctionsSupported = true;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    private TursoSqliteQueryableMethodTranslatingExpressionVisitor(
+        TursoSqliteQueryableMethodTranslatingExpressionVisitor parentVisitor)
+        : base(parentVisitor)
+    {
+        _typeMappingSource = parentVisitor._typeMappingSource;
+        _sqlExpressionFactory = parentVisitor._sqlExpressionFactory;
+        _sqlAliasManager = parentVisitor._sqlAliasManager;
+
+        _areJsonFunctionsSupported = parentVisitor._areJsonFunctionsSupported;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor()
+        => new TursoSqliteQueryableMethodTranslatingExpressionVisitor(this);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateAny(ShapedQueryExpression source, LambdaExpression? predicate)
+    {
+        // Simplify x.Array.Any() => json_array_length(x.Array) > 0 instead of WHERE EXISTS (SELECT 1 FROM json_each(x.Array))
+        if (predicate is null
+            && source.QueryExpression is SelectExpression
+            {
+                Tables: [TableValuedFunctionExpression { Name: "json_each", Schema: null, IsBuiltIn: true, Arguments: [var array] }],
+                Predicate: null,
+                GroupBy: [],
+                Having: null,
+                IsDistinct: false,
+                Limit: null,
+                Offset: null
+            })
+        {
+            var translation =
+                _sqlExpressionFactory.GreaterThan(
+                    _sqlExpressionFactory.Function(
+                        "json_array_length",
+                        new[] { array },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true },
+                        typeof(int)),
+                    _sqlExpressionFactory.Constant(0));
+
+#pragma warning disable EF1001
+            return source.UpdateQueryExpression(new SelectExpression(translation, _sqlAliasManager));
+#pragma warning restore EF1001
+        }
+
+        return base.TranslateAny(source, predicate);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateOrderBy(
+        ShapedQueryExpression source,
+        LambdaExpression keySelector,
+        bool ascending)
+    {
+        var translation = base.TranslateOrderBy(source, keySelector, ascending);
+        if (translation == null)
+        {
+            return null;
+        }
+
+        var orderingExpression = ((SelectExpression)translation.QueryExpression).Orderings.Last();
+        var orderingExpressionType = GetProviderType(orderingExpression.Expression);
+        if (orderingExpressionType == typeof(DateTimeOffset)
+            || orderingExpressionType == typeof(TimeSpan)
+            || orderingExpressionType == typeof(ulong))
+        {
+            throw new NotSupportedException(
+                SqliteStrings.OrderByNotSupported(orderingExpressionType.ShortDisplayName()));
+        }
+
+        return translation;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateThenBy(
+        ShapedQueryExpression source,
+        LambdaExpression keySelector,
+        bool ascending)
+    {
+        var translation = base.TranslateThenBy(source, keySelector, ascending);
+        if (translation == null)
+        {
+            return null;
+        }
+
+        var orderingExpression = ((SelectExpression)translation.QueryExpression).Orderings.Last();
+        var orderingExpressionType = GetProviderType(orderingExpression.Expression);
+        if (orderingExpressionType == typeof(DateTimeOffset)
+            || orderingExpressionType == typeof(TimeSpan)
+            || orderingExpressionType == typeof(ulong))
+        {
+            throw new NotSupportedException(
+                SqliteStrings.OrderByNotSupported(orderingExpressionType.ShortDisplayName()));
+        }
+
+        return translation;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateCount(ShapedQueryExpression source, LambdaExpression? predicate)
+    {
+        // Simplify x.Array.Count() => json_array_length(x.Array) instead of SELECT COUNT(*) FROM json_each(x.Array)
+        if (predicate is null
+            && source.QueryExpression is SelectExpression
+            {
+                Tables: [TableValuedFunctionExpression { Name: "json_each", Schema: null, IsBuiltIn: true, Arguments: [var array] }],
+                Predicate: null,
+                GroupBy: [],
+                Having: null,
+                IsDistinct: false,
+                Limit: null,
+                Offset: null
+            })
+        {
+            var translation = _sqlExpressionFactory.Function(
+                "json_array_length",
+                new[] { array },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true },
+                typeof(int));
+
+#pragma warning disable EF1001
+            return source.UpdateQueryExpression(new SelectExpression(translation, _sqlAliasManager));
+#pragma warning restore EF1001
+        }
+
+        return base.TranslateCount(source, predicate);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslatePrimitiveCollection(
+        SqlExpression sqlExpression,
+        IProperty? property,
+        string tableAlias)
+    {
+        // Support for JSON functions (e.g. json_each) was added in Sqlite 3.38.0 (2022-02-22, see https://www.sqlite.org/json1.html).
+        // This determines whether we have json_each, which is needed to query into JSON columns.
+        if (!_areJsonFunctionsSupported)
+        {
+            AddTranslationErrorDetails(SqliteStrings.QueryingIntoJsonCollectionsNotSupported("3.38.0"));
+
+            return null;
+        }
+
+        var elementTypeMapping = (RelationalTypeMapping?)sqlExpression.TypeMapping?.ElementTypeMapping;
+        var elementClrType = GetSequenceType(sqlExpression.Type);
+        var jsonEachExpression = new JsonEachExpression(tableAlias, sqlExpression);
+
+        // If this is a collection property, get the element's nullability out of metadata. Otherwise, this is a parameter property, in
+        // which case we only have the CLR type (note that we cannot produce different SQLs based on the nullability of an *element* in
+        // a parameter collection - our caching mechanism only supports varying by the nullability of the parameter itself (i.e. the
+        // collection).
+        var isElementNullable = property?.GetElementType()!.IsNullable;
+
+        var keyColumnTypeMapping = _typeMappingSource.FindMapping(typeof(int))!;
+
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        var selectExpression = new SelectExpression(
+            [jsonEachExpression],
+            new ColumnExpression(
+                JsonEachValueColumnName,
+                tableAlias,
+                UnwrapNullableType(elementClrType),
+                elementTypeMapping,
+                isElementNullable ?? IsNullableType(elementClrType)),
+            identifier:
+            [
+                (new ColumnExpression(JsonEachKeyColumnName, tableAlias, typeof(int), keyColumnTypeMapping, nullable: false),
+                    keyColumnTypeMapping.Comparer)
+            ],
+            _sqlAliasManager);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+        // If we have a collection column, we know the type mapping at this point (as opposed to parameters, whose type mapping will get
+        // inferred later based on usage in SqliteInferredTypeMappingApplier); we should be able to apply any SQL logic needed to convert
+        // the JSON value out to its relational counterpart (e.g. datetime() for timestamps, see ApplyJsonSqlConversion).
+        //
+        // However, doing it here would interfere with pattern matching in e.g. TranslateElementAtOrDefault, where we specifically check
+        // for a bare column being projected out of the table - if the user composed any operators over the collection, it's no longer
+        // possible to apply a specialized translation via the -> operator. We could add a way to recognize the special conversions we
+        // compose on top, but instead of going into that complexity, we'll just apply the SQL conversion later, in
+        // SqliteInferredTypeMappingApplier, as if we had a parameter collection.
+
+        // Append an ordering for the json_each 'key' column.
+        selectExpression.AppendOrdering(
+            new OrderingExpression(
+                selectExpression.CreateColumnExpression(
+                    jsonEachExpression,
+                    JsonEachKeyColumnName,
+                    typeof(int),
+                    typeMapping: _typeMappingSource.FindMapping(typeof(int)),
+                    columnNullable: false),
+                ascending: true));
+
+        Expression shaperExpression = new ProjectionBindingExpression(
+            selectExpression, new ProjectionMember(), MakeNullable(elementClrType));
+
+        if (elementClrType != shaperExpression.Type)
+        {
+            Debug.Assert(
+                MakeNullable(elementClrType) == shaperExpression.Type,
+                "expression.Type must be nullable of targetType");
+
+            shaperExpression = Expression.Convert(shaperExpression, elementClrType);
+        }
+
+        return new ShapedQueryExpression(selectExpression, shaperExpression);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression TransformJsonQueryToTable(JsonQueryExpression jsonQueryExpression)
+    {
+        var entityType = jsonQueryExpression.EntityType;
+        var textTypeMapping = _typeMappingSource.FindMapping(typeof(string));
+
+        // TODO: Refactor this out
+        // Calculate the table alias for the json_each expression based on the last named path segment
+        // (or the JSON column name if there are none)
+        var lastNamedPathSegment = jsonQueryExpression.Path.LastOrDefault(ps => ps.PropertyName is not null);
+        var tableAlias = _sqlAliasManager.GenerateTableAlias(lastNamedPathSegment.PropertyName ?? jsonQueryExpression.JsonColumn.Name);
+
+        // Handling a non-primitive JSON array is complicated on SQLite; unlike SQL Server OPENJSON and PostgreSQL jsonb_to_recordset,
+        // SQLite's json_each can only project elements of the array, and not properties within those elements. For example:
+        // SELECT value FROM json_each('[{"a":1,"b":"foo"}, {"a":2,"b":"bar"}]')
+        // This will return two rows, each with a string column representing an array element (i.e. {"a":1,"b":"foo"}). To decompose that
+        // into a and b columns, a further extraction is needed:
+        // SELECT value ->> 'a' AS a, value ->> 'b' AS b FROM json_each('[{"a":1,"b":"foo"}, {"a":2,"b":"bar"}]')
+
+        // We therefore generate a minimal subquery projecting out all the properties and navigations, wrapped by a SelectExpression
+        // containing that:
+        // SELECT ...
+        // FROM (SELECT value ->> 'a' AS a, value ->> 'b' AS b FROM json_each(<JSON column>, <path>)) AS j
+        // WHERE j.a = 8;
+
+        // Unfortunately, while the subquery projects the entity, our EntityProjectionExpression currently supports only bare
+        // ColumnExpression (the above requires JsonScalarExpression). So we hack as if the subquery projects an anonymous type instead,
+        // with a member for each JSON property that needs to be projected. We then wrap it with a SelectExpression the projects a proper
+        // EntityProjectionExpression.
+
+        var jsonEachExpression = new JsonEachExpression(tableAlias, jsonQueryExpression.JsonColumn, jsonQueryExpression.Path);
+
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        var selectExpression = CreateSelect(
+            jsonQueryExpression,
+            jsonEachExpression,
+            JsonEachKeyColumnName,
+            typeof(int),
+            _typeMappingSource.FindMapping(typeof(int))!);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+        selectExpression.AppendOrdering(
+            new OrderingExpression(
+                selectExpression.CreateColumnExpression(
+                    jsonEachExpression,
+                    JsonEachKeyColumnName,
+                    typeof(int),
+                    typeMapping: _typeMappingSource.FindMapping(typeof(int)),
+                    columnNullable: false),
+                ascending: true));
+
+        var propertyJsonScalarExpression = new Dictionary<ProjectionMember, Expression>();
+
+        var jsonColumn = selectExpression.CreateColumnExpression(
+            jsonEachExpression, JsonEachValueColumnName, typeof(string), _typeMappingSource.FindMapping(typeof(string))); // TODO: nullable?
+
+        var containerColumnName = entityType.GetContainerColumnName();
+        Debug.Assert(containerColumnName is not null, "JsonQueryExpression to entity type without a container column name");
+
+        // First step: build a SelectExpression that will execute json_each and project all properties and navigations out, e.g.
+        // (SELECT value ->> 'a' AS a, value ->> 'b' AS b FROM json_each(c."JsonColumn", '$.Something.SomeCollection')
+
+        // We're only interested in properties which actually exist in the JSON, filter out uninteresting shadow keys
+        foreach (var property in entityType.GetPropertiesInHierarchy())
+        {
+            if (property.GetJsonPropertyName() is string jsonPropertyName)
+            {
+                // HACK: currently the only way to project multiple values from a SelectExpression is to simulate a Select out to an anonymous
+                // type; this requires the MethodInfos of the anonymous type properties, from which the projection alias gets taken.
+                // So we create fake members to hold the JSON property name for the alias.
+                var projectionMember = new ProjectionMember().Append(new FakeMemberInfo(jsonPropertyName));
+
+                propertyJsonScalarExpression[projectionMember] = new JsonScalarExpression(
+                    jsonColumn,
+                    new[] { new PathSegment(property.GetJsonPropertyName()!) },
+                    UnwrapNullableType(property.ClrType),
+                    property.GetRelationalTypeMapping(),
+                    property.IsNullable);
+            }
+        }
+
+        foreach (var navigation in jsonQueryExpression.EntityType.GetNavigationsInHierarchy()
+                     .Where(
+                         n => n.ForeignKey.IsOwnership
+                             && n.TargetEntityType.IsMappedToJson()
+                             && n.ForeignKey.PrincipalToDependent == n))
+        {
+            var jsonNavigationName = navigation.TargetEntityType.GetJsonPropertyName();
+            Debug.Assert(jsonNavigationName is not null, "Invalid navigation found on JSON-mapped entity");
+
+            var projectionMember = new ProjectionMember().Append(new FakeMemberInfo(jsonNavigationName));
+
+            propertyJsonScalarExpression[projectionMember] = new JsonScalarExpression(
+                jsonColumn,
+                new[] { new PathSegment(jsonNavigationName) },
+                typeof(string),
+                textTypeMapping,
+                !navigation.ForeignKey.IsRequiredDependent);
+        }
+
+        selectExpression.ReplaceProjection(propertyJsonScalarExpression);
+
+        // Second step: push the above SelectExpression down to a subquery, and project an entity projection from the outer
+        // SelectExpression, i.e.
+        // SELECT "t"."a", "t"."b"
+        // FROM (SELECT value ->> 'a' ... FROM json_each(...))
+
+        selectExpression.PushdownIntoSubquery();
+        var subquery = selectExpression.Tables[0];
+
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        var newOuterSelectExpression = CreateSelect(
+            jsonQueryExpression,
+            subquery,
+            JsonEachKeyColumnName,
+            typeof(int),
+            _typeMappingSource.FindMapping(typeof(int))!);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+        newOuterSelectExpression.AppendOrdering(
+            new OrderingExpression(
+                selectExpression.CreateColumnExpression(
+                    subquery,
+                    JsonEachKeyColumnName,
+                    typeof(int),
+                    typeMapping: _typeMappingSource.FindMapping(typeof(int)),
+                    columnNullable: false),
+                ascending: true));
+
+        return new ShapedQueryExpression(
+            newOuterSelectExpression,
+            new RelationalStructuralTypeShaperExpression(
+                jsonQueryExpression.EntityType,
+                new ProjectionBindingExpression(
+                    newOuterSelectExpression,
+                    new ProjectionMember(),
+                    typeof(ValueBuffer)),
+                false));
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateElementAtOrDefault(
+        ShapedQueryExpression source,
+        Expression index,
+        bool returnDefault)
+    {
+        if (!returnDefault
+            && source.QueryExpression is SelectExpression
+            {
+                Tables:
+                [
+                    TableValuedFunctionExpression
+                    {
+                        Name: "json_each", Schema: null, IsBuiltIn: true, Arguments: [var jsonArrayColumn]
+                    } jsonEachExpression
+                ],
+                Predicate: null,
+                GroupBy: [],
+                Having: null,
+                IsDistinct: false,
+                Orderings: [{ Expression: ColumnExpression { Name: JsonEachKeyColumnName } orderingColumn, IsAscending: true }],
+                Limit: null,
+                Offset: null
+            } selectExpression
+            && orderingColumn.TableAlias == jsonEachExpression.Alias
+            && TranslateExpression(index) is { } translatedIndex)
+        {
+            // Index on JSON array
+
+            // Extract the column projected out of the source, and simplify the subquery to a simple JsonScalarExpression
+            var shaperExpression = source.ShaperExpression;
+            if (shaperExpression is UnaryExpression { NodeType: ExpressionType.Convert } unaryExpression
+                && IsNullableType(unaryExpression.Operand.Type)
+                && UnwrapNullableType(unaryExpression.Operand.Type) == unaryExpression.Type)
+            {
+                shaperExpression = unaryExpression.Operand;
+            }
+
+            if (shaperExpression is ProjectionBindingExpression projectionBindingExpression
+                && selectExpression.GetProjection(projectionBindingExpression) is ColumnExpression projectionColumn)
+            {
+                SqlExpression translation = new JsonScalarExpression(
+                    jsonArrayColumn,
+                    new[] { new PathSegment(translatedIndex) },
+                    projectionColumn.Type,
+                    projectionColumn.TypeMapping,
+                    projectionColumn.IsNullable);
+
+                // If we have a type mapping (i.e. translating over a column rather than a parameter), apply any necessary server-side
+                // conversions.
+                if (projectionColumn.TypeMapping is not null)
+                {
+                    translation = ApplyJsonSqlConversion(
+                        translation, _sqlExpressionFactory, projectionColumn.TypeMapping, projectionColumn.IsNullable);
+                }
+
+#pragma warning disable EF1001
+                return source.UpdateQueryExpression(new SelectExpression(translation, _sqlAliasManager));
+#pragma warning restore EF1001
+            }
+        }
+
+        return base.TranslateElementAtOrDefault(source, index, returnDefault);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override bool IsNaturallyOrdered(SelectExpression selectExpression)
+    {
+        return selectExpression is
+            {
+                Tables: [var mainTable, ..],
+                Orderings:
+                [
+                    {
+                        Expression: ColumnExpression { Name: JsonEachKeyColumnName } orderingColumn,
+                        IsAscending: true
+                    }
+                ]
+            }
+            && orderingColumn.TableAlias == mainTable.Alias
+            && IsJsonEachKeyColumn(selectExpression, orderingColumn);
+
+        bool IsJsonEachKeyColumn(SelectExpression selectExpression, ColumnExpression orderingColumn)
+            => selectExpression.Tables.FirstOrDefault(t => t.Alias == orderingColumn.TableAlias)?.UnwrapJoin() is TableExpressionBase table
+                && (table is JsonEachExpression
+                    || (table is SelectExpression subquery
+                        && subquery.Projection.FirstOrDefault(p => p.Alias == JsonEachKeyColumnName)?.Expression is ColumnExpression
+                            projectedColumn
+                        && IsJsonEachKeyColumn(subquery, projectedColumn)));
+    }
+
+    private static Type GetProviderType(SqlExpression expression)
+        => expression.TypeMapping?.Converter?.ProviderClrType
+            ?? expression.TypeMapping?.ClrType
+            ?? expression.Type;
+
+    private static Type GetSequenceType(Type type)
+    {
+        if (type.IsArray)
+            return type.GetElementType()!;
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            return type.GetGenericArguments()[0];
+
+        foreach (var @interface in type.GetInterfaces())
+        {
+            if (@interface.IsGenericType && @interface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                return @interface.GetGenericArguments()[0];
+        }
+
+        throw new InvalidOperationException($"Type '{type}' is not an enumerable type.");
+    }
+
+    private static Type UnwrapNullableType(Type type)
+        => Nullable.GetUnderlyingType(type) ?? type;
+
+    private static bool IsNullableType(Type type)
+        => !type.IsValueType || Nullable.GetUnderlyingType(type) is not null;
+
+    private static Type MakeNullable(Type type)
+        => IsNullableType(type) ? type : typeof(Nullable<>).MakeGenericType(type);
+
+    /// <summary>
+    ///     Wraps the given expression with any SQL logic necessary to convert a value coming out of a JSON document into the relational value
+    ///     represented by the given type mapping.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    [EntityFrameworkInternal]
+    public static SqlExpression ApplyJsonSqlConversion(
+        SqlExpression expression,
+        SqliteSqlExpressionFactory sqlExpressionFactory,
+        RelationalTypeMapping typeMapping,
+        bool isNullable)
+        => typeMapping switch
+        {
+            // In general unhex returns NULL whenever the decoding fails.
+            // In this case, we assume that the decoding cannot fail, because we
+            // rely on the user to correctly model the database schema and
+            // contents. Under this assumption, `expression` can only be a valid
+            // hex string or NULL, hence unhex simply propagates the nullability
+            // from its argument.
+
+            ByteArrayTypeMapping
+                => sqlExpressionFactory.Function(
+                    "unhex",
+                    new[] { expression },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(byte[]),
+                    typeMapping),
+
+            _ => expression
+        };
+
+    private sealed class FakeMemberInfo(string name) : MemberInfo
+    {
+        public override string Name { get; } = name;
+
+        public override object[] GetCustomAttributes(bool inherit)
+            => throw new NotSupportedException();
+
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+            => throw new NotSupportedException();
+
+        public override bool IsDefined(Type attributeType, bool inherit)
+            => throw new NotSupportedException();
+
+        public override Type? DeclaringType
+            => throw new NotSupportedException();
+
+        public override MemberTypes MemberType
+            => throw new NotSupportedException();
+
+        public override Type? ReflectedType
+            => throw new NotSupportedException();
+    }
+}

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Query/Internal/TursoSqliteQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Query/Internal/TursoSqliteQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Turso.EntityFrameworkCore.Sqlite.Query.Internal;
+
+public sealed class TursoSqliteQueryableMethodTranslatingExpressionVisitorFactory(
+    QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
+    RelationalQueryableMethodTranslatingExpressionVisitorDependencies relationalDependencies) : IQueryableMethodTranslatingExpressionVisitorFactory
+{
+    public QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
+        => new TursoSqliteQueryableMethodTranslatingExpressionVisitor(
+            dependencies,
+            relationalDependencies,
+            (RelationalQueryCompilationContext)queryCompilationContext);
+}

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Storage/Internal/TursoSqliteDatabaseCreator.cs
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Storage/Internal/TursoSqliteDatabaseCreator.cs
@@ -1,0 +1,110 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using TursoSqliteConnection = Turso.Data.Sqlite.SqliteConnection;
+using TursoSqliteConnectionStringBuilder = Turso.Data.Sqlite.SqliteConnectionStringBuilder;
+using TursoSqliteException = Turso.Data.Sqlite.SqliteException;
+using TursoSqliteOpenMode = Turso.Data.Sqlite.SqliteOpenMode;
+
+namespace Turso.EntityFrameworkCore.Sqlite.Storage.Internal;
+
+public class TursoSqliteDatabaseCreator(
+    RelationalDatabaseCreatorDependencies dependencies,
+    ISqliteRelationalConnection connection,
+    IRawSqlCommandBuilder rawSqlCommandBuilder)
+    : RelationalDatabaseCreator(dependencies)
+{
+    private const int SQLITE_CANTOPEN = 14;
+
+    public override void Create()
+    {
+        Dependencies.Connection.Open();
+        try
+        {
+            rawSqlCommandBuilder.Build("PRAGMA journal_mode = 'wal';")
+                .ExecuteNonQuery(
+                    new RelationalCommandParameterObject(
+                        Dependencies.Connection,
+                        null,
+                        null,
+                        null,
+                        Dependencies.CommandLogger,
+                        CommandSource.Migrations));
+        }
+        finally
+        {
+            Dependencies.Connection.Close();
+        }
+    }
+
+    public override bool Exists()
+    {
+        var connectionOptions = new TursoSqliteConnectionStringBuilder(connection.ConnectionString);
+        if (connectionOptions.DataSource.Equals(":memory:", StringComparison.OrdinalIgnoreCase)
+            || connectionOptions.Mode == TursoSqliteOpenMode.Memory)
+        {
+            return true;
+        }
+
+        using var readOnlyConnection = connection.CreateReadOnlyConnection();
+        try
+        {
+            readOnlyConnection.Open(errorsExpected: true);
+        }
+        catch (TursoSqliteException ex) when (ex.SqliteErrorCode == SQLITE_CANTOPEN)
+        {
+            return false;
+        }
+        finally
+        {
+            readOnlyConnection.Close();
+        }
+
+        return true;
+    }
+
+    public override bool HasTables()
+    {
+        var count = (long)rawSqlCommandBuilder
+            .Build("SELECT COUNT(*) FROM \"sqlite_master\" WHERE \"type\" = 'table' AND \"rootpage\" IS NOT NULL;")
+            .ExecuteScalar(
+                new RelationalCommandParameterObject(
+                    Dependencies.Connection,
+                    null,
+                    null,
+                    null,
+                    Dependencies.CommandLogger,
+                    CommandSource.Migrations))!;
+
+        return count != 0;
+    }
+
+    public override void Delete()
+    {
+        var dbConnection = Dependencies.Connection.DbConnection;
+        var wasOpen = dbConnection.State == ConnectionState.Open;
+
+        if (!wasOpen)
+            Dependencies.Connection.Open();
+
+        var path = dbConnection.DataSource;
+        Dependencies.Connection.Close();
+
+        if (!string.IsNullOrEmpty(path) && !path.Equals(":memory:", StringComparison.OrdinalIgnoreCase))
+        {
+            TursoSqliteConnection.ClearAllPools();
+            File.Delete(path);
+            File.Delete(path + "-wal");
+            File.Delete(path + "-shm");
+        }
+        else if (wasOpen)
+        {
+            TursoSqliteConnection.ClearPool(new TursoSqliteConnection(Dependencies.Connection.ConnectionString));
+        }
+
+        if (wasOpen)
+            Dependencies.Connection.Open();
+    }
+}

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Storage/Internal/TursoSqliteRelationalConnection.cs
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Storage/Internal/TursoSqliteRelationalConnection.cs
@@ -1,0 +1,152 @@
+using System.Data.Common;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using TursoSqliteConnection = Turso.Data.Sqlite.SqliteConnection;
+using TursoSqliteConnectionStringBuilder = Turso.Data.Sqlite.SqliteConnectionStringBuilder;
+using TursoSqliteOpenMode = Turso.Data.Sqlite.SqliteOpenMode;
+
+namespace Turso.EntityFrameworkCore.Sqlite.Storage.Internal;
+
+public class TursoSqliteRelationalConnection : SqliteRelationalConnection
+{
+    private readonly IRawSqlCommandBuilder _rawSqlCommandBuilder;
+    private readonly IDiagnosticsLogger<DbLoggerCategory.Infrastructure> _logger;
+    private readonly int? _commandTimeout;
+
+    public TursoSqliteRelationalConnection(
+        RelationalConnectionDependencies dependencies,
+        IRawSqlCommandBuilder rawSqlCommandBuilder,
+        IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger)
+        : base(dependencies, rawSqlCommandBuilder, logger)
+    {
+        _rawSqlCommandBuilder = rawSqlCommandBuilder;
+        _logger = logger;
+
+        var relationalOptions = RelationalOptionsExtension.Extract(dependencies.ContextOptions);
+        _commandTimeout = relationalOptions.CommandTimeout;
+        if (relationalOptions.Connection is TursoSqliteConnection connection)
+            InitializeTursoConnection(connection);
+    }
+
+    protected override DbConnection CreateDbConnection()
+    {
+        var connection = new TursoSqliteConnection(GetValidatedConnectionString());
+        InitializeTursoConnection(connection);
+        return connection;
+    }
+
+    public override ISqliteRelationalConnection CreateReadOnlyConnection()
+    {
+        var connectionStringBuilder = new TursoSqliteConnectionStringBuilder(GetValidatedConnectionString())
+        {
+            Mode = TursoSqliteOpenMode.ReadOnly,
+            Pooling = false
+        };
+
+        var contextOptions = new DbContextOptionsBuilder()
+            .UseTurso(connectionStringBuilder.ToString())
+            .Options;
+
+        return new TursoSqliteRelationalConnection(
+            Dependencies with { ContextOptions = contextOptions },
+            _rawSqlCommandBuilder,
+            _logger);
+    }
+
+    private void InitializeTursoConnection(TursoSqliteConnection connection)
+    {
+        if (_commandTimeout.HasValue)
+            connection.DefaultTimeout = _commandTimeout.Value;
+
+        connection.CreateFunction<string, string, bool?>(
+            "regexp",
+            (pattern, input) => input is null || pattern is null
+                ? null
+                : Regex.IsMatch(input, pattern, RegexOptions.None, TimeSpan.FromMilliseconds(1000)),
+            isDeterministic: true);
+
+        connection.CreateFunction(
+            "ef_mod",
+            (decimal? dividend, decimal? divisor) => divisor == 0m ? null : dividend % divisor,
+            isDeterministic: true);
+
+        connection.CreateFunction(
+            "ef_add",
+            (decimal? left, decimal? right) => left + right,
+            isDeterministic: true);
+
+        connection.CreateFunction(
+            "ef_divide",
+            (decimal? dividend, decimal? divisor) => divisor == 0m ? null : dividend / divisor,
+            isDeterministic: true);
+
+        connection.CreateFunction(
+            "ef_compare",
+            (decimal? left, decimal? right) => left.HasValue && right.HasValue
+                ? decimal.Compare(left.Value, right.Value)
+                : default(int?),
+            isDeterministic: true);
+
+        connection.CreateFunction(
+            "ef_multiply",
+            (decimal? left, decimal? right) => left * right,
+            isDeterministic: true);
+
+        connection.CreateFunction(
+            "ef_negate",
+            (decimal? value) => -value,
+            isDeterministic: true);
+
+        connection.CreateAggregate(
+            "ef_avg",
+            seed: (0m, 0ul),
+            ((decimal Sum, ulong Count) accumulator, decimal? value) => value is null
+                ? accumulator
+                : (accumulator.Sum + value.Value, accumulator.Count + 1),
+            ((decimal Sum, ulong Count) accumulator) => accumulator.Count == 0
+                ? default(decimal?)
+                : accumulator.Sum / accumulator.Count,
+            isDeterministic: true);
+
+        connection.CreateAggregate(
+            "ef_max",
+            seed: null,
+            (decimal? max, decimal? value) => max is null
+                ? value
+                : value is null
+                    ? max
+                    : decimal.Max(max.Value, value.Value),
+            isDeterministic: true);
+
+        connection.CreateAggregate(
+            "ef_min",
+            seed: null,
+            (decimal? min, decimal? value) => min is null
+                ? value
+                : value is null
+                    ? min
+                    : decimal.Min(min.Value, value.Value),
+            isDeterministic: true);
+
+        connection.CreateAggregate(
+            "ef_sum",
+            seed: null,
+            (decimal? sum, decimal? value) => value is null
+                ? sum
+                : sum is null
+                    ? value
+                    : sum.Value + value.Value,
+            isDeterministic: true);
+
+        connection.CreateCollation(
+            "EF_DECIMAL",
+            (left, right) => decimal.Compare(
+                decimal.Parse(left, NumberStyles.Number, CultureInfo.InvariantCulture),
+                decimal.Parse(right, NumberStyles.Number, CultureInfo.InvariantCulture)));
+    }
+}

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Turso.EntityFrameworkCore.Sqlite.csproj
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Turso.EntityFrameworkCore.Sqlite.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>$(TursoTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Turso.EntityFrameworkCore.Sqlite</RootNamespace>
+
+    <PackageId>Turso.EntityFrameworkCore.Sqlite</PackageId>
+    <Title>Turso Entity Framework Core SQLite Provider</Title>
+    <Description>Entity Framework Core integration for Turso local databases using EF Core SQLite translation and Turso.Data.Sqlite execution.</Description>
+    <Authors>Turso authors</Authors>
+    <PackageTags>turso;sqlite;database;entity-framework-core;efcore;linq</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/tursodatabase/turso</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/tursodatabase/turso</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591;EF1001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="9.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Turso.EntityFrameworkCore.Sqlite.csproj
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Turso.EntityFrameworkCore.Sqlite.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://github.com/tursodatabase/turso</PackageProjectUrl>
     <RepositoryUrl>https://github.com/tursodatabase/turso</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591;EF1001</NoWarn>
   </PropertyGroup>
@@ -26,5 +27,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\Readme.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 </Project>

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/TursoDbContextOptionsBuilderExtensions.cs
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/TursoDbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
+using Turso.EntityFrameworkCore.Sqlite.Query.Internal;
+using Turso.EntityFrameworkCore.Sqlite.Storage.Internal;
+using Turso.EntityFrameworkCore.Sqlite.Update.Internal;
+using TursoSqliteConnection = Turso.Data.Sqlite.SqliteConnection;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public static class TursoDbContextOptionsBuilderExtensions
+{
+    public static DbContextOptionsBuilder UseTurso(
+        this DbContextOptionsBuilder optionsBuilder,
+        string? connectionString,
+        Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
+    {
+        optionsBuilder.UseSqlite(connectionString, sqliteOptionsAction);
+        return UseTursoServices(optionsBuilder);
+    }
+
+    public static DbContextOptionsBuilder UseTurso(
+        this DbContextOptionsBuilder optionsBuilder,
+        TursoSqliteConnection connection,
+        Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
+        => UseTurso(optionsBuilder, connection, contextOwnsConnection: false, sqliteOptionsAction);
+
+    public static DbContextOptionsBuilder UseTurso(
+        this DbContextOptionsBuilder optionsBuilder,
+        TursoSqliteConnection connection,
+        bool contextOwnsConnection,
+        Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        optionsBuilder.UseSqlite(connection, contextOwnsConnection, sqliteOptionsAction);
+        return UseTursoServices(optionsBuilder);
+    }
+
+    public static DbContextOptionsBuilder<TContext> UseTurso<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        string? connectionString,
+        Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseTurso((DbContextOptionsBuilder)optionsBuilder, connectionString, sqliteOptionsAction);
+
+    public static DbContextOptionsBuilder<TContext> UseTurso<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        TursoSqliteConnection connection,
+        Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseTurso((DbContextOptionsBuilder)optionsBuilder, connection, sqliteOptionsAction);
+
+    public static DbContextOptionsBuilder<TContext> UseTurso<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        TursoSqliteConnection connection,
+        bool contextOwnsConnection,
+        Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseTurso((DbContextOptionsBuilder)optionsBuilder, connection, contextOwnsConnection, sqliteOptionsAction);
+
+    private static DbContextOptionsBuilder UseTursoServices(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .ReplaceService<ISqliteRelationalConnection, TursoSqliteRelationalConnection>()
+            .ReplaceService<IRelationalDatabaseCreator, TursoSqliteDatabaseCreator>()
+            .ReplaceService<IQuerySqlGeneratorFactory, TursoSqliteQuerySqlGeneratorFactory>()
+            .ReplaceService<IQueryableMethodTranslatingExpressionVisitorFactory, TursoSqliteQueryableMethodTranslatingExpressionVisitorFactory>()
+            .ReplaceService<IUpdateSqlGenerator, TursoSqliteUpdateSqlGenerator>();
+}

--- a/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Update/Internal/TursoSqliteUpdateSqlGenerator.cs
+++ b/bindings/dotnet/src/Turso.EntityFrameworkCore.Sqlite/Update/Internal/TursoSqliteUpdateSqlGenerator.cs
@@ -1,0 +1,111 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
+
+namespace Turso.EntityFrameworkCore.Sqlite.Update.Internal;
+
+public sealed class TursoSqliteUpdateSqlGenerator(UpdateSqlGeneratorDependencies dependencies) : UpdateAndSelectSqlGenerator(dependencies)
+{
+    public override ResultSetMapping AppendInsertOperation(
+            StringBuilder commandStringBuilder,
+            IReadOnlyModificationCommand command,
+            int commandPosition,
+            out bool requiresTransaction)
+        => CanUseReturningClause(command)
+            ? AppendInsertReturningOperation(commandStringBuilder, command, commandPosition, out requiresTransaction)
+            : AppendInsertAndSelectOperation(commandStringBuilder, command, commandPosition, out requiresTransaction);
+
+    public override ResultSetMapping AppendUpdateOperation(
+            StringBuilder commandStringBuilder,
+            IReadOnlyModificationCommand command,
+            int commandPosition,
+            out bool requiresTransaction)
+        => CanUseReturningClause(command)
+            ? AppendUpdateReturningOperation(commandStringBuilder, command, commandPosition, out requiresTransaction)
+            : AppendUpdateAndSelectOperation(commandStringBuilder, command, commandPosition, out requiresTransaction);
+
+    public override ResultSetMapping AppendDeleteOperation(
+            StringBuilder commandStringBuilder,
+            IReadOnlyModificationCommand command,
+            int commandPosition,
+            out bool requiresTransaction)
+        => CanUseReturningClause(command)
+            ? AppendDeleteReturningOperation(commandStringBuilder, command, commandPosition, out requiresTransaction)
+            : AppendDeleteAndSelectOperation(commandStringBuilder, command, commandPosition, out requiresTransaction);
+
+    protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, IColumnModification columnModification)
+    {
+        SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, "rowid");
+        commandStringBuilder.Append(" = last_insert_rowid()");
+    }
+
+    protected override ResultSetMapping AppendSelectAffectedCountCommand(
+        StringBuilder commandStringBuilder,
+        string name,
+        string? schema,
+        int commandPosition)
+    {
+        commandStringBuilder
+            .Append("SELECT changes()")
+            .AppendLine(SqlGenerationHelper.StatementTerminator)
+            .AppendLine();
+
+        return ResultSetMapping.LastInResultSet | ResultSetMapping.ResultSetWithRowsAffectedOnly;
+    }
+
+    protected override void AppendRowsAffectedWhereCondition(StringBuilder commandStringBuilder, int expectedRowsAffected)
+        => commandStringBuilder.Append("changes() = ").Append(expectedRowsAffected);
+
+    public override string GenerateNextSequenceValueOperation(string name, string? schema)
+        => throw new NotSupportedException(SqliteStrings.SequencesNotSupported);
+
+    protected override void AppendUpdateColumnValue(
+        ISqlGenerationHelper updateSqlGeneratorHelper,
+        IColumnModification columnModification,
+        StringBuilder stringBuilder,
+        string name,
+        string? schema)
+    {
+        if (columnModification.JsonPath is not (null or "$"))
+        {
+            stringBuilder.Append("json_set(");
+            updateSqlGeneratorHelper.DelimitIdentifier(stringBuilder, columnModification.ColumnName);
+            stringBuilder.Append(", '");
+            stringBuilder.Append(columnModification.JsonPath);
+            stringBuilder.Append("', ");
+
+            if (columnModification.Property is { IsPrimitiveCollection: false })
+            {
+                var providerClrType = (columnModification.Property.GetTypeMapping().Converter?.ProviderClrType
+                    ?? columnModification.Property.ClrType);
+                providerClrType = Nullable.GetUnderlyingType(providerClrType) ?? providerClrType;
+
+                if (providerClrType == typeof(bool))
+                    stringBuilder.Append("json(");
+
+                base.AppendUpdateColumnValue(updateSqlGeneratorHelper, columnModification, stringBuilder, name, schema);
+
+                if (providerClrType == typeof(bool))
+                    stringBuilder.Append(")");
+            }
+            else
+            {
+                stringBuilder.Append("json(");
+                base.AppendUpdateColumnValue(updateSqlGeneratorHelper, columnModification, stringBuilder, name, schema);
+                stringBuilder.Append(")");
+            }
+
+            stringBuilder.Append(")");
+        }
+        else
+        {
+            base.AppendUpdateColumnValue(updateSqlGeneratorHelper, columnModification, stringBuilder, name, schema);
+        }
+    }
+
+    private static bool CanUseReturningClause(IReadOnlyModificationCommand command)
+        => command.Table?.IsSqlReturningClauseUsed() == true;
+}

--- a/bindings/dotnet/src/Turso.Tests/Turso.Tests.csproj
+++ b/bindings/dotnet/src/Turso.Tests/Turso.Tests.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="AwesomeAssertions" Version="9.1.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
         <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="9.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="NUnit" Version="4.2.2"/>
         <PackageReference Include="NUnit.Analyzers" Version="4.4.0"/>
@@ -26,5 +27,6 @@
         <ProjectReference Include="..\Turso.Raw\Turso.Raw.csproj" />
         <ProjectReference Include="..\Turso.Data\Turso.Data.csproj" />
         <ProjectReference Include="..\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj" />
+        <ProjectReference Include="..\Turso.EntityFrameworkCore.Sqlite\Turso.EntityFrameworkCore.Sqlite.csproj" />
     </ItemGroup>
 </Project>

--- a/bindings/dotnet/src/Turso.Tests/TursoEfCoreTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoEfCoreTests.cs
@@ -1,0 +1,410 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using System.Text.RegularExpressions;
+using Turso.Data.Sqlite;
+
+namespace Turso.Tests;
+
+public class TursoEfCoreTests
+{
+    [Test]
+    public async Task UseTursoCreatesTursoConnectionAndCreatesSchema()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+
+        await context.Database.EnsureCreatedAsync();
+
+        context.Database.GetDbConnection().Should().BeOfType<SqliteConnection>();
+        (await context.Database.CanConnectAsync()).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task DynamicLinqCompositionMaterializesAsync()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+        await SeedAsync(context);
+
+        const string search = "example";
+        IQueryable<Customer> query = context.Customers;
+        query = query.Where(customer => customer.Name.Contains("a"));
+        query = query.Where(customer => customer.Email.Contains(search));
+
+        var customers = await query
+            .OrderBy(customer => customer.Name)
+            .Skip(0)
+            .Take(2)
+            .ToListAsync();
+
+        customers.Select(customer => customer.Name).Should().Equal("Ada", "Clara");
+    }
+
+    [Test]
+    public void SqlGenerationCoversSqliteLinqFeaturesWithoutOpeningDatabase()
+    {
+        using var database = TemporaryDatabase.Create();
+        using var context = CreateContext(database.ConnectionString);
+
+        context.Customers
+            .Where(customer => EF.Functions.Like(customer.Email, "%@example.com")
+                               && Regex.IsMatch(customer.Name, "(?=A)A"))
+            .ToQueryString()
+            .Should()
+            .Contain("LIKE")
+            .And.Contain("REGEXP");
+
+        context.Orders
+            .Where(order => order.Total + 1m > 10m)
+            .OrderBy(order => order.Total)
+            .ToQueryString()
+            .Should()
+            .Contain("ef_add")
+            .And.Contain("ef_compare")
+            .And.Contain("COLLATE EF_DECIMAL");
+
+        context.Customers
+            .Include(customer => customer.Orders.Where(order => order.Total > 0m))
+            .AsSplitQuery()
+            .ToQueryString()
+            .Should()
+            .Contain("SELECT");
+    }
+
+    [Test]
+    public async Task NavigationPropertiesTranslateToJoins()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+        await SeedAsync(context);
+
+        var rows = await context.Customers
+            .Where(customer => customer.Orders.Any(order => order.Total > 10m))
+            .OrderBy(customer => customer.Name)
+            .Select(customer => new
+            {
+                customer.Name,
+                OrderCount = customer.Orders.Count,
+                Total = customer.Orders.Sum(order => order.Total)
+            })
+            .ToListAsync();
+
+        rows.Select(row => (row.Name, row.OrderCount, row.Total))
+            .Should()
+            .Equal(("Clara", 1, 20.00m));
+    }
+
+    [Test]
+    public async Task IncludeAndSplitQueryMaterializeNavigationCollections()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+        await SeedAsync(context);
+
+        var customers = await context.Customers
+            .Include(customer => customer.Orders.Where(order => order.Total > 0m))
+            .AsSplitQuery()
+            .OrderBy(customer => customer.Name)
+            .ToListAsync();
+
+        customers.Select(customer => (customer.Name, customer.Orders.Count))
+            .Should()
+            .Equal(("Ada", 2), ("Bob", 1), ("Clara", 1));
+    }
+
+    [Test]
+    public async Task RawSqlInterpolatedComposesWithLinq()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+        await SeedAsync(context);
+
+        var customers = await context.Customers
+            .FromSqlInterpolated($"SELECT * FROM Customers WHERE IsActive = {true}")
+            .Where(customer => customer.Email.Contains("example"))
+            .OrderBy(customer => customer.Name)
+            .ToListAsync();
+
+        customers.Select(customer => customer.Name).Should().Equal("Ada", "Clara");
+    }
+
+    [Test]
+    public async Task AggregatesGroupingOrderingAndPagingUseEfSqliteHelpers()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+        await SeedAsync(context);
+
+        var totals = await context.Orders
+            .GroupBy(order => order.CustomerId)
+            .Select(group => new
+            {
+                CustomerId = group.Key,
+                Count = group.Count(),
+                Sum = group.Sum(order => order.Total),
+                Average = group.Average(order => order.Total)
+            })
+            .OrderByDescending(group => group.Sum)
+            .Skip(0)
+            .Take(2)
+            .ToListAsync();
+
+        totals.Select(total => (total.Count, total.Sum, total.Average))
+            .Should()
+            .Equal((1, 20.00m, 20.00m), (2, 12.75m, 6.375m));
+    }
+
+    [Test]
+    public async Task DecimalOrderingUsesNumericCollation()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+
+        context.Orders
+            .OrderBy(order => order.Total)
+            .ToQueryString()
+            .Should()
+            .Contain("COLLATE EF_DECIMAL");
+
+        await context.Database.EnsureCreatedAsync();
+
+        var customer = new Customer { Name = "Frank", Email = "frank@example.com", IsActive = true };
+        context.Orders.AddRange(
+            new Order { Customer = customer, Total = 10m, CreatedAt = new DateTime(2026, 1, 1, 10, 0, 0, DateTimeKind.Utc) },
+            new Order { Customer = customer, Total = 9m, CreatedAt = new DateTime(2026, 1, 2, 10, 0, 0, DateTimeKind.Utc) });
+        await context.SaveChangesAsync();
+
+        var totals = await context.Orders
+            .OrderBy(order => order.Total)
+            .Select(order => order.Total)
+            .ToListAsync();
+
+        totals.Should().Equal(9m, 10m);
+    }
+
+    [Test]
+    public async Task SaveChangesAsyncPreservesHighPrecisionDecimal()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+        await context.Database.EnsureCreatedAsync();
+        const decimal expected = 1234567890123456789012345678m;
+
+        var customer = new Customer { Name = "Grace", Email = "grace@example.com", IsActive = true };
+        context.Orders.Add(new Order
+        {
+            Customer = customer,
+            Total = expected,
+            CreatedAt = new DateTime(2026, 1, 1, 10, 0, 0, DateTimeKind.Utc)
+        });
+        await context.SaveChangesAsync();
+
+        var total = await context.Orders.Select(order => order.Total).SingleAsync();
+
+        total.Should().Be(expected);
+    }
+
+    [Test]
+    public async Task ExecuteUpdateDeleteAndTransactionRollbackWork()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+        await SeedAsync(context);
+
+        var updated = await context.Customers
+            .Where(customer => customer.IsActive)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(customer => customer.IsActive, false));
+        updated.Should().Be(2);
+
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        context.Customers.Add(new Customer { Name = "Helen", Email = "helen@example.com", IsActive = true });
+        await context.SaveChangesAsync();
+        await transaction.RollbackAsync();
+
+        (await context.Customers.CountAsync(customer => customer.Name == "Helen")).Should().Be(0);
+
+        var deleted = await context.Customers
+            .Where(customer => !customer.IsActive)
+            .ExecuteDeleteAsync();
+        deleted.Should().Be(3);
+    }
+
+    [Test]
+    public async Task SaveChangesAsyncInsertsUpdatesAndDeletes()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+        await context.Database.EnsureCreatedAsync();
+
+        var customer = new Customer { Name = "Dora", Email = "dora@example.com", IsActive = true };
+        context.Customers.Add(customer);
+        await context.SaveChangesAsync();
+
+        customer.Id.Should().BeGreaterThan(0);
+
+        customer.Email = "dora.updated@example.com";
+        await context.SaveChangesAsync();
+
+        (await context.Customers.SingleAsync()).Email.Should().Be("dora.updated@example.com");
+
+        context.Customers.Remove(customer);
+        await context.SaveChangesAsync();
+
+        (await context.Customers.CountAsync()).Should().Be(0);
+    }
+
+    [Test]
+    public async Task ExistingTursoConnectionCanBeUsedWithEfCore()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var connection = new SqliteConnection(database.ConnectionString);
+        await using var context = CreateContext(connection);
+
+        await context.Database.EnsureCreatedAsync();
+
+        context.Customers.Add(new Customer { Name = "Eve", Email = "eve@example.com", IsActive = true });
+        await context.SaveChangesAsync();
+
+        (await context.Customers.SingleAsync()).Name.Should().Be("Eve");
+    }
+
+    [Test]
+    public async Task EnsureDeletedRemovesWalSidecarFiles()
+    {
+        using var database = TemporaryDatabase.Create();
+        await using var context = CreateContext(database.ConnectionString);
+        await context.Database.EnsureCreatedAsync();
+        await context.Database.CloseConnectionAsync();
+
+        var walPath = database.Path + "-wal";
+        var shmPath = database.Path + "-shm";
+        await File.WriteAllTextAsync(walPath, "wal");
+        await File.WriteAllTextAsync(shmPath, "shm");
+
+        (await context.Database.EnsureDeletedAsync()).Should().BeTrue();
+
+        File.Exists(database.Path).Should().BeFalse();
+        File.Exists(walPath).Should().BeFalse();
+        File.Exists(shmPath).Should().BeFalse();
+    }
+
+    private static TestDbContext CreateContext(string connectionString)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseTurso(connectionString)
+            .Options;
+
+        return new TestDbContext(options);
+    }
+
+    private static TestDbContext CreateContext(SqliteConnection connection)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseTurso(connection)
+            .Options;
+
+        return new TestDbContext(options);
+    }
+
+    private static async Task SeedAsync(TestDbContext context)
+    {
+        await context.Database.EnsureCreatedAsync();
+
+        var ada = new Customer { Name = "Ada", Email = "ada@example.com", IsActive = true };
+        var bob = new Customer { Name = "Bob", Email = "bob@internal.local", IsActive = false };
+        var clara = new Customer { Name = "Clara", Email = "clara@example.com", IsActive = true };
+
+        context.Customers.AddRange(ada, bob, clara);
+        context.Orders.AddRange(
+            new Order { Customer = ada, Total = 5.50m, CreatedAt = new DateTime(2026, 1, 1, 10, 0, 0, DateTimeKind.Utc) },
+            new Order { Customer = ada, Total = 7.25m, CreatedAt = new DateTime(2026, 1, 2, 10, 0, 0, DateTimeKind.Utc) },
+            new Order { Customer = bob, Total = 3.00m, CreatedAt = new DateTime(2026, 1, 3, 10, 0, 0, DateTimeKind.Utc) },
+            new Order { Customer = clara, Total = 20.00m, CreatedAt = new DateTime(2026, 1, 4, 10, 0, 0, DateTimeKind.Utc) });
+
+        await context.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers => Set<Customer>();
+
+        public DbSet<Order> Orders => Set<Order>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(entity =>
+            {
+                entity.HasKey(customer => customer.Id);
+                entity.Property(customer => customer.Id).ValueGeneratedOnAdd();
+                entity.Property(customer => customer.Name).IsRequired();
+                entity.Property(customer => customer.Email).IsRequired();
+                entity.HasMany(customer => customer.Orders)
+                    .WithOne(order => order.Customer)
+                    .HasForeignKey(order => order.CustomerId);
+            });
+
+            modelBuilder.Entity<Order>(entity =>
+            {
+                entity.HasKey(order => order.Id);
+                entity.Property(order => order.Id).ValueGeneratedOnAdd();
+                entity.Property(order => order.Total).HasColumnType("TEXT");
+                entity.Property(order => order.CreatedAt).IsRequired();
+            });
+        }
+    }
+
+    private sealed class Customer
+    {
+        public long Id { get; set; }
+
+        public string Name { get; set; } = "";
+
+        public string Email { get; set; } = "";
+
+        public bool IsActive { get; set; }
+
+        public List<Order> Orders { get; set; } = [];
+    }
+
+    private sealed class Order
+    {
+        public long Id { get; set; }
+
+        public long CustomerId { get; set; }
+
+        public Customer Customer { get; set; } = null!;
+
+        public decimal Total { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+    }
+
+    private sealed class TemporaryDatabase : IDisposable
+    {
+        private TemporaryDatabase(string path)
+        {
+            Path = path;
+            ConnectionString = $"Data Source={path}";
+        }
+
+        public string Path { get; }
+
+        public string ConnectionString { get; }
+
+        public static TemporaryDatabase Create()
+        {
+            var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName() + ".db");
+            return new TemporaryDatabase(path);
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(Path))
+                File.Delete(Path);
+            if (File.Exists(Path + "-wal"))
+                File.Delete(Path + "-wal");
+            if (File.Exists(Path + "-shm"))
+                File.Delete(Path + "-shm");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Turso.EntityFrameworkCore.Sqlite` local EF Core provider with `UseTurso(...)`.
- Reuse EF Core SQLite translation and replace the Turso-specific relational connection, database creator, query SQL generator, query visitor, and update SQL generator services.
- Add EF provider project/solution/Makefile/test wiring, EF Core tests, and local provider README docs with a remote EF limitation note.

## Tests
- `dotnet build .\bindings\dotnet\src\Turso.EntityFrameworkCore.Sqlite\Turso.EntityFrameworkCore.Sqlite.csproj`
- `dotnet build .\bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj`
- `C:\Users\mamoreau\.cargo\bin\cargo.exe build -p turso_sdk_kit --target-dir .\bindings\dotnet\rs_compiled --target x86_64-pc-windows-msvc`
- `dotnet test .\bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --no-build --filter FullyQualifiedName~TursoEfCoreTests`
- `dotnet test .\bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --no-build --filter FullyQualifiedName~SqliteFacadeTests`

## Caveats
- Native `turso_sdk_kit` needed to be built locally before the .NET tests could load the native asset.
- The provider uses EF Core SQLite internal APIs through the pinned EF Core 9.0.9 package.