### PR TITLE
fix(alter): reject DROP COLUMN when CHECK references dropped column

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1024,13 +1024,16 @@ pub fn translate_alter_table(
 
             // Handle CHECK constraints:
             // - Column-level CHECK constraints for the dropped column are silently removed
-            // - Table-level CHECK constraints referencing the dropped column cause an error
+            // - Any other CHECK constraint referencing the dropped column causes an error
             for check in &btree.check_constraints {
-                if check.column.is_some() {
-                    // Column-level constraint: will be removed below
+                if check
+                    .column
+                    .as_ref()
+                    .is_some_and(|col| normalize_ident(col) == col_normalized)
+                {
+                    // Column-level constraint on the dropped column: removed below
                     continue;
                 }
-                // Table-level constraint: check if it references the dropped column
                 if check_expr_references_column(&check.expr, &col_normalized) {
                     return Err(LimboError::ParseError(format!(
                         "error in table {table_name} after drop column: no such column: {column_name}"

--- a/testing/sqltests/tests/alter_table.sqltest
+++ b/testing/sqltests/tests/alter_table.sqltest
@@ -772,13 +772,16 @@ expect {
 }
 
 # Column-level CHECK with table-qualified reference to dropped column → fail
+# Behaviour matches SQLite (DROP rejected). Error text differs for qualified refs:
+# SQLite reports the reference as written (t_check_qual.a); Turso the bare name (a).
+# Regex below accepts both; aligning Turso's message with SQLite is a separate issue.
 @cross-check-integrity
 test fail-drop-column-column-level-check-qualified-ref {
     CREATE TABLE t_check_qual (a INTEGER, b INTEGER CHECK (t_check_qual.a < b));
     ALTER TABLE t_check_qual DROP COLUMN a;
 }
 expect error {
-    error in table t_check_qual after drop column: no such column: a
+    error in table t_check_qual after drop column: no such column: (t_check_qual\.)?a
 }
 
 # Table-level CHECK referencing multiple columns including dropped column → fail

--- a/testing/sqltests/tests/alter_table.sqltest
+++ b/testing/sqltests/tests/alter_table.sqltest
@@ -699,6 +699,7 @@ expect {
     1
 }
 
+# Column-level CHECK on the dropped column only → removed with the column
 @cross-check-integrity
 test drop-column-removes-check-constraint {
     CREATE TABLE t_check (a INTEGER PRIMARY KEY, b REAL CHECK (b BETWEEN 0.0 AND 1000.0), c INTEGER NOT NULL);
@@ -712,6 +713,7 @@ expect {
     2|99
 }
 
+# Table-level CHECK referencing dropped column → fail
 @cross-check-integrity
 test fail-drop-column-table-level-check-constraint {
     CREATE TABLE t_check2 (a INTEGER PRIMARY KEY, b INTEGER, c TEXT, CHECK (b > 0));
@@ -719,6 +721,84 @@ test fail-drop-column-table-level-check-constraint {
 }
 expect error {
     error in table t_check2 after drop column: no such column: b
+}
+
+# Column-level CHECK on another column referencing dropped column → fail
+@cross-check-integrity
+test fail-drop-column-column-level-check-references-other-column {
+    CREATE TABLE t_check3 (a INTEGER, b INTEGER CHECK (b > a));
+    ALTER TABLE t_check3 DROP COLUMN a;
+}
+expect error {
+    error in table t_check3 after drop column: no such column: a
+}
+
+# Same as above; referenced column appears first in the CHECK expression → fail
+@cross-check-integrity
+test fail-drop-column-column-level-check-reverse-expr-order {
+    CREATE TABLE t_check_rev (a INTEGER, b INTEGER CHECK (a <= b));
+    ALTER TABLE t_check_rev DROP COLUMN a;
+}
+expect error {
+    error in table t_check_rev after drop column: no such column: a
+}
+
+# Drop the column that owns the CHECK even when the expr references other columns → succeed
+@cross-check-integrity
+test drop-column-removes-column-level-check-referencing-other-column {
+    CREATE TABLE t_check_own (a INTEGER, b INTEGER CHECK (b > a));
+    INSERT INTO t_check_own VALUES (1, 5);
+    ALTER TABLE t_check_own DROP COLUMN b;
+    INSERT INTO t_check_own (a) VALUES (2);
+    SELECT * FROM t_check_own;
+}
+expect {
+    1
+    2
+}
+
+# Drop a column not referenced by any CHECK → succeed
+@cross-check-integrity
+test drop-column-unrelated-column-with-check-on-other-columns {
+    CREATE TABLE t_check_unrel (a INTEGER, b INTEGER CHECK (b > a), c TEXT);
+    INSERT INTO t_check_unrel VALUES (1, 5, 'x');
+    ALTER TABLE t_check_unrel DROP COLUMN c;
+    INSERT INTO t_check_unrel (a, b) VALUES (2, 10);
+    SELECT * FROM t_check_unrel;
+}
+expect {
+    1|5
+    2|10
+}
+
+# Column-level CHECK with table-qualified reference to dropped column → fail
+@cross-check-integrity
+test fail-drop-column-column-level-check-qualified-ref {
+    CREATE TABLE t_check_qual (a INTEGER, b INTEGER CHECK (t_check_qual.a < b));
+    ALTER TABLE t_check_qual DROP COLUMN a;
+}
+expect error {
+    error in table t_check_qual after drop column: no such column: a
+}
+
+# Table-level CHECK referencing multiple columns including dropped column → fail
+@cross-check-integrity
+test fail-drop-column-table-level-multi-column-check {
+    CREATE TABLE t_check_multi (a INTEGER, b INTEGER, c INTEGER, CHECK (a + b > c));
+    ALTER TABLE t_check_multi DROP COLUMN a;
+}
+expect error {
+    error in table t_check_multi after drop column: no such column: a
+}
+
+# Named column-level CHECK referencing another column → fail
+@cross-check-integrity
+test fail-drop-column-named-column-level-check-references-other-column {
+    CREATE TABLE t_check_named (a INTEGER, b INTEGER CONSTRAINT b_gt_a CHECK (b > a));
+    ALTER TABLE t_check_named DROP COLUMN a;
+}
+expect error {
+    error in table t_check_named after drop column: no such column: a
 }
 
 @cross-check-integrity


### PR DESCRIPTION
Fixes #7646

## Description

Turso incorrectly allowed `ALTER TABLE ... DROP COLUMN` when a column-level CHECK on a *different* column referenced the dropped column. SQLite rejects this with:

`error in table t after drop column: no such column: a`

The bug was in `DROP COLUMN` validation: column-level CHECK constraints were skipped entirely if `check.column` was set, on the assumption they would be removed with their owning column. That is only correct when the dropped column *owns* the constraint, not when another column's CHECK references the dropped column.

Added 7 .sqltest tests covering the issue reproducer, reverse expression order, dropping the owning column, unrelated columns, qualified references, multi-column table-level CHECK, and named constraints.

## Follow-up (separate PR required)
For CHECK constraints that reference a dropped column with a table-qualified name (e.g. CHECK (t_check_qual.a < b)), Turso and SQLite both reject the DROP, but the error text differs:

SQLite: no such column: t_check_qual.a (uses the reference as written in the expression)
Turso: no such column: a (uses the bare dropped column name)
The sqltest fail-drop-column-column-level-check-qualified-ref uses a regex to accept both formats on the SQLite backend cross-check. Aligning Turso's error message with SQLite is out of scope here and should be a separate PR.

## Motivation and context

Fixes #7646

SQLite compatibility bug in `ALTER TABLE DROP COLUMN` + `CHECK` handling. I picked this issue to continue getting familiar with the translate layer and sqltest conventions.

## Description of AI Usage

I used Cursor IDE (Composer 2.5 Fast) as the main working environment for this PR.

**What I did:**
- Chose the issue and drove the workflow (reproducing against sqlite3, discussing the bug and SQLite's error message, deciding on thorough test coverage, pre-PR gate checklist, branch/PR hygiene)
- Verified behaviour manually in the Turso CLI and with `scripts/diff.sh`
- Directed test scope, asked for thorough coverage beyond the minimal reproducer; reviewed and edited test comments
- Ran local validation: `cargo fmt`, `cargo clippy`, targeted sqltests, and `make test`
- Reviewed the final diff before commit and push

**What AI did:**
- Repo navigation, issue discovery, and contribution workflow (turso-contribute skill / AGENTS.md)
- Identified the root cause in `core/translate/alter.rs` and proposed the fix
- Drafted initial tests; I asked for more edge cases and we expanded
- Ran most of the automated commands and helped interpret results (e.g. `make test` big-db timeouts on WSL)

AI did most of the implementation leg work; I orchestrated the process, validated understanding of the bug (including why SQLite reports "no such column"), and made the calls on scope and testing. I reviewed the output and I take responsibility for the changes.

**Checkbox:** Please tick "Allow edits from maintainers" on the PR.