### PR TITLE
core/storage: Remove checkpoint leak intent

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4576,12 +4576,6 @@ impl WalFile {
         Ok(())
     }
 
-    #[aristo::intent(
-        "A checkpoint failure must not leak frames into the main database file\n",
-        id = "aristos:wal_checkpoint_error_no_db_leak",
-        verify = "full",
-        parent = "wal_protocol_correctness"
-    )]
     fn checkpoint_inner(
         &self,
         pager: &Pager,


### PR DESCRIPTION
If a checkpoint fails in the middle, it's fine, because we'll keep replaying from the WAL. The intent here is too strict and not even needed.