### PR TITLE
core/mvcc:  preserve B-tree cleanup markers in MVCC commit logs

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2198,8 +2198,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                     continue;
                 };
                 canonicalize_table_id(&mut committed_version);
+                let is_btree_resident_delete_marker =
+                    |version: &RowVersion| version.btree_resident && version.end().is_some();
                 let replaces_last = entry_versions.last().is_some_and(|last| {
                     last.row.id == committed_version.row.id
+                        && !is_btree_resident_delete_marker(last)
                         && matches!(
                             (&last.begin(), &committed_version.begin()),
                             (
@@ -2218,6 +2221,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 {
                     let same_row_and_begin = |existing: &RowVersion| {
                         existing.row.id == committed_version.row.id
+                            && !is_btree_resident_delete_marker(existing)
+                            && !is_btree_resident_delete_marker(&committed_version)
                             && matches!(
                                 (&existing.begin(), &committed_version.begin()),
                                 (

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7396,6 +7396,44 @@ fn test_mvcc_repeated_delete_after_replace_delete_checkpoint_is_noop() {
 }
 
 #[test]
+fn test_mvcc_checkpoint_reopen_text_pk_upsert_delete_removes_autoindex_entry() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    let mut conn = db.connect();
+    conn.execute("PRAGMA journal_mode=mvcc").unwrap();
+    conn.execute("CREATE TABLE t(k TEXT PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES('k1','orig')").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO t VALUES('k1','u1') ON CONFLICT(k) DO UPDATE SET v=excluded.v")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES('k1','u2') ON CONFLICT(k) DO UPDATE SET v=excluded.v")
+        .unwrap();
+    conn.execute("COMMIT").unwrap();
+
+    conn.close().unwrap();
+    drop(conn);
+    db.restart();
+    conn = db.connect();
+    conn.execute("PRAGMA journal_mode=mvcc").unwrap();
+    conn.execute("DELETE FROM t WHERE k='k1'").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    assert_eq!(
+        get_rows(&conn, "SELECT count(*) FROM t WHERE k='k1'"),
+        vec![vec![Value::from_i64(0)]]
+    );
+    assert!(get_rows(&conn, "SELECT quote(k), quote(v) FROM t").is_empty());
+    assert!(get_rows(
+        &conn,
+        "SELECT quote(k), quote(v) FROM t NOT INDEXED WHERE k='k1'"
+    )
+    .is_empty());
+    assert_integrity_ok(&conn);
+}
+
+#[test]
 fn test_mvcc_checkpoint_integrity_after_upsert_with_secondary_indexes() {
     let db = MvccTestDbNoConn::new_with_random_db();
     let conn = db.connect();


### PR DESCRIPTION
Fixes #7627 

### Prerequisites

MVCC stores row history as versions:

```text
RowVersion {
  begin,
  end,
  btree_resident,
  row
}
```

begin says when a version becomes visible.

end says when a version stops being visible.

btree_resident means this version is tied to data that already exists in the physical B-tree.

When a transaction commits, it walks its own write set:

```text
for each row/index key touched by this transaction:
  inspect that key's version chain
  log only versions this transaction created or ended
```

This matters because a version can be old, but still partly changed by the current transaction:

```text
V1: begin=Timestamp(5), end=TxID(10)
    created by tx 5, ended by tx 10

V2: begin=TxID(10), end=None
    created by tx 10
```

When tx 10 commits, it must log:

```text
DELETE/END V1
UPSERT V2
```

Inside one transaction, the same row can be updated multiple times:

```text
k1 -> u1
k1 -> u2
```

For normal MVCC values, recovery does not need every intermediate value. It only needs the final durable effect:

```text
[u1, u2] -> [u2]
```

So the commit-log builder had a reasonable optimization:

```text
if two adjacent log entries have the same row id and the same begin timestamp, replace the older one with the newer one
```

That optimization is correct for ordinary intermediate values.

### The bug

A btree_resident ended version is different from an ordinary intermediate value.

It means:

```text
there is old physical B-tree state that checkpoint must clean
```

Example start state:

```text
B-tree:
  k1 -> orig

MVCC:
  empty
```

Then one transaction does:

```text
UPSERT k1 -> u1
UPSERT k1 -> u2
```

When the transaction first updates k1, the row already exists physically in the B-tree, but it does not yet have an MVCC version. So MVCC creates a bookkeeping version for that existing physical row:

```text
A: k1 -> orig, begin=tx, end=None, btree_resident=true
```

That is this transaction created the MVCC bookkeeping object for a row that was already in the B-tree. The physical row already existed; btree_resident=true records that fact.

After the two UPSERTs, the relevant versions are:

```text
A: k1 -> orig, begin=tx, end=tx,   btree_resident=true
B: k1 -> u1,   begin=tx, end=tx,   btree_resident=false
C: k1 -> u2,   begin=tx, end=None, btree_resident=false
```

At commit timestamp R, commit logging first filters ordinary same-transaction intermediate values. So B is skipped before the collapse step.

The versions that reach the old collapse logic are:

```text
A: k1 -> orig, begin=R, end=R,    btree_resident=true
C: k1 -> u2,   begin=R, end=None, btree_resident=false
```

A is not final user-visible data. It is the cleanup instruction saying:

```text
the old physical B-tree row k1 -> orig must be removed
```

C says:

```text
the final logical value is k1 -> u2
```

Those are two separate facts.

The old collapse check only looked at:

```text
same row id
same begin timestamp
```

Both A and C matched those checks, so the old code collapsed:

```text
[A, C] -> [C]
```

That lost the cleanup marker.

#### Why We Cannot Just Mark The Final Row As btree_resident

Setting btree_resident on C would not encode the missing operation.

C says:

```text
the final row value is k1 -> u2
```

But A says:

```text
the old physical image k1 -> orig must be removed
```

Those are different facts.

This matters especially for indexes:

```text
old index key:
  (old_value, rowid)

new index key:
  (new_value, rowid)
```

Writing the new key does not delete the old key, because it may live at a different B-tree location. Checkpoint needs the old ended version/marker to know which physical key to remove.

#### Delete path

A pure delete of a row that only exists in the B-tree creates this shape:

```text
T: begin=None, end=tx, btree_resident=true
```

That marker has begin=None, so it does not collide with a final row whose begin=R.

This bug needs the update/UPSERT path:

```text
materialize existing B-tree row:
  M: begin=tx, end=None, btree_resident=true

later end that same version:
  M: begin=tx, end=tx, btree_resident=true

after commit:
  M: begin=R, end=R, btree_resident=true
```

That final begin=R is what made the old collapse check dangerous.

### The Fix

The fix keeps the existing collapse optimization, but adds one guard:

```text
do not replace the previous entry if it is a btree_resident delete marker
```

So normal intermediate values still collapse:

```text
[u1, u2] -> [u2]
```

But physical cleanup markers are preserved:

```text
[btree cleanup marker, final row]
  -> [btree cleanup marker, final row]
```


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

The bug, fix, and also coming up with the nice regression test same as antithesis failure.