### PR TITLE
core: Thread memory allocators into buffer pool

### DIFF
--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -97,7 +97,7 @@ fn database_open_with_allocator_uses_allocator_for_mvstore_skiplist() {
     )
     .unwrap();
     let db_file = StdArc::new(crate::storage::database::DatabaseFile::new(file));
-    let db = crate::Database::open_with_flags_with_allocator(
+    let db = crate::Database::open_with_flags_with_memory_allocators(
         io,
         "open-with-allocator.db",
         db_file,
@@ -105,7 +105,9 @@ fn database_open_with_allocator_uses_allocator_for_mvstore_skiplist() {
         crate::DatabaseOpts::new(),
         None,
         None,
-        alloc,
+        crate::MemoryAllocators::new()
+            .with_mv_store_allocator(alloc.clone())
+            .with_buffer_pool_allocator(alloc),
     )
     .unwrap();
     let conn = db.connect().unwrap();
@@ -115,6 +117,21 @@ fn database_open_with_allocator_uses_allocator_for_mvstore_skiplist() {
 
     assert!(db.get_mv_store().is_some());
     assert!(allocations.load(Ordering::Relaxed) > 0);
+}
+
+#[test]
+fn buffer_pool_uses_allocator_for_arenas() {
+    let allocations = StdArc::new(AtomicUsize::new(0));
+    let alloc = DynAllocator::new(CountingAlloc {
+        allocations: allocations.clone(),
+    });
+    let io: StdArc<dyn crate::IO> = StdArc::new(crate::MemoryIO::new());
+    let pool = crate::BufferPool::begin_init(&io, crate::BufferPool::TEST_ARENA_SIZE, alloc);
+
+    pool.finalize_with_page_size(crate::BufferPool::DEFAULT_PAGE_SIZE)
+        .unwrap();
+
+    assert!(allocations.load(Ordering::Relaxed) >= 2);
 }
 
 #[test]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -303,6 +303,38 @@ impl DatabaseOpts {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct MemoryAllocators {
+    pub mv_store_allocator: alloc::DynAllocator,
+    pub buffer_pool_allocator: alloc::DynAllocator,
+}
+
+impl MemoryAllocators {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_mv_store_allocator(mut self, allocator: alloc::DynAllocator) -> Self {
+        self.mv_store_allocator = allocator;
+        self
+    }
+
+    pub fn with_buffer_pool_allocator(mut self, allocator: alloc::DynAllocator) -> Self {
+        self.buffer_pool_allocator = allocator;
+        self
+    }
+}
+
+impl Default for MemoryAllocators {
+    fn default() -> Self {
+        let allocator = alloc::DynAllocator::default();
+        Self {
+            mv_store_allocator: allocator.clone(),
+            buffer_pool_allocator: allocator,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SharedWalCoordinationOpenTelemetryMode {
     Exclusive,
@@ -698,7 +730,7 @@ impl Database {
         io: &Arc<dyn IO>,
         db_file: Arc<dyn DatabaseStorage>,
         encryption_opts: Option<EncryptionOpts>,
-        mv_store_allocator: alloc::DynAllocator,
+        memory_allocators: MemoryAllocators,
     ) -> Result<Self> {
         let path = path.into();
         let wal_path = wal_path.into();
@@ -731,7 +763,7 @@ impl Database {
 
         let db = Database {
             mv_store,
-            mv_store_allocator,
+            mv_store_allocator: memory_allocators.mv_store_allocator,
             path,
             wal_path,
             schema: Arc::new(Mutex::new(Arc::new({
@@ -749,7 +781,11 @@ impl Database {
             open_flags: flags,
             init_lock: Arc::new(Mutex::new(())),
             opts,
-            buffer_pool: BufferPool::begin_init(io, arena_size),
+            buffer_pool: BufferPool::begin_init(
+                io,
+                arena_size,
+                memory_allocators.buffer_pool_allocator,
+            ),
             n_connections: AtomicUsize::new(0),
 
             init_page_1: Arc::new(ArcSwapOption::new(init_page_1)),
@@ -1050,7 +1086,7 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
     ) -> Result<Arc<Database>> {
-        Self::open_with_flags_with_allocator(
+        Self::open_with_flags_with_memory_allocators(
             io,
             path,
             db_file,
@@ -1058,12 +1094,12 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
-            alloc::DynAllocator::default(),
+            MemoryAllocators::default(),
         )
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn open_with_flags_with_allocator(
+    pub fn open_with_flags_with_memory_allocators(
         io: Arc<dyn IO>,
         path: &str,
         db_file: Arc<dyn DatabaseStorage>,
@@ -1071,11 +1107,11 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        allocator: alloc::DynAllocator,
+        memory_allocators: MemoryAllocators,
     ) -> Result<Arc<Database>> {
         let mut state = OpenDbAsyncState::new();
         loop {
-            match Self::open_with_flags_async_with_allocator(
+            match Self::open_with_flags_async_with_memory_allocators(
                 &mut state,
                 io.clone(),
                 path,
@@ -1084,7 +1120,7 @@ impl Database {
                 opts,
                 encryption_opts.clone(),
                 durable_storage.clone(),
-                allocator.clone(),
+                memory_allocators.clone(),
             )? {
                 IOResult::Done(db) => return Ok(db),
                 IOResult::IO(io_completion) => {
@@ -1113,7 +1149,7 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
     ) -> Result<IOResult<Arc<Database>>> {
-        Self::open_with_flags_async_with_allocator(
+        Self::open_with_flags_async_with_memory_allocators(
             state,
             io,
             path,
@@ -1122,12 +1158,12 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
-            alloc::DynAllocator::default(),
+            MemoryAllocators::default(),
         )
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn open_with_flags_async_with_allocator(
+    pub fn open_with_flags_async_with_memory_allocators(
         state: &mut OpenDbAsyncState,
         io: Arc<dyn IO>,
         path: &str,
@@ -1136,7 +1172,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        allocator: alloc::DynAllocator,
+        memory_allocators: MemoryAllocators,
     ) -> Result<IOResult<Arc<Database>>> {
         let result = Self::open_with_flags_async_internal(
             state,
@@ -1147,7 +1183,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
-            allocator,
+            memory_allocators,
         );
         if result.is_err() {
             // On error, remove the Opening sentinel so other callers can proceed.
@@ -1169,7 +1205,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        allocator: alloc::DynAllocator,
+        memory_allocators: MemoryAllocators,
     ) -> Result<IOResult<Arc<Database>>> {
         // turso-sync-engine creates 2 databases with different names in the same IO if MemoryIO is used
         // in this case we need to bypass registry (as this is MemoryIO DB) but also preserve original distinction in names (e.g. :memory:-draft and :memory:-synced)
@@ -1220,7 +1256,7 @@ impl Database {
         }
 
         // Open the database asynchronously (no registry lock held).
-        let result = Self::open_with_flags_bypass_registry_async_with_allocator(
+        let result = Self::open_with_flags_bypass_registry_async_with_memory_allocators(
             state,
             io.clone(),
             path,
@@ -1230,7 +1266,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
-            allocator,
+            memory_allocators,
         )?;
 
         if let IOResult::Done(ref db) = result {
@@ -1245,7 +1281,7 @@ impl Database {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn open_with_flags_bypass_registry_async_with_allocator(
+    fn open_with_flags_bypass_registry_async_with_memory_allocators(
         state: &mut OpenDbAsyncState,
         io: Arc<dyn IO>,
         path: &str,
@@ -1255,7 +1291,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        allocator: alloc::DynAllocator,
+        memory_allocators: MemoryAllocators,
     ) -> Result<IOResult<Arc<Database>>> {
         let result = Self::open_with_flags_bypass_registry_async_internal(
             state,
@@ -1267,7 +1303,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
-            allocator,
+            memory_allocators,
         );
         if result.is_err() {
             let _ = state.schema_guard.take();
@@ -1332,7 +1368,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
-            alloc::DynAllocator::default(),
+            MemoryAllocators::default(),
         );
         if result.is_err() {
             // schema_guard is set by the open_with_flags_bypass_registry_async_internal - so we release it in case of error
@@ -1353,7 +1389,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        allocator: alloc::DynAllocator,
+        memory_allocators: MemoryAllocators,
     ) -> Result<IOResult<Arc<Database>>> {
         loop {
             tracing::debug!(
@@ -1382,7 +1418,7 @@ impl Database {
                         &io,
                         db_file.clone(),
                         encryption_opts.clone(),
-                        allocator.clone(),
+                        memory_allocators.clone(),
                     )?;
                     db.durable_storage.clone_from(&durable_storage);
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10668,7 +10668,8 @@ mod tests {
         let page_size = 512;
 
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let buffer_pool = BufferPool::begin_init(&io, page_size * 128);
+        let buffer_pool =
+            BufferPool::begin_init(&io, page_size * 128, crate::alloc::DynAllocator::default());
 
         let db_file = Arc::new(DatabaseFile::new(
             io.open_file(":memory:", OpenFlags::Create, false).unwrap(),

--- a/core/storage/buffer_pool.rs
+++ b/core/storage/buffer_pool.rs
@@ -1,7 +1,7 @@
 use branches::unlikely;
 
 use super::{slot_bitmap::AtomicSlotBitmap, sqlite3_ondisk::WAL_FRAME_HEADER_SIZE};
-use crate::alloc::ApiAllocator;
+use crate::alloc::{ApiAllocator, DynAllocator};
 use crate::io::TEMP_BUFFER_CACHE;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sync::Arc;
@@ -109,6 +109,8 @@ struct PoolInner {
     wal_frame_arena: Option<Arc<Arena>>,
     /// The size of each `Arena`, in bytes.
     arena_size: usize,
+    /// Allocator used for arena backing memory.
+    allocator: DynAllocator,
     /// The `[Database::page_size]`, which the `page_arena` will use to
     /// return buffers from `Self::get_page`.
     db_page_size: OnceLock<usize>,
@@ -120,7 +122,7 @@ crate::assert::assert_send_sync!(PoolInner);
 
 impl Default for BufferPool {
     fn default() -> Self {
-        Self::new(Self::DEFAULT_ARENA_SIZE)
+        Self::new(Self::DEFAULT_ARENA_SIZE, DynAllocator::default())
     }
 }
 
@@ -137,7 +139,7 @@ impl BufferPool {
     const MAX_ARENA_SIZE: usize = 32 * 1024 * 1024;
     /// 64kb Minimum arena size
     const MIN_ARENA_SIZE: usize = 1024 * 64;
-    fn new(arena_size: usize) -> Self {
+    fn new(arena_size: usize, allocator: DynAllocator) -> Self {
         turso_assert!(
             (Self::MIN_ARENA_SIZE..Self::MAX_ARENA_SIZE).contains(&arena_size),
             "Arena size out of valid range",
@@ -148,6 +150,7 @@ impl BufferPool {
                 page_arena: None,
                 wal_frame_arena: None,
                 arena_size,
+                allocator,
                 db_page_size: OnceLock::new(),
                 io: None,
             }),
@@ -190,8 +193,8 @@ impl BufferPool {
     /// populating the Arenas. Arenas will not be created until `[BufferPool::finalize_page_size]`,
     /// and the pool will temporarily return temporary buffers to prevent reallocation of the
     /// arena if the page size is set to something other than the default value.
-    pub fn begin_init(io: &Arc<dyn IO>, arena_size: usize) -> Arc<Self> {
-        let pool = Arc::new(BufferPool::new(arena_size));
+    pub fn begin_init(io: &Arc<dyn IO>, arena_size: usize, allocator: DynAllocator) -> Arc<Self> {
+        let pool = Arc::new(BufferPool::new(arena_size, allocator));
         let inner = pool.inner_mut();
         // Just store the IO handle, don't create arena yet
         if inner.io.is_none() {
@@ -282,11 +285,12 @@ impl PoolInner {
     fn init_arenas(&mut self) -> crate::Result<()> {
         let db_page_size = self.get_db_page_size();
         let arena_size = self.arena_size;
+        let allocator = self.allocator.clone();
 
         let io = self.io.as_ref().expect("Pool not initialized").clone();
 
         // Create regular page arena
-        match Arena::new(db_page_size, arena_size, &io) {
+        match Arena::new(db_page_size, arena_size, &io, allocator.clone()) {
             Ok(arena) => {
                 tracing::trace!(
                     "added arena {} with size {} MB and slot size {}",
@@ -306,7 +310,7 @@ impl PoolInner {
 
         // Create WAL frame arena
         let wal_frame_size = db_page_size + WAL_FRAME_HEADER_SIZE;
-        match Arena::new(wal_frame_size, arena_size, &io) {
+        match Arena::new(wal_frame_size, arena_size, &io, allocator) {
             Ok(arena) => {
                 tracing::trace!(
                     "added WAL frame arena {} with size {} MB and slot size {}",
@@ -345,6 +349,8 @@ struct Arena {
     slot_size: usize,
     /// Layout used to allocate the arena backing memory.
     layout: arena::ArenaLayout,
+    /// Allocator that owns `base`.
+    allocator: DynAllocator,
 }
 
 // SAFETY: Arena's base pointer is uniquely owned by the arena. All mutable state
@@ -354,7 +360,7 @@ unsafe impl Sync for Arena {}
 
 impl Drop for Arena {
     fn drop(&mut self) {
-        unsafe { arena::DEFAULT_ARENA_ALLOCATOR.deallocate(self.base, self.layout) };
+        unsafe { self.allocator.deallocate(self.base, self.layout) };
     }
 }
 
@@ -372,7 +378,12 @@ static NEXT_ID: std::sync::atomic::AtomicU32 =
 impl Arena {
     /// Create a new arena with the given size and page size.
     /// NOTE: Minimum arena size is slot_size * 64
-    fn new(slot_size: usize, arena_size: usize, io: &Arc<dyn IO>) -> Result<Self, String> {
+    fn new(
+        slot_size: usize,
+        arena_size: usize,
+        io: &Arc<dyn IO>,
+        allocator: DynAllocator,
+    ) -> Result<Self, String> {
         let min_slots = arena_size.div_ceil(slot_size);
         let rounded_slots = (min_slots.max(64) + 63) & !63;
         let rounded_bytes = rounded_slots * slot_size;
@@ -386,7 +397,7 @@ impl Arena {
         }
         let layout = arena::ArenaLayout::from_size_align(rounded_bytes, arena::ARENA_ALIGNMENT)
             .map_err(|err| format!("invalid arena layout: {err}"))?;
-        let allocation = arena::DEFAULT_ARENA_ALLOCATOR
+        let allocation = allocator
             .allocate(layout)
             .map_err(|_| "arena allocation failed".to_string())?;
         let base = allocation.cast();
@@ -406,6 +417,7 @@ impl Arena {
             allocated_slots: AtomicUsize::new(0),
             slot_size,
             layout,
+            allocator,
         })
     }
 
@@ -445,14 +457,11 @@ impl Arena {
 }
 
 mod arena {
-    use crate::alloc::{Layout, TursoAllocator};
+    use crate::alloc::Layout;
 
     pub type ArenaLayout = Layout;
 
     pub const ARENA_ALIGNMENT: usize = std::mem::size_of::<u8>();
-
-    pub type DefaultArenaAllocator = TursoAllocator;
-    pub const DEFAULT_ARENA_ALLOCATOR: DefaultArenaAllocator = TursoAllocator;
 }
 
 /// Shuttle tests for concurrent buffer pool operations.
@@ -472,7 +481,8 @@ mod shuttle_tests {
 
     fn create_test_pool() -> Arc<BufferPool> {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let pool =
+            BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE, DynAllocator::default());
         pool.finalize_with_page_size(4096).unwrap();
         pool
     }
@@ -664,7 +674,8 @@ mod shuttle_tests {
     fn shuttle_concurrent_finalize() {
         let test = || {
             let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-            let pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+            let pool =
+                BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE, DynAllocator::default());
             let pool2 = Arc::clone(&pool);
             let pool3 = Arc::clone(&pool);
 

--- a/core/storage/buffer_pool.rs
+++ b/core/storage/buffer_pool.rs
@@ -1,6 +1,7 @@
 use branches::unlikely;
 
 use super::{slot_bitmap::AtomicSlotBitmap, sqlite3_ondisk::WAL_FRAME_HEADER_SIZE};
+use crate::alloc::ApiAllocator;
 use crate::io::TEMP_BUFFER_CACHE;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sync::Arc;
@@ -334,26 +335,26 @@ struct Arena {
     /// with `io_uring`, then the ID represents the index of the arena into the ring's
     /// sparse registered buffer array created on the ring's initialization.
     id: u32,
-    /// Base pointer to the arena returned by `mmap`
+    /// Base pointer to the arena allocated through Turso's allocator API.
     base: NonNull<u8>,
     /// Total number of slots currently allocated/in use.
     allocated_slots: AtomicUsize,
     /// Currently free slots (lock-free atomic bitmap).
     free_slots: AtomicSlotBitmap,
-    /// Total size of the arena in bytes
-    arena_size: usize,
     /// Slot size the total arena is divided into.
     slot_size: usize,
+    /// Layout used to allocate the arena backing memory.
+    layout: arena::ArenaLayout,
 }
 
-// SAFETY: Arena's base pointer comes from mmap and is never aliased. All mutable
-// state is behind atomics (AtomicUsize, AtomicSlotBitmap), so concurrent access is safe.
+// SAFETY: Arena's base pointer is uniquely owned by the arena. All mutable state
+// is behind atomics (AtomicUsize, AtomicSlotBitmap), so concurrent access is safe.
 unsafe impl Send for Arena {}
 unsafe impl Sync for Arena {}
 
 impl Drop for Arena {
     fn drop(&mut self) {
-        unsafe { arena::dealloc(self.base.as_ptr(), self.arena_size) };
+        unsafe { arena::DEFAULT_ARENA_ALLOCATOR.deallocate(self.base, self.layout) };
     }
 }
 
@@ -383,8 +384,12 @@ impl Arena {
                 BufferPool::MAX_ARENA_SIZE
             ));
         }
-        let ptr = unsafe { arena::alloc(rounded_bytes) };
-        let base = NonNull::new(ptr).ok_or("Failed to allocate arena")?;
+        let layout = arena::ArenaLayout::from_size_align(rounded_bytes, arena::ARENA_ALIGNMENT)
+            .map_err(|err| format!("invalid arena layout: {err}"))?;
+        let allocation = arena::DEFAULT_ARENA_ALLOCATOR
+            .allocate(layout)
+            .map_err(|_| "arena allocation failed".to_string())?;
+        let base = allocation.cast();
         let id = io
             .register_fixed_buffer(base, rounded_bytes)
             .unwrap_or_else(|_| {
@@ -400,7 +405,7 @@ impl Arena {
             free_slots: map,
             allocated_slots: AtomicUsize::new(0),
             slot_size,
-            arena_size: rounded_bytes,
+            layout,
         })
     }
 
@@ -439,49 +444,15 @@ impl Arena {
     }
 }
 
-#[cfg(all(unix, not(miri)))]
 mod arena {
-    use libc::MAP_ANONYMOUS;
-    use libc::{mmap, munmap, MAP_PRIVATE, PROT_READ, PROT_WRITE};
-    use std::ffi::c_void;
+    use crate::alloc::{Layout, TursoAllocator};
 
-    pub unsafe fn alloc(len: usize) -> *mut u8 {
-        let ptr = mmap(
-            std::ptr::null_mut(),
-            len,
-            PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS,
-            -1,
-            0,
-        );
-        if ptr == libc::MAP_FAILED {
-            panic!("mmap failed: {}", std::io::Error::last_os_error());
-        }
-        #[cfg(target_os = "linux")]
-        {
-            libc::madvise(ptr, len, libc::MADV_HUGEPAGE);
-        }
-        ptr as *mut u8
-    }
+    pub type ArenaLayout = Layout;
 
-    pub unsafe fn dealloc(ptr: *mut u8, len: usize) {
-        let result = munmap(ptr as *mut c_void, len);
-        if result != 0 {
-            panic!("munmap failed: {}", std::io::Error::last_os_error());
-        }
-    }
-}
+    pub const ARENA_ALIGNMENT: usize = std::mem::size_of::<u8>();
 
-#[cfg(any(not(unix), miri))]
-mod arena {
-    pub unsafe fn alloc(len: usize) -> *mut u8 {
-        let layout = std::alloc::Layout::from_size_align(len, std::mem::size_of::<u8>()).unwrap();
-        unsafe { std::alloc::alloc_zeroed(layout) }
-    }
-    pub unsafe fn dealloc(ptr: *mut u8, len: usize) {
-        let layout = std::alloc::Layout::from_size_align(len, std::mem::size_of::<u8>()).unwrap();
-        unsafe { std::alloc::dealloc(ptr, layout) };
-    }
+    pub type DefaultArenaAllocator = TursoAllocator;
+    pub const DEFAULT_ARENA_ALLOCATOR: DefaultArenaAllocator = TursoAllocator;
 }
 
 /// Shuttle tests for concurrent buffer pool operations.

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -5891,7 +5891,11 @@ mod ptrmap_tests {
         //  Construct interfaces for the pager
         let pages = initial_db_pages + 10;
         let sz = std::cmp::max(std::cmp::min(pages, 64), pages);
-        let buffer_pool = BufferPool::begin_init(&io, (sz * page_size) as usize);
+        let buffer_pool = BufferPool::begin_init(
+            &io,
+            (sz * page_size) as usize,
+            crate::alloc::DynAllocator::default(),
+        );
 
         let wal_shared = WalFileShared::new_shared(
             io.open_file("test.db-wal", OpenFlags::Create, false)
@@ -5967,7 +5971,7 @@ mod ptrmap_tests {
             io.open_file("fresh-auto-vacuum.db", OpenFlags::Create, true)
                 .unwrap(),
         ));
-        let buffer_pool = BufferPool::begin_init(&io, 65536);
+        let buffer_pool = BufferPool::begin_init(&io, 65536, crate::alloc::DynAllocator::default());
         let pager = Pager::new(
             db_file,
             None,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -2332,7 +2332,11 @@ mod tests {
             .unwrap();
 
         let page_size: usize = 1024;
-        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let buffer_pool = BufferPool::begin_init(
+            &io,
+            BufferPool::TEST_ARENA_SIZE,
+            crate::alloc::DynAllocator::default(),
+        );
         buffer_pool
             .finalize_with_page_size(page_size)
             .expect("initialize buffer pool");

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -5985,7 +5985,11 @@ pub mod test {
 
     fn make_test_wal() -> (Arc<RwLock<WalFileShared>>, WalFile) {
         let io = shared_wal_test_io();
-        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let buffer_pool = BufferPool::begin_init(
+            &io,
+            BufferPool::TEST_ARENA_SIZE,
+            crate::alloc::DynAllocator::default(),
+        );
         let shared = WalFileShared::new_noop();
         let coordination: Arc<dyn WalCoordination> =
             Arc::new(InProcessWalCoordination::new(shared.clone()));
@@ -5995,14 +5999,22 @@ pub mod test {
 
     fn make_test_wal_from_shared(shared: Arc<RwLock<WalFileShared>>) -> WalFile {
         let io = shared_wal_test_io();
-        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let buffer_pool = BufferPool::begin_init(
+            &io,
+            BufferPool::TEST_ARENA_SIZE,
+            crate::alloc::DynAllocator::default(),
+        );
         let snapshot = shared.read().last_checksum_and_max_frame();
         WalFile::new(io, shared, snapshot, buffer_pool)
     }
 
     fn make_initialized_memory_wal(page_size: u32) -> (Arc<dyn IO>, Arc<BufferPool>, WalFile) {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let buffer_pool = BufferPool::begin_init(
+            &io,
+            BufferPool::TEST_ARENA_SIZE,
+            crate::alloc::DynAllocator::default(),
+        );
         buffer_pool
             .finalize_with_page_size(page_size as usize)
             .unwrap();
@@ -6354,7 +6366,11 @@ pub mod test {
         )
         .unwrap();
 
-        let buffer_pool = BufferPool::begin_init(io, BufferPool::TEST_ARENA_SIZE);
+        let buffer_pool = BufferPool::begin_init(
+            io,
+            BufferPool::TEST_ARENA_SIZE,
+            crate::alloc::DynAllocator::default(),
+        );
         buffer_pool
             .finalize_with_page_size(wal_header.page_size as usize)
             .unwrap();
@@ -6437,7 +6453,11 @@ pub mod test {
         }
 
         let coordination: Arc<dyn WalCoordination> = Arc::new(make_test_coordination(&shared));
-        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let buffer_pool = BufferPool::begin_init(
+            &io,
+            BufferPool::TEST_ARENA_SIZE,
+            crate::alloc::DynAllocator::default(),
+        );
         buffer_pool
             .finalize_with_page_size(snapshot.page_size as usize)
             .unwrap();
@@ -6511,7 +6531,11 @@ pub mod test {
     #[test]
     fn test_wal_explicit_backend_constructor_does_not_keep_shared_handle() {
         let io = shared_wal_test_io();
-        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let buffer_pool = BufferPool::begin_init(
+            &io,
+            BufferPool::TEST_ARENA_SIZE,
+            crate::alloc::DynAllocator::default(),
+        );
         let shared = WalFileShared::new_noop();
         let coordination: Arc<dyn WalCoordination> =
             Arc::new(InProcessWalCoordination::new(shared.clone()));
@@ -7342,7 +7366,11 @@ pub mod test {
         .unwrap();
         assert!(shared.read().runtime.frame_cache.lock().is_empty());
 
-        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let buffer_pool = BufferPool::begin_init(
+            &io,
+            BufferPool::TEST_ARENA_SIZE,
+            crate::alloc::DynAllocator::default(),
+        );
         buffer_pool.finalize_with_page_size(4096).unwrap();
         let wal = WalFile::new_with_shared_coordination(
             io.clone(),
@@ -7454,7 +7482,11 @@ pub mod test {
         authority.install_snapshot(snapshot);
         authority.record_frame(7, 1);
 
-        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let buffer_pool = BufferPool::begin_init(
+            &io,
+            BufferPool::TEST_ARENA_SIZE,
+            crate::alloc::DynAllocator::default(),
+        );
         buffer_pool.finalize_with_page_size(4096).unwrap();
         let wal =
             WalFile::new_with_shared_coordination(io, shared, authority, ((0, 0), 0), buffer_pool);


### PR DESCRIPTION
# Description
- Add explicit MemoryAllocators configuration for MV store and buffer pool allocator domains
- Thread the buffer pool allocator through database open into BufferPool and Arena
- Keep arena allocation/deallocation on the same DynAllocator and update allocator coverage
- removes the previous Mmap allocator for the arenas

# Context
Memory limits

# Ai Usage
Codex did as I instructed

