### PR TITLE
core: fix blob literal handling in materialized views

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -1692,7 +1692,7 @@ impl DbspCompiler {
                         let escaped = t.to_string().replace('\'', "''");
                         ast::Literal::String(format!("'{escaped}'"))
                     }
-                    Value::Blob(b) => ast::Literal::Blob(format!("{b:?}")),
+                    Value::Blob(b) => ast::Literal::Blob(hex::encode_upper(b)),
                     Value::Null => ast::Literal::Null,
                 };
                 Ok(ast::Expr::Literal(lit))

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -1931,7 +1931,13 @@ impl<'a> LogicalPlanBuilder<'a> {
                 };
                 Ok(Value::Text(unquoted.to_string().into()))
             }
-            ast::Literal::Blob(b) => Ok(Value::Blob(b.clone().into())),
+            // The lexer guarantees a valid even-length hex string; decode it to the
+            // actual bytes instead of storing the hex text's UTF-8.
+            ast::Literal::Blob(b) => {
+                Ok(Value::Blob(hex::decode(b).map_err(|_| {
+                    LimboError::ParseError(format!("invalid blob literal: {b}"))
+                })?))
+            }
             ast::Literal::CurrentDate
             | ast::Literal::CurrentTime
             | ast::Literal::CurrentTimestamp => Err(LimboError::ParseError(

--- a/testing/sqltests/turso-tests/materialized_views.sqltest
+++ b/testing/sqltests/turso-tests/materialized_views.sqltest
@@ -2508,3 +2508,25 @@ test matview-reserved-prefix-sqlite {
 expect error {
     object name reserved for internal use: sqlite_matview
 }
+
+# A hex blob literal in a materialized view definition must round-trip to the
+# correct bytes (not panic, and not the UTF-8 of the hex text). See issue #7355.
+test matview-blob-literal {
+    CREATE TABLE t_blob(id INTEGER);
+    INSERT INTO t_blob VALUES (1);
+    CREATE MATERIALIZED VIEW mv_blob AS SELECT x'FF' AS b FROM t_blob;
+    SELECT typeof(b), quote(b), hex(b) FROM mv_blob;
+}
+expect {
+    blob|X'FF'|FF
+}
+
+test matview-blob-literal-multibyte-and-empty {
+    CREATE TABLE t_blob2(id INTEGER);
+    INSERT INTO t_blob2 VALUES (1);
+    CREATE MATERIALIZED VIEW mv_blob2 AS SELECT x'DEADBEEF' AS b, x'' AS e FROM t_blob2;
+    SELECT hex(b), length(b), quote(e), length(e) FROM mv_blob2;
+}
+expect {
+    DEADBEEF|4|X''|0
+}


### PR DESCRIPTION
_Re-opening this fix: my earlier PRs (#7608, #7612, #7614) were auto-closed by
Fossier before review (I have no prior history in the repo yet), so this is a
fresh PR with the same change_

## Summary
A hex blob literal in a materialized view definition (#7355) panics during
emission. The blob is mishandled on the incremental-view path before it ever
reaches `emission.rs`, in two places:

- [`build_literal`](https://github.com/tursodatabase/turso/blob/d4d6777a2685ab9a3ffc8733329743fdfe000c45/core/translate/logical.rs#L1934)
  stores the UTF-8 bytes of the hex *text* (`x'FF'` becomes `[0x46, 0x46]`)
  instead of decoding it, so the view already holds the wrong blob value.
- [the logical-to-AST round-trip](https://github.com/tursodatabase/turso/blob/d4d6777a2685ab9a3ffc8733329743fdfe000c45/core/incremental/compiler.rs#L1695)
  then re-serializes that blob with `Debug` formatting (`format!("{b:?}")`
  produces `"[255]"`), which `emit_literal` reparses as hex via
  `from_str_radix(..).unwrap()` and panics (`emission.rs:43`).

## Fix
Decode the hex literal to real bytes in `build_literal`, and encode the bytes
back to a valid hex string in the round-trip, both via the `hex` crate already
used in the engine (e.g. `core/incremental/dbsp.rs`).

Hardening the `emission.rs` unwrap alone would only convert the panic into an
error while leaving the stored blob wrong, so the fix is at the two sites that
corrupt the value. Ordinary SQL is unaffected; only materialized views build
literals through this path.

## Validation
```sql
CREATE TABLE t(id INT);
CREATE MATERIALIZED VIEW mv AS SELECT x'FF' FROM t;
INSERT INTO t VALUES(1);
SELECT * FROM mv;  -- before: panic; after: returns the blob value
```
- new regression tests in `testing/sqltests/turso-tests/materialized_views.sqltest`
  (`matview-blob-literal`, `matview-blob-literal-multibyte-and-empty`)
- `materialized_views.sqltest`: 112 passed on rust and cli backends
- `cargo fmt`; `cargo clippy --workspace --all-features --all-targets -- --deny=warnings`

Closes #7355
