### PR TITLE
Reject DROP COLUMN when a column-level CHECK references the dropped column

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2969,6 +2969,13 @@ impl CheckConstraint {
     pub fn sql(&self) -> String {
         format!("CHECK({})", self.expr)
     }
+
+    /// True if this is a column-level CHECK defined on `normalized_col`.
+    pub fn is_on_column(&self, normalized_col: &str) -> bool {
+        self.column
+            .as_ref()
+            .is_some_and(|col| normalize_ident(col) == normalized_col)
+    }
 }
 
 /// RAII wrapper that resets its inner value when cloned.

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1022,27 +1022,21 @@ pub fn translate_alter_table(
                 }
             }
 
-            // Handle CHECK constraints:
-            // - Column-level CHECK constraints for the dropped column are silently removed
-            // - Table-level CHECK constraints referencing the dropped column cause an error
+            // Reject the drop if a CHECK that outlives it still references the
+            // dropped column (matches SQLite); the column's own CHECK is dropped with it.
             for check in &btree.check_constraints {
-                if check.column.is_some() {
-                    // Column-level constraint: will be removed below
+                if check.is_on_column(&col_normalized) {
                     continue;
                 }
-                // Table-level constraint: check if it references the dropped column
                 if check_expr_references_column(&check.expr, &col_normalized) {
                     return Err(LimboError::ParseError(format!(
                         "error in table {table_name} after drop column: no such column: {column_name}"
                     )));
                 }
             }
-            // Remove column-level CHECK constraints for the dropped column
-            btree.check_constraints.retain(|c| {
-                c.column
-                    .as_ref()
-                    .is_none_or(|col| normalize_ident(col) != normalize_ident(column_name))
-            });
+            btree
+                .check_constraints
+                .retain(|c| !c.is_on_column(&col_normalized));
 
             // Check if column is used in a foreign key constraint (child side)
             // SQLite does not allow dropping a column that is part of a FK constraint

--- a/testing/sqltests/tests/check_constraint.sqltest
+++ b/testing/sqltests/tests/check_constraint.sqltest
@@ -1908,3 +1908,37 @@ test check_constraint_integer_affinity_coercion_violation {
 expect error {
     CHECK constraint failed: val > 5
 }
+
+# Bug fix (#7646): DROP COLUMN rejected when a column-level CHECK on a surviving column references the dropped column
+@cross-check-integrity
+test check_constraint_drop_column_referenced_by_column_level_check {
+    CREATE TABLE t(a, b CHECK(b > a));
+    ALTER TABLE t DROP COLUMN a;
+}
+expect error {
+}
+
+# Dropping a column whose own column-level CHECK only references itself is allowed
+@cross-check-integrity
+test check_constraint_drop_column_with_own_column_level_check {
+    CREATE TABLE t(a INTEGER CHECK(a > 0), b);
+    INSERT INTO t VALUES(5, 1);
+    ALTER TABLE t DROP COLUMN a;
+    INSERT INTO t(b) VALUES(2);
+    SELECT b FROM t ORDER BY b;
+}
+expect {
+    1
+    2
+}
+
+# Dropping an unrelated column keeps and still enforces a CHECK on another column
+@cross-check-integrity
+test check_constraint_drop_unrelated_column_keeps_column_level_check {
+    CREATE TABLE t(a, b CHECK(b > 0));
+    INSERT INTO t VALUES(1, 5);
+    ALTER TABLE t DROP COLUMN a;
+    INSERT INTO t(b) VALUES(-1);
+}
+expect error {
+}


### PR DESCRIPTION
My first open source PR, so apologies in advance if I get any of the process wrong.

Being upfront: I used an AI coding assistant to help build this. But I made sure I understood the bug before opening it, and I can explain it.

The problem: when you DROP COLUMN, the code checks whether any remaining CHECK constraint still references the column being removed. It only did that for table-level CHECKs. Column-level checks (the ones written inline next to a column) were skipped entirely, on the assumption that an inline check only refers to its own column. That assumption is wrong. You can write b CHECK(b > a), which lives on b but references a. So dropping a left that check behind pointing at a column that no longer exists. After that, every insert or update fails with "no such column", and the broken state is written to disk, so reopening doesn't fix it.

The fix: instead of skipping every column-level check, only skip the one belonging to the column being dropped (it gets removed with the column anyway). Everything else, table-level or a column-level check on a different column, gets validated, and if it references the dropped column the drop is rejected. That's what SQLite does.

Tests: three cases added to check_constraint.sqltest. The main one (drop rejected) fails on main and passes with the fix. The other two confirm valid drops still work. fmt and clippy are clean.

Still new at this, so feedback on anything I did wrong is welcome.
