### PR TITLE
antithesis: squash targeting diff into targeted_coverage.json

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -45,9 +45,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Publish workload
-      run: bash ./scripts/antithesis/publish-workload.sh
-
     - name: Generate diff for targeted testing
       if: ${{ inputs.diff_base != '' }}
       env:
@@ -62,6 +59,16 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           "https://api.github.com/repos/$REPO/compare/$DIFF_BASE...$HEAD_SHA" \
           -o testing/stress/git.diff
+        python3 scripts/antithesis/diff_to_targeted_coverage.py \
+          testing/stress/git.diff -o testing/stress/targeted_coverage.json
+
+    - name: Ensure targeted-coverage placeholder
+      run: |
+        [ -f testing/stress/targeted_coverage.json ] \
+          || : > testing/stress/targeted_coverage.json
+
+    - name: Publish workload
+      run: bash ./scripts/antithesis/publish-workload.sh
 
     - name: Publish config
       run: bash ./scripts/antithesis/publish-config.sh
@@ -85,3 +92,4 @@ jobs:
         additional_parameters: |-
           antithesis.duration=${{ inputs.duration }}
           antithesis.source=${{ github.ref_name }}
+          custom.use_targeted_fuzzing=${{ inputs.diff_base != '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ perf/mobibench/plot/uv.lock
 examples/dotnet/obj/
 
 # testing
+testing/stress/git.diff
+testing/stress/targeted_coverage.json
 testing/limbo_output.txt
 **/limbo_output.txt
 testing/*.log

--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -88,6 +88,9 @@ RUN chmod 777 -R /opt/antithesis/test/v1
 RUN mkdir /opt/antithesis/catalog
 RUN ln -s /opt/antithesis/test/v1/bank-test/*.py /opt/antithesis/catalog
 
+# Empty unless this is a diff-targeted run; consumed by docker-entrypoint.sh.
+COPY testing/stress/targeted_coverage.json /opt/antithesis/targeted_coverage.json
+
 ENV RUST_BACKTRACE=1
 
 ENTRYPOINT ["/bin/docker-entrypoint.sh"]

--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -88,7 +88,6 @@ RUN chmod 777 -R /opt/antithesis/test/v1
 RUN mkdir /opt/antithesis/catalog
 RUN ln -s /opt/antithesis/test/v1/bank-test/*.py /opt/antithesis/catalog
 
-# Empty unless this is a diff-targeted run; consumed by docker-entrypoint.sh.
 COPY testing/stress/targeted_coverage.json /opt/antithesis/targeted_coverage.json
 
 ENV RUST_BACKTRACE=1

--- a/scripts/antithesis/diff_to_targeted_coverage.py
+++ b/scripts/antithesis/diff_to_targeted_coverage.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Squash a unified diff into an Antithesis targeted-coverage file.
+
+Reads a unified diff (the ``git.diff`` produced from a GitHub ``compare`` API
+call) and writes the changed new-side line ranges in the JSON shape Antithesis
+uses to focus the fuzzer on a slice of the code:
+
+    {"antithesis_targeted_coverage": {"locations": [
+        {"file": "core/foo.rs", "begin_line": 10, "end_line": 13}, ...
+    ]}}
+
+Deleted files and pure-deletion hunks have no new-side lines and are skipped.
+"""
+import argparse
+import json
+import re
+import sys
+
+HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def squash(diff_text):
+    locations = []
+    current_file = None
+    skip = False
+    old_left = new_left = 0
+
+    for line in diff_text.splitlines():
+        if old_left > 0 or new_left > 0:
+            head = line[:1]
+            if head == "\\":
+                continue
+            if head == "+":
+                new_left -= 1
+            elif head == "-":
+                old_left -= 1
+            else:
+                old_left -= 1
+                new_left -= 1
+            continue
+
+        if line.startswith("diff --git"):
+            current_file, skip = None, False
+        elif line.startswith("+++ "):
+            path = line[4:].split("\t", 1)[0].rstrip()
+            if path == "/dev/null":
+                current_file, skip = None, True
+            else:
+                current_file = path[2:] if path.startswith("b/") else path
+                skip = False
+        elif line.startswith("@@"):
+            m = HUNK_RE.match(line)
+            if not m:
+                continue
+            old_left = int(m.group(2)) if m.group(2) is not None else 1
+            new_left = int(m.group(4)) if m.group(4) is not None else 1
+            if skip or current_file is None or new_left == 0:
+                continue
+            begin = int(m.group(3))
+            locations.append(
+                {
+                    "file": current_file,
+                    "begin_line": begin,
+                    "end_line": begin + new_left - 1,
+                }
+            )
+
+    return {"antithesis_targeted_coverage": {"locations": locations}}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("diff", nargs="?", help="diff file to read (default: stdin)")
+    parser.add_argument("-o", "--output", help="file to write JSON to (default: stdout)")
+    args = parser.parse_args()
+
+    if args.diff and args.diff != "-":
+        with open(args.diff, encoding="utf-8", errors="replace") as f:
+            diff_text = f.read()
+    else:
+        diff_text = sys.stdin.read()
+
+    out = json.dumps(squash(diff_text), indent=2) + "\n"
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(out)
+    else:
+        sys.stdout.write(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/antithesis/diff_to_targeted_coverage.py
+++ b/scripts/antithesis/diff_to_targeted_coverage.py
@@ -9,7 +9,10 @@ uses to focus the fuzzer on a slice of the code:
         {"file": "core/foo.rs", "begin_line": 10, "end_line": 13}, ...
     ]}}
 
-Deleted files and pure-deletion hunks have no new-side lines and are skipped.
+Only Rust sources are emitted: the coverage-instrumented binary baked into the
+workload (turso_stress) is pure Rust, so line ranges in lockfiles, snapshots,
+YAML, TypeScript, etc. cannot map to anything the fuzzer can target. Deleted
+files and pure-deletion hunks have no new-side lines and are skipped.
 """
 import argparse
 import json
@@ -17,6 +20,8 @@ import re
 import sys
 
 HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+SOURCE_SUFFIX = ".rs"
 
 
 def squash(diff_text):
@@ -55,6 +60,8 @@ def squash(diff_text):
             old_left = int(m.group(2)) if m.group(2) is not None else 1
             new_left = int(m.group(4)) if m.group(4) is not None else 1
             if skip or current_file is None or new_left == 0:
+                continue
+            if not current_file.endswith(SOURCE_SUFFIX):
                 continue
             begin = int(m.group(3))
             locations.append(

--- a/scripts/antithesis/diff_to_targeted_coverage.py
+++ b/scripts/antithesis/diff_to_targeted_coverage.py
@@ -24,7 +24,10 @@ HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 SOURCE_SUFFIX = ".rs"
 
 
-def squash(diff_text):
+# A single linear pass over the diff: the branchiness is inherent to the
+# unified-diff grammar (hunk headers, +/-/context lines, file markers), so
+# splitting it up would scatter the state machine rather than simplify it.
+def squash(diff_text):  # noqa: C901
     locations = []
     current_file = None
     skip = False

--- a/scripts/antithesis/test_diff_to_targeted_coverage.py
+++ b/scripts/antithesis/test_diff_to_targeted_coverage.py
@@ -45,15 +45,25 @@ def test_basic():
 
 
 def test_single_line_hunk():
-    diff = "--- a/x\n+++ b/x\n@@ -5 +7 @@\n-a\n+b\n"
+    diff = "--- a/x.rs\n+++ b/x.rs\n@@ -5 +7 @@\n-a\n+b\n"
     locs = squash(diff)["antithesis_targeted_coverage"]["locations"]
-    assert locs == [{"file": "x", "begin_line": 7, "end_line": 7}], locs
+    assert locs == [{"file": "x.rs", "begin_line": 7, "end_line": 7}], locs
 
 
 def test_added_line_starting_with_plus_is_not_a_header():
-    diff = "--- a/x\n+++ b/x\n@@ -1,1 +1,2 @@\n a\n+++ not a header\n"
+    diff = "--- a/x.rs\n+++ b/x.rs\n@@ -1,1 +1,2 @@\n a\n+++ not a header\n"
     locs = squash(diff)["antithesis_targeted_coverage"]["locations"]
-    assert locs == [{"file": "x", "begin_line": 1, "end_line": 2}], locs
+    assert locs == [{"file": "x.rs", "begin_line": 1, "end_line": 2}], locs
+
+
+def test_non_rust_files_are_excluded():
+    diff = (
+        "--- a/Cargo.lock\n+++ b/Cargo.lock\n@@ -1,1 +1,2 @@\n a\n+b\n"
+        "--- a/x.snap\n+++ b/x.snap\n@@ -1,1 +1,2 @@\n a\n+b\n"
+        "--- a/core/y.rs\n+++ b/core/y.rs\n@@ -1,1 +1,2 @@\n a\n+b\n"
+    )
+    locs = squash(diff)["antithesis_targeted_coverage"]["locations"]
+    assert locs == [{"file": "core/y.rs", "begin_line": 1, "end_line": 2}], locs
 
 
 def test_empty():
@@ -64,5 +74,6 @@ if __name__ == "__main__":
     test_basic()
     test_single_line_hunk()
     test_added_line_starting_with_plus_is_not_a_header()
+    test_non_rust_files_are_excluded()
     test_empty()
     print("ok")

--- a/scripts/antithesis/test_diff_to_targeted_coverage.py
+++ b/scripts/antithesis/test_diff_to_targeted_coverage.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Tests for diff_to_targeted_coverage.squash. Run: python3 <thisfile>."""
+from diff_to_targeted_coverage import squash
+
+SAMPLE = """diff --git a/core/foo.rs b/core/foo.rs
+index 1111111..2222222 100644
+--- a/core/foo.rs
++++ b/core/foo.rs
+@@ -10,3 +10,4 @@ fn foo() {
+ a
+ b
+-c
++d
++e
+@@ -40,0 +41,2 @@
++f
++g
+diff --git a/old.rs b/old.rs
+deleted file mode 100644
+index 3333333..0000000
+--- a/old.rs
++++ /dev/null
+@@ -1,2 +0,0 @@
+-x
+-y
+diff --git a/new.rs b/new.rs
+new file mode 100644
+index 0000000..4444444
+--- /dev/null
++++ b/new.rs
+@@ -0,0 +1,3 @@
++p
++q
++r
+"""
+
+
+def test_basic():
+    locs = squash(SAMPLE)["antithesis_targeted_coverage"]["locations"]
+    assert locs == [
+        {"file": "core/foo.rs", "begin_line": 10, "end_line": 13},
+        {"file": "core/foo.rs", "begin_line": 41, "end_line": 42},
+        {"file": "new.rs", "begin_line": 1, "end_line": 3},
+    ], locs
+
+
+def test_single_line_hunk():
+    diff = "--- a/x\n+++ b/x\n@@ -5 +7 @@\n-a\n+b\n"
+    locs = squash(diff)["antithesis_targeted_coverage"]["locations"]
+    assert locs == [{"file": "x", "begin_line": 7, "end_line": 7}], locs
+
+
+def test_added_line_starting_with_plus_is_not_a_header():
+    diff = "--- a/x\n+++ b/x\n@@ -1,1 +1,2 @@\n a\n+++ not a header\n"
+    locs = squash(diff)["antithesis_targeted_coverage"]["locations"]
+    assert locs == [{"file": "x", "begin_line": 1, "end_line": 2}], locs
+
+
+def test_empty():
+    assert squash("") == {"antithesis_targeted_coverage": {"locations": []}}
+
+
+if __name__ == "__main__":
+    test_basic()
+    test_single_line_hunk()
+    test_added_line_starting_with_plus_is_not_a_header()
+    test_empty()
+    print("ok")

--- a/testing/antithesis/README.md
+++ b/testing/antithesis/README.md
@@ -1,21 +1,5 @@
 # Antithesis Test Suite
 
-## Diff-Targeted (Focused) Runs
-
-The `Antithesis experiment` workflow accepts a `diff_base` input (a branch or SHA). When set, the workflow:
-
-1. fetches the diff `diff_base...HEAD` from the GitHub compare API into `testing/stress/git.diff`,
-2. squashes it into `testing/stress/targeted_coverage.json` via
-   `scripts/antithesis/diff_to_targeted_coverage.py` (changed new-side line ranges, in the
-   `antithesis_targeted_coverage` schema Antithesis uses to focus the fuzzer),
-3. bakes that file into the workload image, and
-4. launches with `custom.use_targeted_fuzzing=true`.
-
-At runtime `docker-entrypoint.sh` copies the file to `$ANTITHESIS_OUTPUT_DIR/targeted_coverage.json`
-only when it is non-empty, so leaving `diff_base` blank reproduces the previous, non-targeted behavior
-exactly. Because the targeting is driven purely by line ranges, you can also "game" it to fuzz an
-arbitrary slice (e.g. a recovery path) by diffing against a base where only those lines differ.
-
 ## How to Dump Artifacts from a Test Run
 
 To dump the stress tool's log and the database from an Antithesis test run, follow these steps. Note that they require

--- a/testing/antithesis/README.md
+++ b/testing/antithesis/README.md
@@ -1,5 +1,21 @@
 # Antithesis Test Suite
 
+## Diff-Targeted (Focused) Runs
+
+The `Antithesis experiment` workflow accepts a `diff_base` input (a branch or SHA). When set, the workflow:
+
+1. fetches the diff `diff_base...HEAD` from the GitHub compare API into `testing/stress/git.diff`,
+2. squashes it into `testing/stress/targeted_coverage.json` via
+   `scripts/antithesis/diff_to_targeted_coverage.py` (changed new-side line ranges, in the
+   `antithesis_targeted_coverage` schema Antithesis uses to focus the fuzzer),
+3. bakes that file into the workload image, and
+4. launches with `custom.use_targeted_fuzzing=true`.
+
+At runtime `docker-entrypoint.sh` copies the file to `$ANTITHESIS_OUTPUT_DIR/targeted_coverage.json`
+only when it is non-empty, so leaving `diff_base` blank reproduces the previous, non-targeted behavior
+exactly. Because the targeting is driven purely by line ranges, you can also "game" it to fuzz an
+arbitrary slice (e.g. a recovery path) by diffing against a base where only those lines differ.
+
 ## How to Dump Artifacts from a Test Run
 
 To dump the stress tool's log and the database from an Antithesis test run, follow these steps. Note that they require

--- a/testing/stress/docker-entrypoint.sh
+++ b/testing/stress/docker-entrypoint.sh
@@ -4,7 +4,8 @@ echo '{"antithesis_setup": { "status": "complete", "details": null }}' > $ANTITH
 
 set -Eeuo pipefail
 
-if [ -s /opt/antithesis/targeted_coverage.json ]; then
+if [ -f /opt/antithesis/targeted_coverage.json ] \
+  && grep -q '"begin_line"' /opt/antithesis/targeted_coverage.json; then
   cp /opt/antithesis/targeted_coverage.json "$ANTITHESIS_OUTPUT_DIR/targeted_coverage.json"
 fi
 

--- a/testing/stress/docker-entrypoint.sh
+++ b/testing/stress/docker-entrypoint.sh
@@ -4,4 +4,8 @@ echo '{"antithesis_setup": { "status": "complete", "details": null }}' > $ANTITH
 
 set -Eeuo pipefail
 
+if [ -s /opt/antithesis/targeted_coverage.json ]; then
+  cp /opt/antithesis/targeted_coverage.json "$ANTITHESIS_OUTPUT_DIR/targeted_coverage.json"
+fi
+
 exec "$@"


### PR DESCRIPTION
This PR integrates with the Antithesis diff-focussing capability. It's based on the instructions from our rep:

> I see you have made changes in the workflow to support the diff strategy.
> So ill lean on your idea.
>
> The change would start by using the git.diff as part of the change here https://github.com/tursodatabase/turso/commit/57c17c0c3775ef7c95a5bf150206c41b6b62b87d#diff-5e54c68238a3eb253a449c77[…]d67f0fe06d0cd19b0a6a79b33de41
> Then using a script to transform (squash) the diff to a json compatible with something that looks like this https://github.com/antithesishq/demo-data-streaming/commit/df0cd1560c935c831ea84120933e3e2aceba7c11
> 
> Claude cooked up this snippet of the script - see if this helps:
> ```
> { antithesis_targeted_coverage: { locations: [
>       .files[] | select(.patch != null) | .filename as $file | .patch
>       | [scan("@@ -[0-9]+(,[0-9]+)? [+]([0-9]+)(,([0-9]+))? @@")] | .[]
>       | { file: $file,
>           begin_line: (.[1] | tonumber),
>           end_line: ((.[1] | tonumber) + (if .[3] then (.[3] | tonumber) else 1 end) - 1) }
>   ] } }Bake this JSON into the workload image ...  Add to the runtime stage of Dockerfile.antithesis:
> ```
>
> COPY targeted_coverage.json /opt/antithesis/targeted_coverage.json
>
> and the copy and load to the env variable (most likely from the docker-entrypoint.sh)
>
> cp /opt/antithesis/targeted_coverage.json "$ANTITHESIS_OUTPUT_DIR/targeted_coverage.json"
>
> I know this is a bit of work so I will standby if you need any help from my end.
>
> This will be gated with a custom.use_targeted_fuzzing which when set true will use this strategy.

This is all AI-generated, but I launched a manual Antithesis experiment, and our rep says that it looks good on their side.