### PR TITLE
sync/sdk-kit: add opt-in fts feature

### DIFF
--- a/sync/sdk-kit/Cargo.toml
+++ b/sync/sdk-kit/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [features]
 pure-rust-crypto = ["turso_core/pure-rust-crypto", "turso_sdk_kit/pure-rust-crypto"]
+fts = ["turso_core/fts", "turso_sdk_kit/fts"]
 
 [lib]
 doc = false


### PR DESCRIPTION
## Description

Adds an opt-in `fts` feature to the `turso_sync_sdk_kit` crate, mirroring the existing `pure-rust-crypto` plumbing and the `sdk-kit` crate's `fts = ["turso_core/fts"]`:

```toml
fts = ["turso_core/fts", "turso_sdk_kit/fts"]
```

Opt-in only — default builds are unchanged.

## Motivation and context

Refs #6255.

The Go bindings load the prebuilt `turso_sync_sdk_kit` library, which currently has no way to include Tantivy FTS: the crate defines no `fts` feature, so even building with `--features fts` fails. As a result the runtime accepts `?experimental=index_method` but `CREATE INDEX ... USING fts` fails with `unknown module name 'fts'` (a `strings` scan of the shipped `libturso_sync_sdk_kit` artifacts v0.5.x–v0.7.0-pre.17 shows no tantivy symbols). The Python binding already enables FTS via `turso_sdk_kit = { features = ["fts"] }`; this PR provides the equivalent hook for the sync SDK used by Go.

This is the first half of #6255 — actually shipping it to Go users also needs `turso-go-platform-libs` to build with `--features fts` (or the feature made default once FTS stabilizes). Happy to follow up there if this lands.

**Validation:** built with `cargo build -p turso_sync_sdk_kit --features fts` on macOS arm64 and exercised end-to-end through `turso.tech/database/tursogo` (system load strategy) via `database/sql`:

```
create fts index: ok           -- CREATE INDEX u_fts ON u USING fts (email, full_name)
fts_match: ok → seller1@epin.com
fts_score: ok → 0.6931471824645996
incremental insert: ok
incremental fts_match: ok → new@x.com
```
