### PR TITLE
Add .NET remote Hrana execution

### DIFF
--- a/bindings/dotnet/Readme.md
+++ b/bindings/dotnet/Readme.md
@@ -1,6 +1,6 @@
 # Turso .NET
 
-ADO.NET bindings for Turso local databases.
+ADO.NET bindings for Turso local and remote databases.
 
 The `Turso.Data.Sqlite` package includes both a SQLite-compatible `Turso.Data.Sqlite` facade and Turso-specific `System.Data.Common` types such as `TursoConnection`, `TursoCommand`, `TursoDataReader`, `TursoParameter`, `TursoTransaction`, and `TursoFactory`.
 
@@ -58,6 +58,24 @@ command.Parameters.Add(parameter);
 var value = command.ExecuteScalar();
 ```
 
+Remote Turso/libSQL databases can use the same `TursoConnection` surface with a remote URL and auth token:
+
+```C#
+await using var connection = new TursoConnection(
+    "Data Source=libsql://example-org.turso.io;Auth Token=eyJ...");
+await connection.OpenAsync();
+
+await using var command = connection.CreateCommand();
+command.CommandText = "SELECT name FROM customers WHERE id = $id";
+command.Parameters.Add(new TursoParameter("$id", 42));
+
+var name = await command.ExecuteScalarAsync();
+```
+
+Remote mode uses the Hrana HTTP `/v2/pipeline` protocol. `libsql://` URLs default to HTTPS; `Tls=False` maps them to HTTP for local development. `ws://` and `wss://` URLs are accepted and mapped to the equivalent HTTP pipeline endpoint. `Auth Token` requires HTTPS unless the host is `localhost` or loopback.
+
+Remote mode currently supports direct single-statement command execution. Remote transactions, ADO.NET batches, and embedded replicas are not enabled yet in the .NET provider. `Replica Path` and `Sync Interval` are parsed so applications fail early with clear errors.
+
 Provider factories are available through `TursoFactory.Instance`:
 
 ```C#
@@ -93,6 +111,11 @@ Supported common connection string keywords include:
 | `Vfs` | Parsed and preserved for compatibility. |
 | `Encryption Cipher` | Turso local encryption cipher. |
 | `Encryption Key` | Hex-encoded encryption key used with `Encryption Cipher`. |
+| `Auth Token` | Bearer token for remote Turso/libSQL URLs. Aliases include `AuthToken` and `Authentication Token`. |
+| `Replica Path` | Reserved for embedded replicas. The .NET provider currently fails early with a clear unsupported error. |
+| `Read Your Writes` | Keeps the remote Hrana session baton across commands. Defaults to `True`. Set `False` for stateless one-shot remote requests. |
+| `Sync Interval` | Reserved for embedded replicas. Automatic sync is not enabled yet. |
+| `Tls` | Optional override for `libsql://` development URLs. Conflicting values with explicit `http://` or `https://` schemes fail early. |
 
 ## SQLite-compatible facade coverage
 
@@ -137,4 +160,4 @@ var options = new DbContextOptionsBuilder<AppDbContext>()
 
 The local provider supports the normal EF Core SQLite query pipeline, including composed `IQueryable<T>` filters, navigation-property joins, ordering, paging, grouping, aggregates, async materialization, and `SaveChangesAsync`. Schema creation can use the standard EF Core SQLite mechanisms such as `EnsureCreated`, `EnsureCreatedAsync`, and migrations against local database files.
 
-Remote `libsql://`/auth-token EF Core support is not part of the local provider. Use the local/embedded provider for EF Core today; remote/serverless EF support needs a separate connection, batching, retry, and transaction design.
+Remote `libsql://`/auth-token EF Core support is not part of the local provider. Use the local/embedded provider for EF Core today; remote/serverless EF support needs a separate connection, retry, and transaction design.

--- a/bindings/dotnet/src/Turso.Data/Turso.Data.csproj
+++ b/bindings/dotnet/src/Turso.Data/Turso.Data.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Turso</RootNamespace>
     
     <Title>Turso ADO.NET Provider</Title>
-    <Description>ADO.NET provider for Turso, exposing SQLite-compatible local database access through System.Data.Common.</Description>
+    <Description>ADO.NET provider for Turso, exposing local and remote database access through System.Data.Common.</Description>
     <Authors>Turso authors</Authors>
     <PackageTags>turso;sqlite;database;ado.net;system.data</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/bindings/dotnet/src/Turso.Data/TursoCommand.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoCommand.cs
@@ -109,8 +109,24 @@ public class TursoCommand : DbCommand
 
     public override int ExecuteNonQuery()
     {
+        if (_connection?.IsRemote == true)
+            return ExecuteRemoteNonQueryAsync(CancellationToken.None).GetAwaiter().GetResult();
+
         using var reader = Execute();
         while (reader.Read())
+        {
+        }
+
+        return reader.RecordsAffected;
+    }
+
+    public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+    {
+        if (_connection?.IsRemote == true)
+            return await ExecuteRemoteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var reader = await ExecuteDbDataReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
         }
 
@@ -125,14 +141,23 @@ public class TursoCommand : DbCommand
             : null;
     }
 
+    public override async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
+    {
+        await using var reader = await ExecuteDbDataReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false)
+            ? reader.GetValue(0)
+            : null;
+    }
+
     public override void Prepare()
     {
         if (_connection is null)
             throw new InvalidOperationException("Connection must be set before preparing a command.");
         if (string.IsNullOrWhiteSpace(CommandText))
             throw new InvalidOperationException("CommandText must be set before preparing a command.");
-        if (_transaction is { IsCompleted: true })
-            throw new InvalidOperationException("The transaction associated with this command has completed.");
+        ValidateTransaction();
+        if (_connection.IsRemote)
+            return;
 
         TursoStatementHandle? preparedStatement = null;
         try
@@ -200,6 +225,17 @@ public class TursoCommand : DbCommand
         return Execute(behavior);
     }
 
+    protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled<DbDataReader>(cancellationToken);
+
+        if (_connection?.IsRemote == true)
+            return ExecuteRemoteAsync(behavior, cancellationToken);
+
+        return Task.FromResult(Execute(behavior));
+    }
+
     private static string RewriteFacadePragmas(string sql, TursoConnection connection)
     {
         var normalized = sql.Trim().TrimEnd(';').Trim();
@@ -234,11 +270,58 @@ public class TursoCommand : DbCommand
         if (_connection is null)
             throw new InvalidOperationException("Connection must be set before executing a command.");
 
+        if (_connection.IsRemote)
+            return ExecuteRemoteAsync(behavior, CancellationToken.None).GetAwaiter().GetResult();
+
         Prepare();
 
         var statement = _statement ?? throw new InvalidOperationException("Command was not prepared.");
         _statement = null;
         var reader = new TursoDataReader(this, statement, behavior);
         return reader;
+    }
+
+    private async Task<DbDataReader> ExecuteRemoteAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+    {
+        if (_connection is null)
+            throw new InvalidOperationException("Connection must be set before executing a command.");
+        if (string.IsNullOrWhiteSpace(CommandText))
+            throw new InvalidOperationException("CommandText must be set before executing a command.");
+        ValidateTransaction();
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var sql = RewriteFacadePragmas(CommandText, _connection);
+        var result = await _connection
+            .ExecuteRemoteAsync(sql, _parameterCollection, wantRows: true, CommandTimeout, cancellationToken)
+            .ConfigureAwait(false);
+        return new TursoRemoteDataReader(this, result, behavior);
+    }
+
+    private async Task<int> ExecuteRemoteNonQueryAsync(CancellationToken cancellationToken)
+    {
+        if (_connection is null)
+            throw new InvalidOperationException("Connection must be set before executing a command.");
+        if (string.IsNullOrWhiteSpace(CommandText))
+            throw new InvalidOperationException("CommandText must be set before executing a command.");
+        ValidateTransaction();
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var sql = RewriteFacadePragmas(CommandText, _connection);
+        var result = await _connection
+            .ExecuteRemoteAsync(sql, _parameterCollection, wantRows: false, CommandTimeout, cancellationToken)
+            .ConfigureAwait(false);
+        return checked((int)result.AffectedRowCount);
+    }
+
+    private void ValidateTransaction()
+    {
+        if (_transaction is null)
+            return;
+        if (_transaction.IsCompleted)
+            throw new InvalidOperationException("The transaction associated with this command has completed.");
+        if (!ReferenceEquals(_transaction.Connection, _connection))
+            throw new InvalidOperationException("The transaction is not associated with the command's connection.");
     }
 }

--- a/bindings/dotnet/src/Turso.Data/TursoConnection.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoConnection.cs
@@ -9,6 +9,7 @@ namespace Turso;
 public class TursoConnection : DbConnection
 {
     private TursoDatabaseHandle? _turso;
+    private TursoRemoteClient? _remoteClient;
     private TursoConnectionOptions _connectionOptions;
     private bool _disposed;
     private bool _readUncommitted;
@@ -32,7 +33,9 @@ public class TursoConnection : DbConnection
 
     public override string ServerVersion => typeof(TursoConnection).Assembly.GetName().Version?.ToString() ?? "0.0.0";
 
-    public override ConnectionState State => _turso is not null ? ConnectionState.Open : ConnectionState.Closed;
+    public override ConnectionState State => _turso is not null || _remoteClient is not null
+        ? ConnectionState.Open
+        : ConnectionState.Closed;
 
     protected override DbProviderFactory DbProviderFactory => TursoFactory.Instance;
 
@@ -45,11 +48,27 @@ public class TursoConnection : DbConnection
         _connectionOptions = TursoConnectionOptions.Parse(connectionString);
     }
 
+    internal TursoConnection(string connectionString, TursoRemoteClient remoteClient)
+    {
+        ArgumentNullException.ThrowIfNull(remoteClient);
+
+        _connectionOptions = TursoConnectionOptions.Parse(connectionString);
+        _remoteClient = remoteClient;
+    }
+
     public override void Open()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        if (_turso is not null)
+        if (_turso is not null || _remoteClient is not null)
             throw new InvalidOperationException("The connection is already open.");
+
+        if (_connectionOptions.IsRemote)
+        {
+            OpenRemote();
+            return;
+        }
+
+        ValidateLocalOnlyOptions();
 
         var filename = _connectionOptions["Data Source"] ?? ":memory:";
         var cipher = _connectionOptions.GetEncryptionCipher();
@@ -68,8 +87,23 @@ public class TursoConnection : DbConnection
         }
     }
 
+    public override Task OpenAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled(cancellationToken);
+
+        Open();
+        return Task.CompletedTask;
+    }
+
     public override void Close()
     {
+        if (_remoteClient is not null)
+        {
+            CloseRemote();
+            return;
+        }
+
         _turso?.Dispose();
         _turso = null;
         _readUncommitted = false;
@@ -86,10 +120,12 @@ public class TursoConnection : DbConnection
 
     protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
     {
-        if (_turso is null)
+        if (_turso is null && _remoteClient is null)
         {
             throw new InvalidOperationException("Turso database is closed.");
         }
+        if (_remoteClient is not null)
+            throw new NotSupportedException("Remote transactions are not supported yet by the .NET provider.");
 
         return new TursoTransaction(this, isolationLevel);
     }
@@ -114,6 +150,8 @@ public class TursoConnection : DbConnection
 
     internal int DefaultTimeout => _connectionOptions.DefaultTimeout;
 
+    internal bool IsRemote => _remoteClient is not null;
+
     internal bool ReadUncommitted
     {
         get => _readUncommitted;
@@ -121,4 +159,88 @@ public class TursoConnection : DbConnection
     }
 
     internal TursoDatabaseHandle Turso => _turso ?? throw new InvalidOperationException("Turso database is closed.");
+
+    internal async Task<RemoteStatementResult> ExecuteRemoteAsync(
+        string sql,
+        TursoParameterCollection parameters,
+        bool wantRows,
+        int commandTimeout,
+        CancellationToken cancellationToken)
+    {
+        var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
+        var closeAfter = !_connectionOptions.ReadYourWrites;
+        try
+        {
+            return await remoteClient.ExecuteAsync(sql, parameters, wantRows, commandTimeout, closeAfter, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TursoRemoteSqlException)
+        {
+            throw;
+        }
+        catch
+        {
+            InvalidateRemoteSession();
+            throw;
+        }
+    }
+
+    private void OpenRemote()
+    {
+        if (_connectionOptions.IsReplica)
+            throw new NotSupportedException("Embedded replica connections are not supported yet by the .NET provider. Use a remote URL without Replica Path for direct remote execution.");
+
+        if (_connectionOptions.SyncInterval > 0)
+            throw new NotSupportedException("Sync Interval requires embedded replica support, which is not supported yet by the .NET provider.");
+
+        if (_connectionOptions.GetEncryptionCipher().HasValue || !string.IsNullOrWhiteSpace(_connectionOptions["Encryption Key"]))
+            throw new InvalidOperationException("Encryption Cipher and Encryption Key are local database options and cannot be used with remote Turso URLs.");
+
+        _remoteClient = new TursoRemoteClient(_connectionOptions.GetRemoteUri(), _connectionOptions.AuthToken);
+    }
+
+    private void ValidateLocalOnlyOptions()
+    {
+        if (!string.IsNullOrWhiteSpace(_connectionOptions.AuthToken))
+            throw new InvalidOperationException("Auth Token requires a remote Turso URL Data Source.");
+        if (!string.IsNullOrWhiteSpace(_connectionOptions.ReplicaPath))
+            throw new InvalidOperationException("Replica Path requires a remote Turso URL Data Source.");
+        if (_connectionOptions.SyncInterval > 0)
+            throw new InvalidOperationException("Sync Interval requires a remote embedded replica connection.");
+        if (_connectionOptions.Tls.HasValue)
+            throw new InvalidOperationException("Tls requires a remote Turso URL Data Source.");
+    }
+
+    private void CloseRemote()
+    {
+        var remoteClient = _remoteClient;
+        if (remoteClient is null)
+            return;
+
+        Exception? closeError = null;
+        try
+        {
+            remoteClient.CloseAsync(DefaultTimeout, CancellationToken.None).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            closeError = ex;
+        }
+        finally
+        {
+            remoteClient.Dispose();
+            _remoteClient = null;
+            _readUncommitted = false;
+        }
+
+        if (closeError is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(closeError).Throw();
+    }
+
+    private void InvalidateRemoteSession()
+    {
+        _remoteClient?.Dispose();
+        _remoteClient = null;
+        _readUncommitted = false;
+    }
 }

--- a/bindings/dotnet/src/Turso.Data/TursoConnectionOptions.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoConnectionOptions.cs
@@ -1,4 +1,5 @@
-﻿using Turso.Raw.Public.Value;
+﻿using System.Globalization;
+using Turso.Raw.Public.Value;
 
 namespace Turso;
 
@@ -21,10 +22,85 @@ public class TursoConnectionOptions
 
     public int DefaultTimeout => _builder.DefaultTimeout;
 
+    public string DataSource => _builder.DataSource;
+
+    public string AuthToken => _builder.AuthToken;
+
+    public string ReplicaPath => _builder.ReplicaPath;
+
+    public bool ReadYourWrites => _builder.ReadYourWrites;
+
+    public int SyncInterval => _builder.SyncInterval;
+
+    public bool? Tls => _builder.Tls;
+
+    public bool IsRemote => IsRemoteDataSource(DataSource);
+
+    public bool IsReplica => IsRemote && !string.IsNullOrWhiteSpace(ReplicaPath);
+
     public TursoEncryptionCipher? GetEncryptionCipher() => _builder.GetEncryptionCipher();
+
+    public Uri GetRemoteUri()
+    {
+        if (!Uri.TryCreate(DataSource, UriKind.Absolute, out var uri) || !IsRemoteScheme(uri.Scheme))
+            throw new InvalidOperationException($"Data Source is not a remote Turso URL: {DataSource}");
+
+        if (!string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment))
+            throw new InvalidOperationException("Remote Turso URLs must not include query strings or fragments.");
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+            throw new InvalidOperationException("Remote Turso URLs must not include embedded user information; use Auth Token instead.");
+        if (string.IsNullOrEmpty(uri.Host))
+            throw new InvalidOperationException("Remote Turso URLs must include a host.");
+
+        var scheme = uri.Scheme.ToLowerInvariant() switch
+        {
+            "libsql" => Tls == false ? "http" : "https",
+            "http" => ValidateTls(uri.Scheme, expectedTls: false),
+            "https" => ValidateTls(uri.Scheme, expectedTls: true),
+            "ws" => ValidateTls(uri.Scheme, expectedTls: false, normalizedScheme: "http"),
+            "wss" => ValidateTls(uri.Scheme, expectedTls: true, normalizedScheme: "https"),
+            _ => throw new InvalidOperationException($"Unsupported remote Turso URL scheme: {uri.Scheme}")
+        };
+
+        var builder = new UriBuilder(uri)
+        {
+            Scheme = scheme,
+            Port = uri.IsDefaultPort ? -1 : uri.Port,
+            UserName = string.Empty,
+            Password = string.Empty,
+        };
+
+        return builder.Uri;
+    }
 
     public static TursoConnectionOptions Parse(string connectionString)
     {
         return new TursoConnectionOptions(new TursoConnectionStringBuilder(connectionString));
+    }
+
+    private static bool IsRemoteDataSource(string dataSource)
+    {
+        return Uri.TryCreate(dataSource, UriKind.Absolute, out var uri)
+               && IsRemoteScheme(uri.Scheme);
+    }
+
+    private static bool IsRemoteScheme(string scheme)
+    {
+        return scheme.Equals("libsql", StringComparison.OrdinalIgnoreCase)
+               || scheme.Equals("http", StringComparison.OrdinalIgnoreCase)
+               || scheme.Equals("https", StringComparison.OrdinalIgnoreCase)
+               || scheme.Equals("ws", StringComparison.OrdinalIgnoreCase)
+               || scheme.Equals("wss", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string ValidateTls(string scheme, bool expectedTls, string? normalizedScheme = null)
+    {
+        if (Tls.HasValue && Tls.Value != expectedTls)
+        {
+            var actual = Tls.Value.ToString(CultureInfo.InvariantCulture);
+            throw new InvalidOperationException($"Tls={actual} conflicts with the {scheme} URL scheme.");
+        }
+
+        return normalizedScheme ?? scheme;
     }
 }

--- a/bindings/dotnet/src/Turso.Data/TursoConnectionStringBuilder.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoConnectionStringBuilder.cs
@@ -30,6 +30,18 @@ public sealed class TursoConnectionStringBuilder : DbConnectionStringBuilder
         ["EncryptionCipher"] = "Encryption Cipher",
         ["Encryption Key"] = "Encryption Key",
         ["EncryptionKey"] = "Encryption Key",
+        ["Auth Token"] = "Auth Token",
+        ["AuthToken"] = "Auth Token",
+        ["Authentication Token"] = "Auth Token",
+        ["AuthenticationToken"] = "Auth Token",
+        ["Replica Path"] = "Replica Path",
+        ["ReplicaPath"] = "Replica Path",
+        ["Read Your Writes"] = "Read Your Writes",
+        ["ReadYourWrites"] = "Read Your Writes",
+        ["Sync Interval"] = "Sync Interval",
+        ["SyncInterval"] = "Sync Interval",
+        ["Tls"] = "Tls",
+        ["TLS"] = "Tls",
     };
 
     public TursoConnectionStringBuilder()
@@ -111,6 +123,40 @@ public sealed class TursoConnectionStringBuilder : DbConnectionStringBuilder
         set => SetString("Encryption Key", value);
     }
 
+    public string AuthToken
+    {
+        get => GetString("Auth Token");
+        set => SetString("Auth Token", value);
+    }
+
+    public string ReplicaPath
+    {
+        get => GetString("Replica Path");
+        set => SetString("Replica Path", value);
+    }
+
+    public bool ReadYourWrites
+    {
+        get => GetBool("Read Your Writes", defaultValue: true);
+        set => this["Read Your Writes"] = value;
+    }
+
+    public int SyncInterval
+    {
+        get => GetInt("Sync Interval", 0);
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            this["Sync Interval"] = value;
+        }
+    }
+
+    public bool? Tls
+    {
+        get => GetNullableBool("Tls");
+        set => SetNullable("Tls", value);
+    }
+
     [AllowNull]
     public override object this[string keyword]
     {
@@ -185,9 +231,11 @@ public sealed class TursoConnectionStringBuilder : DbConnectionStringBuilder
         this[keyword] = value;
     }
 
-    private bool GetBool(string keyword)
+    private bool GetBool(string keyword, bool defaultValue = false)
     {
-        return TryGetValue(keyword, out var value) && Convert.ToBoolean(value, CultureInfo.InvariantCulture);
+        return TryGetValue(keyword, out var value)
+            ? Convert.ToBoolean(value, CultureInfo.InvariantCulture)
+            : defaultValue;
     }
 
     private bool? GetNullableBool(string keyword)

--- a/bindings/dotnet/src/Turso.Data/TursoRemoteClient.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoRemoteClient.cs
@@ -1,0 +1,565 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Turso.Raw.Public;
+using Turso.Raw.Public.Value;
+
+namespace Turso;
+
+internal sealed class TursoRemoteClient : IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly string? _authToken;
+    private readonly bool _disposeHttpClient;
+    private Uri _pipelineUri;
+    private string? _baton;
+
+    public TursoRemoteClient(Uri endpoint, string? authToken)
+        : this(new HttpClient(), endpoint, authToken, disposeHttpClient: true)
+    {
+    }
+
+    internal TursoRemoteClient(HttpClient httpClient, Uri endpoint, string? authToken, bool disposeHttpClient = false)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        _httpClient = httpClient;
+        _pipelineUri = CreatePipelineUri(endpoint);
+        _authToken = string.IsNullOrWhiteSpace(authToken) ? null : authToken;
+        ValidateAuthTokenTransport(_pipelineUri, _authToken);
+        _disposeHttpClient = disposeHttpClient;
+    }
+
+    public async Task<RemoteStatementResult> ExecuteAsync(
+        string sql,
+        TursoParameterCollection parameters,
+        bool wantRows,
+        int commandTimeout,
+        bool closeAfter,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        var request = new RemotePipelineRequest
+        {
+            Baton = _baton,
+            Requests =
+            [
+                RemoteStreamRequest.Execute(BuildStatement(sql, parameters, wantRows)),
+            ],
+        };
+
+        if (closeAfter)
+            request.Requests.Add(RemoteStreamRequest.Close());
+
+        var response = await SendPipelineAsync(request, commandTimeout, cancellationToken).ConfigureAwait(false);
+        UpdateSession(response, closeAfter);
+        return ExtractExecuteResult(response);
+    }
+
+    public async Task CloseAsync(int commandTimeout, CancellationToken cancellationToken)
+    {
+        if (_baton is null)
+            return;
+
+        var request = new RemotePipelineRequest
+        {
+            Baton = _baton,
+            Requests = [RemoteStreamRequest.Close()],
+        };
+
+        var response = await SendPipelineAsync(request, commandTimeout, cancellationToken).ConfigureAwait(false);
+        UpdateSession(response, closeAfter: false);
+        ValidateCloseResult(response);
+        _baton = null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposeHttpClient)
+            _httpClient.Dispose();
+    }
+
+    private async Task<RemotePipelineResponse> SendPipelineAsync(
+        RemotePipelineRequest request,
+        int commandTimeout,
+        CancellationToken cancellationToken)
+    {
+        using var timeout = CreateTimeout(commandTimeout, cancellationToken);
+        var effectiveCancellationToken = timeout?.Token ?? cancellationToken;
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, _pipelineUri)
+        {
+            Content = content,
+        };
+
+        if (_authToken is not null)
+            httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
+
+        using var response = await _httpClient
+            .SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, effectiveCancellationToken)
+            .ConfigureAwait(false);
+
+        var body = await response.Content.ReadAsStringAsync(effectiveCancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new TursoException(
+                $"Remote request failed with HTTP {(int)response.StatusCode} {response.ReasonPhrase}: {body}");
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<RemotePipelineResponse>(body, JsonOptions)
+                   ?? throw new TursoException("Remote request returned an empty response.");
+        }
+        catch (JsonException ex)
+        {
+            throw new TursoException($"Unable to parse remote response: {ex.Message}");
+        }
+    }
+
+    private static CancellationTokenSource? CreateTimeout(int commandTimeout, CancellationToken cancellationToken)
+    {
+        if (commandTimeout <= 0)
+            return null;
+
+        var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(commandTimeout));
+        return timeout;
+    }
+
+    private static void ValidateAuthTokenTransport(Uri endpoint, string? authToken)
+    {
+        if (authToken is null
+            || endpoint.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            || endpoint.IsLoopback)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException("Auth Token requires an HTTPS remote Turso URL unless the host is localhost or loopback.");
+    }
+
+    private static RemoteStatement BuildStatement(string sql, TursoParameterCollection parameters, bool wantRows)
+    {
+        var statement = new RemoteStatement
+        {
+            Sql = sql,
+            WantRows = wantRows,
+        };
+
+        foreach (TursoParameter parameter in parameters)
+        {
+            var value = RemoteRequestValue.FromTursoValue(parameter.ToValue());
+            if (string.IsNullOrEmpty(parameter.ParameterName))
+            {
+                statement.Args.Add(value);
+            }
+            else
+            {
+                statement.NamedArgs.Add(new RemoteNamedArg
+                {
+                    Name = parameter.ParameterName,
+                    Value = value,
+                });
+            }
+        }
+
+        return statement;
+    }
+
+    private static RemoteStatementResult ExtractExecuteResult(RemotePipelineResponse response)
+    {
+        if (response.Results.Count == 0)
+            throw new TursoException("Remote request returned no results.");
+
+        var result = response.Results[0];
+        RemoteStatementResult statementResult;
+        switch (result.Type)
+        {
+            case "ok":
+                if (result.Response is null)
+                    throw new TursoException("Remote request returned an empty ok response.");
+                if (result.Response.Type != "execute")
+                    throw new TursoException($"Remote request returned unexpected response type: {result.Response.Type}");
+                statementResult = result.Response.DeserializeResult<RemoteStatementResult>();
+                break;
+
+            case "error":
+                throw CreateRemoteError(result.Error);
+
+            default:
+                throw new TursoException($"Remote request returned unexpected result type: {result.Type}");
+        }
+
+        ValidateOptionalTrailingClose(response, "Remote request");
+        return statementResult;
+    }
+
+    private static void ValidateOptionalTrailingClose(RemotePipelineResponse response, string operation)
+    {
+        if (response.Results.Count == 1)
+            return;
+        if (response.Results.Count > 2)
+            throw new TursoException($"{operation} returned too many results.");
+
+        var result = response.Results[1];
+        switch (result.Type)
+        {
+            case "ok":
+                if (result.Response?.Type != "close")
+                    throw new TursoException($"{operation} returned unexpected response type: {result.Response?.Type}");
+                break;
+
+            case "error":
+                break;
+
+            default:
+                throw new TursoException($"{operation} returned unexpected result type: {result.Type}");
+        }
+    }
+
+    private static void ValidateCloseResult(RemotePipelineResponse response)
+    {
+        foreach (var result in response.Results)
+        {
+            switch (result.Type)
+            {
+                case "ok":
+                    if (result.Response?.Type is not "close")
+                        throw new TursoException($"Remote close returned unexpected response type: {result.Response?.Type}");
+                    break;
+
+                case "error":
+                    throw CreateRemoteError(result.Error);
+
+                default:
+                    throw new TursoException($"Remote close returned unexpected result type: {result.Type}");
+            }
+        }
+    }
+
+    private static TursoException CreateRemoteError(RemoteError? error)
+    {
+        if (error is null)
+            return new TursoRemoteSqlException("Remote SQL execution failed.");
+
+        return string.IsNullOrWhiteSpace(error.Code)
+            ? new TursoRemoteSqlException($"Remote SQL execution failed: {error.Message}")
+            : new TursoRemoteSqlException($"Remote SQL execution failed: {error.Message} ({error.Code})");
+    }
+
+    private void UpdateSession(RemotePipelineResponse response, bool closeAfter)
+    {
+        if (!string.IsNullOrWhiteSpace(response.BaseUrl))
+        {
+            var pipelineUri = CreatePipelineUri(new Uri(_pipelineUri, response.BaseUrl));
+            ValidateAuthTokenTransport(pipelineUri, _authToken);
+            _pipelineUri = pipelineUri;
+        }
+
+        _baton = closeAfter ? null : response.Baton;
+    }
+
+    private static Uri CreatePipelineUri(Uri endpoint)
+    {
+        var builder = new UriBuilder(endpoint)
+        {
+            Query = string.Empty,
+            Fragment = string.Empty,
+        };
+
+        var path = builder.Path;
+        builder.Path = string.IsNullOrEmpty(path) || path == "/"
+            ? "/v2/pipeline"
+            : path.TrimEnd('/').EndsWith("/v2/pipeline", StringComparison.OrdinalIgnoreCase)
+                ? path
+                : path.TrimEnd('/') + "/v2/pipeline";
+
+        return builder.Uri;
+    }
+
+    private sealed class RemotePipelineRequest
+    {
+        [JsonPropertyName("baton")]
+        public string? Baton { get; init; }
+
+        [JsonPropertyName("requests")]
+        public List<RemoteStreamRequest> Requests { get; init; } = [];
+    }
+
+    private sealed class RemoteStreamRequest
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; init; } = "";
+
+        [JsonPropertyName("stmt")]
+        public RemoteStatement? Statement { get; init; }
+
+        public static RemoteStreamRequest Execute(RemoteStatement statement)
+        {
+            return new RemoteStreamRequest
+            {
+                Type = "execute",
+                Statement = statement,
+            };
+        }
+
+        public static RemoteStreamRequest Close()
+        {
+            return new RemoteStreamRequest
+            {
+                Type = "close",
+            };
+        }
+    }
+
+    private sealed class RemoteStatement
+    {
+        [JsonPropertyName("sql")]
+        public string Sql { get; init; } = "";
+
+        [JsonPropertyName("args")]
+        public List<RemoteRequestValue> Args { get; } = [];
+
+        [JsonPropertyName("named_args")]
+        public List<RemoteNamedArg> NamedArgs { get; } = [];
+
+        [JsonPropertyName("want_rows")]
+        public bool WantRows { get; init; }
+    }
+
+    private sealed class RemoteNamedArg
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = "";
+
+        [JsonPropertyName("value")]
+        public RemoteRequestValue Value { get; init; } = RemoteRequestValue.Null();
+    }
+
+    private sealed class RemoteRequestValue
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; init; } = "";
+
+        [JsonPropertyName("value")]
+        public object? Value { get; init; }
+
+        [JsonPropertyName("base64")]
+        public string? Base64 { get; init; }
+
+        public static RemoteRequestValue Null()
+        {
+            return new RemoteRequestValue
+            {
+                Type = "null",
+            };
+        }
+
+        public static RemoteRequestValue FromTursoValue(TursoValue value)
+        {
+            return value.ValueType switch
+            {
+                TursoValueType.Empty or TursoValueType.Null => Null(),
+                TursoValueType.Integer => new RemoteRequestValue
+                {
+                    Type = "integer",
+                    Value = value.IntValue.ToString(CultureInfo.InvariantCulture),
+                },
+                TursoValueType.Real => new RemoteRequestValue
+                {
+                    Type = "float",
+                    Value = value.RealValue,
+                },
+                TursoValueType.Text => new RemoteRequestValue
+                {
+                    Type = "text",
+                    Value = value.StringValue ?? string.Empty,
+                },
+                TursoValueType.Blob => new RemoteRequestValue
+                {
+                    Type = "blob",
+                    Base64 = Convert.ToBase64String(value.BlobValue ?? []),
+                },
+                _ => throw new ArgumentOutOfRangeException(nameof(value), value.ValueType, null),
+            };
+        }
+    }
+}
+
+internal sealed class RemotePipelineResponse
+{
+    [JsonPropertyName("baton")]
+    public string? Baton { get; init; }
+
+    [JsonPropertyName("base_url")]
+    public string? BaseUrl { get; init; }
+
+    [JsonPropertyName("results")]
+    public List<RemoteStreamResult> Results { get; init; } = [];
+}
+
+internal sealed class RemoteStreamResult
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "";
+
+    [JsonPropertyName("response")]
+    public RemoteStreamResponse? Response { get; init; }
+
+    [JsonPropertyName("error")]
+    public RemoteError? Error { get; init; }
+}
+
+internal sealed class RemoteStreamResponse
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "";
+
+    [JsonPropertyName("result")]
+    public JsonElement Result { get; init; }
+
+    public T DeserializeResult<T>()
+    {
+        if (Result.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            throw new TursoException($"Remote response {Type} did not include a result.");
+
+        try
+        {
+            return Result.Deserialize<T>()
+                   ?? throw new TursoException($"Remote response {Type} returned an empty result.");
+        }
+        catch (JsonException ex)
+        {
+            throw new TursoException($"Unable to parse remote {Type} response: {ex.Message}");
+        }
+    }
+}
+
+internal sealed class RemoteError
+{
+    [JsonPropertyName("message")]
+    public string Message { get; init; } = "";
+
+    [JsonPropertyName("code")]
+    public string? Code { get; init; }
+}
+
+internal sealed class TursoRemoteSqlException(string message) : TursoException(message);
+
+internal sealed class RemoteStatementResult
+{
+    [JsonPropertyName("cols")]
+    public List<RemoteColumn> Columns { get; init; } = [];
+
+    [JsonPropertyName("rows")]
+    public List<List<RemoteResponseValue>> Rows { get; init; } = [];
+
+    [JsonPropertyName("affected_row_count")]
+    public ulong AffectedRowCount { get; init; }
+
+    [JsonPropertyName("last_insert_rowid")]
+    public JsonElement LastInsertRowId { get; init; }
+}
+
+internal sealed class RemoteColumn
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("decltype")]
+    public string? DeclType { get; init; }
+}
+
+internal sealed class RemoteResponseValue
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "";
+
+    [JsonPropertyName("value")]
+    public JsonElement Value { get; init; }
+
+    [JsonPropertyName("base64")]
+    public string? Base64 { get; init; }
+
+    public object ToClrValue()
+    {
+        return Type switch
+        {
+            "null" => DBNull.Value,
+            "integer" => ParseInteger(),
+            "float" => ParseFloat(),
+            "text" => Value.GetString() ?? string.Empty,
+            "blob" => DecodeBase64(Base64 ?? string.Empty),
+            _ => throw new TursoException($"Remote response returned unsupported value type: {Type}"),
+        };
+    }
+
+    public long GetInt64()
+    {
+        return Type switch
+        {
+            "integer" => ParseInteger(),
+            "float" => checked((long)ParseFloat()),
+            "text" => long.Parse(Value.GetString() ?? "", CultureInfo.InvariantCulture),
+            _ => throw new InvalidCastException($"Cannot convert remote {Type} value to Int64."),
+        };
+    }
+
+    public double GetDouble()
+    {
+        return Type switch
+        {
+            "float" => ParseFloat(),
+            "integer" => ParseInteger(),
+            "text" => double.Parse(Value.GetString() ?? "", CultureInfo.InvariantCulture),
+            _ => throw new InvalidCastException($"Cannot convert remote {Type} value to Double."),
+        };
+    }
+
+    public decimal GetDecimal()
+    {
+        return Type switch
+        {
+            "float" => Convert.ToDecimal(ParseFloat(), CultureInfo.InvariantCulture),
+            "integer" => ParseInteger(),
+            "text" => decimal.Parse(Value.GetString() ?? "", CultureInfo.InvariantCulture),
+            _ => throw new InvalidCastException($"Cannot convert remote {Type} value to Decimal."),
+        };
+    }
+
+    private long ParseInteger()
+    {
+        return Value.ValueKind == JsonValueKind.String
+            ? long.Parse(Value.GetString() ?? "", CultureInfo.InvariantCulture)
+            : Value.GetInt64();
+    }
+
+    private double ParseFloat()
+    {
+        return Value.ValueKind == JsonValueKind.String
+            ? double.Parse(Value.GetString() ?? "", CultureInfo.InvariantCulture)
+            : Value.GetDouble();
+    }
+
+    private static byte[] DecodeBase64(string value)
+    {
+        var padding = value.Length % 4;
+        if (padding != 0)
+            value = value.PadRight(value.Length + 4 - padding, '=');
+
+        return Convert.FromBase64String(value);
+    }
+}

--- a/bindings/dotnet/src/Turso.Data/TursoRemoteDataReader.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoRemoteDataReader.cs
@@ -1,0 +1,361 @@
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+
+namespace Turso;
+
+internal sealed class TursoRemoteDataReader : DbDataReader
+{
+    private readonly TursoConnection? _connection;
+    private readonly RemoteStatementResult _result;
+    private readonly CommandBehavior _behavior;
+    private readonly int _recordsAffected;
+    private int _rowIndex = -1;
+    private bool _isClosed;
+
+    public TursoRemoteDataReader(TursoCommand command, RemoteStatementResult result, CommandBehavior behavior)
+        : this(command.Connection as TursoConnection, result, behavior)
+    {
+    }
+
+    private TursoRemoteDataReader(TursoConnection? connection, RemoteStatementResult result, CommandBehavior behavior)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        _connection = connection;
+        _result = result;
+        _behavior = behavior;
+        _recordsAffected = checked((int)result.AffectedRowCount);
+    }
+
+    public override bool GetBoolean(int ordinal)
+    {
+        return CurrentValue(ordinal).GetInt64() != 0;
+    }
+
+    public override byte GetByte(int ordinal)
+    {
+        return checked((byte)CurrentValue(ordinal).GetInt64());
+    }
+
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
+    {
+        return CopyArray((byte[])CurrentValue(ordinal).ToClrValue(), dataOffset, buffer, bufferOffset, length);
+    }
+
+    public override char GetChar(int ordinal)
+    {
+        var value = CurrentValue(ordinal);
+        if (value.Type == "text")
+        {
+            var text = (string)value.ToClrValue();
+            if (text.Length == 1)
+                return text[0];
+        }
+
+        return checked((char)value.GetInt64());
+    }
+
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
+    {
+        return CopyArray(GetString(ordinal).ToCharArray(), dataOffset, buffer, bufferOffset, length);
+    }
+
+    public override string GetDataTypeName(int ordinal)
+    {
+        var value = HasCurrentRow ? CurrentValue(ordinal) : null;
+        if (value is not null)
+            return GetTypeName(value.Type);
+
+        return ordinal >= 0 && ordinal < CurrentResult.Columns.Count
+            ? CurrentResult.Columns[ordinal].DeclType ?? string.Empty
+            : string.Empty;
+    }
+
+    public override DateTime GetDateTime(int ordinal)
+    {
+        var value = CurrentValue(ordinal);
+        return value.Type == "text"
+            ? DateTime.Parse((string)value.ToClrValue(), CultureInfo.InvariantCulture)
+            : throw new InvalidCastException($"Cannot convert remote {value.Type} value to DateTime.");
+    }
+
+    public override decimal GetDecimal(int ordinal)
+    {
+        return CurrentValue(ordinal).GetDecimal();
+    }
+
+    public override double GetDouble(int ordinal)
+    {
+        return CurrentValue(ordinal).GetDouble();
+    }
+
+    public override Type GetFieldType(int ordinal)
+    {
+        EnsureOpen();
+        ValidateOrdinal(ordinal);
+
+        if (HasCurrentRow)
+            return GetClrType(CurrentResult.Rows[_rowIndex][ordinal].Type);
+
+        if (ordinal < CurrentResult.Columns.Count
+            && TryGetClrTypeFromDeclaredType(CurrentResult.Columns[ordinal].DeclType, out var declaredType))
+        {
+            return declaredType;
+        }
+
+        return CurrentResult.Rows.Count > 0 && ordinal < CurrentResult.Rows[0].Count
+            ? GetClrType(CurrentResult.Rows[0][ordinal].Type)
+            : typeof(object);
+    }
+
+    public override float GetFloat(int ordinal)
+    {
+        return (float)CurrentValue(ordinal).GetDouble();
+    }
+
+    public override Guid GetGuid(int ordinal)
+    {
+        return Guid.Parse(GetString(ordinal));
+    }
+
+    public override short GetInt16(int ordinal)
+    {
+        return checked((short)CurrentValue(ordinal).GetInt64());
+    }
+
+    public override int GetInt32(int ordinal)
+    {
+        return checked((int)CurrentValue(ordinal).GetInt64());
+    }
+
+    public override long GetInt64(int ordinal)
+    {
+        return CurrentValue(ordinal).GetInt64();
+    }
+
+    public override string GetName(int ordinal)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(ordinal);
+        return ordinal < CurrentResult.Columns.Count
+            ? CurrentResult.Columns[ordinal].Name ?? string.Empty
+            : string.Empty;
+    }
+
+    public override int GetOrdinal(string name)
+    {
+        for (var i = 0; i < FieldCount; i++)
+        {
+            if (GetName(i) == name)
+                return i;
+        }
+
+        throw new IndexOutOfRangeException($"column {name} not found");
+    }
+
+    public override string GetString(int ordinal)
+    {
+        var value = CurrentValue(ordinal).ToClrValue();
+        return value switch
+        {
+            string text => text,
+            DBNull => throw new InvalidCastException("Cannot convert remote null value to String."),
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? string.Empty,
+        };
+    }
+
+    public override object GetValue(int ordinal)
+    {
+        return CurrentValue(ordinal).ToClrValue();
+    }
+
+    public override int GetValues(object[] values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        var count = Math.Min(values.Length, FieldCount);
+        for (var i = 0; i < count; i++)
+            values[i] = GetValue(i);
+
+        return count;
+    }
+
+    public override bool IsDBNull(int ordinal)
+    {
+        return CurrentValue(ordinal).Type == "null";
+    }
+
+    public override int FieldCount => CurrentResult.Columns.Count > 0
+        ? CurrentResult.Columns.Count
+        : CurrentResult.Rows.Count > 0
+            ? CurrentResult.Rows[0].Count
+            : 0;
+
+    public override object this[int ordinal] => GetValue(ordinal);
+
+    public override object this[string name] => GetValue(GetOrdinal(name));
+
+    public override int RecordsAffected => _recordsAffected;
+
+    public override bool HasRows => CurrentResult.Rows.Count > 0;
+
+    public override bool IsClosed => _isClosed;
+
+    public override bool NextResult()
+    {
+        EnsureOpen();
+        _rowIndex = CurrentResult.Rows.Count;
+        return false;
+    }
+
+    public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
+    {
+        return cancellationToken.IsCancellationRequested
+            ? Task.FromCanceled<bool>(cancellationToken)
+            : Task.FromResult(NextResult());
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !_isClosed && (_behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection)
+            _connection?.Close();
+
+        _isClosed = true;
+        base.Dispose(disposing);
+    }
+
+    public override bool Read()
+    {
+        EnsureOpen();
+        if (_rowIndex + 1 >= CurrentResult.Rows.Count)
+        {
+            _rowIndex = CurrentResult.Rows.Count;
+            return false;
+        }
+
+        _rowIndex++;
+        return true;
+    }
+
+    public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+    {
+        return cancellationToken.IsCancellationRequested
+            ? Task.FromCanceled<bool>(cancellationToken)
+            : Task.FromResult(Read());
+    }
+
+    public override int Depth => 0;
+
+    public override IEnumerator GetEnumerator()
+    {
+        return new DbEnumerator(this, closeReader: false);
+    }
+
+    private RemoteStatementResult CurrentResult => _result;
+
+    private bool HasCurrentRow => _rowIndex >= 0 && _rowIndex < CurrentResult.Rows.Count;
+
+    private RemoteResponseValue CurrentValue(int ordinal)
+    {
+        EnsureOpen();
+        if (!HasCurrentRow)
+            throw new InvalidOperationException("No current row. Call Read before accessing values.");
+
+        ValidateOrdinal(ordinal);
+        var row = CurrentResult.Rows[_rowIndex];
+        if (ordinal >= row.Count)
+            throw new IndexOutOfRangeException($"column ordinal {ordinal} is out of range");
+
+        return row[ordinal];
+    }
+
+    private static long CopyArray<T>(T[] source, long dataOffset, T[]? buffer, int bufferOffset, int length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(dataOffset);
+        ArgumentOutOfRangeException.ThrowIfNegative(bufferOffset);
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+
+        if (dataOffset >= source.LongLength)
+            return 0;
+
+        var available = source.LongLength - dataOffset;
+
+        if (buffer is null)
+            return available;
+
+        if (bufferOffset >= buffer.Length)
+            return 0;
+
+        var count = checked((int)Math.Min(Math.Min(available, length), buffer.Length - bufferOffset));
+        if (count <= 0)
+            return 0;
+
+        Array.Copy(source, checked((int)dataOffset), buffer, bufferOffset, count);
+
+        return count;
+    }
+
+    private static string GetTypeName(string valueType)
+    {
+        return valueType switch
+        {
+            "null" => "NULL",
+            "integer" => "INTEGER",
+            "float" => "REAL",
+            "text" => "TEXT",
+            "blob" => "BLOB",
+            _ => throw new ArgumentOutOfRangeException(nameof(valueType), valueType, null),
+        };
+    }
+
+    private void ValidateOrdinal(int ordinal)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(ordinal);
+        if (ordinal >= FieldCount)
+            throw new IndexOutOfRangeException($"column ordinal {ordinal} is out of range");
+    }
+
+    private static Type GetClrType(string valueType)
+    {
+        return valueType switch
+        {
+            "integer" => typeof(long),
+            "float" => typeof(double),
+            "text" => typeof(string),
+            "blob" => typeof(byte[]),
+            "null" => typeof(DBNull),
+            _ => typeof(object),
+        };
+    }
+
+    private static bool TryGetClrTypeFromDeclaredType(string? declaredType, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Type? clrType)
+    {
+        clrType = null;
+        if (string.IsNullOrWhiteSpace(declaredType))
+            return false;
+
+        var normalized = declaredType.Trim().ToUpperInvariant();
+        if (normalized.Contains("INT", StringComparison.Ordinal))
+            clrType = typeof(long);
+        else if (normalized.Contains("REAL", StringComparison.Ordinal)
+                 || normalized.Contains("FLOA", StringComparison.Ordinal)
+                 || normalized.Contains("DOUB", StringComparison.Ordinal))
+            clrType = typeof(double);
+        else if (normalized.Contains("TEXT", StringComparison.Ordinal)
+                 || normalized.Contains("CHAR", StringComparison.Ordinal)
+                 || normalized.Contains("CLOB", StringComparison.Ordinal))
+            clrType = typeof(string);
+        else if (normalized.Contains("BLOB", StringComparison.Ordinal))
+            clrType = typeof(byte[]);
+
+        return clrType is not null;
+    }
+
+    private void EnsureOpen()
+    {
+        if (IsClosed)
+            throw new InvalidOperationException("The data reader is closed.");
+    }
+}

--- a/bindings/dotnet/src/Turso.Tests/TursoRemoteTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoRemoteTests.cs
@@ -1,0 +1,517 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using AwesomeAssertions;
+using Turso.Raw.Public;
+
+namespace Turso.Tests;
+
+public class TursoRemoteTests
+{
+    [Test]
+    public void TestConnectionStringBuilderNormalizesRemoteKeywords()
+    {
+        var builder = new TursoConnectionStringBuilder(
+            "Data Source=libsql://example.turso.io;AuthToken=secret;ReadYourWrites=False;ReplicaPath=replica.db;SyncInterval=5;TLS=True");
+
+        builder.DataSource.Should().Be("libsql://example.turso.io");
+        builder.AuthToken.Should().Be("secret");
+        builder.ReadYourWrites.Should().BeFalse();
+        builder.ReplicaPath.Should().Be("replica.db");
+        builder.SyncInterval.Should().Be(5);
+        builder.Tls.Should().BeTrue();
+        builder.ConnectionString.Should().Contain("Auth Token=secret");
+        builder.ConnectionString.Should().Contain("Read Your Writes=False");
+        builder.ContainsKey("AuthToken").Should().BeTrue();
+    }
+
+    [Test]
+    public void TestRemoteReplicaFailsBeforeNetworkAccess()
+    {
+        using var connection = new TursoConnection(
+            "Data Source=libsql://example.turso.io;Auth Token=secret;Replica Path=replica.db");
+
+        connection.Invoking(x => x.Open())
+            .Should().Throw<NotSupportedException>()
+            .WithMessage("Embedded replica connections are not supported yet by the .NET provider.*");
+    }
+
+    [Test]
+    public void TestRemoteTlsConflictFailsBeforeNetworkAccess()
+    {
+        using var connection = new TursoConnection("Data Source=http://localhost:8080;Tls=True");
+
+        connection.Invoking(x => x.Open())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Tls=True conflicts with the http URL scheme.");
+    }
+
+    [Test]
+    public void TestRemoteAuthTokenRequiresHttpsExceptLoopback()
+    {
+        using var httpConnection = new TursoConnection("Data Source=http://example.com;Auth Token=secret");
+        httpConnection.Invoking(x => x.Open())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Auth Token requires an HTTPS remote Turso URL unless the host is localhost or loopback.");
+
+        using var libsqlCleartextConnection = new TursoConnection("Data Source=libsql://example.com;Tls=False;Auth Token=secret");
+        libsqlCleartextConnection.Invoking(x => x.Open())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Auth Token requires an HTTPS remote Turso URL unless the host is localhost or loopback.");
+
+        using var loopbackConnection = new TursoConnection("Data Source=http://localhost:8080;Auth Token=secret");
+        loopbackConnection.Open();
+        loopbackConnection.State.Should().Be(System.Data.ConnectionState.Open);
+    }
+
+    [Test]
+    public void TestLocalConnectionRejectsRemoteOnlyOptions()
+    {
+        using var connection = new TursoConnection("Data Source=:memory:;Auth Token=secret");
+
+        connection.Invoking(x => x.Open())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Auth Token requires a remote Turso URL Data Source.");
+    }
+
+    [Test]
+    public void TestRemoteOpenCloseStateDoesNotRequireNetwork()
+    {
+        using var connection = new TursoConnection("Data Source=http://localhost:8080;Read Your Writes=False");
+
+        connection.Open();
+        connection.State.Should().Be(System.Data.ConnectionState.Open);
+        connection.Invoking(x => x.Open())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("The connection is already open.");
+
+        connection.Close();
+        connection.State.Should().Be(System.Data.ConnectionState.Closed);
+    }
+
+    [Test]
+    public void TestRemoteTransactionsAreUnsupportedBeforeNetworkAccess()
+    {
+        using var connection = new TursoConnection("Data Source=http://localhost:8080");
+        connection.Open();
+
+        connection.Invoking(x => x.BeginTransaction())
+            .Should().Throw<NotSupportedException>()
+            .WithMessage("Remote transactions are not supported yet by the .NET provider.");
+    }
+
+    [Test]
+    public void TestRemoteCommandSerializesParametersAndReadsRows()
+    {
+        const string responseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [
+                        { "name": "n", "decltype": "INTEGER" },
+                        { "name": "name", "decltype": "TEXT" }
+                      ],
+                      "rows": [
+                        [
+                          { "type": "integer", "value": "42" },
+                          { "type": "text", "value": "alice" }
+                        ]
+                      ],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                },
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection(
+            $"Data Source={server.Url};Auth Token=secret;Read Your Writes=False");
+        connection.Open();
+
+        using var command = (TursoCommand)connection.CreateCommand();
+        command.CommandText = "SELECT ?, :name";
+        command.Parameters.Add(42);
+        command.Parameters.AddWithValue(":name", "alice");
+
+        using var reader = command.ExecuteReader();
+        reader.FieldCount.Should().Be(2);
+        reader.Read().Should().BeTrue();
+        reader.GetInt64(0).Should().Be(42);
+        reader.GetString(1).Should().Be("alice");
+        reader.Read().Should().BeFalse();
+
+        server.RequestUri.Should().Be(new Uri(server.Url, "/v2/pipeline"));
+        server.Authorization.Should().Be("Bearer secret");
+
+        using var document = JsonDocument.Parse(server.RequestBody);
+        var requests = document.RootElement.GetProperty("requests");
+        requests.GetArrayLength().Should().Be(2);
+        requests[0].GetProperty("type").GetString().Should().Be("execute");
+        requests[0].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("SELECT ?, :name");
+        requests[0].GetProperty("stmt").GetProperty("args")[0].GetProperty("value").GetString().Should().Be("42");
+        requests[0].GetProperty("stmt").GetProperty("named_args")[0].GetProperty("name").GetString().Should().Be(":name");
+        requests[1].GetProperty("type").GetString().Should().Be("close");
+    }
+
+    [Test]
+    public void TestRemoteCommandExecuteScalarUsesSingleStatementPipeline()
+    {
+        const string responseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [
+                        { "name": "value", "decltype": "INTEGER" }
+                      ],
+                      "rows": [
+                        [
+                          { "type": "integer", "value": "123" }
+                        ]
+                      ],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                },
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var command = (TursoCommand)connection.CreateCommand();
+        command.CommandText = "SELECT $value";
+        command.Parameters.AddWithValue("$value", 123);
+
+        command.ExecuteScalar().Should().Be(123L);
+
+        using var document = JsonDocument.Parse(server.RequestBody);
+        var request = document.RootElement.GetProperty("requests")[0];
+        request.GetProperty("type").GetString().Should().Be("execute");
+        request.GetProperty("stmt").GetProperty("sql").GetString().Should().Be("SELECT $value");
+        request.GetProperty("stmt").GetProperty("named_args")[0].GetProperty("name").GetString().Should().Be("$value");
+        request.GetProperty("stmt").GetProperty("want_rows").GetBoolean().Should().BeTrue();
+    }
+
+    [Test]
+    public void TestRemoteReaderDoesNotConvertNullToEmptyString()
+    {
+        const string responseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [
+                        { "name": "value", "decltype": "TEXT" }
+                      ],
+                      "rows": [
+                        [
+                          { "type": "null" }
+                        ]
+                      ],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                },
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT NULL";
+        using var reader = command.ExecuteReader();
+
+        reader.GetDataTypeName(0).Should().Be("TEXT");
+        reader.GetFieldType(0).Should().Be(typeof(string));
+        reader.Read().Should().BeTrue();
+        reader.IsDBNull(0).Should().BeTrue();
+        reader.GetFieldType(0).Should().Be(typeof(DBNull));
+        reader.GetValue(0).Should().Be(DBNull.Value);
+        reader.Invoking(x => x.GetString(0))
+            .Should().Throw<InvalidCastException>()
+            .WithMessage("Cannot convert remote null value to String.");
+        reader.Invoking(x => x.GetDateTime(0))
+            .Should().Throw<InvalidCastException>()
+            .WithMessage("Cannot convert remote null value to DateTime.");
+    }
+
+    [Test]
+    public void TestRemoteNonQueryUsesNoRowsAndIgnoresTrailingCloseError()
+    {
+        const string responseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 1,
+                      "last_insert_rowid": "1"
+                    }
+                  }
+                },
+                {
+                  "type": "error",
+                  "error": {
+                    "message": "close failed",
+                    "code": "CLOSE_FAILED"
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "INSERT INTO t VALUES (1)";
+        command.ExecuteNonQuery().Should().Be(1);
+
+        using var document = JsonDocument.Parse(server.RequestBody);
+        var requests = document.RootElement.GetProperty("requests");
+        requests.GetArrayLength().Should().Be(2);
+        requests[0].GetProperty("stmt").GetProperty("want_rows").GetBoolean().Should().BeFalse();
+        requests[1].GetProperty("type").GetString().Should().Be("close");
+    }
+
+    [Test]
+    public void TestRemoteCommandSurfacesSqlErrors()
+    {
+        const string responseJson = """
+            {
+              "results": [
+                {
+                  "type": "error",
+                  "error": {
+                    "message": "no such table: missing",
+                    "code": "SQLITE_ERROR"
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM missing";
+
+        command.Invoking(x => x.ExecuteScalar())
+            .Should().Throw<TursoException>()
+            .WithMessage("Remote SQL execution failed: no such table: missing (SQLITE_ERROR)");
+    }
+
+    [Test]
+    public void TestRemoteCommandRejectsProtocolErrors()
+    {
+        const string responseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "sequence",
+                    "result": {}
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=True");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+
+        command.Invoking(x => x.ExecuteScalar())
+            .Should().Throw<TursoException>()
+            .WithMessage("Remote request returned unexpected response type: sequence");
+    }
+
+    [Test]
+    public void TestRemoteCommandRejectsCleartextBaseUrlWithAuthToken()
+    {
+        const string responseJson = """
+            {
+              "base_url": "http://example.com",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Auth Token=secret");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+
+        command.Invoking(x => x.ExecuteScalar())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Auth Token requires an HTTPS remote Turso URL unless the host is localhost or loopback.");
+    }
+
+    private sealed class TestRemoteServer : IDisposable
+    {
+        private readonly CancellationTokenSource _cancellation = new();
+        private readonly TcpListener _listener;
+        private readonly Queue<string> _responseJson;
+        private readonly Task _serverTask;
+
+        public TestRemoteServer(params string[] responseJson)
+        {
+            _responseJson = new Queue<string>(responseJson);
+            _listener = new TcpListener(IPAddress.Loopback, port: 0);
+            _listener.Start();
+
+            var endpoint = (IPEndPoint)_listener.LocalEndpoint;
+            Url = new Uri($"http://127.0.0.1:{endpoint.Port}");
+            _serverTask = Task.Run(AcceptLoopAsync);
+        }
+
+        public Uri Url { get; }
+
+        public Uri? RequestUri { get; private set; }
+
+        public string? Authorization { get; private set; }
+
+        public string RequestBody { get; private set; } = "";
+
+        public void Dispose()
+        {
+            _cancellation.Cancel();
+            _listener.Stop();
+            _cancellation.Dispose();
+        }
+
+        private async Task AcceptLoopAsync()
+        {
+            try
+            {
+                while (!_cancellation.IsCancellationRequested)
+                {
+                    using var client = await _listener.AcceptTcpClientAsync(_cancellation.Token);
+                    await HandleClientAsync(client);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient client)
+        {
+            if (_responseJson.Count == 0)
+                throw new InvalidOperationException("No fake HTTP response is available.");
+
+            await using var stream = client.GetStream();
+            using var reader = new StreamReader(stream, Encoding.ASCII, leaveOpen: true);
+
+            var requestLine = await reader.ReadLineAsync()
+                              ?? throw new InvalidOperationException("HTTP request did not include a request line.");
+            var requestParts = requestLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (requestParts.Length < 2)
+                throw new InvalidOperationException($"Invalid HTTP request line: {requestLine}");
+
+            var contentLength = 0;
+            while (await reader.ReadLineAsync() is { Length: > 0 } headerLine)
+            {
+                var separatorIndex = headerLine.IndexOf(':', StringComparison.Ordinal);
+                if (separatorIndex < 0)
+                    continue;
+
+                var name = headerLine[..separatorIndex];
+                var value = headerLine[(separatorIndex + 1)..].Trim();
+                if (name.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+                    contentLength = int.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
+                else if (name.Equals("Authorization", StringComparison.OrdinalIgnoreCase))
+                    Authorization = value;
+                else if (name.Equals("Host", StringComparison.OrdinalIgnoreCase))
+                    RequestUri = new Uri($"{Url.Scheme}://{value}{requestParts[1]}");
+            }
+
+            if (RequestUri is null)
+                RequestUri = new Uri(Url, requestParts[1]);
+
+            if (contentLength > 0)
+            {
+                var buffer = new char[contentLength];
+                var read = 0;
+                while (read < buffer.Length)
+                {
+                    var count = await reader.ReadAsync(buffer.AsMemory(read, buffer.Length - read));
+                    if (count == 0)
+                        break;
+
+                    read += count;
+                }
+
+                RequestBody = new string(buffer, 0, read);
+            }
+
+            var body = Encoding.UTF8.GetBytes(_responseJson.Dequeue());
+            var headers = Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n");
+            await stream.WriteAsync(headers);
+            await stream.WriteAsync(body);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add remote connection string/options parsing and URL/auth-token validation for Turso.Data.
- Add a managed single-statement Hrana HTTP /v2/pipeline client and remote data reader.
- Wire remote ExecuteReader, ExecuteScalar, and ExecuteNonQuery paths for TursoConnection/TursoCommand.
- Document basic remote usage and current limitations.

## Tests
- dotnet build bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj
- dotnet test bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --no-build --filter FullyQualifiedName~TursoRemoteTests
- C:\Users\mamoreau\.cargo\bin\cargo.exe build -p turso_sdk_kit --target-dir .\bindings\dotnet\rs_compiled --target x86_64-pc-windows-msvc
- dotnet test bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --no-build --filter "FullyQualifiedName~SqliteFacadeTests|FullyQualifiedName~TursoEfCoreTests"
- dotnet test bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --no-build