### PR TITLE
ci: fix codspeed runs being treated separately

### DIFF
--- a/.github/workflows/codspeed-memory.yml
+++ b/.github/workflows/codspeed-memory.yml
@@ -8,15 +8,7 @@
 name: CodSpeed Memory
 
 on:
-  push:
-    branches:
-      - "main"
-  pull_request:
-  workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
+  workflow_call:
 
 permissions:
   contents: read
@@ -75,6 +67,7 @@ jobs:
           - mixed
           - scan-heavy
           - series-blob
+          - update-churn
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -21,6 +21,13 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  memory:
+    name: Memory benchmarks
+    uses: ./.github/workflows/codspeed-memory.yml
+    permissions:
+      contents: read
+      id-token: write
+
   discover:
     name: Discover benchmark shards
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
## Description
We need to run the workflows in the same workflow run so that they are treated as a single run