### PR TITLE
core/btree: invalidate shape caches on peer writes; drop trigger workaround

### DIFF
--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -1887,7 +1887,7 @@ mod tests {
                 Ok(IOResult::Done(()))
             }
 
-            fn seek_to_last(&mut self, _always_seek: bool) -> Result<IOResult<()>> {
+            fn seek_to_last(&mut self) -> Result<IOResult<()>> {
                 Ok(IOResult::Done(()))
             }
 

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -2157,7 +2157,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn seek_to_last(&mut self, _always_seek: bool) -> Result<IOResult<()>> {
+    fn seek_to_last(&mut self) -> Result<IOResult<()>> {
         match self.seek(SeekKey::TableRowId(i64::MAX), SeekOp::LE { eq_only: false })? {
             IOResult::Done(_) => Ok(IOResult::Done(())),
             IOResult::IO(iocompletions) => Ok(IOResult::IO(iocompletions)),

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -679,7 +679,7 @@ pub trait CursorTrait: Any + Send + Sync {
     fn get_index_info(&self) -> &Arc<IndexInfo>;
 
     fn seek_end(&mut self) -> Result<IOResult<()>>;
-    fn seek_to_last(&mut self, always_seek: bool) -> Result<IOResult<()>>;
+    fn seek_to_last(&mut self) -> Result<IOResult<()>>;
 
     /// Returns true if this cursor operates in MVCC mode.
     fn is_mvcc(&self) -> bool {
@@ -1486,24 +1486,22 @@ impl BTreeCursor {
 
     /// Move the cursor to the rightmost record in the btree.
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    fn move_to_rightmost(&mut self, always_seek: bool) -> Result<IOResult<bool>> {
+    fn move_to_rightmost(&mut self) -> Result<IOResult<bool>> {
         loop {
             let (move_to_right_state, rightmost_page_id) = &self.move_to_right_state;
             match *move_to_right_state {
                 MoveToRightState::Start => {
-                    if !always_seek {
-                        if let Some(rightmost_page_id) = rightmost_page_id {
-                            // If we know the rightmost page and are already on it, we can skip a seek.
-                            // This optimization is never performed if always_seek = true. always_seek is used
-                            // in cases where we cannot be sure that the btree wasn't modified from under us
-                            // e.g. by a trigger subprogram.
-                            let current_page = self.stack.top_ref();
-                            if current_page.get().id == *rightmost_page_id {
-                                let contents = current_page.get_contents();
-                                let cell_count = contents.cell_count();
-                                self.stack.set_cell_index(cell_count as i32 - 1);
-                                return Ok(IOResult::Done(cell_count > 0));
-                            }
+                    if let Some(rightmost_page_id) = rightmost_page_id {
+                        // If we know the rightmost page and are already on it, we can skip a seek.
+                        // The cache is safe to trust: any modification of this btree — our own
+                        // balancing, or a peer cursor's write (e.g. a trigger subprogram's, via
+                        // the saveAllCursors pass) — invalidates it.
+                        let current_page = self.stack.top_ref();
+                        if current_page.get().id == *rightmost_page_id {
+                            let contents = current_page.get_contents();
+                            let cell_count = contents.cell_count();
+                            self.stack.set_cell_index(cell_count as i32 - 1);
+                            return Ok(IOResult::Done(cell_count > 0));
                         }
                     }
                     let rightmost_page_id = *rightmost_page_id;
@@ -5626,8 +5624,7 @@ impl CursorTrait for BTreeCursor {
             return Ok(IOResult::Done(()));
         }
         self.clear_saved_seek();
-        let always_seek = false;
-        let cursor_has_record = return_if_io!(self.move_to_rightmost(always_seek));
+        let cursor_has_record = return_if_io!(self.move_to_rightmost());
         self.set_has_record(cursor_has_record);
         self.invalidate_record();
         self.read_overflow_state = None;
@@ -6203,6 +6200,10 @@ impl CursorTrait for BTreeCursor {
         if matches!(self.state, CursorState::None) {
             self.pager.invalidate_peer_cursors(self);
             self.invalidate_count_cache();
+            // Every page in this btree is about to be freed, so our own cached
+            // rightmost page id is meaningless too (the id may even be
+            // reallocated to an unrelated page after a refill).
+            self.move_to_right_state.1 = None;
         }
         self.destroy_btree_contents(true)
     }
@@ -6470,6 +6471,13 @@ impl CursorTrait for BTreeCursor {
     /// across an in-flight Insert/Delete — in which case the caller falls back
     /// to invalidate_btree_cache.
     fn try_save_position_for_external_balance(&mut self) -> Result<IOResult<SavePositionResult>> {
+        // The peer is about to modify this btree's structure, so any cached
+        // knowledge of the tree shape goes stale: the rightmost page id
+        // (move_to_rightmost's skip-a-seek optimization) and the memoized
+        // count. Positional state is preserved separately via save_context.
+        // Idempotent, so safe across IO re-entry into this function.
+        self.move_to_right_state.1 = None;
+        self.invalidate_count_cache();
         if self.valid_state != CursorValidState::Valid || !self.has_record() {
             // Nothing to save: cursor has no live position. No invalidation
             // needed either — the stack is already in a state where the next
@@ -6589,11 +6597,11 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn seek_to_last(&mut self, always_seek: bool) -> Result<IOResult<()>> {
+    fn seek_to_last(&mut self) -> Result<IOResult<()>> {
         loop {
             match self.seek_to_last_state {
                 SeekToLastState::Start => {
-                    let has_record = return_if_io!(self.move_to_rightmost(always_seek));
+                    let has_record = return_if_io!(self.move_to_rightmost());
                     self.invalidate_record();
                     self.set_has_record(has_record);
                     self.read_overflow_state = None;
@@ -12296,6 +12304,64 @@ mod tests {
             ));
             (*cursor).register_with_pager();
             cursor
+        }
+
+        /// A peer's insert must invalidate this cursor's cached rightmost
+        /// page id (move_to_rightmost's skip-a-seek optimization). Once the
+        /// peer's appends split the rightmost leaf, a long-lived cursor's
+        /// last() would otherwise trust the stale cache and return the old
+        /// page's last cell instead of the true maximum.
+        #[test]
+        fn peer_write_invalidates_rightmost_page_cache() {
+            let (pager, root_page, _db, _conn) = empty_btree();
+            let mut writer = make_registered_cursor(&pager, root_page, 1);
+            let mut reader = make_registered_cursor(&pager, root_page, 1);
+
+            // Blob payloads so a handful of appends split the rightmost leaf.
+            for rowid in 1..=8 {
+                insert_record(&mut writer, &pager, rowid, Value::Blob(vec![0u8; 1000])).unwrap();
+            }
+
+            // Positions the reader on the last row and caches the rightmost page id.
+            run_until_done(|| reader.last(), pager.deref()).unwrap();
+            let max1 = run_until_done(|| reader.rowid(), pager.deref()).unwrap();
+            assert_eq!(max1, Some(8));
+
+            // Peer appends: balance_quick allocates a new rightmost leaf.
+            for rowid in 9..=16 {
+                insert_record(&mut writer, &pager, rowid, Value::Blob(vec![0u8; 1000])).unwrap();
+            }
+
+            run_until_done(|| reader.last(), pager.deref()).unwrap();
+            let max2 = run_until_done(|| reader.rowid(), pager.deref()).unwrap();
+            assert_eq!(
+                max2,
+                Some(16),
+                "last() must see the true maximum after a peer split the rightmost leaf"
+            );
+        }
+
+        /// A peer's insert must reset this cursor's memoized count():
+        /// count_state stays at CountState::Finish after a full count, so
+        /// without invalidation every later count() returns the stale value.
+        #[test]
+        fn peer_write_invalidates_count_cache() {
+            let (pager, root_page, _db, _conn) = empty_btree();
+            let mut writer = make_registered_cursor(&pager, root_page, 1);
+            let mut reader = make_registered_cursor(&pager, root_page, 1);
+
+            for rowid in 1..=5 {
+                insert_record(&mut writer, &pager, rowid, Value::from_i64(rowid)).unwrap();
+            }
+            let count1 = run_until_done(|| reader.count(), pager.deref()).unwrap();
+            assert_eq!(count1, 5);
+
+            insert_record(&mut writer, &pager, 6, Value::from_i64(6)).unwrap();
+            let count2 = run_until_done(|| reader.count(), pager.deref()).unwrap();
+            assert_eq!(
+                count2, 6,
+                "count() must not return the memoized pre-write value"
+            );
         }
 
         #[test]

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1982,11 +1982,6 @@ impl ProgramBuilder {
             && self.flags.is_multi_write()
             && self.may_abort();
 
-        let contains_trigger_subprograms = self
-            .insns
-            .iter()
-            .any(|(insn, _)| matches!(insn, Insn::Program { .. }));
-
         let prepared = PreparedProgram {
             max_registers: self.next_free_register,
             insns: self.insns,
@@ -2003,7 +1998,6 @@ impl ProgramBuilder {
             )),
             trigger: self.trigger.take(),
             is_subprogram: self.flags.is_subprogram(),
-            contains_trigger_subprograms,
             resolve_type: self.resolve_type,
             prepare_context,
             write_databases: self.write_databases,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10741,11 +10741,7 @@ fn new_rowid_inner(
                 {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut();
-                    // We have an optimization in the btree cursor to not seek if we know the rightmost page and are already on it.
-                    // However, this optimization should NOT never performed in cases where we cannot be sure that the btree wasn't modified from under us
-                    // e.g. by a trigger subprogram.
-                    let always_seek = program.contains_trigger_subprograms;
-                    return_if_io!(cursor.seek_to_last(always_seek));
+                    return_if_io!(cursor.seek_to_last());
                 }
                 if mvcc_already_initialized {
                     *state.active_op_state.new_rowid() = OpNewRowidState::GoNext;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1417,8 +1417,6 @@ pub struct PreparedProgram {
     pub trigger: Option<Arc<Trigger>>,
     /// Whether this program is a subprogram (trigger or FK action) that runs within a parent statement.
     pub is_subprogram: bool,
-    /// Whether the program contains any trigger subprograms.
-    pub contains_trigger_subprograms: bool,
     pub resolve_type: ResolveType,
     pub prepare_context: PrepareContext,
     /// Set of attached database indices that need write transactions.

--- a/testing/sqltests/tests/openread-cursor-reuse-stale-cache.sqltest
+++ b/testing/sqltests/tests/openread-cursor-reuse-stale-cache.sqltest
@@ -1,0 +1,145 @@
+@database :memory:
+
+# Regression tests for stale per-cursor btree caches on reused OpenRead cursors.
+#
+# op_open_read reuses the existing btree cursor when the slot already holds one
+# on the same root page. A correlated scalar subquery therefore runs Last on
+# the same cursor once per outer row. BTreeCursor caches the rightmost page id
+# (move_to_rightmost's skip-a-seek optimization) and a memoized count; when the
+# btree is modified through a *different* cursor (same-statement writer or a
+# trigger subprogram), those shape caches must be invalidated, otherwise Last
+# lands on a page that is no longer the rightmost leaf: wrong max values, NULL
+# from a non-empty table, or a rowid read from an interior page.
+
+setup grow_split_root {
+    CREATE TABLE u(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t(a INTEGER PRIMARY KEY, pad BLOB);
+    INSERT INTO u VALUES (1,0),(2,0),(3,0),(4,0),(5,0),(6,0),(7,0),(8,0);
+    INSERT INTO t VALUES (1, zeroblob(1000));
+    CREATE TRIGGER trg AFTER UPDATE ON u BEGIN
+      INSERT INTO t VALUES ((SELECT max(a)+1 FROM t), zeroblob(1000));
+    END;
+}
+
+@setup grow_split_root
+test openread-reuse-trigger-grow-splits-root {
+    -- t starts as a single leaf-root page; the per-row trigger inserts split it
+    -- into an interior root. A stale rightmost-page cache made Last position on
+    -- the interior page and read a "rowid" from it (debug assert panic).
+    UPDATE u SET b = (SELECT a+0*u.a FROM t ORDER BY a DESC LIMIT 1);
+    SELECT a, b FROM u;
+}
+expect {
+    1|1
+    2|2
+    3|3
+    4|4
+    5|5
+    6|6
+    7|7
+    8|8
+}
+
+setup grow_split_leaf {
+    CREATE TABLE u(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t(a INTEGER PRIMARY KEY, pad BLOB);
+    INSERT INTO u VALUES (1,0),(2,0),(3,0),(4,0),(5,0),(6,0),(7,0),(8,0);
+    INSERT INTO t SELECT value, zeroblob(1000) FROM generate_series(1,12);
+    CREATE TRIGGER trg AFTER UPDATE ON u BEGIN
+      INSERT INTO t VALUES ((SELECT max(a)+1 FROM t), zeroblob(1000));
+    END;
+}
+
+@setup grow_split_leaf
+test openread-reuse-trigger-grow-splits-leaf {
+    -- Multi-page t: the cached rightmost leaf splits but stays a leaf, so the
+    -- stale cache silently returned the old page's last row (b stuck at 12)
+    -- instead of the progressing max.
+    UPDATE u SET b = (SELECT a+0*u.a FROM t ORDER BY a DESC LIMIT 1);
+    SELECT a, b FROM u;
+}
+expect {
+    1|12
+    2|13
+    3|14
+    4|15
+    5|16
+    6|17
+    7|18
+    8|19
+}
+
+setup no_trigger_self_update {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b INT, pad BLOB);
+    INSERT INTO t SELECT value, 0, zeroblob(100) FROM generate_series(1,40);
+}
+
+@setup no_trigger_self_update
+test openread-reuse-same-statement-writer {
+    -- No triggers: the UPDATE's own write cursor grows rows and splits pages
+    -- while the correlated subquery's read cursor runs Last per row. max(a)
+    -- never changes, so every row must see 40; the stale cache returned
+    -- decreasing values (40, 18, 10, 8) as splits progressed.
+    UPDATE t SET b = (SELECT s.a+0*t.a FROM t AS s ORDER BY s.a DESC LIMIT 1), pad = zeroblob(1000);
+    SELECT DISTINCT b FROM t;
+}
+expect {
+    40
+}
+
+setup shrink_delete {
+    CREATE TABLE u(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t(a INTEGER PRIMARY KEY, pad BLOB);
+    INSERT INTO u SELECT value, 0 FROM generate_series(1,6);
+    INSERT INTO t SELECT value, zeroblob(1000) FROM generate_series(1,12);
+    CREATE TRIGGER trg AFTER UPDATE ON u BEGIN
+      DELETE FROM t WHERE a > (SELECT max(a)-3 FROM t);
+    END;
+}
+
+@setup shrink_delete
+test openread-reuse-trigger-delete-shrinks {
+    -- Deletes free the cached rightmost page; the stale cache made Last treat
+    -- the (now empty) page as the whole tree and return NULL from a non-empty
+    -- table.
+    UPDATE u SET b = (SELECT a+0*u.a FROM t ORDER BY a DESC LIMIT 1);
+    SELECT a, b FROM u;
+}
+expect {
+    1|12
+    2|9
+    3|6
+    4|3
+    5|
+    6|
+}
+
+setup index_desc_scan {
+    CREATE TABLE u(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t(a INTEGER PRIMARY KEY, c TEXT);
+    CREATE INDEX tidx ON t(c);
+    INSERT INTO u SELECT value, '' FROM generate_series(1,8);
+    INSERT INTO t SELECT value, printf('%08d', value) || hex(zeroblob(240)) FROM generate_series(1,6);
+    CREATE TRIGGER trg AFTER UPDATE ON u BEGIN
+      INSERT INTO t VALUES ((SELECT max(a)+1 FROM t), printf('%08d', (SELECT max(a)+1 FROM t)) || hex(zeroblob(240)));
+    END;
+}
+
+@setup index_desc_scan
+test openread-reuse-index-descending {
+    -- Same class on an index btree: ORDER BY c DESC LIMIT 1 runs Last on tidx
+    -- while the trigger's inserts split index leaves. The stale cache returned
+    -- the old leaf's largest key instead of the true maximum.
+    UPDATE u SET b = (SELECT substr(c,1,8) || (0*u.a) FROM t ORDER BY c DESC LIMIT 1);
+    SELECT a, b FROM u;
+}
+expect {
+    1|000000060
+    2|000000070
+    3|000000080
+    4|000000090
+    5|000000100
+    6|000000110
+    7|000000120
+    8|000000130
+}


### PR DESCRIPTION
Fixes #7719

## Problem

`BTreeCursor` caches the rightmost page id (`Last`'s skip-a-seek optimization) and the memoized count, but only invalidated them on its **own** balancing. When the btree was modified through another cursor — the statement's write cursor or a trigger subprogram's — the saveAllCursors pass saved the peer's position but left these caches stale. A later `Last` then trusted the stale cache and, depending on what happened to the old rightmost page, returned a stale row, NULL on a non-empty table, or panicked reading a rowid off a now-interior page (`pager.rs:434`).

This was masked before OpenRead cursor reuse (36e634f1c) because `op_open_read` rebuilt the cursor on every execution; the reuse made it user-visible through correlated `(SELECT ... ORDER BY x DESC LIMIT 1)` subqueries whose outer statement (or its triggers) writes to the same table.

## Fix

- Drop both shape caches at the top of `try_save_position_for_external_balance` — the saveAllCursors pass every peer insert/delete drives, mirroring how SQLite clears cached cursor state there. Positional state is still preserved via `save_context`.
- Drop the acting cursor's own rightmost cache in `clear_btree` (freed page ids can be reallocated after a refill).

Read-only cursor reuse never enters the peer-save pass, so #7716's perf win is unaffected.

## Workaround removal

`op_new_rowid` carried a coarse workaround for this exact staleness (12cec1cb7): force a full root-to-leaf descent whenever the program merely *contained* trigger subprograms. Peer writes now invalidate the cache at the source, so the workaround and its plumbing (`always_seek`, `contains_trigger_subprograms`) are removed — NewRowid in trigger-bearing statements gets the skip-a-seek optimization back.

## Testing

- All three SQL reproducers from #7719 (panic, silent wrong values, NULL from non-empty table) fail on main and now match SQLite byte-for-byte.
- Two new NewRowid-path reproducers (trigger delete-shrink and trigger insert-split during multi-row INSERT) match SQLite with the workaround removed — the original workaround commit shipped without a test.
- New unit tests for peer-write shape-cache invalidation; `testing/sqltests/tests/openread-cursor-reuse-stale-cache.sqltest` covers root-split, leaf-split, delete-shrink, index-descending, and same-statement-writer variants. All fail without the fix.
- `cargo test -p turso_core --lib`: 2030 passed. 324 trigger/cursor sqltests pass. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
