### PR TITLE
fix(alter): resolve temp trigger table for RENAME COLUMN on main

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -2581,16 +2581,20 @@ fn rewrite_trigger_sql_for_column_rename(
     let old_col_norm = normalize_ident(old_column_name);
     let new_col_norm = normalize_ident(new_column_name);
 
-    // Get the trigger's owning table to check unqualified column references
+    // Get the trigger's owning table to check unqualified column references.
+    // TEMP triggers live in the temp schema but may target a table in main
+    // or an attached database — resolve the table where it actually lives.
     let trigger_table_name_raw = tbl_name.name.as_str();
     let trigger_table_name = normalize_ident(trigger_table_name_raw);
-    let trigger_table = resolver
-        .with_schema(trigger_database_id, |schema| {
-            schema.get_btree_table(&trigger_table_name)
-        })
-        .ok_or_else(|| {
-            LimboError::ParseError(format!("trigger table not found: {trigger_table_name}"))
-        })?;
+    let trigger_table = resolve_trigger_command_table_for_alter(
+        resolver,
+        trigger_database_id,
+        &trigger_table_name,
+        tbl_name.db_name.as_ref().map(|db| db.as_str()),
+    )
+    .ok_or_else(|| {
+        LimboError::ParseError(format!("trigger table not found: {trigger_table_name}"))
+    })?;
 
     // Check if this trigger references the column being renamed
     // We need to check if the column exists in the table being renamed
@@ -2940,10 +2944,11 @@ fn apply_expr_for_column_rename(
     {
         let ctx_name_norm = normalize_ident(ctx_name);
         let is_renaming = ctx_name_norm == *target_table_name;
-        let table = resolve_trigger_command_table_for_alter(resolver, database_id, &ctx_name_norm)
-            .ok_or_else(|| {
-                LimboError::ParseError(format!("context table not found: {ctx_name_norm}"))
-            })?;
+        let table =
+            resolve_trigger_command_table_for_alter(resolver, database_id, &ctx_name_norm, None)
+                .ok_or_else(|| {
+                    LimboError::ParseError(format!("context table not found: {ctx_name_norm}"))
+                })?;
         Some((table, ctx_name_norm, is_renaming))
     } else {
         None
@@ -3965,15 +3970,17 @@ fn validate_trigger_columns_after_drop(
                 .collect(),
         )
     } else {
-        resolver.with_schema(trigger_database_id, |s| {
-            s.get_table(&trigger_table_norm).and_then(|t| {
-                t.btree().map(|bt| {
-                    bt.columns()
-                        .iter()
-                        .filter_map(|c| c.name.as_deref().map(normalize_ident))
-                        .collect()
-                })
-            })
+        resolve_trigger_command_table_for_alter(
+            resolver,
+            trigger_database_id,
+            &trigger_table_norm,
+            None,
+        )
+        .map(|bt| {
+            bt.columns()
+                .iter()
+                .filter_map(|c| c.name.as_deref().map(normalize_ident))
+                .collect()
         })
     };
 
@@ -5597,26 +5604,43 @@ fn get_table_columns(
     }
 }
 
+/// Resolve the table named in a trigger's `ON <table>` clause during ALTER TABLE.
+///
+/// Triggers are stored in one schema (temp, main, or attached) but may fire on a
+/// table in another e.g. `CREATE TEMP TRIGGER ... ON t` where `t` lives in main.
+/// Callers must look up the target table where it actually resides, not where the
+/// trigger definition is stored.
 fn resolve_trigger_command_table_for_alter(
     resolver: &Resolver,
     trigger_database_id: usize,
     table_name_norm: &str,
+    explicit_db_name: Option<&str>,
 ) -> Option<Arc<BTreeTable>> {
-    if trigger_database_id == crate::TEMP_DB_ID {
+    let lookup_database_id = if let Some(db_name) = explicit_db_name {
+        // Qualified target, e.g. `ON main.t` or `ON attached.t`.
         resolver
-            .with_schema(crate::TEMP_DB_ID, |schema| {
-                schema.get_btree_table(table_name_norm)
-            })
-            .or_else(|| {
-                resolver.with_schema(crate::MAIN_DB_ID, |schema| {
-                    schema.get_btree_table(table_name_norm)
-                })
-            })
+            .resolve_database_id(&ast::QualifiedName::fullname(
+                ast::Name::exact(db_name.to_string()),
+                ast::Name::exact(table_name_norm.to_string()),
+            ))
+            .ok()?
+    } else if trigger_database_id == crate::TEMP_DB_ID {
+        // Unqualified TEMP trigger: prefer temp schema, fall back to main.
+        if resolver.with_schema(crate::TEMP_DB_ID, |schema| {
+            schema.get_btree_table(table_name_norm).is_some()
+        }) {
+            crate::TEMP_DB_ID
+        } else {
+            crate::MAIN_DB_ID
+        }
     } else {
-        resolver.with_schema(trigger_database_id, |schema| {
-            schema.get_btree_table(table_name_norm)
-        })
-    }
+        // Permanent trigger: target table is in the same schema as the trigger.
+        trigger_database_id
+    };
+
+    resolver.with_schema(lookup_database_id, |schema| {
+        schema.get_btree_table(table_name_norm)
+    })
 }
 
 fn merge_column_lists(left: &[String], right: &[String]) -> Vec<String> {

--- a/testing/sqltests/tests/alter_table.sqltest
+++ b/testing/sqltests/tests/alter_table.sqltest
@@ -1854,6 +1854,47 @@ expect pattern {
     CREATE TRIGGER trig1 AFTER INSERT ON t1\s+BEGIN\s+INSERT INTO log VALUES\s*\(NEW\.b\);?\s+END
 }
 
+# TEMP trigger on a main-table target must not block RENAME COLUMN
+@cross-check-integrity
+test alter-table-rename-column-temp-trigger-on-main-table {
+    CREATE TABLE t(a, b);
+    CREATE TEMP TRIGGER trg BEFORE UPDATE ON t BEGIN SELECT 1; END;
+    ALTER TABLE t RENAME COLUMN a TO a2;
+    SELECT group_concat(name) FROM pragma_table_info('t');
+}
+expect {
+    a2,b
+}
+
+# Qualified ON main.t must resolve the main-table target
+@cross-check-integrity
+test alter-table-rename-column-temp-trigger-on-main-qualified {
+    CREATE TABLE t(a, b);
+    CREATE TEMP TRIGGER trg BEFORE UPDATE ON main.t BEGIN SELECT 1; END;
+    ALTER TABLE main.t RENAME COLUMN a TO a2;
+    SELECT group_concat(name) FROM main.pragma_table_info('t');
+}
+expect {
+    a2,b
+}
+
+# Qualified ON main.t must not follow a temp shadow with the same name
+@cross-check-integrity
+test alter-table-rename-column-temp-trigger-on-main-qualified-shadow {
+    CREATE TABLE t(a, b);
+    INSERT INTO main.t VALUES (1, 2);
+    CREATE TEMP TABLE t(x);
+    INSERT INTO temp.t VALUES (99);
+    CREATE TEMP TRIGGER trg BEFORE UPDATE ON main.t BEGIN SELECT 1; END;
+    ALTER TABLE main.t RENAME COLUMN a TO a2;
+    SELECT group_concat(a2 || ':' || b) FROM main.t;
+    SELECT group_concat(x) FROM temp.t;
+}
+expect {
+    1:2
+    99
+}
+
 test alter-table-rename-column-temp-trigger-main-cross-table {
     CREATE TABLE src_temp_main (a INTEGER PRIMARY KEY, b);
     CREATE TABLE log_temp_main (v);


### PR DESCRIPTION
Fixes #7644

## Description

`ALTER TABLE ... RENAME COLUMN` failed with `trigger table not found` when a `TEMP` trigger was defined on a table in `main` (or an attached database). SQLite accepts this; Turso rejected the rename and rolled it back.

During rename-column trigger rewriting, Turso looked up the trigger's `ON <table>` target in the trigger's **own** schema (temp). For `CREATE TEMP TRIGGER ... ON t`, the table `t` lives in `main`, so the lookup failed even though the rename itself was valid.

This PR fixes table resolution for trigger rewrite/validation during `RENAME COLUMN` by resolving the target table where it actually lives, not where the trigger definition is stored.

## Motivation and context

Reproducer from #7644:

```sql
CREATE TABLE t(a, b);
CREATE TEMP TRIGGER trg BEFORE UPDATE ON t BEGIN SELECT 1; END;
ALTER TABLE t RENAME COLUMN a TO a2;
-- Turso (before): Parse error: trigger table not found: t
-- SQLite:         rename succeeds; columns are a2, b
```

**Root cause:** `rewrite_trigger_sql_for_column_rename` called `resolver.with_schema(trigger_database_id, ...)` to find the trigger's owning table. For temp triggers on main-table targets, that schema is wrong.

**Fix:** Extended `resolve_trigger_command_table_for_alter` to:

1. **Unqualified temp trigger** (`ON t`): prefer temp schema if a temp table exists with that name, otherwise fall back to main.
2. **Qualified target** (`ON main.t`, `ON aux.t`): resolve via the explicit database name from the parsed trigger AST.
3. **Permanent triggers:** unchanged — target table is in the same schema as the trigger.

Call sites updated:

- `rewrite_trigger_sql_for_column_rename` — passes `tbl_name.db_name` from the parsed `CREATE TRIGGER` AST
- `apply_expr_for_column_rename` — NEW/OLD context table lookup
- `validate_trigger_columns_after_drop` — column list for the trigger's owning table

**Tests added** (`testing/sqltests/tests/alter_table.sqltest`):

| Test | What it covers |
|------|----------------|
| `alter-table-rename-column-temp-trigger-on-main-table` | Direct reproducer: temp trigger on unqualified main table |
| `alter-table-rename-column-temp-trigger-on-main-qualified` | `ON main.t` qualification |
| `alter-table-rename-column-temp-trigger-on-main-qualified-shadow` | Temp table shadows `main.t`; qualified `ON main.t` must still rename the main table, not the temp shadow |

All three use `@cross-check-integrity` for sqlite3 parity.

**Out of scope:** A separate latent bug around rewriting `NEW.<col>` references in trigger bodies was identified during development but intentionally not fixed here — this PR stays scoped to the table-resolution failure in #7644.

## Description of AI Usage

This PR was developed with **Cursor**, using the **Composer 2.5 Fast** LLM as the primary AI model for implementation assistance (not the generic Cursor Agent label alone).

**How AI was used:**

- Identifying the failing code path (`rewrite_trigger_sql_for_column_rename` / `resolve_trigger_command_table_for_alter`) from the issue reproducer
- Drafting the fix and the three sqltests above
- Running targeted sqltests, `cargo fmt`, `cargo clippy`, and pre-PR test runs
- Drafting and refining this PR description

**Human role:**

- Picked the issue and directed scope (e.g. explicitly deferring the unrelated `NEW.<col>` rewrite bug)
- Reviewed the fix and test scenarios, and orchestrated refactoring
- Considered consequences of renaming `resolve_trigger_command_table_for_alter`, decided against it
- Ran the full pre-PR checklist and validated results before opening the PR

I reviewed all generated code and take responsibility for the final diff.