### PR TITLE
core/mvcc: Prevent MVCC writes from publishing DDL changes while a concurrent integrity check is running

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1436,6 +1436,7 @@ pub struct CommitStateMachine<Clock: LogicalClock, A: ConcurrentAllocator = Turs
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
     did_commit_schema_change: bool,
+    schema_publish_lock_held: bool,
     tx_id: TxID,
     mvcc_store: Arc<MvStore<Clock, A>>,
     connection: Arc<Connection>,
@@ -1536,6 +1537,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             #[cfg(any(test, injected_yields))]
             yield_instance_id: connection.next_yield_instance_id(),
             did_commit_schema_change: schema_did_change_from_tx,
+            schema_publish_lock_held: false,
             tx_id,
             mvcc_store,
             connection,
@@ -1570,6 +1572,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                     .set_tx_state(crate::connection::TransactionState::None);
             }
         }
+        self.release_schema_publish_lock();
 
         let tx_id = self.tx_id;
         let db_id = self.db_id;
@@ -1588,6 +1591,25 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             "Connection should not still reference an MVCC tx after a successful commit",
             { "tx_id": tx_id, "db_id": db_id }
         );
+    }
+
+    fn acquire_schema_publish_lock(&mut self) -> bool {
+        if self.schema_publish_lock_held {
+            return true;
+        }
+        if self.mvcc_store.schema_publish_lock.write() {
+            self.schema_publish_lock_held = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn release_schema_publish_lock(&mut self) {
+        if self.schema_publish_lock_held {
+            self.mvcc_store.schema_publish_lock.unlock();
+            self.schema_publish_lock_held = false;
+        }
     }
 
     fn end_read_tx_for_db(&self) {
@@ -3018,6 +3040,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 }
             }
             CommitState::EndCommitLogicalLog { end_ts } => {
+                let end_ts = *end_ts;
                 let tx = mvcc_store
                     .txs
                     .get(&self.tx_id)
@@ -3032,6 +3055,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                         .map(|header| header.schema_cookie.get())
                         != Some(tx_header.schema_cookie.get());
                 self.did_commit_schema_change = schema_did_change;
+                if schema_did_change && !self.acquire_schema_publish_lock() {
+                    return Ok(TransitionResult::Io(IOCompletions::Single(
+                        Completion::new_yield(),
+                    )));
+                }
                 if schema_did_change {
                     let schema = self.connection.schema.read().clone();
                     self.connection.db.update_schema_if_newer(schema);
@@ -3046,15 +3074,21 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 // applies in FinalizeCommit below.
                 let prev_hdr_ts = mvcc_store
                     .last_global_header_ts
-                    .fetch_max(*end_ts, Ordering::AcqRel);
-                if prev_hdr_ts <= *end_ts {
+                    .fetch_max(end_ts, Ordering::AcqRel);
+                if prev_hdr_ts <= end_ts {
                     self.header.write().replace(tx_header);
                 }
                 tracing::trace!("end_commit_logical_log(tx_id={})", self.tx_id);
-                self.state = CommitState::CommitEnd { end_ts: *end_ts };
+                self.state = CommitState::CommitEnd { end_ts };
                 return Ok(TransitionResult::Continue);
             }
             CommitState::CommitEnd { end_ts } => {
+                let end_ts = *end_ts;
+                if self.did_commit_schema_change && !self.acquire_schema_publish_lock() {
+                    return Ok(TransitionResult::Io(IOCompletions::Single(
+                        Completion::new_yield(),
+                    )));
+                }
                 // Order of operations matters here:
                 // 1. Advance logical log writer offset (makes the written bytes "owned")
                 // 2. Mark transaction Committed
@@ -3091,23 +3125,20 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                         .storage
                         .advance_logical_log_offset_after_success(append_bytes)?;
                 }
-                tx_unlocked
-                    .state
-                    .store(TransactionState::Committed(*end_ts));
+                tx_unlocked.state.store(TransactionState::Committed(end_ts));
 
                 // Hand off to the chunked rewriter. Between chunks readers
                 // resolve any unwritten TxID refs via `txs[tx_id]` which now
                 // reports Committed(end_ts).
-                self.state = CommitState::RewriteLiveVersions(RewriteLiveVersionsCtx {
-                    end_ts: *end_ts,
-                    cursor: 0,
-                });
+                self.state =
+                    CommitState::RewriteLiveVersions(RewriteLiveVersionsCtx { end_ts, cursor: 0 });
                 Ok(TransitionResult::Continue)
             }
             // Chunked: yields every MVCC_COMMIT_BATCH_SIZE rowids. Same
             // helper-dispatch reason as BuildLogRecord above.
             CommitState::RewriteLiveVersions(_) => self.step_rewrite_live_versions(mvcc_store),
             CommitState::FinalizeCommit { end_ts } => {
+                let end_ts = *end_ts;
                 let tx = mvcc_store
                     .txs
                     .get(&self.tx_id)
@@ -3144,15 +3175,15 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                     // lower value can cause data loss / corruption.
                     let last_committed_ts = mvcc_store
                         .last_committed_tx_ts
-                        .fetch_max(*end_ts, Ordering::AcqRel);
-                    if last_committed_ts <= *end_ts {
+                        .fetch_max(end_ts, Ordering::AcqRel);
+                    if last_committed_ts <= end_ts {
                         global_header.replace(tx_header);
                     }
                 }
                 if self.did_commit_schema_change {
                     mvcc_store
                         .last_committed_schema_change_ts
-                        .fetch_max(*end_ts, Ordering::AcqRel);
+                        .fetch_max(end_ts, Ordering::AcqRel);
                 }
 
                 // We have now updated all the versions with a reference to the
@@ -3170,6 +3201,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 }
                 inject_transition_yield!(self, CommitYieldPoint::BeforeFinishCommittedTx);
                 mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)?;
+                self.release_schema_publish_lock();
                 inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                 if mvcc_store.storage.should_checkpoint() {
                     let state_machine = StateMachine::new(CheckpointStateMachine::new(
@@ -3194,7 +3226,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 if mvcc_store.should_gc() {
                     mvcc_store.gc_incremental(MvStore::<Clock>::MAX_CHAINS_PER_GC);
                 }
-                tracing::trace!("logged(tx_id={}, end_ts={})", self.tx_id, *end_ts);
+                tracing::trace!("logged(tx_id={}, end_ts={})", self.tx_id, end_ts);
                 self.finalize(mvcc_store)?;
                 Ok(TransitionResult::Done(()))
             }
@@ -3501,6 +3533,25 @@ pub struct RowidAllocator {
     initialized: AtomicBool,
 }
 
+/// Held while an MVCC `PRAGMA integrity_check` is running.
+///
+/// The statement was compiled with the table and index roots from one schema,
+/// but MVCC does not keep a matching `Schema` snapshot for the transaction.
+/// While this guard is alive, DDL commits cannot publish a different root map
+/// under that statement. Ordinary row writes can still commit through normal
+/// MVCC visibility rules.
+pub(crate) struct MvccIntegrityCheckGuard {
+    schema_publish_lock: Arc<TursoRwLock>,
+}
+
+impl Drop for MvccIntegrityCheckGuard {
+    fn drop(&mut self) {
+        // ProgramState owns the guard, so finishing, resetting, or aborting the
+        // statement all release waiting DDL here.
+        self.schema_publish_lock.unlock();
+    }
+}
+
 /// Sub state machine for [`MvStore::bootstrap_nonblock`]. Carried by the
 /// open state machine (`OpenDbAsyncPhase::BootstrapMvStore`) across the
 /// metadata-bootstrap IO chain so opening an MVCC database does not block on
@@ -3770,6 +3821,17 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// - Immediately TRUNCATE checkpoint the WAL into the database file.
     /// - Release the blocking_checkpoint_lock.
     blocking_checkpoint_lock: Arc<TursoRwLock>,
+    /// Serializes MVCC schema/root publication against `PRAGMA integrity_check`.
+    ///
+    /// MVCC gives a transaction-scoped row snapshot and header/schema cookie,
+    /// but not a transaction-scoped `Schema` object. `PRAGMA integrity_check`
+    /// compiles from the connection's schema view and bakes table/index roots
+    /// into ordinary VDBE ops that scan tables, probe indexes, and count index
+    /// entries. A fully versioned schema catalog would be the broader fix; this
+    /// narrower lock instead prevents schema-changing commits from publishing a
+    /// different root view while integrity_check is mid-statement, without
+    /// serializing ordinary DML commits.
+    schema_publish_lock: Arc<TursoRwLock>,
     /// The highest transaction ID that has been made durable in the WAL.
     /// Used to skip checkpointing transactions from mv store to WAL that have already been processed.
     durable_txid_max: AtomicU64,
@@ -3934,6 +3996,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             commit_coordinator: Arc::new(CommitCoordinator::new()),
             global_header: Arc::new(RwLock::new(None)),
             blocking_checkpoint_lock: Arc::new(TursoRwLock::new()),
+            schema_publish_lock: Arc::new(TursoRwLock::new()),
             durable_txid_max: AtomicU64::new(0),
             last_committed_schema_change_ts: AtomicU64::new(0),
             last_committed_tx_ts: AtomicU64::new(0),
@@ -5553,6 +5616,18 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         }
 
         Ok(tx_id)
+    }
+
+    /// `PRAGMA integrity_check` mixes a compiled schema/root view with generated
+    /// table/index bytecode, so in MVCC mode schema-changing commits must not
+    /// publish a new view while it runs.
+    pub(crate) fn begin_integrity_check_guard(&self) -> Result<MvccIntegrityCheckGuard> {
+        if !self.schema_publish_lock.read() {
+            return Err(LimboError::Busy);
+        }
+        Ok(MvccIntegrityCheckGuard {
+            schema_publish_lock: self.schema_publish_lock.clone(),
+        })
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::TxInsert)]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2762,6 +2762,236 @@ fn test_running_integrity_check_reprepares_after_checkpoint_root_publish() {
     );
 }
 
+/// `PRAGMA integrity_check` scans the durable B-tree image directly, so it must
+/// serialize behind an active MVCC checkpoint while that checkpoint owns the
+/// stop-the-world checkpoint lock.
+#[test]
+fn test_integrity_check_is_busy_during_running_mvcc_checkpoint() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+        .unwrap();
+    writer
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    writer.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+
+    for id in 1..=64 {
+        writer
+            .execute(format!("INSERT INTO t VALUES ({id}, 'v{id}')"))
+            .unwrap();
+    }
+
+    let integrity_conn = db.connect();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    let injector =
+        FixedYieldInjector::new([CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point()]);
+    writer.set_yield_injector(Some(injector.clone()));
+    let mut checkpointing_insert = writer
+        .prepare("INSERT INTO t VALUES (1000, 'late')")
+        .unwrap();
+
+    for _ in 0..10_000 {
+        match checkpointing_insert.step().unwrap() {
+            crate::StepResult::Yield if injector.is_empty() => break,
+            crate::StepResult::IO | crate::StepResult::Yield => {}
+            crate::StepResult::Done => {
+                panic!("INSERT completed before checkpoint durable-boundary yield fired")
+            }
+            other => panic!("unexpected INSERT step result before yield: {other:?}"),
+        }
+    }
+    assert!(
+        injector.is_empty(),
+        "expected INSERT auto-checkpoint to yield while holding the checkpoint lock"
+    );
+
+    let mut integrity_check = integrity_conn.prepare("PRAGMA integrity_check").unwrap();
+    match integrity_check.step() {
+        Err(LimboError::Busy) | Ok(crate::StepResult::Busy) => {}
+        other => panic!("integrity_check should be busy during MVCC checkpoint, got {other:?}"),
+    }
+    drop(integrity_check);
+
+    loop {
+        match checkpointing_insert.step().unwrap() {
+            crate::StepResult::Done => break,
+            crate::StepResult::IO => writer.db.io.step().unwrap(),
+            crate::StepResult::Yield => {}
+            other => panic!("unexpected INSERT step result while finishing checkpoint: {other:?}"),
+        }
+    }
+    writer.set_yield_injector(None);
+
+    let rows = get_rows(&writer, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn test_integrity_check_runs_during_uncommitted_mvcc_schema_writer() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, payload TEXT)")
+        .unwrap();
+    for id in 1..=105 {
+        setup
+            .execute(format!("INSERT INTO t(payload) VALUES ('p{id}')"))
+            .unwrap();
+    }
+    setup
+        .execute("CREATE INDEX idx_t_payload ON t(payload)")
+        .unwrap();
+
+    let writer = db.connect();
+    writer.execute("BEGIN IMMEDIATE").unwrap();
+    writer.execute("DROP INDEX idx_t_payload").unwrap();
+    writer
+        .execute("INSERT INTO t(payload) VALUES ('late')")
+        .unwrap();
+
+    let observer = db.connect();
+    let rows = get_rows(&observer, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+
+    writer.execute("COMMIT").unwrap();
+    let rows = get_rows(&observer, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn test_running_integrity_check_allows_mvcc_index_dml_writer() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+    for id in 1..=32 {
+        setup
+            .execute(format!("INSERT INTO t VALUES ({id}, 'p{id}')"))
+            .unwrap();
+    }
+    setup
+        .execute("CREATE INDEX idx_t_payload ON t(payload)")
+        .unwrap();
+
+    let integrity_conn = db.connect();
+    let writer = db.connect();
+    let injector = FixedYieldInjector::new([CursorYieldPoint::NextStart.point()]);
+    integrity_conn.set_yield_injector(Some(injector.clone()));
+    let mut integrity_check = integrity_conn.prepare("PRAGMA integrity_check").unwrap();
+
+    for _ in 0..10_000 {
+        match integrity_check.step().unwrap() {
+            crate::StepResult::Yield if injector.is_empty() => break,
+            crate::StepResult::IO => integrity_conn.db.io.step().unwrap(),
+            crate::StepResult::Yield | crate::StepResult::Row => {}
+            crate::StepResult::Done => {
+                panic!("integrity_check completed before cursor yield fired")
+            }
+            crate::StepResult::Busy | crate::StepResult::Interrupt => {
+                panic!("unexpected integrity_check step result while waiting for yield")
+            }
+        }
+    }
+    assert!(
+        injector.is_empty(),
+        "expected integrity_check to yield while holding its MVCC guard"
+    );
+
+    writer
+        .execute("INSERT INTO t VALUES (1000, 'late')")
+        .unwrap();
+
+    integrity_conn.set_yield_injector(None);
+    let rows = integrity_check.run_collect_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn test_running_integrity_check_blocks_mvcc_schema_publish() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+    for id in 1..=32 {
+        setup
+            .execute(format!("INSERT INTO t VALUES ({id}, 'p{id}')"))
+            .unwrap();
+    }
+    setup
+        .execute("CREATE INDEX idx_t_payload ON t(payload)")
+        .unwrap();
+
+    let integrity_conn = db.connect();
+    let writer = db.connect();
+    let injector = FixedYieldInjector::new([CursorYieldPoint::NextStart.point()]);
+    integrity_conn.set_yield_injector(Some(injector.clone()));
+    let mut integrity_check = integrity_conn.prepare("PRAGMA integrity_check").unwrap();
+
+    for _ in 0..10_000 {
+        match integrity_check.step().unwrap() {
+            crate::StepResult::Yield if injector.is_empty() => break,
+            crate::StepResult::IO => integrity_conn.db.io.step().unwrap(),
+            crate::StepResult::Yield | crate::StepResult::Row => {}
+            crate::StepResult::Done => {
+                panic!("integrity_check completed before cursor yield fired")
+            }
+            crate::StepResult::Busy | crate::StepResult::Interrupt => {
+                panic!("unexpected integrity_check step result while waiting for yield")
+            }
+        }
+    }
+    assert!(
+        injector.is_empty(),
+        "expected integrity_check to yield while holding its MVCC guard"
+    );
+
+    let mut create_index = writer
+        .prepare("CREATE INDEX idx_t_payload_2 ON t(payload)")
+        .unwrap();
+    for _ in 0..10_000 {
+        match create_index.step() {
+            Ok(crate::StepResult::Done) => {
+                panic!("schema-changing writer completed while integrity_check held")
+            }
+            Ok(crate::StepResult::IO) | Ok(crate::StepResult::Yield) => {
+                writer.db.io.step().unwrap();
+            }
+            Ok(crate::StepResult::Row) => {
+                panic!("CREATE INDEX should not produce rows")
+            }
+            Ok(crate::StepResult::Busy) | Err(LimboError::Busy) => break,
+            Ok(crate::StepResult::Interrupt) => {
+                panic!("CREATE INDEX should not be interrupted")
+            }
+            Err(err) => panic!("unexpected CREATE INDEX error: {err:?}"),
+        }
+    }
+
+    integrity_conn.set_yield_injector(None);
+    let rows = integrity_check.run_collect_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+
+    create_index.run_collect_rows().unwrap();
+
+    writer
+        .execute("INSERT INTO t VALUES (1000, 'late')")
+        .unwrap();
+    let rows = get_rows(&writer, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
 /// Steps:
 /// 1. Create an MVCC database with a table and unique index whose roots are still logical MVCC roots.
 /// 2. Open a deferred transaction on a second connection without starting its MVCC read transaction yet.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3048,6 +3048,12 @@ pub fn halt(
         return Ok(InsnFunctionStepResult::Done);
     }
 
+    // The integrity_check bytecode is finished once it reaches Halt. Release
+    // its schema guard before autocommit closes the MVCC read transaction:
+    // that close can wait on a schema-changing commit dependency, and the
+    // schema-changing commit may be waiting for this guard.
+    state.release_mvcc_integrity_check_guard();
+
     if auto_commit {
         // In autocommit mode, a statement that leaves deferred violations must fail here,
         // and it also ends the transaction.
@@ -13777,6 +13783,9 @@ pub fn op_integrity_check(
     };
     match state.active_op_state.integrity_check() {
         OpIntegrityCheckState::Start => {
+            if let Some(mv_store) = mv_store.as_ref() {
+                state.begin_mvcc_integrity_check_guard(mv_store)?;
+            }
             let (freelist_trunk_page, db_size) = return_if_io!(with_header(
                 &target_pager,
                 mv_store.as_ref(),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -39,7 +39,10 @@ pub use crate::translate::collate::CollationSeq;
 use crate::{
     error::LimboError,
     function::FuncCtx,
-    mvcc::{database::CommitStateMachine, MvccClock},
+    mvcc::{
+        database::{CommitStateMachine, MvccIntegrityCheckGuard},
+        MvccClock,
+    },
     numeric::Numeric,
     return_if_io,
     schema::Trigger,
@@ -763,6 +766,8 @@ pub struct ProgramState {
     /// Number of immediate foreign key violations that occurred during the active statement. If nonzero,
     /// the statement subtransactionwill roll back.
     fk_immediate_violations_during_stmt: AtomicIsize,
+    /// Held by MVCC `PRAGMA integrity_check`.
+    mvcc_integrity_check_guard: Option<MvccIntegrityCheckGuard>,
     uses_subjournal: bool,
     /// Whether this statement is an active write inside an explicit transaction.
     pub(crate) is_active_write: bool,
@@ -823,6 +828,7 @@ impl ProgramState {
             auto_txn_cleanup: TxnCleanup::None,
             fk_deferred_violations_when_stmt_started: AtomicIsize::new(0),
             fk_immediate_violations_during_stmt: AtomicIsize::new(0),
+            mvcc_integrity_check_guard: None,
             rowsets: HashMap::default(),
             bloom_filters: HashMap::default(),
             hash_tables: HashMap::default(),
@@ -953,6 +959,7 @@ impl ProgramState {
             .store(0, Ordering::SeqCst);
         self.fk_deferred_violations_when_stmt_started
             .store(0, Ordering::SeqCst);
+        self.release_mvcc_integrity_check_guard();
         self.rowsets.clear();
         self.bloom_filters.clear();
         self.hash_tables.clear();
@@ -977,6 +984,17 @@ impl ProgramState {
 
     pub(crate) fn record_total_change(&self) {
         self.n_total_change.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn begin_mvcc_integrity_check_guard(&mut self, mv_store: &MvStore) -> Result<()> {
+        if self.mvcc_integrity_check_guard.is_none() {
+            self.mvcc_integrity_check_guard = Some(mv_store.begin_integrity_check_guard()?);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn release_mvcc_integrity_check_guard(&mut self) {
+        self.mvcc_integrity_check_guard = None;
     }
 
     /// Whether this statement owns the implicit autocommit transaction it is
@@ -1497,12 +1515,15 @@ impl Program {
         match &result {
             Ok(StepResult::Done) => {
                 state.execution_state = ProgramExecutionState::Done;
+                state.release_mvcc_integrity_check_guard();
             }
             Ok(StepResult::Interrupt) => {
                 state.execution_state = ProgramExecutionState::Interrupted;
+                state.release_mvcc_integrity_check_guard();
             }
             Err(_) => {
                 state.execution_state = ProgramExecutionState::Failed;
+                state.release_mvcc_integrity_check_guard();
             }
             _ => {}
         }

--- a/testing/concurrent-simulator/chaotic_mvcc.rs
+++ b/testing/concurrent-simulator/chaotic_mvcc.rs
@@ -1,0 +1,192 @@
+//! Chaotic MVCC workloads that stress schema churn around checkpointing.
+
+use rand::Rng;
+use rand_chacha::ChaCha8Rng;
+
+use crate::AUTOINC_TABLE_NAME;
+use crate::chaotic_elle::{ChaoticWorkload, ChaoticWorkloadProfile};
+use crate::operations::{OpResult, Operation};
+
+const HIGH_CHECKPOINT_THRESHOLD: i64 = 1_000_000;
+
+/// Broad MVCC checkpoint/schema churn profile.
+///
+/// This deliberately stays at the SQL/operation layer: it creates and drops
+/// indexes, changes MVCC checkpoint pressure, scans schema, and performs DML
+/// against an indexed table while Whopper's normal scheduler and randomized
+/// yield injector choose the interleavings.
+pub struct MvccCheckpointSchemaChurnProfile {
+    index_slots: usize,
+}
+
+impl MvccCheckpointSchemaChurnProfile {
+    pub fn new() -> Self {
+        Self { index_slots: 8 }
+    }
+
+    fn index_name(&self, rng: &mut ChaCha8Rng) -> String {
+        let slot = rng.random_range(0..self.index_slots);
+        format!("whopper_mvcc_payload_idx_{slot}")
+    }
+
+    fn checkpoint_threshold(value: i64) -> Operation {
+        Operation::Select {
+            sql: format!("PRAGMA mvcc_checkpoint_threshold = {value}"),
+        }
+    }
+
+    fn create_payload_index(index_name: String) -> Operation {
+        Operation::CreateIndex {
+            sql: format!(
+                "CREATE INDEX IF NOT EXISTS {index_name} ON {AUTOINC_TABLE_NAME}(payload)"
+            ),
+            index_name,
+            table_name: AUTOINC_TABLE_NAME.to_string(),
+        }
+    }
+
+    fn drop_payload_index(index_name: String) -> Operation {
+        Operation::DropIndex {
+            sql: format!("DROP INDEX IF EXISTS {index_name}"),
+            index_name,
+        }
+    }
+
+    fn insert_payload(rng: &mut ChaCha8Rng, fiber_id: usize) -> Operation {
+        Operation::AutoincInsert {
+            payload: format!(
+                "mvcc_schema_churn_{fiber_id}_{}",
+                rng.random_range(0..1_000_000_000u32)
+            ),
+        }
+    }
+
+    fn update_payload(rng: &mut ChaCha8Rng) -> Operation {
+        let suffix = rng.random_range(0..1_000_000u32);
+        Operation::Update {
+            sql: format!(
+                "UPDATE {AUTOINC_TABLE_NAME} \
+                 SET payload = payload || '_u{suffix}' \
+                 WHERE id IN (SELECT id FROM {AUTOINC_TABLE_NAME} ORDER BY id DESC LIMIT 1)"
+            ),
+        }
+    }
+
+    fn delete_recent_row(rng: &mut ChaCha8Rng) -> Operation {
+        Operation::AutoincDelete {
+            id: rng.random_range(1..10_000i64),
+        }
+    }
+
+    fn schema_scan() -> Operation {
+        Operation::Select {
+            sql: format!(
+                "SELECT name, rootpage FROM sqlite_schema \
+                 WHERE tbl_name = '{AUTOINC_TABLE_NAME}' ORDER BY name"
+            ),
+        }
+    }
+
+    fn payload_probe() -> Operation {
+        Operation::Select {
+            sql: format!(
+                "SELECT id FROM {AUTOINC_TABLE_NAME} \
+                 WHERE payload >= 'mvcc_schema_churn' ORDER BY payload LIMIT 8"
+            ),
+        }
+    }
+}
+
+impl Default for MvccCheckpointSchemaChurnProfile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct MvccCheckpointSchemaChurnWorkload {
+    ops: Vec<Operation>,
+    index: usize,
+}
+
+impl MvccCheckpointSchemaChurnWorkload {
+    fn new(ops: Vec<Operation>) -> Self {
+        Self { ops, index: 0 }
+    }
+}
+
+impl ChaoticWorkload for MvccCheckpointSchemaChurnWorkload {
+    fn next(&mut self, result: Option<OpResult>) -> Option<Operation> {
+        if let Some(Err(e)) = &result {
+            tracing::trace!("mvcc checkpoint/schema churn operation error: {}", e);
+            return None;
+        }
+
+        let op = self.ops.get(self.index).cloned();
+        self.index += usize::from(op.is_some());
+        op
+    }
+}
+
+impl ChaoticWorkloadProfile for MvccCheckpointSchemaChurnProfile {
+    fn generate(&self, mut rng: ChaCha8Rng, fiber_id: usize) -> Box<dyn ChaoticWorkload> {
+        let index_name = self.index_name(&mut rng);
+        let ops = match rng.random_range(0..6u32) {
+            // Frequent auto-checkpoint candidates. If one yields before the
+            // checkpoint lock, other fibers can change schema underneath it.
+            0 => vec![
+                Self::checkpoint_threshold(0),
+                Self::insert_payload(&mut rng, fiber_id),
+                Self::update_payload(&mut rng),
+                Self::schema_scan(),
+            ],
+            // Create an index under checkpoint pressure, then leave later
+            // indexed rows for another checkpoint to collect.
+            1 => vec![
+                Self::checkpoint_threshold(0),
+                Self::create_payload_index(index_name),
+                Self::checkpoint_threshold(HIGH_CHECKPOINT_THRESHOLD),
+                Self::insert_payload(&mut rng, fiber_id),
+                Self::update_payload(&mut rng),
+                Self::schema_scan(),
+            ],
+            // Drop/recreate across threshold changes to exercise stale index
+            // identity, rootpage reuse, and row-version filtering.
+            2 => vec![
+                Self::checkpoint_threshold(HIGH_CHECKPOINT_THRESHOLD),
+                Self::drop_payload_index(index_name.clone()),
+                Self::insert_payload(&mut rng, fiber_id),
+                Self::checkpoint_threshold(0),
+                Self::create_payload_index(index_name),
+                Self::payload_probe(),
+            ],
+            // Keep indexed DML hot while checkpointing is aggressive.
+            3 => vec![
+                Self::checkpoint_threshold(0),
+                Self::create_payload_index(index_name),
+                Self::insert_payload(&mut rng, fiber_id),
+                Self::insert_payload(&mut rng, fiber_id),
+                Self::payload_probe(),
+            ],
+            // Schema churn with data changes on both sides.
+            4 => vec![
+                Self::checkpoint_threshold(0),
+                Self::create_payload_index(index_name.clone()),
+                Self::insert_payload(&mut rng, fiber_id),
+                Self::drop_payload_index(index_name.clone()),
+                Self::create_payload_index(index_name),
+                Self::schema_scan(),
+            ],
+            // Cheap observer sequence that keeps connections refreshing schema
+            // and reading through any currently live payload indexes.
+            _ => vec![
+                Self::schema_scan(),
+                Self::payload_probe(),
+                Self::checkpoint_threshold(0),
+                Self::insert_payload(&mut rng, fiber_id),
+                Self::delete_recent_row(&mut rng),
+            ],
+        };
+
+        Box::new(MvccCheckpointSchemaChurnWorkload::new(ops))
+    }
+}

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -26,6 +26,7 @@ use turso_parser::ast::{ColumnConstraint, SortOrder};
 
 mod allocation_fault;
 pub mod chaotic_elle;
+pub mod chaotic_mvcc;
 pub mod elle;
 pub mod error_handling;
 mod io;

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -10,6 +10,7 @@ use turso_whopper::multiprocess::{MultiprocessOpts, MultiprocessWhopper};
 use turso_whopper::{
     StepResult, Whopper, WhopperOpts,
     chaotic_elle::{ChaoticElleProfile, ChaoticWorkloadProfile, ElleModelKind},
+    chaotic_mvcc::MvccCheckpointSchemaChurnProfile,
     properties::*,
     workloads::*,
 };
@@ -419,7 +420,18 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
             Box::new(AutoincWatermarkMonotonicity::new()),
         ];
 
-        (w, p, vec![], vec![])
+        let chaotic: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)> =
+            if args.enable_mvcc && args.mode != "recovery-heavy" {
+                vec![(
+                    0.35,
+                    "mvcc-checkpoint-schema-churn",
+                    Box::new(MvccCheckpointSchemaChurnProfile::new()),
+                )]
+            } else {
+                vec![]
+            };
+
+        (w, p, vec![], chaotic)
     }
 }
 

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -1,5 +1,6 @@
 use rand_chacha::ChaCha8Rng;
 use rand_chacha::rand_core::SeedableRng;
+use std::process::Command;
 use std::sync::Arc;
 use turso_core::{Database, DatabaseOpts, IO, OpenFlags, Statement};
 use turso_whopper::{IOFaultConfig, SimulatorIO};
@@ -12,6 +13,56 @@ fn run_to_done(stmt: &mut Statement, io: &SimulatorIO) {
             _ => {}
         }
     }
+}
+
+#[test]
+fn test_mvcc_integrity_check_schema_churn_seed() {
+    let output = Command::new(env!("CARGO_BIN_EXE_turso_whopper"))
+        .env("SEED", "1")
+        .args([
+            "--enable-mvcc",
+            "--max-steps",
+            "100000",
+            "--max-connections",
+            "4",
+            "--allocation-fault-probability",
+            "0",
+        ])
+        .output()
+        .expect("run turso_whopper");
+
+    assert!(
+        output.status.success(),
+        "turso_whopper failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_mvcc_integrity_check_schema_publish_dependency_seed() {
+    let output = Command::new(env!("CARGO_BIN_EXE_turso_whopper"))
+        .env("SEED", "10246767071894117048")
+        .args([
+            "--mode",
+            "fast",
+            "--max-steps",
+            "10000",
+            "--reopen-probability",
+            "0.01",
+            "--enable-mvcc",
+            "--allocation-fault-probability",
+            "0.01",
+        ])
+        .output()
+        .expect("run turso_whopper");
+
+    assert!(
+        output.status.success(),
+        "turso_whopper failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 /// Regression test for MVCC concurrent commit yield-spin deadlock.


### PR DESCRIPTION
while an integrity check is running, a concurrent mvcc write can mutate the `Schema` object that the integrity checker uses to determine which roots to check. in lieu of completely transaction-local schema objects, this pr just serializes DDL changes with integrity checks so that they can't happen concurrently. normal MVCC DML can continue unimpeded