### PR TITLE
sim: fix stale-transaction handling in the concurrent simulator

### DIFF
--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -38,7 +38,10 @@ use crate::{
         metrics::Remaining,
         property::{InteractiveQueryInfo, Property, PropertyDiscriminants},
     },
-    runner::env::SimulatorEnv,
+    runner::{
+        env::SimulatorEnv,
+        execution::{is_recoverable_tx_error, reconcile_recoverable_tx_error},
+    },
 };
 
 type PropertyQueryGenFunc<'a, R, G> =
@@ -1013,8 +1016,21 @@ impl Property {
                                     return Ok(Ok(()));
                                 }
 
-                                // On error we rollback the transaction if there is any active here
-                                env.rollback_conn(connection_index);
+                                if is_recoverable_tx_error(err) {
+                                    // A recoverable concurrency error: reconcile the
+                                    // model with the engine the same way the main
+                                    // execution path does — drop the model's
+                                    // transaction only if the engine rolled back (or
+                                    // we issue the prescribed rollback for a doomed
+                                    // stale-snapshot transaction); leave a still-live
+                                    // transaction intact otherwise.
+                                    reconcile_recoverable_tx_error(env, connection_index, err);
+                                } else {
+                                    // A genuine injected IO fault: the engine discarded
+                                    // the statement (and its autocommit transaction), so
+                                    // discard it from the model too.
+                                    env.rollback_conn(connection_index);
+                                }
                                 Ok(Ok(()))
                             }
                         }

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -558,6 +558,9 @@ impl Shadow for Query {
     fn shadow(&self, env: &mut ShadowTablesMut) -> Self::Result {
         // First check if we are not in a deferred transaction, if we are create a snapshot
         env.upgrade_transaction(self);
+        // Lazily pin the read snapshot of any attached database this query
+        // touches, matching turso's per-attached-database snapshot acquisition.
+        env.ensure_dbs_pinned(self);
 
         match self {
             Query::Create(create) => create.shadow(env),

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::mem;
 use std::ops::{Deref, DerefMut};
@@ -126,6 +126,15 @@ pub enum TxOperation {
     },
 }
 
+/// Replace all tables belonging to attached database `db` (i.e. named
+/// `"{db}.<table>"`) inside `tables` with the supplied `fresh` set. Used to pin
+/// an attached database's read snapshot lazily on first access within a
+/// transaction.
+fn refresh_db_tables(tables: &mut Vec<Table>, db: &str, fresh: &[Table]) {
+    tables.retain(|t| t.name.split_once('.').map(|(p, _)| p != db).unwrap_or(true));
+    tables.extend(fresh.iter().cloned());
+}
+
 /// Database snapshot
 #[derive(Debug, Clone)]
 pub struct Snapshot {
@@ -137,6 +146,14 @@ pub struct Snapshot {
     savepoints: Vec<ShadowSavepoint>,
 
     transaction_mode: TransactionMode,
+
+    /// Attached databases (by name, e.g. "aux2") whose read snapshot has been
+    /// pinned for this transaction. Unlike the main database — whose snapshot is
+    /// pinned at the transaction's first read — turso (matching SQLite) acquires
+    /// each *attached* database's read snapshot lazily, on first access to that
+    /// database within the transaction. The main database is implicitly always
+    /// pinned (its tables carry no `db.` prefix), so it is never listed here.
+    pinned_dbs: HashSet<String>,
 }
 
 impl Snapshot {
@@ -672,6 +689,70 @@ where
         *self.transaction_tables = Some(TransactionTables::Deferred);
     }
 
+    /// Pin the read snapshot of every *attached* database referenced by `query`
+    /// that has not yet been accessed in this transaction.
+    ///
+    /// The main database is snapshotted eagerly at transaction start (see
+    /// [`Self::create_snapshot`]), which matches turso's per-database strong
+    /// serializability. Attached databases, however, get their read snapshot
+    /// lazily on first access — a row another connection commits to an attached
+    /// database *after* this transaction began is visible on the transaction's
+    /// first read of that attached database (verified against both turso and
+    /// SQLite). To mirror that, we refresh the attached database's tables from
+    /// the latest committed state at the moment it is first touched, and inject
+    /// that freshly-pinned base into any pre-existing savepoints (a savepoint
+    /// rollback releases writes, not the read snapshot, so earlier savepoints
+    /// must also observe the pinned base).
+    pub fn ensure_dbs_pinned(&mut self, query: &Query) {
+        // Only a materialized transaction snapshot has anything to pin; in
+        // autocommit (and in a not-yet-snapshotted deferred transaction) reads
+        // and writes go straight to committed state. Check that before computing
+        // `uses()` so the common autocommit path avoids the allocation.
+        if !matches!(
+            self.transaction_tables,
+            Some(TransactionTables::Snapshot(_))
+        ) {
+            return;
+        }
+        // `uses()` rather than `dependencies()`: it additionally reports the
+        // target of a `CREATE TABLE`, so an attached database is pinned *before*
+        // a freshly created (still uncommitted) table is layered into the
+        // working set — otherwise a later read of a sibling table in the same
+        // attached database would refresh from committed state and drop it.
+        let deps = query.uses();
+        if deps.is_empty() {
+            return;
+        }
+        let committed = &*self.commited_tables;
+        let Some(TransactionTables::Snapshot(snapshot)) = self.transaction_tables.as_mut() else {
+            return;
+        };
+        for dep in &deps {
+            let Some((db, _)) = dep.split_once('.') else {
+                // Unqualified name: belongs to the (already-pinned) main database.
+                continue;
+            };
+            if !snapshot.pinned_dbs.insert(db.to_string()) {
+                // Already pinned earlier in this transaction.
+                continue;
+            }
+            let fresh: Vec<Table> = committed
+                .iter()
+                .filter(|t| {
+                    t.name
+                        .split_once('.')
+                        .map(|(p, _)| p == db)
+                        .unwrap_or(false)
+                })
+                .cloned()
+                .collect();
+            refresh_db_tables(&mut snapshot.current_tables, db, &fresh);
+            for savepoint in &mut snapshot.savepoints {
+                refresh_db_tables(&mut savepoint.current_tables, db, &fresh);
+            }
+        }
+    }
+
     #[inline]
     pub fn create_snapshot(&mut self, transaction_mode: TransactionMode) {
         *self.transaction_tables = Some(TransactionTables::Snapshot(Snapshot {
@@ -679,6 +760,7 @@ where
             operations: Vec::new(),
             savepoints: Vec::new(),
             transaction_mode,
+            pinned_dbs: HashSet::new(),
         }));
     }
 
@@ -1027,6 +1109,90 @@ mod tests {
             .expect("outer transaction should remain open")
             .expect_snaphot();
         assert!(snapshot.savepoints.is_empty());
+    }
+
+    /// The main database snapshot is pinned at transaction start, but each
+    /// attached database's snapshot is acquired lazily on first access (matching
+    /// turso/SQLite). Verify the model reflects both behaviors.
+    #[test]
+    fn attached_db_snapshot_is_pinned_lazily_on_first_access() {
+        use crate::model::Query;
+        use sql_generation::model::query::{Select, predicate::Predicate};
+
+        let row = |n: i64| vec![SimValue(turso_core::Value::from_i64(n))];
+        let table = |name: &str, rows: Vec<Vec<SimValue>>| Table {
+            name: name.to_string(),
+            columns: vec![],
+            rows,
+            indexes: vec![],
+        };
+        let select = |t: &str| Query::Select(Select::simple(t.to_string(), Predicate::true_()));
+        let rows_of = |tt: &Option<TransactionTables>, name: &str| -> usize {
+            tt.as_ref()
+                .unwrap()
+                .expect_snaphot()
+                .current_tables
+                .iter()
+                .find(|t| t.name == name)
+                .unwrap()
+                .rows
+                .len()
+        };
+
+        let mut commited_tables = vec![
+            table("main_t", vec![row(1)]),
+            table("aux1.aux_t", vec![row(10)]),
+        ];
+        let mut transaction_tables = None;
+        let mut sequences = Vec::new();
+
+        // Open a read transaction: the main snapshot is taken now.
+        shadow_tables_mut(
+            &mut commited_tables,
+            &mut transaction_tables,
+            &mut sequences,
+        )
+        .create_snapshot(TransactionMode::Read);
+
+        // Another connection commits to both databases after our snapshot began.
+        commited_tables[0].rows.push(row(2)); // main_t
+        commited_tables[1].rows.push(row(20)); // aux1.aux_t
+
+        {
+            let mut tables = shadow_tables_mut(
+                &mut commited_tables,
+                &mut transaction_tables,
+                &mut sequences,
+            );
+            // First access to aux1 pins it now -> observes the just-committed row.
+            tables.ensure_dbs_pinned(&select("aux1.aux_t"));
+            // Touching the main database changes nothing: it was pinned at start.
+            tables.ensure_dbs_pinned(&select("main_t"));
+        }
+        assert_eq!(
+            rows_of(&transaction_tables, "aux1.aux_t"),
+            2,
+            "attached db pinned lazily must observe a commit made before its first access"
+        );
+        assert_eq!(
+            rows_of(&transaction_tables, "main_t"),
+            1,
+            "main db snapshot is pinned at transaction start and must not observe later commits"
+        );
+
+        // A further commit to aux1 after it was pinned must not become visible.
+        commited_tables[1].rows.push(row(30));
+        shadow_tables_mut(
+            &mut commited_tables,
+            &mut transaction_tables,
+            &mut sequences,
+        )
+        .ensure_dbs_pinned(&select("aux1.aux_t"));
+        assert_eq!(
+            rows_of(&transaction_tables, "aux1.aux_t"),
+            2,
+            "once pinned, an attached db must not observe later commits"
+        );
     }
 }
 

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -17,6 +17,13 @@ use turso_core::{Connection, LimboError, Result, Value};
 ///   retries. The simulator's outer loop treats them as transient and
 ///   moves on (no progress to undo because the engine never acquired
 ///   the resource).
+/// - SchemaUpdated: another connection committed DDL while this connection
+///   holds an open transaction whose (data and schema) snapshot predates that
+///   DDL. The engine reprepares internally, but cannot reconcile a statement
+///   against a snapshot older than the committed schema, so it surfaces this
+///   the same way it surfaces a stale read snapshot — the schema-level analog
+///   of BusySnapshot. The caller is expected to roll back and retry; nothing
+///   was applied, so we treat it as transient.
 /// - ParseError("sequence \"...\" does not exist"): cross-connection
 ///   schema-lag artifact. Connection A's `CREATE SEQUENCE` commits;
 ///   connection B picks the seq from the model and runs `nextval`
@@ -24,13 +31,14 @@ use turso_core::{Connection, LimboError, Result, Value};
 ///   The model is consistent and the engine is consistent; only B's
 ///   per-connection schema cache is one beat behind. Treat it like
 ///   any other transient retry trigger.
-fn is_recoverable_tx_error(err: &LimboError) -> bool {
+pub(crate) fn is_recoverable_tx_error(err: &LimboError) -> bool {
     matches!(
         err,
         LimboError::WriteWriteConflict
             | LimboError::TxError(_)
             | LimboError::Busy
             | LimboError::BusySnapshot
+            | LimboError::SchemaUpdated
     ) || matches!(
         err,
         LimboError::ParseError(msg)
@@ -38,9 +46,50 @@ fn is_recoverable_tx_error(err: &LimboError) -> bool {
     )
 }
 
-/// Returns true if the error indicates the transaction was rolled back by the database.
-fn error_causes_rollback(err: &LimboError) -> bool {
+/// Returns true if the error indicates the engine already rolled the
+/// transaction back on its own (so the model just needs to follow suit).
+pub(crate) fn error_causes_rollback(err: &LimboError) -> bool {
     matches!(err, LimboError::WriteWriteConflict)
+}
+
+/// Returns true if the error leaves the engine's transaction open but doomed:
+/// the connection's snapshot (data and/or schema) is stale, so no further
+/// statement can make progress and the engine's prescribed recovery is to
+/// "rollback and retry the whole transaction" (the exact wording of the
+/// BusySnapshot error). The simulator must issue that rollback itself —
+/// otherwise the connection stays wedged in the dead transaction and every
+/// subsequent statement fails with a fresh stale-snapshot error.
+pub(crate) fn error_requires_client_rollback(err: &LimboError) -> bool {
+    matches!(err, LimboError::BusySnapshot | LimboError::SchemaUpdated)
+}
+
+/// Reconcile the simulator's model with the engine after a recoverable
+/// transaction error, keeping the two consistent:
+/// - the engine auto-rolled-back (e.g. WriteWriteConflict): drop the model's
+///   transaction to match;
+/// - the engine left the transaction open but doomed (stale snapshot/schema):
+///   issue a real `ROLLBACK` so both engine and model return to autocommit;
+/// - otherwise transient (Busy, cross-connection schema lag): the transaction
+///   is intact on both sides, so leave it alone.
+pub(crate) fn reconcile_recoverable_tx_error(
+    env: &mut SimulatorEnv,
+    connection_index: usize,
+    err: &LimboError,
+) {
+    if !env.conn_in_transaction(connection_index) {
+        return;
+    }
+    if error_causes_rollback(err) {
+        env.rollback_conn(connection_index);
+    } else if error_requires_client_rollback(err) {
+        if let SimConnection::LimboConnection(conn) = &env.connections[connection_index] {
+            // Best-effort: the transaction is open but doomed, so ROLLBACK
+            // succeeds; if the engine already closed it we simply ignore the
+            // resulting "no active transaction" error.
+            let _ = conn.execute("ROLLBACK");
+        }
+        env.rollback_conn(connection_index);
+    }
 }
 
 use crate::{
@@ -244,9 +293,7 @@ pub fn execute_interaction_turso(
             {
                 let continuation = match err {
                     err if is_recoverable_tx_error(err) => {
-                        if error_causes_rollback(err) && env.conn_in_transaction(connection_index) {
-                            env.rollback_conn(connection_index);
-                        }
+                        reconcile_recoverable_tx_error(env, connection_index, err);
                         ExecutionContinuation::NextInteractionOutsideThisProperty
                     }
                     LimboError::Constraint(_) => {
@@ -348,17 +395,34 @@ pub fn execute_interaction_turso(
 }
 
 fn limbo_integrity_check(conn: &Arc<Connection>) -> Result<()> {
-    let mut rows = conn.query("PRAGMA integrity_check;")?.unwrap();
+    // The integrity check is an opportunistic diagnostic, not part of the
+    // workload. When it is run on a connection that holds a transaction whose
+    // snapshot has gone stale (another connection committed DDL or advanced the
+    // WAL past it), reading the schema/pages surfaces a recoverable transaction
+    // error (e.g. SchemaUpdated, BusySnapshot). That is an expected concurrent
+    // condition, not corruption, so skip the check rather than failing the run.
+    // The post-simulation integrity check runs on a fresh connection and still
+    // validates the database.
+    let mut rows = match conn.query("PRAGMA integrity_check;") {
+        Ok(rows) => rows.unwrap(),
+        Err(err) if is_recoverable_tx_error(&err) => return Ok(()),
+        Err(err) => return Err(err),
+    };
     let mut result = Vec::new();
 
-    rows.run_with_row_callback(|row| {
+    if let Err(err) = rows.run_with_row_callback(|row| {
         let val = match row.get_value(0) {
             turso_core::Value::Text(text) => text.as_str().to_string(),
             _ => unreachable!(),
         };
         result.push(val);
         Ok(())
-    })?;
+    }) {
+        if is_recoverable_tx_error(&err) {
+            return Ok(());
+        }
+        return Err(err);
+    }
 
     if result.is_empty() {
         return Err(LimboError::InternalError(


### PR DESCRIPTION
## What

Fixes simulator failures of the form "table ... should contain all of its
expected values ... model has more rows than the database" (and cascading
SchemaUpdated / "no such table" errors) that occur when a connection gets
wedged in a transaction whose snapshot has gone stale.

This is a pre-existing simulator-model bug, surfaced as flaky CI noise on an
unrelated PR (the simulator runs a fresh random seed per iteration). The
engine behaves correctly -- verified against the sqlite3 CLI.

## Three bugs fixed

1. Spurious model rollback on BusySnapshot -- the model rolled back its
   transaction while the engine kept the read snapshot alive, desyncing them.
2. Attached-DB snapshots modeled eagerly -- turso (like SQLite) acquires each
   attached database's read snapshot lazily, on first access; the model froze
   them all at the transaction's first read.
3. Doomed transactions were never recovered -- the engine's contract for
   BusySnapshot / SchemaUpdated is "rollback and retry"; the simulator never
   issued it, so a connection stayed wedged for thousands of interactions.

## Changes (testing/simulator/)

- env.rs: lazy per-attached-database snapshot pinning (+ unit test)
- model/mod.rs: invoke pinning from Query::shadow
- execution.rs: unified recoverable-error reconciliation that issues the
  prescribed ROLLBACK; SchemaUpdated recoverable; integrity-check tolerance
- property.rs: FaultyQuery uses the same reconciliation

## Validation

- Failing seed 17630452897155007180 now runs to completion, integrity check passing
- 28 simulator unit tests pass; clippy/fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
