### PR TITLE
core/translate: report composite primary key position in table_info

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -10,7 +10,7 @@ use turso_parser::ast::PragmaName;
 use turso_parser::ast::{self, Expr, Literal};
 
 use super::integrity_check::{
-    MAX_INTEGRITY_CHECK_ERRORS, translate_integrity_check, translate_quick_check,
+    translate_integrity_check, translate_quick_check, MAX_INTEGRITY_CHECK_ERRORS,
 };
 use crate::function::Func;
 use crate::pragma::pragma_for;
@@ -22,10 +22,10 @@ use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
 use crate::translate::emitter::{Resolver, TransactionMode};
 use crate::translate::plan::BitSet;
-use crate::util::{IOExt as _, normalize_ident, parse_signed_number, parse_string};
+use crate::util::{normalize_ident, parse_signed_number, parse_string, IOExt as _};
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
 use crate::vdbe::insn::{Cookie, Insn};
-use crate::{CaptureDataChangesInfo, LimboError, Numeric, Value, bail_parse_error};
+use crate::{bail_parse_error, CaptureDataChangesInfo, LimboError, Numeric, Value};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -10,11 +10,11 @@ use turso_parser::ast::PragmaName;
 use turso_parser::ast::{self, Expr, Literal};
 
 use super::integrity_check::{
-    translate_integrity_check, translate_quick_check, MAX_INTEGRITY_CHECK_ERRORS,
+    MAX_INTEGRITY_CHECK_ERRORS, translate_integrity_check, translate_quick_check,
 };
 use crate::function::Func;
 use crate::pragma::pragma_for;
-use crate::schema::Schema;
+use crate::schema::{Schema, Table};
 use crate::storage::encryption::{CipherMode, EncryptionKey};
 use crate::storage::pager::AutoVacuumMode;
 use crate::storage::pager::Pager;
@@ -22,10 +22,10 @@ use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
 use crate::translate::emitter::{Resolver, TransactionMode};
 use crate::translate::plan::BitSet;
-use crate::util::{normalize_ident, parse_signed_number, parse_string, IOExt as _};
+use crate::util::{IOExt as _, normalize_ident, parse_signed_number, parse_string};
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
 use crate::vdbe::insn::{Cookie, Insn};
-use crate::{bail_parse_error, CaptureDataChangesInfo, LimboError, Numeric, Value};
+use crate::{CaptureDataChangesInfo, LimboError, Numeric, Value, bail_parse_error};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
@@ -1303,13 +1303,38 @@ fn query_pragma(
                 let lookup_name = normalize_table_pragma_lookup_name(table_database_id, &name);
                 resolver.with_schema(table_database_id, |db_schema| {
                     if let Some(table) = db_schema.get_table(&lookup_name) {
-                        emit_columns_for_table_info(program, table.columns(), base_reg, false);
+                        let primary_key_columns = match table.as_ref() {
+                            Table::BTree(bt) => Some(bt.primary_key_columns.as_slice()),
+                            _ => None,
+                        };
+                        emit_columns_for_table_info(
+                            program,
+                            table.columns(),
+                            primary_key_columns,
+                            base_reg,
+                            false,
+                        );
                     } else if let Some(view_mutex) = db_schema.get_materialized_view(&lookup_name) {
                         let view = view_mutex.lock();
                         let flat_columns = view.column_schema.flat_columns();
-                        emit_columns_for_table_info(program, &flat_columns, base_reg, false);
+                        emit_columns_for_table_info(
+                            program,
+                            &flat_columns,
+                            // Materialized views have btree storage (implicit rowid) but no
+                            // declared PRIMARY KEY on their output columns; pk is always 0.
+                            None,
+                            base_reg,
+                            false,
+                        );
                     } else if let Some(view) = db_schema.get_view(&lookup_name) {
-                        emit_columns_for_table_info(program, &view.columns, base_reg, false);
+                        emit_columns_for_table_info(
+                            program,
+                            &view.columns,
+                            // Views are query definitions, not tables; pk is always 0.
+                            None,
+                            base_reg,
+                            false,
+                        );
                     }
                 });
             }
@@ -1338,13 +1363,38 @@ fn query_pragma(
                 let lookup_name = normalize_table_pragma_lookup_name(table_database_id, &name);
                 resolver.with_schema(table_database_id, |db_schema| {
                     if let Some(table) = db_schema.get_table(&lookup_name) {
-                        emit_columns_for_table_info(program, table.columns(), base_reg, true);
+                        let primary_key_columns = match table.as_ref() {
+                            Table::BTree(bt) => Some(bt.primary_key_columns.as_slice()),
+                            _ => None,
+                        };
+                        emit_columns_for_table_info(
+                            program,
+                            table.columns(),
+                            primary_key_columns,
+                            base_reg,
+                            true,
+                        );
                     } else if let Some(view_mutex) = db_schema.get_materialized_view(&lookup_name) {
                         let view = view_mutex.lock();
                         let flat_columns = view.column_schema.flat_columns();
-                        emit_columns_for_table_info(program, &flat_columns, base_reg, true);
+                        emit_columns_for_table_info(
+                            program,
+                            &flat_columns,
+                            // Materialized views have btree storage (implicit rowid) but no
+                            // declared PRIMARY KEY on their output columns; pk is always 0.
+                            None,
+                            base_reg,
+                            true,
+                        );
                     } else if let Some(view) = db_schema.get_view(&lookup_name) {
-                        emit_columns_for_table_info(program, &view.columns, base_reg, true);
+                        emit_columns_for_table_info(
+                            program,
+                            &view.columns,
+                            // Views are query definitions, not tables; pk is always 0.
+                            None,
+                            base_reg,
+                            true,
+                        );
                     }
                 });
             }
@@ -1702,11 +1752,23 @@ fn query_pragma(
     }
 }
 
+/// 0-based index of `column` within `primary_key_columns`, if present.
+fn column_pk_index(
+    column: &crate::schema::Column,
+    primary_key_columns: &[(String, turso_parser::ast::SortOrder)],
+) -> Option<usize> {
+    let name = column.name.as_deref()?;
+    primary_key_columns
+        .iter()
+        .position(|(pk_name, _)| name.eq_ignore_ascii_case(pk_name))
+}
+
 /// Helper function to emit column information for PRAGMA table_info
 /// Used by both tables and views since they now have the same column emission logic
 fn emit_columns_for_table_info(
     program: &mut ProgramBuilder,
     columns: &[crate::schema::Column],
+    primary_key_columns: Option<&[(String, turso_parser::ast::SortOrder)]>,
     base_reg: usize,
     extended: bool,
 ) {
@@ -1761,8 +1823,12 @@ fn emit_columns_for_table_info(
             }
         }
 
-        // pk
-        program.emit_bool(column.primary_key(), base_reg + 5);
+        // pk — 1-based position within the primary key, or 0 if not part of the key
+        let pk = primary_key_columns
+            .and_then(|pk_cols| column_pk_index(column, pk_cols))
+            .map(|index| (index + 1) as i64)
+            .unwrap_or(0);
+        program.emit_int(pk, base_reg + 5);
 
         if extended {
             program.emit_int(column_type, base_reg + 6);
@@ -1842,9 +1908,9 @@ fn is_database_empty(schema: &Schema, pager: &Arc<Pager>) -> crate::Result<bool>
     }
     if let Some(table_arc) = schema.tables.values().next() {
         let table_name = match table_arc.as_ref() {
-            crate::schema::Table::BTree(tbl) => &tbl.name,
-            crate::schema::Table::Virtual(tbl) => &tbl.name,
-            crate::schema::Table::FromClauseSubquery(tbl) => &tbl.name,
+            Table::BTree(tbl) => &tbl.name,
+            Table::Virtual(tbl) => &tbl.name,
+            Table::FromClauseSubquery(tbl) => &tbl.name,
         };
 
         if table_name != "sqlite_schema" {

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1823,11 +1823,19 @@ fn emit_columns_for_table_info(
             }
         }
 
-        // pk — 1-based position within the primary key, or 0 if not part of the key
-        let pk = primary_key_columns
-            .and_then(|pk_cols| column_pk_index(column, pk_cols))
-            .map(|index| (index + 1) as i64)
-            .unwrap_or(0);
+        // pk — 1-based position within the primary key, or 0 if not part of the key.
+        // B-tree tables use composite key order from schema; virtual tables fall back to
+        // the per-column primary key flag (always 0 or 1 for vtabs).
+        let pk = match primary_key_columns.and_then(|pk_cols| column_pk_index(column, pk_cols)) {
+            Some(index) => (index + 1) as i64,
+            None => {
+                if column.primary_key() {
+                    1
+                } else {
+                    0
+                }
+            }
+        };
         program.emit_int(pk, base_reg + 5);
 
         if extended {

--- a/sqlite/conformance/sqlite-sqltests/pragma/table_info_composite_pk.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/table_info_composite_pk.sqltest
@@ -1,0 +1,43 @@
+@database :memory:
+
+# Regression test for #7647: PRAGMA table_info pk is the 1-based position within
+# a composite primary key, not a boolean.
+test table-info-composite-primary-key {
+    CREATE TABLE t(a, b, c, d, PRIMARY KEY(c, a, d));
+    SELECT name, pk FROM pragma_table_info('t') ORDER BY cid;
+}
+expect {
+    a|2
+    b|0
+    c|1
+    d|3
+}
+
+test table-info-single-primary-key {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, x TEXT);
+    SELECT name, pk FROM pragma_table_info('t') ORDER BY cid;
+}
+expect {
+    id|1
+    x|0
+}
+
+test table-info-no-primary-key {
+    CREATE TABLE t(a, b);
+    SELECT name, pk FROM pragma_table_info('t') ORDER BY cid;
+}
+expect {
+    a|0
+    b|0
+}
+
+# View columns never report pk position, even when selecting from a table with a PK.
+test table-info-view {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b);
+    CREATE VIEW v AS SELECT * FROM t;
+    SELECT name, pk FROM pragma_table_info('v') ORDER BY cid;
+}
+expect {
+    a|0
+    b|0
+}

--- a/sqlite/conformance/sqlite-sqltests/pragma/table_info_materialized_view.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/table_info_materialized_view.sqltest
@@ -1,0 +1,15 @@
+@database :memory:
+@skip-file-if mvcc "materialized views not supported in MVCC mode"
+@skip-file-if sqlite "materialized views are a turso-specific feature"
+@requires materialized_views "requires materialized view support"
+
+# Materialized view output columns have no declared PRIMARY KEY metadata.
+test table-info-materialized-view {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b);
+    CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
+    SELECT name, pk FROM pragma_table_info('mv') ORDER BY cid;
+}
+expect {
+    a|0
+    b|0
+}


### PR DESCRIPTION
## Description

Fixes #7647.

`PRAGMA table_info` and `PRAGMA table_xinfo` previously returned `pk=1` for any primary-key column, including composite keys. SQLite returns the **1-based position** of each column within the composite key (e.g. for `PRIMARY KEY(c, a, d)`, column `c` is `1`, `a` is `2`, `d` is `3`).

This change looks up each column's position in `BTreeTable.primary_key_columns` and emits that value. Views and materialized views still report `pk=0` for all columns, matching SQLite.
Tests:
- `testing/sqltests/tests/pragma/table_info_composite_pk.sqltest` — composite PK, single PK, no PK, and view cases
- `testing/sqltests/tests/pragma/table_info_materialized_view.sqltest` — materialized view case (Turso-specific)

Note: SQLite returns pk = 0 for every column in PRAGMA table_info on a virtual table, even when the module schema declares an inline PRIMARY KEY. My initial changes did the same in Turso (all vtab columns got pk = 0), which broke pragma-table-info-hidden-columns in testing/system/vtab.test which expects key to report pk = 1 for the kv_store module (key TEXT PRIMARY KEY). Aligning with SQLite here would be a separate, intentional change.

## Motivation and context
Used this to familiarise myself with the codebase and conventions.

Fixes #7647.

## Description of AI Usage
Used Cursor with Composer 2.5Fast as a coding assistant while working on this issue. It helped explore the codebase, explore coding styles to ensure consistency, discuss different ways of implementing the fix including nuances around avoiding Arc / add ref, and write `.sqltest` cases.