### PR TITLE
refresh mvcc schema for checkpoint state machine when it acquires checkpoint lock

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -159,6 +159,8 @@ pub struct CheckpointStateMachine<Clock: LogicalClock, A: ConcurrentAllocator = 
     mvstore: Arc<MvStore<Clock, A>>,
     /// Connection to the database
     connection: Arc<Connection>,
+    /// Database whose pager and schema this checkpoint is writing.
+    database_id: usize,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
     /// Lock used to block other transactions from running during the checkpoint
@@ -620,6 +622,38 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         self.durable_txid_max_new = durable_tx_max;
     }
 
+    fn refresh_schema_metadata(&mut self) {
+        // Use the shared DB schema (not the per-connection cache, which may be
+        // stale) for the database whose pager we're checkpointing. Unlike WAL
+        // mode, MVCC checkpoint writes from the mv store back to the pager, so
+        // the schema must match the pager being checkpointed.
+        let schema = self.connection.clone_shared_schema(self.database_id);
+        self.index_id_to_index = schema
+            .indexes
+            .values()
+            .flatten()
+            .map(|index| {
+                turso_assert!(index.root_page != 0, "index root_page must be non-zero");
+                (
+                    self.mvstore.get_table_id_from_root_page(index.root_page),
+                    index.clone(),
+                )
+            })
+            .collect();
+        self.mvcc_meta_table = schema.get_btree_table(MVCC_META_TABLE_NAME).map(|table| {
+            turso_assert!(
+                table.root_page != 0,
+                "mvcc meta table root_page must be non-zero"
+            );
+            (
+                self.mvstore.get_table_id_from_root_page(table.root_page),
+                table.columns().len(),
+            )
+        });
+        self.durable_mvcc_metadata =
+            !self.connection.db.is_in_memory_db() && self.mvcc_meta_table.is_some();
+    }
+
     pub fn new(
         pager: Arc<Pager>,
         mvstore: Arc<MvStore<Clock, A>>,
@@ -629,39 +663,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         database_id: usize,
     ) -> Self {
         let checkpoint_lock = mvstore.blocking_checkpoint_lock.clone();
-        // Use the shared DB schema (not the per-connection cache, which may be
-        // stale) for the database whose pager we're checkpointing. Unlike WAL
-        // mode, MVCC checkpoint writes from the mv store back to the pager —
-        // so the schema must match the pager being checkpointed.
-        let schema = connection.clone_shared_schema(database_id);
-        let index_id_to_index = schema
-            .indexes
-            .values()
-            .flatten()
-            .map(|index| {
-                turso_assert!(index.root_page != 0, "index root_page must be non-zero");
-                (
-                    mvstore.get_table_id_from_root_page(index.root_page),
-                    index.clone(),
-                )
-            })
-            .collect();
-        let mvcc_meta_table = schema.get_btree_table(MVCC_META_TABLE_NAME).map(|table| {
-            turso_assert!(
-                table.root_page != 0,
-                "mvcc meta table root_page must be non-zero"
-            );
-            (
-                mvstore.get_table_id_from_root_page(table.root_page),
-                table.columns().len(),
-            )
-        });
-        let durable_mvcc_metadata = !connection.db.is_in_memory_db() && mvcc_meta_table.is_some();
         let durable_tx_max = mvstore.durable_txid_max.load(Ordering::SeqCst);
         let durable_txid_max_old = NonZeroU64::new(durable_tx_max);
         #[cfg(any(test, injected_yields))]
         let yield_instance_id = connection.next_yield_instance_id();
-        Self {
+        let mut checkpoint = Self {
             state: CheckpointState::AcquireLock,
             lock_states: LockStates {
                 blocking_checkpoint_lock_held: false,
@@ -673,6 +679,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             durable_txid_max_new: durable_tx_max,
             mvstore,
             connection,
+            database_id,
             #[cfg(any(test, injected_yields))]
             yield_instance_id,
             checkpoint_lock,
@@ -684,19 +691,21 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             destroyed_tables: HashSet::default(),
             destroyed_indexes: HashSet::default(),
             index_write_set: crate::alloc::vec![],
-            index_id_to_index,
+            index_id_to_index: HashMap::default(),
             checkpoint_result: None,
             update_transaction_state,
             sync_mode,
-            mvcc_meta_table,
-            durable_mvcc_metadata,
+            mvcc_meta_table: None,
+            durable_mvcc_metadata: false,
             staged_checkpoint_header: None,
             header_staged_for_commit: false,
             collect_table_cursor: None,
             collect_index_tableid_cursor: None,
             collect_index_key_cursor: None,
             seq_compact: None,
-        }
+        };
+        checkpoint.refresh_schema_metadata();
+        checkpoint
     }
 
     #[cfg(test)]
@@ -1494,8 +1503,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
                 // Checkpoint state machines can be created before they are run.
                 // Resample after serializing with other checkpoints so already-durable
-                // index deletes are not replayed.
+                // index deletes are not replayed, and keep schema-derived index metadata
+                // aligned with the refreshed durable boundary.
                 self.refresh_checkpoint_bounds();
+                self.refresh_schema_metadata();
                 self.state = CheckpointState::CollectTableRows;
                 Ok(TransitionResult::Continue)
             }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -14071,6 +14071,94 @@ fn test_checkpoint_recovers_after_crash_restart_drop_recreate_index() {
     assert_eq!(rows[1][1].to_string(), "post_2");
 }
 
+/// Regression for the production panic:
+/// "Index struct for index_id ... must exist when checkpointing index rows".
+///
+/// The delayed checkpoint comes from the normal MVCC auto-checkpoint-on-commit
+/// path:
+/// 1. An INSERT commits with `mvcc_checkpoint_threshold = 0` and yields at the
+///    checkpoint's `BeforeAcquireLock` point, after the checkpoint has captured
+///    the schema but before it has collected rows.
+/// 2. A second connection creates a new index while auto-checkpointing remains
+///    enabled, making the index schema row durable after the delayed checkpoint's
+///    schema snapshot.
+/// 3. A later INSERT writes a fresh index row version for that now-durable index.
+/// 4. The background connection observes the new schema through normal SQL, so
+///    the resumed checkpoint no longer fails early as a stale-schema write.
+/// 5. Resuming the delayed checkpoint refreshes its durable watermark, skips the
+///    durable CREATE INDEX schema row, but still collects the fresh index row.
+///    The checkpoint-local `index_id_to_index` map must have been refreshed
+///    alongside the durable watermark so `WriteIndexRow` can open the index.
+#[test]
+fn test_auto_checkpoint_refreshes_index_metadata_after_schema_change() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let db = MvccTestDbNoConn::new_with_random_db();
+
+    let conn_a = db.connect();
+    conn_a
+        .execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+        .unwrap();
+    conn_a
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn_a.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+    let conn_b = db.connect();
+    conn_b
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    conn_b.set_yield_injector(Some(FixedYieldInjector::new([
+        CheckpointYieldPoint::BeforeAcquireLock.point(),
+    ])));
+
+    let mut delayed_ckpt = conn_b
+        .prepare("INSERT INTO t VALUES (10, 'pre_idx')")
+        .unwrap();
+    let mut ckpt_yielded = false;
+    for _ in 0..1000 {
+        match delayed_ckpt.step().unwrap() {
+            StepResult::Yield => {
+                ckpt_yielded = true;
+                break;
+            }
+            StepResult::Done => break,
+            StepResult::IO => conn_b.db.io.step().unwrap(),
+            StepResult::Row | StepResult::Busy | StepResult::Interrupt => {}
+        }
+    }
+    conn_b.set_yield_injector(None);
+    assert!(
+        ckpt_yielded,
+        "auto-checkpoint should yield at BeforeAcquireLock with its schema snapshot captured"
+    );
+
+    conn_a.execute("CREATE INDEX idx ON t(v)").unwrap();
+    conn_a
+        .execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+        .unwrap();
+    conn_a.execute("INSERT INTO t VALUES (2, 'b')").unwrap();
+    let rows = get_rows(
+        &conn_b,
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND name = 'idx'",
+    );
+    assert_eq!(rows.len(), 1);
+
+    delayed_ckpt.run_ignore_rows().unwrap();
+
+    let rows = get_rows(&conn_a, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "a");
+    assert_eq!(rows[1][0].as_int().unwrap(), 2);
+    assert_eq!(rows[1][1].to_string(), "b");
+    assert_eq!(rows[2][0].as_int().unwrap(), 10);
+    assert_eq!(rows[2][1].to_string(), "pre_idx");
+
+    let rows = get_rows(&conn_a, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
 /// Reproducer for recovery of a dropped checkpointed index.
 ///
 /// Sequence:


### PR DESCRIPTION
MVCC checkpoint state machines can be created before they are run. Refresh mvcc schema when the checkpoint SM acquires the checkpoint lock