### PR TITLE
core: match SQLite for i64::MIN hex literal negation in defaults

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -445,7 +445,13 @@ pub(crate) fn eval_constant_default_value(expr: &ast::Expr) -> Result<Value> {
             match (op, value) {
                 (ast::UnaryOperator::Positive, value) => Ok(value),
                 (ast::UnaryOperator::Negative, Value::Numeric(Numeric::Integer(i))) => {
-                    Ok(Value::from_i64(-i))
+                    // Hex literals like 0x8000000000000000 parse to i64::MIN, whose
+                    // negation does not fit in an i64. Match SQLite's valueFromExpr,
+                    // which promotes -(i64::MIN) to the REAL value 2^63.
+                    match i.checked_neg() {
+                        Some(negated) => Ok(Value::from_i64(negated)),
+                        None => Ok(Value::from_f64(-(i64::MIN as f64))),
+                    }
                 }
                 (ast::UnaryOperator::Negative, Value::Numeric(Numeric::Float(f))) => {
                     Ok(Value::from_f64(-f64::from(f)))

--- a/core/util.rs
+++ b/core/util.rs
@@ -1421,7 +1421,11 @@ pub fn parse_numeric_literal(text: &str) -> Result<Value> {
     } else if text.starts_with("-0x") || text.starts_with("-0X") {
         let value = u64::from_str_radix(&text[3..], 16)? as i64;
         if value == i64::MIN {
-            return Err(LimboError::IntegerOverflow);
+            // Negating i64::MIN overflows. SQLite's codeInteger rejects this at
+            // prepare time with "hex literal too big"; do the same.
+            return Err(LimboError::ParseError(format!(
+                "hex literal too big: {text}"
+            )));
         }
         return Ok(Value::from_i64(-value));
     }
@@ -6575,8 +6579,11 @@ pub mod tests {
             parse_numeric_literal("-0x1234").unwrap(),
             Value::from_i64(-4660)
         );
-        // too big hex
-        assert!(parse_numeric_literal("-0x8000000000000000").is_err());
+        // too big hex: matches SQLite's prepare-time error
+        assert!(parse_numeric_literal("-0x8000000000000000")
+            .unwrap_err()
+            .to_string()
+            .contains("hex literal too big: -0x8000000000000000"));
     }
 
     #[test]

--- a/sqlite/conformance/sqlite-sqltests/alter-add-column-default-negate-overflow.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter-add-column-default-negate-overflow.sqltest
@@ -1,0 +1,78 @@
+# Regression test for https://github.com/tursodatabase/turso/issues/4621
+# Negating a hex literal that parses to i64::MIN in an ALTER TABLE ADD COLUMN
+# DEFAULT expression must not panic with "attempt to negate with overflow".
+#
+# SQLite accepts the ALTER: its valueFromExpr promotes -(i64::MIN) to the
+# REAL value 2^63, so pre-existing rows read 9.22337203685478e+18. Statements
+# that code-generate the default (e.g. a subsequent INSERT) are rejected at
+# prepare time with "hex literal too big". We match that behavior.
+
+@database :memory:
+
+test alter-add-column-default-negate-min-int {
+    CREATE TABLE t (a INTEGER);
+    INSERT INTO t VALUES (1);
+    ALTER TABLE t ADD COLUMN b DEFAULT -0x8000000000000000;
+    SELECT a, b, typeof(b) FROM t;
+}
+expect {
+    1|9.22337203685478e+18|real
+}
+# JS outputs large numbers as full integers rather than scientific notation
+expect @js {
+    1|9223372036854776000|real
+}
+
+test alter-add-column-default-negate-min-int-parenthesized {
+    CREATE TABLE t (a INTEGER);
+    INSERT INTO t VALUES (1);
+    ALTER TABLE t ADD COLUMN b DEFAULT (-0x8000000000000000);
+    SELECT a, b, typeof(b) FROM t;
+}
+expect {
+    1|9.22337203685478e+18|real
+}
+# JS outputs large numbers as full integers rather than scientific notation
+expect @js {
+    1|9223372036854776000|real
+}
+
+# Code-generating the overflowing default (new row insertion) fails at
+# prepare time, like SQLite.
+test alter-add-column-default-negate-min-int-insert {
+    CREATE TABLE t (a INTEGER);
+    ALTER TABLE t ADD COLUMN b DEFAULT -0x8000000000000000;
+    INSERT INTO t (a) VALUES (1);
+}
+expect error {
+    hex literal too big: -0x8000000000000000
+}
+
+# Negating the literal directly is also a prepare-time error, like SQLite.
+test select-negate-min-int-hex-literal {
+    SELECT -0x8000000000000000;
+}
+expect error {
+    hex literal too big: -0x8000000000000000
+}
+
+test alter-add-column-default-negate-ok {
+    CREATE TABLE t2 (a INTEGER);
+    ALTER TABLE t2 ADD COLUMN b DEFAULT -0x1;
+    INSERT INTO t2 (a) VALUES (1);
+    SELECT b FROM t2;
+}
+expect {
+    -1
+}
+
+# Boundary: negating i64::MAX is fine, only i64::MIN overflows.
+test alter-add-column-default-negate-max-int {
+    CREATE TABLE t3 (a INTEGER);
+    ALTER TABLE t3 ADD COLUMN b DEFAULT -0x7fffffffffffffff;
+    INSERT INTO t3 (a) VALUES (1);
+    SELECT b FROM t3;
+}
+expect {
+    -9223372036854775807
+}


### PR DESCRIPTION
eval_constant_default_value() constant-folds unary-minus DEFAULT
expressions for ALTER TABLE ADD COLUMN with an unchecked negation. A
hex literal such as 0x8000000000000000 parses to i64::MIN (the u64
value is reinterpreted as i64), so negating it overflowed and panicked
with "attempt to negate with overflow" in debug builds.

Fix this the way SQLite does, so the whole scenario stays compatible:

- eval_constant_default_value() now mirrors SQLite's valueFromExpr and
  promotes -(i64::MIN) to the REAL value 2^63. The ALTER TABLE succeeds
  and pre-existing rows read the default as 9.22337203685478e+18, just
  like SQLite.

- parse_numeric_literal() now rejects -0x8000000000000000 with SQLite's
  prepare-time message "hex literal too big: -0x8000000000000000"
  (previously "Runtime error: integer overflow"), matching SQLite's
  codeInteger. This covers SELECT -0x8000000000000000 and any statement
  that code-generates the stored default, such as an INSERT after the
  ALTER.

The regression test covers the plain and parenthesized i64::MIN ALTER
cases, the prepare-time INSERT and SELECT errors, and the
-0x7fffffffffffffff boundary, and passes unmodified on both the rust
backend and the sqlite3 CLI backend.

Fixes #4621