### PR TITLE
github: Never mark issues as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,6 +21,6 @@ jobs:
           ascending: true
           stale-pr-message: 'This pull request has been marked as stale due to inactivity. It will be closed in 7 days if no further activity occurs.'
           close-pr-message: 'This pull request has been closed due to inactivity. Please feel free to reopen it if you have further updates.'
-          days-before-issue-stale: 365
+          days-before-issue-stale: -1  # -1 means never mark issues as stale
           days-before-stale: 30
           days-before-close: 7


### PR DESCRIPTION
We mark pull requests as stale after enough inactivity because they bit-rot over time if nobody works on them. However, issues don't really have this problem. They may end up being fixed over time, but we can find that out by attempting to reproduce.