### PR TITLE
core/translate: propagate fallible Vec allocations

### DIFF
--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -107,3 +107,32 @@ pub trait TryClone: Sized {
 
     fn try_clone(&self) -> Result<Self, Self::Error>;
 }
+
+impl<T> TryClone for Option<T>
+where
+    T: TryClone,
+{
+    type Error = T::Error;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        match self {
+            Some(value) => Ok(Some(value.try_clone()?)),
+            None => Ok(None),
+        }
+    }
+}
+
+impl<T, E> TryClone for Result<T, E>
+where
+    T: TryClone,
+    E: TryClone<Error = T::Error>,
+{
+    type Error = T::Error;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        match self {
+            Ok(value) => Ok(Ok(value.try_clone()?)),
+            Err(err) => Ok(Err(err.try_clone()?)),
+        }
+    }
+}

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -188,7 +188,7 @@ macro_rules! __turso_alloc_try_vec {
                 <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity_ext(
                     $crate::__turso_alloc_vec_count!($($element),+),
                 )?;
-            $(values.try_push($element)?;)+
+            $(values.push($element)?;)+
             Ok::<_, $crate::alloc::TryReserveError>(values)
         })()
     }};

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -188,7 +188,7 @@ macro_rules! __turso_alloc_try_vec {
                 <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity_ext(
                     $crate::__turso_alloc_vec_count!($($element),+),
                 )?;
-            $(values.push($element)?;)+
+            $(values.push($element);)+
             Ok::<_, $crate::alloc::TryReserveError>(values)
         })()
     }};

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -4,7 +4,7 @@ use divan::{black_box, AllocProfiler, Bencher};
 use mimalloc::MiMalloc;
 use rustc_hash::FxBuildHasher;
 use turso_core::alloc::{
-    self, TursoBinaryHeapExt, TursoFromIterator, TursoHashMapExt, TursoHashSetExt,
+    self, TryClone, TursoBinaryHeapExt, TursoFromIterator, TursoHashMapExt, TursoHashSetExt,
     TursoIteratorExt, TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt,
 };
 
@@ -42,6 +42,22 @@ impl NonCopyValue {
             ],
         }
     }
+}
+
+fn copy_values_turso(len: usize) -> alloc::Vec<usize> {
+    (0..len).try_collect().unwrap()
+}
+
+fn copy_values_std(len: usize) -> std::vec::Vec<usize> {
+    (0..len).collect()
+}
+
+fn non_copy_values_turso(len: usize) -> alloc::Vec<NonCopyValue> {
+    (0..len).map(NonCopyValue::new).try_collect().unwrap()
+}
+
+fn non_copy_values_std(len: usize) -> std::vec::Vec<NonCopyValue> {
+    (0..len).map(NonCopyValue::new).collect()
 }
 
 struct LowerBoundOnly<I> {
@@ -135,6 +151,29 @@ fn vec_extend_std(bencher: Bencher, len: usize) {
         values.extend((0..len).map(black_box));
         black_box(values)
     });
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_clone_std(bencher: Bencher, len: usize) {
+    #[expect(clippy::redundant_clone)]
+    bencher
+        .with_inputs(|| copy_values_std(len))
+        .bench_local_values(|values| black_box(values).clone());
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_clone_turso(bencher: Bencher, len: usize) {
+    #[expect(clippy::redundant_clone)]
+    bencher
+        .with_inputs(|| copy_values_turso(len))
+        .bench_local_values(|values| black_box(values).clone());
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_try_clone_turso(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| copy_values_turso(len))
+        .bench_local_values(|values| black_box(values).try_clone().unwrap());
 }
 
 #[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
@@ -712,6 +751,27 @@ fn vec_non_copy_extend_turso(bencher: Bencher, len: usize) {
         .unwrap();
         black_box(values)
     });
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_clone_std(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| non_copy_values_std(len))
+        .bench_local_values(|values| black_box(values).clone());
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_clone_turso(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| non_copy_values_turso(len))
+        .bench_local_values(|values| black_box(values).clone());
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_try_clone_turso(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| non_copy_values_turso(len))
+        .bench_local_values(|values| black_box(values).try_clone().unwrap());
 }
 
 #[turso_macros::divan_bench(args = [64, 1_024, 16_384])]

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(nightly, feature(allocator_api))]
 
-use divan::{black_box, AllocProfiler, Bencher};
+use divan::{black_box, black_box_drop, AllocProfiler, Bencher};
 use mimalloc::MiMalloc;
 use rustc_hash::FxBuildHasher;
 use turso_core::alloc::{
@@ -757,14 +757,24 @@ fn vec_non_copy_extend_turso(bencher: Bencher, len: usize) {
 fn vec_non_copy_clone_std(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| non_copy_values_std(len))
-        .bench_local_values(|values| black_box(values).clone());
+        .bench_local_values(|values| {
+            let values = black_box(values);
+            let cloned = values.clone();
+            black_box(values.len());
+            black_box_drop(cloned);
+        });
 }
 
 #[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
 fn vec_non_copy_clone_turso(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| non_copy_values_turso(len))
-        .bench_local_values(|values| black_box(values).clone());
+        .bench_local_values(|values| {
+            let values = black_box(values);
+            let cloned = values.clone();
+            black_box(values.len());
+            black_box_drop(cloned);
+        });
 }
 
 #[turso_macros::divan_bench(args = [64, 1_024, 16_384])]

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -5484,7 +5484,7 @@ impl Index {
                     let configuration = IndexMethodConfiguration {
                         table_name: table.name.clone(),
                         index_name: index_name.clone(),
-                        columns: index_columns.clone(),
+                        columns: index_columns.try_clone()?,
                         parameters,
                     };
                     let descriptor = module.attach(&configuration)?;

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2705,48 +2705,48 @@ pub enum ColumnLayout {
 }
 
 impl ColumnLayout {
-    pub fn from_table(table: &Table) -> Self {
+    pub fn from_table(table: &Table) -> Result<Self, TryReserveError> {
         match table {
             Table::BTree(btree) => Self::from_btree(btree),
-            Table::Virtual(vtable) => Self::Identity {
+            Table::Virtual(vtable) => Ok(Self::Identity {
                 column_count: vtable.as_ref().columns.len(),
-            },
-            Table::FromClauseSubquery(subquery) => Self::Identity {
+            }),
+            Table::FromClauseSubquery(subquery) => Ok(Self::Identity {
                 column_count: subquery.columns.len(),
-            },
+            }),
         }
     }
 
-    pub fn from_btree(btree: &BTreeTable) -> Self {
+    pub fn from_btree(btree: &BTreeTable) -> Result<Self, TryReserveError> {
         let total = btree.columns.len();
         let non_virtual_col_count = btree
             .columns
             .iter()
             .filter(|c| !c.is_virtual_generated())
             .count();
-        let offsets = btree.logical_to_physical_map.clone();
+        let offsets = btree.logical_to_physical_map.try_clone()?;
         let is_identity = non_virtual_col_count == total && offsets.iter().copied().eq(0..total);
         if is_identity {
-            Self::Identity {
+            Ok(Self::Identity {
                 column_count: total,
-            }
+            })
         } else {
-            Self::Mapped {
+            Ok(Self::Mapped {
                 offsets,
                 non_virtual_col_count,
-            }
+            })
         }
     }
 
-    pub fn from_columns(columns: &[Column]) -> Self {
+    pub fn from_columns(columns: &[Column]) -> Result<Self, TryReserveError> {
         let total = columns.len();
         let non_virtual_col_count = columns.iter().filter(|c| !c.is_virtual_generated()).count();
         if non_virtual_col_count == total {
-            return Self::Identity {
+            return Ok(Self::Identity {
                 column_count: total,
-            };
+            });
         }
-        let mut offsets = vec![0usize; total];
+        let mut offsets = try_vec![0usize; total]?;
         let mut nv_idx = 0;
         let mut v_idx = non_virtual_col_count;
         for (i, col) in columns.iter().enumerate() {
@@ -2758,10 +2758,10 @@ impl ColumnLayout {
                 nv_idx += 1;
             }
         }
-        Self::Mapped {
+        Ok(Self::Mapped {
             offsets,
             non_virtual_col_count,
-        }
+        })
     }
 
     /// Map a schema column index to its register offset.
@@ -3349,7 +3349,7 @@ impl BTreeTable {
     }
 
     /// Build a `ColumnLayout` for this table's register mapping.
-    pub fn column_layout(&self) -> ColumnLayout {
+    pub fn column_layout(&self) -> Result<ColumnLayout, TryReserveError> {
         ColumnLayout::from_btree(self)
     }
 

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     error::SQLITE_CONSTRAINT_CHECK,
     function::{AlterTableFunc, Func},
-    schema::{CheckConstraint, Column, ForeignKey, Table, RESERVED_TABLE_PREFIXES},
+    schema::{CheckConstraint, Column, ColumnLayout, ForeignKey, Table, RESERVED_TABLE_PREFIXES},
     translate::{
         emitter::{emit_check_constraints, gencol::compute_virtual_columns, Resolver},
         expr::{translate_expr, walk_expr, walk_expr_mut, WalkControl},
@@ -622,7 +622,7 @@ fn emit_add_virtual_column_validation(
         dest: rowid_reg,
     });
 
-    let layout = resolved_table.column_layout();
+    let layout = resolved_table.column_layout()?;
     let base_dest_reg = program.alloc_registers(layout.column_count());
     for (idx, table_column) in resolved_table.columns().iter().enumerate() {
         if table_column.is_virtual_generated() || table_column.is_rowid_alias() {
@@ -1159,6 +1159,26 @@ pub fn translate_alter_table(
                 ));
             };
 
+            let rewrite_rows = if !original_btree.columns()[dropped_index].is_virtual_generated() {
+                let source_column_by_schema_idx: Vec<Option<usize>> = btree
+                    .columns()
+                    .iter()
+                    .enumerate()
+                    .map(|(new_idx, column)| {
+                        if column.is_virtual_generated() {
+                            None
+                        } else if new_idx < dropped_index {
+                            Some(new_idx)
+                        } else {
+                            Some(new_idx + 1)
+                        }
+                    })
+                    .collect();
+                Some((source_column_by_schema_idx, btree.column_layout()?))
+            } else {
+                None
+            };
+
             translate_update_for_schema_change(
                 update,
                 resolver,
@@ -1166,27 +1186,13 @@ pub fn translate_alter_table(
                 connection,
                 input,
                 |program| {
-                    if !original_btree.columns()[dropped_index].is_virtual_generated() {
-                        let source_column_by_schema_idx = btree
-                            .columns()
-                            .iter()
-                            .enumerate()
-                            .map(|(new_idx, column)| {
-                                if column.is_virtual_generated() {
-                                    None
-                                } else if new_idx < dropped_index {
-                                    Some(new_idx)
-                                } else {
-                                    Some(new_idx + 1)
-                                }
-                            })
-                            .collect();
-
+                    if let Some((source_column_by_schema_idx, layout)) = &rewrite_rows {
                         emit_rewrite_table_rows(
                             program,
                             original_btree.clone(),
                             &btree,
                             source_column_by_schema_idx,
+                            layout,
                             connection,
                             database_id,
                         );
@@ -2199,7 +2205,7 @@ pub fn translate_alter_table(
                 )?;
 
                 let original_columns = original_btree.columns();
-                let source_column_by_schema_idx = rewritten_table
+                let source_column_by_schema_idx: Vec<Option<usize>> = rewritten_table
                     .columns()
                     .iter()
                     .enumerate()
@@ -2225,11 +2231,13 @@ pub fn translate_alter_table(
                         }
                     })
                     .collect();
+                let layout = rewritten_table.column_layout()?;
                 emit_rewrite_table_rows(
                     program,
                     original_btree.clone(),
                     &rewritten_table,
-                    source_column_by_schema_idx,
+                    &source_column_by_schema_idx,
+                    &layout,
                     connection,
                     database_id,
                 );
@@ -2268,7 +2276,8 @@ fn emit_rewrite_table_rows(
     program: &mut ProgramBuilder,
     original_btree: Arc<BTreeTable>,
     rewritten_table: &BTreeTable,
-    source_column_by_schema_idx: Vec<Option<usize>>,
+    source_column_by_schema_idx: &[Option<usize>],
+    layout: &ColumnLayout,
     connection: &Arc<crate::Connection>,
     database_id: usize,
 ) {
@@ -2277,7 +2286,6 @@ fn emit_rewrite_table_rows(
         rewritten_table.columns().len()
     );
 
-    let layout = rewritten_table.column_layout();
     let non_virtual_column_count = layout.num_non_virtual_cols();
     let root_page = rewritten_table.root_page;
     let table_name = rewritten_table.name.clone();

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -845,7 +845,7 @@ fn emit_compound_order_by(
     // We append a sequence number as an extra sort key after the ORDER BY columns
     // to break ties by insertion order, matching SQLite's merge-based compound SELECT
     // which naturally outputs left-arm rows before right-arm rows for equal keys.
-    let mut order_collations_nulls: crate::alloc::Vec<(
+    let order_collations_nulls: crate::alloc::Vec<(
         SortOrder,
         Option<crate::translate::collate::CollationSeq>,
         Option<turso_parser::ast::NullsOrder>,
@@ -858,49 +858,50 @@ fn emit_compound_order_by(
                 .and_then(|c| c.collation);
             (*order, collation, *nulls)
         })
+        // Sequence tie-breaker: preserves insertion order for rows with equal ORDER BY keys
+        .chain(std::iter::once((SortOrder::Asc, None, None)))
         .try_collect()?;
-    // Sequence tie-breaker: preserves insertion order for rows with equal ORDER BY keys
-    order_collations_nulls.push((SortOrder::Asc, None, None));
 
     // Compute deduplication remappings: which result columns share a sort key slot.
     // The sorter layout is: [order_by_keys..., sequence, non-dedup data cols...]
     let seq_slot = order_by.len();
     let data_start = order_by.len() + 1; // data columns start after ORDER BY keys + sequence
-    let mut remappings: Vec<(usize, bool)> = Vec::with_capacity(num_result_cols);
     let mut non_dedup_count = 0;
-    for col_idx in 0..num_result_cols {
-        if let Some((sort_key_idx, _)) = order_by
-            .iter()
-            .enumerate()
-            .find(|(_, (ob_col, _, _))| *ob_col == col_idx)
-        {
-            // This result column is also a sort key - deduplicate
-            remappings.push((sort_key_idx, true));
-        } else {
-            remappings.push((data_start + non_dedup_count, false));
-            non_dedup_count += 1;
-        }
-    }
+    let remappings: crate::alloc::Vec<(usize, bool)> = (0..num_result_cols)
+        .map(|col_idx| {
+            if let Some((sort_key_idx, _)) = order_by
+                .iter()
+                .enumerate()
+                .find(|(_, (ob_col, _, _))| *ob_col == col_idx)
+            {
+                // This result column is also a sort key - deduplicate.
+                (sort_key_idx, true)
+            } else {
+                let mapping = (data_start + non_dedup_count, false);
+                non_dedup_count += 1;
+                mapping
+            }
+        })
+        .try_collect()?;
     let sorter_column_count = order_by.len() + 1 + non_dedup_count;
 
     let sort_cursor = program.alloc_cursor_id(CursorType::Sorter);
     // Resolve custom type comparators for ORDER BY columns (e.g. numeric(10,2) needs
     // NumericLt to sort correctly instead of default blob/text comparison).
-    let mut comparators: crate::alloc::Vec<Option<crate::vdbe::insn::SortComparatorType>> =
-        order_by
-            .iter()
-            .map(|(col_idx, _, _)| {
-                program.result_columns.get(*col_idx).and_then(|rc| {
-                    custom_type_comparator(
-                        &rc.expr,
-                        &program.table_references,
-                        right_most_ctx.resolver.schema(),
-                    )
-                })
+    let comparators: crate::alloc::Vec<Option<crate::vdbe::insn::SortComparatorType>> = order_by
+        .iter()
+        .map(|(col_idx, _, _)| {
+            program.result_columns.get(*col_idx).and_then(|rc| {
+                custom_type_comparator(
+                    &rc.expr,
+                    &program.table_references,
+                    right_most_ctx.resolver.schema(),
+                )
             })
-            .try_collect()?;
-    // No comparator needed for the sequence tie-breaker column
-    comparators.push(None);
+        })
+        // No comparator needed for the sequence tie-breaker column
+        .chain(std::iter::once(None))
+        .try_collect()?;
     program.emit_insn(Insn::SorterOpen {
         cursor_id: sort_cursor,
         columns: order_collations_nulls.len(),

--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -802,7 +802,7 @@ fn emit_delete_row_common(
         let columns_start_reg = columns_start_reg
             .expect("columns_start_reg must be provided when there are triggers or RETURNING");
         let delete_table = unsafe { &*table_reference };
-        let delete_layout = ColumnLayout::from_columns(delete_table.columns());
+        let delete_layout = ColumnLayout::from_columns(delete_table.columns())?;
         let cache_state = seed_returning_row_image_in_cache(
             program,
             table_references,

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -22,7 +22,7 @@ use super::{
     trigger_exec::{get_triggers_including_temp, has_triggers_including_temp},
     window::WindowMetadata,
 };
-use crate::alloc::TursoIteratorExt;
+use crate::alloc::{TryClone, TursoIteratorExt};
 use crate::instrument;
 use crate::schema::{
     BTreeTable, CheckConstraint, Column, ColumnLayout, GeneratedType, IndexColumn, Schema, Table,
@@ -1809,7 +1809,7 @@ pub(crate) fn emit_columns_and_dependencies(
         program.alloc_registers(non_rowid_targets.len())
     };
     let extra_base = {
-        let mut dependencies_not_in_targets: ColumnMask = dependencies.clone();
+        let mut dependencies_not_in_targets: ColumnMask = dependencies.try_clone()?;
         dependencies_not_in_targets -= &target_mask;
 
         let extra_count = table

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -452,7 +452,9 @@ pub(crate) fn emit_materialized_build_inputs(
         };
         let internal_id = program.table_reference_counter.next();
         let columns = match &spec.mode {
-            MaterializedBuildInputMode::RowidOnly => crate::alloc::vec![build_rowid_column()],
+            MaterializedBuildInputMode::RowidOnly => {
+                std::iter::once(build_rowid_column()).try_collect()?
+            }
             MaterializedBuildInputMode::KeyPayload {
                 num_keys,
                 payload_columns,
@@ -738,28 +740,20 @@ fn build_materialized_input_columns(
     num_keys: usize,
     payload_columns: &[MaterializedColumnRef],
 ) -> Result<crate::alloc::Vec<Column>> {
-    let mut columns = crate::alloc::vec![];
-    columns.try_reserve(num_keys + payload_columns.len())?;
-    for i in 0..num_keys {
-        columns.push(Column::new_default_text(
-            Some(format!("key_{i}")),
-            "BLOB".to_string(),
-            None,
-        ));
-    }
-    for (i, payload) in payload_columns.iter().enumerate() {
-        let name = Some(format!("payload_{i}"));
-        let column = match payload {
-            MaterializedColumnRef::RowId { .. } => {
-                Column::new_default_integer(name, "INTEGER".to_string(), None)
+    Ok((0..num_keys)
+        .map(|i| Column::new_default_text(Some(format!("key_{i}")), "BLOB".to_string(), None))
+        .chain(payload_columns.iter().enumerate().map(|(i, payload)| {
+            let name = Some(format!("payload_{i}"));
+            match payload {
+                MaterializedColumnRef::RowId { .. } => {
+                    Column::new_default_integer(name, "INTEGER".to_string(), None)
+                }
+                MaterializedColumnRef::Column { .. } => {
+                    Column::new_default_text(name, "BLOB".to_string(), None)
+                }
             }
-            MaterializedColumnRef::Column { .. } => {
-                Column::new_default_text(name, "BLOB".to_string(), None)
-            }
-        };
-        columns.push(column);
-    }
-    Ok(columns)
+        }))
+        .try_collect()?)
 }
 
 /// Construct a SELECT plan that materializes build-side inputs into an ephemeral table.

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1241,7 +1241,7 @@ fn emit_update_insns<'a>(
     };
     let table_name = target_table.table.get_name();
     let start = if is_virtual_table { beg + 2 } else { beg + 1 };
-    let layout = ColumnLayout::from_table(&target_table.as_ref().table);
+    let layout = ColumnLayout::from_table(&target_table.as_ref().table)?;
     let affected_columns = match target_table.table.btree() {
         Some(btree) => btree.columns_affected_by_update(&updated_column_indices)?,
         None => updated_column_indices.clone(),

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1,6 +1,6 @@
 use super::gencol::compute_virtual_columns;
 use super::TranslateCtx;
-use crate::alloc::TursoIteratorExt;
+use crate::alloc::{TryClone, TursoIteratorExt};
 use crate::schema::{Column, ColumnLayout, GeneratedType, Table};
 use crate::translate::insert::halt_desc_and_on_error;
 use crate::translate::plan::ColumnMask;
@@ -186,7 +186,7 @@ pub fn emit_program_for_update(
             internal_id: target_table.internal_id,
             table: target_table.table.clone(),
             using_dedup_hidden_cols: ColumnMask::default(),
-            col_used_mask: target_table.col_used_mask.clone(),
+            col_used_mask: target_table.col_used_mask.try_clone()?,
             cte_select: None,
             cte_explicit_columns: vec![],
             cte_id: None,

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -586,7 +586,7 @@ pub fn stabilize_new_row_for_fk(
         return Ok(());
     }
 
-    let layout = table_btree.column_layout();
+    let layout = table_btree.column_layout()?;
     for (pk_name, _) in &table_btree.primary_key_columns {
         let (pos, col) = table_btree
             .get_column(pk_name)
@@ -668,7 +668,7 @@ pub fn emit_parent_index_key_change_checks(
     }
 
     let idx_len = index.columns.len();
-    let layout = table_btree.column_layout();
+    let layout = table_btree.column_layout()?;
     let some_idx_columns_are_virtual = index
         .columns
         .iter()
@@ -2145,7 +2145,7 @@ impl ForeignKeyActions<PreparedFkDeleteAction> {
                                 &parent_bt,
                                 parent_cols,
                                 replace_values_start,
-                                &ColumnLayout::from_btree(&parent_bt),
+                                &ColumnLayout::from_btree(&parent_bt)?,
                                 replace_rowid_reg,
                                 new_key_start,
                             )?;
@@ -2292,7 +2292,7 @@ pub fn fire_fk_update_actions(
     let old_image_layout = ColumnLayout::Identity {
         column_count: parent_bt.columns().len(),
     };
-    let new_image_layout = ColumnLayout::from_btree(&parent_bt);
+    let new_image_layout = ColumnLayout::from_btree(&parent_bt)?;
 
     for fk_ref in resolver.with_schema(database_id, |s| {
         s.resolved_fks_referencing(parent_table_name)

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,4 +1,4 @@
-use crate::alloc::TursoIteratorExt;
+use crate::alloc::{TryClone, TursoIteratorExt};
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::Func;
 use crate::index_method::IndexMethodConfiguration;
@@ -199,7 +199,7 @@ pub fn translate_create_index(
             index_method = Some(index_module.attach(&IndexMethodConfiguration {
                 table_name: tbl.name.clone(),
                 index_name: idx_name.clone(),
-                columns: columns.clone(),
+                columns: columns.try_clone()?,
                 parameters,
             })?);
         }

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -902,6 +902,7 @@ fn resolve_sorted_columns_with_resolver(
                 GeneratedType::Virtual { expr, .. } => Some(expr.clone()),
                 GeneratedType::NotGenerated => None,
             };
+            // Capacity is preallocated to cols.len(); this loop pushes at most one column per input.
             resolved.push(IndexColumn {
                 name: column_name,
                 order,
@@ -915,6 +916,7 @@ fn resolve_sorted_columns_with_resolver(
         if !validate_index_expression(unwrapped_expr, table) {
             crate::bail_parse_error!("Error: invalid expression in CREATE INDEX: {}", sc.expr);
         }
+        // Capacity is preallocated to cols.len(); this loop pushes at most one column per input.
         resolved.push(IndexColumn {
             name: sc.expr.to_string(),
             order,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -897,7 +897,7 @@ pub fn translate_insert(
         // Child-side FK check must run before any writes (IdxInsert / Insert).
         // For immediate FKs this emits a direct Halt, so no index entry is written
         // when the parent is missing — matching SQLite's bytecode order.
-        let fk_layout = btree_table.column_layout();
+        let fk_layout = btree_table.column_layout()?;
         emit_fk_child_insert_checks(
             program,
             &btree_table,
@@ -1082,7 +1082,7 @@ pub fn translate_insert(
                 insertion.first_col_register(),
                 insertion.record_register(),
                 insertion.key_register(),
-                &ColumnLayout::from_table(&table),
+                &ColumnLayout::from_table(&table)?,
             ))
         } else {
             None
@@ -1110,7 +1110,7 @@ pub fn translate_insert(
             insertion.first_col_register(),
             insertion.key_register(),
             resolver,
-            &btree_table.column_layout(),
+            &btree_table.column_layout()?,
         )?;
         let result: Result<()> = (|| {
             for subquery in returning_subqueries
@@ -1145,7 +1145,7 @@ pub fn translate_insert(
             insertion.key_register(),
             resolver,
             ctx.returning_buffer.as_ref(),
-            &btree_table.column_layout(),
+            &btree_table.column_layout()?,
         )?;
     }
     program.emit_insn(Insn::Goto {
@@ -2509,6 +2509,7 @@ fn build_insertion<'a>(
     let layout = table
         .btree()
         .map(|bt| bt.column_layout())
+        .transpose()?
         .unwrap_or(ColumnLayout::Identity {
             column_count: num_cols,
         });
@@ -4317,7 +4318,7 @@ fn emit_custom_type_encode(
         .iter()
         .map(|m| m.column.clone())
         .collect();
-    let layout = ColumnLayout::from_columns(&columns);
+    let layout = ColumnLayout::from_columns(&columns)?;
     crate::translate::expr::emit_custom_type_encode_columns(
         program,
         resolver,

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::alloc::TursoIteratorExt;
+use crate::alloc::{TryClone, TursoIteratorExt};
 use crate::schema::GeneratedType;
 use crate::translate::emitter::HashLabels;
 use crate::translate::plan::ColumnUsedMask;
@@ -174,7 +174,7 @@ impl<'a, 'plan> HashBuildPlanner<'a, 'plan> {
                 }
                 _ => {
                     let payload_signature_columns: ColumnUsedMask =
-                        build_table.col_used_mask.clone();
+                        build_table.col_used_mask.try_clone()?;
                     let payload_columns = payload_signature_columns
                         .iter()
                         .map(|col_idx| {

--- a/core/translate/main_loop/in_seek.rs
+++ b/core/translate/main_loop/in_seek.rs
@@ -27,14 +27,14 @@ pub(super) fn open_in_seek_source_cursor(
                 name: String::new(),
                 table_name: String::new(),
                 root_page: 0,
-                columns: crate::alloc::vec![IndexColumn {
+                columns: crate::alloc::try_vec![IndexColumn {
                     name: String::new(),
                     order: SortOrder::Asc,
                     pos_in_table: 0,
                     collation,
                     default: None,
                     expr: None,
-                }],
+                }]?,
                 unique: true,
                 ephemeral: true,
                 has_rowid: false,

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -5,7 +5,7 @@ use smallvec::SmallVec;
 use turso_ext::{ConstraintInfo, ConstraintUsage, ResultCode};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
 
-use crate::alloc::TursoIteratorExt;
+use crate::alloc::{TursoIteratorExt, TursoTryWithCapacityExt};
 use crate::schema::Schema;
 use crate::stats::AnalyzeStats;
 use crate::translate::collate::CollationSeq;
@@ -1573,7 +1573,7 @@ fn find_best_access_method_for_subquery(
     }
 
     let ephemeral_index =
-        materialized_subquery_ephemeral_index(rhs_table, subquery, &key_col_positions);
+        materialized_subquery_ephemeral_index(rhs_table, subquery, &key_col_positions)?;
     let (iter_dir, _is_index_ordered, order_satisfiability_bonus) =
         materialized_subquery_order_properties(
             rhs_table,
@@ -1655,8 +1655,9 @@ fn materialized_subquery_ephemeral_index(
     rhs_table: &JoinedTable,
     subquery: &FromClauseSubquery,
     key_col_positions: &[usize],
-) -> Arc<Index> {
-    let mut index_columns: crate::alloc::Vec<IndexColumn> = crate::alloc::vec![];
+) -> Result<Arc<Index>> {
+    let mut index_columns: crate::alloc::Vec<IndexColumn> =
+        crate::alloc::Vec::try_with_capacity_ext(subquery.columns.len())?;
     let mut seen_col_positions = std::collections::HashSet::new();
 
     for &col_pos in key_col_positions {
@@ -1667,6 +1668,7 @@ fn materialized_subquery_ephemeral_index(
         if !seen_col_positions.insert(col_pos) {
             continue;
         }
+        // Capacity is preallocated to subquery.columns.len(); key columns are deduplicated.
         index_columns.push(IndexColumn {
             name: column.name.clone().unwrap_or_default(),
             order: SortOrder::Asc,
@@ -1681,6 +1683,7 @@ fn materialized_subquery_ephemeral_index(
         if seen_col_positions.contains(&col_pos) {
             continue;
         }
+        // Capacity is preallocated to subquery.columns.len(); non-key columns fill the remainder.
         index_columns.push(IndexColumn {
             name: column.name.clone().unwrap_or_default(),
             order: SortOrder::Asc,
@@ -1691,7 +1694,7 @@ fn materialized_subquery_ephemeral_index(
         });
     }
 
-    Arc::new(Index {
+    Ok(Arc::new(Index {
         // Match the runtime autoindex naming so EQP and bytecode make it clear
         // that this is a synthetic probe/index-on-temp-table path.
         name: format!("ephemeral_subquery_{}", rhs_table.internal_id),
@@ -1704,7 +1707,7 @@ fn materialized_subquery_ephemeral_index(
         has_rowid: true,
         index_method: None,
         on_conflict: None,
-    })
+    }))
 }
 
 /// Decide whether the synthetic materialized-subquery index would also satisfy

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -12,7 +12,7 @@ use super::{
     order::OrderTarget,
     AvailableIndexes, IndexMethodCandidate,
 };
-use crate::alloc::TursoIteratorExt;
+use crate::alloc::{TryClone, TursoIteratorExt};
 use crate::{
     schema::Schema,
     stats::AnalyzeStats,
@@ -348,7 +348,7 @@ pub fn join_lhs_and_rhs<'a>(
             let probe_cardinality = *rhs_base_rows;
 
             let prior_mask = {
-                let mut mask = lhs_mask.clone();
+                let mut mask = lhs_mask.try_clone()?;
                 mask.clear(build_table_idx);
                 mask
             };
@@ -1177,7 +1177,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
 
                 // If there are no other tables except RHS, skip.
                 let lhs_mask = {
-                    let mut copy = mask.clone();
+                    let mut copy = mask.try_clone()?;
                     copy.clear(rhs_idx);
                     copy
                 };

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1123,8 +1123,8 @@ fn update_from_scratch_col_name(idx: usize) -> String {
     format!("__update_from_{idx}")
 }
 
-fn update_from_scratch_columns(set_clause_count: usize) -> crate::alloc::Vec<Column> {
-    (0..set_clause_count)
+fn update_from_scratch_columns(set_clause_count: usize) -> Result<crate::alloc::Vec<Column>> {
+    Ok((0..set_clause_count)
         .map(|idx| {
             // Keep scratch-table columns at BLOB affinity so materializing SET payloads
             // does not coerce values before the real target-column affinity is applied.
@@ -1138,8 +1138,7 @@ fn update_from_scratch_columns(set_clause_count: usize) -> crate::alloc::Vec<Col
                 ColDef::default(),
             )
         })
-        .try_collect()
-        .expect(crate::alloc::ALLOC_ERR_MSG)
+        .try_collect()?)
 }
 
 /// Build the SELECT that gathers the stable write set for an UPDATE before the
@@ -1156,9 +1155,9 @@ fn build_update_write_set_plan(
     let scratch_table_id = program.table_reference_counter.next();
     let is_update_from = !plan.from_tables.joined_tables().is_empty();
     let columns = if is_update_from {
-        update_from_scratch_columns(plan.set_clauses.len())
+        update_from_scratch_columns(plan.set_clauses.len())?
     } else {
-        crate::alloc::vec![(*ROWID_COLUMN).clone()]
+        std::iter::once((*ROWID_COLUMN).clone()).try_collect()?
     };
     let ephemeral_table = Arc::new(BTreeTable::new(
         0, // root_page, not relevant for ephemeral table definition
@@ -2337,7 +2336,7 @@ fn optimize_table_access(
                     let ephemeral_index = ephemeral_index_build(
                         &table_references.joined_tables_mut()[table_idx],
                         &usable_constraint_refs,
-                    );
+                    )?;
 
                     mark_seek_constraints_consumed(
                         &table_constraints.constraints,
@@ -3214,7 +3213,7 @@ impl Optimizable for ast::Expr {
 fn ephemeral_index_build(
     table_reference: &JoinedTable,
     constraint_refs: &[RangeConstraintRef],
-) -> Index {
+) -> Result<Index> {
     let mut ephemeral_columns: crate::alloc::Vec<IndexColumn> = table_reference
         .columns()
         .iter()
@@ -3235,8 +3234,7 @@ fn ephemeral_index_build(
         })
         // only include columns that are used in the query
         .filter(|c| table_reference.column_is_used(c.pos_in_table))
-        .try_collect()
-        .expect(crate::alloc::ALLOC_ERR_MSG);
+        .try_collect()?;
     // sort so that constraints first, then rest in whatever order they were in in the table
     ephemeral_columns.sort_by(|a, b| {
         let a_constraint = constraint_refs
@@ -3274,7 +3272,7 @@ fn ephemeral_index_build(
         on_conflict: None,
     };
 
-    ephemeral_index
+    Ok(ephemeral_index)
 }
 
 /// Build a [SeekDef] for a given list of [Constraint]s

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -6,7 +6,7 @@
 //! union/intersection-specific decomposition, costing, and residual handling on
 //! top.
 
-use crate::alloc::TursoIteratorExt;
+use crate::alloc::{TryClone, TursoIteratorExt};
 use crate::schema::{Index, Schema};
 use crate::stats::AnalyzeStats;
 use crate::translate::expr::expr_references_any_subquery;
@@ -955,7 +955,7 @@ pub fn consider_multi_index_union(
             continue;
         }
 
-        let mut allowed_mask = lhs_mask.clone();
+        let mut allowed_mask = lhs_mask.try_clone()?;
         let Some(rhs_idx) = table_references
             .joined_tables()
             .iter()

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2288,8 +2288,7 @@ impl JoinedTable {
                     ColDef::default(),
                 )
             })
-            .try_collect::<alloc::Vec<_>>()
-            .expect(crate::alloc::ALLOC_ERR_MSG);
+            .try_collect::<alloc::Vec<_>>()?;
 
         for (i, column) in columns.iter_mut().enumerate() {
             if super::expr::expr_is_array(
@@ -2402,8 +2401,7 @@ impl JoinedTable {
                     ColDef::default(),
                 )
             })
-            .try_collect::<alloc::Vec<_>>()
-            .expect(crate::alloc::ALLOC_ERR_MSG);
+            .try_collect::<alloc::Vec<_>>()?;
 
         for (i, column) in columns.iter_mut().enumerate() {
             if super::expr::expr_is_array(&result_columns[i].expr, Some(table_references)) {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1660,6 +1660,17 @@ impl IntoIterator for ColumnMask {
     }
 }
 
+impl alloc::TryClone for ColumnMask {
+    type Error = alloc::TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            bitset: self.bitset.try_clone()?,
+            has_rowid_sentinel: self.has_rowid_sentinel,
+        })
+    }
+}
+
 /// Dense bitset optimized for the common case where all elements ≤64, with heap-allocated overflow.
 ///
 /// *WARNING*: This bitset occupies `O(max_num)` space when `max_num > 64`,
@@ -1679,6 +1690,18 @@ impl<T> Default for BitSet<T> {
             overflow: None,
             _phantom: PhantomData,
         }
+    }
+}
+
+impl<T> alloc::TryClone for BitSet<T> {
+    type Error = alloc::TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            inline: self.inline,
+            overflow: self.overflow.try_clone()?,
+            _phantom: PhantomData,
+        })
     }
 }
 
@@ -1988,8 +2011,6 @@ impl<T> TryFrom<u128> for BitSet<T> {
     type Error = alloc::TryReserveError;
 
     fn try_from(from: u128) -> Result<Self, Self::Error> {
-        use crate::alloc::*;
-
         let high = (from >> 64) as u64;
         let overflow = match high != 0 {
             true => Some(alloc::try_vec![high]?),

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -2115,7 +2115,7 @@ pub fn translate_drop_table(
         // cursor id 1
         let sqlite_schema_cursor_id_1 =
             program.alloc_cursor_id(CursorType::BTreeTable(schema_table.clone()));
-        let columns = crate::alloc::vec![Column::new(
+        let columns = crate::alloc::try_vec![Column::new(
             Some("rowid".to_string()),
             "INTEGER".to_string(),
             None,
@@ -2123,7 +2123,7 @@ pub fn translate_drop_table(
             Type::Integer,
             None,
             ColDef::default(),
-        )];
+        )]?;
         let simple_table_rc = Arc::new(BTreeTable::new(
             0, // root_page, not relevant for ephemeral table definition
             "ephemeral_scratch".to_string(),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::alloc::TursoSliceExt;
+use crate::alloc::{TryClone, TursoSliceExt};
 
 use rustc_hash::FxHashMap as HashMap;
 use turso_parser::ast::{self, SortOrder, SubqueryType};
@@ -551,7 +551,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                     table: t.table.clone(),
                     identifier: t.identifier.clone(),
                     internal_id: t.internal_id,
-                    using_dedup_hidden_cols: t.using_dedup_hidden_cols.clone(),
+                    using_dedup_hidden_cols: t.using_dedup_hidden_cols.try_clone()?,
                     col_used_mask: ColumnUsedMask::default(),
                     cte_select: t.cte_select.clone(),
                     cte_explicit_columns: t.cte_explicit_columns.clone(),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1689,7 +1689,7 @@ fn emit_materialized_subquery_table(
         0,
         String::new(),
         crate::alloc::vec![],
-        columns.try_to_vec().expect(crate::alloc::ALLOC_ERR_MSG),
+        columns.try_to_vec()?,
         BTreeCharacteristics::HAS_ROWID,
         crate::alloc::vec![],
         crate::alloc::vec![],

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -490,7 +490,7 @@ pub fn emit_upsert(
         target_pc: ctx.loop_labels.row_done,
     });
     let num_cols = ctx.table.columns().len();
-    let layout = ctx.table.column_layout();
+    let layout = ctx.table.column_layout()?;
 
     let table_ref_id = table_references
         .joined_tables()


### PR DESCRIPTION
## Description

- propagate `crate::alloc::Vec` allocation failures through the translate path instead of relying on infallible growth/copy operations
- add `TryClone` coverage for allocator-backed `Vec`, `Option`, `Result`, `BitSet`, and `ColumnMask` copy paths used by translate
- add microbenchmarks comparing std `Vec::clone`, Turso `Vec::clone`, and Turso `Vec::try_clone` on stable/nightly paths
- clean up remaining production non-empty `crate::alloc::vec!` constructors in translate to use `try_vec!`
- error handling on the translate path is easier as there is no "global" mutable state that we care. You either produce a valid program or you do not. 
