### PR TITLE
core: allow custom allocator for MVStore

### DIFF
--- a/core/alloc/arc.rs
+++ b/core/alloc/arc.rs
@@ -6,4 +6,4 @@ mod imp;
 #[path = "arc/stable.rs"]
 mod imp;
 
-pub use imp::{try_arc_slice_from_slice, ArcSlice};
+pub use imp::{try_arc_slice_from_slice, try_arc_slice_from_slice_in, ArcSlice};

--- a/core/alloc/arc/nightly.rs
+++ b/core/alloc/arc/nightly.rs
@@ -1,8 +1,15 @@
-use crate::alloc::{TryReserveError, TursoAllocator};
+use crate::alloc::{ConcurrentAllocator, DynAllocator, TryReserveError};
 
-pub type ArcSlice<T> = std::sync::Arc<[T], TursoAllocator>;
+pub type ArcSlice<T, A = DynAllocator> = std::sync::Arc<[T], A>;
 
 pub fn try_arc_slice_from_slice<T: Clone>(slice: &[T]) -> Result<ArcSlice<T>, TryReserveError> {
-    std::sync::Arc::<[T], TursoAllocator>::try_clone_from_ref_in(slice, TursoAllocator)
+    try_arc_slice_from_slice_in(slice, DynAllocator::default())
+}
+
+pub fn try_arc_slice_from_slice_in<T: Clone, A: ConcurrentAllocator>(
+    slice: &[T],
+    alloc: A,
+) -> Result<ArcSlice<T>, TryReserveError> {
+    std::sync::Arc::<[T], DynAllocator>::try_clone_from_ref_in(slice, DynAllocator::new(alloc))
         .map_err(|_| TryReserveError)
 }

--- a/core/alloc/arc/stable.rs
+++ b/core/alloc/arc/stable.rs
@@ -5,3 +5,10 @@ pub type ArcSlice<T> = crate::sync::Arc<[T]>;
 pub fn try_arc_slice_from_slice<T: Clone>(slice: &[T]) -> Result<ArcSlice<T>, TryReserveError> {
     Ok(crate::sync::Arc::from(slice))
 }
+
+pub fn try_arc_slice_from_slice_in<T: Clone, A>(
+    slice: &[T],
+    _alloc: A,
+) -> Result<ArcSlice<T>, TryReserveError> {
+    try_arc_slice_from_slice(slice)
+}

--- a/core/alloc/collections/mod.rs
+++ b/core/alloc/collections/mod.rs
@@ -17,5 +17,5 @@ pub use traits::TursoFromIteratorIn;
 pub use traits::{
     TryClone, TursoAllocExt, TursoBinaryHeapExt, TursoBoxExt, TursoFromIterator, TursoHashMapExt,
     TursoHashSetExt, TursoIteratorExt, TursoNewExt, TursoSliceExt, TursoTryNewExt,
-    TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt,
+    TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt, TursoVecInExt,
 };

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -25,6 +25,12 @@ pub trait TursoVecExt<T>: Sized {
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError>;
 }
 
+pub trait TursoVecInExt<T, A>: Sized {
+    fn new_in(alloc: A) -> Self;
+    fn with_capacity_in(capacity: usize, alloc: A) -> Self;
+    fn try_with_capacity_in(capacity: usize, alloc: A) -> Result<Self, TryReserveError>;
+}
+
 pub trait TursoHashMapExt<K, V>: Sized {
     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, TryReserveError>;
 }

--- a/core/alloc/collections/vec/mod.rs
+++ b/core/alloc/collections/vec/mod.rs
@@ -3,7 +3,8 @@ mod nightly;
 
 #[cfg(not(nightly))]
 use super::{
-    TryClone, TursoAllocExt, TursoFromIterator, TursoSliceExt, TursoTryWithCapacityExt, TursoVecExt,
+    TryClone, TursoAllocExt, TursoFromIterator, TursoSliceExt, TursoTryWithCapacityExt,
+    TursoVecExt, TursoVecInExt,
 };
 #[cfg(not(nightly))]
 use crate::alloc::{TryReserveError, Vec};
@@ -37,6 +38,26 @@ impl<T> TursoVecExt<T> for Vec<T> {
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
         self.push(value);
         Ok(())
+    }
+}
+
+#[cfg(not(nightly))]
+impl<T, A> TursoVecInExt<T, A> for Vec<T> {
+    #[inline(always)]
+    fn new_in(_alloc: A) -> Self {
+        vec()
+    }
+
+    #[inline(always)]
+    fn with_capacity_in(capacity: usize, _alloc: A) -> Self {
+        vec_with_capacity(capacity)
+    }
+
+    #[inline(always)]
+    fn try_with_capacity_in(capacity: usize, alloc: A) -> Result<Self, TryReserveError> {
+        Ok(<Self as TursoVecInExt<T, A>>::with_capacity_in(
+            capacity, alloc,
+        ))
     }
 }
 

--- a/core/alloc/collections/vec/nightly.rs
+++ b/core/alloc/collections/vec/nightly.rs
@@ -2,12 +2,16 @@ use std::{alloc::Allocator, iter::TrustedLen, ptr, slice};
 
 use super::super::{
     TryClone, TursoAllocExt, TursoFromIterator, TursoFromIteratorIn, TursoSliceExt,
-    TursoTryWithCapacityExt, TursoVecExt,
+    TursoTryWithCapacityExt, TursoVecExt, TursoVecInExt,
 };
 use crate::alloc::{TryReserveError, TursoAllocator, Vec};
 
 pub(super) const fn vec<T>() -> Vec<T> {
     Vec::new_in(TursoAllocator)
+}
+
+fn vec_in<T, A: std::alloc::Allocator>(alloc: A) -> Vec<T, A> {
+    Vec::new_in(alloc)
 }
 
 impl<T> TursoAllocExt for Vec<T> {
@@ -35,6 +39,26 @@ impl<T> TursoVecExt<T> for Vec<T> {
                 }
             }
         }
+    }
+}
+
+impl<T, A> TursoVecInExt<T, A> for Vec<T, A>
+where
+    A: std::alloc::Allocator,
+{
+    #[inline(always)]
+    fn new_in(alloc: A) -> Self {
+        vec_in(alloc)
+    }
+
+    #[inline(always)]
+    fn with_capacity_in(capacity: usize, alloc: A) -> Self {
+        Vec::with_capacity_in(capacity, alloc)
+    }
+
+    #[inline(always)]
+    fn try_with_capacity_in(capacity: usize, alloc: A) -> Result<Self, TryReserveError> {
+        Vec::try_with_capacity_in(capacity, alloc).map_err(TryReserveError::from)
     }
 }
 

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -27,7 +27,7 @@ pub use collections::TursoFromIteratorIn;
 pub use collections::{
     TryClone, TursoAllocExt, TursoBinaryHeapExt, TursoBoxExt, TursoFromIterator, TursoHashMapExt,
     TursoHashSetExt, TursoIteratorExt, TursoNewExt, TursoSliceExt, TursoTryNewExt,
-    TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt,
+    TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt, TursoVecInExt,
 };
 
 pub const ALLOC_ERR_MSG: &str = "TODO: fallible allocations";

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -4,7 +4,7 @@
 //! available. Builds compiled with `--cfg nightly` use Rust's unstable
 //! `allocator_api` collection parameters.
 
-use std::fmt;
+use std::{fmt, ptr::NonNull};
 
 mod allocation_site;
 mod api;
@@ -68,6 +68,46 @@ impl<A: ApiAllocator + Clone + Send + Sync + 'static> ConcurrentAllocator for A 
 pub struct TursoAllocator;
 
 pub type Allocator = TursoAllocator;
+
+#[derive(Clone)]
+pub struct DynAllocator {
+    inner: Arc<dyn ApiAllocator + Send + Sync>,
+}
+
+impl DynAllocator {
+    pub fn new<A>(alloc: A) -> Self
+    where
+        A: ApiAllocator + Send + Sync + 'static,
+    {
+        Self {
+            inner: Arc::new(alloc),
+        }
+    }
+}
+
+impl Default for DynAllocator {
+    fn default() -> Self {
+        Self::new(TursoAllocator)
+    }
+}
+
+impl fmt::Debug for DynAllocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DynAllocator").finish_non_exhaustive()
+    }
+}
+
+unsafe impl ApiAllocator for DynAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        self.inner.allocate(layout)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            self.inner.deallocate(ptr, layout);
+        }
+    }
+}
 
 pub type Box<T> = std::boxed::Box<T>;
 

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -20,7 +20,7 @@ pub use allocation_site::{
 /// stable, `std::alloc::Allocator` on `--cfg nightly` builds.
 pub use api::ApiAllocator;
 pub use api::{AllocError, Global, Layout};
-pub use arc::{try_arc_slice_from_slice, ArcSlice};
+pub use arc::{try_arc_slice_from_slice, try_arc_slice_from_slice_in, ArcSlice};
 pub use backend::{set_allocator, SetAllocatorError, TursoAllocBackend};
 #[cfg(nightly)]
 pub use collections::TursoFromIteratorIn;

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -1,4 +1,11 @@
 use super::*;
+use std::{
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc as StdArc,
+    },
+};
 
 struct LowerBoundOnly {
     next: usize,
@@ -42,6 +49,72 @@ impl Iterator for UnderreportedLowerBound {
     fn size_hint(&self) -> (usize, Option<usize>) {
         ((self.end - self.next).saturating_sub(1), None)
     }
+}
+
+struct CountingAlloc {
+    allocations: StdArc<AtomicUsize>,
+}
+
+unsafe impl ApiAllocator for CountingAlloc {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        self.allocations.fetch_add(1, Ordering::Relaxed);
+        <Global as ApiAllocator>::allocate(&Global, layout)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            <Global as ApiAllocator>::deallocate(&Global, ptr, layout);
+        }
+    }
+}
+
+#[test]
+fn dyn_allocator_delegates_skiplist_allocations() {
+    let allocations = StdArc::new(AtomicUsize::new(0));
+    let alloc = DynAllocator::new(CountingAlloc {
+        allocations: allocations.clone(),
+    });
+    let map: crate::skiplist::SkipMap<i32, i32, _, DynAllocator> =
+        crate::skiplist::SkipMap::new_in(alloc);
+
+    map.try_insert(1, 2).unwrap();
+
+    assert!(allocations.load(Ordering::Relaxed) > 0);
+}
+
+#[test]
+fn database_open_with_allocator_uses_allocator_for_mvstore_skiplist() {
+    let allocations = StdArc::new(AtomicUsize::new(0));
+    let alloc = DynAllocator::new(CountingAlloc {
+        allocations: allocations.clone(),
+    });
+    let io = StdArc::new(crate::MemoryIO::new());
+    let file = crate::IO::open_file(
+        io.as_ref(),
+        "open-with-allocator.db",
+        crate::OpenFlags::Create,
+        true,
+    )
+    .unwrap();
+    let db_file = StdArc::new(crate::storage::database::DatabaseFile::new(file));
+    let db = crate::Database::open_with_flags_with_allocator(
+        io,
+        "open-with-allocator.db",
+        db_file,
+        crate::OpenFlags::default(),
+        crate::DatabaseOpts::new(),
+        None,
+        None,
+        alloc,
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+
+    allocations.store(0, Ordering::Relaxed);
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+
+    assert!(db.get_mv_store().is_some());
+    assert!(allocations.load(Ordering::Relaxed) > 0);
 }
 
 #[test]

--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -14,6 +14,7 @@ use codspeed_criterion_compat::{
     async_executor::FuturesExecutor, criterion_group, criterion_main, Criterion, Throughput,
 };
 
+use turso_core::alloc::DynAllocator;
 use turso_core::mvcc::clock::MvccClock;
 use turso_core::mvcc::database::{MvStore, Row, RowID, RowKey};
 use turso_core::types::{IOResult, ImmutableRecord, Text};
@@ -22,7 +23,7 @@ use turso_core::{Connection, Database, MemoryIO, Statement, StepResult, Value};
 struct BenchDb {
     _db: Arc<Database>,
     conn: Arc<Connection>,
-    mvcc_store: Arc<MvStore<MvccClock>>,
+    mvcc_store: Arc<MvStore<MvccClock, DynAllocator>>,
 }
 
 fn bench_db() -> BenchDb {

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3114,6 +3114,7 @@ impl Connection {
                             init.db.open_flags,
                             init.db.durable_storage.clone(),
                             enc_ctx,
+                            init.db.mv_store_allocator.clone(),
                         )?;
                         init.db.mv_store.store(Some(mv_store));
                         *state = AttachDatabaseState::Bootstrap(Box::new(

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1,3 +1,4 @@
+use crate::alloc::ALLOC_ERR_MSG;
 use crate::sync::Arc;
 use crate::turso_assert;
 use crate::turso_debug_assert;
@@ -689,12 +690,15 @@ impl HybridBTreeDirectory {
         // Create cursor and seek to first uncached chunk
         let mut cursor =
             BTreeCursor::new(self.pager.clone(), self.btree_root_page, Self::CHUNK_LEN);
-        cursor.index_info = Some(Arc::new(IndexInfo {
-            has_rowid: false,
-            num_cols: Self::CHUNK_LEN,
-            key_info: crate::alloc::vec![key_info(), key_info(), key_info()],
-            is_unique: false,
-        }));
+        cursor.index_info = Some(Arc::new(
+            IndexInfo::new(
+                [key_info(), key_info(), key_info()],
+                false,
+                Self::CHUNK_LEN,
+                false,
+            )
+            .expect(ALLOC_ERR_MSG),
+        ));
 
         let seek_key = ImmutableRecord::from_values(
             &[
@@ -1868,12 +1872,12 @@ impl FtsCursor {
         self.btree_root_page = Some(root_page);
 
         let mut cursor = BTreeCursor::new(pager, root_page, 3);
-        cursor.index_info = Some(Arc::new(IndexInfo {
-            has_rowid: false,
-            num_cols: 3,
-            key_info: crate::alloc::vec![key_info(), key_info(), key_info()],
-            is_unique: false,
-        }));
+        cursor.index_info = Some(Arc::new(IndexInfo::new(
+            [key_info(), key_info(), key_info()],
+            false,
+            3,
+            false,
+        )?));
         self.fts_dir_cursor = Some(cursor);
         Ok(())
     }

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -188,13 +188,17 @@ pub(crate) fn open_table_cursor(
 }
 
 /// helper method to open index BTree cursor in the index method implementation
-pub(crate) fn open_index_cursor(
+pub(crate) fn open_index_cursor<I, E>(
     connection: &Connection,
     database_id: usize,
     table: &str,
     index: &str,
-    keys: crate::alloc::Vec<KeyInfo>,
-) -> Result<BTreeCursor> {
+    keys: I,
+) -> Result<BTreeCursor>
+where
+    I: IntoIterator<Item = KeyInfo, IntoIter = E>,
+    E: ExactSizeIterator<Item = KeyInfo>,
+{
     let pager = connection.get_pager_from_database_index(&database_id)?;
     let Some(scratch) = connection.with_schema(database_id, |schema| {
         schema.get_index(table, index).cloned()
@@ -203,13 +207,15 @@ pub(crate) fn open_index_cursor(
             "index {index} for table {table} not found",
         )));
     };
-    let mut cursor = BTreeCursor::new(pager, scratch.root_page, keys.len());
-    cursor.index_info = Some(Arc::new(IndexInfo {
-        has_rowid: false,
-        num_cols: keys.len(),
-        key_info: keys,
-        is_unique: scratch.unique,
-    }));
+    let keys = keys.into_iter();
+    let num_cols = keys.len();
+    let mut cursor = BTreeCursor::new(pager, scratch.root_page, num_cols);
+    cursor.index_info = Some(Arc::new(IndexInfo::new(
+        keys,
+        false,
+        num_cols,
+        scratch.unique,
+    )?));
     Ok(cursor)
 }
 

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -486,7 +486,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
             &self.configuration.table_name,
             &self.inverted_index_btree,
             // component, length, rowid
-            crate::alloc::vec![key_info(), key_info(), key_info()],
+            [key_info(), key_info(), key_info()],
         )?);
         self.stats_cursor = Some(open_index_cursor(
             connection,
@@ -494,7 +494,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
             &self.configuration.table_name,
             &self.stats_btree,
             // component
-            crate::alloc::vec![key_info()],
+            [key_info()],
         )?);
         self.main_btree = Some(open_table_cursor(
             connection,
@@ -515,7 +515,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
             &self.configuration.table_name,
             &self.inverted_index_btree,
             // component, length, rowid
-            crate::alloc::vec![key_info(), key_info(), key_info()],
+            [key_info(), key_info(), key_info()],
         )?);
         self.stats_cursor = Some(open_index_cursor(
             connection,
@@ -523,7 +523,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
             &self.configuration.table_name,
             &self.stats_btree,
             // component
-            crate::alloc::vec![key_info()],
+            [key_info()],
         )?);
         Ok(IOResult::Done(()))
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -362,9 +362,9 @@ pub enum TempStore {
     Memory = 2,
 }
 
-pub(crate) type MvStore = mvcc::MvStore<mvcc::MvccClock>;
+pub(crate) type MvStore = mvcc::MvStore<mvcc::MvccClock, alloc::DynAllocator>;
 
-pub(crate) type MvCursor = mvcc::cursor::MvccLazyCursor<mvcc::MvccClock>;
+pub(crate) type MvCursor = mvcc::cursor::MvccLazyCursor<mvcc::MvccClock, alloc::DynAllocator>;
 
 /// Returns true for in memory databases (i.e. databases backed by MemoryIO)
 ///
@@ -590,8 +590,9 @@ pub fn clear_database_registry() {
 ///
 /// Do that `Database` object is cached and can be long lived. DO NOT store anything sensitive like
 /// encryption key here.
-pub struct Database {
-    mv_store: ArcSwapOption<MvStore>,
+pub struct Database<A: alloc::ConcurrentAllocator = alloc::DynAllocator> {
+    mv_store: ArcSwapOption<mvcc::MvStore<mvcc::MvccClock, A>>,
+    mv_store_allocator: A,
     schema: Arc<Mutex<Arc<Schema>>>,
     pub db_file: Arc<dyn DatabaseStorage>,
     pub path: String,
@@ -688,6 +689,7 @@ impl Database {
         is_memory_like(&self.path)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new(
         opts: DatabaseOpts,
         flags: OpenFlags,
@@ -696,6 +698,7 @@ impl Database {
         io: &Arc<dyn IO>,
         db_file: Arc<dyn DatabaseStorage>,
         encryption_opts: Option<EncryptionOpts>,
+        mv_store_allocator: alloc::DynAllocator,
     ) -> Result<Self> {
         let path = path.into();
         let wal_path = wal_path.into();
@@ -728,6 +731,7 @@ impl Database {
 
         let db = Database {
             mv_store,
+            mv_store_allocator,
             path,
             wal_path,
             schema: Arc::new(Mutex::new(Arc::new({
@@ -1046,9 +1050,32 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
     ) -> Result<Arc<Database>> {
+        Self::open_with_flags_with_allocator(
+            io,
+            path,
+            db_file,
+            flags,
+            opts,
+            encryption_opts,
+            durable_storage,
+            alloc::DynAllocator::default(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_with_flags_with_allocator(
+        io: Arc<dyn IO>,
+        path: &str,
+        db_file: Arc<dyn DatabaseStorage>,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        allocator: alloc::DynAllocator,
+    ) -> Result<Arc<Database>> {
         let mut state = OpenDbAsyncState::new();
         loop {
-            match Self::open_with_flags_async(
+            match Self::open_with_flags_async_with_allocator(
                 &mut state,
                 io.clone(),
                 path,
@@ -1057,6 +1084,7 @@ impl Database {
                 opts,
                 encryption_opts.clone(),
                 durable_storage.clone(),
+                allocator.clone(),
             )? {
                 IOResult::Done(db) => return Ok(db),
                 IOResult::IO(io_completion) => {
@@ -1085,6 +1113,31 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
     ) -> Result<IOResult<Arc<Database>>> {
+        Self::open_with_flags_async_with_allocator(
+            state,
+            io,
+            path,
+            db_file,
+            flags,
+            opts,
+            encryption_opts,
+            durable_storage,
+            alloc::DynAllocator::default(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_with_flags_async_with_allocator(
+        state: &mut OpenDbAsyncState,
+        io: Arc<dyn IO>,
+        path: &str,
+        db_file: Arc<dyn DatabaseStorage>,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        allocator: alloc::DynAllocator,
+    ) -> Result<IOResult<Arc<Database>>> {
         let result = Self::open_with_flags_async_internal(
             state,
             io,
@@ -1094,6 +1147,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
+            allocator,
         );
         if result.is_err() {
             // On error, remove the Opening sentinel so other callers can proceed.
@@ -1115,6 +1169,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        allocator: alloc::DynAllocator,
     ) -> Result<IOResult<Arc<Database>>> {
         // turso-sync-engine creates 2 databases with different names in the same IO if MemoryIO is used
         // in this case we need to bypass registry (as this is MemoryIO DB) but also preserve original distinction in names (e.g. :memory:-draft and :memory:-synced)
@@ -1165,7 +1220,7 @@ impl Database {
         }
 
         // Open the database asynchronously (no registry lock held).
-        let result = Self::open_with_flags_bypass_registry_async(
+        let result = Self::open_with_flags_bypass_registry_async_with_allocator(
             state,
             io.clone(),
             path,
@@ -1175,6 +1230,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
+            allocator,
         )?;
 
         if let IOResult::Done(ref db) = result {
@@ -1186,6 +1242,37 @@ impl Database {
         }
 
         Ok(result)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn open_with_flags_bypass_registry_async_with_allocator(
+        state: &mut OpenDbAsyncState,
+        io: Arc<dyn IO>,
+        path: &str,
+        wal_path: Option<&str>,
+        db_file: Arc<dyn DatabaseStorage>,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        allocator: alloc::DynAllocator,
+    ) -> Result<IOResult<Arc<Database>>> {
+        let result = Self::open_with_flags_bypass_registry_async_internal(
+            state,
+            io,
+            path,
+            wal_path,
+            db_file,
+            flags,
+            opts,
+            encryption_opts,
+            durable_storage,
+            allocator,
+        );
+        if result.is_err() {
+            let _ = state.schema_guard.take();
+        }
+        result
     }
 
     /// method for tests - for all other code we must use async alternative
@@ -1245,6 +1332,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
+            alloc::DynAllocator::default(),
         );
         if result.is_err() {
             // schema_guard is set by the open_with_flags_bypass_registry_async_internal - so we release it in case of error
@@ -1265,6 +1353,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        allocator: alloc::DynAllocator,
     ) -> Result<IOResult<Arc<Database>>> {
         loop {
             tracing::debug!(
@@ -1293,6 +1382,7 @@ impl Database {
                         &io,
                         db_file.clone(),
                         encryption_opts.clone(),
+                        allocator.clone(),
                     )?;
                     db.durable_storage.clone_from(&durable_storage);
 
@@ -1917,6 +2007,7 @@ impl Database {
                             self.open_flags,
                             self.durable_storage.clone(),
                             enc_ctx,
+                            self.mv_store_allocator.clone(),
                         )?;
                         self.mv_store.store(Some(mv_store));
                     }

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1550,12 +1550,13 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                                 let MvccCursorType::Index(index_info) = &self.mv_cursor_type else {
                                     panic!("SeekKey::IndexKey requires Index cursor type");
                                 };
-                                Arc::new(IndexInfo {
-                                    key_info: index_info.key_info.clone(),
-                                    has_rowid: index_info.has_rowid,
-                                    num_cols: index_key.column_count(),
-                                    is_unique: index_info.is_unique,
-                                })
+                                Arc::new(IndexInfo::new_in(
+                                    index_info.key_info.iter().cloned(),
+                                    index_info.has_rowid,
+                                    index_key.column_count(),
+                                    index_info.is_unique,
+                                    self.db.allocator(),
+                                )?)
                             };
                             let sortable_key =
                                 SortableIndexKey::new_from_record((*index_key).clone(), index_info);

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,5 +1,5 @@
-use crate::alloc::TryReserveError;
-use crate::skiplist::map::Entry;
+use crate::alloc::{ConcurrentAllocator, TryReserveError, TursoAllocator};
+use crate::skiplist::{comparator::BasicComparator, map::Entry};
 use crate::turso_assert;
 
 use crate::mvcc::clock::LogicalClock;
@@ -136,7 +136,9 @@ impl YieldPointMarker for CursorYieldPoint {
 }
 
 #[cfg(any(test, injected_yields))]
-impl<Clock: LogicalClock + 'static> ProvidesYieldContext for MvccLazyCursor<Clock> {
+impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> ProvidesYieldContext
+    for MvccLazyCursor<Clock, A>
+{
     fn yield_context(&self) -> YieldContext {
         YieldContext::new(
             self.connection.yield_injector(),
@@ -301,11 +303,11 @@ pub enum MvccCursorType {
     Index(Arc<IndexInfo>),
 }
 
-pub(crate) type MvccIterator<'l, T, A = crate::alloc::TursoAllocator> = Box<
-    dyn Iterator<Item = Entry<'l, T, RowVersions, crate::skiplist::comparator::BasicComparator, A>>
-        + Send
-        + Sync,
->;
+pub(crate) type MvccEntry<'l, T, A = TursoAllocator> =
+    Entry<'l, T, RowVersions, BasicComparator, A>;
+
+pub(crate) type MvccIterator<'l, T, A = TursoAllocator> =
+    Box<dyn Iterator<Item = MvccEntry<'l, T, A>> + Send + Sync>;
 
 /// Extends the lifetime of a SkipMap iterator to `'static`.
 ///
@@ -336,27 +338,13 @@ macro_rules! static_iterator_hack {
         unsafe {
             std::mem::transmute::<
                 Box<
-                    dyn Iterator<
-                            Item = Entry<
-                                '_,
-                                $key_type,
-                                RowVersions,
-                                crate::skiplist::comparator::BasicComparator,
-                                $alloc,
-                            >,
-                        > + Send
+                    dyn Iterator<Item = crate::mvcc::cursor::MvccEntry<'_, $key_type, $alloc>>
+                        + Send
                         + Sync,
                 >,
                 Box<
-                    dyn Iterator<
-                            Item = Entry<
-                                'static,
-                                $key_type,
-                                RowVersions,
-                                crate::skiplist::comparator::BasicComparator,
-                                $alloc,
-                            >,
-                        > + Send
+                    dyn Iterator<Item = crate::mvcc::cursor::MvccEntry<'static, $key_type, $alloc>>
+                        + Send
                         + Sync,
                 >,
             >($iter)
@@ -372,14 +360,14 @@ pub(crate) use static_iterator_hack;
 /// Forward index cursors only; [`reset`](Self::reset) on any reposition, since
 /// the finger is monotonic.
 #[derive(Default)]
-pub(crate) enum IndexShadowFinger {
+pub(crate) enum IndexShadowFinger<A: ConcurrentAllocator = TursoAllocator> {
     /// Not yet created; built lazily on the next shadow check.
     #[default]
     Uninitialized,
     /// Positioned at `key`, holding its version chain. The shadow bit is resolved
     /// lazily (only when a B-tree row matches this key exactly)
     Peeked {
-        iter: MvccIterator<'static, Arc<SortableIndexKey>>,
+        iter: MvccIterator<'static, Arc<SortableIndexKey>, A>,
         key: Arc<SortableIndexKey>,
         versions: RowVersions,
     },
@@ -387,7 +375,7 @@ pub(crate) enum IndexShadowFinger {
     Exhausted,
 }
 
-impl IndexShadowFinger {
+impl<A: ConcurrentAllocator> IndexShadowFinger<A> {
     /// Reset so the next shadow check rebuilds the finger. Required on any B-tree
     /// reposition (seek/rewind): a finger left ahead of the new position would
     /// report a shadowed row as valid.
@@ -398,7 +386,7 @@ impl IndexShadowFinger {
     /// Advance `iter` to its next entry, cloning the key and version-chain `Arc`
     /// (both cheap) so no borrowed skiplist `Entry` is held afterward. The shadow
     /// bit is deliberately not resolved here — see [`Self::Peeked`].
-    fn advance(mut iter: MvccIterator<'static, Arc<SortableIndexKey>>) -> Self {
+    fn advance(mut iter: MvccIterator<'static, Arc<SortableIndexKey>, A>) -> Self {
         match iter.next() {
             Some(entry) => Self::Peeked {
                 key: entry.key().clone(),
@@ -414,7 +402,7 @@ impl IndexShadowFinger {
     /// [`MvStore::query_btree_version_is_valid`] for index keys.
     pub(crate) fn btree_row_is_valid<Clock: LogicalClock>(
         &mut self,
-        db: &MvStore<Clock>,
+        db: &MvStore<Clock, A>,
         table_id: MVTableId,
         tx_id: u64,
         key: &Arc<SortableIndexKey>,
@@ -428,9 +416,7 @@ impl IndexShadowFinger {
                 // than at the start of `index_rows`, so a seek-initiated scan does
                 // not re-walk every preceding version on its first row check.
                 let iter_box: Box<
-                    dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RowVersions>>
-                        + Send
-                        + Sync,
+                    dyn Iterator<Item = MvccEntry<'_, Arc<SortableIndexKey>, A>> + Send + Sync,
                 > = match index_rows {
                     Some(index_rows) => {
                         Box::new(index_rows.value().range::<SortableIndexKey, _>((
@@ -440,7 +426,7 @@ impl IndexShadowFinger {
                     }
                     None => Box::new(std::iter::empty()),
                 };
-                static_iterator_hack!(iter_box, Arc<SortableIndexKey>)
+                static_iterator_hack!(iter_box, Arc<SortableIndexKey>, A)
             };
             *self = Self::advance(iter);
         }
@@ -474,17 +460,17 @@ impl IndexShadowFinger {
     }
 }
 
-pub struct MvccLazyCursor<Clock: LogicalClock + 'static> {
-    pub db: Arc<MvStore<Clock>>,
+pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator = TursoAllocator> {
+    pub db: Arc<MvStore<Clock, A>>,
     #[cfg(any(test, injected_yields))]
     connection: Arc<Connection>,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
     current_pos: CursorPosition,
     /// Stateful MVCC table iterator if this is a table cursor.
-    table_iterator: Option<MvccIterator<'static, RowID>>,
+    table_iterator: Option<MvccIterator<'static, RowID, A>>,
     /// Stateful MVCC index iterator if this is an index cursor.
-    index_iterator: Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
+    index_iterator: Option<MvccIterator<'static, Arc<SortableIndexKey>, A>>,
     mv_cursor_type: MvccCursorType,
     table_id: MVTableId,
     tx_id: u64,
@@ -500,7 +486,7 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static> {
     /// Dual-cursor peek state for proper iteration
     dual_peek: DualCursorPeek,
     /// Forward-scan finger over `index_rows`; see [`IndexShadowFinger`].
-    index_finger: IndexShadowFinger,
+    index_finger: IndexShadowFinger<A>,
 }
 
 pub enum NextRowidResult {
@@ -515,15 +501,15 @@ pub enum NextRowidResult {
     FindRandom,
 }
 
-impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
+impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock, A> {
     pub fn new(
-        db: Arc<MvStore<Clock>>,
+        db: Arc<MvStore<Clock, A>>,
         connection: &Arc<Connection>,
         tx_id: u64,
         root_page_or_table_id: i64,
         mv_cursor_type: MvccCursorType,
         btree_cursor: Box<dyn CursorTrait>,
-    ) -> Result<MvccLazyCursor<Clock>> {
+    ) -> Result<MvccLazyCursor<Clock, A>> {
         turso_assert!(
             (&*btree_cursor as &dyn Any).is::<BTreeCursor>(),
             "BTreeCursor expected for mvcc cursor"
@@ -1112,24 +1098,23 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                 let range =
                     create_seek_range(Bound::Included(start_rowid), IterationDirection::Forwards);
                 let iter_box = Box::new(self.db.rows.range(range));
-                self.table_iterator = Some(static_iterator_hack!(iter_box, RowID));
+                self.table_iterator = Some(static_iterator_hack!(iter_box, RowID, A));
             }
             MvccCursorType::Index(_) => {
                 let index_rows = self.db.get_or_create_index_rows(self.table_id)?;
                 let index_rows = index_rows.value();
                 let iter_box: Box<
-                    dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RowVersions>>
-                        + Send
-                        + Sync,
+                    dyn Iterator<Item = MvccEntry<'_, Arc<SortableIndexKey>, A>> + Send + Sync,
                 > = Box::new(index_rows.iter());
-                self.index_iterator = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));
+                self.index_iterator =
+                    Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>, A));
             }
         }
         Ok(())
     }
 }
 
-impl<Clock: LogicalClock + 'static> Drop for MvccLazyCursor<Clock> {
+impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> Drop for MvccLazyCursor<Clock, A> {
     fn drop(&mut self) {
         // Release the per-table RowidAllocator lock if a Statement was dropped
         // while paused at an op_new_rowid IO yield. end_new_rowid is a no-op
@@ -1138,7 +1123,9 @@ impl<Clock: LogicalClock + 'static> Drop for MvccLazyCursor<Clock> {
     }
 }
 
-impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
+impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
+    for MvccLazyCursor<Clock, A>
+{
     fn last(&mut self) -> Result<IOResult<()>> {
         // A cursor may be NullRow'd during outer-join unmatched emission.
         // Repositioning to a real row must clear that synthetic NULL state.
@@ -2049,18 +2036,17 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                     std::ops::Bound::Unbounded,
                 );
                 let iter_box = Box::new(self.db.rows.range(range));
-                self.table_iterator = Some(static_iterator_hack!(iter_box, RowID));
+                self.table_iterator = Some(static_iterator_hack!(iter_box, RowID, A));
             }
             MvccCursorType::Index(_) => {
                 // For index cursors, initialize the iterator to the beginning
                 let index_rows = self.db.get_or_create_index_rows(self.table_id)?;
                 let index_rows = index_rows.value();
                 let iter_box: Box<
-                    dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RowVersions>>
-                        + Send
-                        + Sync,
+                    dyn Iterator<Item = MvccEntry<'_, Arc<SortableIndexKey>, A>> + Send + Sync,
                 > = Box::new(index_rows.iter());
-                self.index_iterator = Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>));
+                self.index_iterator =
+                    Some(static_iterator_hack!(iter_box, Arc<SortableIndexKey>, A));
             }
         }
 
@@ -2134,7 +2120,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
     }
 }
 
-impl<Clock: LogicalClock> Debug for MvccLazyCursor<Clock> {
+impl<Clock: LogicalClock, A: ConcurrentAllocator> Debug for MvccLazyCursor<Clock, A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MvccLazyCursor")
             .field("current_pos", &self.current_pos)

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1696,7 +1696,12 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 let num_columns = record.column_count();
                 crate::with_mv_store_allocation_site!(
                     RowPayload,
-                    Row::new_table_row(row_id, record.get_payload(), num_columns)
+                    Row::new_table_row_in(
+                        row_id,
+                        record.get_payload(),
+                        num_columns,
+                        self.db.allocator(),
+                    )
                 )
             }
             MvccCursorType::Index(_) => {
@@ -1813,7 +1818,12 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
             let row = match &self.mv_cursor_type {
                 MvccCursorType::Table => crate::with_mv_store_allocation_site!(
                     RowPayload,
-                    Row::new_table_row(rowid.clone(), record.get_payload(), column_count)
+                    Row::new_table_row_in(
+                        rowid.clone(),
+                        record.get_payload(),
+                        column_count,
+                        self.db.allocator(),
+                    )
                 ),
                 MvccCursorType::Index(_) => Ok(Row::new_index_row(rowid.clone(), column_count)),
             }?;

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -25,8 +25,8 @@ use std::ops::Bound;
 #[cfg(any(test, injected_yields))]
 use strum::EnumCount;
 
-#[derive(Debug, Clone)]
-enum CursorPosition {
+#[derive(Clone)]
+enum CursorPosition<A: ConcurrentAllocator = TursoAllocator> {
     /// We haven't loaded any row yet.
     BeforeFirst,
     /// We have loaded a row. This position points to a rowid in either MVCC index or in BTree.
@@ -38,10 +38,26 @@ enum CursorPosition {
         /// iterator so `read_mvcc_current_row` can skip a second `self.rows.get`.
         /// `Some` only for MVCC table rows reached via the scan path; `None`
         /// (btree rows, index rows, seek/insert positions) falls back to a lookup.
-        versions: Option<RowVersions>,
+        versions: Option<RowVersions<A>>,
     },
     /// We have reached the end of the table.
     End,
+}
+
+impl<A: ConcurrentAllocator> Debug for CursorPosition<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BeforeFirst => f.write_str("BeforeFirst"),
+            Self::Loaded {
+                row_id, in_btree, ..
+            } => f
+                .debug_struct("Loaded")
+                .field("row_id", row_id)
+                .field("in_btree", in_btree)
+                .finish_non_exhaustive(),
+            Self::End => f.write_str("End"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -188,18 +204,27 @@ fn cursor_yield_key(tx_id: u64, table_id: MVTableId) -> u64 {
 /// With DualCursorPeek we track the "peeked" next value for each cursor in the dual-cursor iteration,
 /// so that we always return the correct 'next' value (e.g. if mvcc has 1 and 3 and btree has 2 and 4,
 /// we should return 1, 2, 3, 4 in order).
-#[derive(Debug, Clone, Default)]
-struct DualCursorPeek {
+#[derive(Debug, Clone)]
+struct DualCursorPeek<A: ConcurrentAllocator = TursoAllocator> {
     /// Next row available from MVCC
-    mvcc_peek: CursorPeek,
+    mvcc_peek: CursorPeek<A>,
     /// Next row available from btree
-    btree_peek: CursorPeek,
+    btree_peek: CursorPeek<A>,
 }
 
-impl DualCursorPeek {
+impl<A: ConcurrentAllocator> Default for DualCursorPeek<A> {
+    fn default() -> Self {
+        Self {
+            mvcc_peek: CursorPeek::default(),
+            btree_peek: CursorPeek::default(),
+        }
+    }
+}
+
+impl<A: ConcurrentAllocator> DualCursorPeek<A> {
     /// Returns the next row key, whether the row is from the BTree, and (for
     /// MVCC winners) the resolved version chain captured during iteration.
-    fn get_next(&self, dir: IterationDirection) -> Option<(RowKey, bool, Option<RowVersions>)> {
+    fn get_next(&self, dir: IterationDirection) -> Option<(RowKey, bool, Option<RowVersions<A>>)> {
         tracing::trace!(
             "get_next: mvcc_key: {:?}, btree_key: {:?}",
             self.mvcc_peek.get_row_key(),
@@ -234,7 +259,7 @@ impl DualCursorPeek {
         &self,
         table_id: MVTableId,
         dir: IterationDirection,
-    ) -> CursorPosition {
+    ) -> CursorPosition<A> {
         match self.get_next(dir) {
             Some((row_key, in_btree, versions)) => CursorPosition::Loaded {
                 row_id: RowID {
@@ -268,20 +293,25 @@ impl DualCursorPeek {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-enum CursorPeek {
-    #[default]
+#[derive(Debug, Clone)]
+enum CursorPeek<A: ConcurrentAllocator = TursoAllocator> {
     Uninitialized,
     Row {
         key: RowKey,
         /// Resolved MVCC version chain, set when this peek came from the MVCC
         /// table iterator. `None` for btree peeks and index peeks.
-        versions: Option<RowVersions>,
+        versions: Option<RowVersions<A>>,
     },
     Exhausted,
 }
 
-impl CursorPeek {
+impl<A: ConcurrentAllocator> Default for CursorPeek<A> {
+    fn default() -> Self {
+        Self::Uninitialized
+    }
+}
+
+impl<A: ConcurrentAllocator> CursorPeek<A> {
     pub fn get_row_key(&self) -> Option<&RowKey> {
         match self {
             CursorPeek::Row { key, .. } => Some(key),
@@ -289,7 +319,7 @@ impl CursorPeek {
         }
     }
 
-    pub fn get_versions(&self) -> Option<RowVersions> {
+    pub fn get_versions(&self) -> Option<RowVersions<A>> {
         match self {
             CursorPeek::Row { versions, .. } => versions.clone(),
             _ => None,
@@ -304,7 +334,7 @@ pub enum MvccCursorType {
 }
 
 pub(crate) type MvccEntry<'l, T, A = TursoAllocator> =
-    Entry<'l, T, RowVersions, BasicComparator, A>;
+    Entry<'l, T, RowVersions<A>, BasicComparator, A>;
 
 pub(crate) type MvccIterator<'l, T, A = TursoAllocator> =
     Box<dyn Iterator<Item = MvccEntry<'l, T, A>> + Send + Sync>;
@@ -369,7 +399,7 @@ pub(crate) enum IndexShadowFinger<A: ConcurrentAllocator = TursoAllocator> {
     Peeked {
         iter: MvccIterator<'static, Arc<SortableIndexKey>, A>,
         key: Arc<SortableIndexKey>,
-        versions: RowVersions,
+        versions: RowVersions<A>,
     },
     /// Ran past the last version; every remaining B-tree row is visible.
     Exhausted,
@@ -466,7 +496,7 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator 
     connection: Arc<Connection>,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
-    current_pos: CursorPosition,
+    current_pos: CursorPosition<A>,
     /// Stateful MVCC table iterator if this is a table cursor.
     table_iterator: Option<MvccIterator<'static, RowID, A>>,
     /// Stateful MVCC index iterator if this is an index cursor.
@@ -484,7 +514,7 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator 
     count_state: Option<CountState>,
     btree_advance_state: Option<AdvanceBtreeState>,
     /// Dual-cursor peek state for proper iteration
-    dual_peek: DualCursorPeek,
+    dual_peek: DualCursorPeek<A>,
     /// Forward-scan finger over `index_rows`; see [`IndexShadowFinger`].
     index_finger: IndexShadowFinger<A>,
 }
@@ -723,7 +753,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         Ok(self.reusable_immutable_record.as_mut().unwrap())
     }
 
-    fn get_current_pos(&self) -> CursorPosition {
+    fn get_current_pos(&self) -> CursorPosition<A> {
         self.current_pos.clone()
     }
 

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2623,7 +2623,8 @@ mod tests {
         }
     }
 
-    fn checkpoint_for_collect_tests() -> CheckpointStateMachine<crate::mvcc::clock::MvccClock> {
+    fn checkpoint_for_collect_tests(
+    ) -> CheckpointStateMachine<crate::mvcc::clock::MvccClock, crate::alloc::DynAllocator> {
         let db = MvccTestDbNoConn::new();
         let conn = db.connect();
         let mvstore = db.get_mvcc_store();

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1466,10 +1466,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         );
         let row = with_mvcc_checkpoint_allocation_site!(
             CheckpointMetadataPayload,
-            Row::new_table_row(
+            Row::new_table_row_in(
                 RowID::new(table_id, RowKey::Int(1)),
                 record.get_payload(),
                 num_columns,
+                self.mvstore.allocator(),
             )?
         );
         with_mvcc_checkpoint_allocation_site!(CheckpointWriteSet, {
@@ -1793,6 +1794,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                             .expect("Table ID does not have a root page")
                     };
                     let row_version = {
+                        let alloc = self.mvstore.allocator();
                         let (row_version, _) = self
                             .get_current_row_version_mut(write_set_index)
                             .ok_or_else(|| {
@@ -1810,7 +1812,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         // a durable btree and a stale rootpage=0 schema row.
                         // TODO: make this rewrite resumable before re-enabling fault injection.
                         row_version.row.data = Some(crate::without_allocation_faults!(
-                            crate::alloc::try_arc_slice_from_slice(record.get_payload())?
+                            crate::alloc::try_arc_slice_from_slice_in(record.get_payload(), alloc)?
                         ));
                         row_version.clone()
                     };
@@ -1833,6 +1835,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                             .expect("Index ID does not have a root page")
                     };
                     let row_version = {
+                        let alloc = self.mvstore.allocator();
                         let (row_version, _) = self
                             .get_current_row_version_mut(write_set_index)
                             .ok_or_else(|| {
@@ -1849,7 +1852,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         // a durable btree and a stale rootpage=0 schema row.
                         // TODO: make this rewrite resumable before re-enabling fault injection.
                         row_version.row.data = Some(crate::without_allocation_faults!(
-                            crate::alloc::try_arc_slice_from_slice(record.get_payload())?
+                            crate::alloc::try_arc_slice_from_slice_in(record.get_payload(), alloc)?
                         ));
                         row_version.clone()
                     };

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1344,7 +1344,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             if let Some(entry) = self.mvstore.rows.get(row_id) {
                 let is_now_empty = {
                     let mut versions = entry.value().write();
-                    MvStore::<Clock>::gc_version_chain(&mut versions, lwm, ckpt_max);
+                    MvStore::<Clock, A>::gc_version_chain(&mut versions, lwm, ckpt_max);
                     versions.is_empty()
                 };
                 if is_now_empty {
@@ -1408,7 +1408,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         .get(sortable_key)
                         .expect("index row from write set must exist in inner map");
                     let mut versions = inner_entry.value().write();
-                    MvStore::<Clock>::gc_version_chain(&mut versions, lwm, ckpt_max);
+                    MvStore::<Clock, A>::gc_version_chain(&mut versions, lwm, ckpt_max);
                     versions.is_empty()
                 };
                 if is_now_empty {
@@ -2703,9 +2703,15 @@ mod tests {
         let row_count = COLLECT_PREEMPTION_THRESHOLD + 10;
         for i in 0..row_count as i64 {
             let version = committed_table_row_version(table_id, i);
+            let mut versions =
+                <crate::mvcc::database::RowVersionChain<crate::alloc::DynAllocator> as crate::alloc::TursoVecInExt<
+                    RowVersion,
+                    crate::alloc::DynAllocator,
+                >>::new_in(crate::alloc::DynAllocator::default());
+            versions.push(version);
             mvstore.rows.insert(
                 RowID::new(table_id, RowKey::Int(i)),
-                Arc::new(RwLock::new(crate::alloc::vec![version])),
+                Arc::new(RwLock::new(versions)),
             );
         }
 
@@ -2778,10 +2784,13 @@ mod tests {
         for i in 0..row_count as i64 {
             let version = committed_table_row_version(table_id, i);
             let row_id = RowID::new(table_id, RowKey::Int(i));
-            mvstore.rows.insert(
-                row_id,
-                Arc::new(RwLock::new(crate::alloc::vec![version.clone()])),
-            );
+            let mut versions =
+                <crate::mvcc::database::RowVersionChain<crate::alloc::DynAllocator> as crate::alloc::TursoVecInExt<
+                    RowVersion,
+                    crate::alloc::DynAllocator,
+                >>::new_in(crate::alloc::DynAllocator::default());
+            versions.push(version.clone());
+            mvstore.rows.insert(row_id, Arc::new(RwLock::new(versions)));
             checkpoint.write_set.push((version, None));
         }
         checkpoint.state = CheckpointState::GcTableRows {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2510,23 +2510,26 @@ mod tests {
         end: Option<u64>,
         btree_resident: bool,
     ) -> (Arc<SortableIndexKey>, RowVersion) {
-        let index_info = Arc::new(IndexInfo {
-            key_info: vec![
-                KeyInfo {
-                    sort_order: SortOrder::Asc,
-                    collation: CollationSeq::Binary,
-                    nulls_order: None,
-                },
-                KeyInfo {
-                    sort_order: SortOrder::Asc,
-                    collation: CollationSeq::Binary,
-                    nulls_order: None,
-                },
-            ],
-            has_rowid: true,
-            num_cols: 2,
-            is_unique: true,
-        });
+        let index_info = Arc::new(
+            IndexInfo::new(
+                vec![
+                    KeyInfo {
+                        sort_order: SortOrder::Asc,
+                        collation: CollationSeq::Binary,
+                        nulls_order: None,
+                    },
+                    KeyInfo {
+                        sort_order: SortOrder::Asc,
+                        collation: CollationSeq::Binary,
+                        nulls_order: None,
+                    },
+                ],
+                true,
+                2,
+                true,
+            )
+            .unwrap(),
+        );
         let key_record = ImmutableRecord::from_values(
             &[
                 Value::Text(crate::types::Text::new(key_text.to_string())),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -113,6 +113,11 @@ struct YieldContext;
 pub struct MVTableId(i64);
 
 /// The versions of a single row.
+///
+/// This associated type keeps `RowVersionChain<A>` allocator-shaped in MVCC
+/// code without scattering `cfg(nightly)` branches. Stable Rust cannot define
+/// a `Vec<T, A>` type alias that ignores `A`, so the stable implementation
+/// maps every allocator to the allocator-free `Vec<RowVersion>`.
 pub trait RowVersionAllocator: ConcurrentAllocator {
     type RowVersionChain: std::fmt::Debug;
 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1,5 +1,6 @@
 use crate::alloc::{
-    ConcurrentAllocator, TryReserveError, TursoAllocator, TursoTryWithCapacityExt, ALLOC_ERR_MSG,
+    ConcurrentAllocator, TryReserveError, TursoAllocator, TursoTryWithCapacityExt, TursoVecInExt,
+    ALLOC_ERR_MSG,
 };
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::cursor::{static_iterator_hack, MvccIterator};
@@ -112,11 +113,25 @@ struct YieldContext;
 pub struct MVTableId(i64);
 
 /// The versions of a single row.
-pub type RowVersionChain = crate::alloc::Vec<RowVersion>;
-pub type RowVersions = Arc<RwLock<RowVersionChain>>;
-type TableRowEntry<'a, A = TursoAllocator> = Entry<'a, RowID, RowVersions, BasicComparator, A>;
+pub trait RowVersionAllocator: ConcurrentAllocator {
+    type RowVersionChain: std::fmt::Debug;
+}
+
+#[cfg(not(nightly))]
+impl<A: ConcurrentAllocator> RowVersionAllocator for A {
+    type RowVersionChain = crate::alloc::Vec<RowVersion>;
+}
+
+#[cfg(nightly)]
+impl<A: ConcurrentAllocator> RowVersionAllocator for A {
+    type RowVersionChain = crate::alloc::Vec<RowVersion, A>;
+}
+
+pub type RowVersionChain<A = TursoAllocator> = <A as RowVersionAllocator>::RowVersionChain;
+pub type RowVersions<A = TursoAllocator> = Arc<RwLock<RowVersionChain<A>>>;
+type TableRowEntry<'a, A = TursoAllocator> = Entry<'a, RowID, RowVersions<A>, BasicComparator, A>;
 type IndexRowEntry<'a, A = TursoAllocator> =
-    Entry<'a, Arc<SortableIndexKey>, RowVersions, BasicComparator, A>;
+    Entry<'a, Arc<SortableIndexKey>, RowVersions<A>, BasicComparator, A>;
 type IndexRowsEntry<'a, A = TursoAllocator> =
     Entry<'a, MVTableId, IndexRowsMap<A>, BasicComparator, A>;
 type TableRowIterator<'a, A = TursoAllocator> =
@@ -127,7 +142,7 @@ type IndexRowIterator<'a, A = TursoAllocator> =
 /// Per-index map of sortable keys to their version chains, stored as the
 /// values of [`MvStore::index_rows`].
 pub type IndexRowsMap<A = TursoAllocator> =
-    SkipMap<Arc<SortableIndexKey>, RowVersions, BasicComparator, A>;
+    SkipMap<Arc<SortableIndexKey>, RowVersions<A>, BasicComparator, A>;
 
 impl MVTableId {
     pub fn new(value: i64) -> Self {
@@ -707,8 +722,8 @@ enum SavepointKind {
 }
 
 /// Tracks row/index version deltas created inside a single savepoint scope.
-#[derive(Debug, Default)]
-pub struct Savepoint {
+#[derive(Debug)]
+pub struct Savepoint<A: RowVersionAllocator = TursoAllocator> {
     kind: SavepointKind,
     deferred_fk_violations: isize,
     header: DatabaseHeader,
@@ -723,10 +738,26 @@ pub struct Savepoint {
     deleted_index_versions: Vec<((MVTableId, Arc<SortableIndexKey>), u64)>,
     /// RowIDs that were NEWLY added to write_set by this savepoint.
     /// On rollback: only these should be removed from write_set.
-    newly_added_to_write_set: Vec<(RowID, RowVersions)>,
+    newly_added_to_write_set: Vec<(RowID, RowVersions<A>)>,
 }
 
-impl Savepoint {
+impl<A: RowVersionAllocator> Default for Savepoint<A> {
+    fn default() -> Self {
+        Self {
+            kind: SavepointKind::default(),
+            deferred_fk_violations: 0,
+            header: DatabaseHeader::default(),
+            header_dirty: false,
+            created_table_versions: Vec::new(),
+            created_index_versions: Vec::new(),
+            deleted_table_versions: Vec::new(),
+            deleted_index_versions: Vec::new(),
+            newly_added_to_write_set: Vec::new(),
+        }
+    }
+}
+
+impl<A: RowVersionAllocator> Savepoint<A> {
     /// Creates an internal statement savepoint used for per-statement rollback.
     fn statement(header: DatabaseHeader, header_dirty: bool) -> Self {
         Self {
@@ -759,7 +790,7 @@ impl Savepoint {
     /// Merges child savepoint deltas into this savepoint.
     ///
     /// Called when releasing nested savepoints so outer rollback still has a full undo set.
-    fn merge_from(&mut self, mut other: Savepoint) {
+    fn merge_from(&mut self, mut other: Savepoint<A>) {
         self.created_table_versions
             .append(&mut other.created_table_versions);
         self.created_index_versions
@@ -773,16 +804,16 @@ impl Savepoint {
     }
 }
 
-struct SavepointRollbackResult {
+struct SavepointRollbackResult<A: RowVersionAllocator = TursoAllocator> {
     /// Savepoints that were rolled back, in the order they were created (oldest to newest).
-    rolledback_savepoints: Vec<Savepoint>,
+    rolledback_savepoints: Vec<Savepoint<A>>,
     /// Deferred FK counter snapshot captured at the target named savepoint.
     deferred_fk_violations: isize,
 }
 
-#[derive(Debug, Default)]
-struct WriteSet {
-    entries: Vec<(RowID, RowVersions)>,
+#[derive(Debug)]
+struct WriteSet<A: RowVersionAllocator = TursoAllocator> {
+    entries: Vec<(RowID, RowVersions<A>)>,
     /// A set of the pointer addresses of the `RowVersions`. Used to deduplicate entries.
     ///
     /// This is correct because instances of [RowVersions] are created once per [RowID] and then
@@ -791,13 +822,22 @@ struct WriteSet {
     seen: HashSet<usize>,
 }
 
-impl WriteSet {
+impl<A: RowVersionAllocator> Default for WriteSet<A> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            seen: HashSet::default(),
+        }
+    }
+}
+
+impl<A: RowVersionAllocator> WriteSet<A> {
     fn new() -> Self {
         Self::default()
     }
 
     /// Returns `true` if this `RowVersions` was not already contained in the write set.
-    fn insert(&mut self, id: RowID, row_versions: RowVersions) -> bool {
+    fn insert(&mut self, id: RowID, row_versions: RowVersions<A>) -> bool {
         let ptr = Arc::as_ptr(&row_versions) as usize;
         if self.seen.insert(ptr) {
             self.entries.push((id, row_versions));
@@ -811,12 +851,12 @@ impl WriteSet {
         self.entries.is_empty()
     }
 
-    fn iter(&self) -> std::slice::Iter<'_, (RowID, RowVersions)> {
+    fn iter(&self) -> std::slice::Iter<'_, (RowID, RowVersions<A>)> {
         self.entries.iter()
     }
 
     /// Retain entries where `keep(rowid, row_versions)` returns true.
-    fn retain<F: FnMut(&RowID, &RowVersions) -> bool>(&mut self, mut keep: F) {
+    fn retain<F: FnMut(&RowID, &RowVersions<A>) -> bool>(&mut self, mut keep: F) {
         let seen = &mut self.seen;
         self.entries.retain(|(rowid, rv)| {
             if keep(rowid, rv) {
@@ -829,14 +869,14 @@ impl WriteSet {
     }
 
     /// Clones the write set into a [Vec].
-    fn to_vec(&self) -> Vec<(RowID, RowVersions)> {
+    fn to_vec(&self) -> Vec<(RowID, RowVersions<A>)> {
         self.entries.clone()
     }
 }
 
 /// Transaction
 #[derive(Debug)]
-pub struct Transaction {
+pub struct Transaction<A: RowVersionAllocator = TursoAllocator> {
     /// The state of the transaction.
     state: AtomicTransactionState,
     /// The transaction ID.
@@ -844,14 +884,14 @@ pub struct Transaction {
     /// The transaction begin timestamp.
     begin_ts: u64,
     /// The transaction write set. Only writer is the [Transaction]'s own connection.
-    write_set: Mutex<WriteSet>,
+    write_set: Mutex<WriteSet<A>>,
     /// The transaction header.
     header: RwLock<DatabaseHeader>,
     /// True when the transaction mutated its local database header snapshot.
     header_dirty: AtomicBool,
     /// Stack of savepoints for statement-level rollback.
     /// Each savepoint tracks versions created/deleted during that statement.
-    savepoint_stack: RwLock<Vec<Savepoint>>,
+    savepoint_stack: RwLock<Vec<Savepoint<A>>>,
     /// True when this transaction currently holds the serialized logical-log commit lock.
     pager_commit_lock_held: AtomicBool,
     /// Number of unresolved commit dependencies (must reach 0 before commit).
@@ -868,8 +908,8 @@ pub struct Transaction {
     commit_dep_set: Mutex<HashSet<TxID>>,
 }
 
-impl Transaction {
-    fn new(tx_id: u64, begin_ts: u64, header: DatabaseHeader) -> Transaction {
+impl<A: RowVersionAllocator> Transaction<A> {
+    fn new(tx_id: u64, begin_ts: u64, header: DatabaseHeader) -> Transaction<A> {
         Transaction {
             state: TransactionState::Active.into(),
             tx_id,
@@ -885,7 +925,7 @@ impl Transaction {
         }
     }
 
-    fn insert_to_write_set(&self, id: RowID, row_versions: RowVersions) {
+    fn insert_to_write_set(&self, id: RowID, row_versions: RowVersions<A>) {
         // Always record in the current savepoint's `newly_added_to_write_set`.
         // Duplicates here are harmless: `rollback_savepoint_changes` collects
         // touched rowids into a BTreeSet (dedup), and the actual write_set
@@ -955,7 +995,7 @@ impl Transaction {
         }
     }
 
-    fn pop_statement_savepoint(&self) -> Option<Savepoint> {
+    fn pop_statement_savepoint(&self) -> Option<Savepoint<A>> {
         let mut savepoints = self.savepoint_stack.write();
         if !matches!(
             savepoints.last().map(|savepoint| &savepoint.kind),
@@ -1000,7 +1040,7 @@ impl Transaction {
             return commits_transaction;
         }
 
-        let drained: Vec<Savepoint> = savepoints.drain(target_idx..).collect();
+        let drained: Vec<Savepoint<A>> = savepoints.drain(target_idx..).collect();
         if let Some(parent) = savepoints.last_mut() {
             for savepoint in drained {
                 parent.merge_from(savepoint);
@@ -1012,7 +1052,7 @@ impl Transaction {
     /// Find the named savepoint to rollback to and pop all savepoints above it. Returns the rolled
     /// back savepoints and net change in deferred FK violations for undoing changes to transaction
     /// state.
-    fn rollback_to_named_savepoint(&self, name: &str) -> Option<SavepointRollbackResult> {
+    fn rollback_to_named_savepoint(&self, name: &str) -> Option<SavepointRollbackResult<A>> {
         let mut savepoints = self.savepoint_stack.write();
         let target_idx = savepoints.iter().rposition(|savepoint| {
             matches!(
@@ -1039,7 +1079,7 @@ impl Transaction {
         let header = savepoints[target_idx].header;
         let header_dirty = savepoints[target_idx].header_dirty;
 
-        let drained: Vec<Savepoint> = savepoints.drain(target_idx..).collect();
+        let drained: Vec<Savepoint<A>> = savepoints.drain(target_idx..).collect();
         savepoints.push(Savepoint::named(
             target_name,
             starts_transaction,
@@ -1116,7 +1156,7 @@ impl Transaction {
     }
 }
 
-impl std::fmt::Display for Transaction {
+impl<A: RowVersionAllocator> std::fmt::Display for Transaction<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         write!(
             f,
@@ -1606,7 +1646,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         &self,
         rowid: &RowID,
         end_ts: u64,
-        tx: &Transaction,
+        tx: &Transaction<A>,
         mvcc_store: &Arc<MvStore<Clock, A>>,
     ) -> Result<()> {
         let row_versions = mvcc_store.rows.get(rowid);
@@ -1630,7 +1670,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         &self,
         rowid: &RowID,
         end_ts: u64,
-        tx: &Transaction,
+        tx: &Transaction<A>,
         mvcc_store: &Arc<MvStore<Clock, A>>,
     ) -> Result<()> {
         let RowKey::Record(record) = &rowid.row_id else {
@@ -1691,7 +1731,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
     fn check_version_conflicts(
         &self,
         end_ts: u64,
-        tx: &Transaction,
+        tx: &Transaction<A>,
         mvcc_store: &Arc<MvStore<Clock, A>>,
         row_versions: &[RowVersion],
     ) -> Result<()> {
@@ -1996,7 +2036,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             }
         };
 
-        let collect_versions = |row_versions: &RowVersions,
+        let collect_versions = |row_versions: &RowVersions<A>,
                                 log_record: &mut LogRecord|
          -> Result<()> {
             // `log_record.row_versions` is the logical transaction log. Recovery
@@ -2272,7 +2312,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         {
             let _ = mvcc_store;
             let _ = log_record;
-            return Ok(());
+            Ok(())
         }
 
         #[cfg(feature = "conn_raw_api")]
@@ -3716,7 +3756,7 @@ pub struct RecoverCtx {
 /// A multi-version concurrency control database.
 #[derive(Debug)]
 pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator> {
-    pub rows: SkipMap<RowID, RowVersions, BasicComparator, A>,
+    pub rows: SkipMap<RowID, RowVersions<A>, BasicComparator, A>,
     /// Table ID is an opaque identifier that is only meaningful to the MV store.
     /// Each checkpointed MVCC table corresponds to a single B-tree on the pager,
     /// which naturally has a root page.
@@ -3733,7 +3773,7 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// because operations like last() on an index are much easier when we don't have to take the
     /// table identifier into account.
     pub index_rows: SkipMap<MVTableId, IndexRowsMap<A>, BasicComparator, A>,
-    txs: SkipMap<TxID, Transaction, BasicComparator, A>,
+    txs: SkipMap<TxID, Transaction<A>, BasicComparator, A>,
     /// Final state for removed transactions. Readers may still race with stale TxID
     /// references in row versions after a transaction is removed from `txs`.
     finalized_tx_states: SkipMap<TxID, TransactionState, BasicComparator, A>,
@@ -4949,7 +4989,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     pub(crate) fn read_visible_from_versions(
         &self,
         tx_id: TxID,
-        versions: &RowVersions,
+        versions: &RowVersions<A>,
     ) -> Result<Option<Row>> {
         let tx = self
             .txs
@@ -4976,7 +5016,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     pub(crate) fn read_visible_into_record(
         &self,
         tx_id: TxID,
-        versions: &RowVersions,
+        versions: &RowVersions<A>,
         record: &mut ImmutableRecord,
     ) -> Result<bool> {
         let tx = self
@@ -5040,7 +5080,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         table_id: MVTableId,
         mv_store_iterator: &mut Option<MvccIterator<'static, RowID, A>>,
         tx_id: TxID,
-    ) -> Option<(RowID, RowVersions)> {
+    ) -> Option<(RowID, RowVersions<A>)> {
         let mv_store_iterator = mv_store_iterator.as_mut().expect(
             "mv_store_iterator must be initialized when calling get_row_id_for_table_in_direction",
         );
@@ -5100,7 +5140,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// (O(log N)) per scanned row with an amortized-O(1) merge step.
     pub(crate) fn index_chain_invalidates_btree(
         &self,
-        versions: &RwLock<RowVersionChain>,
+        versions: &RwLock<RowVersionChain<A>>,
         tx_id: TxID,
     ) -> bool {
         let tx = self
@@ -5173,9 +5213,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
     fn find_last_visible_version(
         &self,
-        tx: &Transaction,
+        tx: &Transaction<A>,
         row: &TableRowEntry<'_, A>,
-    ) -> Option<(RowID, RowVersions)> {
+    ) -> Option<(RowID, RowVersions<A>)> {
         row.value()
             .read()
             .iter()
@@ -5186,7 +5226,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
     fn find_last_visible_index_version(
         &self,
-        tx: &Transaction,
+        tx: &Transaction<A>,
         row: IndexRowEntry<'_, A>,
     ) -> Option<RowID> {
         row.value()
@@ -5197,7 +5237,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             .map(|version| version.row.id.clone())
     }
 
-    fn find_next_visible_index_row<'a, I>(&self, tx: &Transaction, mut rows: I) -> Option<RowID>
+    fn find_next_visible_index_row<'a, I>(&self, tx: &Transaction<A>, mut rows: I) -> Option<RowID>
     where
         I: Iterator<Item = IndexRowEntry<'a, A>>,
     {
@@ -5211,10 +5251,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
     fn find_next_visible_table_row<'a, I>(
         &self,
-        tx: &Transaction,
+        tx: &Transaction<A>,
         mut rows: I,
         table_id: MVTableId,
-    ) -> Option<(RowID, RowVersions)>
+    ) -> Option<(RowID, RowVersions<A>)>
     where
         I: Iterator<Item = TableRowEntry<'a, A>>,
     {
@@ -5556,7 +5596,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::TxInsert)]
-    fn insert_tx_entry(&self, tx_id: TxID, tx: Transaction) -> Result<(), TryReserveError> {
+    fn insert_tx_entry(&self, tx_id: TxID, tx: Transaction<A>) -> Result<(), TryReserveError> {
         self.txs.try_insert(tx_id, tx)?;
         Ok(())
     }
@@ -5901,7 +5941,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
         // Snapshot under the lock so we can drop it before recursing into
         // `rollback_rowid` (which may take other locks).
-        let write_set_snapshot: Vec<(RowID, RowVersions)> = tx.write_set.lock().to_vec();
+        let write_set_snapshot: Vec<(RowID, RowVersions<A>)> = tx.write_set.lock().to_vec();
         for (_rowid, row_versions) in &write_set_snapshot {
             for rv in row_versions.write().iter_mut() {
                 rollback_row_version(tx_id, rv);
@@ -5956,7 +5996,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         }
     }
 
-    fn unlock_commit_lock_if_held(&self, tx: &Transaction) {
+    fn unlock_commit_lock_if_held(&self, tx: &Transaction<A>) {
         if tx.pager_commit_lock_held.swap(false, Ordering::AcqRel) {
             self.commit_coordinator.pager_commit_lock.unlock();
         }
@@ -6057,7 +6097,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         Ok(Some(deferred_fk_violations))
     }
 
-    fn rollback_savepoint_changes(&self, tx_id: TxID, savepoint: Savepoint) {
+    fn rollback_savepoint_changes(&self, tx_id: TxID, savepoint: Savepoint<A>) {
         let Savepoint {
             header,
             header_dirty,
@@ -6757,7 +6797,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Rule 3: Current checkpointed sole-survivor (end=None, b <= ckpt_max,
     ///         b < lwm, no other versions remain) — remove.
     ///
-    fn gc_version_chain(versions: &mut RowVersionChain, lwm: u64, ckpt_max: u64) -> usize {
+    fn gc_version_chain(versions: &mut RowVersionChain<A>, lwm: u64, ckpt_max: u64) -> usize {
         let before = versions.len();
 
         // Rule 1: aborted garbage
@@ -6816,7 +6856,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// peak allocation forever. Capacity drops to a quarter of its current
     /// value — deliberately not to fit — when the survivors occupy less than
     /// a quarter of it, so steady-state chains keep slack for new versions.
-    fn shrink_version_chain_allocation(versions: &mut RowVersionChain) {
+    fn shrink_version_chain_allocation(versions: &mut RowVersionChain<A>) {
         let capacity = versions.capacity();
         if capacity > Self::CHAIN_SHRINK_MIN_CAPACITY && versions.len() < capacity / 4 {
             versions.shrink_to(capacity / 4);
@@ -6854,17 +6894,24 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         id: RowID,
         row_version: RowVersion,
-    ) -> Result<RowVersions, TryReserveError> {
+    ) -> Result<RowVersions<A>, TryReserveError> {
         let row_versions = self.get_or_create_table_row_versions(id)?;
         self.insert_version_raw(&mut row_versions.write(), row_version)?;
         Ok(row_versions)
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::TableRowsEntry)]
-    fn get_or_create_table_row_versions(&self, id: RowID) -> Result<RowVersions, TryReserveError> {
-        let versions = self
-            .rows
-            .try_get_or_insert_with(id, || Arc::new(RwLock::new(crate::alloc::vec![])))?;
+    fn get_or_create_table_row_versions(
+        &self,
+        id: RowID,
+    ) -> Result<RowVersions<A>, TryReserveError> {
+        let alloc = self.alloc.clone();
+        let versions = self.rows.try_get_or_insert_with(id, move || {
+            Arc::new(RwLock::new(<RowVersionChain<A> as TursoVecInExt<
+                RowVersion,
+                A,
+            >>::new_in(alloc)))
+        })?;
         Ok(versions.value().clone())
     }
 
@@ -6888,7 +6935,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         index_id: MVTableId,
         key: Arc<SortableIndexKey>,
         mut row_version: RowVersion,
-    ) -> Result<(Arc<SortableIndexKey>, RowVersions)> {
+    ) -> Result<(Arc<SortableIndexKey>, RowVersions<A>)> {
         let index = self.get_or_create_index_rows(index_id)?;
         let index = index.value();
         let entry = self.get_or_create_index_key_entry(index, key)?;
@@ -6920,8 +6967,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         index: &'a IndexRowsMap<A>,
         key: Arc<SortableIndexKey>,
     ) -> Result<IndexRowEntry<'a, A>, TryReserveError> {
-        let entry =
-            index.try_get_or_insert_with(key, || Arc::new(RwLock::new(crate::alloc::vec![])))?;
+        let alloc = self.alloc.clone();
+        let entry = index.try_get_or_insert_with(key, move || {
+            Arc::new(RwLock::new(<RowVersionChain<A> as TursoVecInExt<
+                RowVersion,
+                A,
+            >>::new_in(alloc)))
+        })?;
         Ok(entry)
     }
 
@@ -6930,7 +6982,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::RowVersionReserve)]
     pub fn insert_version_raw(
         &self,
-        versions: &mut RowVersionChain,
+        versions: &mut RowVersionChain<A>,
         row_version: RowVersion,
     ) -> Result<(), TryReserveError> {
         // NOTICE: this is an insert a'la insertion sort, with pessimistic linear complexity.
@@ -8443,9 +8495,9 @@ pub fn create_seek_range<K: Ord>(
 /// Ref: https://www.cs.cmu.edu/~15721-f24/papers/Hekaton.pdf , page 301,
 /// 2.6. Updating a Version.
 fn is_write_write_conflict<A: ConcurrentAllocator>(
-    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+    txs: &SkipMap<TxID, Transaction<A>, BasicComparator, A>,
     finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
-    tx: &Transaction,
+    tx: &Transaction<A>,
     rv: &RowVersion,
 ) -> bool {
     match rv.end() {
@@ -8522,8 +8574,8 @@ impl RowVersion {
     /// * End timestamp is not applicable yet, meaning deletion of row is not visible to this transaction
     fn is_visible_to<A: ConcurrentAllocator>(
         &self,
-        tx: &Transaction,
-        txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+        tx: &Transaction<A>,
+        txs: &SkipMap<TxID, Transaction<A>, BasicComparator, A>,
         finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     ) -> bool {
         is_begin_visible(txs, finalized_tx_states, tx, self)
@@ -8540,8 +8592,8 @@ impl RowVersion {
     /// This is used by dual-cursor to determine if a B-tree row should be shown or hidden.
     fn is_btree_invalidating_version<A: ConcurrentAllocator>(
         &self,
-        tx: &Transaction,
-        txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+        tx: &Transaction<A>,
+        txs: &SkipMap<TxID, Transaction<A>, BasicComparator, A>,
         finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     ) -> bool {
         // If the version is fully visible, it invalidates the B-tree
@@ -8603,8 +8655,8 @@ impl RowVersion {
 /// The lock on `commit_dep_set` serializes with the drain in commit/abort
 /// resolution, preventing the race where we push an entry after the drain.
 fn register_commit_dependency<A: ConcurrentAllocator>(
-    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
-    dependent_tx: &Transaction,
+    txs: &SkipMap<TxID, Transaction<A>, BasicComparator, A>,
+    dependent_tx: &Transaction<A>,
     depended_on_tx_id: TxID,
 ) {
     turso_assert!(
@@ -8661,7 +8713,7 @@ fn register_commit_dependency<A: ConcurrentAllocator>(
 }
 
 fn lookup_tx_state<A: ConcurrentAllocator>(
-    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+    txs: &SkipMap<TxID, Transaction<A>, BasicComparator, A>,
     finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
     tx_id: TxID,
 ) -> Option<TransactionState> {
@@ -8688,9 +8740,9 @@ fn lookup_finalized_tx_state<A: ConcurrentAllocator>(
 }
 
 fn is_begin_visible<A: ConcurrentAllocator>(
-    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+    txs: &SkipMap<TxID, Transaction<A>, BasicComparator, A>,
     finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
-    tx: &Transaction,
+    tx: &Transaction<A>,
     rv: &RowVersion,
 ) -> bool {
     match rv.begin() {
@@ -8779,9 +8831,9 @@ fn is_begin_visible<A: ConcurrentAllocator>(
 }
 
 fn is_end_visible<A: ConcurrentAllocator>(
-    txs: &SkipMap<TxID, Transaction, BasicComparator, A>,
+    txs: &SkipMap<TxID, Transaction<A>, BasicComparator, A>,
     finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
-    current_tx: &Transaction,
+    current_tx: &Transaction<A>,
     row_version: &RowVersion,
 ) -> bool {
     match row_version.end() {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -354,9 +354,18 @@ impl Row {
         data: &[u8],
         column_count: usize,
     ) -> Result<Self, TryReserveError> {
+        Self::new_table_row_in(id, data, column_count, TursoAllocator)
+    }
+
+    pub fn new_table_row_in<A: ConcurrentAllocator>(
+        id: RowID,
+        data: &[u8],
+        column_count: usize,
+        alloc: A,
+    ) -> Result<Self, TryReserveError> {
         Ok(Self {
             id,
-            data: Some(crate::alloc::try_arc_slice_from_slice(data)?),
+            data: Some(crate::alloc::try_arc_slice_from_slice_in(data, alloc)?),
             column_count,
         })
     }
@@ -3902,6 +3911,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 }
 
 impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
+    pub(crate) fn allocator(&self) -> A {
+        self.alloc.clone()
+    }
+
     fn uses_durable_mvcc_metadata(&self, connection: &Arc<Connection>) -> bool {
         !connection.db.is_in_memory_db()
     }
@@ -7892,9 +7905,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         continue;
                     }
 
-                    let next_rec = ctx
-                        .reader
-                        .parsed_op_to_streaming(parsed_op, &mut get_index_info)?;
+                    let next_rec = ctx.reader.parsed_op_to_streaming_in(
+                        parsed_op,
+                        &mut get_index_info,
+                        self.alloc.clone(),
+                    )?;
 
                     tracing::trace!("next_rec {next_rec:?}");
 
@@ -8051,16 +8066,27 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     if let Some(record) = schema_rows.get(&rowid_int) {
                                         // Preserve the pre-delete sqlite_schema record in recovered
                                         // tombstones so checkpoint can still recover B-tree identity.
-                                        Row::new_table_row(
+                                        Row::new_table_row_in(
                                             rowid.clone(),
                                             record.as_blob(),
                                             record.column_count(),
+                                            self.alloc.clone(),
                                         )?
                                     } else {
-                                        Row::new_table_row(rowid.clone(), &[], 0)?
+                                        Row::new_table_row_in(
+                                            rowid.clone(),
+                                            &[],
+                                            0,
+                                            self.alloc.clone(),
+                                        )?
                                     }
                                 } else {
-                                    Row::new_table_row(rowid.clone(), &[], 0)?
+                                    Row::new_table_row_in(
+                                        rowid.clone(),
+                                        &[],
+                                        0,
+                                        self.alloc.clone(),
+                                    )?
                                 }
                             );
                             if let Some(versions) = self.rows.get(&rowid) {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -7708,15 +7708,18 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 .unwrap_or_else(|| i64::from(index_id))
         };
 
-        let find_index_info = |schema: &Schema, root_page: i64| -> Result<Option<Arc<IndexInfo>>> {
-            schema
-                .indexes
-                .values()
-                .flatten()
-                .find(|idx| idx.root_page == root_page)
-                .map(|idx| IndexInfo::new_from_index(idx.as_ref()).map(Arc::new))
-                .transpose()
-        };
+        let find_index_info =
+            |schema: &Schema, root_page: i64| -> Result<Option<Arc<IndexInfo>>, TryReserveError> {
+                schema
+                    .indexes
+                    .values()
+                    .flatten()
+                    .find(|idx| idx.root_page == root_page)
+                    .map(|idx| {
+                        IndexInfo::new_from_index_in(idx.as_ref(), self.alloc.clone()).map(Arc::new)
+                    })
+                    .transpose()
+            };
 
         let schema_has_index_root = |schema: &Schema, root_page: i64| -> bool {
             schema

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -47,7 +47,7 @@ pub(crate) struct MvccTestDbNoConn {
     _temp_dir: Option<tempfile::TempDir>,
 }
 pub(crate) struct MvccTestDb {
-    pub(crate) mvcc_store: Arc<MvStore<MvccClock>>,
+    pub(crate) mvcc_store: Arc<crate::MvStore>,
     pub(crate) db: Arc<Database>,
     pub(crate) conn: Arc<Connection>,
 }
@@ -713,7 +713,7 @@ impl MvccTestDbNoConn {
         self.get_db().connect_with_encryption(enc_key).unwrap()
     }
 
-    pub fn get_mvcc_store(&self) -> Arc<MvStore<MvccClock>> {
+    pub fn get_mvcc_store(&self) -> Arc<crate::MvStore> {
         self.get_db().get_mv_store().clone().unwrap()
     }
 }
@@ -729,7 +729,7 @@ pub(crate) fn generate_simple_string_record(data: &str) -> ImmutableRecord {
 }
 
 fn advance_checkpoint_until_wal_has_commit_frame(
-    mvcc_store: Arc<MvStore<MvccClock>>,
+    mvcc_store: Arc<crate::MvStore>,
     conn: &Arc<Connection>,
 ) {
     let pager = conn.pager.load().clone();
@@ -4200,7 +4200,7 @@ fn test_mvcc_cursor_next_yields_with_injected_yield() {
 }
 
 pub(crate) fn commit_tx(
-    mv_store: Arc<MvStore<MvccClock>>,
+    mv_store: Arc<crate::MvStore>,
     conn: &Arc<Connection>,
     tx_id: u64,
 ) -> Result<()> {
@@ -5244,8 +5244,8 @@ fn test_index_finger_no_spurious_dep_on_stepped_over_key() {
         btree_resident: false,
     };
     store
-        .index_rows
-        .get_or_insert_with(table_id, SkipMap::new)
+        .get_or_create_index_rows(table_id)
+        .unwrap()
         .value()
         .insert(key20, Arc::new(RwLock::new(crate::alloc::vec![tombstone])));
 
@@ -10287,7 +10287,7 @@ fn test_concurrent_commit_yield_spin() {
     assert_eq!(rows[0][0].as_int().unwrap(), 1);
 }
 
-fn abandon_commit_after_first_io(conn: &Arc<Connection>, mv_store: &Arc<MvStore<MvccClock>>) {
+fn abandon_commit_after_first_io(conn: &Arc<Connection>, mv_store: &Arc<crate::MvStore>) {
     let lock = &mv_store.commit_coordinator.pager_commit_lock;
     assert!(lock.write(), "should acquire commit lock");
 
@@ -15684,7 +15684,7 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
         .unwrap();
 
-    let mv_store: Arc<MvStore<MvccClock>> = db.get_mv_store().clone().unwrap();
+    let mv_store: Arc<crate::MvStore> = db.get_mv_store().clone().unwrap();
 
     // Step 3: open a CONCURRENT tx, do an INSERT, then arm log_tx Busy.
     conn_a.execute("BEGIN CONCURRENT").unwrap();

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -235,6 +235,21 @@ fn mv_store_skiplist_allocations_are_fallible() {
     assert!(store.rows.is_empty());
 }
 
+#[cfg(nightly)]
+#[test]
+fn row_payload_allocation_uses_passed_allocator() {
+    let alloc = FailOnDemandAlloc::default();
+    let row_id = RowID::new(MVTableId::from(-2), RowKey::Int(1));
+
+    alloc.fail_allocations(true);
+    let result = Row::new_table_row_in(row_id.clone(), &[1, 2, 3], 1, alloc.clone());
+    assert!(matches!(result, Err(crate::alloc::TryReserveError)));
+
+    alloc.fail_allocations(false);
+    let row = Row::new_table_row_in(row_id, &[1, 2, 3], 1, alloc).unwrap();
+    assert_eq!(row.payload(), &[1, 2, 3]);
+}
+
 #[test]
 fn mv_store_insert_allocation_failure_leaves_tx_state_untouched() {
     let alloc = FailOnDemandAlloc::default();

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -5228,16 +5228,19 @@ fn test_index_finger_no_spurious_dep_on_stepped_over_key() {
     let table_id = MVTableId::from(-999_i64);
 
     // Single-column ascending integer index key.
-    let info = std::sync::Arc::new(crate::types::IndexInfo {
-        key_info: crate::alloc::vec![crate::types::KeyInfo {
-            sort_order: turso_parser::ast::SortOrder::Asc,
-            collation: crate::translate::collate::CollationSeq::Binary,
-            nulls_order: None,
-        }],
-        has_rowid: false,
-        num_cols: 1,
-        is_unique: false,
-    });
+    let info = std::sync::Arc::new(
+        crate::types::IndexInfo::new(
+            crate::alloc::vec![crate::types::KeyInfo {
+                sort_order: turso_parser::ast::SortOrder::Asc,
+                collation: crate::translate::collate::CollationSeq::Binary,
+                nulls_order: None,
+            }],
+            false,
+            1,
+            false,
+        )
+        .unwrap(),
+    );
     let idx_key = |v: i64| {
         let rec = crate::types::ImmutableRecord::from_values(&[Value::from_i64(v)], 1).unwrap();
         std::sync::Arc::new(SortableIndexKey::new_from_record(rec, info.clone()))

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashSet as HashSet;
 
 use super::*;
-use crate::alloc::{TursoIteratorExt, TursoTryWithCapacityExt};
+use crate::alloc::{TursoAllocator, TursoIteratorExt, TursoTryWithCapacityExt};
 use crate::io::{PlatformIO, IO};
 use crate::mvcc::clock::MvccClock;
 use crate::mvcc::cursor::{CursorYieldPoint, MvccCursorType};
@@ -246,7 +246,7 @@ fn mv_store_insert_allocation_failure_leaves_tx_state_untouched() {
     .unwrap();
 
     let tx_id = 7;
-    let tx = new_tx(tx_id, 1, TransactionState::Active);
+    let tx = new_tx_in::<FailOnDemandAlloc>(tx_id, 1, TransactionState::Active);
     tx.begin_savepoint();
     store.txs.try_insert(tx_id, tx).unwrap();
 
@@ -4833,6 +4833,14 @@ or not found |                    | the timestamp.
 */
 
 fn new_tx(tx_id: TxID, begin_ts: u64, state: TransactionState) -> Transaction {
+    new_tx_in(tx_id, begin_ts, state)
+}
+
+fn new_tx_in<A: super::RowVersionAllocator>(
+    tx_id: TxID,
+    begin_ts: u64,
+    state: TransactionState,
+) -> Transaction<A> {
     let state = state.into();
     Transaction {
         state,
@@ -5226,11 +5234,12 @@ fn test_index_finger_no_spurious_dep_on_stepped_over_key() {
     let writer_id: TxID = 9_000_050;
     store.txs.insert(
         writer_id,
-        new_tx(writer_id, 1, TransactionState::Preparing(40)),
+        new_tx_in::<crate::alloc::DynAllocator>(writer_id, 1, TransactionState::Preparing(40)),
     );
-    store
-        .txs
-        .insert(reader_id, new_tx(reader_id, 100, TransactionState::Active));
+    store.txs.insert(
+        reader_id,
+        new_tx_in::<crate::alloc::DynAllocator>(reader_id, 100, TransactionState::Active),
+    );
 
     // MVCC-only tombstone at key 20: committed insert (begin Timestamp) deleted
     // by the Preparing writer (end TxID). Not present in the B-tree.
@@ -5243,11 +5252,17 @@ fn test_index_finger_no_spurious_dep_on_stepped_over_key() {
         row: Row::new_index_row(row_id, 1),
         btree_resident: false,
     };
+    let mut tombstone_versions =
+        <RowVersionChain<crate::alloc::DynAllocator> as crate::alloc::TursoVecInExt<
+            RowVersion,
+            crate::alloc::DynAllocator,
+        >>::new_in(crate::alloc::DynAllocator::default());
+    tombstone_versions.push(tombstone);
     store
         .get_or_create_index_rows(table_id)
         .unwrap()
         .value()
-        .insert(key20, Arc::new(RwLock::new(crate::alloc::vec![tombstone])));
+        .insert(key20, Arc::new(RwLock::new(tombstone_versions)));
 
     let mut finger = IndexShadowFinger::default();
     // B-tree key 10: finger seeds at the first index key >= 10 (key 20), which is
@@ -6497,7 +6512,7 @@ fn transaction_display() {
 
     let empty_versions = || Arc::new(RwLock::new(crate::alloc::vec![]));
     let write_set = Mutex::new({
-        let mut write_set = WriteSet::new();
+        let mut write_set: WriteSet = WriteSet::new();
         write_set.insert(RowID::new((-2).into(), RowKey::Int(11)), empty_versions());
         write_set.insert(RowID::new((-2).into(), RowKey::Int(13)), empty_versions());
         write_set
@@ -8094,7 +8109,7 @@ fn test_gc_rule3_not_firing_with_unremovable_superseded() {
 #[test]
 /// GC on an empty version chain is a no-op. Verifies no panics or off-by-one errors.
 fn test_gc_noop_on_empty() {
-    let mut versions: RowVersionChain = crate::alloc::vec![];
+    let mut versions: RowVersionChain<TursoAllocator> = crate::alloc::vec![];
     let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 10, 5);
     assert_eq!(dropped, 0);
 }
@@ -8213,7 +8228,7 @@ fn test_gc_shrinks_version_chain_capacity() {
 
     // One committed current version that survives GC (b=1 > ckpt_max=0, so
     // rule 3 doesn't fire), plus a burst of aborted garbage (always removed).
-    let mut versions: RowVersionChain =
+    let mut versions: RowVersionChain<TursoAllocator> =
         std::iter::once(make_version(Some(TxTimestampOrID::Timestamp(1)), None))
             .chain((0..1023).map(|_| make_version(None, None)))
             .try_collect()
@@ -8231,7 +8246,7 @@ fn test_gc_shrinks_version_chain_capacity() {
     );
 
     // A chain emptied entirely also releases its allocation.
-    let mut versions: RowVersionChain = (0..1024)
+    let mut versions: RowVersionChain<TursoAllocator> = (0..1024)
         .map(|_| make_version(None, None))
         .try_collect()
         .unwrap();
@@ -8247,7 +8262,9 @@ fn test_gc_shrinks_version_chain_capacity() {
 
     // Small chains are not worth a realloc: capacity at or below the minimum
     // threshold is left untouched even when fully emptied.
-    let mut small: RowVersionChain = RowVersionChain::try_with_capacity_ext(16).unwrap();
+    let mut small: RowVersionChain<TursoAllocator> =
+        <RowVersionChain<TursoAllocator> as TursoTryWithCapacityExt>::try_with_capacity_ext(16)
+            .unwrap();
     small.push(make_version(None, None));
     let capacity_before = small.capacity();
     MvStore::<MvccClock>::gc_version_chain(&mut small, 0, 0);
@@ -8979,7 +8996,7 @@ fn test_gc_e2e_index_rows_collected_after_checkpoint() {
 /// Represents a version chain entry for quickcheck.
 #[derive(Debug, Clone)]
 struct ArbitraryVersionChain {
-    versions: RowVersionChain,
+    versions: RowVersionChain<TursoAllocator>,
     lwm: u64,
     ckpt_max: u64,
 }
@@ -9046,7 +9063,7 @@ impl Arbitrary for ArbitraryVersionChain {
     fn arbitrary(g: &mut Gen) -> Self {
         // 1..8 versions (no empty chains — they trivially pass all properties)
         let len = usize::arbitrary(g) % 8 + 1;
-        let versions: RowVersionChain = (0..len)
+        let versions: RowVersionChain<TursoAllocator> = (0..len)
             .map(|_| arbitrary_row_version(g))
             .try_collect()
             .unwrap();

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -236,6 +236,7 @@ use crate::sync::Arc;
 use crate::sync::RwLock;
 use crate::turso_assert;
 use crate::{
+    alloc::{ConcurrentAllocator, TursoAllocator},
     io::{CompletionGroup, ReadComplete},
     io_yield_one,
     mvcc::database::{LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey},
@@ -3471,6 +3472,15 @@ impl StreamingLogicalLogReader {
         parsed_op: ParsedOp,
         get_index_info: &mut impl FnMut(MVTableId, IndexOpKind) -> Result<Arc<IndexInfo>>,
     ) -> Result<StreamingResult> {
+        self.parsed_op_to_streaming_in(parsed_op, get_index_info, TursoAllocator)
+    }
+
+    pub(crate) fn parsed_op_to_streaming_in<A: ConcurrentAllocator>(
+        &self,
+        parsed_op: ParsedOp,
+        get_index_info: &mut impl FnMut(MVTableId, IndexOpKind) -> Result<Arc<IndexInfo>>,
+        alloc: A,
+    ) -> Result<StreamingResult> {
         match parsed_op {
             ParsedOp::UpsertTable {
                 table_id,
@@ -3486,10 +3496,11 @@ impl StreamingLogicalLogReader {
                     crate::types::ImmutableRecordRef::from_bin_record(&record_bytes).column_count();
                 let row = crate::with_mv_store_allocation_site!(
                     RowPayload,
-                    Row::new_table_row(
+                    Row::new_table_row_in(
                         RowID::new(table_id, rowid.row_id.clone()),
                         &record_bytes,
                         column_count,
+                        alloc,
                     )?
                 );
                 Ok(StreamingResult::UpsertTableRow {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -6258,15 +6258,7 @@ mod tests {
             2,
         )
         .unwrap();
-        let sortable_key = SortableIndexKey::new_from_record(
-            key_record,
-            Arc::new(IndexInfo {
-                has_rowid: true,
-                num_cols: 2,
-                is_unique: false,
-                ..Default::default()
-            }),
-        );
+        let sortable_key = SortableIndexKey::new_from_record(key_record, test_index_info());
         let row_id = RowID::new(table_id, RowKey::Record(Arc::new(sortable_key)));
         let row = Row::new_index_row(row_id, 2);
         crate::mvcc::database::RowVersion {
@@ -6281,12 +6273,26 @@ mod tests {
     }
 
     fn test_index_info() -> Arc<IndexInfo> {
-        Arc::new(IndexInfo {
-            has_rowid: true,
-            num_cols: 2,
-            is_unique: false,
-            ..Default::default()
-        })
+        Arc::new(
+            IndexInfo::new(
+                [
+                    crate::types::KeyInfo {
+                        sort_order: turso_parser::ast::SortOrder::Asc,
+                        collation: crate::translate::collate::CollationSeq::Binary,
+                        nulls_order: None,
+                    },
+                    crate::types::KeyInfo {
+                        sort_order: turso_parser::ast::SortOrder::Asc,
+                        collation: crate::translate::collate::CollationSeq::Binary,
+                        nulls_order: None,
+                    },
+                ],
+                true,
+                2,
+                false,
+            )
+            .unwrap(),
+        )
     }
 
     fn make_test_raw_table_row_version(

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -11,6 +11,7 @@ use super::{
         write_varint_to_vec, IndexInteriorCell, IndexLeafCell, OverflowCell, MINIMUM_CELL_SIZE,
     },
 };
+#[cfg(test)]
 use crate::alloc::TursoIteratorExt;
 use crate::{
     io::CompletionGroup,
@@ -869,27 +870,20 @@ impl BTreeCursor {
         num_columns: usize,
     ) -> Self {
         let mut cursor = Self::new(pager, root_page, num_columns);
-        let key_info = table
-            .primary_key_columns
-            .iter()
-            .map(|(col_name, order)| {
-                let (_, column) = table
-                    .get_column(col_name)
-                    .expect("WITHOUT ROWID primary key column should exist");
-                crate::types::KeyInfo {
-                    sort_order: *order,
-                    collation: column.collation_opt().unwrap_or_default(),
-                    nulls_order: None,
-                }
-            })
-            .try_collect::<crate::alloc::Vec<_>>()
-            .expect("TODO: fallible allocations");
-        cursor.index_info = Some(Arc::new(IndexInfo {
-            key_info,
-            has_rowid: false,
-            num_cols: table.primary_key_columns.len(),
-            is_unique: true,
-        }));
+        let key_info = table.primary_key_columns.iter().map(|(col_name, order)| {
+            let (_, column) = table
+                .get_column(col_name)
+                .expect("WITHOUT ROWID primary key column should exist");
+            crate::types::KeyInfo {
+                sort_order: *order,
+                collation: column.collation_opt().unwrap_or_default(),
+                nulls_order: None,
+            }
+        });
+        cursor.index_info = Some(Arc::new(
+            IndexInfo::new(key_info, false, table.primary_key_columns.len(), true)
+                .expect("TODO: fallible allocations"),
+        ));
         cursor
     }
 

--- a/core/storage/journal_mode.rs
+++ b/core/storage/journal_mode.rs
@@ -1,7 +1,7 @@
 use crate::sync::Arc;
 
 use crate::storage::sqlite3_ondisk::Version;
-use crate::{mvcc, LimboError, MvStore, OpenFlags, Result, IO};
+use crate::{alloc::DynAllocator, mvcc, LimboError, MvStore, OpenFlags, Result, IO};
 
 #[derive(
     Debug,
@@ -68,6 +68,7 @@ pub fn open_mv_store(
     flags: OpenFlags,
     durable_storage: Option<Arc<dyn mvcc::persistent_storage::DurableStorage>>,
     encryption_ctx: Option<crate::storage::encryption::EncryptionContext>,
+    allocator: DynAllocator,
 ) -> Result<Arc<MvStore>> {
     // `encryption_ctx` encrypts database pages, but a custom DurableStorage
     // writes the MVCC log itself. If the database is encrypted, the custom
@@ -98,5 +99,9 @@ pub fn open_mv_store(
             ))
         };
 
-    Ok(Arc::new(MvStore::new(mvcc::MvccClock::new(), storage)?))
+    Ok(Arc::new(MvStore::new_in(
+        mvcc::MvccClock::new(),
+        storage,
+        allocator,
+    )?))
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -4,7 +4,6 @@ use either::Either;
 use turso_ext::{AggCtx, ContextDestructor, FinalizeFunction, StepFunction, ValueDestructor};
 use turso_parser::ast::SortOrder;
 
-use crate::alloc::vec;
 use crate::alloc::*;
 use crate::error::LimboError;
 use crate::ext::{ExtValue, ExtValueType};
@@ -2001,6 +2000,11 @@ pub struct KeyInfo {
     pub nulls_order: Option<turso_parser::ast::NullsOrder>,
 }
 
+#[cfg(not(nightly))]
+pub type IndexKeyInfo = Vec<KeyInfo>;
+#[cfg(nightly)]
+pub type IndexKeyInfo = Vec<KeyInfo, DynAllocator>;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Metadata about an index, used for handling and comparing index keys.
 ///
@@ -2009,7 +2013,7 @@ pub struct KeyInfo {
 /// in the index.
 pub struct IndexInfo {
     /// Specifies the sorting order (ascending or descending) for each column in the index.
-    pub key_info: Vec<KeyInfo>,
+    pub key_info: IndexKeyInfo,
     /// Indicates whether the index includes a row ID column.
     pub has_rowid: bool,
     /// The total number of columns in the index, including the row ID column if present.
@@ -2021,7 +2025,7 @@ pub struct IndexInfo {
 impl Default for IndexInfo {
     fn default() -> Self {
         Self {
-            key_info: vec![],
+            key_info: Self::key_info_in(TursoAllocator),
             has_rowid: true,
             num_cols: 1,
             is_unique: false,
@@ -2030,8 +2034,76 @@ impl Default for IndexInfo {
 }
 
 impl IndexInfo {
-    pub fn new_from_index(index: &Index) -> Result<Self> {
-        let mut key_info: Vec<KeyInfo> = index
+    pub fn key_info_in<A: ConcurrentAllocator>(alloc: A) -> IndexKeyInfo {
+        <IndexKeyInfo as TursoVecInExt<KeyInfo, DynAllocator>>::new_in(DynAllocator::new(alloc))
+    }
+
+    #[cfg(not(nightly))]
+    pub fn key_info_from_iter_in<A, I>(
+        key_info: I,
+        _alloc: A,
+    ) -> Result<IndexKeyInfo, TryReserveError>
+    where
+        A: ConcurrentAllocator,
+        I: IntoIterator<Item = KeyInfo>,
+    {
+        key_info.into_iter().try_collect()
+    }
+
+    #[cfg(nightly)]
+    pub fn key_info_from_iter_in<A, I>(
+        key_info: I,
+        alloc: A,
+    ) -> Result<IndexKeyInfo, TryReserveError>
+    where
+        A: ConcurrentAllocator,
+        I: IntoIterator<Item = KeyInfo>,
+    {
+        key_info
+            .into_iter()
+            .try_collect_in(DynAllocator::new(alloc))
+    }
+
+    pub fn new<I>(
+        key_info: I,
+        has_rowid: bool,
+        num_cols: usize,
+        is_unique: bool,
+    ) -> Result<Self, TryReserveError>
+    where
+        I: IntoIterator<Item = KeyInfo>,
+    {
+        Self::new_in(key_info, has_rowid, num_cols, is_unique, TursoAllocator)
+    }
+
+    pub fn new_in<A, I>(
+        key_info: I,
+        has_rowid: bool,
+        num_cols: usize,
+        is_unique: bool,
+        alloc: A,
+    ) -> Result<Self, TryReserveError>
+    where
+        A: ConcurrentAllocator,
+        I: IntoIterator<Item = KeyInfo>,
+    {
+        Ok(Self {
+            key_info: Self::key_info_from_iter_in(key_info, alloc)?,
+            has_rowid,
+            num_cols,
+            is_unique,
+        })
+    }
+
+    pub fn new_from_index(index: &Index) -> Result<Self, TryReserveError> {
+        Self::new_from_index_in(index, TursoAllocator)
+    }
+
+    pub fn new_from_index_in<A: ConcurrentAllocator>(
+        index: &Index,
+        alloc: A,
+    ) -> Result<Self, TryReserveError> {
+        let key_info = index
             .columns
             .iter()
             .map(|c| KeyInfo {
@@ -2039,21 +2111,18 @@ impl IndexInfo {
                 collation: c.collation.unwrap_or_default(),
                 nulls_order: None,
             })
-            .try_collect()?;
-        if index.has_rowid {
-            key_info.try_push(KeyInfo {
+            .chain(index.has_rowid.then_some(KeyInfo {
                 sort_order: SortOrder::Asc,
                 collation: CollationSeq::Binary,
                 nulls_order: None,
-            })?;
-        }
-        let this = Self {
+            }));
+        Self::new_in(
             key_info,
-            has_rowid: index.has_rowid,
-            num_cols: index.columns.len() + (index.has_rowid as usize),
-            is_unique: index.unique,
-        };
-        Ok(this)
+            index.has_rowid,
+            index.columns.len() + (index.has_rowid as usize),
+            index.unique,
+            alloc,
+        )
     }
 }
 
@@ -3390,21 +3459,20 @@ mod tests {
         sort_orders: Vec<SortOrder>,
         collations: Vec<CollationSeq>,
     ) -> IndexInfo {
-        IndexInfo {
-            key_info: sort_orders
+        IndexInfo::new(
+            sort_orders
                 .into_iter()
                 .zip(collations)
                 .map(|(sort_order, collation)| KeyInfo {
                     sort_order,
                     collation,
                     nulls_order: None,
-                })
-                .try_collect()
-                .unwrap(),
-            has_rowid: false,
+                }),
+            false,
             num_cols,
-            is_unique: false,
-        }
+            false,
+        )
+        .unwrap()
     }
 
     fn assert_compare_matches_full_comparison(

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -126,7 +126,7 @@ impl Affinity {
     }
 
     /// Convert affinity to the corresponding Type enum
-    pub fn to_type(&self) -> crate::schema::Type {
+    pub fn to_type(self) -> crate::schema::Type {
         use crate::schema::Type;
         match self {
             Affinity::Blob => Type::Blob,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{TursoSliceExt, TursoTryWithCapacityExt};
+use crate::alloc::{DynAllocator, TursoSliceExt, TursoTryWithCapacityExt};
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::{AccumulatorFunc, AlterTableFunc, WindowFunc};
 use crate::io::TempFile;
@@ -138,6 +138,8 @@ use super::{make_record, Program, ProgramState, Register};
 #[cfg(feature = "fs")]
 use crate::connection::resolve_ext_path;
 use crate::{bail_constraint_error, must_be_btree_cursor, MvStore, Pager, Result};
+
+type MvccCheckpointStateMachine = CheckpointStateMachine<MvccClock, DynAllocator>;
 
 /// Macro to destructure an Insn enum variant, only to be used when it
 /// is *impossible* to be another variant.
@@ -15840,7 +15842,7 @@ pub struct OpJournalModeState {
     /// The new journal mode we're changing to
     pub new_mode: Option<journal_mode::JournalMode>,
     /// Checkpoint state machine for MVCC mode
-    pub checkpoint_sm: Option<StateMachine<Box<CheckpointStateMachine<MvccClock>>>>,
+    pub checkpoint_sm: Option<StateMachine<Box<MvccCheckpointStateMachine>>>,
     /// Bootstrap state machine when switching into MVCC mode
     pub bootstrap_state: BootstrapState,
     /// Page reference for writing header
@@ -16099,6 +16101,7 @@ fn op_journal_mode_inner(
                         program.connection.db.open_flags,
                         program.connection.db.durable_storage.clone(),
                         enc_ctx,
+                        program.connection.db.mv_store_allocator.clone(),
                     )?;
                     // Arm the abandonment guard *before* the irreversible
                     // store install + demote so a reset/drop at any subsequent

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1267,7 +1267,11 @@ pub fn op_open_read(
                 index.as_ref(),
                 num_columns,
             )?);
-            let index_info = Arc::new(IndexInfo::new_from_index(index)?);
+            let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
+                IndexInfo::new_from_index_in(index, mv_store.allocator())?
+            } else {
+                IndexInfo::new_from_index(index)?
+            });
             let cursor =
                 maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Index(index_info))?;
             cursors
@@ -11079,7 +11083,11 @@ pub fn op_open_write(
                 index.as_ref(),
                 num_columns,
             )?);
-            let index_info = Arc::new(IndexInfo::new_from_index(index)?);
+            let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
+                IndexInfo::new_from_index_in(index, mv_store.allocator())?
+            } else {
+                IndexInfo::new_from_index(index)?
+            });
             let cursor =
                 maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Index(index_info))?;
             cursors

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -37,6 +37,7 @@ pub mod value;
 // for benchmarks
 pub use crate::translate::collate::CollationSeq;
 use crate::{
+    alloc::DynAllocator,
     error::LimboError,
     function::FuncCtx,
     mvcc::{database::CommitStateMachine, MvccClock},
@@ -98,6 +99,8 @@ use std::{
     task::Waker,
 };
 use tracing::{instrument, Level};
+
+type MvccCommitStateMachine = CommitStateMachine<MvccClock, DynAllocator>;
 
 /// State machine for committing view deltas with I/O handling
 #[derive(Debug, Clone)]
@@ -188,11 +191,11 @@ enum CommitState {
     /// Committing attached database pagers after main pager commit is done.
     CommittingAttached,
     CommittingMvcc {
-        state_machine: StateMachine<Box<CommitStateMachine<MvccClock>>>,
+        state_machine: StateMachine<Box<MvccCommitStateMachine>>,
     },
     /// Committing MVCC transactions on attached databases after main MVCC commit is done.
     CommittingAttachedMvcc {
-        state_machine: StateMachine<Box<CommitStateMachine<MvccClock>>>,
+        state_machine: StateMachine<Box<MvccCommitStateMachine>>,
         db_id: usize,
         mv_store: Arc<MvStore>,
     },
@@ -694,7 +697,7 @@ pub struct ProgramState {
     /// entry and drives it one step per opcode call, yielding
     /// `InsnFunctionStepResult::IO` between steps. Cleared on terminal
     /// outcome (Done / Conflict / Err) and on statement reset.
-    pub sequence_inner_commit: Option<StateMachine<Box<CommitStateMachine<MvccClock>>>>,
+    pub sequence_inner_commit: Option<StateMachine<Box<MvccCommitStateMachine>>>,
     /// State for a pending sequence inner-tx wrap, set by
     /// `Insn::SequenceBeginInnerTx` (Wrapped path only) and cleared
     /// by `Insn::SequenceCommitInnerTx` on any terminal outcome.
@@ -2350,7 +2353,7 @@ impl Program {
     #[instrument(skip(self, commit_state, mv_store), level = Level::DEBUG)]
     fn step_end_mvcc_txn(
         &self,
-        commit_state: &mut StateMachine<Box<CommitStateMachine<MvccClock>>>,
+        commit_state: &mut StateMachine<Box<MvccCommitStateMachine>>,
         mv_store: &Arc<MvStore>,
     ) -> Result<IOResult<()>> {
         commit_state.step(mv_store)


### PR DESCRIPTION
## Summary

- add `DynAllocator` and make `Database`/MVStore carry the allocator for MVCC skiplist storage
- add allocator-aware database open APIs, including the async path used by server callers
- keep public database returns erased to `DynAllocator` while making MVCC cursor/state machine types allocator-compatible
- route MVCC row payload storage through allocator-aware `ArcSlice` construction
- propagate the MVStore allocator into `IndexInfo`/`SortableIndexKey` key metadata
- cover direct skiplist allocation and database-open MVStore allocation with tests
