### PR TITLE
fix(vtab): insert every row of a multi-row VALUES into virtual tables

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -3293,12 +3293,15 @@ fn translate_virtual_table_insert(
     if virtual_table.readonly() && !allow_dbpage_write {
         crate::bail_constraint_error!("Table is read-only: {}", virtual_table.name);
     }
-    let (num_values, value) = match &mut body {
+    let (num_values, rows) = match &mut body {
         InsertBody::Select(select, None) => match &mut select.body.select {
-            OneSelect::Values(values) => (values[0].len(), values.pop().unwrap()),
+            OneSelect::Values(values) => {
+                let num_values = values[0].len();
+                (num_values, std::mem::take(values))
+            }
             _ => crate::bail_parse_error!("Virtual tables only support VALUES clause in INSERT"),
         },
-        InsertBody::DefaultValues => (0, vec![]),
+        InsertBody::DefaultValues => (0, vec![vec![]]),
         _ => crate::bail_parse_error!("Unsupported INSERT body for virtual tables"),
     };
     let table = Table::Virtual(virtual_table.clone());
@@ -3321,16 +3324,17 @@ fn translate_virtual_table_insert(
      * argv[2..] = column values
      * */
     let insertion = build_insertion(program, &table, &columns, num_values)?;
-
-    translate_rows_single(program, &value, &insertion, resolver, false)?;
     let conflict_action = on_conflict.as_ref().map(|c| c.bit_value()).unwrap_or(0) as u16;
 
-    program.emit_insn(Insn::VUpdate {
-        cursor_id,
-        arg_count: insertion.col_mappings.len() + 2, // +1 for NULL, +1 for rowid
-        start_reg: registers_start,
-        conflict_action,
-    });
+    for value in &rows {
+        translate_rows_single(program, value, &insertion, resolver, false)?;
+        program.emit_insn(Insn::VUpdate {
+            cursor_id,
+            arg_count: insertion.col_mappings.len() + 2, // +1 for NULL, +1 for rowid
+            start_reg: registers_start,
+            conflict_action,
+        });
+    }
 
     program.emit_insn(Insn::Close { cursor_id });
 

--- a/testing/system/vtab.test
+++ b/testing/system/vtab.test
@@ -51,6 +51,14 @@ do_execsql_test_on_specific_db {:memory:} drop-virtual-table {
     DROP TABLE t;
 } {}
 
+do_execsql_test_on_specific_db {:memory:} insert-multi-row-values-into-vtab {
+    CREATE VIRTUAL TABLE v USING kv_store;
+    INSERT INTO v(key, value) VALUES ('k1', 'v1'), ('k2', 'v2'), ('k3', 'v3');
+    SELECT key, value FROM v ORDER BY key;
+} {k1|v1
+k2|v2
+k3|v3}
+
 do_execsql_test_in_memory_error_content drop-virtual-table-twice {
     CREATE VIRTUAL TABLE t USING kv_store;
     INSERT INTO t VALUES ('hello', 'world');


### PR DESCRIPTION
## Summary

`INSERT INTO <vtab> VALUES (row1), (row2), ..., (rowN)` into a writable virtual table silently inserted only the **last** row. `translate_virtual_table_insert` popped the last `VALUES` row and discarded the rest, emitting a single `VUpdate`.

Per SQLite, a multi-row `VALUES` clause inserts one row per parenthesized list, and a writable virtual table's `xUpdate` is invoked once per inserted row.

## Fix

Keep all `VALUES` rows and emit one `VUpdate` per row. The `argv` register block (`NULL`, rowid, column values) is set up once and rewritten for each row, so this reuses the existing single-row translation path inside the loop. `DEFAULT VALUES` still inserts a single row.

## Testing

Added to `testing/system/vtab.test`:

```tcl
do_execsql_test_on_specific_db {:memory:} insert-multi-row-values-into-vtab {
    CREATE VIRTUAL TABLE v USING kv_store;
    INSERT INTO v(key, value) VALUES ('k1', 'v1'), ('k2', 'v2'), ('k3', 'v3');
    SELECT key, value FROM v ORDER BY key;
} {k1 v1 k2 v2 k3 v3}
```

Verified against the `kv_store` test extension:

```
INSERT INTO v(key, value) VALUES ('k1','v1'), ('k2','v2'), ('k3','v3');
SELECT key, value FROM v ORDER BY key;
-- before: k3|v3 only
-- after:  k1|v1, k2|v2, k3|v3
```

Single-row and positional (`INSERT INTO v VALUES (...)`) inserts are unchanged. `cargo fmt --check` and `cargo clippy -p turso_core` are clean.

Closes #6775
