### PR TITLE
core/vdbe: avoid overflow when cache_size is i32::MIN

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6776,9 +6776,9 @@ pub fn op_sorter_open(
 
     // Set the buffer size threshold to be roughly the same as the limit configured for the page-cache.
     let max_buffer_size_bytes = if cache_size < 0 {
-        (cache_size.abs() * 1024) as usize
+        (cache_size.unsigned_abs() as usize).saturating_mul(1024)
     } else {
-        (cache_size as usize) * page_size
+        (cache_size as usize).saturating_mul(page_size)
     };
     let mut order = Vec::try_with_capacity_ext(order_collations_nulls.len())
         .expect("TODO: fallible allocations");

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -391,6 +391,36 @@ fn test_pragma_cache_size_min_value(db: TempDatabase) {
     assert_eq!(*value, 200);
 }
 
+#[turso_macros::test(mvcc)]
+fn test_pragma_cache_size_i32_min_order_by(db: TempDatabase) {
+    let conn = db.connect_limbo();
+
+    // Regression test for issue #7150: setting cache_size to i32::MIN and then
+    // running an ORDER BY query used to panic in op_sorter_open due to i32::abs()
+    // overflowing on i32::MIN.
+    let min_val = i32::MIN;
+    conn.execute(format!("PRAGMA cache_size = {min_val}"))
+        .unwrap();
+
+    // Sanity check: the connection must actually hold i32::MIN, otherwise the
+    // ORDER BY below no longer exercises the overflow path in op_sorter_open.
+    let rows = limbo_exec_rows(&conn, "PRAGMA cache_size");
+    assert_eq!(rows, vec![vec![RValue::Integer(min_val as i64)]]);
+
+    conn.execute("CREATE TABLE items (id TEXT)").unwrap();
+    conn.execute("INSERT INTO items VALUES ('b'), ('a')")
+        .unwrap();
+
+    let rows = limbo_exec_rows(&conn, "SELECT id FROM items ORDER BY id");
+    assert_eq!(
+        rows,
+        vec![
+            vec![RValue::Text("a".to_string())],
+            vec![RValue::Text("b".to_string())],
+        ]
+    );
+}
+
 #[turso_macros::test]
 fn test_pragma_wal_checkpoint_targets_attached_database(db: TempDatabase) {
     let conn = db.connect_limbo();


### PR DESCRIPTION
op_sorter_open computed the sorter buffer size threshold with
`cache_size.abs() * 1024` when the configured cache_size was negative.
When cache_size was set to i32::MIN (e.g. via PRAGMA cache_size), calling
abs() overflowed and panicked, since i32::MIN has no positive counterpart.
The multiplications could also overflow usize on 32-bit targets (e.g.
wasm32) for large cache_size magnitudes, in both the negative (`* 1024`)
and positive (`* page_size`) branches.

Use unsigned_abs() to take the magnitude without overflow and compute
both branches with saturating_mul in usize so the threshold saturates
instead of panicking or wrapping. Add an integration regression test
that sets PRAGMA cache_size to i32::MIN and runs an ORDER BY query.
This fixes the ORDER BY query panic reported in issue #7150.

Fixes #7150