### PR TITLE
core: allow deterministic date functions in generated columns

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4024,6 +4024,7 @@ fn is_unsafe_datetime_modifier(expr: &Expr) -> bool {
 fn string_literal_eq(value: &str, expected: &str) -> bool {
     value.trim_matches('\'').eq_ignore_ascii_case(expected)
 }
+
 pub(crate) fn validate_generated_expr(expr: &Expr) -> Result<()> {
     use ast::Expr;
     match expr {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,7 +1,7 @@
 use crate::alloc::vec;
 use crate::alloc::TursoFromIterator;
 use crate::alloc::*;
-use crate::function::{Deterministic, Func};
+use crate::function::{Deterministic, Func, ScalarFunc};
 use crate::incremental::view::IncrementalView;
 use crate::incremental::{compiler::DBSP_CIRCUIT_VERSION, operator::create_dbsp_state_index};
 use crate::index_method::{IndexMethodAttachment, IndexMethodConfiguration};
@@ -3956,6 +3956,74 @@ pub fn render_gencol_expr_sql_with_new_names(expr: &Expr, columns: &[Column]) ->
     Ok(clone.to_string())
 }
 
+pub(crate) fn is_deterministic_schema_function_call(func: &Func, args: &[Box<Expr>]) -> bool {
+    match func {
+        Func::Scalar(
+            ScalarFunc::Date
+            | ScalarFunc::Time
+            | ScalarFunc::DateTime
+            | ScalarFunc::UnixEpoch
+            | ScalarFunc::JulianDay
+            | ScalarFunc::StrfTime
+            | ScalarFunc::TimeDiff,
+        ) => is_deterministic_datetime_call(func, args),
+        _ => func.is_deterministic(),
+    }
+}
+
+// SQLite allows date/time functions in schema-persistent expressions only when
+// they do not depend on the current clock or local timezone. This applies to
+// expression indexes, partial index WHERE clauses, and generated columns.
+fn is_deterministic_datetime_call(func: &Func, args: &[Box<Expr>]) -> bool {
+    match func {
+        Func::Scalar(ScalarFunc::Date)
+        | Func::Scalar(ScalarFunc::Time)
+        | Func::Scalar(ScalarFunc::DateTime)
+        | Func::Scalar(ScalarFunc::UnixEpoch)
+        | Func::Scalar(ScalarFunc::JulianDay) => {
+            !args.is_empty()
+                && !is_current_time_expr(args[0].as_ref())
+                && !args[1..]
+                    .iter()
+                    .any(|arg| is_unsafe_datetime_modifier(arg.as_ref()))
+        }
+        Func::Scalar(ScalarFunc::StrfTime) => {
+            args.len() >= 2
+                && !is_current_time_expr(args[1].as_ref())
+                && !args[2..]
+                    .iter()
+                    .any(|arg| is_unsafe_datetime_modifier(arg.as_ref()))
+        }
+        Func::Scalar(ScalarFunc::TimeDiff) => {
+            !args.iter().any(|arg| is_current_time_expr(arg.as_ref()))
+        }
+        _ => unreachable!("non-datetime function passed to datetime index validator"),
+    }
+}
+
+fn is_current_time_expr(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Literal(ast::Literal::String(value)) if string_literal_eq(value, "now")
+    ) || matches!(
+        expr,
+        Expr::Literal(
+            ast::Literal::CurrentDate | ast::Literal::CurrentTime | ast::Literal::CurrentTimestamp
+        )
+    )
+}
+
+fn is_unsafe_datetime_modifier(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Literal(ast::Literal::String(value))
+            if string_literal_eq(value, "localtime") || string_literal_eq(value, "utc")
+    ) || is_current_time_expr(expr)
+}
+
+fn string_literal_eq(value: &str, expected: &str) -> bool {
+    value.trim_matches('\'').eq_ignore_ascii_case(expected)
+}
 pub(crate) fn validate_generated_expr(expr: &Expr) -> Result<()> {
     use ast::Expr;
     match expr {
@@ -3993,7 +4061,7 @@ pub(crate) fn validate_generated_expr(expr: &Expr) -> Result<()> {
             if matches!(func, Func::Agg(_)) {
                 bail_parse_error!("aggregate functions prohibited in generated columns");
             }
-            if !func.is_deterministic() {
+            if !is_deterministic_schema_function_call(&func, args) {
                 bail_parse_error!("non-deterministic functions prohibited in generated columns");
             }
             for arg in args {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,6 +1,6 @@
 use crate::alloc::TursoIteratorExt;
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
-use crate::function::{Deterministic, Func, ScalarFunc};
+use crate::function::Func;
 use crate::index_method::IndexMethodConfiguration;
 use crate::numeric::Numeric;
 use crate::schema::{Column, GeneratedType, Table, EXPR_INDEX_SENTINEL, RESERVED_TABLE_PREFIXES};
@@ -22,7 +22,10 @@ use crate::vdbe::builder::{CursorKey, ProgramBuilderOpts, SelfTableContext};
 use crate::vdbe::insn::{to_u16, CmpInsFlags, Cookie};
 use crate::{bail_parse_error, CaptureDataChangesExt, LimboError, MAIN_DB_ID, TEMP_DB_ID};
 use crate::{
-    schema::{BTreeTable, Index, IndexColumn, PseudoCursorType, SchemaObjectType},
+    schema::{
+        is_deterministic_schema_function_call, BTreeTable, Index, IndexColumn, PseudoCursorType,
+        SchemaObjectType,
+    },
     storage::pager::CreateBTreeFlags,
     util::{escape_sql_string_literal, normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX},
     vdbe::{
@@ -1018,7 +1021,7 @@ fn validate_index_expression(expr: &Expr, table: &BTreeTable) -> bool {
     let is_deterministic_fn = |name: &str, args: &[Box<Expr>]| {
         let n = normalize_ident(name);
         Func::resolve_function(&n, args.len())
-            .is_ok_and(|f| f.is_some_and(|f| is_valid_index_function_call(&f, args)))
+            .is_ok_and(|f| f.is_some_and(|f| is_deterministic_schema_function_call(&f, args)))
     };
 
     let mut ok = true;
@@ -1087,74 +1090,6 @@ fn validate_index_expression(expr: &Expr, table: &BTreeTable) -> bool {
         })
     });
     ok
-}
-
-fn is_valid_index_function_call(func: &Func, args: &[Box<Expr>]) -> bool {
-    match func {
-        Func::Scalar(
-            ScalarFunc::Date
-            | ScalarFunc::Time
-            | ScalarFunc::DateTime
-            | ScalarFunc::UnixEpoch
-            | ScalarFunc::JulianDay
-            | ScalarFunc::StrfTime
-            | ScalarFunc::TimeDiff,
-        ) => is_deterministic_datetime_index_call(func, args),
-        _ => func.is_deterministic(),
-    }
-}
-
-// SQLite allows date/time functions in expression indexes only when they do not
-// depend on the current clock or local timezone.
-fn is_deterministic_datetime_index_call(func: &Func, args: &[Box<Expr>]) -> bool {
-    match func {
-        Func::Scalar(ScalarFunc::Date)
-        | Func::Scalar(ScalarFunc::Time)
-        | Func::Scalar(ScalarFunc::DateTime)
-        | Func::Scalar(ScalarFunc::UnixEpoch)
-        | Func::Scalar(ScalarFunc::JulianDay) => {
-            !args.is_empty()
-                && !is_current_time_expr(args[0].as_ref())
-                && !args[1..]
-                    .iter()
-                    .any(|arg| is_unsafe_datetime_modifier(arg.as_ref()))
-        }
-        Func::Scalar(ScalarFunc::StrfTime) => {
-            args.len() >= 2
-                && !is_current_time_expr(args[1].as_ref())
-                && !args[2..]
-                    .iter()
-                    .any(|arg| is_unsafe_datetime_modifier(arg.as_ref()))
-        }
-        Func::Scalar(ScalarFunc::TimeDiff) => {
-            !args.iter().any(|arg| is_current_time_expr(arg.as_ref()))
-        }
-        _ => unreachable!("non-datetime function passed to datetime index validator"),
-    }
-}
-
-fn is_current_time_expr(expr: &Expr) -> bool {
-    matches!(
-        expr,
-        Expr::Literal(ast::Literal::String(value)) if string_literal_eq(value, "now")
-    ) || matches!(
-        expr,
-        Expr::Literal(
-            ast::Literal::CurrentDate | ast::Literal::CurrentTime | ast::Literal::CurrentTimestamp
-        )
-    )
-}
-
-fn is_unsafe_datetime_modifier(expr: &Expr) -> bool {
-    matches!(
-        expr,
-        Expr::Literal(ast::Literal::String(value))
-            if string_literal_eq(value, "localtime") || string_literal_eq(value, "utc")
-    ) || is_current_time_expr(expr)
-}
-
-fn string_literal_eq(value: &str, expected: &str) -> bool {
-    value.trim_matches('\'').eq_ignore_ascii_case(expected)
 }
 
 fn emit_index_column_value_from_cursor(

--- a/testing/sqltests/tests/create_index.sqltest
+++ b/testing/sqltests/tests/create_index.sqltest
@@ -223,6 +223,19 @@ test create-index-strftime-now-remains-rejected {
 expect error {
 }
 
+@cross-check-integrity
+test create-index-date-literal {
+    CREATE TABLE logs("created" TEXT NOT NULL);
+    CREATE INDEX idx_logs_date_literal ON logs(date('2020-01-02'));
+    INSERT INTO logs VALUES ('2024-01-01 12:34:56');
+    SELECT name
+    FROM sqlite_schema
+    WHERE type = 'index' AND name = 'idx_logs_date_literal';
+}
+expect {
+    idx_logs_date_literal
+}
+
 # Multiple columns where one is a string literal not matching any column should fail.
 # SQLite error: "no such column: literal"
 @cross-check-integrity

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -3890,6 +3890,15 @@ expect error {
     non-deterministic functions prohibited in generated columns
 }
 
+test gencol_deterministic_date_function {
+    CREATE TABLE t_issue_7061(a, b AS (date('2020-01-02')));
+    INSERT INTO t_issue_7061(a) VALUES(1);
+    SELECT b FROM t_issue_7061;
+}
+expect {
+    2020-01-02
+}
+
 # SQLite defers the error to the INSERT for these functions.
 test gencol_error_nondeterministic_datetime {
     CREATE TABLE t5(a INT, b TEXT GENERATED ALWAYS AS (datetime('now')));


### PR DESCRIPTION
## Description

This fixes generated column validation to use the same argument-sensitive determinism check that expression indexes already used.

I moved the helper function used by expression indexes into `core/schema.rs` so it can be shared between expression index and generated column validation.

## Motivation and context
Fixes #7061


## Description of AI Usage
Used to generate tests
