### PR TITLE
Add .NET remote transactions and batches

### DIFF
--- a/bindings/dotnet/Readme.md
+++ b/bindings/dotnet/Readme.md
@@ -74,7 +74,27 @@ var name = await command.ExecuteScalarAsync();
 
 Remote mode uses the Hrana HTTP `/v2/pipeline` protocol. `libsql://` URLs default to HTTPS; `Tls=False` maps them to HTTP for local development. `ws://` and `wss://` URLs are accepted and mapped to the equivalent HTTP pipeline endpoint. `Auth Token` requires HTTPS unless the host is `localhost` or loopback.
 
-Remote mode currently supports direct single-statement command execution. Remote transactions, ADO.NET batches, and embedded replicas are not enabled yet in the .NET provider. `Replica Path` and `Sync Interval` are parsed so applications fail early with clear errors.
+Remote mode also supports ADO.NET `DbBatch` for latency-sensitive workloads that should be sent in one Hrana batch:
+
+```C#
+await using var batch = connection.CreateBatch();
+
+var insert = batch.CreateBatchCommand();
+insert.CommandText = "INSERT INTO customers(name) VALUES ($name)";
+var name = insert.CreateParameter();
+name.ParameterName = "$name";
+name.Value = "Alice";
+insert.Parameters.Add(name);
+batch.BatchCommands.Add(insert);
+
+var select = batch.CreateBatchCommand();
+select.CommandText = "SELECT COUNT(*) FROM customers";
+batch.BatchCommands.Add(select);
+
+await using var reader = await batch.ExecuteReaderAsync();
+```
+
+Embedded replicas are not enabled yet in the .NET provider. `Replica Path` and `Sync Interval` are parsed so applications fail early with clear errors, and `TursoConnection.Sync()` / `SyncAsync(CancellationToken)` are reserved for that mode once `turso_sync_sdk_kit` is packaged and wired through .NET.
 
 Provider factories are available through `TursoFactory.Instance`:
 

--- a/bindings/dotnet/src/Turso.Data/TursoBatch.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoBatch.cs
@@ -1,0 +1,184 @@
+using System.Data;
+using System.Data.Common;
+using Turso.Raw.Public;
+
+namespace Turso;
+
+public sealed class TursoBatch : DbBatch
+{
+    private readonly TursoBatchCommandCollection _batchCommands = new();
+    private TursoConnection? _connection;
+    private TursoTransaction? _transaction;
+    private int _timeout = 30;
+
+    public TursoBatch()
+    {
+    }
+
+    public TursoBatch(TursoConnection connection)
+    {
+        _connection = connection;
+        _timeout = connection.DefaultTimeout;
+    }
+
+    protected override DbBatchCommandCollection DbBatchCommands => _batchCommands;
+
+    public new TursoBatchCommandCollection BatchCommands => _batchCommands;
+
+    protected override DbConnection? DbConnection
+    {
+        get => _connection;
+        set
+        {
+            if (value is null)
+            {
+                _connection = null;
+                return;
+            }
+
+            _connection = value as TursoConnection
+                          ?? throw new ArgumentException("Connection must be a TursoConnection.", nameof(value));
+            _timeout = _connection.DefaultTimeout;
+        }
+    }
+
+    protected override DbTransaction? DbTransaction
+    {
+        get => _transaction;
+        set
+        {
+            if (value is null)
+            {
+                _transaction = null;
+                return;
+            }
+
+            _transaction = value as TursoTransaction
+                           ?? throw new ArgumentException("Transaction must be a TursoTransaction.", nameof(value));
+        }
+    }
+
+    public override int Timeout
+    {
+        get => _timeout;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            _timeout = value;
+        }
+    }
+
+    public override void Cancel()
+    {
+    }
+
+    public override int ExecuteNonQuery()
+    {
+        var results = ExecuteBatch(wantRows: false, CancellationToken.None).GetAwaiter().GetResult();
+        return SetRecordsAffected(results);
+    }
+
+    public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+    {
+        var results = await ExecuteBatch(wantRows: false, cancellationToken).ConfigureAwait(false);
+        return SetRecordsAffected(results);
+    }
+
+    public override object? ExecuteScalar()
+    {
+        using var reader = ExecuteDbDataReader(CommandBehavior.Default);
+        return reader.Read() ? reader.GetValue(0) : null;
+    }
+
+    public override async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
+    {
+        await using var reader = await ExecuteDbDataReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false) ? reader.GetValue(0) : null;
+    }
+
+    public override void Prepare()
+    {
+        ValidateBatch();
+    }
+
+    public override Task PrepareAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled(cancellationToken);
+
+        Prepare();
+        return Task.CompletedTask;
+    }
+
+    protected override DbBatchCommand CreateDbBatchCommand()
+    {
+        return new TursoBatchCommand();
+    }
+
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+    {
+        var results = ExecuteBatch(wantRows: true, CancellationToken.None).GetAwaiter().GetResult();
+        SetRecordsAffected(results);
+        return new TursoRemoteDataReader(_connection, results, behavior);
+    }
+
+    protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(
+        CommandBehavior behavior,
+        CancellationToken cancellationToken)
+    {
+        var results = await ExecuteBatch(wantRows: true, cancellationToken).ConfigureAwait(false);
+        SetRecordsAffected(results);
+        return new TursoRemoteDataReader(_connection, results, behavior);
+    }
+
+    private Task<IReadOnlyList<RemoteStatementResult>> ExecuteBatch(bool wantRows, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled<IReadOnlyList<RemoteStatementResult>>(cancellationToken);
+
+        var connection = ValidateBatch();
+        if (!connection.IsRemote)
+            throw new NotSupportedException("Turso batch execution is currently supported only for remote connections.");
+
+        return connection.ExecuteRemoteBatchAsync(_batchCommands.AsReadOnly(), Timeout, wantRows, cancellationToken);
+    }
+
+    private TursoConnection ValidateBatch()
+    {
+        var connection = _connection ?? throw new InvalidOperationException("Connection must be set before executing a batch.");
+        if (connection.State != ConnectionState.Open)
+            throw new InvalidOperationException("Turso database is closed.");
+        if (_transaction is { IsCompleted: true })
+            throw new InvalidOperationException("The transaction associated with this batch has completed.");
+        if (_transaction is not null && !ReferenceEquals(_transaction.Connection, connection))
+            throw new InvalidOperationException("The transaction is not associated with the batch's connection.");
+        if (_batchCommands.Count == 0)
+            throw new InvalidOperationException("Batch must contain at least one command.");
+
+        foreach (var command in _batchCommands.AsReadOnly())
+        {
+            if (string.IsNullOrWhiteSpace(command.CommandText))
+                throw new InvalidOperationException("Batch command text must be set before executing a batch.");
+            if (command.CommandType != CommandType.Text)
+                throw new NotSupportedException("TursoBatchCommand only supports CommandType.Text.");
+        }
+
+        return connection;
+    }
+
+    private int SetRecordsAffected(IReadOnlyList<RemoteStatementResult> results)
+    {
+        if (results.Count != _batchCommands.Count)
+            throw new TursoException($"Batch result count {results.Count} did not match command count {_batchCommands.Count}.");
+
+        var total = 0;
+        for (var i = 0; i < results.Count; i++)
+        {
+            var recordsAffected = checked((int)results[i].AffectedRowCount);
+            _batchCommands.AsReadOnly()[i].SetRecordsAffected(recordsAffected);
+            total = checked(total + recordsAffected);
+        }
+
+        return total;
+    }
+}

--- a/bindings/dotnet/src/Turso.Data/TursoBatchCommand.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoBatchCommand.cs
@@ -1,0 +1,59 @@
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Turso;
+
+public sealed class TursoBatchCommand : DbBatchCommand
+{
+    private readonly TursoParameterCollection _parameters = new();
+    private string _commandText = "";
+    private CommandType _commandType = CommandType.Text;
+    private int _recordsAffected = -1;
+
+    public TursoBatchCommand()
+    {
+    }
+
+    public TursoBatchCommand(string commandText)
+    {
+        CommandText = commandText;
+    }
+
+    [AllowNull]
+    public override string CommandText
+    {
+        get => _commandText;
+        set => _commandText = value ?? "";
+    }
+
+    public override CommandType CommandType
+    {
+        get => _commandType;
+        set
+        {
+            if (value != CommandType.Text)
+                throw new NotSupportedException("TursoBatchCommand only supports CommandType.Text.");
+
+            _commandType = value;
+        }
+    }
+
+    protected override DbParameterCollection DbParameterCollection => _parameters;
+
+    public new TursoParameterCollection Parameters => _parameters;
+
+    public override int RecordsAffected => _recordsAffected;
+
+    public override bool CanCreateParameter => true;
+
+    public override DbParameter CreateParameter()
+    {
+        return new TursoParameter();
+    }
+
+    internal void SetRecordsAffected(int recordsAffected)
+    {
+        _recordsAffected = recordsAffected;
+    }
+}

--- a/bindings/dotnet/src/Turso.Data/TursoBatchCommandCollection.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoBatchCommandCollection.cs
@@ -1,0 +1,80 @@
+using System.Data.Common;
+
+namespace Turso;
+
+public sealed class TursoBatchCommandCollection : DbBatchCommandCollection
+{
+    private readonly List<TursoBatchCommand> _commands = [];
+
+    public override int Count => _commands.Count;
+
+    public override bool IsReadOnly => false;
+
+    public override void Add(DbBatchCommand item)
+    {
+        _commands.Add(RequireTursoBatchCommand(item));
+    }
+
+    public override void Clear()
+    {
+        _commands.Clear();
+    }
+
+    public override bool Contains(DbBatchCommand item)
+    {
+        return item is TursoBatchCommand command && _commands.Contains(command);
+    }
+
+    public override void CopyTo(DbBatchCommand[] array, int arrayIndex)
+    {
+        ArgumentNullException.ThrowIfNull(array);
+        for (var i = 0; i < _commands.Count; i++)
+            array[arrayIndex + i] = _commands[i];
+    }
+
+    public override IEnumerator<DbBatchCommand> GetEnumerator()
+    {
+        return _commands.GetEnumerator();
+    }
+
+    public override int IndexOf(DbBatchCommand item)
+    {
+        return item is TursoBatchCommand command ? _commands.IndexOf(command) : -1;
+    }
+
+    public override void Insert(int index, DbBatchCommand item)
+    {
+        _commands.Insert(index, RequireTursoBatchCommand(item));
+    }
+
+    public override bool Remove(DbBatchCommand item)
+    {
+        return item is TursoBatchCommand command && _commands.Remove(command);
+    }
+
+    public override void RemoveAt(int index)
+    {
+        _commands.RemoveAt(index);
+    }
+
+    protected override DbBatchCommand GetBatchCommand(int index)
+    {
+        return _commands[index];
+    }
+
+    protected override void SetBatchCommand(int index, DbBatchCommand batchCommand)
+    {
+        _commands[index] = RequireTursoBatchCommand(batchCommand);
+    }
+
+    internal IReadOnlyList<TursoBatchCommand> AsReadOnly()
+    {
+        return _commands;
+    }
+
+    private static TursoBatchCommand RequireTursoBatchCommand(DbBatchCommand command)
+    {
+        return command as TursoBatchCommand
+               ?? throw new ArgumentException("Batch command must be a TursoBatchCommand.", nameof(command));
+    }
+}

--- a/bindings/dotnet/src/Turso.Data/TursoConnection.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoConnection.cs
@@ -13,6 +13,7 @@ public class TursoConnection : DbConnection
     private TursoConnectionOptions _connectionOptions;
     private bool _disposed;
     private bool _readUncommitted;
+    private bool _remoteTransactionActive;
 
     [AllowNull]
     public override string ConnectionString
@@ -37,6 +38,8 @@ public class TursoConnection : DbConnection
         ? ConnectionState.Open
         : ConnectionState.Closed;
 
+    public override bool CanCreateBatch => _connectionOptions.IsRemote && !_connectionOptions.IsReplica;
+
     protected override DbProviderFactory DbProviderFactory => TursoFactory.Instance;
 
     public TursoConnection() : this("")
@@ -46,14 +49,6 @@ public class TursoConnection : DbConnection
     public TursoConnection(string connectionString)
     {
         _connectionOptions = TursoConnectionOptions.Parse(connectionString);
-    }
-
-    internal TursoConnection(string connectionString, TursoRemoteClient remoteClient)
-    {
-        ArgumentNullException.ThrowIfNull(remoteClient);
-
-        _connectionOptions = TursoConnectionOptions.Parse(connectionString);
-        _remoteClient = remoteClient;
     }
 
     public override void Open()
@@ -124,8 +119,6 @@ public class TursoConnection : DbConnection
         {
             throw new InvalidOperationException("Turso database is closed.");
         }
-        if (_remoteClient is not null)
-            throw new NotSupportedException("Remote transactions are not supported yet by the .NET provider.");
 
         return new TursoTransaction(this, isolationLevel);
     }
@@ -135,12 +128,38 @@ public class TursoConnection : DbConnection
         return new TursoCommand(this);
     }
 
+    protected override DbBatch CreateDbBatch()
+    {
+        if (!CanCreateBatch)
+            throw new NotSupportedException("Turso batch execution is currently supported only for remote connections.");
+
+        return new TursoBatch(this);
+    }
+
     public int ExecuteNonQuery(string sql)
     {
         using var command = CreateCommand();
         command.CommandText = sql;
 
         return command.ExecuteNonQuery();
+    }
+
+    public void Sync()
+    {
+        SyncAsync(CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    public Task SyncAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled(cancellationToken);
+        if (State != ConnectionState.Open)
+            throw new InvalidOperationException("Turso database is closed.");
+        if (!_connectionOptions.IsReplica)
+            throw new NotSupportedException("Sync requires an embedded replica connection.");
+
+        throw new NotSupportedException("Embedded replica sync is not supported yet by the .NET provider.");
     }
 
     public override void ChangeDatabase(string databaseName)
@@ -168,7 +187,7 @@ public class TursoConnection : DbConnection
         CancellationToken cancellationToken)
     {
         var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
-        var closeAfter = !_connectionOptions.ReadYourWrites;
+        var closeAfter = !_connectionOptions.ReadYourWrites && !_remoteTransactionActive;
         try
         {
             return await remoteClient.ExecuteAsync(sql, parameters, wantRows, commandTimeout, closeAfter, cancellationToken)
@@ -182,6 +201,119 @@ public class TursoConnection : DbConnection
         {
             InvalidateRemoteSession();
             throw;
+        }
+    }
+
+    internal async Task<IReadOnlyList<RemoteStatementResult>> ExecuteRemoteBatchAsync(
+        IReadOnlyList<TursoBatchCommand> batchCommands,
+        int commandTimeout,
+        bool wantRows,
+        CancellationToken cancellationToken)
+    {
+        var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
+        var closeAfter = !_connectionOptions.ReadYourWrites && !_remoteTransactionActive;
+        try
+        {
+            return await remoteClient.ExecuteBatchAsync(batchCommands, commandTimeout, wantRows, closeAfter, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TursoRemoteSqlException)
+        {
+            throw;
+        }
+        catch
+        {
+            InvalidateRemoteSession();
+            throw;
+        }
+    }
+
+    internal void BeginRemoteTransaction(IsolationLevel isolationLevel)
+    {
+        _ = isolationLevel;
+        var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
+        if (_remoteTransactionActive)
+            throw new InvalidOperationException("A transaction is already active on this connection.");
+
+        _remoteTransactionActive = true;
+        try
+        {
+            remoteClient
+                .ExecuteAsync("BEGIN", new TursoParameterCollection(), wantRows: false, DefaultTimeout, closeAfter: false, CancellationToken.None)
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch (TursoRemoteSqlException)
+        {
+            _remoteTransactionActive = false;
+            throw;
+        }
+        catch
+        {
+            InvalidateRemoteSession();
+            throw;
+        }
+    }
+
+    internal void CommitRemoteTransaction()
+    {
+        var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
+        if (!_remoteTransactionActive)
+            throw new InvalidOperationException("No remote transaction is active on this connection.");
+
+        try
+        {
+            remoteClient
+                .ExecuteAsync("COMMIT", new TursoParameterCollection(), wantRows: false, DefaultTimeout, closeAfter: false, CancellationToken.None)
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch (TursoRemoteSqlException)
+        {
+            throw;
+        }
+        catch
+        {
+            InvalidateRemoteSession();
+            throw;
+        }
+
+        _remoteTransactionActive = false;
+    }
+
+    internal void RollbackRemoteTransaction()
+    {
+        var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
+        if (!_remoteTransactionActive)
+            throw new InvalidOperationException("No remote transaction is active on this connection.");
+
+        try
+        {
+            remoteClient
+                .ExecuteAsync("ROLLBACK", new TursoParameterCollection(), wantRows: false, DefaultTimeout, closeAfter: false, CancellationToken.None)
+                .GetAwaiter()
+                .GetResult();
+            _remoteTransactionActive = false;
+        }
+        catch
+        {
+            InvalidateRemoteSession();
+            throw;
+        }
+    }
+
+    internal void CloseRemoteSessionIfStateless()
+    {
+        if (_connectionOptions.ReadYourWrites || _remoteClient is not { HasOpenSession: true } remoteClient)
+            return;
+
+        try
+        {
+            remoteClient.CloseAsync(DefaultTimeout, CancellationToken.None).GetAwaiter().GetResult();
+        }
+        catch
+        {
+            InvalidateRemoteSession();
         }
     }
 
@@ -220,7 +352,17 @@ public class TursoConnection : DbConnection
         Exception? closeError = null;
         try
         {
-            remoteClient.CloseAsync(DefaultTimeout, CancellationToken.None).GetAwaiter().GetResult();
+            if (_remoteTransactionActive)
+            {
+                remoteClient
+                    .ExecuteAsync("ROLLBACK", new TursoParameterCollection(), wantRows: false, DefaultTimeout, closeAfter: true, CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
+            }
+            else
+            {
+                remoteClient.CloseAsync(DefaultTimeout, CancellationToken.None).GetAwaiter().GetResult();
+            }
         }
         catch (Exception ex)
         {
@@ -230,6 +372,7 @@ public class TursoConnection : DbConnection
         {
             remoteClient.Dispose();
             _remoteClient = null;
+            _remoteTransactionActive = false;
             _readUncommitted = false;
         }
 
@@ -241,6 +384,7 @@ public class TursoConnection : DbConnection
     {
         _remoteClient?.Dispose();
         _remoteClient = null;
+        _remoteTransactionActive = false;
         _readUncommitted = false;
     }
 }

--- a/bindings/dotnet/src/Turso.Data/TursoRemoteClient.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoRemoteClient.cs
@@ -38,6 +38,8 @@ internal sealed class TursoRemoteClient : IDisposable
         _disposeHttpClient = disposeHttpClient;
     }
 
+    public bool HasOpenSession => _baton is not null;
+
     public async Task<RemoteStatementResult> ExecuteAsync(
         string sql,
         TursoParameterCollection parameters,
@@ -64,6 +66,38 @@ internal sealed class TursoRemoteClient : IDisposable
         var response = await SendPipelineAsync(request, commandTimeout, cancellationToken).ConfigureAwait(false);
         UpdateSession(response, closeAfter);
         return ExtractExecuteResult(response);
+    }
+
+    public async Task<IReadOnlyList<RemoteStatementResult>> ExecuteBatchAsync(
+        IReadOnlyList<TursoBatchCommand> commands,
+        int commandTimeout,
+        bool wantRows,
+        bool closeAfter,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(commands);
+        if (commands.Count == 0)
+            throw new InvalidOperationException("Batch must contain at least one command.");
+
+        var steps = new List<RemoteBatchStep>(commands.Count);
+        foreach (var command in commands)
+            steps.Add(new RemoteBatchStep { Statement = BuildStatement(command.CommandText, command.Parameters, wantRows) });
+
+        var request = new RemotePipelineRequest
+        {
+            Baton = _baton,
+            Requests =
+            [
+                RemoteStreamRequest.Batch(new RemoteBatch { Steps = steps }),
+            ],
+        };
+
+        if (closeAfter)
+            request.Requests.Add(RemoteStreamRequest.Close());
+
+        var response = await SendPipelineAsync(request, commandTimeout, cancellationToken).ConfigureAwait(false);
+        UpdateSession(response, closeAfter);
+        return ExtractBatchResults(response, commands.Count);
     }
 
     public async Task CloseAsync(int commandTimeout, CancellationToken cancellationToken)
@@ -207,6 +241,36 @@ internal sealed class TursoRemoteClient : IDisposable
         return statementResult;
     }
 
+    private static IReadOnlyList<RemoteStatementResult> ExtractBatchResults(RemotePipelineResponse response, int expectedCount)
+    {
+        if (response.Results.Count == 0)
+            throw new TursoException("Remote batch returned no results.");
+
+        var result = response.Results[0];
+        List<RemoteStatementResult> statementResults;
+        switch (result.Type)
+        {
+            case "ok":
+                if (result.Response is null)
+                    throw new TursoException("Remote batch returned an empty ok response.");
+                if (result.Response.Type != "batch")
+                    throw new TursoException($"Remote batch returned unexpected response type: {result.Response.Type}");
+
+                var batch = result.Response.DeserializeResult<RemoteBatchResult>();
+                statementResults = ExtractBatchStepResults(batch, expectedCount);
+                break;
+
+            case "error":
+                throw CreateRemoteError(result.Error);
+
+            default:
+                throw new TursoException($"Remote batch returned unexpected result type: {result.Type}");
+        }
+
+        ValidateOptionalTrailingClose(response, "Remote batch");
+        return statementResults;
+    }
+
     private static void ValidateOptionalTrailingClose(RemotePipelineResponse response, string operation)
     {
         if (response.Results.Count == 1)
@@ -228,6 +292,31 @@ internal sealed class TursoRemoteClient : IDisposable
             default:
                 throw new TursoException($"{operation} returned unexpected result type: {result.Type}");
         }
+    }
+
+    private static List<RemoteStatementResult> ExtractBatchStepResults(RemoteBatchResult batch, int expectedCount)
+    {
+        if (batch.StepErrors.Count != expectedCount || batch.StepResults.Count != expectedCount)
+        {
+            throw new TursoException(
+                $"Remote batch returned an unexpected result shape: {batch.StepResults.Count} results, {batch.StepErrors.Count} errors, expected {expectedCount}.");
+        }
+
+        for (var i = 0; i < batch.StepErrors.Count; i++)
+        {
+            if (batch.StepErrors[i] is { } error)
+                throw CreateRemoteError(error);
+        }
+
+        var statementResults = new List<RemoteStatementResult>(expectedCount);
+        for (var i = 0; i < batch.StepResults.Count; i++)
+        {
+            var stepResult = batch.StepResults[i]
+                             ?? throw new TursoException($"Remote batch did not return a result for step {i}.");
+            statementResults.Add(stepResult);
+        }
+
+        return statementResults;
     }
 
     private static void ValidateCloseResult(RemotePipelineResponse response)
@@ -307,12 +396,24 @@ internal sealed class TursoRemoteClient : IDisposable
         [JsonPropertyName("stmt")]
         public RemoteStatement? Statement { get; init; }
 
+        [JsonPropertyName("batch")]
+        public RemoteBatch? BatchRequest { get; init; }
+
         public static RemoteStreamRequest Execute(RemoteStatement statement)
         {
             return new RemoteStreamRequest
             {
                 Type = "execute",
                 Statement = statement,
+            };
+        }
+
+        public static RemoteStreamRequest Batch(RemoteBatch batch)
+        {
+            return new RemoteStreamRequest
+            {
+                Type = "batch",
+                BatchRequest = batch,
             };
         }
 
@@ -338,6 +439,18 @@ internal sealed class TursoRemoteClient : IDisposable
 
         [JsonPropertyName("want_rows")]
         public bool WantRows { get; init; }
+    }
+
+    private sealed class RemoteBatch
+    {
+        [JsonPropertyName("steps")]
+        public List<RemoteBatchStep> Steps { get; init; } = [];
+    }
+
+    private sealed class RemoteBatchStep
+    {
+        [JsonPropertyName("stmt")]
+        public RemoteStatement Statement { get; init; } = new();
     }
 
     private sealed class RemoteNamedArg
@@ -458,6 +571,15 @@ internal sealed class RemoteError
 }
 
 internal sealed class TursoRemoteSqlException(string message) : TursoException(message);
+
+internal sealed class RemoteBatchResult
+{
+    [JsonPropertyName("step_results")]
+    public List<RemoteStatementResult?> StepResults { get; init; } = [];
+
+    [JsonPropertyName("step_errors")]
+    public List<RemoteError?> StepErrors { get; init; } = [];
+}
 
 internal sealed class RemoteStatementResult
 {

--- a/bindings/dotnet/src/Turso.Data/TursoRemoteDataReader.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoRemoteDataReader.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Globalization;
@@ -8,25 +9,27 @@ namespace Turso;
 internal sealed class TursoRemoteDataReader : DbDataReader
 {
     private readonly TursoConnection? _connection;
-    private readonly RemoteStatementResult _result;
+    private readonly IReadOnlyList<RemoteStatementResult> _results;
     private readonly CommandBehavior _behavior;
     private readonly int _recordsAffected;
+    private int _resultIndex;
     private int _rowIndex = -1;
     private bool _isClosed;
 
     public TursoRemoteDataReader(TursoCommand command, RemoteStatementResult result, CommandBehavior behavior)
-        : this(command.Connection as TursoConnection, result, behavior)
+        : this(command.Connection as TursoConnection, [result], behavior)
     {
     }
 
-    private TursoRemoteDataReader(TursoConnection? connection, RemoteStatementResult result, CommandBehavior behavior)
+    public TursoRemoteDataReader(TursoConnection? connection, IReadOnlyList<RemoteStatementResult> results, CommandBehavior behavior)
     {
-        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(results);
 
         _connection = connection;
-        _result = result;
+        _results = results;
         _behavior = behavior;
-        _recordsAffected = checked((int)result.AffectedRowCount);
+        foreach (var result in results)
+            _recordsAffected = checked(_recordsAffected + (int)result.AffectedRowCount);
     }
 
     public override bool GetBoolean(int ordinal)
@@ -206,8 +209,15 @@ internal sealed class TursoRemoteDataReader : DbDataReader
     public override bool NextResult()
     {
         EnsureOpen();
-        _rowIndex = CurrentResult.Rows.Count;
-        return false;
+        if (_resultIndex + 1 >= _results.Count)
+        {
+            _rowIndex = CurrentResult.Rows.Count;
+            return false;
+        }
+
+        _resultIndex++;
+        _rowIndex = -1;
+        return true;
     }
 
     public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
@@ -253,7 +263,16 @@ internal sealed class TursoRemoteDataReader : DbDataReader
         return new DbEnumerator(this, closeReader: false);
     }
 
-    private RemoteStatementResult CurrentResult => _result;
+    private RemoteStatementResult CurrentResult
+    {
+        get
+        {
+            if (_results.Count == 0)
+                throw new InvalidOperationException("The data reader has no result sets.");
+
+            return _results[_resultIndex];
+        }
+    }
 
     private bool HasCurrentRow => _rowIndex >= 0 && _rowIndex < CurrentResult.Rows.Count;
 

--- a/bindings/dotnet/src/Turso.Data/TursoTransaction.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoTransaction.cs
@@ -17,14 +17,20 @@ public class TursoTransaction : DbTransaction
         if (_isolationLevel == IsolationLevel.ReadUncommitted)
             connection.ReadUncommitted = true;
 
-        connection.ExecuteNonQuery("BEGIN");
+        if (connection.IsRemote)
+            connection.BeginRemoteTransaction(_isolationLevel);
+        else
+            connection.ExecuteNonQuery("BEGIN");
     }
 
     protected override void Dispose(bool disposing)
     {
         if (!_completed)
         {
-            Rollback();
+            if (_connection.State == System.Data.ConnectionState.Closed)
+                CompleteTransaction();
+            else
+                Rollback();
         }
 
         base.Dispose(disposing);
@@ -39,13 +45,51 @@ public class TursoTransaction : DbTransaction
     public override void Commit()
     {
         ThrowIfCompleted();
-        _connection.ExecuteNonQuery("COMMIT;");
-        CompleteTransaction();
+        if (_connection.IsRemote)
+        {
+            try
+            {
+                _connection.CommitRemoteTransaction();
+            }
+            catch (TursoRemoteSqlException)
+            {
+                throw;
+            }
+            catch
+            {
+                CompleteTransaction();
+                throw;
+            }
+
+            CompleteTransaction();
+            _connection.CloseRemoteSessionIfStateless();
+            return;
+        }
+        else
+        {
+            _connection.ExecuteNonQuery("COMMIT;");
+            CompleteTransaction();
+        }
     }
 
     public override void Rollback()
     {
         ThrowIfCompleted();
+        if (_connection.IsRemote)
+        {
+            try
+            {
+                _connection.RollbackRemoteTransaction();
+            }
+            finally
+            {
+                CompleteTransaction();
+            }
+
+            _connection.CloseRemoteSessionIfStateless();
+            return;
+        }
+
         try
         {
             _connection.ExecuteNonQuery("ROLLBACK;");

--- a/bindings/dotnet/src/Turso.Tests/TursoRemoteTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoRemoteTests.cs
@@ -76,6 +76,19 @@ public class TursoRemoteTests
     }
 
     [Test]
+    public void TestCanCreateBatchIsRemoteOnly()
+    {
+        using var localConnection = new TursoConnection("Data Source=:memory:");
+        localConnection.CanCreateBatch.Should().BeFalse();
+        localConnection.Invoking(x => x.CreateBatch())
+            .Should().Throw<NotSupportedException>()
+            .WithMessage("Turso batch execution is currently supported only for remote connections.");
+
+        using var remoteConnection = new TursoConnection("Data Source=https://example.com");
+        remoteConnection.CanCreateBatch.Should().BeTrue();
+    }
+
+    [Test]
     public void TestRemoteOpenCloseStateDoesNotRequireNetwork()
     {
         using var connection = new TursoConnection("Data Source=http://localhost:8080;Read Your Writes=False");
@@ -88,17 +101,6 @@ public class TursoRemoteTests
 
         connection.Close();
         connection.State.Should().Be(System.Data.ConnectionState.Closed);
-    }
-
-    [Test]
-    public void TestRemoteTransactionsAreUnsupportedBeforeNetworkAccess()
-    {
-        using var connection = new TursoConnection("Data Source=http://localhost:8080");
-        connection.Open();
-
-        connection.Invoking(x => x.BeginTransaction())
-            .Should().Throw<NotSupportedException>()
-            .WithMessage("Remote transactions are not supported yet by the .NET provider.");
     }
 
     [Test]
@@ -214,7 +216,6 @@ public class TursoRemoteTests
         request.GetProperty("stmt").GetProperty("named_args")[0].GetProperty("name").GetString().Should().Be("$value");
         request.GetProperty("stmt").GetProperty("want_rows").GetBoolean().Should().BeTrue();
     }
-
     [Test]
     public void TestRemoteReaderDoesNotConvertNullToEmptyString()
     {
@@ -406,6 +407,792 @@ public class TursoRemoteTests
             .WithMessage("Auth Token requires an HTTPS remote Turso URL unless the host is localhost or loopback.");
     }
 
+    [Test]
+    public void TestRemoteTransactionsUseBaton()
+    {
+        const string beginResponseJson = """
+            {
+              "baton": "stream.1",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string commitResponseJson = """
+            {
+              "baton": "stream.2",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string closeResponseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(beginResponseJson, commitResponseJson, closeResponseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction();
+        transaction.Commit();
+
+        server.RequestBodies.Should().HaveCount(3);
+        using var beginDocument = JsonDocument.Parse(server.RequestBodies[0]);
+        beginDocument.RootElement.TryGetProperty("baton", out _).Should().BeFalse();
+        beginDocument.RootElement.GetProperty("requests").GetArrayLength().Should().Be(1);
+        beginDocument.RootElement.GetProperty("requests")[0].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("BEGIN");
+
+        using var commitDocument = JsonDocument.Parse(server.RequestBodies[1]);
+        commitDocument.RootElement.GetProperty("baton").GetString().Should().Be("stream.1");
+        var commitRequests = commitDocument.RootElement.GetProperty("requests");
+        commitRequests.GetArrayLength().Should().Be(1);
+        commitRequests[0].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("COMMIT");
+
+        using var closeDocument = JsonDocument.Parse(server.RequestBodies[2]);
+        closeDocument.RootElement.GetProperty("baton").GetString().Should().Be("stream.2");
+        closeDocument.RootElement.GetProperty("requests").GetArrayLength().Should().Be(1);
+        closeDocument.RootElement.GetProperty("requests")[0].GetProperty("type").GetString().Should().Be("close");
+    }
+
+    [Test]
+    public void TestRemoteCommandAndBatchRejectTransactionFromDifferentConnection()
+    {
+        const string beginResponseJson = """
+            {
+              "baton": "stream.1",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string rollbackResponseJson = """
+            {
+              "baton": "stream.2",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string closeResponseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server1 = new TestRemoteServer(beginResponseJson, rollbackResponseJson, closeResponseJson);
+        using var connection1 = new TursoConnection($"Data Source={server1.Url};Read Your Writes=False");
+        connection1.Open();
+        using var transaction = connection1.BeginTransaction();
+
+        using var server2 = new TestRemoteServer();
+        using var connection2 = new TursoConnection($"Data Source={server2.Url};Read Your Writes=True");
+        connection2.Open();
+
+        using var command = connection2.CreateCommand();
+        command.CommandText = "SELECT 1";
+        command.Transaction = transaction;
+        command.Invoking(x => x.ExecuteScalar())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("The transaction is not associated with the command's connection.");
+
+        using var batch = (TursoBatch)connection2.CreateBatch();
+        batch.Transaction = transaction;
+        var batchCommand = batch.CreateBatchCommand();
+        batchCommand.CommandText = "SELECT 1";
+        batch.BatchCommands.Add(batchCommand);
+        batch.Invoking(x => x.ExecuteNonQuery())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("The transaction is not associated with the batch's connection.");
+
+        server2.RequestBodies.Should().BeEmpty();
+    }
+
+    [Test]
+    public void TestRemoteTransactionRollbackUsesErrorResponseBaton()
+    {
+        const string beginResponseJson = """
+            {
+              "baton": "stream.1",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string commandErrorResponseJson = """
+            {
+              "baton": "stream.2",
+              "results": [
+                {
+                  "type": "error",
+                  "error": {
+                    "message": "no such table: missing",
+                    "code": "SQLITE_ERROR"
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string rollbackResponseJson = """
+            {
+              "baton": "stream.3",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string closeResponseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(beginResponseJson, commandErrorResponseJson, rollbackResponseJson, closeResponseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction();
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "SELECT * FROM missing";
+        command.Invoking(x => x.ExecuteNonQuery())
+            .Should().Throw<TursoException>()
+            .WithMessage("Remote SQL execution failed: no such table: missing (SQLITE_ERROR)");
+
+        transaction.Rollback();
+
+        server.RequestBodies.Should().HaveCount(4);
+        using var rollbackDocument = JsonDocument.Parse(server.RequestBodies[2]);
+        rollbackDocument.RootElement.GetProperty("baton").GetString().Should().Be("stream.2");
+        var rollbackRequests = rollbackDocument.RootElement.GetProperty("requests");
+        rollbackRequests.GetArrayLength().Should().Be(1);
+        rollbackRequests[0].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("ROLLBACK");
+
+        using var closeDocument = JsonDocument.Parse(server.RequestBodies[3]);
+        closeDocument.RootElement.GetProperty("baton").GetString().Should().Be("stream.3");
+        closeDocument.RootElement.GetProperty("requests").GetArrayLength().Should().Be(1);
+        closeDocument.RootElement.GetProperty("requests")[0].GetProperty("type").GetString().Should().Be("close");
+    }
+
+    [Test]
+    public void TestRemoteCommitDoesNotThrowWhenPostCommitCloseFails()
+    {
+        const string beginResponseJson = """
+            {
+              "baton": "stream.1",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string commitResponseJson = """
+            {
+              "baton": "stream.2",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string closeErrorResponseJson = """
+            {
+              "results": [
+                {
+                  "type": "error",
+                  "error": {
+                    "message": "close failed",
+                    "code": "CLOSE_FAILED"
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(beginResponseJson, commitResponseJson, closeErrorResponseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction();
+        transaction.Invoking(x => x.Commit()).Should().NotThrow();
+        connection.State.Should().Be(System.Data.ConnectionState.Closed);
+    }
+
+    [Test]
+    public void TestRemoteCommitSqlErrorKeepsBatonForRollback()
+    {
+        const string beginResponseJson = """
+            {
+              "baton": "stream.1",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string commitErrorResponseJson = """
+            {
+              "baton": "stream.2",
+              "results": [
+                {
+                  "type": "error",
+                  "error": {
+                    "message": "FOREIGN KEY constraint failed",
+                    "code": "SQLITE_CONSTRAINT_FOREIGNKEY"
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string rollbackResponseJson = """
+            {
+              "baton": "stream.3",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string closeResponseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(beginResponseJson, commitErrorResponseJson, rollbackResponseJson, closeResponseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction();
+        transaction.Invoking(x => x.Commit())
+            .Should().Throw<TursoException>()
+            .WithMessage("Remote SQL execution failed: FOREIGN KEY constraint failed (SQLITE_CONSTRAINT_FOREIGNKEY)");
+
+        transaction.Rollback();
+
+        using var rollbackDocument = JsonDocument.Parse(server.RequestBodies[2]);
+        rollbackDocument.RootElement.GetProperty("baton").GetString().Should().Be("stream.2");
+        rollbackDocument.RootElement.GetProperty("requests")[0].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("ROLLBACK");
+    }
+
+    [Test]
+    public void TestRemoteCommitTransportFailureInvalidatesConnection()
+    {
+        const string beginResponseJson = """
+            {
+              "baton": "stream.1",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(beginResponseJson, "not json");
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction();
+        transaction.Invoking(x => x.Commit())
+            .Should().Throw<TursoException>()
+            .WithMessage("Unable to parse remote response:*");
+        connection.State.Should().Be(System.Data.ConnectionState.Closed);
+    }
+
+    [Test]
+    public void TestRemoteBeginTransportFailureInvalidatesConnection()
+    {
+        using var server = new TestRemoteServer("not json");
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=True");
+        connection.Open();
+
+        connection.Invoking(x => x.BeginTransaction())
+            .Should().Throw<TursoException>()
+            .WithMessage("Unable to parse remote response:*");
+        connection.State.Should().Be(System.Data.ConnectionState.Closed);
+    }
+
+    [Test]
+    public void TestRemoteInTransactionTransportFailureInvalidatesConnection()
+    {
+        const string beginResponseJson = """
+            {
+              "baton": "stream.1",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(beginResponseJson, "not json");
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=True");
+        connection.Open();
+
+        var transaction = connection.BeginTransaction();
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "INSERT INTO t VALUES (1)";
+
+        command.Invoking(x => x.ExecuteNonQuery())
+            .Should().Throw<TursoException>()
+            .WithMessage("Unable to parse remote response:*");
+        connection.State.Should().Be(System.Data.ConnectionState.Closed);
+        transaction.Invoking(x => x.Dispose()).Should().NotThrow();
+    }
+
+    [Test]
+    public void TestRemoteRollbackFailureInvalidatesConnection()
+    {
+        const string beginResponseJson = """
+            {
+              "baton": "stream.1",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [],
+                      "rows": [],
+                      "affected_row_count": 0,
+                      "last_insert_rowid": null
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string rollbackErrorResponseJson = """
+            {
+              "baton": "stream.2",
+              "results": [
+                {
+                  "type": "error",
+                  "error": {
+                    "message": "rollback failed",
+                    "code": "ROLLBACK_FAILED"
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(beginResponseJson, rollbackErrorResponseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction();
+        transaction.Invoking(x => x.Rollback())
+            .Should().Throw<TursoException>()
+            .WithMessage("Remote SQL execution failed: rollback failed (ROLLBACK_FAILED)");
+        connection.State.Should().Be(System.Data.ConnectionState.Closed);
+    }
+
+    [Test]
+    public void TestRemoteBatchSerializesStatementsAndReadsMultipleResults()
+    {
+        const string responseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "batch",
+                    "result": {
+                      "step_results": [
+                        {
+                          "cols": [
+                            { "name": "n", "decltype": "INTEGER" }
+                          ],
+                          "rows": [
+                            [
+                              { "type": "integer", "value": "7" }
+                            ]
+                          ],
+                          "affected_row_count": 0,
+                          "last_insert_rowid": null
+                        },
+                        {
+                          "cols": [],
+                          "rows": [],
+                          "affected_row_count": 2,
+                          "last_insert_rowid": "3"
+                        }
+                      ],
+                      "step_errors": [null, null]
+                    }
+                  }
+                },
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var batch = (TursoBatch)connection.CreateBatch();
+        var select = (TursoBatchCommand)batch.CreateBatchCommand();
+        select.CommandText = "SELECT ?";
+        select.Parameters.Add(7);
+        batch.BatchCommands.Add(select);
+
+        var insert = (TursoBatchCommand)batch.CreateBatchCommand();
+        insert.CommandText = "INSERT INTO t VALUES (:name), (:other)";
+        insert.Parameters.AddWithValue(":name", "alice");
+        insert.Parameters.AddWithValue(":other", "bob");
+        batch.BatchCommands.Add(insert);
+
+        using var reader = batch.ExecuteReader();
+        reader.Read().Should().BeTrue();
+        reader.GetInt64(0).Should().Be(7);
+        reader.NextResult().Should().BeTrue();
+        reader.Read().Should().BeFalse();
+        reader.RecordsAffected.Should().Be(2);
+        select.RecordsAffected.Should().Be(0);
+        insert.RecordsAffected.Should().Be(2);
+
+        using var document = JsonDocument.Parse(server.RequestBody);
+        var requests = document.RootElement.GetProperty("requests");
+        requests.GetArrayLength().Should().Be(2);
+        requests[0].GetProperty("type").GetString().Should().Be("batch");
+        var steps = requests[0].GetProperty("batch").GetProperty("steps");
+        steps.GetArrayLength().Should().Be(2);
+        steps[0].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("SELECT ?");
+        steps[0].GetProperty("stmt").GetProperty("args")[0].GetProperty("value").GetString().Should().Be("7");
+        steps[1].GetProperty("stmt").GetProperty("named_args")[0].GetProperty("name").GetString().Should().Be(":name");
+        requests[1].GetProperty("type").GetString().Should().Be("close");
+    }
+
+    [Test]
+    public void TestRemoteBatchNonQueryUsesNoRowsAndIgnoresTrailingCloseError()
+    {
+        const string responseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "batch",
+                    "result": {
+                      "step_results": [
+                        {
+                          "cols": [],
+                          "rows": [],
+                          "affected_row_count": 3,
+                          "last_insert_rowid": "3"
+                        }
+                      ],
+                      "step_errors": [null]
+                    }
+                  }
+                },
+                {
+                  "type": "error",
+                  "error": {
+                    "message": "close failed",
+                    "code": "CLOSE_FAILED"
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using var batch = (TursoBatch)connection.CreateBatch();
+        var command = (TursoBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = "INSERT INTO t VALUES (1), (2), (3)";
+        batch.BatchCommands.Add(command);
+
+        batch.ExecuteNonQuery().Should().Be(3);
+        command.RecordsAffected.Should().Be(3);
+
+        using var document = JsonDocument.Parse(server.RequestBody);
+        var requests = document.RootElement.GetProperty("requests");
+        requests.GetArrayLength().Should().Be(2);
+        requests[0].GetProperty("type").GetString().Should().Be("batch");
+        var steps = requests[0].GetProperty("batch").GetProperty("steps");
+        steps.GetArrayLength().Should().Be(1);
+        steps[0].GetProperty("stmt").GetProperty("want_rows").GetBoolean().Should().BeFalse();
+        requests[1].GetProperty("type").GetString().Should().Be("close");
+    }
+
+    [Test]
+    public void TestRemoteBatchSurfacesStepErrors()
+    {
+        const string responseJson = """
+            {
+              "baton": "stream.1",
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "batch",
+                    "result": {
+                      "step_results": [null],
+                      "step_errors": [
+                        {
+                          "message": "no such table: missing",
+                          "code": "SQLITE_ERROR"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        const string closeResponseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson, closeResponseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=True");
+        connection.Open();
+
+        using var batch = (TursoBatch)connection.CreateBatch();
+        var command = (TursoBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = "SELECT * FROM missing";
+        batch.BatchCommands.Add(command);
+
+        batch.Invoking(x => x.ExecuteNonQuery())
+            .Should().Throw<TursoException>()
+            .WithMessage("Remote SQL execution failed: no such table: missing (SQLITE_ERROR)");
+    }
+
+    [Test]
+    public void TestRemoteBatchRejectsMismatchedStepErrors()
+    {
+        const string responseJson = """
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "batch",
+                    "result": {
+                      "step_results": [null],
+                      "step_errors": []
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=True");
+        connection.Open();
+
+        using var batch = (TursoBatch)connection.CreateBatch();
+        var command = (TursoBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = "SELECT * FROM missing";
+        batch.BatchCommands.Add(command);
+
+        batch.Invoking(x => x.ExecuteNonQuery())
+            .Should().Throw<TursoException>()
+            .WithMessage("Remote batch returned an unexpected result shape: 1 results, 0 errors, expected 1.");
+    }
+
+    [Test]
+    public void TestSyncRequiresReplicaConnection()
+    {
+        using var connection = new TursoConnection("Data Source=http://localhost:8080");
+        connection.Open();
+
+        connection.Invoking(x => x.Sync())
+            .Should().Throw<NotSupportedException>()
+            .WithMessage("Sync requires an embedded replica connection.");
+    }
+
+    [Test]
+    public async Task TestSyncAsyncRequiresReplicaConnection()
+    {
+        using var connection = new TursoConnection("Data Source=http://localhost:8080");
+        connection.Open();
+
+        var act = async () => await connection.SyncAsync();
+        await act.Should().ThrowAsync<NotSupportedException>()
+            .WithMessage("Sync requires an embedded replica connection.");
+    }
+
     private sealed class TestRemoteServer : IDisposable
     {
         private readonly CancellationTokenSource _cancellation = new();
@@ -431,6 +1218,8 @@ public class TursoRemoteTests
         public string? Authorization { get; private set; }
 
         public string RequestBody { get; private set; } = "";
+
+        public List<string> RequestBodies { get; } = [];
 
         public void Dispose()
         {
@@ -506,6 +1295,7 @@ public class TursoRemoteTests
 
                 RequestBody = new string(buffer, 0, read);
             }
+            RequestBodies.Add(RequestBody);
 
             var body = Encoding.UTF8.GetBytes(_responseJson.Dequeue());
             var headers = Encoding.ASCII.GetBytes(


### PR DESCRIPTION
## Summary
- Add remote transaction baton semantics for .NET Hrana connections.
- Add ADO.NET DbBatch support with remote batch serialization and multi-result readers.
- Add unsupported Sync()/SyncAsync() stubs for embedded-replica API surface.
- Add focused remote transaction/batch tests and README documentation.

## Validation
- dotnet build bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj -v minimal
- dotnet test bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --no-build --filter TursoRemoteTests -v minimal
- dotnet test bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --no-build -v minimal
