### PR TITLE
test: pin BLOB return type for time constructor functions

### DIFF
--- a/testing/sqltests/turso-tests/time.sqltest
+++ b/testing/sqltests/turso-tests/time.sqltest
@@ -428,3 +428,38 @@ expect {
     3600000000000
 }
 
+test time_constructor_types {
+    SELECT typeof(time_now());
+    SELECT typeof(time_date(2024, 1, 1));
+    SELECT typeof(time_unix(1700000000));
+    SELECT typeof(time_milli(1700000000000));
+    SELECT typeof(time_micro(1700000000000000));
+    SELECT typeof(time_nano(1700000000000000000));
+    SELECT typeof(make_date(2024, 1, 1));
+    SELECT typeof(make_timestamp(2024, 1, 1, 0, 0, 0));
+    SELECT typeof(to_timestamp(1700000000));
+    SELECT typeof(time_parse('2024-01-01'));
+}
+expect {
+    blob
+    blob
+    blob
+    blob
+    blob
+    blob
+    blob
+    blob
+    blob
+    blob
+}
+
+@requires strict "uses STRICT tables"
+test time_now_strict_blob_column {
+    CREATE TABLE t (t BLOB) STRICT;
+    INSERT INTO t VALUES (time_now());
+    SELECT typeof(t) FROM t;
+}
+expect {
+    blob
+}
+


### PR DESCRIPTION
## Summary

Reopening #7667 (which Fossier auto-closed) from a fresh branch with a signed commit.

Adds regression tests for the time extension constructor return types. The
constructor functions return a 13-byte time BLOB (version(1) + seconds(8) +
nanoseconds(4)) matching the sqlean-time reference, but the docs table in
`docs/sql-reference/extensions.mdx` mislabels them as INTEGER.

This was reported in #7665 as a strict-table insert error:
```sql
CREATE TABLE X (time INTEGER) STRICT;
INSERT INTO X (time) VALUES (time_now());  -- fails: BLOB != INTEGER
```

## Changes

- `test time_constructor_types`: pins `typeof()` for all 10 time
  constructor functions to `blob`. Prevents any future "fix" that
  would change the return type and silently break the rest of the
  extension (`time_fmt_iso`, `time_get_year`, `time_add`, etc.
  all expect a BLOB input).
- `test time_now_strict_blob_column`: demonstrates the correct
  workaround for the reporter's use case (declare the column as BLOB).

## Note

The fix for the docs mismatch is intentionally NOT in this PR. That
change belongs in the `tursodatabase/turso-docs` repo and will be sent
as a separate PR.

## Verification

- `cargo build --bin test-runner` clean
- `./target/debug/test-runner check turso-tests` clean
- `test-runner run turso-tests/time.sqltest --backend cli` all 36
  tests pass (34 existing + 2 new)
- `cargo fmt --check` clean

## On Fossier

Fossier trust check failed on the first PR (49.2/100, prior_interaction=0).
This is a clean, scoped change that only adds two tests. Requesting manual
review or a VOUCHED.td entry.

Refs #7665