### PR TITLE
core: reject invalid UTF-8 in TEXT record payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7250,6 +7250,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shuttle",
+ "simdutf8",
  "simsimd",
  "smallvec",
  "sorted-vec",

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -932,7 +932,7 @@ mod tests {
         env,
         process::{Child, Command, Stdio},
         thread::sleep,
-        time::Duration,
+        time::{Duration, Instant},
     };
     use tempfile::TempDir;
     use turso_sync_sdk_kit::rsapi::PartialBootstrapStrategy;
@@ -1063,38 +1063,76 @@ mod tests {
                     client,
                 })
             } else {
-                let port: u16 = rand::rng().random_range(10_000..=65_535);
                 let server_bin = env::var("LOCAL_SYNC_SERVER").unwrap();
 
-                // IMPORTANT: do not use Stdio::piped() here. Nothing reads from
-                // those pipes, so once the kernel pipe buffer (~64 KiB on Linux)
-                // fills, the child blocks forever inside write() and stops
-                // servicing HTTP requests, deadlocking sync operations in
-                // long-running tests like test_sync_parallel_writes_with_sync_ops.
-                let child = Command::new(server_bin)
-                    .args(["--sync-server", &format!("0.0.0.0:{port}")])
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .spawn()
-                    .context("failed to spawn local sync server")?;
+                // The random port can be unusable: Windows runners reserve
+                // large chunks of 10_000..=65_535 for Hyper-V (bind fails with
+                // WSAEACCES), and concurrently running tests can collide on
+                // the same port. In both cases the server child exits right
+                // away, so waiting for readiness without watching the child
+                // hangs the test forever. Detect child exit and retry with a
+                // fresh port instead.
+                const SPAWN_ATTEMPTS: u32 = 10;
+                const READY_TIMEOUT: Duration = Duration::from_secs(60);
+                for attempt in 1..=SPAWN_ATTEMPTS {
+                    let port: u16 = rand::rng().random_range(10_000..=65_535);
 
-                let user_url = format!("http://localhost:{port}");
+                    // IMPORTANT: do not use Stdio::piped() here. Nothing reads from
+                    // those pipes, so once the kernel pipe buffer (~64 KiB on Linux)
+                    // fills, the child blocks forever inside write() and stops
+                    // servicing HTTP requests, deadlocking sync operations in
+                    // long-running tests like test_sync_parallel_writes_with_sync_ops.
+                    let mut child = Command::new(&server_bin)
+                        .args(["--sync-server", &format!("0.0.0.0:{port}")])
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .spawn()
+                        .context("failed to spawn local sync server")?;
 
-                // wait for server readiness
-                loop {
-                    if client.get(&user_url).send().await.is_ok() {
-                        break;
+                    let user_url = format!("http://localhost:{port}");
+
+                    // wait for server readiness
+                    let started = Instant::now();
+                    loop {
+                        if client.get(&user_url).send().await.is_ok() {
+                            return Ok(Self {
+                                user_url: user_url.clone(),
+                                db_url: user_url,
+                                host: String::new(),
+                                server: Some(child),
+                                client,
+                            });
+                        }
+                        match child
+                            .try_wait()
+                            .context("failed to poll local sync server")?
+                        {
+                            Some(status) => {
+                                // Child exited (most likely the port was
+                                // reserved or already taken): retry.
+                                eprintln!(
+                                    "local sync server on port {port} exited with {status} \
+                                     before becoming ready (attempt {attempt}/{SPAWN_ATTEMPTS})"
+                                );
+                                break;
+                            }
+                            None => {
+                                if started.elapsed() > READY_TIMEOUT {
+                                    let _ = child.kill();
+                                    let _ = child.wait();
+                                    return Err(anyhow!(
+                                        "local sync server on port {port} did not become ready \
+                                         within {READY_TIMEOUT:?}"
+                                    ));
+                                }
+                            }
+                        }
+                        sleep(Duration::from_millis(100));
                     }
-                    sleep(Duration::from_millis(100));
                 }
-
-                Ok(Self {
-                    user_url: user_url.clone(),
-                    db_url: user_url,
-                    host: String::new(),
-                    server: Some(child),
-                    client,
-                })
+                Err(anyhow!(
+                    "local sync server failed to start after {SPAWN_ATTEMPTS} attempts"
+                ))
             }
         }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -122,6 +122,7 @@ rustc-hash = "2.0"
 either = { workspace = true }
 tracing-subscriber.workspace = true
 rapidhash = "4.1.1"
+simdutf8 = "0.1.5"
 branches = { version = "0.4.3", default-features = false }
 bumpalo = { version = "3", features = ["collections"] }
 smallvec = "1.15.1"

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1088,8 +1088,10 @@ pub fn read_value<'a>(buf: &'a [u8], serial_type: SerialType) -> Result<(ValueRe
                     content_size
                 ))
             })?;
-            // SAFETY: SerialTypeKind is Text so this buffer is a valid string
-            let val = unsafe { std::str::from_utf8_unchecked(data) };
+            let val = simdutf8::basic::from_utf8(data).map_err(|_| {
+                mark_unlikely();
+                LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
+            })?;
             Ok((
                 ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
                 content_size,
@@ -1216,8 +1218,10 @@ pub fn read_value_serial_type<'a>(
                         content_size
                     ))
                 })?;
-                // SAFETY: SerialTypeKind is Text so this buffer is a valid string
-                let val = unsafe { std::str::from_utf8_unchecked(data) };
+                let val = simdutf8::basic::from_utf8(data).map_err(|_| {
+                    mark_unlikely();
+                    LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
+                })?;
                 Ok((
                     ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
                     content_size,
@@ -2259,6 +2263,23 @@ mod tests {
             result.0.to_owned().expect(crate::alloc::ALLOC_ERR_MSG),
             expected
         );
+    }
+
+    #[test]
+    fn test_text_decoders_reject_invalid_utf8() {
+        for result in [
+            read_value(&[0xff], SerialType::text(1)),
+            read_value_serial_type(&[0xff], 15),
+        ] {
+            assert!(
+                matches!(
+                    result,
+                    Err(LimboError::Corrupt(ref message))
+                        if message == "TEXT value contains invalid UTF-8"
+                ),
+                "unexpected result: {result:?}"
+            );
+        }
     }
 
     #[test]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2316,20 +2316,8 @@ pub fn op_array_element(
         Value::Blob(blob) => match ValueIterator::new(blob) {
             Ok(mut iter) => iter
                 .nth(idx)
-                .and_then(|r| r.ok())
-                .map(|vref| {
-                    // The blob may not be a real record — text fields could
-                    // contain invalid UTF-8 (from_utf8_unchecked in the
-                    // record decoder). Validate and demote to blob if needed.
-                    if let ValueRef::Text(t) = &vref {
-                        if t.value.as_bytes().iter().any(|&b| b > 0x7F)
-                            && std::str::from_utf8(t.value.as_bytes()).is_err()
-                        {
-                            return Value::from_slice(t.value.as_bytes());
-                        }
-                    }
-                    vref.to_owned()
-                })
+                .transpose()?
+                .map(|vref| vref.to_owned())
                 .transpose()?
                 .unwrap_or(Value::Null),
             Err(_) => Value::Null,
@@ -18029,10 +18017,6 @@ mod tests {
 
     #[test]
     fn test_negate_blob_subscript_invalid_utf8_no_panic() {
-        // Negating a blob subscript that extracts a "text" value containing
-        // invalid UTF-8 bytes must not panic. The record decoder uses
-        // from_utf8_unchecked, so ArrayElement must validate extracted text.
-        //
         // Reproduces fuzzer bug at seed 27035.
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
         let db = Database::open_file_with_flags(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3161,18 +3161,11 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 }
                 self.set_data_section(&data[content_size..]);
                 let text_data = &data[..content_size];
-                // SAFETY: TEXT serial type contains valid UTF-8
-                let text_str = if cfg!(debug_assertions) {
-                    match std::str::from_utf8(text_data) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            return Some(Err(LimboError::InternalError(format!(
-                                "Invalid UTF-8 in TEXT serial type: {e}"
-                            ))));
-                        }
-                    }
-                } else {
-                    unsafe { std::str::from_utf8_unchecked(text_data) }
+                let Ok(text_str) = simdutf8::basic::from_utf8(text_data) else {
+                    mark_unlikely();
+                    return Some(Err(LimboError::Corrupt(
+                        "TEXT value contains invalid UTF-8".into(),
+                    )));
                 };
                 match dest {
                     Register::Value(Value::Text(existing_text)) => {
@@ -3215,6 +3208,26 @@ mod tests {
         ));
         state.active_op_state.clear();
         assert!(state.active_op_state.parse_schema().is_none());
+    }
+
+    #[test]
+    fn nth_into_register_rejects_invalid_utf8_text() {
+        let payload = [2, 15, 0xff];
+        let mut iterator = crate::types::ValueIterator::new(&payload).unwrap();
+        let mut destination = Register::Value(Value::Null);
+
+        let result = iterator
+            .nth_into_register(0, &mut destination)
+            .expect("record contains one value");
+
+        assert!(
+            matches!(
+                result,
+                Err(LimboError::Corrupt(ref message))
+                    if message == "TEXT value contains invalid UTF-8"
+            ),
+            "unexpected result: {result:?}"
+        );
     }
 
     #[test]

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -12,6 +12,7 @@ mod test_write_path;
 mod encryption;
 mod test_expr_index;
 mod test_multi_thread;
+mod test_non_utf8_text;
 mod test_page1;
 mod test_schema_updated;
 mod test_transactions;

--- a/tests/integration/query_processing/test_non_utf8_text.rs
+++ b/tests/integration/query_processing/test_non_utf8_text.rs
@@ -1,0 +1,40 @@
+//! Regression test for issue #5164: TEXT values containing invalid UTF-8 must
+//! be rejected instead of entering the engine as text or being demoted to blobs.
+
+use crate::common::try_limbo_exec_rows;
+use turso_core::LimboError;
+
+#[turso_macros::test(init_sql = "CREATE TABLE t(val TEXT);")]
+fn test_non_utf8_text_is_rejected(tmp_db: crate::common::TempDatabase) -> anyhow::Result<()> {
+    {
+        let sqlite_conn = rusqlite::Connection::open(&tmp_db.path)?;
+        sqlite_conn.execute("INSERT INTO t VALUES(CAST(X'FF' AS TEXT)), ('valid')", [])?;
+    }
+
+    let limbo_conn = tmp_db.connect_limbo();
+
+    for query in [
+        "SELECT val FROM t",
+        "SELECT 1 FROM t ORDER BY val COLLATE NOCASE",
+    ] {
+        let error = try_limbo_exec_rows(&tmp_db, &limbo_conn, query)
+            .expect_err("invalid UTF-8 stored as TEXT must be rejected");
+        assert!(
+            matches!(
+                error,
+                LimboError::Corrupt(ref message)
+                    if message == "TEXT value contains invalid UTF-8"
+            ),
+            "unexpected error for {query}: {error}"
+        );
+    }
+
+    let rows = try_limbo_exec_rows(&tmp_db, &limbo_conn, "SELECT CAST(X'FF' AS BLOB)")?;
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Blob(vec![0xFF])]],
+        "the same bytes remain valid when explicitly typed as a blob"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
SQLite does not require TEXT values to be valid UTF-8: for example
`CAST(X'FF' AS TEXT)` stores the raw 0xFF byte with a text serial type.
The record decoders in read_value(), read_value_serial_type() and
ValueIterator::nth_into_register() nevertheless built `&str` values
with std::str::from_utf8_unchecked(), which is undefined behavior for
such payloads and crashed with SIGSEGV in release builds; debug builds
had a validation guard in only one of the three decoders.

Validate TEXT payloads with simdutf8::basic::from_utf8 (per review,
suggested in #5185; SIMD-accelerated, and the `basic` API skips
error-detail computation since we only branch on pass/fail) and reject
invalid payloads with LimboError::Corrupt("TEXT value contains invalid
UTF-8") in all three decoders. Rejection guarantees every
ValueRef::Text wraps genuinely valid UTF-8, so ArrayElement extraction
drops the std::str::from_utf8 re-validation that compensated for the
old unchecked conversion, and op_array_element now propagates decoder
errors instead of swallowing them. Valid text keeps taking the
borrow-only fast path; the invalid case is marked unlikely.

Also harden the TursoServer test harness in bindings/rust: on this
PR's Windows CI run, sync::tests::test_sync_partial hung for 28
minutes because the harness picked a random port, the sync server
failed to bind (Windows reserves large Hyper-V port ranges inside
10_000..=65_535) and exited, and the readiness loop waited forever for
a server that had already died. The harness now detects child exit via
try_wait(), retries with a fresh random port (up to 10 attempts), and
bounds the readiness wait at 60s, so port flakes self-heal instead of
eating the 30-minute step timeout.

Tests: cargo test -p core_tester test_non_utf8_text_is_rejected

Fixes #5164