### PR TITLE
feat: Implement FULL OUTER JOIN and RIGHT JOIN

### DIFF
--- a/core/translate/desugar.rs
+++ b/core/translate/desugar.rs
@@ -1,0 +1,118 @@
+use crate::Result;
+use turso_parser::ast;
+
+pub fn desugar_outer_joins(select: &mut ast::Select) -> Result<()> {
+    desugar_one_select(&mut select.body.select)?;
+    for compound in &mut select.body.compounds {
+        desugar_one_select(&mut compound.select)?;
+    }
+    Ok(())
+}
+
+fn desugar_one_select(select: &mut ast::OneSelect) -> Result<()> {
+    if let ast::OneSelect::Select { columns, from, .. } = select {
+        if let Some(from_clause) = from {
+            let has_right_join = from_clause.joins.iter().any(|j| {
+                if let ast::JoinOperator::TypedJoin(Some(join_type)) = &j.operator {
+                    join_type.contains(ast::JoinType::RIGHT)
+                } else {
+                    false
+                }
+            });
+
+            if !has_right_join {
+                return Ok(());
+            }
+
+            // Expand Star
+            let mut new_columns = vec![];
+            for col in columns.iter() {
+                if let ast::ResultColumn::Star = col {
+                    let names = get_top_level_table_names(from_clause);
+                    for name in names {
+                        new_columns.push(ast::ResultColumn::TableStar(name));
+                    }
+                } else {
+                    new_columns.push(col.clone());
+                }
+            }
+            *columns = new_columns;
+
+            // Rewrite RIGHT JOIN to LEFT JOIN by folding the joins left-to-right
+            let mut current_select = from_clause.select.clone();
+            let mut current_joins = vec![];
+
+            for join in from_clause.joins.drain(..) {
+                let is_right = if let ast::JoinOperator::TypedJoin(Some(join_type)) = &join.operator {
+                    join_type.contains(ast::JoinType::RIGHT) && !join_type.contains(ast::JoinType::LEFT)
+                } else {
+                    false
+                };
+
+                if is_right {
+                    let new_join_type = ast::JoinType::LEFT | ast::JoinType::OUTER;
+                    let new_operator = ast::JoinOperator::TypedJoin(Some(new_join_type));
+                    
+                    // Group everything accumulated so far
+                    let lhs = if current_joins.is_empty() {
+                        current_select
+                    } else {
+                        Box::new(ast::SelectTable::Sub(
+                            ast::FromClause {
+                                select: current_select,
+                                joins: current_joins,
+                            },
+                            None,
+                        ))
+                    };
+                    
+                    // The RHS becomes the new base select, and we LEFT JOIN the LHS
+                    current_select = join.table.clone();
+                    current_joins = vec![ast::JoinedSelectTable {
+                        operator: new_operator,
+                        table: lhs,
+                        constraint: join.constraint.clone(),
+                    }];
+                } else {
+                    current_joins.push(join);
+                }
+            }
+
+            from_clause.select = current_select;
+            from_clause.joins = current_joins;
+        }
+    }
+    Ok(())
+}
+
+fn get_top_level_table_names(from: &ast::FromClause) -> Vec<ast::Name> {
+    let mut names = vec![];
+    names.push(get_select_table_name(&from.select));
+    for join in &from.joins {
+        names.push(get_select_table_name(&join.table));
+    }
+    names
+}
+
+fn get_select_table_name(table: &ast::SelectTable) -> ast::Name {
+    match table {
+        ast::SelectTable::Table(qname, alias, _) => {
+            alias.as_ref().map(|a| match a {
+                ast::As::As(n) => n.clone(),
+                ast::As::Elided(n) => n.clone(),
+            }).unwrap_or_else(|| qname.name.clone())
+        }
+        ast::SelectTable::TableCall(qname, _, alias) => {
+            alias.as_ref().map(|a| match a {
+                ast::As::As(n) => n.clone(),
+                ast::As::Elided(n) => n.clone(),
+            }).unwrap_or_else(|| qname.name.clone())
+        }
+        ast::SelectTable::Select(_, alias) | ast::SelectTable::Sub(_, alias) => {
+            alias.as_ref().map(|a| match a {
+                ast::As::As(n) => n.clone(),
+                ast::As::Elided(n) => n.clone(),
+            }).unwrap_or_else(|| ast::Name::exact("subquery".to_string()))
+        }
+    }
+}

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -17,7 +17,8 @@ use super::group_by::{
     group_by_agg_phase, group_by_emit_row_phase, init_group_by, GroupByMetadata, GroupByRowSource,
 };
 use super::main_loop::{
-    close_loop, emit_loop, init_distinct, init_loop, open_loop, LeftJoinMetadata, LoopLabels,
+    close_loop, emit_loop, init_distinct, init_loop, open_loop,
+    FullJoinMetadata, LeftJoinMetadata, LoopLabels,
 };
 use super::order_by::{emit_order_by, init_order_by, SortMetadata};
 use super::plan::{
@@ -279,6 +280,9 @@ pub struct TranslateCtx<'a> {
     /// mapping between table loop index and associated metadata (for left joins only)
     /// this metadata exists for the right table in a given left join
     pub meta_left_joins: Vec<Option<LeftJoinMetadata>>,
+    /// mapping between table loop index and associated metadata (for full outer joins)
+    /// this metadata exists for the right table in a given full outer join
+    pub meta_full_joins: Vec<Option<FullJoinMetadata>>,
     pub resolver: Resolver<'a>,
     /// Hash table contexts for hash joins, keyed by build table index.
     pub hash_table_contexts: HashMap<usize, HashCtx>,
@@ -320,6 +324,7 @@ impl<'a> TranslateCtx<'a> {
             reg_result_cols_start: None,
             meta_group_by: None,
             meta_left_joins: (0..table_count).map(|_| None).collect(),
+            meta_full_joins: (0..table_count).map(|_| None).collect(),
             meta_sort: None,
             hash_table_contexts: HashMap::default(),
             materialized_build_inputs: HashMap::default(),
@@ -1297,6 +1302,81 @@ pub fn emit_query<'a>(
         &plan.join_order,
         OperationMode::SELECT,
     )?;
+
+    // Handle FULL OUTER JOIN secondary loops to emit unmatched rows from the right tables
+    for (table_index, table) in plan.table_references.joined_tables().iter().enumerate() {
+        if let Some(join_info) = table.join_info.as_ref() {
+            if join_info.is_full {
+                let fj_meta = t_ctx.meta_full_joins[table_index].as_ref().unwrap();
+                let loop_start = program.allocate_label();
+                let loop_end = program.allocate_label();
+
+                // 1. For all tables before this one, emit NullRow so they output NULLs
+                for i in 0..table_index {
+                    let prior_table = &plan.table_references.joined_tables()[i];
+                    let cursor_id = program.resolve_cursor_id_safe(&crate::vdbe::builder::CursorKey::table(prior_table.internal_id)).unwrap();
+                    program.emit_insn(Insn::NullRow { cursor_id });
+                }
+
+                // 2. Rewind the right table cursor
+                let rhs_cursor_id = program.resolve_cursor_id_safe(&crate::vdbe::builder::CursorKey::table(table.internal_id)).unwrap();
+                program.emit_insn(Insn::Rewind {
+                    cursor_id: rhs_cursor_id,
+                    pc_if_empty: loop_end,
+                });
+
+                // 3. Loop start
+                program.preassign_label_to_next_insn(loop_start);
+
+                // 4. Check if the rowid is in the ephemeral cursor
+                let reg_rowid = program.alloc_register();
+                program.emit_insn(Insn::RowId {
+                    cursor_id: rhs_cursor_id,
+                    dest: reg_rowid,
+                });
+                
+                let label_next = program.allocate_label();
+                program.emit_insn(Insn::Found {
+                    cursor_id: fj_meta.ephemeral_cursor_id,
+                    target_pc: label_next,
+                    record_reg: reg_rowid,
+                    num_regs: 1,
+                });
+
+                // 5. Evaluate WHERE clause!
+                // We evaluate ALL predicates for this row, but SKIP inner join conditions
+                // since the left side of the join is completely missing (we are generating NULLs for them).
+                for j_idx in 0..plan.join_order.len() {
+                    crate::translate::main_loop::emit_conditions(
+                        program,
+                        &t_ctx,
+                        &plan.table_references,
+                        &plan.join_order,
+                        &plan.where_clause,
+                        j_idx,
+                        label_next,
+                        false,
+                        false, // evaluate_join_conditions = false
+                        &mut [],
+                        crate::translate::main_loop::SubqueryRefFilter::All,
+                    )?;
+                }
+
+                // 6. Emit the result row (projection / aggregate / sorter)
+                crate::translate::main_loop::emit_loop(program, t_ctx, plan)?;
+
+                // 7. Advance right table loop
+                program.preassign_label_to_next_insn(label_next);
+                program.emit_insn(Insn::Next {
+                    cursor_id: rhs_cursor_id,
+                    pc_if_next: loop_start,
+                });
+                
+                // 8. End of loop
+                program.preassign_label_to_next_insn(loop_end);
+            }
+        }
+    }
 
     program.preassign_label_to_next_insn(after_main_loop_label);
 

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -58,6 +58,13 @@ pub struct LeftJoinMetadata {
     pub label_match_flag_check_value: BranchOffset,
 }
 
+// Metadata for handling FULL OUTER JOIN operations
+#[derive(Debug)]
+pub struct FullJoinMetadata {
+    // cursor to an ephemeral index that tracks the rowids of the right table that have been matched
+    pub ephemeral_cursor_id: CursorID,
+}
+
 /// Jump labels for each loop in the query's main execution loop
 #[derive(Debug, Clone, Copy)]
 pub struct LoopLabels {
@@ -170,6 +177,34 @@ pub fn init_loop(
                     label_match_flag_check_value: program.allocate_label(),
                 };
                 t_ctx.meta_left_joins[table_index] = Some(lj_metadata);
+            }
+            if join_info.is_full {
+                let ephemeral_index = std::sync::Arc::new(crate::schema::Index {
+                    columns: vec![crate::schema::IndexColumn {
+                        name: "rowid".to_string(),
+                        order: turso_parser::ast::SortOrder::Asc,
+                        pos_in_table: 0,
+                        collation: None,
+                        default: None,
+                        expr: None,
+                    }],
+                    ephemeral: true,
+                    table_name: String::new(),
+                    name: String::new(),
+                    root_page: 0,
+                    unique: false,
+                    has_rowid: false,
+                    where_clause: None,
+                    index_method: None,
+                });
+                let ephemeral_cursor_id = program.alloc_cursor_id(crate::vdbe::builder::CursorType::BTreeIndex(ephemeral_index));
+                program.emit_insn(Insn::OpenEphemeral {
+                    cursor_id: ephemeral_cursor_id,
+                    is_table: false, // index to track matched rowids
+                });
+                t_ctx.meta_full_joins[table_index] = Some(FullJoinMetadata {
+                    ephemeral_cursor_id,
+                });
             }
         }
         let (table_cursor_id, index_cursor_id) =
@@ -1434,6 +1469,7 @@ pub fn open_loop(
                     hash_table_id,
                 )?;
 
+
                 let num_keys = hash_join_op.join_keys.len();
 
                 // Hash Table Probe Phase
@@ -1611,6 +1647,7 @@ pub fn open_loop(
             join_index,
             condition_fail_target,
             true,
+            true, // evaluate_join_conditions = true
             subqueries,
             SubqueryRefFilter::All,
         )?;
@@ -1628,6 +1665,35 @@ pub fn open_loop(
                     dest: lj_meta.reg_match_flag,
                 });
             }
+            if join_info.is_full {
+                let fj_meta = t_ctx.meta_full_joins[joined_table_index].as_ref().unwrap();
+                let table_cursor_id = program
+                    .resolve_cursor_id_safe(&crate::vdbe::builder::CursorKey::table(table.internal_id))
+                    .expect("table cursor should be open");
+                
+                let reg_rowid = program.alloc_register();
+                program.emit_insn(Insn::RowId {
+                    cursor_id: table_cursor_id,
+                    dest: reg_rowid,
+                });
+                
+                let record_reg = program.alloc_register();
+                program.emit_insn(Insn::MakeRecord {
+                    start_reg: reg_rowid as u16,
+                    count: 1,
+                    dest_reg: record_reg as u16,
+                    index_name: None,
+                    affinity_str: None,
+                });
+
+                program.emit_insn(Insn::IdxInsert {
+                    cursor_id: fj_meta.ephemeral_cursor_id,
+                    record_reg,
+                    unpacked_start: Some(reg_rowid),
+                    unpacked_count: Some(1),
+                    flags: crate::vdbe::insn::IdxInsertFlags::default(),
+                });
+            }
         }
 
         // emit conditions that do not reference subquery results
@@ -1640,6 +1706,7 @@ pub fn open_loop(
             join_index,
             condition_fail_target,
             false,
+            true, // evaluate_join_conditions = true
             subqueries,
             SubqueryRefFilter::WithoutSubqueryRefs,
         )?;
@@ -1674,6 +1741,7 @@ pub fn open_loop(
             join_index,
             condition_fail_target,
             false,
+            true, // evaluate_join_conditions = true
             subqueries,
             SubqueryRefFilter::WithSubqueryRefs,
         )?;
@@ -1708,18 +1776,15 @@ fn condition_references_subquery(expr: &Expr, subqueries: &[NonFromClauseSubquer
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum SubqueryRefFilter {
-    /// Emit all conditions regardless of subquery references
+pub enum SubqueryRefFilter {
     All,
-    /// Only emit conditions that do NOT reference subqueries (for early evaluation)
-    WithoutSubqueryRefs,
-    /// Only emit conditions that DO reference subqueries (for late evaluation)
     WithSubqueryRefs,
+    WithoutSubqueryRefs,
 }
 
 #[allow(clippy::too_many_arguments)]
 /// Emits WHERE/ON predicates that must be evaluated at the current join loop.
-fn emit_conditions(
+pub fn emit_conditions(
     program: &mut ProgramBuilder,
     t_ctx: &&mut TranslateCtx,
     table_references: &TableReferences,
@@ -1728,11 +1793,13 @@ fn emit_conditions(
     join_index: usize,
     next: BranchOffset,
     from_outer_join: bool,
+    evaluate_join_conditions: bool,
     subqueries: &[NonFromClauseSubquery],
     subquery_ref_filter: SubqueryRefFilter,
 ) -> Result<()> {
     for cond in predicates
         .iter()
+        .filter(|cond| evaluate_join_conditions || !cond.is_join_condition)
         .filter(|cond| cond.from_outer_join.is_some() == from_outer_join)
         .filter(|cond| {
             cond.should_eval_at_loop(join_index, join_order, subqueries, Some(table_references))

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod attach;
 pub(crate) mod collate;
 mod compound_select;
 pub(crate) mod delete;
+pub(crate) mod desugar;
 pub(crate) mod display;
 pub(crate) mod emitter;
 pub(crate) mod expr;

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -2031,7 +2031,7 @@ mod tests {
             _create_table_reference(
                 t2,
                 Some(JoinInfo {
-                    outer: false,
+                    outer: false, is_full: false,
                     using: vec![],
                 }),
                 table_id_counter.next(),
@@ -2154,7 +2154,7 @@ mod tests {
             _create_table_reference(
                 table_customers,
                 Some(JoinInfo {
-                    outer: false,
+                    outer: false, is_full: false,
                     using: vec![],
                 }),
                 table_id_counter.next(),
@@ -2162,7 +2162,7 @@ mod tests {
             _create_table_reference(
                 table_order_items,
                 Some(JoinInfo {
-                    outer: false,
+                    outer: false, is_full: false,
                     using: vec![],
                 }),
                 table_id_counter.next(),
@@ -2364,7 +2364,7 @@ mod tests {
             _create_table_reference(
                 t2,
                 Some(JoinInfo {
-                    outer: false,
+                    outer: false, is_full: false,
                     using: vec![],
                 }),
                 table_id_counter.next(),
@@ -2372,7 +2372,7 @@ mod tests {
             _create_table_reference(
                 t3,
                 Some(JoinInfo {
-                    outer: false,
+                    outer: false, is_full: false,
                     using: vec![],
                 }),
                 table_id_counter.next(),
@@ -2487,7 +2487,7 @@ mod tests {
                 _create_table_reference(
                     t.clone(),
                     Some(JoinInfo {
-                        outer: false,
+                        outer: false, is_full: false,
                         using: vec![],
                     }),
                     table_id_counter.next(),
@@ -2496,7 +2496,7 @@ mod tests {
             refs.push(_create_table_reference(
                 fact_table,
                 Some(JoinInfo {
-                    outer: false,
+                    outer: false, is_full: false,
                     using: vec![],
                 }),
                 table_id_counter.next(),
@@ -2759,6 +2759,7 @@ mod tests {
                 Box::new(Expr::Literal(ast::Literal::Numeric(5.to_string()))),
             ),
             from_outer_join: None,
+            is_join_condition: false,
             consumed: false,
         }];
 
@@ -2875,6 +2876,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(5.to_string()))),
                 ),
                 from_outer_join: None,
+            is_join_condition: false,
                 consumed: false,
             },
             WhereTerm {
@@ -2889,6 +2891,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(7.to_string()))),
                 ),
                 from_outer_join: None,
+            is_join_condition: false,
                 consumed: false,
             },
         ];
@@ -3010,6 +3013,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(5.to_string()))),
                 ),
                 from_outer_join: None,
+            is_join_condition: false,
                 consumed: false,
             },
             WhereTerm {
@@ -3024,6 +3028,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(10.to_string()))),
                 ),
                 from_outer_join: None,
+            is_join_condition: false,
                 consumed: false,
             },
             WhereTerm {
@@ -3038,6 +3043,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(7.to_string()))),
                 ),
                 from_outer_join: None,
+            is_join_condition: false,
                 consumed: false,
             },
         ];
@@ -3178,6 +3184,7 @@ mod tests {
         WhereTerm {
             expr: Expr::Binary(Box::new(lhs), op, Box::new(rhs)),
             from_outer_join: None,
+            is_join_condition: false,
             consumed: false,
         }
     }
@@ -3224,7 +3231,7 @@ mod tests {
             _create_table_reference(
                 t2,
                 Some(JoinInfo {
-                    outer: false,
+                    outer: false, is_full: false,
                     using: vec![],
                 }),
                 table_id_counter.next(),

--- a/core/translate/optimizer/lift_common_subexpressions.rs
+++ b/core/translate/optimizer/lift_common_subexpressions.rs
@@ -125,6 +125,7 @@ pub(crate) fn lift_common_subexpressions_from_binary_or_terms(
             where_clause.push(WhereTerm {
                 expr: common_expr_to_add,
                 from_outer_join: term_from_outer_join,
+                is_join_condition: false,
                 consumed: false,
             });
         }
@@ -258,6 +259,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr,
             from_outer_join: None,
+            is_join_condition: false,
             consumed: false,
         }];
 
@@ -360,6 +362,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr,
             from_outer_join: None,
+            is_join_condition: false,
             consumed: false,
         }];
 
@@ -427,6 +430,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr.clone(),
             from_outer_join: None,
+            is_join_condition: false,
             consumed: false,
         }];
 
@@ -496,6 +500,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr,
             from_outer_join: Some(TableInternalId::default()), // Set from_outer_join
+            is_join_condition: false,
             consumed: false,
         }];
 
@@ -548,6 +553,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: single_expr.clone(),
             from_outer_join: None,
+            is_join_condition: false,
             consumed: false,
         }];
 
@@ -597,6 +603,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr,
             from_outer_join: None,
+            is_join_condition: false,
             consumed: false,
         }];
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -134,6 +134,10 @@ pub struct WhereTerm {
     /// right-side table of the OUTER JOIN (in this case, s). When evaluating conditions, if [WhereTerm::from_outer_join]
     /// is set, we force evaluation to happen during that table's loop.
     pub from_outer_join: Option<TableInternalId>,
+    /// Whether the condition came from a JOIN constraint (ON or USING) as opposed to a WHERE clause.
+    /// This is used during FULL OUTER JOIN unmatched row emission to avoid filtering out unmatched rows
+    /// using inner join constraints that were intended for the left side of the join.
+    pub is_join_condition: bool,
     /// Whether the condition has been consumed by the optimizer in some way, and it should not be evaluated
     /// in the normal place where WHERE terms are evaluated.
     /// A term may have been consumed e.g. if:
@@ -189,6 +193,7 @@ impl From<Expr> for WhereTerm {
         Self {
             expr: value,
             from_outer_join: None,
+            is_join_condition: false,
             consumed: false,
         }
     }
@@ -660,6 +665,8 @@ pub fn select_star(tables: &[JoinedTable], out_columns: &mut Vec<ResultSetColumn
 pub struct JoinInfo {
     /// Whether this is an OUTER JOIN.
     pub outer: bool,
+    /// Whether this is a FULL OUTER JOIN.
+    pub is_full: bool,
     /// The USING clause for the join, if any. NATURAL JOIN is transformed into USING (col1, col2, ...).
     pub using: Vec<ast::Name>,
 }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1638,19 +1638,20 @@ fn parse_join(
         connection,
     )?;
 
-    let (outer, natural) = match join_operator {
+    let (outer, is_full, natural) = match join_operator {
         ast::JoinOperator::TypedJoin(Some(join_type)) => {
-            if join_type.contains(JoinType::RIGHT) {
+            let is_outer = join_type.contains(JoinType::OUTER);
+            let is_full = join_type.contains(JoinType::LEFT | JoinType::RIGHT);
+            if join_type.contains(JoinType::RIGHT) && !is_full {
                 crate::bail_parse_error!("RIGHT JOIN is not supported");
             }
             if join_type.contains(JoinType::CROSS) {
                 crate::bail_parse_error!("CROSS JOIN is not supported");
             }
-            let is_outer = join_type.contains(JoinType::OUTER);
             let is_natural = join_type.contains(JoinType::NATURAL);
-            (is_outer, is_natural)
+            (is_outer, is_full, is_natural)
         }
-        _ => (false, false),
+        _ => (false, false, false),
     };
 
     if natural && constraint.is_some() {
@@ -1727,6 +1728,7 @@ fn parse_join(
                     } else {
                         None
                     };
+                    predicate.is_join_condition = true;
                     bind_and_rewrite_expr(
                         &mut predicate.expr,
                         Some(table_references),
@@ -1813,6 +1815,7 @@ fn parse_join(
                         } else {
                             None
                         },
+                        is_join_condition: true,
                         consumed: false,
                     });
                 }
@@ -1827,7 +1830,7 @@ fn parse_join(
         .joined_tables_mut()
         .get_mut(last_idx)
         .unwrap();
-    rightmost_table.join_info = Some(JoinInfo { outer, using });
+    rightmost_table.join_info = Some(JoinInfo { outer, is_full, using });
 
     Ok(())
 }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -91,13 +91,14 @@ pub fn translate_select(
 }
 
 pub fn prepare_select_plan(
-    select: ast::Select,
+    mut select: ast::Select,
     resolver: &Resolver,
     program: &mut ProgramBuilder,
     outer_query_refs: &[OuterQueryReference],
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<Plan> {
+    crate::translate::desugar::desugar_outer_joins(&mut select)?;
     let compounds = select.body.compounds;
     match compounds.is_empty() {
         true => Ok(Plan::Select(prepare_one_select_plan(
@@ -741,6 +742,7 @@ fn add_vtab_predicates_to_where_clause(
         plan.where_clause.push(WhereTerm {
             expr,
             from_outer_join,
+            is_join_condition: false,
             consumed: false,
         });
     }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1097,6 +1097,9 @@ pub fn emit_from_clause_subquery(
                 meta_left_joins: (0..select_plan.joined_tables().len())
                     .map(|_| None)
                     .collect(),
+                meta_full_joins: (0..select_plan.joined_tables().len())
+                    .map(|_| None)
+                    .collect(),
                 meta_sort: None,
                 reg_agg_start: None,
                 reg_nonagg_emit_once_flag: None,
@@ -1194,6 +1197,9 @@ fn emit_materialized_cte(
                 meta_left_joins: (0..select_plan.joined_tables().len())
                     .map(|_| None)
                     .collect(),
+                meta_full_joins: (0..select_plan.joined_tables().len())
+                    .map(|_| None)
+                    .collect(),
                 meta_sort: None,
                 reg_agg_start: None,
                 reg_nonagg_emit_once_flag: None,
@@ -1277,6 +1283,9 @@ fn emit_indexed_materialized_subquery(
                 label_main_loop_end: None,
                 meta_group_by: None,
                 meta_left_joins: (0..select_plan.joined_tables().len())
+                    .map(|_| None)
+                    .collect(),
+                meta_full_joins: (0..select_plan.joined_tables().len())
                     .map(|_| None)
                     .collect(),
                 meta_sort: None,

--- a/testing/runner/tests/issue_5908.sqltest
+++ b/testing/runner/tests/issue_5908.sqltest
@@ -1,0 +1,31 @@
+@database :memory:
+
+setup basic {
+    CREATE TABLE t1(a INTEGER, b INTEGER);
+    CREATE TABLE t2(c INTEGER, d INTEGER);
+    INSERT INTO t1 VALUES (1, 10);
+    INSERT INTO t1 VALUES (2, 20);
+    INSERT INTO t2 VALUES (1, 100);
+    INSERT INTO t2 VALUES (3, 300);
+}
+
+@setup basic
+test test1 {
+    SELECT * FROM t1 RIGHT JOIN t2 ON t1.a = t2.c;
+}
+expect {
+    1|10|1|100
+    ||3|300
+}
+
+@setup basic
+test test2 {
+    SELECT t2.c, t1.a FROM t1 RIGHT JOIN t2 ON t1.a = t2.c;
+}
+expect {
+    1|1
+    3|
+}
+
+
+

--- a/testing/runner/tests/join/memory.sqltest
+++ b/testing/runner/tests/join/memory.sqltest
@@ -394,7 +394,6 @@ expect {
     3|3
 }
 
-@skip-if sqlite "sqlite supports full outer joins"
 test full-outer-join {
 	create table t(a);
 	create table u(a);
@@ -402,7 +401,10 @@ test full-outer-join {
 	insert into u values (2), (3);
 	select coalesce(t.a, u.a) as a from t full outer join u using(a) order by a;
 }
-expect error {
+expect {
+	1
+	2
+	3
 }
 
 # Regression test for LEFT JOIN + materialized subquery bug


### PR DESCRIPTION
This PR implements `FULL OUTER JOIN` and `RIGHT JOIN` support.

### Changes
- **Parser & Planner**: Allowed `RIGHT JOIN` syntax natively. `FULL OUTER JOIN` is parsed properly.
- **Desugaring**: `RIGHT JOIN` is gracefully desugared into `LEFT JOIN` by swapping the left and right tables in `desugar_outer_joins`, preserving VDBE compatibility.
- **VDBE Execution (`FULL OUTER JOIN`)**:
  - Implemented an ephemeral index to keep track of matched rows from the right table during the initial join loop in `main_loop.rs`.
  - Added a secondary post-loop over the right table in `emitter.rs`. For each row, we query the ephemeral index (`Found`) using the row's `rowid`.
  - Unmatched rows are emitted with the left side fields padded as `NULL`.

Fixes #5908
Fixes #5788