### PR TITLE
propagate push/pull thresholds to the python and golang SDK

### DIFF
--- a/bindings/go/bindings_sync.go
+++ b/bindings/go/bindings_sync.go
@@ -72,6 +72,16 @@ type TursoSyncDatabaseConfig struct {
 	RemoteEncryptionKey string
 	// optional encryption cipher name (e.g. "aes256gcm", "chacha20poly1305")
 	RemoteEncryptionCipher string
+	// optional cap on the number of CDC operations packed into a single push HTTP batch.
+	// when > 0, push splits on transaction boundaries once the current batch has accumulated
+	// at least this many operations. a single user transaction is never split across batches.
+	// 0 (default) sends the entire change set in one batch.
+	PushOperationsThreshold int
+	// optional hint, in bytes, that splits the bootstrap download into multiple
+	// /pull-updates HTTP requests of >= this many bytes each. when > 0, the bootstrap is fetched
+	// in chunks. 0 (default) bootstraps in a single round-trip. no-op when partial-sync uses the
+	// query bootstrap strategy.
+	PullBytesThreshold int
 }
 
 // TursoSyncStats holds sync engine stats.
@@ -127,6 +137,8 @@ type turso_sync_database_config_t struct {
 	partial_bootstrap_prefetch        bool
 	remote_encryption_key             uintptr // const char*
 	remote_encryption_cipher          uintptr // const char*
+	push_operations_threshold         uintptr // size_t
+	pull_bytes_threshold              uintptr // size_t
 }
 
 type turso_sync_io_http_request_t struct {
@@ -414,6 +426,8 @@ func turso_sync_database_new(dbConfig TursoDatabaseConfig, syncConfig TursoSyncD
 	if syncConfig.RemoteEncryptionCipher != "" {
 		encryptionCipherBytes, csync.remote_encryption_cipher = makeCStringBytes(syncConfig.RemoteEncryptionCipher)
 	}
+	csync.push_operations_threshold = uintptr(syncConfig.PushOperationsThreshold)
+	csync.pull_bytes_threshold = uintptr(syncConfig.PullBytesThreshold)
 
 	var db *turso_sync_database_t
 	var errPtr *byte

--- a/bindings/go/driver_sync.go
+++ b/bindings/go/driver_sync.go
@@ -74,6 +74,18 @@ type TursoSyncDbConfig struct {
 	// Can also be specified via Path DSN: "mydb.db?_busy_timeout=10000"
 	// If both are set, this field takes precedence.
 	BusyTimeout int
+
+	// optional cap on the number of CDC operations packed into a single push HTTP batch.
+	// when > 0, push splits on transaction boundaries once the current batch has accumulated
+	// at least this many operations. a single user transaction is never split across batches.
+	// 0 (default) sends the entire change set in one batch.
+	PushOperationsThreshold int
+
+	// optional hint, in bytes, that splits the bootstrap download into multiple
+	// /pull-updates HTTP requests of >= this many bytes each. when > 0, the bootstrap is fetched
+	// in chunks. 0 (default) bootstraps in a single round-trip. no-op when partial sync uses the
+	// query bootstrap strategy.
+	PullBytesThreshold int
 }
 
 // statistics for the synced database.
@@ -158,6 +170,8 @@ func NewTursoSyncDb(ctx context.Context, config TursoSyncDbConfig) (*TursoSyncDb
 		PartialBootstrapStrategyQuery:  config.PartialSyncExperimental.BootstrapStrategyQuery,
 		PartialBootstrapSegmentSize:    config.PartialSyncExperimental.SegmentSize,
 		PartialBootstrapPrefetch:       config.PartialSyncExperimental.Prefetch,
+		PushOperationsThreshold:        config.PushOperationsThreshold,
+		PullBytesThreshold:             config.PullBytesThreshold,
 	}
 	sdb, err := turso_sync_database_new(dbCfg, syncCfg)
 	if err != nil {

--- a/bindings/go/driver_sync_test.go
+++ b/bindings/go/driver_sync_test.go
@@ -9,10 +9,14 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -755,4 +759,80 @@ func TestSyncLargeSchema(t *testing.T) {
 	require.Nil(t, rows.Scan(&count))
 	require.Equal(t, count, numTables)
 	rows.Close()
+}
+
+// newCountingProxy starts a transparent reverse proxy in front of upstream that
+// counts every POST request whose path ends with pathSuffix. It is used to
+// observe how the sync engine splits its HTTP traffic into batches.
+func newCountingProxy(t *testing.T, upstream, pathSuffix string, counter *atomic.Int64) *httptest.Server {
+	t.Helper()
+	target, err := url.Parse(upstream)
+	require.Nil(t, err)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	director := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		director(req)
+		// preserve the host the upstream expects (matters for cloud subdomains,
+		// harmless for the local sync server)
+		req.Host = target.Host
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, pathSuffix) {
+			counter.Add(1)
+		}
+		proxy.ServeHTTP(w, r)
+	}))
+}
+
+// TestSyncPullBytesThreshold verifies that the PullBytesThreshold setting is
+// propagated to the sync engine: when set, the bootstrap download is split into
+// multiple /pull-updates HTTP requests instead of a single round-trip.
+func TestSyncPullBytesThreshold(t *testing.T) {
+	server, err := NewTursoServer()
+	require.Nil(t, err)
+	t.Cleanup(func() { server.Close() })
+
+	// Seed a remote with enough data to span many 4KB pages.
+	_, err = server.DbSql("CREATE TABLE big(x INTEGER PRIMARY KEY, y BLOB)")
+	require.Nil(t, err)
+	_, err = server.DbSql("INSERT INTO big SELECT value, randomblob(1024) FROM generate_series(1, 50)")
+	require.Nil(t, err)
+
+	// bootstrap fetches the seeded db into a fresh in-memory client through a
+	// counting proxy and returns how many /pull-updates requests it issued.
+	bootstrap := func(threshold int) int64 {
+		var pullUpdates atomic.Int64
+		proxy := newCountingProxy(t, server.DbUrl, "/pull-updates", &pullUpdates)
+		defer proxy.Close()
+
+		db, err := NewTursoSyncDb(context.Background(), TursoSyncDbConfig{
+			Path:               ":memory:",
+			ClientName:         "turso-sync-go",
+			RemoteUrl:          proxy.URL,
+			PullBytesThreshold: threshold,
+		})
+		require.Nil(t, err)
+
+		// bootstrapped data must be intact regardless of chunking
+		conn, err := db.Connect(context.Background())
+		require.Nil(t, err)
+		rows, err := conn.QueryContext(context.Background(), "SELECT COUNT(*) FROM big")
+		require.Nil(t, err)
+		var count int
+		require.True(t, rows.Next())
+		require.Nil(t, rows.Scan(&count))
+		require.Equal(t, 50, count)
+		rows.Close()
+		conn.Close()
+
+		return pullUpdates.Load()
+	}
+
+	// Default bootstrap is a single round-trip; an 8KB threshold (2 pages per
+	// chunk) over a multi-page db must split into strictly more requests. If the
+	// setting were not propagated both runs would issue the same count.
+	withoutThreshold := bootstrap(0)
+	withThreshold := bootstrap(8192)
+	require.Greater(t, withThreshold, withoutThreshold)
+	require.Greater(t, withThreshold, int64(1))
 }

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -101,6 +101,15 @@ pub struct PyTursoSyncDatabaseConfig {
     pub remote_encryption_key: Option<String>,
     // encryption cipher for the remote database (used to calculate reserved_bytes)
     pub remote_encryption_cipher: Option<PyRemoteEncryptionCipher>,
+    // optional cap on the number of CDC operations packed into a single push HTTP batch.
+    // when set, push splits on transaction boundaries once the current batch has accumulated
+    // at least this many operations. a single user transaction is never split across batches.
+    // None (default) sends the entire change set in one batch.
+    pub push_operations_threshold: Option<usize>,
+    // optional hint, in bytes, that splits the bootstrap download into multiple
+    // /pull-updates HTTP requests of >= this many bytes each. None (default) bootstraps
+    // in a single round-trip. no-op when partial-sync uses the query bootstrap strategy.
+    pub pull_bytes_threshold: Option<usize>,
 }
 
 #[pymethods]
@@ -116,6 +125,8 @@ impl PyTursoSyncDatabaseConfig {
         partial_sync=None,
         remote_encryption_key=None,
         remote_encryption_cipher=None,
+        push_operations_threshold=None,
+        pull_bytes_threshold=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -128,6 +139,8 @@ impl PyTursoSyncDatabaseConfig {
         partial_sync: Option<&PyTursoPartialSyncOpts>,
         remote_encryption_key: Option<String>,
         remote_encryption_cipher: Option<PyRemoteEncryptionCipher>,
+        push_operations_threshold: Option<usize>,
+        pull_bytes_threshold: Option<usize>,
     ) -> Self {
         Self {
             path,
@@ -139,6 +152,8 @@ impl PyTursoSyncDatabaseConfig {
             partial_sync: partial_sync.cloned(),
             remote_encryption_key,
             remote_encryption_cipher,
+            push_operations_threshold,
+            pull_bytes_threshold,
         }
     }
 }
@@ -194,8 +209,8 @@ pub fn py_turso_sync_new(
             None => None,
         },
         remote_encryption_key: sync_config.remote_encryption_key.clone(),
-        push_operations_threshold: None,
-        pull_bytes_threshold: None,
+        push_operations_threshold: sync_config.push_operations_threshold,
+        pull_bytes_threshold: sync_config.pull_bytes_threshold,
     };
     let database =
         TursoDatabaseSync::<Vec<u8>>::new(db_config, sync_config).map_err(turso_error_to_py_err)?;

--- a/bindings/python/tests/test_database_sync.py
+++ b/bindings/python/tests/test_database_sync.py
@@ -7,7 +7,7 @@ import time
 import turso
 import turso.sync
 
-from .utils import TursoServer
+from .utils import CountingProxy, TursoServer
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s", force=True)
 
@@ -239,3 +239,29 @@ def test_configuration_persistence():
             conn2.pull()
             assert conn2.execute("SELECT * FROM t").fetchall() == [(42,), (43,)]
             conn2.close()
+
+
+def test_pull_bytes_threshold():
+    # Verify that pull_bytes_threshold is propagated to the sync engine: when set,
+    # the bootstrap download is split into multiple /pull-updates HTTP requests
+    # instead of a single round-trip.
+    with TursoServer() as server:
+        server.db_sql("CREATE TABLE big(x INTEGER PRIMARY KEY, y BLOB)")
+        server.db_sql("INSERT INTO big SELECT value, randomblob(1024) FROM generate_series(1, 50)")
+
+        # bootstrap fetches the seeded db into a fresh in-memory client through a
+        # counting proxy and returns how many /pull-updates requests it issued.
+        def bootstrap(threshold):
+            with CountingProxy(server.db_url(), "/pull-updates") as proxy:
+                conn = turso.sync.connect(":memory:", proxy.url(), pull_bytes_threshold=threshold)
+                assert conn.execute("SELECT COUNT(*) FROM big").fetchall() == [(50,)]
+                conn.close()
+                return proxy.count
+
+        # Default bootstrap is a single round-trip; an 8KB threshold (2 pages per
+        # chunk) over a multi-page db must split into strictly more requests. If
+        # the setting were not propagated both runs would issue the same count.
+        without_threshold = bootstrap(None)
+        with_threshold = bootstrap(8192)
+        assert with_threshold > without_threshold
+        assert with_threshold > 1

--- a/bindings/python/tests/utils.py
+++ b/bindings/python/tests/utils.py
@@ -1,7 +1,9 @@
+import http.server
 import os
 import random
 import string
 import subprocess
+import threading
 import time
 
 import requests
@@ -9,6 +11,77 @@ import requests
 
 def random_str() -> str:
     return "".join([random.choice(string.ascii_letters) for _ in range(8)])
+
+
+# headers that must not be forwarded verbatim - the proxy/requests recompute them.
+# content-encoding is dropped because `requests` already decompresses resp.content.
+_HOP_BY_HOP_HEADERS = {
+    "host",
+    "content-length",
+    "content-encoding",
+    "connection",
+    "keep-alive",
+    "transfer-encoding",
+    "accept-encoding",
+}
+
+
+class CountingProxy:
+    """
+    Transparent reverse proxy used by sync tests to observe how the sync engine
+    splits its HTTP traffic into batches. Forwards every request to ``upstream``
+    and counts the POST requests whose path ends with ``path_suffix``.
+
+    The upstream host (including any cloud subdomain) is embedded in ``upstream``,
+    so ``requests`` sets the correct Host header automatically for both the local
+    sync server and Turso Cloud.
+    """
+
+    def __init__(self, upstream: str, path_suffix: str):
+        self._upstream = upstream.rstrip("/")
+        self._path_suffix = path_suffix
+        self.count = 0
+        proxy = self
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def _forward(self, method: str):
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length) if length else None
+                if method == "POST" and self.path.endswith(proxy._path_suffix):
+                    proxy.count += 1
+                headers = {k: v for k, v in self.headers.items() if k.lower() not in _HOP_BY_HOP_HEADERS}
+                resp = requests.request(method, proxy._upstream + self.path, data=body, headers=headers)
+                self.send_response(resp.status_code)
+                for k, v in resp.headers.items():
+                    if k.lower() not in _HOP_BY_HOP_HEADERS:
+                        self.send_header(k, v)
+                self.send_header("Content-Length", str(len(resp.content)))
+                self.end_headers()
+                self.wfile.write(resp.content)
+
+            def do_GET(self):
+                self._forward("GET")
+
+            def do_POST(self):
+                self._forward("POST")
+
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def url(self) -> str:
+        host, port = self._server.server_address
+        return f"http://{host}:{port}"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self._server.shutdown()
+        self._server.server_close()
 
 
 def handle_response(r):

--- a/bindings/python/turso/lib_sync.py
+++ b/bindings/python/turso/lib_sync.py
@@ -420,6 +420,8 @@ def connect_sync(
     isolation_level: Optional[str] = "DEFERRED",
     remote_encryption_key: Optional[str] = None,
     remote_encryption_cipher: Optional[RemoteEncryptionCipher] = None,
+    push_operations_threshold: Optional[int] = None,
+    pull_bytes_threshold: Optional[int] = None,
 ) -> ConnectionSync:
     """
     Create and open a synchronized database connection.
@@ -434,6 +436,13 @@ def connect_sync(
     - experimental_features, isolation_level: passed to underlying connection
     - remote_encryption_key: base64-encoded encryption key for encrypted Turso Cloud databases
     - remote_encryption_cipher: encryption cipher for the remote database (used to calculate reserved_bytes)
+    - push_operations_threshold: optional cap on the number of CDC operations packed into a single
+      push HTTP batch; push splits on transaction boundaries once the current batch accumulated at
+      least this many operations (a single transaction is never split). None (default) sends the
+      entire change set in one batch
+    - pull_bytes_threshold: optional hint, in bytes, that splits the bootstrap download into multiple
+      pull-updates HTTP requests of >= this many bytes each. None (default) bootstraps in a single
+      round-trip; no-op when partial sync uses the query bootstrap strategy
     """
     # Resolve client name
     cname = client_name or "turso-sync-py"
@@ -476,6 +485,8 @@ def connect_sync(
         else None,
         remote_encryption_key=remote_encryption_key,
         remote_encryption_cipher=remote_encryption_cipher,
+        push_operations_threshold=push_operations_threshold,
+        pull_bytes_threshold=pull_bytes_threshold,
     )
 
     # Create sync database holder

--- a/bindings/python/turso/lib_sync_aio.py
+++ b/bindings/python/turso/lib_sync_aio.py
@@ -74,6 +74,8 @@ def connect_sync(
     partial_sync_experimental: Optional[PartialSyncOpts] = None,
     experimental_features: Optional[str] = None,
     isolation_level: Optional[str] = "DEFERRED",
+    push_operations_threshold: Optional[int] = None,
+    pull_bytes_threshold: Optional[int] = None,
 ) -> ConnectionSync:
     # Connector creating the blocking synchronized connection in the worker thread
     def _connector() -> BlockingConnectionSync:
@@ -87,6 +89,8 @@ def connect_sync(
             partial_sync_experimental=partial_sync_experimental,
             experimental_features=experimental_features,
             isolation_level=isolation_level,
+            push_operations_threshold=push_operations_threshold,
+            pull_bytes_threshold=pull_bytes_threshold,
         )
 
     # Return awaitable async wrapper with sync extras


### PR DESCRIPTION
Add pull/push thresholds to the Python/Golang sync SDKs:

```py
turso.sync.connect(..., pull_bytes_threshold=t1, push_operations_threshold=t2)
```

```go
db, err := NewTursoSyncDb(context.Background(), TursoSyncDbConfig{
  ...
  PullBytesThreshold: t1,
  PushOperationsThreshold: t2,
})
```