### PR TITLE
 core/btree: clear abandoned B-tree overflow cells

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5495,8 +5495,77 @@ impl ProvidesYieldContext for BTreeCursor {
     }
 }
 
+impl BTreeCursor {
+    fn clear_transient_overflow_cells(&mut self) {
+        // Overflow cells are page-local scratch for the cursor's in-flight balance.
+        // If the cursor is abandoned after queueing them, cached pages may outlive
+        // the cursor and must not carry that scratch into later writes.
+        if matches!(self.state, CursorState::None)
+            && matches!(self.balance_state.sub_state, BalanceSubState::Start)
+        {
+            turso_assert!(
+                self.balance_state.balance_info.is_none(),
+                "idle cursor has balance info"
+            );
+            // No write or balance operation is in progress, so this cursor has no
+            // transient overflow cells to clean up.
+            return;
+        }
+
+        for page in self.stack.stack.iter().flatten() {
+            page.get().overflow_cells.clear();
+        }
+
+        // Insert/overwrite can stage overflow cells before balance_info is populated.
+        // If the cursor is dropped in that window, this page handle is the only owner
+        // of that transient state.
+        match &self.state {
+            CursorState::Write(WriteState::Insert { page, .. })
+            | CursorState::Write(WriteState::Overwrite { page, .. }) => {
+                page.get().overflow_cells.clear();
+            }
+            CursorState::Write(WriteState::Start)
+            | CursorState::Write(WriteState::Balancing)
+            | CursorState::Write(WriteState::Finish)
+            | CursorState::Destroy(_)
+            | CursorState::Delete(_)
+            | CursorState::None => {}
+        }
+
+        if let Some(balance_info) = &self.balance_state.balance_info {
+            for page in balance_info.pages_to_balance.iter().flatten() {
+                page.get().overflow_cells.clear();
+            }
+        }
+
+        // Newly allocated/reused sibling pages are tracked only by BalanceContext until
+        // non-root balancing finishes. If the cursor is dropped before then, clear any
+        // overflow scratch from those pages explicitly.
+        match &self.balance_state.sub_state {
+            BalanceSubState::NonRootDoBalancingAllocate {
+                context: Some(context),
+                ..
+            }
+            | BalanceSubState::NonRootDoBalancingFinish { context } => {
+                for page in context.pages_to_balance_new.iter().flatten() {
+                    page.get().overflow_cells.clear();
+                }
+            }
+            BalanceSubState::Start
+            | BalanceSubState::BalanceRoot
+            | BalanceSubState::Decide
+            | BalanceSubState::Quick
+            | BalanceSubState::NonRootPickSiblings
+            | BalanceSubState::NonRootDoBalancing
+            | BalanceSubState::NonRootDoBalancingAllocate { context: None, .. }
+            | BalanceSubState::FreePages { .. } => {}
+        }
+    }
+}
+
 impl Drop for BTreeCursor {
     fn drop(&mut self) {
+        self.clear_transient_overflow_cells();
         if !self
             .did_register
             .load(crate::sync::atomic::Ordering::Relaxed)
@@ -7620,6 +7689,7 @@ fn find_free_slot(
 pub fn btree_init_page(page: &PageRef, page_type: PageType, offset: usize, usable_space: usize) {
     // setup btree page
     let contents = page.get_contents();
+    contents.overflow_cells.clear();
     tracing::debug!(
         "btree_init_page(id={}, offset={}, usable_space={})",
         page.get().id,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -13,6 +13,9 @@ use super::{
 };
 #[cfg(test)]
 use crate::alloc::TursoIteratorExt;
+#[cfg(any(test, injected_yields))]
+use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
+use crate::mvcc::yield_points::inject_io_yield;
 use crate::{
     io::CompletionGroup,
     io_yield_one,
@@ -340,6 +343,25 @@ enum WriteState {
     },
     Balancing,
     Finish,
+}
+
+#[cfg(any(test, injected_yields))]
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub(crate) enum BTreeWriteYieldPoint {
+    AfterInsertOverflowCellBeforeBalance,
+}
+
+#[cfg(any(test, injected_yields))]
+const BTREE_WRITE_YIELD_FAMILY: u64 = 0x4254_5245_5752_4954;
+
+#[cfg(any(test, injected_yields))]
+impl YieldPointMarker for BTreeWriteYieldPoint {
+    const POINT_COUNT: u8 = 1;
+
+    fn ordinal(self) -> u8 {
+        self as u8
+    }
 }
 
 struct ReadPayloadOverflow {
@@ -777,6 +799,10 @@ pub struct BTreeCursor {
     /// itself into the registry). Direct BTreeCursor::new callers (tests,
     /// internal utilities) bypass that path; their Drop skips unregister.
     did_register: crate::sync::atomic::AtomicBool,
+    #[cfg(any(test, injected_yields))]
+    yield_injector: Option<Arc<dyn crate::mvcc::yield_points::YieldInjector>>,
+    #[cfg(any(test, injected_yields))]
+    yield_instance_id: u64,
 }
 
 /// Records the in-flight descent for `iteration_pending_descent`. The direction
@@ -856,7 +882,17 @@ impl BTreeCursor {
             pending_peer_save: None,
             has_peers: crate::sync::atomic::AtomicBool::new(false),
             did_register: crate::sync::atomic::AtomicBool::new(false),
+            #[cfg(any(test, injected_yields))]
+            yield_injector: None,
+            #[cfg(any(test, injected_yields))]
+            yield_instance_id: 0,
         }
+    }
+
+    #[cfg(any(test, injected_yields))]
+    pub(crate) fn install_yield_context(&mut self, connection: &crate::Connection) {
+        self.yield_injector = connection.yield_injector();
+        self.yield_instance_id = connection.next_yield_instance_id();
     }
 
     pub fn new_table(pager: Arc<Pager>, root_page: i64, num_columns: usize) -> Self {
@@ -2668,6 +2704,10 @@ impl BTreeCursor {
                         turso_assert!(matches!(self.balance_state.sub_state, BalanceSubState::Start), "no balancing operation should be in progress during insert", { "state": self.state, "sub_state": self.balance_state.sub_state });
                         // If we balance, we must save the cursor position and seek to it later.
                         self.save_context(CursorContext::seek_eq_only(bkey));
+                        inject_io_yield!(
+                            self,
+                            BTreeWriteYieldPoint::AfterInsertOverflowCellBeforeBalance
+                        );
                     } else {
                         *write_state = WriteState::Finish;
                     }
@@ -5440,6 +5480,18 @@ impl BTreeCursor {
     pub fn allocate_page(&self, page_type: PageType, offset: usize) -> Result<IOResult<PageRef>> {
         self.pager
             .do_allocate_page(page_type, offset, BtreePageAllocMode::Any)
+    }
+}
+
+#[cfg(any(test, injected_yields))]
+impl ProvidesYieldContext for BTreeCursor {
+    fn yield_context(&self) -> YieldContext {
+        YieldContext::new(
+            self.yield_injector.clone(),
+            None,
+            self.yield_instance_id,
+            BTREE_WRITE_YIELD_FAMILY ^ self.root_page as u64,
+        )
     }
 }
 
@@ -8493,7 +8545,7 @@ fn _insert_into_cell(
         #[cfg(debug_assertions)]
         {
             if let Some(overflow_cell) = page.overflow_cells.last() {
-                turso_assert!(overflow_cell.index + 1 == cell_idx, "multiple overflow cells can only occur when a parent overflows during balancing as divider cells are inserted into it. those cells should always be in-order and sequential");
+                turso_assert!(overflow_cell.index + 1 == cell_idx, "multiple overflow cells can only occur when a parent overflows during balancing as divider cells are inserted into it. those cells should always be in-order and sequential", { "page_id": page.id, "last_overflow_index": overflow_cell.index, "cell_idx": cell_idx, "cell_count": page.cell_count(), "overflow_count": page.overflow_cells.len() });
             }
         }
         page.overflow_cells.push(OverflowCell {
@@ -8966,6 +9018,10 @@ mod tests {
     use super::*;
     use crate::{
         io::{Buffer, MemoryIO, OpenFlags, IO},
+        mvcc::{
+            yield_hooks::YieldPointMarker,
+            yield_points::{YieldInjector, YieldPoint},
+        },
         schema::IndexColumn,
         storage::{
             database::DatabaseFile, page_cache::PageCache, pager::default_page1,
@@ -8977,7 +9033,14 @@ mod tests {
         WalFileShared,
     };
     use arc_swap::ArcSwapOption;
-    use std::{mem::transmute, ops::Deref, sync::Arc};
+    use std::{
+        mem::transmute,
+        ops::Deref,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+    };
 
     use tempfile::TempDir;
 
@@ -8991,6 +9054,55 @@ mod tests {
     };
 
     use super::{btree_init_page, defragment_page, drop_cell, insert_into_cell};
+
+    #[derive(Debug)]
+    struct TargetedYieldInjector {
+        point: YieldPoint,
+        selection_key: u64,
+        fired: AtomicBool,
+    }
+
+    impl TargetedYieldInjector {
+        fn new(point: YieldPoint, selection_key: u64) -> Arc<Self> {
+            Arc::new(Self {
+                point,
+                selection_key,
+                fired: AtomicBool::new(false),
+            })
+        }
+
+        fn fired(&self) -> bool {
+            self.fired.load(Ordering::Acquire)
+        }
+    }
+
+    impl YieldInjector for TargetedYieldInjector {
+        fn should_yield(&self, _instance_id: u64, selection_key: u64, point: YieldPoint) -> bool {
+            point == self.point
+                && selection_key == self.selection_key
+                && !self.fired.swap(true, Ordering::AcqRel)
+        }
+    }
+
+    fn btree_write_selection_key(root_page: i64) -> u64 {
+        BTREE_WRITE_YIELD_FAMILY ^ root_page as u64
+    }
+
+    fn query_single_i64(conn: &Arc<Connection>, sql: &str) -> i64 {
+        let mut stmt = conn.prepare(sql).unwrap();
+        match stmt.step().unwrap() {
+            StepResult::Row => stmt.row().unwrap().get::<i64>(0).unwrap(),
+            other => panic!("expected a row, got {other:?}"),
+        }
+    }
+
+    fn query_single_text(conn: &Arc<Connection>, sql: &str) -> String {
+        let mut stmt = conn.prepare(sql).unwrap();
+        match stmt.step().unwrap() {
+            StepResult::Row => stmt.row().unwrap().get::<String>(0).unwrap(),
+            other => panic!("expected a row, got {other:?}"),
+        }
+    }
 
     #[allow(clippy::arc_with_non_send_sync)]
     fn get_page(id: usize) -> PageRef {
@@ -9020,6 +9132,201 @@ mod tests {
         let db = Database::open_file(io.clone(), path.to_str().unwrap()).unwrap();
 
         db
+    }
+
+    #[test]
+    fn wal_reuses_freelist_leaf_after_abandoned_overflowing_insert() {
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, "freelist-stale-overflow.db").unwrap();
+        let conn = db.connect().unwrap();
+
+        conn.execute("PRAGMA journal_mode = WAL").unwrap();
+        conn.execute(
+            "CREATE TABLE red_rain_308 (
+                slow_desk_238 INTEGER NOT NULL,
+                quiet_tree_398 TEXT NOT NULL,
+                smart_dog_422 REAL UNIQUE,
+                new_hill_140 TEXT,
+                light_door_957 REAL,
+                wild_dog_803 TEXT NOT NULL,
+                new_flower_28 BLOB,
+                old_fish_931 TEXT PRIMARY KEY
+            )",
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE full_fish_194 (
+                brave_star_722 TEXT PRIMARY KEY,
+                hot_star_957 NUMERIC,
+                empty_chair_834 REAL
+            )",
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO red_rain_308 (
+                slow_desk_238, quiet_tree_398, smart_dog_422, new_hill_140,
+                light_door_957, wild_dog_803, new_flower_28, old_fish_931
+            ) VALUES (
+                1, 'seed', 0.24, 'seed', 1.0, 'seed', zeroblob(3600), 'existing_unique'
+            )",
+        )
+        .unwrap();
+        for id in 2..260 {
+            conn.execute(format!(
+                "INSERT INTO red_rain_308 (
+                    slow_desk_238, quiet_tree_398, smart_dog_422, new_hill_140,
+                    light_door_957, wild_dog_803, new_flower_28, old_fish_931
+                ) VALUES (
+                    {id}, 'quiet_tree_{id}', {id}.0, 'new_hill_{id}',
+                    1.5, 'wild_dog_{id}', zeroblob(3600), 'seed_{id}'
+                )"
+            ))
+            .unwrap();
+        }
+
+        conn.execute("BEGIN").unwrap();
+        conn.execute("DELETE FROM red_rain_308 WHERE old_fish_931 = 'seed_2'")
+            .unwrap();
+        conn.execute("SAVEPOINT sp_91").unwrap();
+        conn.execute(
+            "INSERT INTO full_fish_194 (brave_star_722, hot_star_957, empty_chair_834)
+             VALUES ('sweet_fish_597', 328, 7.71)",
+        )
+        .unwrap();
+
+        let red_rain_root_page = query_single_i64(
+            &conn,
+            "SELECT rootpage FROM sqlite_schema
+             WHERE type = 'table' AND name = 'red_rain_308'",
+        );
+        let injector = TargetedYieldInjector::new(
+            BTreeWriteYieldPoint::AfterInsertOverflowCellBeforeBalance.point(),
+            btree_write_selection_key(red_rain_root_page),
+        );
+        conn.set_yield_injector(Some(injector.clone()));
+        let mut abandoned = conn
+            .prepare(
+                "INSERT INTO red_rain_308 (
+                    slow_desk_238, quiet_tree_398, smart_dog_422, new_hill_140,
+                    light_door_957, wild_dog_803, new_flower_28, old_fish_931
+                ) VALUES (
+                    926, 'dry_hill_411', 9.24, 'blue_hill_65',
+                    7.50, 'happy_moon_474', zeroblob(7200), 'smart_rock_113'
+                )",
+            )
+            .unwrap();
+        assert!(matches!(abandoned.step().unwrap(), StepResult::Yield));
+        assert!(injector.fired());
+        abandoned.reset().unwrap();
+        drop(abandoned);
+        conn.set_yield_injector(None);
+
+        conn.execute("DELETE FROM red_rain_308 WHERE slow_desk_238 BETWEEN 2 AND 240")
+            .unwrap();
+        conn.execute("RELEASE sp_91").unwrap();
+
+        assert!(conn
+            .execute(
+                "INSERT INTO red_rain_308 (
+                    slow_desk_238, quiet_tree_398, smart_dog_422, new_hill_140,
+                    light_door_957, wild_dog_803, new_flower_28, old_fish_931
+                ) VALUES (
+                    927, 'dry_hill_412', 0.24, 'blue_hill_66',
+                    7.50, 'happy_moon_475', x'736f66745f73746f6e655f313732', 'smart_rock_114'
+                )"
+            )
+            .is_err());
+
+        for id in 300..420 {
+            conn.execute(format!(
+                "INSERT INTO red_rain_308 (
+                    slow_desk_238, quiet_tree_398, smart_dog_422, new_hill_140,
+                    light_door_957, wild_dog_803, new_flower_28, old_fish_931
+                ) VALUES (
+                    {id}, 'quiet_tree_{id}', {id}.0, 'new_hill_{id}',
+                    1.5, 'wild_dog_{id}', zeroblob(3600), 'reuse_{id}'
+                )"
+            ))
+            .unwrap();
+        }
+
+        conn.execute("ROLLBACK").unwrap();
+        assert_eq!(query_single_text(&conn, "PRAGMA integrity_check"), "ok");
+    }
+
+    #[test]
+    fn wal_overflowing_insert_resumes_after_yield_before_balance() {
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, "resume-overflow-yield.db").unwrap();
+        let conn = db.connect().unwrap();
+
+        conn.execute("PRAGMA journal_mode = WAL").unwrap();
+        conn.execute(
+            "CREATE TABLE red_rain_308 (
+                slow_desk_238 INTEGER NOT NULL,
+                quiet_tree_398 TEXT NOT NULL,
+                smart_dog_422 REAL UNIQUE,
+                new_hill_140 TEXT,
+                light_door_957 REAL,
+                wild_dog_803 TEXT NOT NULL,
+                new_flower_28 BLOB,
+                old_fish_931 TEXT PRIMARY KEY
+            )",
+        )
+        .unwrap();
+
+        for id in 1..260 {
+            conn.execute(format!(
+                "INSERT INTO red_rain_308 (
+                    slow_desk_238, quiet_tree_398, smart_dog_422, new_hill_140,
+                    light_door_957, wild_dog_803, new_flower_28, old_fish_931
+                ) VALUES (
+                    {id}, 'quiet_tree_{id}', {id}.0, 'new_hill_{id}',
+                    1.5, 'wild_dog_{id}', zeroblob(3600), 'seed_{id}'
+                )"
+            ))
+            .unwrap();
+        }
+
+        let red_rain_root_page = query_single_i64(
+            &conn,
+            "SELECT rootpage FROM sqlite_schema
+             WHERE type = 'table' AND name = 'red_rain_308'",
+        );
+        let injector = TargetedYieldInjector::new(
+            BTreeWriteYieldPoint::AfterInsertOverflowCellBeforeBalance.point(),
+            btree_write_selection_key(red_rain_root_page),
+        );
+        conn.set_yield_injector(Some(injector.clone()));
+        let mut stmt = conn
+            .prepare(
+                "INSERT INTO red_rain_308 (
+                    slow_desk_238, quiet_tree_398, smart_dog_422, new_hill_140,
+                    light_door_957, wild_dog_803, new_flower_28, old_fish_931
+                ) VALUES (
+                    926, 'dry_hill_411', 9.24, 'blue_hill_65',
+                    7.50, 'happy_moon_474', zeroblob(7200), 'smart_rock_113'
+                )",
+            )
+            .unwrap();
+
+        assert!(matches!(stmt.step().unwrap(), StepResult::Yield));
+        assert!(injector.fired());
+        assert!(matches!(stmt.step().unwrap(), StepResult::Done));
+        drop(stmt);
+        conn.set_yield_injector(None);
+
+        assert_eq!(
+            query_single_i64(
+                &conn,
+                "SELECT COUNT(*) FROM red_rain_308 WHERE old_fish_931 = 'smart_rock_113'",
+            ),
+            1
+        );
+        assert_eq!(query_single_text(&conn, "PRAGMA integrity_check"), "ok");
     }
 
     fn ensure_cell(page: &mut PageContent, cell_idx: usize, payload: &Vec<u8>) {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4131,6 +4131,11 @@ impl Pager {
                                 page.get().id
                             )));
                         }
+                        turso_assert!(
+                            page.get().overflow_cells.is_empty(),
+                            "dirty page still has overflow cells at commit time",
+                            { "page_id": page.get().id }
+                        );
                         commit_info.page_source_cursor += 1;
                         commit_info.collected_pages.push(page);
 
@@ -4936,14 +4941,11 @@ impl Pager {
                                 "free_page page id mismatch",
                                 { "expected": page_id, "actual": page.get().id }
                             );
-                            if page.is_loaded() {
-                                let page_contents = page.get_contents();
-                                page_contents.overflow_cells.clear();
-                            }
                             (page, None)
                         }
                         None => return_if_io!(self.read_page(page_id as i64)),
                     };
+                    page.get().overflow_cells.clear();
                     header.freelist_pages = (header.freelist_pages.get() + 1).into();
 
                     let trunk_page_id = header.freelist_trunk_page.get();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -101,11 +101,21 @@ use crate::pseudo::PseudoCursor;
 use crate::storage::btree::{BTreeCursor, BTreeKey};
 
 #[inline]
-fn install_btree_cursor_yield_context(cursor: &mut BTreeCursor, connection: &Arc<Connection>) {
+fn btree_cursor_with_yield_context(
+    cursor: Box<BTreeCursor>,
+    connection: &Arc<Connection>,
+) -> Box<BTreeCursor> {
     #[cfg(any(test, injected_yields))]
-    cursor.install_yield_context(connection);
+    {
+        let mut cursor = cursor;
+        cursor.install_yield_context(connection);
+        cursor
+    }
     #[cfg(not(any(test, injected_yields)))]
-    let _ = (cursor, connection);
+    {
+        let _ = connection;
+        cursor
+    }
 }
 
 use super::{
@@ -1214,13 +1224,11 @@ pub fn op_open_read(
             // This is a materialized view with storage
             // Create btree cursor for reading the persistent data
 
-            let mut btree_cursor = BTreeCursor::new_table(
+            let btree_cursor = Box::new(BTreeCursor::new_table(
                 pager.clone(),
                 maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 num_columns,
-            );
-            install_btree_cursor_yield_context(&mut btree_cursor, &program.connection);
-            let btree_cursor = Box::new(btree_cursor);
+            ));
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
 
             // Get the view name and look up or create its transaction state
@@ -1251,22 +1259,18 @@ pub fn op_open_read(
                 ));
             }
             let btree_cursor: Box<dyn CursorTrait> = if table.has_rowid {
-                let mut cursor = BTreeCursor::new_table(
+                Box::new(BTreeCursor::new_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                     num_columns,
-                );
-                install_btree_cursor_yield_context(&mut cursor, &program.connection);
-                Box::new(cursor)
+                ))
             } else {
-                let mut cursor = BTreeCursor::new_without_rowid_table(
+                Box::new(BTreeCursor::new_without_rowid_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                     table.as_ref(),
                     num_columns,
-                );
-                install_btree_cursor_yield_context(&mut cursor, &program.connection);
-                Box::new(cursor)
+                ))
             };
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
             cursors
@@ -1275,14 +1279,12 @@ pub fn op_open_read(
                 .replace(Cursor::new_btree(cursor));
         }
         CursorType::BTreeIndex(index) => {
-            let mut btree_cursor = BTreeCursor::new_index(
+            let btree_cursor = Box::new(BTreeCursor::new_index(
                 pager,
                 maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 index.as_ref(),
                 num_columns,
-            )?;
-            install_btree_cursor_yield_context(&mut btree_cursor, &program.connection);
-            let btree_cursor = Box::new(btree_cursor);
+            )?);
             let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
                 IndexInfo::new_from_index_in(index, mv_store.allocator())?
             } else {
@@ -11093,14 +11095,15 @@ pub fn op_open_write(
         };
         if let Some(index) = maybe_index {
             let num_columns = index.columns.len();
-            let mut btree_cursor = BTreeCursor::new_index(
-                pager,
-                maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
-                index.as_ref(),
-                num_columns,
-            )?;
-            install_btree_cursor_yield_context(&mut btree_cursor, &program.connection);
-            let btree_cursor = Box::new(btree_cursor);
+            let btree_cursor = btree_cursor_with_yield_context(
+                Box::new(BTreeCursor::new_index(
+                    pager,
+                    maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
+                    index.as_ref(),
+                    num_columns,
+                )?),
+                &program.connection,
+            );
             let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
                 IndexInfo::new_from_index_in(index, mv_store.allocator())?
             } else {
@@ -11130,24 +11133,24 @@ pub fn op_open_write(
 
             let btree_cursor: Box<dyn CursorTrait> = match cursor_type {
                 CursorType::BTreeTable(table_rc) if !table_rc.has_rowid => {
-                    let mut cursor = BTreeCursor::new_without_rowid_table(
+                    btree_cursor_with_yield_context(
+                        Box::new(BTreeCursor::new_without_rowid_table(
+                            pager,
+                            maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
+                            table_rc.as_ref(),
+                            num_columns,
+                        )),
+                        &program.connection,
+                    )
+                }
+                _ => btree_cursor_with_yield_context(
+                    Box::new(BTreeCursor::new_table(
                         pager,
                         maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
-                        table_rc.as_ref(),
                         num_columns,
-                    );
-                    install_btree_cursor_yield_context(&mut cursor, &program.connection);
-                    Box::new(cursor)
-                }
-                _ => {
-                    let mut cursor = BTreeCursor::new_table(
-                        pager,
-                        maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
-                        num_columns,
-                    );
-                    install_btree_cursor_yield_context(&mut cursor, &program.connection);
-                    Box::new(cursor)
-                }
+                    )),
+                    &program.connection,
+                ),
             };
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
             cursors
@@ -13423,7 +13426,7 @@ pub fn op_open_ephemeral(
                 _ => unreachable!("This should not have happened"),
             };
 
-            let mut cursor = if let CursorType::BTreeIndex(index) = cursor_type {
+            let cursor = if let CursorType::BTreeIndex(index) = cursor_type {
                 BTreeCursor::new_index(pager.clone(), root_page, index, num_columns)
             } else {
                 Ok(BTreeCursor::new_table(
@@ -13432,7 +13435,6 @@ pub fn op_open_ephemeral(
                     num_columns,
                 ))
             }?;
-            install_btree_cursor_yield_context(&mut cursor, &program.connection);
             *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::Rewind {
                 cursor: Box::new(cursor),
                 temp_file: temp_file.take(),
@@ -13540,22 +13542,18 @@ pub fn op_open_dup(
                 ));
             }
             let cursor: Box<dyn CursorTrait> = if table.has_rowid {
-                let mut cursor = BTreeCursor::new_table(
+                Box::new(BTreeCursor::new_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                     table.columns().len(),
-                );
-                install_btree_cursor_yield_context(&mut cursor, &program.connection);
-                Box::new(cursor)
+                ))
             } else {
-                let mut cursor = BTreeCursor::new_without_rowid_table(
+                Box::new(BTreeCursor::new_without_rowid_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                     table.as_ref(),
                     table.columns().len(),
-                );
-                install_btree_cursor_yield_context(&mut cursor, &program.connection);
-                Box::new(cursor)
+                ))
             };
             let cursor: Box<dyn CursorTrait> = if !is_ephemeral {
                 if let Some(tx_id) = program.connection.get_mv_tx_id() {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -100,6 +100,14 @@ use crate::pseudo::PseudoCursor;
 
 use crate::storage::btree::{BTreeCursor, BTreeKey};
 
+#[inline]
+fn install_btree_cursor_yield_context(cursor: &mut BTreeCursor, connection: &Arc<Connection>) {
+    #[cfg(any(test, injected_yields))]
+    cursor.install_yield_context(connection);
+    #[cfg(not(any(test, injected_yields)))]
+    let _ = (cursor, connection);
+}
+
 use super::{
     array::{
         array_values_from_blob, compare_arrays, compute_array_length, compute_array_length_at_dim,
@@ -1206,11 +1214,13 @@ pub fn op_open_read(
             // This is a materialized view with storage
             // Create btree cursor for reading the persistent data
 
-            let btree_cursor = Box::new(BTreeCursor::new_table(
+            let mut btree_cursor = BTreeCursor::new_table(
                 pager.clone(),
                 maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 num_columns,
-            ));
+            );
+            install_btree_cursor_yield_context(&mut btree_cursor, &program.connection);
+            let btree_cursor = Box::new(btree_cursor);
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
 
             // Get the view name and look up or create its transaction state
@@ -1241,18 +1251,22 @@ pub fn op_open_read(
                 ));
             }
             let btree_cursor: Box<dyn CursorTrait> = if table.has_rowid {
-                Box::new(BTreeCursor::new_table(
+                let mut cursor = BTreeCursor::new_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                     num_columns,
-                ))
+                );
+                install_btree_cursor_yield_context(&mut cursor, &program.connection);
+                Box::new(cursor)
             } else {
-                Box::new(BTreeCursor::new_without_rowid_table(
+                let mut cursor = BTreeCursor::new_without_rowid_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                     table.as_ref(),
                     num_columns,
-                ))
+                );
+                install_btree_cursor_yield_context(&mut cursor, &program.connection);
+                Box::new(cursor)
             };
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
             cursors
@@ -1261,12 +1275,14 @@ pub fn op_open_read(
                 .replace(Cursor::new_btree(cursor));
         }
         CursorType::BTreeIndex(index) => {
-            let btree_cursor = Box::new(BTreeCursor::new_index(
+            let mut btree_cursor = BTreeCursor::new_index(
                 pager,
                 maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 index.as_ref(),
                 num_columns,
-            )?);
+            )?;
+            install_btree_cursor_yield_context(&mut btree_cursor, &program.connection);
+            let btree_cursor = Box::new(btree_cursor);
             let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
                 IndexInfo::new_from_index_in(index, mv_store.allocator())?
             } else {
@@ -11077,12 +11093,14 @@ pub fn op_open_write(
         };
         if let Some(index) = maybe_index {
             let num_columns = index.columns.len();
-            let btree_cursor = Box::new(BTreeCursor::new_index(
+            let mut btree_cursor = BTreeCursor::new_index(
                 pager,
                 maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                 index.as_ref(),
                 num_columns,
-            )?);
+            )?;
+            install_btree_cursor_yield_context(&mut btree_cursor, &program.connection);
+            let btree_cursor = Box::new(btree_cursor);
             let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
                 IndexInfo::new_from_index_in(index, mv_store.allocator())?
             } else {
@@ -11112,18 +11130,24 @@ pub fn op_open_write(
 
             let btree_cursor: Box<dyn CursorTrait> = match cursor_type {
                 CursorType::BTreeTable(table_rc) if !table_rc.has_rowid => {
-                    Box::new(BTreeCursor::new_without_rowid_table(
+                    let mut cursor = BTreeCursor::new_without_rowid_table(
                         pager,
                         maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                         table_rc.as_ref(),
                         num_columns,
-                    ))
+                    );
+                    install_btree_cursor_yield_context(&mut cursor, &program.connection);
+                    Box::new(cursor)
                 }
-                _ => Box::new(BTreeCursor::new_table(
-                    pager,
-                    maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
-                    num_columns,
-                )),
+                _ => {
+                    let mut cursor = BTreeCursor::new_table(
+                        pager,
+                        maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
+                        num_columns,
+                    );
+                    install_btree_cursor_yield_context(&mut cursor, &program.connection);
+                    Box::new(cursor)
+                }
             };
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
             cursors
@@ -13399,7 +13423,7 @@ pub fn op_open_ephemeral(
                 _ => unreachable!("This should not have happened"),
             };
 
-            let cursor = if let CursorType::BTreeIndex(index) = cursor_type {
+            let mut cursor = if let CursorType::BTreeIndex(index) = cursor_type {
                 BTreeCursor::new_index(pager.clone(), root_page, index, num_columns)
             } else {
                 Ok(BTreeCursor::new_table(
@@ -13408,6 +13432,7 @@ pub fn op_open_ephemeral(
                     num_columns,
                 ))
             }?;
+            install_btree_cursor_yield_context(&mut cursor, &program.connection);
             *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::Rewind {
                 cursor: Box::new(cursor),
                 temp_file: temp_file.take(),
@@ -13515,18 +13540,22 @@ pub fn op_open_dup(
                 ));
             }
             let cursor: Box<dyn CursorTrait> = if table.has_rowid {
-                Box::new(BTreeCursor::new_table(
+                let mut cursor = BTreeCursor::new_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                     table.columns().len(),
-                ))
+                );
+                install_btree_cursor_yield_context(&mut cursor, &program.connection);
+                Box::new(cursor)
             } else {
-                Box::new(BTreeCursor::new_without_rowid_table(
+                let mut cursor = BTreeCursor::new_without_rowid_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                     table.as_ref(),
                     table.columns().len(),
-                ))
+                );
+                install_btree_cursor_yield_context(&mut cursor, &program.connection);
+                Box::new(cursor)
             };
             let cursor: Box<dyn CursorTrait> = if !is_ephemeral {
                 if let Some(tx_id) = program.connection.get_mv_tx_id() {


### PR DESCRIPTION
## Prerequisites

In memory Turso pages have two kinds of data:

1. Real page bytes: the page data which is also written to disk
2. Transient in-memory state: in memory only transient data

One piece of such data is `overflow_cells`.

Imagine you insert a really yuge row, if it does not fit inside a B Tree page cell, for such data we stage an OverflowCell:

```text
large INSERT
   |
   v
page bytes get a compact/local cell
overflow_cells gets a transient cell payload
   |
   v
balance algo reads page bytes + overflow_cells together
   |
   v
final page layout is written (with overflow_cells data spread all over)
overflow_cells must be empty again
```

so `overflow_cells` is not durable page content. It is only temporary balancing state.

A cached page may be reused across statements, cursors, and later page roles, but it must never carry leftover `overflow_cells`.

The invariant should be:

```text
after insert/balance finishes, aborts, yields, resets, or drops:
    page.overflow_cells == []
```

A page in the cache should look like this when idle:

```text
PageRef
├── page bytes: valid SQLite page image
└── overflow_cells: []
```

## Bug

If the statement interupted in middle or dropped, then we were not clearing the overflow data

```text
INSERT large row

page bytes:
  cell[1] = local payload

overflow_cells:
  [ OverflowCell { index: 1, full payload ... } ]

YIELD happens here
statement is reset/dropped before balance completes
```

After the statement was abandoned, the cached page still had the transient data

That stale `overflow_cells` vector then survived into later normal SQL operations. Those later operations reused the same cached page object. From the storage layer’s point of view, the page now had a mix of:

```text
new real page bytes
old transient overflow metadata
```

The patch makes abandoned cursor/page cleanup clear transient overflow data. It also clears `overflow_cells` when initializing/reusing pages and asserts that dirty pages are not committed with leftover overflow state.

Comes with a regression test which manages to hit the assertion:

```rust
running 1 test

thread 'storage::btree::tests::wal_reuses_freelist_leaf_after_abandoned_overflowing_insert' panicked at core/storage/btree.rs:8548:17:
multiple overflow cells can only occur when a parent overflows during balancing as divider cells are inserted into it. those cells should always be in-order and sequential | page_id=265, last_overflow_index=1, cell_idx=1, cell_count=1, overflow_count=1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test storage::btree::tests::wal_reuses_freelist_leaf_after_abandoned_overflowing_insert ... FAILED

failures:

failures:
    storage::btree::tests::wal_reuses_freelist_leaf_after_abandoned_overflowing_insert

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2045 filtered out; finished in 0.15s
```

## Description of AI Usage

Debugging, and the test 