### PR TITLE
Clarify in CONTRIBUTING.md that mold linker is Linux only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ cargo test
 
 ### Configuring `mold` Linker
 
-The `mold` linker can reduce your build time from a minute to just few seconds.
+The `mold` linker (Linux only) can reduce your build time from a minute to just few seconds.
 
 First, install `mold`:
 


### PR DESCRIPTION
As penberg suggested on #7616, this adds "(Linux only)" to the mold linker section in CONTRIBUTING.md since mold uses the ELF format and does not support macOS (Mach-O) executables.