### PR TITLE
fix duplicate rowid allocation in cdc instructions v2 emission

### DIFF
--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -778,7 +778,6 @@ fn emit_delete_row_common(
             };
             emit_cdc_insns(
                 program,
-                &t_ctx.resolver,
                 OperationMode::DELETE,
                 cdc_cursor_id,
                 rowid_reg,

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1201,7 +1201,6 @@ pub fn emit_cdc_full_record(
 #[allow(clippy::too_many_arguments)]
 pub fn emit_cdc_insns(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     operation_mode: OperationMode,
     cdc_cursor_id: usize,
     rowid_reg: usize,
@@ -1214,7 +1213,6 @@ pub fn emit_cdc_insns(
     match cdc_info.map(|info| info.cdc_version()) {
         Some(crate::CdcVersion::V2) => emit_cdc_insns_v2(
             program,
-            resolver,
             operation_mode,
             cdc_cursor_id,
             rowid_reg,
@@ -1225,7 +1223,6 @@ pub fn emit_cdc_insns(
         ),
         Some(crate::CdcVersion::V1) => emit_cdc_insns_v1(
             program,
-            resolver,
             operation_mode,
             cdc_cursor_id,
             rowid_reg,
@@ -1243,7 +1240,6 @@ pub fn emit_cdc_insns(
 #[allow(clippy::too_many_arguments)]
 fn emit_cdc_insns_v1(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     operation_mode: OperationMode,
     cdc_cursor_id: usize,
     rowid_reg: usize,
@@ -1260,11 +1256,8 @@ fn emit_cdc_insns_v1(
     });
     program.mark_last_insn_constant();
 
-    let Some(unixepoch_fn) = resolver.resolve_function("unixepoch", 0)? else {
-        bail_parse_error!("no function {}", "unixepoch");
-    };
     let unixepoch_fn_ctx = crate::function::FuncCtx {
-        func: unixepoch_fn,
+        func: Func::Scalar(crate::function::ScalarFunc::UnixEpoch),
         arg_count: 0,
     };
 
@@ -1356,7 +1349,6 @@ fn emit_cdc_insns_v1(
 #[allow(clippy::too_many_arguments)]
 fn emit_cdc_insns_v2(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     operation_mode: OperationMode,
     cdc_cursor_id: usize,
     rowid_reg: usize,
@@ -1374,11 +1366,8 @@ fn emit_cdc_insns_v2(
     program.mark_last_insn_constant();
 
     // change_time = unixepoch()
-    let Some(unixepoch_fn) = resolver.resolve_function("unixepoch", 0)? else {
-        bail_parse_error!("no function {}", "unixepoch");
-    };
     let unixepoch_fn_ctx = crate::function::FuncCtx {
-        func: unixepoch_fn,
+        func: Func::Scalar(crate::function::ScalarFunc::UnixEpoch),
         arg_count: 0,
     };
     program.emit_insn(Insn::Function {

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1396,11 +1396,8 @@ fn emit_cdc_insns_v2(
         rowid_reg: candidate_reg,
         prev_largest_reg: 0,
     });
-    let Some(conn_txn_id_fn) = resolver.resolve_function("conn_txn_id", 1)? else {
-        bail_parse_error!("no function {}", "conn_txn_id");
-    };
     let conn_txn_id_fn_ctx = crate::function::FuncCtx {
-        func: conn_txn_id_fn,
+        func: Func::Scalar(crate::function::ScalarFunc::ConnTxnId),
         arg_count: 1,
     };
     program.emit_insn(Insn::Function {
@@ -1466,13 +1463,6 @@ fn emit_cdc_insns_v2(
         program.mark_last_insn_constant();
     }
 
-    let rowid_reg = program.alloc_register();
-    program.emit_insn(Insn::NewRowid {
-        cursor: cdc_cursor_id,
-        rowid_reg,
-        prev_largest_reg: 0,
-    });
-
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
         start_reg: to_u16(turso_cdc_registers),
@@ -1484,7 +1474,7 @@ fn emit_cdc_insns_v2(
 
     program.emit_insn(Insn::Insert {
         cursor: cdc_cursor_id,
-        key_reg: rowid_reg,
+        key_reg: candidate_reg,
         record_reg,
         flag: InsertFlags::new()
             .skip_last_rowid()

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2565,7 +2565,6 @@ fn emit_update_insns<'a>(
                 if updates_rowid {
                     emit_cdc_insns(
                         program,
-                        &t_ctx.resolver,
                         OperationMode::DELETE,
                         cdc_cursor_id,
                         cdc_rowid_before_reg,
@@ -2576,7 +2575,6 @@ fn emit_update_insns<'a>(
                     )?;
                     emit_cdc_insns(
                         program,
-                        &t_ctx.resolver,
                         OperationMode::INSERT,
                         cdc_cursor_id,
                         cdc_rowid_after_reg,
@@ -2588,7 +2586,6 @@ fn emit_update_insns<'a>(
                 } else {
                     emit_cdc_insns(
                         program,
-                        &t_ctx.resolver,
                         OperationMode::UPDATE(if uses_write_set {
                             UpdateRowSource::PrebuiltEphemeralTable {
                                 ephemeral_table_cursor_id: iteration_cursor_id,

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1310,7 +1310,6 @@ pub fn translate_drop_index(
         };
         emit_cdc_insns(
             program,
-            resolver,
             OperationMode::DELETE,
             cdc_cursor_id,
             row_id_reg,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1089,7 +1089,6 @@ pub fn translate_insert(
         };
         emit_cdc_insns(
             program,
-            resolver,
             OperationMode::INSERT,
             *cdc_cursor_id,
             insertion.key_register(),
@@ -3873,7 +3872,6 @@ fn emit_replace_delete_conflicting_row(
         };
         emit_cdc_insns(
             program,
-            resolver,
             OperationMode::DELETE,
             cdc_cursor_id,
             ctx.conflict_rowid_reg,

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1554,7 +1554,6 @@ pub fn emit_schema_entry(
         };
         emit_cdc_insns(
             program,
-            resolver,
             OperationMode::INSERT,
             cdc_table_cursor_id,
             rowid_reg,
@@ -1914,7 +1913,6 @@ pub fn translate_drop_table(
         };
         emit_cdc_insns(
             program,
-            resolver,
             OperationMode::DELETE,
             cdc_cursor_id,
             row_id_reg,

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -1281,7 +1281,6 @@ pub fn emit_upsert(
             };
             emit_cdc_insns(
                 program,
-                resolver,
                 OperationMode::DELETE,
                 cdc_id,
                 ctx.conflict_rowid_reg,
@@ -1301,7 +1300,6 @@ pub fn emit_upsert(
             };
             emit_cdc_insns(
                 program,
-                resolver,
                 OperationMode::INSERT,
                 cdc_id,
                 new_rowid,
@@ -1336,7 +1334,6 @@ pub fn emit_upsert(
             };
             emit_cdc_insns(
                 program,
-                resolver,
                 OperationMode::UPDATE(UpdateRowSource::Normal),
                 cdc_id,
                 ctx.conflict_rowid_reg,


### PR DESCRIPTION
This keeps being fixed on mvcc sync branch which enables CDC for MVCC and it seemed like it should be extracted out to a quick fix PR.
