### PR TITLE
randomize some turso-stress params and run SQLite integrity check as an `eventually` command

### DIFF
--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -75,6 +75,7 @@ COPY --from=builder /app/target/wheels/* /tmp
 RUN pip install --break-system-packages /tmp/*.whl
 
 WORKDIR /app
+COPY ./testing/antithesis/random.sh ./testing/antithesis/sqlite_integrity_check.py /opt/antithesis/test/v1/
 COPY ./testing/antithesis/bank-test/*.py /opt/antithesis/test/v1/bank-test/
 COPY ./testing/antithesis/stress-composer/*.py /opt/antithesis/test/v1/stress-composer/
 COPY ./testing/antithesis/stress /opt/antithesis/test/v1/stress

--- a/testing/antithesis/random.sh
+++ b/testing/antithesis/random.sh
@@ -1,0 +1,3 @@
+random_range() {
+    python3 -c "from antithesis.random import get_random; print($1 + get_random() % ($2 - $1 + 1))"
+}

--- a/testing/antithesis/sqlite_integrity_check.py
+++ b/testing/antithesis/sqlite_integrity_check.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env -S python3 -u
+
+import os
+import sqlite3
+import sys
+
+import turso
+from antithesis.assertions import always, unreachable
+
+db_file = "/tmp/stress.db"
+
+if not os.path.exists(db_file):
+    print(f"{db_file} does not exist")
+    sys.exit(1)
+
+try:
+    turso_con = turso.connect(db_file)
+    mode = turso_con.execute("pragma journal_mode = 'wal'").fetchall()
+    turso_con.close()
+    print(f"journal_mode: {mode}")
+except Exception as e:
+    print(f"error switching database to wal mode: {e}")
+    unreachable("error switching database to wal mode", {"path": db_file, "error": str(e)})
+    sys.exit(0)
+
+try:
+    con = sqlite3.connect(db_file)
+    rows = [row[0] for row in con.execute("pragma integrity_check")]
+except sqlite3.Error as e:
+    print(f"error performing sqlite integrity check: {e}")
+    unreachable("error performing sqlite integrity check", {"path": db_file, "error": str(e)})
+    sys.exit(0)
+
+print("\n".join(map(str, rows)))
+
+always(len(rows) > 0, "sqlite integrity check returned rows", {"path": db_file})
+
+ok = len(rows) > 0 and str(rows[0]).lower() == "ok"
+always(ok, "sqlite integrity check passed", {"path": db_file, "rows": rows})

--- a/testing/antithesis/stress-io_uring-mvcc/eventually_sqlite_integrity_check.py
+++ b/testing/antithesis/stress-io_uring-mvcc/eventually_sqlite_integrity_check.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env -S python3 -u
+
+import os
+import runpy
+
+runpy.run_path(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "sqlite_integrity_check.py"))

--- a/testing/antithesis/stress-io_uring-mvcc/singleton_driver_stress.sh
+++ b/testing/antithesis/stress-io_uring-mvcc/singleton_driver_stress.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-/bin/turso_stress --nr-threads 2 --nr-iterations 10000 --vfs io_uring --tx-mode concurrent
+source "$(dirname "$0")/../random.sh"
+
+sqlite3 /tmp/stress.db 'vacuum'
+
+/bin/turso_stress --nr-threads "$(random_range 1 5)" --nr-iterations "$(random_range 1000 9999)" --vfs io_uring --tx-mode concurrent --db-file /tmp/stress.db

--- a/testing/antithesis/stress-io_uring/eventually_sqlite_integrity_check.py
+++ b/testing/antithesis/stress-io_uring/eventually_sqlite_integrity_check.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env -S python3 -u
+
+import os
+import runpy
+
+runpy.run_path(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "sqlite_integrity_check.py"))

--- a/testing/antithesis/stress-io_uring/singleton_driver_stress.sh
+++ b/testing/antithesis/stress-io_uring/singleton_driver_stress.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-/bin/turso_stress --nr-threads 2 --nr-iterations 10000 --vfs io_uring
+source "$(dirname "$0")/../random.sh"
+
+sqlite3 /tmp/stress.db 'vacuum'
+
+/bin/turso_stress --nr-threads "$(random_range 1 5)" --nr-iterations "$(random_range 1000 9999)" --vfs io_uring --db-file /tmp/stress.db

--- a/testing/antithesis/stress-memory_yield/singleton_driver_stress.sh
+++ b/testing/antithesis/stress-memory_yield/singleton_driver_stress.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-/bin/turso_stress --nr-threads 2 --nr-iterations 10000 --vfs memory_yield
+source "$(dirname "$0")/../random.sh"
+
+sqlite3 /tmp/stress.db 'vacuum'
+
+/bin/turso_stress --nr-threads "$(random_range 1 5)" --nr-iterations "$(random_range 1000 9999)" --vfs memory_yield --db-file /tmp/stress.db

--- a/testing/antithesis/stress-mvcc/eventually_sqlite_integrity_check.py
+++ b/testing/antithesis/stress-mvcc/eventually_sqlite_integrity_check.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env -S python3 -u
+
+import os
+import runpy
+
+runpy.run_path(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "sqlite_integrity_check.py"))

--- a/testing/antithesis/stress-mvcc/singleton_driver_stress.sh
+++ b/testing/antithesis/stress-mvcc/singleton_driver_stress.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-/bin/turso_stress --nr-threads 2 --nr-iterations 10000 --tx-mode concurrent
+source "$(dirname "$0")/../random.sh"
+
+sqlite3 /tmp/stress.db 'vacuum'
+
+/bin/turso_stress --nr-threads "$(random_range 1 5)" --nr-iterations "$(random_range 1000 9999)" --tx-mode concurrent --db-file /tmp/stress.db

--- a/testing/antithesis/stress-unreliable/eventually_sqlite_integrity_check.py
+++ b/testing/antithesis/stress-unreliable/eventually_sqlite_integrity_check.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env -S python3 -u
+
+import os
+import runpy
+
+runpy.run_path(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "sqlite_integrity_check.py"))

--- a/testing/antithesis/stress-unreliable/singleton_driver_stress.sh
+++ b/testing/antithesis/stress-unreliable/singleton_driver_stress.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-LD_PRELOAD=/usr/lib/unreliable-libc.so /bin/turso_stress --nr-iterations 10000
+source "$(dirname "$0")/../random.sh"
+
+sqlite3 /tmp/stress.db 'vacuum'
+
+LD_PRELOAD=/usr/lib/unreliable-libc.so /bin/turso_stress --nr-threads "$(random_range 1 5)" --nr-iterations "$(random_range 1000 9999)" --db-file /tmp/stress.db


### PR DESCRIPTION
## Description

2 improvements to Antithesis testing:
* randomize some turso-stress parameters in Antithesis, so that we get better test coverage
* run the SQLite integrity check as an "eventually" test command, so that the integrity check runs even if the singleton doesn't complete

I launched a [15-minute test](https://turso.antithesis.com/report/qe42hlUJRPHkyL04h70n4wKp/5yWw7xDqqveKbtb6w2DskrPj9uIfGYiz0mMk6nCrCh4.html?auth=v2.public.eyJuYmYiOiIyMDI2LTA3LTAzVDEyOjQ0OjQ0LjA2ODgwMzAyNloiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiNXlXdzd4RHFxdmVLYnRiNncyRHNrclBqOXVJZkdZaXowbU1rNm5DckNoNC5odG1sIiwicmVwb3J0X2lkIjoicWU0MmhsVUpSUEhreUwwNGg3MG40d0twIn19fVYJBdebzZgxS88_Koumu08O7DsiX92b5RXoeTueaoRWvHH_Rz5EP9NH-ECNwKVP9q0DfEQkCONRGrk5OYejTQw) on this branch, and it completed successfully (with one unrelated error)