### PR TITLE
antithesis: don't bake targeted_coverage.json into non-targeted runs

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -62,11 +62,6 @@ jobs:
         python3 scripts/antithesis/diff_to_targeted_coverage.py \
           testing/stress/git.diff -o testing/stress/targeted_coverage.json
 
-    - name: Ensure targeted-coverage placeholder
-      run: |
-        [ -f testing/stress/targeted_coverage.json ] \
-          || : > testing/stress/targeted_coverage.json
-
     - name: Publish workload
       run: bash ./scripts/antithesis/publish-workload.sh
 

--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -88,7 +88,7 @@ RUN chmod 777 -R /opt/antithesis/test/v1
 RUN mkdir /opt/antithesis/catalog
 RUN ln -s /opt/antithesis/test/v1/bank-test/*.py /opt/antithesis/catalog
 
-COPY testing/stress/targeted_coverage.json /opt/antithesis/targeted_coverage.json
+COPY testing/stress/targeted_coverage.jso[n] /opt/antithesis/
 
 ENV RUST_BACKTRACE=1
 


### PR DESCRIPTION
## Description

We lost finding history in Antithesis on scheduled runs. My hypothesis is that we don't have diff targeting on scheduled runs, but we created an empty file anyways, so Antithesis probably considered that it was a targeted run that didn't have a lineage. Regardless, it can't hurt not to skip creating the file if it's not needed.

I launched an Antithesis experiment with this, and it passes. It doesn't have any history, but that is to be expected, because manual tests on branches pass in the branch name as the source, so they don't share the same lineage as main.

In other words, I don't know if this is the right fix, but it can't hurt.