### PR TITLE
fix(pragma): silently ignore unknown PRAGMA names

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -225,9 +225,9 @@ pub fn translate_pragma(
         return Ok(());
     }
 
-    let pragma = match PragmaName::from_str(name.name.as_str()) {
-        Ok(pragma) => pragma,
-        Err(_) => bail_parse_error!("Not a valid pragma name"),
+    let Ok(pragma) = PragmaName::from_str(name.name.as_str()) else {
+        // SQLite silently ignores unknown PRAGMA names.
+        return Ok(());
     };
 
     let database_id = resolver.resolve_database_id(name)?;

--- a/testing/sqltests/tests/pragma-unknown-no-op.sqltest
+++ b/testing/sqltests/tests/pragma-unknown-no-op.sqltest
@@ -1,0 +1,33 @@
+@database :memory:
+
+# Regression test for #7645: unknown PRAGMA names are silently ignored (SQLite behavior).
+test unknown-pragma-recursive-triggers {
+    PRAGMA recursive_triggers=OFF;
+    SELECT 1;
+}
+expect {
+    1
+}
+
+test unknown-pragma-reverse-unordered-selects {
+    PRAGMA reverse_unordered_selects=ON;
+    SELECT 1;
+}
+expect {
+    1
+}
+
+test unknown-pragma-legacy-alter-table {
+    PRAGMA legacy_alter_table=OFF;
+    SELECT 1;
+}
+expect {
+    1
+}
+
+test known-pragma-still-works {
+    PRAGMA foreign_keys;
+}
+expect {
+    0
+}

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -1,6 +1,5 @@
 use crate::common::{limbo_exec_rows, TempDatabase};
 use rusqlite::types::Value as RValue;
-#[cfg(not(target_vendor = "apple"))]
 use turso_core::{Numeric, StepResult, Value};
 
 #[turso_macros::test(mvcc)]

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -1,7 +1,6 @@
 use crate::common::{limbo_exec_rows, TempDatabase};
 use rusqlite::types::Value as RValue;
 #[cfg(not(target_vendor = "apple"))]
-use turso_core::LimboError;
 use turso_core::{Numeric, StepResult, Value};
 
 #[turso_macros::test(mvcc)]
@@ -275,15 +274,8 @@ fn test_pragma_fullfsync(db: TempDatabase) {
     conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
         .unwrap();
 
-    // On non-Apple platforms, fullfsync pragma should not exist
-    let result = conn.execute("PRAGMA fullfsync=1");
-    assert!(
-        matches!(
-            result,
-            Err(LimboError::ParseError(e)) if e.contains("Not a valid pragma name")
-        ),
-        "fullfsync pragma should not be available on non-Apple platforms"
-    );
+    // On non-Apple platforms, fullfsync is unknown and silently ignored (SQLite behavior).
+    conn.execute("PRAGMA fullfsync=1").unwrap();
 }
 
 #[turso_macros::test(mvcc)]


### PR DESCRIPTION
Fixes #7645

## Description

Turso currently raises a parse error (`Not a valid pragma name`) for unknown PRAGMA names. SQLite silently ignores them.

This returns early from `translate_pragma` when `PragmaName::from_str` fails, matching SQLite's no-op behaviour.

Changes:
- `core/translate/pragma.rs` — silently ignore unknown PRAGMA names
- `testing/sqltests/tests/pragma-unknown-no-op.sqltest` — regression tests
- `tests/integration/pragma.rs` — update `test_pragma_fullfsync` on non-Apple platforms

SQLite reference: https://sqlite.org/pragma.html — *"No error messages are generated if an unknown pragma is issued."*

## Motivation and context

Fixes #7645

This is my first contribution to Turso. I've been writing software for ~25 years and have a long-standing interest in SQL, SQLite, Turso and Rust. I picked this up to help familiarise myself with the codebase and practices, more so than any particular motivation to fix this specific problem and hopefully make some meaningful contributions moving forwards. This is also my first time contributing to an open source project like this!

## Description of AI Usage

I used Cursor IDE with the Composer 2.5 model for assistance with repo navigation, test conventions, and the contribution workflow. I also used it to help find me suitable first issues to work on. I reviewed the diff, ran tests locally (`cargo fmt`, `cargo clippy`, targeted pragma tests, and `make test`), and can explain the change.