### PR TITLE
core: fsync WAL when raw frame insert session force-commits

### DIFF
--- a/core/benches/write_perf_benchmark.rs
+++ b/core/benches/write_perf_benchmark.rs
@@ -607,7 +607,7 @@ fn bench_delete_performance(criterion: &mut Criterion) {
 
 /// Benchmark: Large transaction commit (many dirty pages)
 ///
-/// Specifically targets the commit_dirty_pages path with many pages
+/// Specifically targets the commit_wal path with many pages
 #[turso_macros::codspeed_criterion_benchmark]
 fn bench_large_transaction_commit(criterion: &mut Criterion) {
     let enable_rusqlite =

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2036,12 +2036,12 @@ impl Connection {
                 pager
                     .io
                     .block(|| {
-                        return_if_io!(pager.commit_dirty_pages(
+                        return_if_io!(pager.commit_wal(
                             WalAutoActions::empty(),
                             self.get_sync_mode(),
                             self.get_data_sync_retry(),
                         ));
-                        pager.commit_dirty_pages_end();
+                        pager.commit_wal_end();
                         Ok(IOResult::Done(()))
                     })
                     .err()

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1001,9 +1001,15 @@ enum CommitState {
     PrepareFrames { db_size: u32 },
     /// All frames prepared, writes are in flight
     WaitWrites,
-    /// Writes are complete, wait for WAL sync to complete
+    /// Wait for the WAL fsync that makes the commit durable. Every commit
+    /// converges here once its writes (if any) have completed. The fsync is
+    /// submitted here, and skipped when the WAL is not dirty (no frames
+    /// appended since the last successful fsync) or sync_mode is not FULL.
+    /// Commits that prepared frames continue to WalCommitDone to publish
+    /// them; otherwise the commit finishes here, since frames written through
+    /// `write_frame_raw` published themselves when they were appended.
     WaitSync,
-    /// Wait for WAL sync to complete and finalize the WAL commit.
+    /// Finalize the WAL commit by publishing the prepared frames.
     /// After this state, the write transaction is durable.
     /// If autocheckpoint is enabled and the autocheckpoint threshold is reached, checkpoint will be attempted.
     WalCommitDone,
@@ -2965,7 +2971,7 @@ impl Pager {
             if update_transaction_state {
                 connection.set_tx_state(TransactionState::None);
             }
-            self.commit_dirty_pages_end();
+            self.commit_wal_end();
         };
 
         loop {
@@ -2996,7 +3002,7 @@ impl Pager {
                     return Ok(IOResult::Done(()));
                 }
                 _ => {
-                    return_if_io!(self.commit_dirty_pages(
+                    return_if_io!(self.commit_wal(
                         connection.wal_auto_actions(),
                         connection.get_sync_mode(),
                         connection.get_data_sync_retry(),
@@ -3388,7 +3394,7 @@ impl Pager {
     }
 
     /// Flush all dirty pages to disk (async/re-entrant).
-    /// Unlike commit_dirty_pages, this function does not commit, checkpoint nor sync the WAL/Database.
+    /// Unlike commit_wal, this function does not commit, checkpoint nor sync the WAL/Database.
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn cacheflush(&self) -> Result<IOResult<Vec<Completion>>> {
         let wal = self
@@ -3939,8 +3945,11 @@ impl Pager {
         Ok(IOResult::Done(()))
     }
 
-    /// Flush all dirty pages to disk.
-    /// In the base case, it will write the dirty pages to the WAL and then fsync the WAL.
+    /// Commit the write transaction to the WAL: write any dirty pages as WAL
+    /// frames, fsync the WAL if it is dirty, and publish the commit. The WAL
+    /// can be dirty without any dirty pages (frames inserted through
+    /// `write_frame_raw` bypass dirty-page tracking), so under
+    /// synchronous=FULL this fsyncs even when there is nothing to write.
     /// If the WAL size is over the checkpoint threshold, it will checkpoint the WAL to
     /// the database file and then fsync the database file.
     ///
@@ -3949,7 +3958,7 @@ impl Pager {
     /// gates the post-commit auto-checkpoint when `should_checkpoint()` is
     /// true.
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn commit_dirty_pages(
+    pub fn commit_wal(
         &self,
         allowed_auto_actions: WalAutoActions,
         sync_mode: SyncMode,
@@ -3967,30 +3976,29 @@ impl Pager {
             return Ok(IOResult::IO(c));
         }
 
-        let result =
-            self.commit_dirty_pages_inner(allowed_auto_actions, sync_mode, data_sync_retry);
+        let result = self.commit_wal_inner(allowed_auto_actions, sync_mode, data_sync_retry);
         if result.is_err() {
             self.commit_info.write().reset();
         }
         result
     }
 
-    pub fn commit_dirty_pages_end(&self) {
+    pub fn commit_wal_end(&self) {
         self.commit_info.write().reset();
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
     #[aristo::intent("A commit frame must reach stable storage via fsync before the transaction is reported as durable\n", id = "aristos:wal_commit_requires_fsync", verify = "full", parent = "wal_protocol_correctness")]
-    fn commit_dirty_pages_inner(
+    fn commit_wal_inner(
         &self,
         allowed_auto_actions: WalAutoActions,
         sync_mode: SyncMode,
         data_sync_retry: bool,
     ) -> Result<IOResult<()>> {
         let Some(wal) = self.wal.as_ref() else {
-            turso_soft_unreachable!("commit_dirty_pages() called without WAL");
+            turso_soft_unreachable!("commit_wal() called without WAL");
             return Err(LimboError::InternalError(
-                "commit_dirty_pages() called without WAL".into(),
+                "commit_wal() called without WAL".into(),
             ));
         };
 
@@ -4029,7 +4037,14 @@ impl Pager {
                     let dirty_pages = self.dirty_pages.read();
 
                     if dirty_pages.is_empty() {
-                        return Ok(IOResult::Done(()));
+                        // No dirty pages to flush, but that does not mean the
+                        // WAL is clean: frames written through
+                        // write_frame_raw() bypass dirty-page tracking, and
+                        // callers (e.g. the sync engine ending a raw-insert
+                        // session) treat this commit as their durability
+                        // barrier. WaitSync fsyncs if the WAL is dirty.
+                        commit_info.state = CommitState::WaitSync;
+                        continue;
                     }
                     commit_info.initialize(dirty_pages.len() as usize);
                     let mut cache = self.page_cache.write();
@@ -4193,16 +4208,9 @@ impl Pager {
                     }
                     commit_info.completions.clear();
                     commit_info.completion_group = None;
-                    // Writes done, submit fsync if needed.
-                    // NORMAL mode skips fsync on WAL commit (but still fsyncs on checkpoint and wal restart).
-                    if sync_mode == SyncMode::Full {
-                        let sync_c = wal.sync(self.get_sync_type())?;
-                        // Reuse the existing Vec instead of allocating a new one
-                        commit_info.completions.push(sync_c);
-                        commit_info.state = CommitState::WaitSync;
-                    } else {
-                        commit_info.state = CommitState::WalCommitDone;
-                    }
+                    // All writes complete; WaitSync submits the WAL fsync if
+                    // one is owed.
+                    commit_info.state = CommitState::WaitSync;
                 }
                 // To protect against partial writes, we MUST ensure that all write Completions
                 // finish before submitting the fsync. It is possible that a partial write will
@@ -4212,29 +4220,60 @@ impl Pager {
                 // to ensure durability in the case of partial writes is to ensure the pwritev
                 // completes before the fsync is submitted.
                 CommitState::WaitSync => {
-                    let sync_c = self.commit_info.read().completions[0].clone();
-                    // Wait for fsync to complete
-                    if !sync_c.finished() {
-                        io_yield_one!(sync_c);
-                    }
-                    // Check for fsync error as we might need to panic on data_sync_retry=off
-                    let mut commit_info = self.commit_info.write();
-                    if !sync_c.succeeded() {
-                        commit_info.completions.clear();
-                        commit_info.prepared_frames.clear();
-
-                        if !data_sync_retry {
-                            panic!(
-                                "fsync error (data_sync_retry=off): {:?}",
-                                sync_c.get_error()
-                            );
+                    // A pending completion means a previous entry into this
+                    // state already submitted the fsync; wait on it instead
+                    // of submitting a second one. At most one fsync is ever in
+                    // flight, so completions holds either the pending fsync or
+                    // nothing.
+                    assert!(
+                        self.commit_info.read().completions.len() <= 1,
+                        "WaitSync expects at most one in-flight fsync completion"
+                    );
+                    let pending = self.commit_info.read().completions.first().cloned();
+                    let sync_c = match pending {
+                        Some(c) => Some(c),
+                        // Skip the fsync when the WAL is not dirty (no frames
+                        // appended since the last successful fsync).
+                        // NORMAL mode skips fsync on WAL commit (but still
+                        // fsyncs on checkpoint and wal restart).
+                        None if sync_mode == SyncMode::Full && wal.is_dirty() => {
+                            let sync_c = wal.sync(self.get_sync_type())?;
+                            self.commit_info.write().completions.push(sync_c.clone());
+                            Some(sync_c)
                         }
-                        return Err(LimboError::CompletionError(CompletionError::IOError(
-                            std::io::ErrorKind::Other,
-                            "sync",
-                        )));
+                        None => None,
+                    };
+                    if let Some(sync_c) = sync_c {
+                        // Wait for fsync to complete
+                        if !sync_c.finished() {
+                            io_yield_one!(sync_c);
+                        }
+                        // Check for fsync error as we might need to panic on data_sync_retry=off
+                        let mut commit_info = self.commit_info.write();
+                        if !sync_c.succeeded() {
+                            commit_info.completions.clear();
+                            commit_info.prepared_frames.clear();
+
+                            if !data_sync_retry {
+                                panic!(
+                                    "fsync error (data_sync_retry=off): {:?}",
+                                    sync_c.get_error()
+                                );
+                            }
+                            return Err(LimboError::CompletionError(CompletionError::IOError(
+                                std::io::ErrorKind::Other,
+                                "sync",
+                            )));
+                        }
+                        commit_info.completions.clear();
                     }
-                    commit_info.completions.clear();
+                    let mut commit_info = self.commit_info.write();
+                    if commit_info.prepared_frames.is_empty() {
+                        // Nothing to publish: the frames this fsync covered
+                        // published themselves via finish_append_frames_commit()
+                        // when they were appended.
+                        return Ok(IOResult::Done(()));
+                    }
                     commit_info.state = CommitState::WalCommitDone;
                 }
                 CommitState::WalCommitDone => {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -721,6 +721,11 @@ pub trait Wal: Debug + Send + Sync {
     fn publish_backfill(&self, max_frame: u64);
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion>;
     fn is_syncing(&self) -> bool;
+    /// Whether the WAL file is dirty: frames were appended that no successful
+    /// WAL fsync has covered yet. A dirty WAL owes an fsync before a commit
+    /// may be reported durable, even when the committer itself has no dirty
+    /// pages to write (e.g. frames inserted through [Wal::write_frame_raw]).
+    fn is_dirty(&self) -> bool;
     fn get_max_frame_in_wal(&self) -> u64;
     fn get_checkpoint_seq(&self) -> u32;
     fn get_max_frame(&self) -> u64;
@@ -2631,6 +2636,14 @@ pub struct WalFile {
     /// meaning the coordination backend's max_frame is behind our connection-local
     /// max_frame. Cleared once `finish_append_frames_commit` publishes the state.
     has_unpublished_frames: AtomicBool,
+
+    /// The WAL file is dirty: frames were appended that no successful fsync
+    /// has covered yet. Set whenever a frame is recorded via
+    /// `complete_append_frame`, cleared when a WAL fsync completes
+    /// successfully. A dirty WAL owes an fsync before a commit may be
+    /// reported durable under synchronous=FULL.
+    /// Shared with the fsync completion callback, hence the Arc.
+    dirty: Arc<AtomicBool>,
 }
 
 impl fmt::Debug for WalFile {
@@ -3842,10 +3855,13 @@ impl Wal for WalFile {
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion> {
         tracing::debug!("wal_sync");
         let syncing = self.syncing.clone();
+        let dirty = self.dirty.clone();
         let completion = Completion::new_sync(move |result| {
             tracing::debug!("wal_sync finish");
             if let Err(err) = result {
                 tracing::debug!("wal_sync failed: {err}");
+            } else {
+                dirty.store(false, Ordering::Release);
             }
             syncing.store(false, Ordering::Release);
         });
@@ -3858,6 +3874,10 @@ impl Wal for WalFile {
     // Currently used for assertion purposes
     fn is_syncing(&self) -> bool {
         self.syncing.load(Ordering::Acquire)
+    }
+
+    fn is_dirty(&self) -> bool {
+        self.dirty.load(Ordering::Acquire)
     }
 
     fn get_max_frame_in_wal(&self) -> u64 {
@@ -4510,6 +4530,7 @@ impl WalFile {
             checkpoint_guard: RwLock::new(None),
             io_ctx: RwLock::new(IOContext::default()),
             has_unpublished_frames: AtomicBool::new(false),
+            dirty: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -4553,6 +4574,7 @@ impl WalFile {
     }
 
     fn complete_append_frame(&self, page_id: u64, frame_id: u64, checksums: (u32, u32)) {
+        self.dirty.store(true, Ordering::Release);
         *self.last_checksum.write() = checksums;
         self.max_frame.store(frame_id, Ordering::Release);
         self.coordination.cache_frame(page_id, frame_id);
@@ -5639,7 +5661,7 @@ impl WalFileShared {
             self.metadata.max_frame.store(0, Ordering::Release);
             self.metadata.nbackfills.store(0, Ordering::Release);
             self.metadata.last_checksum = (hdr.checksum_1, hdr.checksum_2);
-            // `prepare_wal_start` (used in the `commit_dirty_pages_inner`) do the work only if WAL is not initialized yet (so, self.initialized is false)
+            // `prepare_wal_start` (used in the `commit_wal_inner`) do the work only if WAL is not initialized yet (so, self.initialized is false)
             // we change WAL state here, so on next write attempt `prepare_wal_start` will update WAL header
             self.metadata.initialized.store(false, Ordering::Release);
         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2301,7 +2301,7 @@ impl Program {
                     // Commit dirty pages to WAL, then end write+read transactions.
                     // We disable auto-checkpoint and avoid pager.commit_tx() since
                     // the checkpoint logic can leave read locks held.
-                    match attached_pager.commit_dirty_pages(
+                    match attached_pager.commit_wal(
                         WalAutoActions::empty(),
                         SyncMode::Normal,
                         false,
@@ -2309,7 +2309,7 @@ impl Program {
                         Ok(IOResult::Done(_)) => {}
                         Ok(IOResult::IO(io)) => {
                             // IO pending — return so the caller can yield and re-enter.
-                            // commit_dirty_pages tracks its own internal state, so calling
+                            // commit_wal tracks its own internal state, so calling
                             // it again on re-entry will resume correctly.
                             return Ok(IOResult::IO(io));
                         }
@@ -2320,7 +2320,7 @@ impl Program {
                     connection.publish_database_schema(db_id);
                     attached_pager.end_write_tx();
                     attached_pager.end_read_tx();
-                    attached_pager.commit_dirty_pages_end();
+                    attached_pager.commit_wal_end();
                 } else {
                     // Discard any local schema changes on rollback
                     connection.database_schemas().write().remove(&db_id);

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -1093,7 +1093,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             assert!(!replay.conn().get_auto_commit());
         }
 
-        // Final: now we did all necessary operations as one big transaction and we are ready to commit
+        // Final: now we did all necessary operations as one big transaction and we are ready to commit.
+        // wal_insert_end(force_commit=true) fsyncs the WAL before returning, so the
+        // caller can durably record this revision as synced in the metadata.
         main_conn.end_nested();
         main_session.wal_session.end(true)?;
 


### PR DESCRIPTION
wal_insert_frame() pwrites frames directly into the WAL and commit frames publish max_frame immediately, but nothing on that path fsyncs. Durability was left to the commit machinery at session end, whose fsync sits behind the empty-dirty-set early return; raw inserts bypass dirty-page tracking, so a pure raw-frame session skipped the fsync entirely. The sync engine then durably records the revision as synced in its metadata, so a crash could permanently lose changes the metadata claims were applied. Sessions that also replayed local SQL were saved incidentally by the fsync their dirty pages triggered.

Fix it in the commit state machine: the WAL now tracks a dirty flag, set whenever a frame is appended (complete_append_frame is the common funnel for the normal append path and write_frame_raw) and cleared when a WAL fsync completes successfully. Every commit converges on WaitSync once its writes, if any, complete; WaitSync submits the fsync, skipping it when the WAL is not dirty or sync_mode is not FULL. Commits with prepared frames continue to WalCommitDone to publish them; raw-frame commits finish at WaitSync, since their frames published themselves at insert time. Invariant: a FULL commit always leaves the WAL fsynced, with exactly one fsync, no matter which path wrote the frames.

Rename commit_dirty_pages() to commit_wal(): it commits the transaction's WAL state whether or not any pages are dirty.

Found by Aristo.