### PR TITLE
add allocator-aware arc-swap support

### DIFF
--- a/vendor/arc-swap/Cargo.toml
+++ b/vendor/arc-swap/Cargo.toml
@@ -34,6 +34,9 @@ features = [
     "weak",
 ]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }
+
 [profile.bench]
 debug = 2
 

--- a/vendor/arc-swap/src/access.rs
+++ b/vendor/arc-swap/src/access.rs
@@ -90,6 +90,8 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::sync::Arc;
 
+#[cfg(nightly)]
+use super::ref_cnt::ArcSwapAllocator;
 use super::ref_cnt::RefCnt;
 use super::strategy::Strategy;
 use super::{ArcSwapAny, Guard};
@@ -156,6 +158,7 @@ impl<T: RefCnt, S: Strategy<T>> Access<T> for ArcSwapAny<T, S> {
 #[doc(hidden)]
 pub struct DirectDeref<T: RefCnt, S: Strategy<T>>(Guard<T, S>);
 
+#[cfg(not(nightly))]
 impl<T, S: Strategy<Arc<T>>> Deref for DirectDeref<Arc<T>, S> {
     type Target = T;
     fn deref(&self) -> &T {
@@ -163,8 +166,33 @@ impl<T, S: Strategy<Arc<T>>> Deref for DirectDeref<Arc<T>, S> {
     }
 }
 
+#[cfg(nightly)]
+impl<T, A, S> Deref for DirectDeref<Arc<T, A>, S>
+where
+    A: ArcSwapAllocator,
+    S: Strategy<Arc<T, A>>,
+{
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.0.deref().deref()
+    }
+}
+
+#[cfg(not(nightly))]
 impl<T, S: Strategy<Arc<T>>> Access<T> for ArcSwapAny<Arc<T>, S> {
     type Guard = DirectDeref<Arc<T>, S>;
+    fn load(&self) -> Self::Guard {
+        DirectDeref(self.load())
+    }
+}
+
+#[cfg(nightly)]
+impl<T, A, S> Access<T> for ArcSwapAny<Arc<T, A>, S>
+where
+    A: ArcSwapAllocator,
+    S: Strategy<Arc<T, A>>,
+{
+    type Guard = DirectDeref<Arc<T, A>, S>;
     fn load(&self) -> Self::Guard {
         DirectDeref(self.load())
     }

--- a/vendor/arc-swap/src/debt/list.rs
+++ b/vendor/arc-swap/src/debt/list.rs
@@ -139,7 +139,7 @@ impl Node {
     }
 
     /// Mark this node that a writer is currently playing with it.
-    pub fn reserve_writer(&self) -> NodeReservation {
+    pub fn reserve_writer(&self) -> NodeReservation<'_> {
         self.active_writers.fetch_add(1, Acquire);
         NodeReservation(self)
     }
@@ -194,7 +194,7 @@ impl Node {
     }
 
     /// Iterate over the fast slots.
-    pub(crate) fn fast_slots(&self) -> Iter<Debt> {
+    pub(crate) fn fast_slots(&self) -> Iter<'_, Debt> {
         self.fast.into_iter()
     }
 

--- a/vendor/arc-swap/src/debt/mod.rs
+++ b/vendor/arc-swap/src/debt/mod.rs
@@ -78,13 +78,18 @@ impl Debt {
     }
 
     /// Pays all the debts on the given pointer and the storage.
-    pub(crate) fn pay_all<T, R>(ptr: *const T::Base, storage_addr: usize, replacement: R)
+    pub(crate) fn pay_all<T, R>(
+        ptr: *const T::Base,
+        storage_addr: usize,
+        replacement: R,
+        allocator: &T::Allocator,
+    )
     where
         T: RefCnt,
         R: Fn() -> T,
     {
         LocalNode::with(|local| {
-            let val = unsafe { T::from_ptr(ptr) };
+            let val = unsafe { T::from_ptr(ptr, allocator) };
             // Pre-pay one ref count that can be safely put into a debt slot to pay it.
             T::inc(&val);
 

--- a/vendor/arc-swap/src/lib.rs
+++ b/vendor/arc-swap/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(deprecated)]
+#![cfg_attr(nightly, feature(allocator_api))]
 #![cfg_attr(feature = "experimental-thread-local", no_std)]
 #![cfg_attr(feature = "experimental-thread-local", feature(thread_local))]
 
@@ -154,6 +155,8 @@ use alloc::sync::Arc;
 use crate::access::{Access, Map};
 pub use crate::as_raw::AsRaw;
 pub use crate::cache::Cache;
+#[cfg(nightly)]
+pub use crate::ref_cnt::ArcSwapAllocator;
 pub use crate::ref_cnt::RefCnt;
 use crate::strategy::hybrid::{DefaultConfig, HybridStrategy};
 use crate::strategy::sealed::Protected;
@@ -304,10 +307,16 @@ where
 /// [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 /// [`from`]: https://doc.rust-lang.org/nightly/std/convert/trait.From.html#tymethod.from
 /// [`RefCnt`]: trait.RefCnt.html
-pub struct ArcSwapAny<T: RefCnt, S: Strategy<T> = DefaultStrategy> {
+pub struct ArcSwapAny<
+    T: RefCnt<Allocator = A>,
+    S: Strategy<T> = DefaultStrategy,
+    A: Clone + Default = <T as RefCnt>::Allocator,
+> {
     // Notes: AtomicPtr needs Sized
     /// The actual pointer, extracted from the Arc.
     ptr: AtomicPtr<T::Base>,
+    /// Allocator/context used to reconstruct pointers from raw storage.
+    allocator: A,
 
     /// We are basically an Arc in disguise. Inherit parameters from Arc by pretending to contain
     /// it.
@@ -317,27 +326,40 @@ pub struct ArcSwapAny<T: RefCnt, S: Strategy<T> = DefaultStrategy> {
     strategy: S,
 }
 
-impl<T: RefCnt, S: Default + Strategy<T>> From<T> for ArcSwapAny<T, S> {
+impl<T, S, A> From<T> for ArcSwapAny<T, S, A>
+where
+    T: RefCnt<Allocator = A>,
+    S: Default + Strategy<T>,
+    A: Clone + Default,
+{
     fn from(val: T) -> Self {
         Self::with_strategy(val, S::default())
     }
 }
 
-impl<T: RefCnt, S: Strategy<T>> Drop for ArcSwapAny<T, S> {
+impl<T, S, A> Drop for ArcSwapAny<T, S, A>
+where
+    T: RefCnt<Allocator = A>,
+    S: Strategy<T>,
+    A: Clone + Default,
+{
     fn drop(&mut self) {
         let ptr = *self.ptr.get_mut();
         unsafe {
             // To pay any possible debts
-            self.strategy.wait_for_readers(ptr, &self.ptr);
+            self.strategy
+                .wait_for_readers(ptr, &self.ptr, &self.allocator);
             // We are getting rid of the one stored ref count
-            T::dec(ptr);
+            T::dec(ptr, &self.allocator);
         }
     }
 }
 
-impl<T, S: Strategy<T>> Debug for ArcSwapAny<T, S>
+impl<T, S, A> Debug for ArcSwapAny<T, S, A>
 where
-    T: Debug + RefCnt,
+    T: Debug + RefCnt<Allocator = A>,
+    S: Strategy<T>,
+    A: Clone + Default,
 {
     fn fmt(&self, formatter: &mut Formatter) -> FmtResult {
         formatter
@@ -347,22 +369,34 @@ where
     }
 }
 
-impl<T, S: Strategy<T>> Display for ArcSwapAny<T, S>
+impl<T, S, A> Display for ArcSwapAny<T, S, A>
 where
-    T: Display + RefCnt,
+    T: Display + RefCnt<Allocator = A>,
+    S: Strategy<T>,
+    A: Clone + Default,
 {
     fn fmt(&self, formatter: &mut Formatter) -> FmtResult {
         self.load().fmt(formatter)
     }
 }
 
-impl<T: RefCnt + Default, S: Default + Strategy<T>> Default for ArcSwapAny<T, S> {
+impl<T, S, A> Default for ArcSwapAny<T, S, A>
+where
+    T: RefCnt<Allocator = A> + Default,
+    S: Default + Strategy<T>,
+    A: Clone + Default,
+{
     fn default() -> Self {
         Self::new(T::default())
     }
 }
 
-impl<T: RefCnt, S: Strategy<T>> ArcSwapAny<T, S> {
+impl<T, S, A> ArcSwapAny<T, S, A>
+where
+    T: RefCnt<Allocator = A>,
+    S: Strategy<T>,
+    A: Clone + Default,
+{
     /// Constructs a new storage.
     pub fn new(val: T) -> Self
     where
@@ -371,14 +405,29 @@ impl<T: RefCnt, S: Strategy<T>> ArcSwapAny<T, S> {
         Self::from(val)
     }
 
+    /// Constructs a new storage with an explicit allocator/context.
+    pub fn new_in(val: T, allocator: A) -> Self
+    where
+        S: Default,
+    {
+        Self::with_strategy_in(val, S::default(), allocator)
+    }
+
     /// Constructs a new storage while customizing the protection strategy.
     pub fn with_strategy(val: T, strategy: S) -> Self {
+        let allocator = T::allocator(&val);
+        Self::with_strategy_in(val, strategy, allocator)
+    }
+
+    /// Constructs a new storage with an explicit allocator/context.
+    pub fn with_strategy_in(val: T, strategy: S, allocator: A) -> Self {
         // The AtomicPtr requires *mut in its interface. We are more like *const, so we cast it.
         // However, we always go back to *const right away when we get the pointer on the other
         // side, so it should be fine.
         let ptr = T::into_ptr(val);
         Self {
             ptr: AtomicPtr::new(ptr),
+            allocator,
             _phantom_arc: PhantomData,
             strategy,
         }
@@ -388,9 +437,13 @@ impl<T: RefCnt, S: Strategy<T>> ArcSwapAny<T, S> {
     pub fn into_inner(mut self) -> T {
         let ptr = *self.ptr.get_mut();
         // To pay all the debts
-        unsafe { self.strategy.wait_for_readers(ptr, &self.ptr) };
+        unsafe {
+            self.strategy
+                .wait_for_readers(ptr, &self.ptr, &self.allocator)
+        };
+        let allocator = self.allocator.clone();
         mem::forget(self);
-        unsafe { T::from_ptr(ptr) }
+        unsafe { T::from_ptr(ptr, &allocator) }
     }
 
     /// Loads the value.
@@ -451,7 +504,7 @@ impl<T: RefCnt, S: Strategy<T>> ArcSwapAny<T, S> {
     /// ```
     #[inline]
     pub fn load(&self) -> Guard<T, S> {
-        let protected = unsafe { self.strategy.load(&self.ptr) };
+        let protected = unsafe { self.strategy.load(&self.ptr, &self.allocator) };
         Guard { inner: protected }
     }
 
@@ -471,8 +524,9 @@ impl<T: RefCnt, S: Strategy<T>> ArcSwapAny<T, S> {
         // SeqCst to synchronize the time lines with the group counters.
         let old = self.ptr.swap(new, Ordering::SeqCst);
         unsafe {
-            self.strategy.wait_for_readers(old, &self.ptr);
-            T::from_ptr(old)
+            self.strategy
+                .wait_for_readers(old, &self.ptr, &self.allocator);
+            T::from_ptr(old, &self.allocator)
         }
     }
 
@@ -497,7 +551,8 @@ impl<T: RefCnt, S: Strategy<T>> ArcSwapAny<T, S> {
         C: AsRaw<T::Base>,
         S: CaS<T>,
     {
-        let protected = unsafe { self.strategy.compare_and_swap(&self.ptr, current, new) };
+        let protected =
+            unsafe { self.strategy.compare_and_swap(&self.ptr, current, new, &self.allocator) };
         Guard { inner: protected }
     }
 
@@ -682,8 +737,17 @@ impl<T: RefCnt, S: Strategy<T>> ArcSwapAny<T, S> {
 ///
 /// This is a type alias only. Most of its methods are described on
 /// [`ArcSwapAny`](struct.ArcSwapAny.html).
+#[cfg(not(nightly))]
 pub type ArcSwap<T> = ArcSwapAny<Arc<T>>;
 
+/// An atomic storage for `Arc`.
+///
+/// This is a type alias only. Most of its methods are described on
+/// [`ArcSwapAny`](struct.ArcSwapAny.html).
+#[cfg(nightly)]
+pub type ArcSwap<T, A = alloc::alloc::Global> = ArcSwapAny<Arc<T, A>, DefaultStrategy, A>;
+
+#[cfg(not(nightly))]
 impl<T, S: Strategy<Arc<T>>> ArcSwapAny<Arc<T>, S> {
     /// A convenience constructor directly from the pointed-to value.
     ///
@@ -693,6 +757,37 @@ impl<T, S: Strategy<Arc<T>>> ArcSwapAny<Arc<T>, S> {
         S: Default,
     {
         Self::from(Arc::new(val))
+    }
+}
+
+#[cfg(nightly)]
+impl<T, S> ArcSwapAny<Arc<T, alloc::alloc::Global>, S>
+where
+    S: Strategy<Arc<T, alloc::alloc::Global>>,
+{
+    /// A convenience constructor directly from the pointed-to value.
+    ///
+    /// Direct equivalent for `ArcSwap::new(Arc::new(val))`.
+    pub fn from_pointee(val: T) -> Self
+    where
+        S: Default,
+    {
+        Self::from_pointee_in(val, alloc::alloc::Global)
+    }
+}
+
+#[cfg(nightly)]
+impl<T, A, S> ArcSwapAny<Arc<T, A>, S>
+where
+    A: ArcSwapAllocator,
+    S: Strategy<Arc<T, A>>,
+{
+    /// A convenience constructor directly from the pointed-to value and allocator.
+    pub fn from_pointee_in(val: T, allocator: A) -> Self
+    where
+        S: Default,
+    {
+        Self::new_in(Arc::new_in(val, allocator.clone()), allocator)
     }
 }
 
@@ -716,8 +811,18 @@ impl<T, S: Strategy<Arc<T>>> ArcSwapAny<Arc<T>, S> {
 /// assert!(shared.swap(Some(Arc::new(42))).is_none());
 /// assert_eq!(42, **shared.load_full().as_ref().unwrap());
 /// ```
+#[cfg(not(nightly))]
 pub type ArcSwapOption<T> = ArcSwapAny<Option<Arc<T>>>;
 
+/// An atomic storage for `Option<Arc>`.
+///
+/// This is very similar to [`ArcSwap`](type.ArcSwap.html), but allows storing NULL values, which
+/// is useful in some situations.
+#[cfg(nightly)]
+pub type ArcSwapOption<T, A = alloc::alloc::Global> =
+    ArcSwapAny<Option<Arc<T, A>>, DefaultStrategy, A>;
+
+#[cfg(not(nightly))]
 impl<T, S: Strategy<Option<Arc<T>>>> ArcSwapAny<Option<Arc<T>>, S> {
     /// A convenience constructor directly from a pointed-to value.
     ///
@@ -751,6 +856,57 @@ impl<T, S: Strategy<Option<Arc<T>>>> ArcSwapAny<Option<Arc<T>>, S> {
     }
 }
 
+#[cfg(nightly)]
+impl<T, S> ArcSwapAny<Option<Arc<T, alloc::alloc::Global>>, S>
+where
+    S: Strategy<Option<Arc<T, alloc::alloc::Global>>>,
+{
+    /// A convenience constructor directly from a pointed-to value.
+    ///
+    /// This just allocates the `Arc` under the hood.
+    pub fn from_pointee<V: Into<Option<T>>>(val: V) -> Self
+    where
+        S: Default,
+    {
+        Self::from_pointee_in(val, alloc::alloc::Global)
+    }
+
+    /// A convenience constructor for an empty value.
+    ///
+    /// This is equivalent to `ArcSwapOption::new(None)`.
+    pub fn empty() -> Self
+    where
+        S: Default,
+    {
+        Self::empty_in(alloc::alloc::Global)
+    }
+}
+
+#[cfg(nightly)]
+impl<T, A, S> ArcSwapAny<Option<Arc<T, A>>, S>
+where
+    A: ArcSwapAllocator,
+    S: Strategy<Option<Arc<T, A>>>,
+{
+    /// A convenience constructor directly from a pointed-to value and allocator.
+    pub fn from_pointee_in<V: Into<Option<T>>>(val: V, allocator: A) -> Self
+    where
+        S: Default,
+    {
+        let val = val.into().map(|val| Arc::new_in(val, allocator.clone()));
+        Self::new_in(val, allocator)
+    }
+
+    /// A convenience constructor for an empty value with an explicit allocator.
+    pub fn empty_in(allocator: A) -> Self
+    where
+        S: Default,
+    {
+        Self::new_in(None, allocator)
+    }
+}
+
+#[cfg(not(nightly))]
 impl<T> ArcSwapOption<T> {
     /// A const-fn equivalent of [empty].
     ///
@@ -774,6 +930,28 @@ impl<T> ArcSwapOption<T> {
     pub const fn const_empty() -> Self {
         Self {
             ptr: AtomicPtr::new(ptr::null_mut()),
+            allocator: (),
+            _phantom_arc: PhantomData,
+            strategy: HybridStrategy {
+                _config: DefaultConfig,
+            },
+        }
+    }
+}
+
+#[cfg(nightly)]
+impl<T> ArcSwapOption<T> {
+    /// A const-fn equivalent of [empty].
+    ///
+    /// Just like [empty], this creates an `None`-holding `ArcSwapOption`. The [empty] is, however,
+    /// more general ‒ this is available only for the default strategy, while [empty] is for any
+    /// [Default]-constructible strategy (current or future one).
+    ///
+    /// [empty]: ArcSwapAny::empty
+    pub const fn const_empty() -> Self {
+        Self {
+            ptr: AtomicPtr::new(ptr::null_mut()),
+            allocator: alloc::alloc::Global,
             _phantom_arc: PhantomData,
             strategy: HybridStrategy {
                 _config: DefaultConfig,
@@ -790,7 +968,16 @@ impl<T> ArcSwapOption<T> {
 /// See the [`IndependentStrategy`] for further details.
 // Being phased out. Will deprecate once we verify in production that the new strategy works fine.
 #[doc(hidden)]
+#[cfg(not(nightly))]
 pub type IndependentArcSwap<T> = ArcSwapAny<Arc<T>, IndependentStrategy>;
+
+/// An atomic storage that doesn't share the internal generation locks with others.
+///
+/// See the [`IndependentStrategy`] for further details.
+#[doc(hidden)]
+#[cfg(nightly)]
+pub type IndependentArcSwap<T, A = alloc::alloc::Global> =
+    ArcSwapAny<Arc<T, A>, IndependentStrategy, A>;
 
 /// Arc swap for the [Weak] pointer.
 ///
@@ -803,8 +990,55 @@ pub type IndependentArcSwap<T> = ArcSwapAny<Arc<T>, IndependentStrategy>;
 /// Needs the `weak` feature turned on.
 ///
 /// [Weak]: std::sync::Weak
-#[cfg(feature = "weak")]
+#[cfg(all(feature = "weak", not(nightly)))]
 pub type ArcSwapWeak<T> = ArcSwapAny<alloc::sync::Weak<T>>;
+
+/// Arc swap for the [Weak] pointer.
+///
+/// Needs the `weak` feature turned on.
+#[cfg(all(feature = "weak", nightly))]
+pub type ArcSwapWeak<T, A = alloc::alloc::Global> =
+    ArcSwapAny<alloc::sync::Weak<T, A>, DefaultStrategy, A>;
+
+#[cfg(all(test, nightly))]
+mod allocator_tests {
+    use alloc::alloc::{AllocError, Allocator, Global, Layout};
+    use alloc::sync::Arc;
+    use core::ptr::NonNull;
+
+    use super::{ArcSwapAllocator, ArcSwapOption};
+
+    #[derive(Clone, Default)]
+    struct TestAllocator;
+
+    unsafe impl Allocator for TestAllocator {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            <Global as Allocator>::allocate(&Global, layout)
+        }
+
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+            unsafe {
+                <Global as Allocator>::deallocate(&Global, ptr, layout);
+            }
+        }
+    }
+
+    unsafe impl ArcSwapAllocator for TestAllocator {}
+
+    #[test]
+    fn option_empty_in_preserves_allocator_for_later_store() {
+        let allocator = TestAllocator;
+        let shared = ArcSwapOption::<usize, TestAllocator>::empty_in(allocator.clone());
+
+        shared.store(Some(Arc::new_in(42, allocator.clone())));
+
+        let loaded = shared.load_full();
+        assert_eq!(42, **loaded.as_ref().unwrap());
+        let previous = shared.swap(None);
+        assert_eq!(42, **previous.as_ref().unwrap());
+        assert!(shared.load_full().is_none());
+    }
+}
 
 macro_rules! t {
     ($name: ident, $strategy: ty) => {

--- a/vendor/arc-swap/src/ref_cnt.rs
+++ b/vendor/arc-swap/src/ref_cnt.rs
@@ -1,8 +1,22 @@
+#[cfg(nightly)]
+use alloc::alloc::{Allocator, Global};
 use core::mem;
 use core::ptr;
 
 use alloc::rc::Rc;
 use alloc::sync::Arc;
+
+/// Allocator values that can be used by `arc-swap`.
+///
+/// `ArcSwapAny` stores one allocator context and uses it whenever it rebuilds
+/// an allocator-aware pointer from its raw pointee. The allocator type is part
+/// of the `ArcSwapAny` type, so values stored in the container use the same
+/// allocator generic.
+#[cfg(nightly)]
+pub unsafe trait ArcSwapAllocator: Allocator + Clone + Default {}
+
+#[cfg(nightly)]
+unsafe impl ArcSwapAllocator for Global {}
 
 /// A trait describing smart reference counted pointers.
 ///
@@ -39,6 +53,11 @@ use alloc::sync::Arc;
 pub unsafe trait RefCnt: Clone {
     /// The base type the pointer points to.
     type Base;
+    /// Context needed to reconstruct a smart pointer from its raw pointer.
+    type Allocator: Clone + Default;
+
+    /// Returns the allocator/context associated with this pointer.
+    fn allocator(me: &Self) -> Self::Allocator;
 
     /// Converts the smart pointer into a raw pointer, without affecting the reference count.
     ///
@@ -65,7 +84,7 @@ pub unsafe trait RefCnt: Clone {
     /// # Safety
     ///
     /// This must not be called by code outside of this crate.
-    unsafe fn from_ptr(ptr: *const Self::Base) -> Self;
+    unsafe fn from_ptr(ptr: *const Self::Base, allocator: &Self::Allocator) -> Self;
 
     /// Increments the reference count by one.
     ///
@@ -83,13 +102,18 @@ pub unsafe trait RefCnt: Clone {
     /// # Safety
     ///
     /// This must not be called by code outside of this crate.
-    unsafe fn dec(ptr: *const Self::Base) {
-        drop(Self::from_ptr(ptr));
+    unsafe fn dec(ptr: *const Self::Base, allocator: &Self::Allocator) {
+        drop(Self::from_ptr(ptr, allocator));
     }
 }
 
+#[cfg(not(nightly))]
 unsafe impl<T> RefCnt for Arc<T> {
     type Base = T;
+    type Allocator = ();
+
+    fn allocator(_me: &Self) -> Self::Allocator {}
+
     fn into_ptr(me: Arc<T>) -> *mut T {
         Arc::into_raw(me) as *mut T
     }
@@ -118,13 +142,42 @@ unsafe impl<T> RefCnt for Arc<T> {
 
         ptr
     }
-    unsafe fn from_ptr(ptr: *const T) -> Arc<T> {
+    unsafe fn from_ptr(ptr: *const T, _allocator: &Self::Allocator) -> Arc<T> {
         Arc::from_raw(ptr)
+    }
+}
+
+#[cfg(nightly)]
+unsafe impl<T, A> RefCnt for Arc<T, A>
+where
+    A: ArcSwapAllocator,
+{
+    type Base = T;
+    type Allocator = A;
+
+    fn allocator(me: &Self) -> Self::Allocator {
+        Arc::allocator(me).clone()
+    }
+
+    fn into_ptr(me: Arc<T, A>) -> *mut T {
+        Arc::into_raw_with_allocator(me).0 as *mut T
+    }
+
+    fn as_ptr(me: &Arc<T, A>) -> *mut T {
+        Arc::as_ptr(me) as *mut T
+    }
+
+    unsafe fn from_ptr(ptr: *const T, allocator: &Self::Allocator) -> Arc<T, A> {
+        Arc::from_raw_in(ptr, allocator.clone())
     }
 }
 
 unsafe impl<T> RefCnt for Rc<T> {
     type Base = T;
+    type Allocator = ();
+
+    fn allocator(_me: &Self) -> Self::Allocator {}
+
     fn into_ptr(me: Rc<T>) -> *mut T {
         Rc::into_raw(me) as *mut T
     }
@@ -153,24 +206,30 @@ unsafe impl<T> RefCnt for Rc<T> {
 
         ptr
     }
-    unsafe fn from_ptr(ptr: *const T) -> Rc<T> {
+    unsafe fn from_ptr(ptr: *const T, _allocator: &Self::Allocator) -> Rc<T> {
         Rc::from_raw(ptr)
     }
 }
 
 unsafe impl<T: RefCnt> RefCnt for Option<T> {
     type Base = T::Base;
+    type Allocator = T::Allocator;
+
+    fn allocator(me: &Self) -> Self::Allocator {
+        me.as_ref().map(T::allocator).unwrap_or_default()
+    }
+
     fn into_ptr(me: Option<T>) -> *mut T::Base {
         me.map(T::into_ptr).unwrap_or_else(ptr::null_mut)
     }
     fn as_ptr(me: &Option<T>) -> *mut T::Base {
         me.as_ref().map(T::as_ptr).unwrap_or_else(ptr::null_mut)
     }
-    unsafe fn from_ptr(ptr: *const T::Base) -> Option<T> {
+    unsafe fn from_ptr(ptr: *const T::Base, allocator: &Self::Allocator) -> Option<T> {
         if ptr.is_null() {
             None
         } else {
-            Some(T::from_ptr(ptr))
+            Some(T::from_ptr(ptr, allocator))
         }
     }
 }

--- a/vendor/arc-swap/src/strategy/hybrid.rs
+++ b/vendor/arc-swap/src/strategy/hybrid.rs
@@ -30,16 +30,24 @@ pub struct HybridProtection<T: RefCnt> {
 }
 
 impl<T: RefCnt> HybridProtection<T> {
-    pub(super) unsafe fn new(ptr: *const T::Base, debt: Option<&'static Debt>) -> Self {
+    pub(super) unsafe fn new(
+        ptr: *const T::Base,
+        debt: Option<&'static Debt>,
+        allocator: &T::Allocator,
+    ) -> Self {
         Self {
             debt,
-            ptr: ManuallyDrop::new(T::from_ptr(ptr)),
+            ptr: ManuallyDrop::new(T::from_ptr(ptr, allocator)),
         }
     }
 
     /// Try getting a dept into a fast slot.
     #[inline]
-    fn attempt(node: &LocalNode, storage: &AtomicPtr<T::Base>) -> Option<Self> {
+    fn attempt(
+        node: &LocalNode,
+        storage: &AtomicPtr<T::Base>,
+        allocator: &T::Allocator,
+    ) -> Option<Self> {
         // Relaxed is good enough here, see the Acquire below
         let ptr = storage.load(Relaxed);
         // Try to get a debt slot. If not possible, fail.
@@ -51,7 +59,7 @@ impl<T: RefCnt> HybridProtection<T> {
         let confirm = storage.load(SeqCst);
         if ptr == confirm {
             // Successfully got a debt
-            Some(unsafe { Self::new(ptr, Some(debt)) })
+            Some(unsafe { Self::new(ptr, Some(debt), allocator) })
         } else if debt.pay::<T>(ptr) {
             // It changed in the meantime, we return the debt (that is on the outdated pointer,
             // possibly destroyed) and fail.
@@ -59,12 +67,16 @@ impl<T: RefCnt> HybridProtection<T> {
         } else {
             // It changed in the meantime, but the debt for the previous pointer was already paid
             // for by someone else, so we are fine using it.
-            Some(unsafe { Self::new(ptr, None) })
+            Some(unsafe { Self::new(ptr, None, allocator) })
         }
     }
 
     /// Get a debt slot using the slower but always successful mechanism.
-    fn fallback(node: &LocalNode, storage: &AtomicPtr<T::Base>) -> Self {
+    fn fallback(
+        node: &LocalNode,
+        storage: &AtomicPtr<T::Base>,
+        allocator: &T::Allocator,
+    ) -> Self {
         // First, we claim a debt slot and store the address of the atomic pointer there, so the
         // writer can optionally help us out with loading and protecting something.
         let gen = node.new_helping(storage as *const _ as usize);
@@ -78,17 +90,17 @@ impl<T: RefCnt> HybridProtection<T> {
         match node.confirm_helping(gen, candidate as usize) {
             Ok(debt) => {
                 // The fast path -> we got the debt confirmed alright.
-                Self::from_inner(unsafe { Self::new(candidate, Some(debt)).into_inner() })
+                Self::from_inner(unsafe { Self::new(candidate, Some(debt), allocator).into_inner() })
             }
             Err((unused_debt, replacement)) => {
                 // The debt is on the candidate we provided and it is unused, we so we just pay it
                 // back right away.
                 if !unused_debt.pay::<T>(candidate) {
-                    unsafe { T::dec(candidate) };
+                    unsafe { T::dec(candidate, allocator) };
                 }
                 // We got a (possibly) different pointer out. But that one is already protected and
                 // the slot is paid back.
-                unsafe { Self::new(replacement as *mut _, None) }
+                unsafe { Self::new(replacement as *mut _, None, allocator) }
             }
         }
     }
@@ -140,7 +152,8 @@ impl<T: RefCnt> Protected<T> for HybridProtection<T> {
             Some(debt) => {
                 let ptr = T::inc(&self.ptr);
                 if !debt.pay::<T>(ptr) {
-                    unsafe { T::dec(ptr) };
+                    let allocator = T::allocator(&self.ptr);
+                    unsafe { T::dec(ptr, &allocator) };
                 }
             }
         }
@@ -183,23 +196,32 @@ where
     Cfg: Config,
 {
     type Protected = HybridProtection<T>;
-    unsafe fn load(&self, storage: &AtomicPtr<T::Base>) -> Self::Protected {
+    unsafe fn load(
+        &self,
+        storage: &AtomicPtr<T::Base>,
+        allocator: &T::Allocator,
+    ) -> Self::Protected {
         LocalNode::with(|node| {
             let fast = if Cfg::USE_FAST {
-                HybridProtection::attempt(node, storage)
+                HybridProtection::attempt(node, storage, allocator)
             } else {
                 None
             };
-            fast.unwrap_or_else(|| HybridProtection::fallback(node, storage))
+            fast.unwrap_or_else(|| HybridProtection::fallback(node, storage, allocator))
         })
     }
-    unsafe fn wait_for_readers(&self, old: *const T::Base, storage: &AtomicPtr<T::Base>) {
+    unsafe fn wait_for_readers(
+        &self,
+        old: *const T::Base,
+        storage: &AtomicPtr<T::Base>,
+        allocator: &T::Allocator,
+    ) {
         // The pay_all may need to provide fresh replacement values if someone else is loading from
         // this particular storage. We do so by the exact same way, by `load` ‒ it's OK, a writer
         // does not hold a slot and the reader doesn't recurse back into writer, so we won't run
         // out of slots.
-        let replacement = || self.load(storage).into_inner();
-        Debt::pay_all::<T, _>(old, storage as *const _ as usize, replacement);
+        let replacement = || self.load(storage, allocator).into_inner();
+        Debt::pay_all::<T, _>(old, storage as *const _ as usize, replacement, allocator);
     }
 }
 
@@ -209,9 +231,10 @@ impl<T: RefCnt, Cfg: Config> CaS<T> for HybridStrategy<Cfg> {
         storage: &AtomicPtr<T::Base>,
         current: C,
         new: T,
+        allocator: &T::Allocator,
     ) -> Self::Protected {
         loop {
-            let old = <Self as InnerStrategy<T>>::load(self, storage);
+            let old = <Self as InnerStrategy<T>>::load(self, storage, allocator);
             // Observation of their inequality is enough to make a verdict
             if old.as_ptr() != current.as_raw() {
                 return old;
@@ -224,10 +247,15 @@ impl<T: RefCnt, Cfg: Config> CaS<T> for HybridStrategy<Cfg> {
             {
                 // We successfully put the new value in. The ref count went in there too.
                 T::into_ptr(new);
-                <Self as InnerStrategy<T>>::wait_for_readers(self, old.as_ptr(), storage);
+                <Self as InnerStrategy<T>>::wait_for_readers(
+                    self,
+                    old.as_ptr(),
+                    storage,
+                    allocator,
+                );
                 // We just got one ref count out of the storage and we have one in old. We don't
                 // need two.
-                T::dec(old.as_ptr());
+                T::dec(old.as_ptr(), allocator);
                 return old;
             }
         }

--- a/vendor/arc-swap/src/strategy/mod.rs
+++ b/vendor/arc-swap/src/strategy/mod.rs
@@ -132,8 +132,17 @@ pub(crate) mod sealed {
     pub trait InnerStrategy<T: RefCnt> {
         // Drop „unlocks“
         type Protected: Protected<T>;
-        unsafe fn load(&self, storage: &AtomicPtr<T::Base>) -> Self::Protected;
-        unsafe fn wait_for_readers(&self, old: *const T::Base, storage: &AtomicPtr<T::Base>);
+        unsafe fn load(
+            &self,
+            storage: &AtomicPtr<T::Base>,
+            allocator: &T::Allocator,
+        ) -> Self::Protected;
+        unsafe fn wait_for_readers(
+            &self,
+            old: *const T::Base,
+            storage: &AtomicPtr<T::Base>,
+            allocator: &T::Allocator,
+        );
     }
 
     pub trait CaS<T: RefCnt>: InnerStrategy<T> {
@@ -142,6 +151,7 @@ pub(crate) mod sealed {
             storage: &AtomicPtr<T::Base>,
             current: C,
             new: T,
+            allocator: &T::Allocator,
         ) -> Self::Protected;
     }
 }

--- a/vendor/arc-swap/src/strategy/rw_lock.rs
+++ b/vendor/arc-swap/src/strategy/rw_lock.rs
@@ -20,16 +20,21 @@ impl<T: RefCnt> Protected<T> for T {
 
 impl<T: RefCnt> InnerStrategy<T> for RwLock<()> {
     type Protected = T;
-    unsafe fn load(&self, storage: &AtomicPtr<T::Base>) -> T {
+    unsafe fn load(&self, storage: &AtomicPtr<T::Base>, allocator: &T::Allocator) -> T {
         let _guard = self.read().expect("We don't panic in here");
         let ptr = storage.load(Ordering::Acquire);
-        let ptr = T::from_ptr(ptr as *const T::Base);
+        let ptr = T::from_ptr(ptr as *const T::Base, allocator);
         T::inc(&ptr);
 
         ptr
     }
 
-    unsafe fn wait_for_readers(&self, _: *const T::Base, _: &AtomicPtr<T::Base>) {
+    unsafe fn wait_for_readers(
+        &self,
+        _: *const T::Base,
+        _: &AtomicPtr<T::Base>,
+        _: &T::Allocator,
+    ) {
         // By acquiring the write lock, we make sure there are no read locks present across it.
         drop(self.write().expect("We don't panic in here"));
     }
@@ -41,6 +46,7 @@ impl<T: RefCnt> CaS<T> for RwLock<()> {
         storage: &AtomicPtr<T::Base>,
         current: C,
         new: T,
+        allocator: &T::Allocator,
     ) -> Self::Protected {
         let _lock = self.write();
         let cur = current.as_raw();
@@ -50,12 +56,12 @@ impl<T: RefCnt> CaS<T> for RwLock<()> {
             Ok(old) => old,
             Err(old) => old,
         };
-        let old = T::from_ptr(old as *const T::Base);
+        let old = T::from_ptr(old as *const T::Base, allocator);
         if swapped.is_err() {
             // If the new didn't go in, we need to destroy it and increment count in the old that
             // we just duplicated
             T::inc(&old);
-            drop(T::from_ptr(new));
+            drop(T::from_ptr(new, allocator));
         }
         drop(current);
         old

--- a/vendor/arc-swap/src/weak.rs
+++ b/vendor/arc-swap/src/weak.rs
@@ -3,10 +3,17 @@ use core::ptr;
 use alloc::rc::Weak as RcWeak;
 use alloc::sync::Weak;
 
+#[cfg(nightly)]
+use crate::ArcSwapAllocator;
 use crate::RefCnt;
 
+#[cfg(not(nightly))]
 unsafe impl<T> RefCnt for Weak<T> {
     type Base = T;
+    type Allocator = ();
+
+    fn allocator(_me: &Self) -> Self::Allocator {}
+
     fn as_ptr(me: &Self) -> *mut T {
         if Weak::ptr_eq(&Weak::new(), me) {
             ptr::null_mut()
@@ -21,7 +28,7 @@ unsafe impl<T> RefCnt for Weak<T> {
             Weak::into_raw(me) as *mut T
         }
     }
-    unsafe fn from_ptr(ptr: *const T) -> Self {
+    unsafe fn from_ptr(ptr: *const T, _allocator: &Self::Allocator) -> Self {
         if ptr.is_null() {
             Weak::new()
         } else {
@@ -30,8 +37,51 @@ unsafe impl<T> RefCnt for Weak<T> {
     }
 }
 
+#[cfg(nightly)]
+unsafe impl<T, A> RefCnt for Weak<T, A>
+where
+    A: ArcSwapAllocator,
+{
+    type Base = T;
+    type Allocator = A;
+
+    fn allocator(me: &Self) -> Self::Allocator {
+        Weak::allocator(me).clone()
+    }
+
+    fn as_ptr(me: &Self) -> *mut T {
+        let empty = Weak::new_in(Weak::allocator(me).clone());
+        if Weak::ptr_eq(&empty, me) {
+            ptr::null_mut()
+        } else {
+            Weak::as_ptr(me) as *mut T
+        }
+    }
+
+    fn into_ptr(me: Self) -> *mut T {
+        let empty = Weak::new_in(Weak::allocator(&me).clone());
+        if Weak::ptr_eq(&empty, &me) {
+            ptr::null_mut()
+        } else {
+            Weak::into_raw_with_allocator(me).0 as *mut T
+        }
+    }
+
+    unsafe fn from_ptr(ptr: *const T, allocator: &Self::Allocator) -> Self {
+        if ptr.is_null() {
+            Weak::new_in(allocator.clone())
+        } else {
+            Weak::from_raw_in(ptr, allocator.clone())
+        }
+    }
+}
+
 unsafe impl<T> RefCnt for RcWeak<T> {
     type Base = T;
+    type Allocator = ();
+
+    fn allocator(_me: &Self) -> Self::Allocator {}
+
     fn as_ptr(me: &Self) -> *mut T {
         if RcWeak::ptr_eq(&RcWeak::new(), me) {
             ptr::null_mut()
@@ -46,7 +96,7 @@ unsafe impl<T> RefCnt for RcWeak<T> {
             RcWeak::into_raw(me) as *mut T
         }
     }
-    unsafe fn from_ptr(ptr: *const T) -> Self {
+    unsafe fn from_ptr(ptr: *const T, _allocator: &Self::Allocator) -> Self {
         if ptr.is_null() {
             RcWeak::new()
         } else {


### PR DESCRIPTION
## Summary

- Make the vendored `arc-swap` crate allocator-aware on nightly.
- Add an `ArcSwapAllocator` marker bound for allocator-aware `Arc<T, A>` and `Weak<T, A>` support.
- Thread the `ArcSwapAny` allocator context through load, swap, compare-and-swap, debt repayment, wait-for-readers, and drop paths.
- Make the allocator a type-level property of `ArcSwapAny<T, S, A>` with `T: RefCnt<Allocator = A>`, so aliases like `ArcSwap<T, A>` force the same allocator generic.
- Add explicit `from_pointee_in` / `empty_in` constructors for custom allocator use.

This PR is stacked on the vendor-only branch
