### PR TITLE
Add better-sqlite3-compatible user-defined scalar functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6757,6 +6757,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "turso_core",
+ "turso_ext",
  "turso_parser",
 ]
 

--- a/bindings/javascript/Cargo.toml
+++ b/bindings/javascript/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 turso_core = { workspace = true, features = ["fts"] }
+turso_ext = { workspace = true }
 turso_parser = { workspace = true }
 napi = { version = "3.8.3", default-features = false, features = ["napi6"] }
 napi-derive = { version = "3.5.2", default-features = true }

--- a/bindings/javascript/packages/common/compat.ts
+++ b/bindings/javascript/packages/common/compat.ts
@@ -1,4 +1,5 @@
 import { bindParams } from "./bind.js";
+import { registerScalarFunction } from "./function.js";
 import { SqliteError } from "./sqlite-error.js";
 import { NativeDatabase, NativeStatement, QueryOptions, STEP_IO, STEP_ROW, STEP_DONE } from "./types.js";
 
@@ -235,7 +236,8 @@ class Database {
   }
 
   function(name, options, fn) {
-    throw new Error("not implemented");
+    registerScalarFunction(this.db, name, options, fn);
+    return this;
   }
 
   aggregate(name, options) {

--- a/bindings/javascript/packages/common/function.ts
+++ b/bindings/javascript/packages/common/function.ts
@@ -1,0 +1,46 @@
+import { NativeDatabase } from "./types.js";
+
+export interface ScalarFunctionOptions {
+  varargs?: boolean;
+  deterministic?: boolean;
+  safeIntegers?: boolean;
+  directOnly?: boolean;
+}
+
+type ScalarFunctionImpl = (...args: any[]) => any;
+
+const MAX_FUNCTION_ARGUMENTS = 127;
+
+export function registerScalarFunction(
+  db: NativeDatabase,
+  name: string,
+  optionsOrFn: ScalarFunctionOptions | ScalarFunctionImpl,
+  maybeFn?: ScalarFunctionImpl,
+): void {
+  const options = typeof optionsOrFn === "function" ? {} : optionsOrFn ?? {};
+  const fn = typeof optionsOrFn === "function" ? optionsOrFn : maybeFn;
+
+  if (typeof name !== "string") {
+    throw new TypeError("Expected first argument to be a string");
+  }
+  if (typeof fn !== "function") {
+    throw new TypeError("Expected last argument to be a function");
+  }
+
+  const varargs = options.varargs === true;
+  const deterministic = options.deterministic === true;
+  const safeIntegers = options.safeIntegers === true;
+
+  let arity = -1;
+  if (!varargs) {
+    arity = fn.length;
+    if (!Number.isInteger(arity) || arity < 0) {
+      throw new TypeError("Expected function.length to be a non-negative integer");
+    }
+    if (arity > MAX_FUNCTION_ARGUMENTS) {
+      throw new RangeError(`User-defined functions cannot have more than ${MAX_FUNCTION_ARGUMENTS} arguments`);
+    }
+  }
+
+  db.registerScalarFunction(name, arity, deterministic, safeIntegers, (args: any[]) => fn(...args));
+}

--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -1,5 +1,6 @@
 import { AsyncLock } from "./async-lock.js";
 import { bindParams } from "./bind.js";
+import { registerScalarFunction } from "./function.js";
 import { SqliteError } from "./sqlite-error.js";
 import { NativeDatabase, NativeStatement, QueryOptions, STEP_IO, STEP_ROW, STEP_DONE, DatabaseOpts } from "./types.js";
 
@@ -504,7 +505,8 @@ class Database {
   }
 
   function(name, options, fn) {
-    throw new Error("not implemented");
+    registerScalarFunction(this.db, name, options, fn);
+    return this;
   }
 
   aggregate(name, options) {

--- a/bindings/javascript/packages/common/types.ts
+++ b/bindings/javascript/packages/common/types.ts
@@ -45,6 +45,8 @@ export interface NativeDatabase {
     executor(sql: string, queryOptions?: QueryOptions): NativeExecutor;
 
     defaultSafeIntegers(toggle: boolean);
+    registerScalarFunction(name: string, arity: number, deterministic: boolean, safeIntegers: boolean, callback: (args: any[]) => any): void;
+    unregisterScalarFunction(name: string): void;
     inTransaction(): boolean;
     totalChanges(): number;
     changes(): number;

--- a/bindings/javascript/packages/native/function.test.ts
+++ b/bindings/javascript/packages/native/function.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from 'vitest'
+import { Database } from './compat.js'
+import BetterSqlite3 from 'better-sqlite3'
+
+test('scalar function results match better-sqlite3', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('add2', (a, b) => a + b);
+    }
+    const sql = 'SELECT add2(2, 3)';
+    expect(turso.prepare(sql).pluck().get()).toBe(5);
+    expect(turso.prepare(sql).pluck().get()).toEqual(sqlite.prepare(sql).pluck().get());
+})
+
+test('function returns the database for chaining', () => {
+    const turso = new Database(':memory:');
+    expect(turso.function('id', (x) => x)).toBe(turso);
+})
+
+test('values round-trip through a user function', () => {
+    const turso = new Database(':memory:');
+    turso.function('echo', (x) => x);
+
+    expect(turso.prepare('SELECT echo(42)').pluck().get()).toBe(42);
+    expect(turso.prepare('SELECT echo(3.5)').pluck().get()).toBe(3.5);
+    expect(turso.prepare("SELECT echo('hello')").pluck().get()).toBe('hello');
+    expect(turso.prepare('SELECT echo(NULL)').pluck().get()).toBe(null);
+
+    const blob = turso.prepare("SELECT echo(x'01ff')").pluck().get();
+    expect(Buffer.isBuffer(blob)).toBe(true);
+    expect([...blob]).toEqual([1, 255]);
+})
+
+test('null arguments are passed as null', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('arg_is_null', (x) => (x === null ? 1 : 0));
+    }
+    expect(turso.prepare('SELECT arg_is_null(NULL)').pluck().get()).toBe(1);
+    expect(turso.prepare('SELECT arg_is_null(7)').pluck().get()).toBe(0);
+    expect(turso.prepare('SELECT arg_is_null(NULL)').pluck().get())
+        .toEqual(sqlite.prepare('SELECT arg_is_null(NULL)').pluck().get());
+})
+
+test('varargs functions receive every argument', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('joiner', { varargs: true }, (...args) => args.join('-'));
+    }
+    const sql = "SELECT joiner('a', 'b', 'c', 'd')";
+    expect(turso.prepare(sql).pluck().get()).toBe('a-b-c-d');
+    expect(turso.prepare(sql).pluck().get()).toEqual(sqlite.prepare(sql).pluck().get());
+})
+
+test('wrong number of arguments throws like better-sqlite3', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('one', (a) => a);
+    }
+    expect(() => turso.prepare('SELECT one(1, 2)').get()).toThrow();
+    expect(() => sqlite.prepare('SELECT one(1, 2)').get()).toThrow();
+})
+
+test('returning a Buffer produces a BLOB', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('payload', () => Buffer.from([1, 2, 254]));
+    }
+    expect(turso.prepare('SELECT length(payload())').pluck().get()).toBe(3);
+    expect(turso.prepare('SELECT hex(payload())').pluck().get()).toBe('0102FE');
+    expect(turso.prepare('SELECT hex(payload())').pluck().get())
+        .toEqual(sqlite.prepare('SELECT hex(payload())').pluck().get());
+})
+
+test('NaN return becomes NULL', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('nope', () => NaN);
+    }
+    expect(turso.prepare('SELECT nope() IS NULL').pluck().get()).toBe(1);
+    expect(sqlite.prepare('SELECT nope() IS NULL').pluck().get()).toBe(1);
+})
+
+test('safeIntegers passes integer arguments as BigInt', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('isbig', { safeIntegers: true }, (n) => (typeof n === 'bigint' ? 1 : 0));
+    }
+    expect(turso.prepare('SELECT isbig(10)').pluck().get()).toBe(1);
+    expect(sqlite.prepare('SELECT isbig(10)').pluck().get()).toBe(1);
+})
+
+test('returning a BigInt preserves 64-bit integers', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('big', () => 9007199254740993n);
+    }
+    expect(turso.prepare('SELECT big() = 9007199254740993').pluck().get()).toBe(1);
+    expect(sqlite.prepare('SELECT big() = 9007199254740993').pluck().get()).toBe(1);
+})
+
+test('returning a boolean is rejected like better-sqlite3', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('truthy', () => true);
+    }
+    expect(() => turso.prepare('SELECT truthy()').get()).toThrow();
+    expect(() => sqlite.prepare('SELECT truthy()').get()).toThrow();
+})
+
+test('a thrown error propagates out of the query', () => {
+    const turso = new Database(':memory:');
+    const sqlite = new BetterSqlite3(':memory:');
+    for (const db of [turso, sqlite]) {
+        db.function('boom', () => { throw new Error('kaboom'); });
+    }
+    expect(() => turso.prepare('SELECT boom()').get()).toThrow(/kaboom/);
+    expect(() => sqlite.prepare('SELECT boom()').get()).toThrow(/kaboom/);
+})
+
+test('a deterministic function works in a WHERE clause', () => {
+    const turso = new Database(':memory:');
+    turso.function('is_even', { deterministic: true }, (x) => (x % 2 === 0 ? 1 : 0));
+    turso.exec('CREATE TABLE t(x)');
+    turso.exec('INSERT INTO t VALUES (1), (2), (3), (4)');
+    const rows = turso.prepare('SELECT x FROM t WHERE is_even(x) ORDER BY x').pluck().all();
+    expect(rows).toEqual([2, 4]);
+})
+
+test('invalid registration arguments throw', () => {
+    const turso = new Database(':memory:');
+    expect(() => turso.function('bad')).toThrow();
+    expect(() => turso.function(42, () => 1)).toThrow();
+})
+
+test('re-registering a function name replaces it', () => {
+    const turso = new Database(':memory:');
+    turso.function('v', () => 1);
+    expect(turso.prepare('SELECT v()').pluck().get()).toBe(1);
+    turso.function('v', () => 2);
+    expect(turso.prepare('SELECT v()').pluck().get()).toBe(2);
+})

--- a/bindings/javascript/packages/native/index.d.ts
+++ b/bindings/javascript/packages/native/index.d.ts
@@ -85,6 +85,8 @@ export declare class Database {
    * * `toggle` - Whether to use safe integers by default.
    */
   defaultSafeIntegers(toggle?: boolean | undefined | null): void
+  registerScalarFunction(name: string, arity: number, deterministic: boolean, safeIntegers: boolean, callback: unknown): void
+  unregisterScalarFunction(name: string): void
   /** Runs the I/O loop synchronously. */
   ioLoopSync(): void
   /** Runs the I/O loop asynchronously, returning a Promise. */

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -24,6 +24,9 @@ use std::{
 };
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::format::FmtSpan;
+use turso_ext::{
+    ContextDestructor, ResultCode, Value as ExtValue, ValueDestructor, ValueType as ExtValueType,
+};
 
 /// Shared ownership of a `turso_core::Statement` that can be explicitly finalized.
 ///
@@ -594,6 +597,63 @@ impl Database {
         Ok(())
     }
 
+    #[napi(js_name = "registerScalarFunction")]
+    pub fn register_scalar_function(
+        &self,
+        env: Env,
+        name: String,
+        arity: i32,
+        deterministic: bool,
+        safe_integers: bool,
+        callback: Unknown,
+    ) -> napi::Result<()> {
+        let conn = self.conn()?;
+        let name_c = std::ffi::CString::new(name.clone())
+            .map_err(|_| create_generic_error("function name must not contain a NUL byte"))?;
+        let mut func_ref = std::ptr::null_mut();
+        check_status!(
+            unsafe {
+                napi::sys::napi_create_reference(env.raw(), callback.raw(), 1, &mut func_ref)
+            },
+            "failed to reference the user-defined function"
+        )?;
+        let context = Box::into_raw(Box::new(JsScalarFunction {
+            func_ref,
+            env: env.raw(),
+            safe_integers,
+        })) as usize;
+        let api = unsafe { conn._build_turso_ext() };
+        let result = unsafe {
+            (api.register_scalar_function)(
+                api.ctx,
+                name_c.as_ptr(),
+                arity,
+                deterministic,
+                context,
+                js_scalar_trampoline,
+                Some(drop_js_scalar_function),
+                None,
+            )
+        };
+        unsafe { conn._free_extension_ctx(api) };
+        if result == ResultCode::OK {
+            Ok(())
+        } else {
+            unsafe { drop_js_scalar_function(context) };
+            Err(create_generic_error(&format!(
+                "failed to register function '{name}'"
+            )))
+        }
+    }
+
+    #[napi(js_name = "unregisterScalarFunction")]
+    pub fn unregister_scalar_function(&self, name: String) -> napi::Result<()> {
+        self.conn()?
+            .unregister_scalar_function(&name)
+            .map_err(|e| to_generic_error("failed to unregister function", e))?;
+        Ok(())
+    }
+
     /// Runs the I/O loop synchronously.
     #[napi]
     pub fn io_loop_sync(&self) -> napi::Result<()> {
@@ -1021,6 +1081,206 @@ fn to_js_value<'a>(
             }
         }
     }
+}
+
+const UNSUPPORTED_RETURN: &str =
+    "user-defined function returned a value that is not a number, bigint, string, Buffer, or null";
+
+struct JsScalarFunction {
+    func_ref: napi::sys::napi_ref,
+    env: napi::sys::napi_env,
+    safe_integers: bool,
+}
+
+fn ext_value_to_core(value: &ExtValue) -> turso_core::Value {
+    match value.value_type() {
+        ExtValueType::Null | ExtValueType::Error => turso_core::Value::Null,
+        ExtValueType::Integer => value
+            .to_integer()
+            .map(turso_core::Value::from_i64)
+            .unwrap_or(turso_core::Value::Null),
+        ExtValueType::Float => value
+            .to_float()
+            .map(turso_core::Value::from_f64)
+            .unwrap_or(turso_core::Value::Null),
+        ExtValueType::Text => value
+            .to_text()
+            .map(|text| turso_core::Value::build_text(text.to_string()))
+            .unwrap_or(turso_core::Value::Null),
+        ExtValueType::Blob => value
+            .to_blob()
+            .map(turso_core::Value::Blob)
+            .unwrap_or(turso_core::Value::Null),
+    }
+}
+
+fn js_value_to_ext(value: Unknown) -> std::result::Result<ExtValue, String> {
+    let value_type = value.get_type().map_err(|err| err.to_string())?;
+    match value_type {
+        ValueType::Undefined | ValueType::Null => Ok(ExtValue::null()),
+        ValueType::Number => {
+            let number: f64 = unsafe { value.cast() }.map_err(|err| err.to_string())?;
+            if number.is_nan() {
+                Ok(ExtValue::null())
+            } else if number.fract() == 0.0
+                && number >= i64::MIN as f64
+                && number <= i64::MAX as f64
+            {
+                Ok(ExtValue::from_integer(number as i64))
+            } else {
+                Ok(ExtValue::from_float(number))
+            }
+        }
+        ValueType::BigInt => {
+            let bigint: BigInt = unsafe { value.cast() }.map_err(|err| err.to_string())?;
+            let (signed, lossless) = bigint.get_i64();
+            if lossless {
+                Ok(ExtValue::from_integer(signed))
+            } else {
+                Err("user-defined function returned a BigInt outside the range of a 64-bit signed integer".to_string())
+            }
+        }
+        ValueType::String => {
+            let text = value
+                .coerce_to_string()
+                .and_then(|text| text.into_utf8())
+                .map_err(|err| err.to_string())?;
+            let text = text.as_str().map_err(|err| err.to_string())?.to_string();
+            Ok(ExtValue::from_text(text))
+        }
+        ValueType::Object => {
+            let object = value.coerce_to_object().map_err(|err| err.to_string())?;
+            if object.is_buffer().unwrap_or(false) || object.is_typedarray().unwrap_or(false) {
+                let length = object
+                    .get_named_property::<u32>("length")
+                    .map_err(|err| err.to_string())?;
+                let mut bytes = Vec::with_capacity(length as usize);
+                for index in 0..length {
+                    let byte = object
+                        .get_element::<u32>(index)
+                        .map_err(|err| err.to_string())?;
+                    bytes.push(byte as u8);
+                }
+                Ok(ExtValue::from_blob(bytes))
+            } else {
+                Err(UNSUPPORTED_RETURN.to_string())
+            }
+        }
+        _ => Err(UNSUPPORTED_RETURN.to_string()),
+    }
+}
+
+fn exception_message(env_raw: napi::sys::napi_env, exception: napi::sys::napi_value) -> String {
+    if let Ok(unknown) = unsafe { Unknown::from_napi_value(env_raw, exception) } {
+        if let Ok(object) = unknown.coerce_to_object() {
+            if let Ok(message) = object.get_named_property::<String>("message") {
+                if !message.is_empty() {
+                    return message;
+                }
+            }
+        }
+    }
+    if let Ok(unknown) = unsafe { Unknown::from_napi_value(env_raw, exception) } {
+        if let Ok(text) = unknown.coerce_to_string().and_then(|text| text.into_utf8()) {
+            if let Ok(text) = text.as_str() {
+                return text.to_string();
+            }
+        }
+    }
+    "user-defined function threw an exception".to_string()
+}
+
+unsafe fn invoke_js_scalar(
+    function: &JsScalarFunction,
+    argc: i32,
+    argv: *const ExtValue,
+) -> ExtValue {
+    let env = napi::Env::from_raw(function.env);
+    let arg_count = argc.max(0) as usize;
+    let mut array = match env.create_array(arg_count as u32) {
+        Ok(array) => array,
+        Err(err) => return ExtValue::error_with_message(err.to_string()),
+    };
+    for index in 0..arg_count {
+        let value = ext_value_to_core(unsafe { &*argv.add(index) });
+        match to_js_value(&env, &value, function.safe_integers) {
+            Ok(js_value) => {
+                if let Err(err) = array.set(index as u32, js_value) {
+                    return ExtValue::error_with_message(err.to_string());
+                }
+            }
+            Err(err) => return ExtValue::error_with_message(err.to_string()),
+        }
+    }
+    let arguments = match array.coerce_to_object() {
+        Ok(object) => object.to_unknown().raw(),
+        Err(err) => return ExtValue::error_with_message(err.to_string()),
+    };
+
+    let mut callback = std::ptr::null_mut();
+    if unsafe {
+        napi::sys::napi_get_reference_value(function.env, function.func_ref, &mut callback)
+    } != napi::sys::Status::napi_ok
+    {
+        return ExtValue::error_with_message("failed to resolve user-defined function".to_string());
+    }
+    let mut this = std::ptr::null_mut();
+    unsafe { napi::sys::napi_get_undefined(function.env, &mut this) };
+    let arguments = [arguments];
+    let mut raw_result = std::ptr::null_mut();
+    let status = unsafe {
+        napi::sys::napi_call_function(
+            function.env,
+            this,
+            callback,
+            arguments.len(),
+            arguments.as_ptr(),
+            &mut raw_result,
+        )
+    };
+
+    let mut pending = false;
+    unsafe { napi::sys::napi_is_exception_pending(function.env, &mut pending) };
+    if pending {
+        let mut exception = std::ptr::null_mut();
+        unsafe { napi::sys::napi_get_and_clear_last_exception(function.env, &mut exception) };
+        return ExtValue::error_with_message(exception_message(function.env, exception));
+    }
+    if status != napi::sys::Status::napi_ok {
+        return ExtValue::error_with_message("failed to call user-defined function".to_string());
+    }
+
+    match unsafe { Unknown::from_napi_value(function.env, raw_result) } {
+        Ok(result) => match js_value_to_ext(result) {
+            Ok(value) => value,
+            Err(message) => ExtValue::error_with_message(message),
+        },
+        Err(err) => ExtValue::error_with_message(err.to_string()),
+    }
+}
+
+unsafe extern "C" fn js_scalar_trampoline(
+    context: usize,
+    argc: i32,
+    argv: *const ExtValue,
+    _context_destructor: Option<ContextDestructor>,
+    _value_destructor: Option<ValueDestructor>,
+) -> ExtValue {
+    let function = unsafe { &*(context as *const JsScalarFunction) };
+    let mut scope = std::ptr::null_mut();
+    if unsafe { napi::sys::napi_open_handle_scope(function.env, &mut scope) }
+        != napi::sys::Status::napi_ok
+    {
+        return ExtValue::error_with_message("failed to open a napi handle scope".to_string());
+    }
+    let result = unsafe { invoke_js_scalar(function, argc, argv) };
+    unsafe { napi::sys::napi_close_handle_scope(function.env, scope) };
+    result
+}
+
+unsafe extern "C" fn drop_js_scalar_function(context: usize) {
+    let function = unsafe { Box::from_raw(context as *mut JsScalarFunction) };
+    unsafe { napi::sys::napi_delete_reference(function.env, function.func_ref) };
 }
 
 #[cfg(test)]

--- a/bindings/rust/src/connection.rs
+++ b/bindings/rust/src/connection.rs
@@ -242,6 +242,30 @@ impl Connection {
         conn.set_busy_timeout(duration);
         Ok(())
     }
+
+    pub fn register_scalar_function<F>(
+        &self,
+        name: &str,
+        arity: i32,
+        deterministic: bool,
+        function: F,
+    ) -> Result<()>
+    where
+        F: Fn(&[turso_core::Value]) -> turso_core::Result<turso_core::Value>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let conn = self.get_inner_connection()?;
+        conn.register_scalar_function(name, arity, deterministic, function)?;
+        Ok(())
+    }
+
+    pub fn unregister_scalar_function(&self, name: &str) -> Result<()> {
+        let conn = self.get_inner_connection()?;
+        conn.unregister_scalar_function(name)?;
+        Ok(())
+    }
 }
 
 impl Debug for Connection {

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -63,6 +63,38 @@ async fn test_rows_next() {
 }
 
 #[tokio::test]
+async fn test_register_scalar_function() {
+    use turso::core::Value as CoreValue;
+
+    let db = Builder::new_local(":memory:").build().await.unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.register_scalar_function("rust_concat", 2, true, |args| {
+        let mut combined = String::new();
+        for arg in args {
+            if let CoreValue::Text(text) = arg {
+                combined.push_str(text.as_str());
+            }
+        }
+        Ok(CoreValue::build_text(combined))
+    })
+    .unwrap();
+
+    let mut rows = conn
+        .query("SELECT rust_concat('ab', 'cd')", ())
+        .await
+        .unwrap();
+    let value = rows.next().await.unwrap().unwrap().get_value(0).unwrap();
+    assert_eq!(value, Value::Text("abcd".to_string()));
+
+    conn.unregister_scalar_function("rust_concat").unwrap();
+    assert!(conn
+        .query("SELECT rust_concat('ab', 'cd')", ())
+        .await
+        .is_err());
+}
+
+#[tokio::test]
 async fn test_cacheflush() {
     let builder = Builder::new_local("test.db");
     let db = builder.build().await.unwrap();

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -4027,12 +4027,10 @@ impl Connection {
             .read()
             .functions
             .values()
+            .flatten()
             .map(|f| {
                 let is_agg = f.func.is_aggregate();
-                let argc = match &f.func {
-                    function::ExtFunc::Aggregate { argc, .. } => *argc,
-                    function::ExtFunc::Scalar { argc, .. } => *argc,
-                };
+                let argc = f.func.argc();
                 (
                     f.name.clone(),
                     is_agg,
@@ -4628,7 +4626,7 @@ pub type StepResult = vdbe::StepResult;
 
 #[derive(Default)]
 pub struct SymbolTable {
-    pub functions: HashMap<String, Arc<function::ExternalFunc>>,
+    pub functions: HashMap<String, Vec<Arc<function::ExternalFunc>>>,
     pub collations: HashMap<u32, Arc<function::ExternalCollation>>,
     pub vtabs: HashMap<String, Arc<VirtualTable>>,
     pub vtab_modules: HashMap<String, Arc<crate::ext::VTabImpl>>,
@@ -4681,15 +4679,15 @@ impl SymbolTable {
         name: &str,
         arg_count: usize,
     ) -> Option<Arc<function::ExternalFunc>> {
-        self.functions
+        let overloads = self
+            .functions
             .get(name)
+            .or_else(|| self.functions.get(&crate::util::normalize_ident(name)))?;
+        overloads
+            .iter()
+            .find(|func| func.func.argc() == arg_count as i32)
+            .or_else(|| overloads.iter().find(|func| func.func.argc() < 0))
             .cloned()
-            .or_else(|| {
-                self.functions
-                    .get(&crate::util::normalize_ident(name))
-                    .cloned()
-            })
-            .filter(|func| func.func.matches_arg_count(arg_count))
     }
 
     pub fn resolve_collation(&self, name: &str) -> Option<CollationSeq> {
@@ -4700,8 +4698,8 @@ impl SymbolTable {
     }
 
     pub fn extend(&mut self, other: &SymbolTable) {
-        for (name, func) in &other.functions {
-            self.functions.insert(name.clone(), func.clone());
+        for (name, funcs) in &other.functions {
+            self.functions.insert(name.clone(), funcs.clone());
         }
         for (id, collation) in &other.collations {
             self.collations.insert(*id, collation.clone());

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -95,6 +95,39 @@ pub struct VTabImpl {
     pub implementation: Arc<VTabModuleImpl>,
 }
 
+type BoxedScalarFn = Box<dyn Fn(&[crate::Value]) -> crate::Result<crate::Value> + Send + Sync>;
+
+struct UserScalarFunction {
+    call: BoxedScalarFn,
+}
+
+unsafe extern "C" fn dispatch_user_scalar(
+    context: usize,
+    argc: i32,
+    argv: *const ExtValue,
+    _context_destructor: Option<ContextDestructor>,
+    _value_destructor: Option<ValueDestructor>,
+) -> ExtValue {
+    let function = unsafe { &*(context as *const UserScalarFunction) };
+    let mut args = Vec::with_capacity(argc.max(0) as usize);
+    if argc > 0 && !argv.is_null() {
+        for raw in unsafe { std::slice::from_raw_parts(argv, argc as usize) } {
+            match crate::Value::from_ffi_ref(raw) {
+                Ok(value) => args.push(value),
+                Err(err) => return ExtValue::error_with_message(err.to_string()),
+            }
+        }
+    }
+    match (function.call)(&args) {
+        Ok(value) => value.to_ffi(),
+        Err(err) => ExtValue::error_with_message(err.to_string()),
+    }
+}
+
+unsafe extern "C" fn drop_user_scalar(context: usize) {
+    drop(unsafe { Box::from_raw(context as *mut UserScalarFunction) });
+}
+
 pub(crate) unsafe fn register_scalar_function(
     ctx: *mut c_void,
     name: *const c_char,
@@ -350,5 +383,67 @@ impl Connection {
             return;
         }
         let _ = unsafe { Box::from_raw(api.ctx as *mut ExtensionCtx) };
+    }
+
+    pub fn register_scalar_function<F>(
+        &self,
+        name: &str,
+        arity: i32,
+        deterministic: bool,
+        function: F,
+    ) -> crate::Result<()>
+    where
+        F: Fn(&[crate::Value]) -> crate::Result<crate::Value> + Send + Sync + 'static,
+    {
+        let name_c = CString::new(name).map_err(|_| {
+            crate::LimboError::InvalidArgument(format!(
+                "scalar function name must not contain a NUL byte: {name:?}"
+            ))
+        })?;
+        let context = Box::into_raw(Box::new(UserScalarFunction {
+            call: Box::new(function),
+        })) as usize;
+        let api = unsafe { self._build_turso_ext() };
+        let result = unsafe {
+            (api.register_scalar_function)(
+                api.ctx,
+                name_c.as_ptr(),
+                arity,
+                deterministic,
+                context,
+                dispatch_user_scalar,
+                Some(drop_user_scalar),
+                None,
+            )
+        };
+        unsafe { self._free_extension_ctx(api) };
+        if result == ResultCode::OK {
+            Ok(())
+        } else {
+            unsafe { drop_user_scalar(context) };
+            Err(crate::LimboError::InvalidArgument(format!(
+                "failed to register scalar function {name:?}: {result}"
+            )))
+        }
+    }
+
+    pub fn unregister_scalar_function(&self, name: &str) -> crate::Result<()> {
+        let name_c = CString::new(name).map_err(|_| {
+            crate::LimboError::InvalidArgument(format!(
+                "scalar function name must not contain a NUL byte: {name:?}"
+            ))
+        })?;
+        let api = unsafe { self._build_turso_ext() };
+        let result = unsafe { (api.unregister_function)(api.ctx, name_c.as_ptr()) };
+        unsafe { self._free_extension_ctx(api) };
+        match result {
+            ResultCode::OK => Ok(()),
+            ResultCode::NotFound => Err(crate::LimboError::InvalidArgument(format!(
+                "no such function: {name}"
+            ))),
+            other => Err(crate::LimboError::InvalidArgument(format!(
+                "failed to unregister function {name:?}: {other}"
+            ))),
+        }
     }
 }

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -154,20 +154,20 @@ pub(crate) unsafe extern "C" fn register_scalar_function_with_options(
         Ok(s) => crate::util::normalize_ident(s),
         Err(_) => return ResultCode::InvalidArgs,
     };
+    let func = Arc::new(ExternalFunc::new_scalar(
+        name_str.clone(),
+        argc,
+        deterministic,
+        context,
+        callback,
+        context_destructor,
+        value_destructor,
+    ));
     let ext_ctx = unsafe { &mut *(ctx as *mut ExtensionCtx) };
     unsafe {
-        (*ext_ctx.syms).functions.insert(
-            name_str.clone(),
-            Arc::new(ExternalFunc::new_scalar(
-                name_str,
-                argc,
-                deterministic,
-                context,
-                callback,
-                context_destructor,
-                value_destructor,
-            )),
-        );
+        let overloads = (*ext_ctx.syms).functions.entry(name_str).or_default();
+        overloads.retain(|existing| existing.func.argc() != argc);
+        overloads.push(func);
         if !ext_ctx.prepare_context_generation.is_null() {
             (*ext_ctx.prepare_context_generation).fetch_add(1, Ordering::Release);
         }
@@ -219,20 +219,20 @@ pub(crate) unsafe extern "C" fn register_aggregate_function(
         Ok(s) => crate::util::normalize_ident(s),
         Err(_) => return ResultCode::InvalidArgs,
     };
+    let func = Arc::new(ExternalFunc::new_aggregate(
+        name_str.clone(),
+        args,
+        context,
+        (init_func, step_func, finalize_func),
+        context_destructor,
+        aggregate_destructor,
+        value_destructor,
+    ));
     let ext_ctx = unsafe { &mut *(ctx as *mut ExtensionCtx) };
     unsafe {
-        (*ext_ctx.syms).functions.insert(
-            name_str.clone(),
-            Arc::new(ExternalFunc::new_aggregate(
-                name_str,
-                args,
-                context,
-                (init_func, step_func, finalize_func),
-                context_destructor,
-                aggregate_destructor,
-                value_destructor,
-            )),
-        );
+        let overloads = (*ext_ctx.syms).functions.entry(name_str).or_default();
+        overloads.retain(|existing| existing.func.argc() != args);
+        overloads.push(func);
         if !ext_ctx.prepare_context_generation.is_null() {
             (*ext_ctx.prepare_context_generation).fetch_add(1, Ordering::Release);
         }

--- a/core/function.rs
+++ b/core/function.rs
@@ -111,6 +111,12 @@ impl ExtFunc {
         }
     }
 
+    pub fn argc(&self) -> i32 {
+        match self {
+            Self::Scalar { argc, .. } | Self::Aggregate { argc, .. } => *argc,
+        }
+    }
+
     pub fn is_aggregate(&self) -> bool {
         matches!(self, Self::Aggregate { .. })
     }

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -465,13 +465,10 @@ impl<'a> Resolver<'a> {
         func_name: &str,
         arg_count: usize,
     ) -> Result<Option<Func>, LimboError> {
-        match Func::resolve_function(func_name, arg_count)? {
-            Some(func) => Ok(Some(func)),
-            None => Ok(self
-                .symbol_table
-                .resolve_function(func_name, arg_count)
-                .map(Func::External)),
+        if let Some(external) = self.symbol_table.resolve_function(func_name, arg_count) {
+            return Ok(Some(Func::External(external)));
         }
+        Func::resolve_function(func_name, arg_count)
     }
 
     pub(crate) fn enable_expr_to_reg_cache(&mut self) {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -889,6 +889,30 @@ impl TursoConnection {
         result_code_to_result(result, "register external scalar function")
     }
 
+    pub fn register_scalar_function<F>(
+        &self,
+        name: &str,
+        arity: i32,
+        deterministic: bool,
+        function: F,
+    ) -> Result<(), TursoError>
+    where
+        F: Fn(&[turso_core::Value]) -> turso_core::Result<turso_core::Value>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.connection
+            .register_scalar_function(name, arity, deterministic, function)
+            .map_err(TursoError::from)
+    }
+
+    pub fn unregister_scalar_function(&self, name: &str) -> Result<(), TursoError> {
+        self.connection
+            .unregister_scalar_function(name)
+            .map_err(TursoError::from)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn register_external_aggregate_function(
         &self,

--- a/sql_generation/generation/expr.rs
+++ b/sql_generation/generation/expr.rs
@@ -7,7 +7,7 @@ use crate::{
         frequency, gen_random_text, one_of, pick, pick_index, Arbitrary, ArbitraryFrom,
         ArbitrarySized, ArbitrarySizedFrom, GenerationContext,
     },
-    model::table::SimValue,
+    model::{query::predicate::SIM_UDF_NAMES, table::SimValue},
 };
 
 impl<T> Arbitrary for Box<T>
@@ -169,6 +169,21 @@ impl ArbitrarySized for Expr {
                                         UnaryOperator::arbitrary(rng, context),
                                         Box::arbitrary_sized(rng, context, size - 1),
                                     )
+                                }),
+                                Box::new(|rng: &mut R| {
+                                    let name =
+                                        SIM_UDF_NAMES[rng.random_range(0..SIM_UDF_NAMES.len())];
+                                    Expr::FunctionCall {
+                                        name: Name::exact(name.to_string()),
+                                        distinctness: None,
+                                        args: vec![Box::arbitrary_sized(rng, context, size - 1)],
+                                        order_by: Vec::new(),
+                                        within_group: Vec::new(),
+                                        filter_over: ast::FunctionTail {
+                                            filter_clause: None,
+                                            over_clause: None,
+                                        },
+                                    }
                                 }),
                                 // TODO: skip Exists for now
                                 // TODO: skip Function Call for now

--- a/sql_generation/model/query/predicate.rs
+++ b/sql_generation/model/query/predicate.rs
@@ -156,7 +156,41 @@ pub fn expr_to_value<T: TableContext>(
             assert_eq!(exprs.len(), 1);
             expr_to_value(&exprs[0], row, table)
         }
+        ast::Expr::FunctionCall { name, args, .. } => {
+            let argument = args
+                .first()
+                .and_then(|arg| expr_to_value(arg, row, table))?;
+            eval_sim_udf(&name.as_str().to_ascii_lowercase(), &argument.0).map(SimValue)
+        }
         _ => unreachable!("{:?}", expr),
+    }
+}
+
+pub const SIM_UDF_NAMES: &[&str] = &["sim_double", "sim_is_even"];
+
+pub fn eval_sim_udf(name: &str, argument: &turso_core::Value) -> Option<turso_core::Value> {
+    match name {
+        "sim_double" => Some(sim_double(argument)),
+        "sim_is_even" => Some(sim_is_even(argument)),
+        _ => None,
+    }
+}
+
+fn sim_double(value: &turso_core::Value) -> turso_core::Value {
+    match value {
+        turso_core::Value::Numeric(turso_core::Numeric::Integer(n)) => {
+            turso_core::Value::from_i64(n.wrapping_mul(2))
+        }
+        _ => turso_core::Value::Null,
+    }
+}
+
+fn sim_is_even(value: &turso_core::Value) -> turso_core::Value {
+    match value {
+        turso_core::Value::Numeric(turso_core::Numeric::Integer(n)) => {
+            turso_core::Value::from_i64((n % 2 == 0) as i64)
+        }
+        _ => turso_core::Value::Null,
     }
 }
 

--- a/testing/differential-oracle/fuzzer/Cargo.toml
+++ b/testing/differential-oracle/fuzzer/Cargo.toml
@@ -25,7 +25,7 @@ path = "lib.rs"
 turso_core = { workspace = true, features = ["simulator"] }
 sql_gen_prop = { path = "../sql_gen_prop" }
 sql_gen = { path = "../sql_gen", features = ["serde"] }
-rusqlite.workspace = true
+rusqlite = { workspace = true, features = ["functions"] }
 rand.workspace = true
 rand_chacha.workspace = true
 anyhow.workspace = true

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -28,6 +28,88 @@ use crate::schema::SchemaIntrospector;
 pub use sql_gen::TreeMode;
 use sql_gen_prop::SqlValue;
 
+fn register_oracle_udfs(
+    turso: &turso_core::Connection,
+    sqlite: &rusqlite::Connection,
+) -> Result<()> {
+    turso
+        .register_scalar_function("sim_double", 1, true, |args| {
+            Ok(oracle_sim_double(
+                args.first().unwrap_or(&turso_core::Value::Null),
+            ))
+        })
+        .context("register sim_double on Turso")?;
+    turso
+        .register_scalar_function("sim_is_even", 1, true, |args| {
+            Ok(oracle_sim_is_even(
+                args.first().unwrap_or(&turso_core::Value::Null),
+            ))
+        })
+        .context("register sim_is_even on Turso")?;
+
+    use rusqlite::functions::FunctionFlags;
+    let flags = FunctionFlags::SQLITE_UTF8 | FunctionFlags::SQLITE_DETERMINISTIC;
+    sqlite
+        .create_scalar_function("sim_double", 1, flags, |ctx| {
+            Ok(core_value_to_sqlite(oracle_sim_double(
+                &sqlite_value_to_core(ctx.get_raw(0)),
+            )))
+        })
+        .context("register sim_double on SQLite")?;
+    sqlite
+        .create_scalar_function("sim_is_even", 1, flags, |ctx| {
+            Ok(core_value_to_sqlite(oracle_sim_is_even(
+                &sqlite_value_to_core(ctx.get_raw(0)),
+            )))
+        })
+        .context("register sim_is_even on SQLite")?;
+    Ok(())
+}
+
+fn oracle_sim_double(value: &turso_core::Value) -> turso_core::Value {
+    match value {
+        turso_core::Value::Numeric(turso_core::Numeric::Integer(n)) => {
+            turso_core::Value::from_i64(n.wrapping_mul(2))
+        }
+        _ => turso_core::Value::Null,
+    }
+}
+
+fn oracle_sim_is_even(value: &turso_core::Value) -> turso_core::Value {
+    match value {
+        turso_core::Value::Numeric(turso_core::Numeric::Integer(n)) => {
+            turso_core::Value::from_i64((n % 2 == 0) as i64)
+        }
+        _ => turso_core::Value::Null,
+    }
+}
+
+fn sqlite_value_to_core(value: rusqlite::types::ValueRef<'_>) -> turso_core::Value {
+    match value {
+        rusqlite::types::ValueRef::Null => turso_core::Value::Null,
+        rusqlite::types::ValueRef::Integer(n) => turso_core::Value::from_i64(n),
+        rusqlite::types::ValueRef::Real(f) => turso_core::Value::from_f64(f),
+        rusqlite::types::ValueRef::Text(bytes) => {
+            turso_core::Value::build_text(String::from_utf8_lossy(bytes).into_owned())
+        }
+        rusqlite::types::ValueRef::Blob(bytes) => turso_core::Value::Blob(bytes.to_vec()),
+    }
+}
+
+fn core_value_to_sqlite(value: turso_core::Value) -> rusqlite::types::Value {
+    match value {
+        turso_core::Value::Null => rusqlite::types::Value::Null,
+        turso_core::Value::Numeric(turso_core::Numeric::Integer(n)) => {
+            rusqlite::types::Value::Integer(n)
+        }
+        turso_core::Value::Numeric(turso_core::Numeric::Float(f)) => {
+            rusqlite::types::Value::Real(f64::from(f))
+        }
+        turso_core::Value::Text(text) => rusqlite::types::Value::Text(text.as_str().to_string()),
+        turso_core::Value::Blob(blob) => rusqlite::types::Value::Blob(blob),
+    }
+}
+
 /// Configuration for the simulator.
 #[derive(Debug, Clone)]
 pub struct SimConfig {
@@ -227,6 +309,8 @@ impl Fuzzer {
             .execute("ATTACH ':memory:' AS aux", [])
             .context("Failed to ATTACH on SQLite")?;
         tracing::info!("Attached ':memory:' AS aux on both connections");
+
+        register_oracle_udfs(&turso_conn, &sqlite_conn)?;
 
         // Enable MVCC after ATTACH (ATTACH is not supported in MVCC mode)
         if config.mvcc {

--- a/testing/differential-oracle/sql_gen/src/functions.rs
+++ b/testing/differential-oracle/sql_gen/src/functions.rs
@@ -182,6 +182,14 @@ pub static SCALAR_FUNCTIONS: &[FunctionDef] = &[
         .args(&[ANY])
         .returns(DataType::Integer)
         .category(FunctionCategory::Math),
+    FunctionDef::new("sim_double")
+        .args(&[INT])
+        .returns(DataType::Integer)
+        .category(FunctionCategory::Math),
+    FunctionDef::new("sim_is_even")
+        .args(&[INT])
+        .returns(DataType::Integer)
+        .category(FunctionCategory::Math),
     FunctionDef::new("RANDOM")
         .arity(0, 0)
         .returns(DataType::Integer)

--- a/testing/simulator/Cargo.toml
+++ b/testing/simulator/Cargo.toml
@@ -38,7 +38,7 @@ clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 notify = "8.0.0"
-rusqlite.workspace = true
+rusqlite = { workspace = true, features = ["functions"] }
 dirs = "6.0.0"
 chrono = { workspace = true, default-features = true, features = ["serde"] }
 tracing = { workspace = true }

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -909,6 +909,7 @@ fn reopen_database(env: &mut SimulatorEnv) {
             for i in 0..num_conns {
                 let conn = rusqlite::Connection::open(env.get_db_path())
                     .expect("Failed to open SQLite connection");
+                crate::runner::env::register_simulator_rusqlite_udfs(&conn);
                 for name in &env.attached_dbs {
                     let aux_path = env.get_aux_db_path(name);
                     conn.execute(&format!("ATTACH '{}' AS {name}", aux_path.display()), [])
@@ -953,6 +954,7 @@ fn reopen_database(env: &mut SimulatorEnv) {
 
             for i in 0..num_conns {
                 let conn = env.db.as_ref().expect("db to be Some").connect().unwrap();
+                crate::runner::env::register_simulator_turso_udfs(&conn);
                 for name in &env.attached_dbs {
                     let aux_path = env.get_aux_db_path(name);
                     conn.execute(format!("ATTACH '{}' AS {name}", aux_path.display()))

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1462,13 +1462,14 @@ impl SimulatorEnv {
                     conn.execute(format!("PRAGMA cache_size = {}", self.opts.cache_size))
                         .expect("set pragma cache_size");
                 }
+                register_simulator_turso_udfs(&conn);
                 self.connections[connection_index] = SimConnection::LimboConnection(conn);
             }
             SimulationType::Differential => {
-                self.connections[connection_index] = SimConnection::SQLiteConnection(
-                    rusqlite::Connection::open(self.get_db_path())
-                        .expect("Failed to open SQLite connection"),
-                );
+                let conn = rusqlite::Connection::open(self.get_db_path())
+                    .expect("Failed to open SQLite connection");
+                register_simulator_rusqlite_udfs(&conn);
+                self.connections[connection_index] = SimConnection::SQLiteConnection(conn);
             }
         };
 
@@ -1599,6 +1600,66 @@ impl SimConnection {
             }
             SimConnection::Disconnected => {}
         }
+    }
+}
+
+pub(crate) fn register_simulator_turso_udfs(conn: &turso_core::Connection) {
+    for &name in sql_generation::model::query::predicate::SIM_UDF_NAMES {
+        let eval_name = name.to_string();
+        conn.register_scalar_function(name, 1, true, move |args| {
+            let argument = args.first().cloned().unwrap_or(turso_core::Value::Null);
+            Ok(
+                sql_generation::model::query::predicate::eval_sim_udf(&eval_name, &argument)
+                    .unwrap_or(turso_core::Value::Null),
+            )
+        })
+        .expect("register simulator scalar UDF on turso connection");
+    }
+}
+
+pub(crate) fn register_simulator_rusqlite_udfs(conn: &rusqlite::Connection) {
+    use rusqlite::functions::FunctionFlags;
+    for &name in sql_generation::model::query::predicate::SIM_UDF_NAMES {
+        let eval_name = name.to_string();
+        conn.create_scalar_function(
+            name,
+            1,
+            FunctionFlags::SQLITE_UTF8 | FunctionFlags::SQLITE_DETERMINISTIC,
+            move |ctx| {
+                let argument = rusqlite_value_to_core(ctx.get_raw(0));
+                let result =
+                    sql_generation::model::query::predicate::eval_sim_udf(&eval_name, &argument)
+                        .unwrap_or(turso_core::Value::Null);
+                Ok(core_value_to_rusqlite(result))
+            },
+        )
+        .expect("register simulator scalar UDF on sqlite connection");
+    }
+}
+
+fn rusqlite_value_to_core(value: rusqlite::types::ValueRef<'_>) -> turso_core::Value {
+    match value {
+        rusqlite::types::ValueRef::Null => turso_core::Value::Null,
+        rusqlite::types::ValueRef::Integer(n) => turso_core::Value::from_i64(n),
+        rusqlite::types::ValueRef::Real(f) => turso_core::Value::from_f64(f),
+        rusqlite::types::ValueRef::Text(bytes) => {
+            turso_core::Value::build_text(String::from_utf8_lossy(bytes).into_owned())
+        }
+        rusqlite::types::ValueRef::Blob(bytes) => turso_core::Value::Blob(bytes.to_vec()),
+    }
+}
+
+fn core_value_to_rusqlite(value: turso_core::Value) -> rusqlite::types::Value {
+    match value {
+        turso_core::Value::Null => rusqlite::types::Value::Null,
+        turso_core::Value::Numeric(turso_core::Numeric::Integer(n)) => {
+            rusqlite::types::Value::Integer(n)
+        }
+        turso_core::Value::Numeric(turso_core::Numeric::Float(f)) => {
+            rusqlite::types::Value::Real(f64::from(f))
+        }
+        turso_core::Value::Text(text) => rusqlite::types::Value::Text(text.as_str().to_string()),
+        turso_core::Value::Blob(blob) => rusqlite::types::Value::Blob(blob),
     }
 }
 

--- a/testing/sqltests/src/backends/rust.rs
+++ b/testing/sqltests/src/backends/rust.rs
@@ -35,6 +35,65 @@ fn apply_turso_experimental_features(mut builder: Builder) -> Builder {
     builder
 }
 
+fn register_test_udf(conn: &Connection) -> Result<(), BackendError> {
+    use turso::core::{LimboError, Numeric, Value as CoreValue};
+
+    conn.register_scalar_function("test_udf", -1, true, |args| {
+        let Some(CoreValue::Text(behavior)) = args.first() else {
+            return Err(LimboError::InvalidArgument(
+                "test_udf: first argument must be a behavior name".to_string(),
+            ));
+        };
+        let rest = &args[1..];
+        match behavior.as_str() {
+            "echo" => Ok(rest.first().cloned().unwrap_or(CoreValue::Null)),
+            "const" => Ok(CoreValue::from_i64(42)),
+            "null" => Ok(CoreValue::Null),
+            "argc" => Ok(CoreValue::from_i64(rest.len() as i64)),
+            "add" => {
+                let sum = rest
+                    .iter()
+                    .filter_map(|arg| match arg {
+                        CoreValue::Numeric(Numeric::Integer(value)) => Some(*value),
+                        _ => None,
+                    })
+                    .sum::<i64>();
+                Ok(CoreValue::from_i64(sum))
+            }
+            "concat" => {
+                let combined: String = rest
+                    .iter()
+                    .filter_map(|arg| match arg {
+                        CoreValue::Text(text) => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect();
+                Ok(CoreValue::build_text(combined))
+            }
+            "upper" => {
+                let text = match rest.first() {
+                    Some(CoreValue::Text(text)) => text.as_str().to_uppercase(),
+                    _ => String::new(),
+                };
+                Ok(CoreValue::build_text(text))
+            }
+            "len" => {
+                let length = match rest.first() {
+                    Some(CoreValue::Text(text)) => text.as_str().chars().count() as i64,
+                    Some(CoreValue::Blob(blob)) => blob.len() as i64,
+                    _ => 0,
+                };
+                Ok(CoreValue::from_i64(length))
+            }
+            "boom" => Err(LimboError::InvalidArgument("test_udf: boom".to_string())),
+            other => Err(LimboError::InvalidArgument(format!(
+                "test_udf: unknown behavior '{other}'"
+            ))),
+        }
+    })
+    .map_err(|e| BackendError::CreateDatabase(e.to_string()))
+}
+
 /// Native Rust backend using Turso bindings directly
 pub struct RustBackend {
     /// Resolver for default database paths
@@ -130,6 +189,8 @@ impl SqlBackend for RustBackend {
         let conn = db
             .connect()
             .map_err(|e| BackendError::CreateDatabase(e.to_string()))?;
+
+        register_test_udf(&conn)?;
 
         // Prepend MVCC pragma if enabled (skip for readonly databases; the generated readonly DBs are already in MVCC mode).
         if self.mvcc && !config.readonly {

--- a/testing/sqltests/tests/user_defined_functions.sqltest
+++ b/testing/sqltests/tests/user_defined_functions.sqltest
@@ -1,0 +1,100 @@
+@database :memory:
+
+@backend rust
+test test-udf-echo-integer {
+    SELECT test_udf('echo', 7);
+}
+expect {
+    7
+}
+
+@backend rust
+test test-udf-echo-text {
+    SELECT test_udf('echo', 'hello');
+}
+expect {
+    hello
+}
+
+@backend rust
+test test-udf-const {
+    SELECT test_udf('const');
+}
+expect {
+    42
+}
+
+@backend rust
+test test-udf-null-is-null {
+    SELECT test_udf('null') IS NULL;
+}
+expect {
+    1
+}
+
+@backend rust
+test test-udf-argc {
+    SELECT test_udf('argc', 10, 20, 30);
+}
+expect {
+    3
+}
+
+@backend rust
+test test-udf-add {
+    SELECT test_udf('add', 2, 3, 4);
+}
+expect {
+    9
+}
+
+@backend rust
+test test-udf-concat {
+    SELECT test_udf('concat', 'a', 'b', 'c');
+}
+expect {
+    abc
+}
+
+@backend rust
+test test-udf-upper {
+    SELECT test_udf('upper', 'hello');
+}
+expect {
+    HELLO
+}
+
+@backend rust
+test test-udf-len {
+    SELECT test_udf('len', 'hello');
+}
+expect {
+    5
+}
+
+@backend rust
+test test-udf-in-where-clause {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), (2), (3), (4);
+    SELECT x FROM t WHERE test_udf('add', x, x) >= 6 ORDER BY x;
+}
+expect {
+    3
+    4
+}
+
+@backend rust
+test test-udf-unknown-behavior-errors {
+    SELECT test_udf('does-not-exist');
+}
+expect error {
+    unknown behavior 'does-not-exist'
+}
+
+@backend rust
+test test-udf-explicit-error {
+    SELECT test_udf('boom');
+}
+expect error {
+    test_udf: boom
+}

--- a/tests/integration/external_apis.rs
+++ b/tests/integration/external_apis.rs
@@ -964,6 +964,26 @@ fn closure_scalar_supports_multiple_arities(tmp_db: TempDatabase) -> anyhow::Res
     Ok(())
 }
 
+#[turso_macros::test]
+fn closure_scalar_shadows_builtin_functions(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    let builtin: Vec<(i64,)> = conn.exec_rows("SELECT abs(-5)");
+    assert_eq!(builtin, vec![(5,)]);
+
+    conn.register_scalar_function("abs", 1, true, |_args| Ok(Value::from_i64(42)))?;
+    let shadowed: Vec<(i64,)> = conn.exec_rows("SELECT abs(-5)");
+    assert_eq!(shadowed, vec![(42,)]);
+
+    let other = tmp_db.connect_limbo();
+    let other_builtin: Vec<(i64,)> = other.exec_rows("SELECT abs(-5)");
+    assert_eq!(other_builtin, vec![(5,)]);
+
+    conn.unregister_scalar_function("abs")?;
+    let restored: Vec<(i64,)> = conn.exec_rows("SELECT abs(-5)");
+    assert_eq!(restored, vec![(5,)]);
+    Ok(())
+}
+
 unsafe extern "C" fn dotnet_nocase_collation(
     _context: usize,
     left_ptr: *const u8,

--- a/tests/integration/external_apis.rs
+++ b/tests/integration/external_apis.rs
@@ -940,6 +940,30 @@ fn closure_scalar_reregistration_replaces_and_unregister_removes(
     Ok(())
 }
 
+#[turso_macros::test]
+fn closure_scalar_supports_multiple_arities(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.register_scalar_function("udf_n", 1, true, |_args| Ok(Value::from_i64(1)))?;
+    conn.register_scalar_function("udf_n", 2, true, |_args| Ok(Value::from_i64(2)))?;
+    conn.register_scalar_function("udf_n", -1, true, |args| {
+        Ok(Value::from_i64(100 + args.len() as i64))
+    })?;
+
+    let one: Vec<(i64,)> = conn.exec_rows("SELECT udf_n(10)");
+    assert_eq!(one, vec![(1,)]);
+    let two: Vec<(i64,)> = conn.exec_rows("SELECT udf_n(10, 20)");
+    assert_eq!(two, vec![(2,)]);
+    let variadic: Vec<(i64,)> = conn.exec_rows("SELECT udf_n(10, 20, 30)");
+    assert_eq!(variadic, vec![(103,)]);
+
+    conn.register_scalar_function("udf_n", 1, true, |_args| Ok(Value::from_i64(11)))?;
+    let replaced: Vec<(i64,)> = conn.exec_rows("SELECT udf_n(10)");
+    assert_eq!(replaced, vec![(11,)]);
+    let unchanged: Vec<(i64,)> = conn.exec_rows("SELECT udf_n(10, 20)");
+    assert_eq!(unchanged, vec![(2,)]);
+    Ok(())
+}
+
 unsafe extern "C" fn dotnet_nocase_collation(
     _context: usize,
     left_ptr: *const u8,

--- a/tests/integration/external_apis.rs
+++ b/tests/integration/external_apis.rs
@@ -10,7 +10,7 @@ use std::{
         Arc,
     },
 };
-use turso_core::{Connection, LimboError, StepResult};
+use turso_core::{Connection, LimboError, StepResult, Value};
 use turso_ext::{
     AggCtx, ContextDestructor, FinalizeFunction, InitAggFunction, ResultCode, ScalarDerive,
     ScalarFunc, ScalarFunction, StepFunction, Value as ExtValue, ValueDestructor,
@@ -811,6 +811,132 @@ fn managed_aggregate_errors_leave_connection_usable(tmp_db: TempDatabase) -> any
         counters.aggregate_inits.load(AtomicOrdering::SeqCst),
         counters.aggregate_drops.load(AtomicOrdering::SeqCst)
     );
+    Ok(())
+}
+
+#[turso_macros::test]
+fn closure_scalar_round_trips_every_value_type(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.register_scalar_function("closure_echo", 1, true, |args| Ok(args[0].clone()))?;
+
+    let integers: Vec<(i64,)> = conn.exec_rows("SELECT closure_echo(42)");
+    assert_eq!(integers, vec![(42,)]);
+    let floats: Vec<(f64,)> = conn.exec_rows("SELECT closure_echo(3.5)");
+    assert_eq!(floats, vec![(3.5,)]);
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT closure_echo('hi')"),
+        vec![vec![SqliteValue::Text("hi".to_string())]]
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT closure_echo(x'01ff')"),
+        vec![vec![SqliteValue::Blob(vec![0x01, 0xff])]]
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT closure_echo(NULL)"),
+        vec![vec![SqliteValue::Null]]
+    );
+    Ok(())
+}
+
+#[turso_macros::test]
+fn closure_scalar_enforces_fixed_arity(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.register_scalar_function("udf_pair", 2, true, |args| {
+        Ok(Value::from_i64(args.len() as i64))
+    })?;
+
+    let matched: Vec<(i64,)> = conn.exec_rows("SELECT udf_pair(10, 20)");
+    assert_eq!(matched, vec![(2,)]);
+    assert!(conn.prepare("SELECT udf_pair(10)").is_err());
+    assert!(conn.prepare("SELECT udf_pair(10, 20, 30)").is_err());
+    Ok(())
+}
+
+#[turso_macros::test]
+fn closure_scalar_variadic_receives_every_argument(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.register_scalar_function("udf_argcount", -1, true, |args| {
+        Ok(Value::from_i64(args.len() as i64))
+    })?;
+
+    let none: Vec<(i64,)> = conn.exec_rows("SELECT udf_argcount()");
+    assert_eq!(none, vec![(0,)]);
+    let several: Vec<(i64,)> = conn.exec_rows("SELECT udf_argcount(1, 'a', x'00')");
+    assert_eq!(several, vec![(3,)]);
+    Ok(())
+}
+
+#[turso_macros::test]
+fn closure_scalar_propagates_errors(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.register_scalar_function("udf_boom", 1, false, |_args| {
+        Err(LimboError::InvalidArgument("kaboom".to_string()))
+    })?;
+
+    let err = conn.execute("SELECT udf_boom(1)").unwrap_err();
+    assert!(matches!(err, LimboError::ExtensionError(_)));
+    assert!(err.to_string().contains("kaboom"));
+
+    let usable: Vec<(i64,)> = conn.exec_rows("SELECT 1");
+    assert_eq!(usable, vec![(1,)]);
+    Ok(())
+}
+
+#[turso_macros::test]
+fn closure_scalar_reports_arity_and_determinism(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.register_scalar_function("udf_pure", 1, true, |args| Ok(args[0].clone()))?;
+    conn.register_scalar_function("udf_impure", 2, false, |_args| Ok(Value::Null))?;
+
+    let function_list: Vec<(String, i64, String, String, i64, i64)> =
+        conn.exec_rows("PRAGMA function_list");
+    let pure = function_list
+        .iter()
+        .find(|(name, ..)| name == "udf_pure")
+        .expect("udf_pure should be listed");
+    assert_eq!(pure.2, "s");
+    assert_eq!(pure.4, 1);
+    assert_ne!(pure.5 & 0x800, 0);
+
+    let impure = function_list
+        .iter()
+        .find(|(name, ..)| name == "udf_impure")
+        .expect("udf_impure should be listed");
+    assert_eq!(impure.4, 2);
+    assert_eq!(impure.5 & 0x800, 0);
+    Ok(())
+}
+
+#[turso_macros::test]
+fn closure_scalar_registration_is_per_connection(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn_a = tmp_db.connect_limbo();
+    let conn_b = tmp_db.connect_limbo();
+    conn_a.register_scalar_function("udf_only_a", 0, true, |_args| Ok(Value::from_i64(7)))?;
+
+    let visible: Vec<(i64,)> = conn_a.exec_rows("SELECT udf_only_a()");
+    assert_eq!(visible, vec![(7,)]);
+    let err = conn_b.prepare("SELECT udf_only_a()").unwrap_err();
+    assert!(err.to_string().contains("no such function"));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn closure_scalar_reregistration_replaces_and_unregister_removes(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.register_scalar_function("udf_v", 0, true, |_args| Ok(Value::from_i64(1)))?;
+    let first: Vec<(i64,)> = conn.exec_rows("SELECT udf_v()");
+    assert_eq!(first, vec![(1,)]);
+
+    conn.register_scalar_function("udf_v", 0, true, |_args| Ok(Value::from_i64(2)))?;
+    let second: Vec<(i64,)> = conn.exec_rows("SELECT udf_v()");
+    assert_eq!(second, vec![(2,)]);
+
+    conn.unregister_scalar_function("udf_v")?;
+    let err = conn.prepare("SELECT udf_v()").unwrap_err();
+    assert!(err.to_string().contains("no such function"));
+    assert!(conn.unregister_scalar_function("udf_v").is_err());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Implements per-connection user-defined **scalar** functions, exposed as a better-sqlite3-compatible `Database#function()` in the JavaScript bindings and as an ergonomic closure API in the Rust SDK, and wires them into both simulators. Semantics follow SQLite's `sqlite3_create_function_v2` and better-sqlite3's docs.

Aggregates, window, and table functions are intentionally out of scope for this PR.

## What's included

| Area | Change |
|---|---|
| **Core** | `Connection::register_scalar_function` / `unregister_scalar_function` — ergonomic `Fn(&[Value]) -> Result<Value>` closures over the existing per-connection extension symbol table |
| **Rust SDK** | Same closure API exposed on `turso_sdk_kit::TursoConnection` and `turso::Connection` |
| **JS binding** | `Database#function(name, [options], fn)` in the `compat` (better-sqlite3) and `promise` layers, honoring `deterministic` / `varargs` / `safeIntegers` |
| **sqltests** | A stubbed dispatcher `test_udf(behavior, …)` registered on the rust backend, with `.sqltest` coverage |
| **Simulator** (`testing/simulator`) | `sim_double` / `sim_is_even` registered on turso + rusqlite, generated in free selects, evaluated by the shadow model, validated differentially |
| **Differential oracle** (`testing/differential-oracle`) | The same functions added to the generator's scalar list (arbitrary locations), registered on both engines, validated against SQLite |

## SQLite / better-sqlite3 semantics

- Arity from `fn.length` (or `-1` with `varargs`); fixed arity enforced at prepare time.
- **Multiple arities per name coexist** (exact-arity match preferred, variadic fallback); same name+arity re-registers in place.
- **User functions shadow built-ins** of the same name+arity, per connection; unregistering restores the built-in.
- `deterministic` recorded as optimizer metadata; a thrown callback aborts the statement and surfaces its message.
- JS marshalling: `null`/`undefined`→NULL, integral number→INTEGER else REAL, `BigInt`→INTEGER (range-checked), string→TEXT, `Buffer`/`Uint8Array`→BLOB, `NaN`→NULL, boolean/object→error.

## Testing

- **Rust** (`tests/integration/external_apis.rs`): value round-trip, arity enforcement, variadic, error propagation, determinism metadata, per-connection isolation, re-register/unregister, **multiple arities**, **builtin shadowing**. Existing `managed_*` and builtin-function suites still pass.
- **JS** (`vitest`): 15 tests asserting parity against the real `better-sqlite3` dev-dependency (type mapping, varargs, safeIntegers, BigInt, Buffer, NaN, error propagation, boolean rejection, arity, use in WHERE).
- **sqltests**: behavior + WHERE-clause + error cases (rust backend).
- **Simulators**: differential runs pass; UDF calls confirmed generated (main sim: default + differential; oracle: ~1600 calls/function across arbitrary positions, 0 oracle failures, clean integrity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGDkDqCmdivstfaRc5qMBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGDkDqCmdivstfaRc5qMBW)_