### PR TITLE
fix nonblocking read_page race and wal frame cache slot reuse corruption

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3158,6 +3158,7 @@ impl Pager {
             return Ok((page, c));
         }
 
+        page.set_locked();
         let c =
             self.begin_read_disk_page(page_idx as usize, page.clone(), allow_empty_read, &io_ctx)?;
         Ok((page, c))
@@ -3203,11 +3204,26 @@ impl Pager {
                         "attempted to read page but got different page",
                         { "expected_page": page_idx, "actual_page": page.get().id }
                     );
+                    if !page.is_loaded() {
+                        // The page is cache-resident but its read is still in
+                        // flight: `read_page` publishes a page into the shared
+                        // cache (via `cache_insert` below) *before* its disk
+                        // read completes, and `PageCache::get` deliberately
+                        // hands out locked-but-unloaded in-flight pages. We have
+                        // no completion to surface on this path (the disk-read
+                        // completion was consumed by the original caller and the
+                        // `pending_reads` entry has already been removed), so
+                        // returning `Done((page, None))` would hand the caller a
+                        // locked, unloaded page with nothing to wait on: a torn
+                        // / uninitialized read, or a concurrent writer filling
+                        // the buffer underneath the reader.
+                        io_yield_one!(crate::Completion::new_yield());
+                    }
                     return Ok(IOResult::Done((page, None)));
                 }
             }
 
-            tracing::debug!("read_page_nonblock(page_idx = {page_idx}) = reading page from disk");
+            tracing::debug!("read_page(page_idx = {page_idx}) = reading page from disk");
             let (page, c) = self.read_page_no_cache(page_idx, None, false)?;
             self.pending_reads.write().insert(
                 page_idx,
@@ -6158,6 +6174,61 @@ mod ptrmap_tests {
             pager.pending_reads.read().get(&target_idx).is_none(),
             "pending_reads entry must be cleared once read_page_nonblock returns Done"
         );
+    }
+
+    /// Concurrency contract: a page can be cache-resident while its disk read
+    /// is still in flight (locked, not loaded) — `read_page` inserts into the
+    /// shared cache before the read completes, and `PageCache::get` hands out
+    /// such in-flight pages. A second reader hitting the cache-hit fast path
+    /// must NOT receive that unloaded page with `None` (no completion to wait
+    /// on); it must yield and re-enter until the read completes. Otherwise the
+    /// caller reads a torn / uninitialized buffer, or races a writer filling
+    /// the buffer underneath it.
+    #[test]
+    fn read_page_nonblock_inflight_cache_hit_yields_not_done() {
+        let pager = test_pager_setup(4096, 10);
+
+        let target_idx: i64 = 9999;
+        assert!(
+            pager.cache_get(target_idx as usize).unwrap().is_none(),
+            "test precondition: target page must not be in cache"
+        );
+
+        // Synthesize an in-flight read that has already been published to the
+        // shared cache: locked (a read is outstanding) but not loaded (the
+        // buffer hasn't been filled yet). This is exactly the state a page is
+        // in between `cache_insert` and the disk-read completion firing.
+        let inflight: PageRef = Arc::new(Page::new(target_idx));
+        inflight.set_locked();
+        assert!(!inflight.is_loaded());
+        pager
+            .page_cache
+            .write()
+            .insert(PageCacheKey::new(target_idx as usize), inflight.clone())
+            .unwrap();
+
+        // The fast path finds the page in cache but must refuse to return it
+        // without a completion, because it is not yet loaded.
+        match pager.read_page(target_idx).unwrap() {
+            IOResult::IO(_) => {}
+            IOResult::Done((page, c)) => panic!(
+                "read_page handed out an in-flight (locked, unloaded) page on the \
+                 cache-hit fast path: loaded={}, completion={}",
+                page.is_loaded(),
+                c.is_some()
+            ),
+        }
+
+        // Once the read completes (page becomes loaded), the same cache-hit
+        // fast path returns Done with no completion, as before.
+        inflight.set_loaded();
+        match pager.read_page(target_idx).unwrap() {
+            IOResult::Done((page, c)) => {
+                assert!(Arc::ptr_eq(&page, &inflight));
+                assert!(c.is_none(), "loaded cache hit must not return a completion");
+            }
+            IOResult::IO(_) => panic!("loaded cache hit must not yield"),
+        }
     }
 }
 

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1482,6 +1482,7 @@ impl BuildSharedWal {
             },
             runtime: WalSharedRuntime {
                 frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
+                frame_cache_high_water: AtomicU64::new(0),
                 file: Some(file.clone()),
                 read_locks,
                 vacuum_lock: TursoRwLock::new(),
@@ -1869,19 +1870,23 @@ impl StreamingWalReader {
             return;
         }
         let wfs = self.wal_shared.read();
-        {
-            let mut frame_cache = wfs.runtime.frame_cache.lock();
-            for (page, mut frames) in state.pending_frames.drain() {
-                // Only include frames up to last valid commit
-                frames.retain(|&f| f <= state.last_valid_frame);
-                if !frames.is_empty() {
-                    frame_cache.entry(page).or_default().extend(frames);
-                }
+        let mut frame_cache = wfs.runtime.frame_cache.lock();
+        for (page, mut frames) in state.pending_frames.drain() {
+            // Only include frames up to last valid commit
+            frames.retain(|&f| f <= state.last_valid_frame);
+            if !frames.is_empty() {
+                frame_cache.entry(page).or_default().extend(frames);
             }
         }
         wfs.metadata
             .max_frame
             .store(state.last_valid_frame, Ordering::Release);
+        // Recovery populates `frame_cache` directly (not via `cache_frame`), so
+        // seed the high-water with the recovered frames; otherwise the first
+        // post-recovery rewind/slot-reuse could go undetected.
+        wfs.runtime
+            .frame_cache_high_water
+            .fetch_max(state.last_valid_frame, Ordering::AcqRel);
     }
 
     /// Finalizes the loading process

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1249,6 +1249,29 @@ impl WalCoordination for InProcessWalCoordination {
     fn cache_frame(&self, page_id: u64, frame_id: u64) {
         let shared = self.shared.read();
         let mut frame_cache = shared.runtime.frame_cache.lock();
+        // Frame-slot reuse / append-position rewind guard. Within a WAL
+        // generation frames are appended with strictly increasing numbers, so
+        // a `frame_id` that does not exceed the current high-water means the
+        // slots from `frame_id` upward are being overwritten: by frames from a
+        // prior uncommitted/aborted append that was never rolled back out of
+        // the cache, or by another connection reusing the slots after a
+        // rewind. Drop every stale `page -> frame` mapping for those slots
+        // before recording the new one, otherwise `find_frame` can return a
+        // frame slot that now physically holds a different page (corruption).
+        // (Per-page frame lists are kept ascending, so popping the tail
+        // `>= frame_id` removes exactly the overwritten suffix.)
+        let high_water = shared
+            .runtime
+            .frame_cache_high_water
+            .load(Ordering::Acquire);
+        if frame_id <= high_water {
+            frame_cache.retain(|_page_id, frames| {
+                while frames.last().is_some_and(|&frame| frame >= frame_id) {
+                    frames.pop();
+                }
+                !frames.is_empty()
+            });
+        }
         match frame_cache.get_mut(&page_id) {
             Some(frames) => {
                 frames.push(frame_id);
@@ -1257,6 +1280,10 @@ impl WalCoordination for InProcessWalCoordination {
                 frame_cache.insert(page_id, vec![frame_id]);
             }
         }
+        shared
+            .runtime
+            .frame_cache_high_water
+            .store(frame_id, Ordering::Release);
     }
 
     fn rollback_cache(&self, max_frame: u64) {
@@ -1268,6 +1295,19 @@ impl WalCoordination for InProcessWalCoordination {
             }
             !frames.is_empty()
         });
+        // Keep the high-water consistent with the truncation so a subsequent
+        // append at `max_frame + 1` is not misread as a rewind.
+        if shared
+            .runtime
+            .frame_cache_high_water
+            .load(Ordering::Acquire)
+            > max_frame
+        {
+            shared
+                .runtime
+                .frame_cache_high_water
+                .store(max_frame, Ordering::Release);
+        }
     }
 
     fn should_checkpoint_on_close(&self) -> bool {
@@ -1442,6 +1482,10 @@ impl ShmWalCoordination {
         Self::install_local_snapshot(&mut shared, snapshot, true);
         shared.metadata.initialized.store(false, Ordering::Release);
         shared.runtime.frame_cache.lock().clear();
+        shared
+            .runtime
+            .frame_cache_high_water
+            .store(0, Ordering::Release);
         shared.runtime.overflow_fallback_coverage.lock().clear();
     }
 
@@ -1733,6 +1777,10 @@ impl ShmWalCoordination {
             Self::install_local_snapshot(&mut shared, restarted, true);
             shared.metadata.initialized.store(false, Ordering::Release);
             shared.runtime.frame_cache.lock().clear();
+            shared
+                .runtime
+                .frame_cache_high_water
+                .store(0, Ordering::Release);
             shared.runtime.overflow_fallback_coverage.lock().clear();
             shared.runtime.read_locks[0].set_value_exclusive(0);
             shared.runtime.read_locks[1].set_value_exclusive(0);
@@ -2677,6 +2725,15 @@ pub struct WalSharedRuntime {
     // we don't need WAL's index file. So we can do stuff like this without shared memory.
     // TODO: this will need refactoring because this is incredible memory inefficient.
     pub frame_cache: Arc<SpinLock<FxHashMap<u64, Vec<u64>>>>,
+    /// Highest frame number currently recorded in `frame_cache` for the active
+    /// WAL generation. Used to detect frame-slot reuse / append-position
+    /// rewinds: within a generation frames are appended with strictly
+    /// increasing numbers, so caching a frame that is not above this watermark
+    /// means the slots from that frame upward are being overwritten and any
+    /// stale `page -> frame` mappings for them must be purged (otherwise
+    /// `find_frame` can return a frame slot that now holds a different page).
+    /// Only read/written while holding the `frame_cache` lock.
+    pub frame_cache_high_water: AtomicU64,
     pub file: Option<Arc<dyn File>>,
     /// Read locks advertise the maximum WAL frame a reader may access.
     /// Slot 0 is special, when it is held (shared) the reader bypasses the WAL and uses the main DB file.
@@ -5405,6 +5462,7 @@ impl WalFileShared {
             },
             runtime: WalSharedRuntime {
                 frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
+                frame_cache_high_water: AtomicU64::new(0),
                 file: Some(file),
                 read_locks,
                 vacuum_lock: TursoRwLock::new(),
@@ -5480,6 +5538,7 @@ impl WalFileShared {
             },
             runtime: WalSharedRuntime {
                 frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
+                frame_cache_high_water: AtomicU64::new(0),
                 file: None,
                 read_locks,
                 vacuum_lock: TursoRwLock::new(),
@@ -5521,6 +5580,7 @@ impl WalFileShared {
             },
             runtime: WalSharedRuntime {
                 frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
+                frame_cache_high_water: AtomicU64::new(0),
                 file: Some(file),
                 read_locks,
                 vacuum_lock: TursoRwLock::new(),
@@ -5571,6 +5631,9 @@ impl WalFileShared {
         }
 
         self.runtime.frame_cache.lock().clear();
+        self.runtime
+            .frame_cache_high_water
+            .store(0, Ordering::Release);
         // read-marks
         self.runtime.read_locks[0].set_value_exclusive(0);
         self.runtime.read_locks[1].set_value_exclusive(0);
@@ -6583,9 +6646,11 @@ pub mod test {
         let (shared, _wal) = make_test_wal();
         let coordination = make_test_coordination(&shared);
 
+        // Frames are cached in WAL append order (globally ascending): page 7 at
+        // frame 2, page 9 at frame 4, page 7 again at frame 5.
         coordination.cache_frame(7, 2);
-        coordination.cache_frame(7, 5);
         coordination.cache_frame(9, 4);
+        coordination.cache_frame(7, 5);
 
         assert_eq!(coordination.find_frame(7, 0, 5, None), Some(5));
         assert_eq!(coordination.iter_latest_frames(0, 5), vec![(7, 5), (9, 4)]);
@@ -6598,6 +6663,50 @@ pub mod test {
             shared.read().runtime.frame_cache.lock().get(&7),
             Some(&vec![2])
         );
+    }
+
+    /// Regression test for WAL frame-index aliasing corruption: when a WAL
+    /// frame slot is reused for a different page (the append position rewinds
+    /// to an already-cached frame — e.g. an aborted/uncommitted append's slots
+    /// being overwritten, or a different connection reusing the slots), the
+    /// stale `page -> frame` mapping for that slot must be purged. Otherwise
+    /// `find_frame` can hand a page a frame number whose slot now physically
+    /// holds a different page, and the reader gets the wrong page's bytes
+    /// (surfacing as "non-index page" / "Invalid page type" / corruption).
+    #[test]
+    fn cache_frame_purges_stale_mapping_on_frame_slot_reuse() {
+        let (shared, _wal) = make_test_wal();
+        let coordination = make_test_coordination(&shared);
+
+        // Ascending append: page 7 @3, page 9 @4, page 7 @5.
+        coordination.cache_frame(7, 3);
+        coordination.cache_frame(9, 4);
+        coordination.cache_frame(7, 5);
+        assert_eq!(coordination.find_frame(9, 0, 10, None), Some(4));
+
+        // The append position rewinds and frame slots 4 and 5 are overwritten,
+        // now belonging to page 11 (@4) and page 13 (@5). The earlier owners of
+        // those slots (page 9 @4, page 7 @5) must no longer be reachable.
+        coordination.cache_frame(11, 4);
+        coordination.cache_frame(13, 5);
+
+        assert_eq!(
+            coordination.find_frame(9, 0, 10, None),
+            None,
+            "stale page 9 -> frame 4 mapping must be purged once slot 4 is reused"
+        );
+        assert_eq!(
+            coordination.find_frame(11, 0, 10, None),
+            Some(4),
+            "page 11 now owns frame slot 4"
+        );
+        assert_eq!(
+            coordination.find_frame(13, 0, 10, None),
+            Some(5),
+            "page 13 now owns frame slot 5"
+        );
+        // Page 7's still-valid lower frame (3) survives; its stale 5 is gone.
+        assert_eq!(coordination.find_frame(7, 0, 10, None), Some(3));
     }
 
     #[test]


### PR DESCRIPTION
This PR addresses the corruption issue that https://github.com/wadamek65 reported on discord here: https://discord.com/channels/933071162680958986/1520062235341357056/1520083942882148552

### The Bug:

The shared WAL frame index `WalFileShared.runtime.frame_cache` could map a page to a frame slot that physically held a different page. The `cache_frame` method only ever appended and never removed a stale page->frame entry when a frame slot was reused (append-position rewind from an aborted/uncommitted transaction, or another connection reusing slots). `find_frame` then returned a frame whose bytes belonged to another page, the cursor reads wrong page and we get `non-index page / Invalid page type: 0 / inconsistent overflow chain`, sometimes durable. Concurrent readers were required to reproduce because their read-marks block the WAL restarts that otherwise clear `frame_cache`.


### Reproducer: (with fix)
<img width="1177" height="574" alt="image" src="https://github.com/user-attachments/assets/3fbcca28-932f-44a0-8f63-cb7d5a855a3f" />
