### PR TITLE
Fix WAL spill frame reuse during page spills

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -385,6 +385,9 @@ jobs:
           - name: in-process-mvcc
             iterations: 25
             args: "--mode fast --reopen-probability 0.01 --enable-mvcc --allocation-fault-probability 0.01"
+          - name: btree-rebalance
+            iterations: 5
+            args: "--mode btree-rebalance --allocation-fault-probability 0"
           - name: multiprocess
             iterations: 10
             args: "--mode fast --multiprocess --connections-per-process 4 --processes 4"

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -898,12 +898,27 @@ impl WalCoordination for InProcessWalCoordination {
         let range = frame_watermark
             .map(|x| 0..=x)
             .unwrap_or(min_frame..=max_frame);
-        frame_cache.get(&page_id).and_then(|frames| {
+        let result = frame_cache.get(&page_id).and_then(|frames| {
             frames
                 .iter()
                 .rfind(|&&frame| range.contains(&frame))
                 .copied()
-        })
+        });
+        if page_id == 12075 || result == Some(5161) {
+            let frames = frame_cache.get(&page_id).cloned().unwrap_or_default();
+            let checkpoint_seq = shared.metadata.wal_header.lock().checkpoint_seq;
+            let shared_snapshot = WalSnapshot {
+                max_frame: shared.metadata.max_frame.load(Ordering::Acquire),
+                nbackfills: shared.metadata.nbackfills.load(Ordering::Acquire),
+                last_checksum: shared.metadata.last_checksum,
+                checkpoint_seq,
+                transaction_count: shared.metadata.transaction_count.load(Ordering::Acquire),
+            };
+            eprintln!(
+                "[WHOPPER_FIND_FRAME_PROBE] page_id={page_id} result={result:?} min_frame={min_frame} max_frame={max_frame} frame_watermark={frame_watermark:?} shared_snapshot={shared_snapshot:?} frames={frames:?}"
+            );
+        }
+        result
     }
 
     fn iter_latest_frames(&self, min_frame: u64, max_frame: u64) -> Vec<(u64, u64)> {
@@ -4082,7 +4097,15 @@ impl Wal for WalFile {
                         local_state.snapshot.max_frame + 1,
                     )
                 } else if snapshot != local_state.snapshot {
-                    if self.has_unpublished_frames.load(Ordering::Acquire) {
+                    let has_unpublished_frames =
+                        self.has_unpublished_frames.load(Ordering::Acquire);
+                    if local_state.snapshot.max_frame > snapshot.max_frame {
+                        eprintln!(
+                            "[WHOPPER_PREPARE_FRAMES_PROBE] snapshot_mismatch has_unpublished_frames={has_unpublished_frames} authority={snapshot:?} local={:?}",
+                            local_state.snapshot
+                        );
+                    }
+                    if has_unpublished_frames {
                         // Spill/raw frames have no commit marker yet
                         // (db_size == 0), so the coordination backend's
                         // max_frame is behind our local max_frame. Chain from
@@ -4259,6 +4282,14 @@ impl Wal for WalFile {
                 frame_db_size,
                 &data_to_write,
             );
+            if page_id == 12075 || page_id == 11505 || next_frame_id == 5161 {
+                let frame = frame_bytes.as_slice();
+                let page_prefix = &frame[WAL_FRAME_HEADER_SIZE
+                    ..WAL_FRAME_HEADER_SIZE + 8.min(shared_page_size as usize)];
+                eprintln!(
+                    "[WHOPPER_WAL_APPEND_PROBE] build frame_id={next_frame_id} page_id={page_id} page_prefix={page_prefix:02x?}"
+                );
+            }
             iovecs.push(frame_bytes);
 
             // (page, assigned_frame_id, cumulative_checksum_at_this_frame)
@@ -4305,6 +4336,14 @@ impl Wal for WalFile {
 
         for (page, fid, csum) in &page_frame_and_checksum {
             self.complete_append_frame(page.get().id as u64, *fid, *csum);
+            if page.get().id == 12075 || page.get().id == 11505 || *fid == 5161 {
+                eprintln!(
+                    "[WHOPPER_WAL_APPEND_PROBE] index frame_id={fid} current_page_id={} wal_tag={:?} has_unpublished_frames={}",
+                    page.get().id,
+                    page.wal_tag_pair(),
+                    self.has_unpublished_frames.load(Ordering::Acquire)
+                );
+            }
         }
 
         Ok(c)

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2563,10 +2563,9 @@ pub struct WalFile {
 
     io_ctx: RwLock<IOContext>,
 
-    /// Set when `write_frame_raw` appends frames without a commit marker
-    /// (`db_size == 0`), meaning the coordination backend's max_frame is
-    /// behind our connection-local max_frame. Cleared once
-    /// `finish_append_frames_commit` publishes the state.
+    /// Set when WAL frames are appended without a commit marker (`db_size == 0`),
+    /// meaning the coordination backend's max_frame is behind our connection-local
+    /// max_frame. Cleared once `finish_append_frames_commit` publishes the state.
     has_unpublished_frames: AtomicBool,
 }
 
@@ -4084,8 +4083,8 @@ impl Wal for WalFile {
                     )
                 } else if snapshot != local_state.snapshot {
                     if self.has_unpublished_frames.load(Ordering::Acquire) {
-                        // write_frame_raw appended frames without a commit
-                        // marker (db_size == 0), so the coordination backend's
+                        // Spill/raw frames have no commit marker yet
+                        // (db_size == 0), so the coordination backend's
                         // max_frame is behind our local max_frame. Chain from
                         // local state so we don't overwrite those frames.
                         (
@@ -4297,6 +4296,12 @@ impl Wal for WalFile {
         let c = file.pwritev(start_off, iovecs, c)?;
 
         self.io.drain_completions(std::slice::from_ref(&c))?;
+
+        if !page_frame_and_checksum.is_empty() {
+            // Spill frames are durable but unpublished until the commit marker
+            // advances the shared WAL snapshot.
+            self.has_unpublished_frames.store(true, Ordering::Release);
+        }
 
         for (page, fid, csum) in &page_frame_and_checksum {
             self.complete_append_frame(page.get().id as u64, *fid, *csum);

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -5937,6 +5937,36 @@ pub mod test {
         expected
     }
 
+    #[test]
+    fn append_frames_vectored_spill_frames_are_not_reused_by_next_prepare() {
+        let page_size = 512;
+        let (_io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let spill_page = page_with_pattern(7, 0x70, &buffer_pool);
+
+        let completion = wal
+            .append_frames_vectored(vec![spill_page], PageSize::new(page_size).unwrap())
+            .unwrap();
+        assert!(completion.succeeded());
+        assert_eq!(wal.get_max_frame(), 1);
+        assert_eq!(wal.get_max_frame_in_wal(), 0);
+
+        let commit_page = page_with_pattern(9, 0x90, &buffer_pool);
+        let prepared = wal
+            .prepare_frames(
+                &[commit_page],
+                PageSize::new(page_size).unwrap(),
+                Some(99),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(
+            prepared.metadata[0].1, 2,
+            "prepare_frames must chain after unpublished spill frames"
+        );
+        assert_eq!(prepared.final_max_frame, 2);
+    }
+
     fn wait_for_completion_error(io: &Arc<dyn IO>, completion: Completion) -> CompletionError {
         match io.wait_for_completion(completion) {
             Err(LimboError::CompletionError(err)) => err,

--- a/testing/concurrent-simulator/chaotic_btree.rs
+++ b/testing/concurrent-simulator/chaotic_btree.rs
@@ -1,0 +1,305 @@
+//! Chaotic btree workloads that bias Whopper toward non-root page balancing.
+//!
+//! The workload keeps one large table hot, deletes committed key bands to seed
+//! the freelist, then refills those holes under savepoints with large payloads.
+//! That shape is meant to exercise page-number reassignment during
+//! `balance_non_root`, especially when a small page size makes splits frequent.
+
+use rand::Rng;
+use rand_chacha::ChaCha8Rng;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use crate::chaotic_elle::{ChaoticWorkload, ChaoticWorkloadProfile};
+use crate::operations::{OpResult, Operation, TxMode};
+
+const DEFAULT_TABLE_NAME: &str = "btree_rebalance";
+const BLOCK_WIDTH: i64 = 10_000;
+const FREELIST_ROWS: i64 = 384;
+const WARMUP_ROWS: i64 = 512;
+const DELETE_BAND_WIDTH: i64 = 64;
+const WARMUP_PERMUTATION_MULTIPLIER: i64 = 73;
+
+/// Generates multi-statement btree churn transactions.
+pub struct BtreeRebalanceProfile {
+    table_name: String,
+    block_counter: AtomicI64,
+}
+
+impl BtreeRebalanceProfile {
+    pub fn new(table_name: impl Into<String>) -> Self {
+        Self {
+            table_name: table_name.into(),
+            block_counter: AtomicI64::new(0),
+        }
+    }
+}
+
+impl Default for BtreeRebalanceProfile {
+    fn default() -> Self {
+        Self::new(DEFAULT_TABLE_NAME)
+    }
+}
+
+struct BtreeRebalanceWorkload {
+    ops: Vec<Operation>,
+    index: usize,
+}
+
+impl BtreeRebalanceWorkload {
+    fn new(ops: Vec<Operation>) -> Self {
+        Self { ops, index: 0 }
+    }
+}
+
+impl ChaoticWorkload for BtreeRebalanceWorkload {
+    fn next(&mut self, result: Option<OpResult>) -> Option<Operation> {
+        if let Some(Err(e)) = &result {
+            tracing::trace!("btree rebalance workload stopped after operation error: {e}");
+            return None;
+        }
+
+        let op = self.ops.get(self.index).cloned()?;
+        self.index += 1;
+        Some(op)
+    }
+}
+
+impl ChaoticWorkloadProfile for BtreeRebalanceProfile {
+    fn generate(&self, mut rng: ChaCha8Rng, fiber_id: usize) -> Box<dyn ChaoticWorkload> {
+        let block = self.block_counter.fetch_add(1, Ordering::Relaxed);
+        let block_base = (block * 32 + (fiber_id % 32) as i64) * BLOCK_WIDTH;
+        let freelist_table_name = format!("{}_freelist", self.table_name);
+        let savepoint_name = format!("btree_sp_{fiber_id}");
+        let mut ops = Vec::new();
+
+        push_setup_ops(&mut ops, &self.table_name, &freelist_table_name);
+        push_seed_freelist_tx(&mut ops, &freelist_table_name, block_base, &mut rng);
+        push_warmup_tx(&mut ops, &self.table_name, block_base, &mut rng);
+        push_free_freelist_tx(&mut ops, &freelist_table_name, block_base);
+        push_churn_tx(
+            &mut ops,
+            &self.table_name,
+            block_base,
+            &savepoint_name,
+            &mut rng,
+        );
+
+        ops.push(Operation::IntegrityCheck);
+
+        Box::new(BtreeRebalanceWorkload::new(ops))
+    }
+}
+
+fn push_setup_ops(ops: &mut Vec<Operation>, table_name: &str, freelist_table_name: &str) {
+    ops.push(Operation::Execute {
+        sql: "PRAGMA cache_size = 12".to_string(),
+    });
+    ops.push(Operation::Execute {
+        sql: format!(
+            "CREATE TABLE IF NOT EXISTS {freelist_table_name} (\
+             id INTEGER PRIMARY KEY, \
+             pad BLOB NOT NULL)"
+        ),
+    });
+    ops.push(Operation::Execute {
+        sql: format!(
+            "CREATE TABLE IF NOT EXISTS {table_name} (\
+             id INTEGER PRIMARY KEY, \
+             k INTEGER NOT NULL, \
+             pad BLOB NOT NULL, \
+             tag TEXT NOT NULL)"
+        ),
+    });
+    ops.push(Operation::Execute {
+        sql: format!("CREATE INDEX IF NOT EXISTS idx_{table_name}_k ON {table_name}(k)"),
+    });
+    ops.push(Operation::Execute {
+        sql: format!("CREATE INDEX IF NOT EXISTS idx_{table_name}_tag_k ON {table_name}(tag, k)"),
+    });
+}
+
+fn push_seed_freelist_tx(
+    ops: &mut Vec<Operation>,
+    freelist_table_name: &str,
+    block_base: i64,
+    rng: &mut ChaCha8Rng,
+) {
+    ops.push(Operation::Begin {
+        mode: TxMode::Immediate,
+    });
+
+    for ordinal in 0..FREELIST_ROWS {
+        let id = block_base + ordinal;
+        let payload_len = random_payload_len(rng);
+        ops.push(Operation::Insert {
+            sql: format!(
+                "INSERT OR REPLACE INTO {freelist_table_name}(id, pad) \
+                 VALUES ({id}, zeroblob({payload_len}))"
+            ),
+        });
+    }
+
+    ops.push(Operation::Commit);
+}
+
+fn push_warmup_tx(
+    ops: &mut Vec<Operation>,
+    table_name: &str,
+    block_base: i64,
+    rng: &mut ChaCha8Rng,
+) {
+    ops.push(Operation::Begin {
+        mode: TxMode::Immediate,
+    });
+
+    for ordinal in 0..WARMUP_ROWS {
+        let id = permuted_block_id(block_base, ordinal);
+        let payload_len = random_payload_len(rng);
+        ops.push(insert_op(table_name, id, payload_len, rng));
+    }
+
+    ops.push(Operation::Commit);
+}
+
+fn push_free_freelist_tx(ops: &mut Vec<Operation>, freelist_table_name: &str, block_base: i64) {
+    let end = block_base + FREELIST_ROWS - 1;
+    ops.push(Operation::Begin {
+        mode: TxMode::Immediate,
+    });
+    ops.push(Operation::Delete {
+        sql: format!("DELETE FROM {freelist_table_name} WHERE id BETWEEN {block_base} AND {end}"),
+    });
+    ops.push(Operation::Commit);
+}
+
+fn push_churn_tx(
+    ops: &mut Vec<Operation>,
+    table_name: &str,
+    block_base: i64,
+    savepoint_name: &str,
+    rng: &mut ChaCha8Rng,
+) {
+    ops.push(Operation::Begin {
+        mode: TxMode::Immediate,
+    });
+
+    let band_count = rng.random_range(2..=4);
+    let max_first_band = (WARMUP_ROWS / DELETE_BAND_WIDTH) - 1 - ((band_count - 1) * 2);
+    let first_band = rng.random_range(0..=max_first_band);
+    for band_idx in 0..band_count {
+        let start_ordinal = (first_band + band_idx * 2) * DELETE_BAND_WIDTH;
+        let start = block_base + start_ordinal;
+        let end = start + DELETE_BAND_WIDTH - 1;
+        ops.push(Operation::Delete {
+            sql: format!("DELETE FROM {table_name} WHERE id BETWEEN {start} AND {end}"),
+        });
+    }
+
+    ops.push(Operation::Commit);
+    ops.push(Operation::Begin {
+        mode: TxMode::Immediate,
+    });
+    ops.push(Operation::Savepoint {
+        name: savepoint_name.to_string(),
+    });
+
+    for band_idx in 0..band_count {
+        let start_ordinal = (first_band + band_idx * 2) * DELETE_BAND_WIDTH;
+        for ordinal in start_ordinal..start_ordinal + DELETE_BAND_WIDTH {
+            let id = block_base + ordinal;
+            let payload_len = random_payload_len(rng);
+            ops.push(insert_op(table_name, id, payload_len, rng));
+        }
+    }
+
+    let update_count = rng.random_range(2..=5);
+    for _ in 0..update_count {
+        let start_ordinal = rng.random_range(0..WARMUP_ROWS - 32);
+        let start = block_base + start_ordinal;
+        let end = start + rng.random_range(8..32);
+        let tag = rng.random_range(0..64);
+        let payload_len = random_payload_len(rng);
+        let delta = rng.random_range(1..4096);
+        ops.push(Operation::Update {
+            sql: format!(
+                "UPDATE {table_name} \
+                 SET k = k + {delta}, tag = 'tag_{tag}', pad = zeroblob({payload_len}) \
+                 WHERE id BETWEEN {start} AND {end}"
+            ),
+        });
+    }
+
+    if rng.random_bool(0.35) {
+        ops.push(Operation::RollbackToSavepoint {
+            name: savepoint_name.to_string(),
+        });
+    }
+    ops.push(Operation::ReleaseSavepoint {
+        name: savepoint_name.to_string(),
+    });
+
+    if rng.random_bool(0.85) {
+        ops.push(Operation::Commit);
+    } else {
+        ops.push(Operation::Rollback);
+    }
+}
+
+fn permuted_block_id(block_base: i64, ordinal: i64) -> i64 {
+    block_base + ((ordinal * WARMUP_PERMUTATION_MULTIPLIER) % WARMUP_ROWS)
+}
+
+fn insert_op(table_name: &str, id: i64, payload_len: usize, rng: &mut ChaCha8Rng) -> Operation {
+    let tag = rng.random_range(0..64);
+    let k = rng.random_range(0..1_000_000);
+    Operation::Insert {
+        sql: format!(
+            "INSERT OR REPLACE INTO {table_name}(id, k, pad, tag) \
+             VALUES ({id}, {k}, zeroblob({payload_len}), 'tag_{tag}')"
+        ),
+    }
+}
+
+fn random_payload_len(rng: &mut ChaCha8Rng) -> usize {
+    if rng.random_bool(0.2) {
+        rng.random_range(6 * 1024..16 * 1024)
+    } else {
+        rng.random_range(700..6 * 1024)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    #[test]
+    fn generated_workload_contains_savepoint_churn() {
+        let profile = BtreeRebalanceProfile::default();
+        let mut workload = profile.generate(ChaCha8Rng::seed_from_u64(17), 3);
+        let mut ops = Vec::new();
+        let mut result = None;
+
+        while let Some(op) = workload.next(result.take()) {
+            ops.push(op);
+            result = Some(Ok(Vec::new()));
+        }
+
+        assert!(
+            ops.iter()
+                .any(|op| matches!(op, Operation::Savepoint { .. }))
+        );
+        assert!(
+            ops.iter()
+                .any(|op| matches!(op, Operation::ReleaseSavepoint { .. }))
+        );
+        assert!(
+            ops.iter()
+                .filter(|op| matches!(op, Operation::Insert { .. }))
+                .count()
+                > (FREELIST_ROWS + WARMUP_ROWS) as usize
+        );
+        assert!(ops.iter().any(|op| matches!(op, Operation::Delete { .. })));
+        assert!(ops.iter().any(|op| matches!(op, Operation::IntegrityCheck)));
+    }
+}

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -25,6 +25,7 @@ use turso_core::{
 use turso_parser::ast::{ColumnConstraint, SortOrder};
 
 mod allocation_fault;
+pub mod chaotic_btree;
 pub mod chaotic_elle;
 pub mod elle;
 pub mod error_handling;
@@ -389,6 +390,20 @@ impl WhopperOpts {
             close_connections_gracefully: false,
             reopen_probability: 0.1,
             ..Self::fast()
+        }
+    }
+
+    pub fn btree_rebalance() -> Self {
+        Self {
+            max_steps: 500_000,
+            schema_bias: SchemaBias {
+                non_rowid_pk_prob: 0.0,
+                unique_col_prob: 0.0,
+                num_tables_range: 0..=0,
+                num_columns_range: 2..=2,
+                initial_rows_per_table: 0,
+            },
+            ..Default::default()
         }
     }
 

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -9,6 +9,7 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 use turso_whopper::multiprocess::{MultiprocessOpts, MultiprocessWhopper};
 use turso_whopper::{
     StepResult, Whopper, WhopperOpts,
+    chaotic_btree::BtreeRebalanceProfile,
     chaotic_elle::{ChaoticElleProfile, ChaoticWorkloadProfile, ElleModelKind},
     properties::*,
     workloads::*,
@@ -30,7 +31,7 @@ struct Args {
     #[command(subcommand)]
     subcommand: Option<SubCmd>,
 
-    /// Simulation mode (fast, chaos, ragnarök/ragnarok)
+    /// Simulation mode (fast, chaos, btree-rebalance/btree-rekey, recovery-heavy, ragnarök/ragnarok)
     #[arg(long, default_value = "fast")]
     mode: String,
     /// Max connections
@@ -162,6 +163,7 @@ fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
     let base_max_steps = match args.mode.as_str() {
         "fast" => 100_000,
         "chaos" => 10_000_000,
+        "btree-rebalance" | "btree-rekey" => 500_000,
         "ragnarök" | "ragnarok" => 1_000_000,
         mode => return Err(anyhow::anyhow!("Unknown mode: {}", mode)),
     };
@@ -386,6 +388,19 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
         let et = vec![(table_name.to_string(), create_sql.to_string())];
 
         (w, p, et, chaotic)
+    } else if is_btree_rebalance_mode(&args.mode) {
+        let w: Vec<(u32, Box<dyn Workload>)> = vec![
+            (20, Box::new(IntegrityCheckWorkload)),
+            (5, Box::new(WalCheckpointWorkload)),
+        ];
+        let p: Vec<Box<dyn Property>> = vec![Box::new(IntegrityCheckProperty)];
+        let chaotic: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)> = vec![(
+            1.0,
+            "btree-rebalance",
+            Box::new(BtreeRebalanceProfile::default()),
+        )];
+
+        (w, p, vec![], chaotic)
     } else {
         let w: Vec<(u32, Box<dyn Workload>)> = vec![
             (10, Box::new(IntegrityCheckWorkload)),
@@ -433,6 +448,7 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
     let mut base_opts = match args.mode.as_str() {
         "fast" => WhopperOpts::fast(),
         "chaos" => WhopperOpts::chaos(),
+        "btree-rebalance" | "btree-rekey" => WhopperOpts::btree_rebalance(),
         "ragnarök" | "ragnarok" => WhopperOpts::ragnarok(),
         "recovery-heavy" => WhopperOpts::recovery_heavy(),
         mode => return Err(anyhow::anyhow!("Unknown mode: {}", mode)),
@@ -461,6 +477,10 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         .with_allocation_fault_probability(args.allocation_fault_probability);
 
     Ok(opts)
+}
+
+fn is_btree_rebalance_mode(mode: &str) -> bool {
+    matches!(mode, "btree-rebalance" | "btree-rekey")
 }
 
 fn format_stats(stats: &turso_whopper::Stats, elle_mode: bool) -> String {

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -56,8 +56,16 @@ pub enum Operation {
     Commit,
     /// Rollback current transaction
     Rollback,
+    /// Create a savepoint within the current transaction
+    Savepoint { name: String },
+    /// Roll back to a savepoint without leaving the outer transaction
+    RollbackToSavepoint { name: String },
+    /// Release a savepoint without leaving the outer transaction
+    ReleaseSavepoint { name: String },
     /// Run PRAGMA integrity_check
     IntegrityCheck,
+    /// Execute a statement that does not need workload-specific state tracking.
+    Execute { sql: String },
     /// Run WAL checkpoint with specified mode
     WalCheckpoint { mode: String },
     /// Create a simple key-value table
@@ -163,7 +171,11 @@ impl Operation {
             Operation::Begin { mode } => mode.as_sql().to_string(),
             Operation::Commit => "COMMIT".to_string(),
             Operation::Rollback => "ROLLBACK".to_string(),
+            Operation::Savepoint { name } => format!("SAVEPOINT {name}"),
+            Operation::RollbackToSavepoint { name } => format!("ROLLBACK TO SAVEPOINT {name}"),
+            Operation::ReleaseSavepoint { name } => format!("RELEASE SAVEPOINT {name}"),
             Operation::IntegrityCheck => "PRAGMA integrity_check".to_string(),
+            Operation::Execute { sql } => sql.clone(),
             Operation::WalCheckpoint { mode } => format!("PRAGMA wal_checkpoint({mode})"),
             Operation::CreateSimpleTable { table_name } => {
                 format!(


### PR DESCRIPTION
## Summary
- add the whopper btree rebalance workload used to reproduce the corruption path
- mark vectored WAL spill frames as unpublished before advancing local WAL state, so later commit preparation chains after spilled frames instead of reusing frame ids
- add a focused regression test for spill frame reuse
- keep temporary `WHOPPER_*_PROBE` instrumentation in a separate commit for now

## Root cause
`append_frames_vectored()` advanced local WAL frame state and the frame cache for spill frames, but did not set `has_unpublished_frames`. When shared committed WAL state lagged local spill state, `prepare_frames()` could reseed from the shared snapshot and reuse frame ids that were already occupied by spill frames.

fixes: https://linear.app/turso/issue/ENG-78/corrupt-error-in-savepoint-invalid-page-type-0

