### PR TITLE
core/vdbe: fix stale doc comment on ArrayDecode output format

### DIFF
--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -650,8 +650,8 @@ pub enum Insn {
         col_name: Arc<str>,
     },
 
-    /// Convert a native record-format BLOB back to JSON text for display.
-    /// Input: reg = record-format BLOB. Output: reg = JSON text '[1,2,3]'.
+    /// Convert a native record-format BLOB back to PostgreSQL-style array text for display.
+    /// Input: reg = record-format BLOB. Output: reg = PG array text like '{1,2,3}'.
     ArrayDecode {
         reg: usize,
     },


### PR DESCRIPTION
## What
The doc comment on `Insn::ArrayDecode` claimed it converts a record-format BLOB back to JSON text (`'[1,2,3]'`), but the actual implementation in `array.rs` serializes to PostgreSQL-style array text (curly braces, PG quoting rules for NULL/strings), which is also what the CLI actually displays for array columns.

## Why

Found this while digging into #5898 (VACUUM INTO + rich types). I was trying to reproduce the reported bug and wrote test SQL using JSON array literal syntax based on this comment, which doesn't work, since arrays are actually built with `ARRAY[...]` syntax and displayed in PG format. Fixing the comment so it matches the real behavior.

No behavior change, comment-only fix.

## Description of AI Usage

I used Claude Code in a guided/by-hand mode while investigating #5898. It helped me: reproduce the reported bug (which led to discovering this separate, smaller comment inaccuracy along the way), explained Rust and VDBE concepts I didn't know yet (enums as tagged unions, macros vs functions, lifetimes, blob/hex formatting), and used grep to point me to the relevant files. All the reading, decision-making, and the actual 2-line comment edit were done by me by hand after those explanations. Claude drafted the initial PR description text based on our investigation, which I reviewed and am submitting as my own.