### PR TITLE
github: skip dotnet code signing on non-main branches

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -191,13 +191,15 @@ jobs:
         run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official'
 
       # Code-sign the Windows native DLL with Azure Artifact Signing (formerly
-      # Trusted Signing). Runs only for the windows-msvc targets and only when
-      # the AZURE_SIGNING_ENABLED repo variable is set to "true" (so forks and
-      # PRs without access to the signing secrets are skipped). The action only
-      # works on Windows runners, which is why signing happens here in the
-      # native build job rather than in the Linux pack/publish job.
+      # Trusted Signing). Runs only for the windows-msvc targets, only when
+      # the AZURE_SIGNING_ENABLED repo variable is set to "true", and only on
+      # main pushes or manual dispatch: the Entra federated credential matches
+      # the exact ref (refs/heads/main), so OIDC login fails on any other
+      # branch, and dev-branch artifacts don't need signing anyway. The action
+      # only works on Windows runners, which is why signing happens here in
+      # the native build job rather than in the Linux pack/publish job.
       - name: Azure login (OIDC) for code signing
-        if: ${{ contains(matrix.target, 'pc-windows-msvc') && vars.AZURE_SIGNING_ENABLED == 'true' }}
+        if: ${{ contains(matrix.target, 'pc-windows-msvc') && vars.AZURE_SIGNING_ENABLED == 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -205,7 +207,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Code sign Windows native library
-        if: ${{ contains(matrix.target, 'pc-windows-msvc') && vars.AZURE_SIGNING_ENABLED == 'true' }}
+        if: ${{ contains(matrix.target, 'pc-windows-msvc') && vars.AZURE_SIGNING_ENABLED == 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') }}
         uses: azure/trusted-signing-action@v0
         with:
           endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -81,11 +81,18 @@ for full detail.
    certificate, and the billing account type (Individual vs Organization) must
    match the validation type.
 3. **Register an Entra app for CI** and add a **federated credential** for GitHub
-   OIDC. The subject must match both workflows' triggers:
-   - `dotnet-publish.yml` runs on **branch pushes** →
-     `repo:tursodatabase/turso:ref:refs/heads/*`
-   - `release.yml` runs on **tag pushes** →
-     `repo:tursodatabase/turso:ref:refs/tags/*`
+   OIDC. Classic federated credentials match the subject **exactly** — a
+   literal `*` in the subject never wildcard-matches, so a credential like
+   `refs/heads/*` silently fails with `AADSTS7002131`. The subjects must
+   match the refs the workflows sign on:
+   - `dotnet-publish.yml` signs only on **main pushes** (and manual dispatch
+     from main) → `repo:tursodatabase/turso:ref:refs/heads/main`
+   - `release.yml` runs on **tag pushes**, where the ref differs per release,
+     so an exact-match subject is impossible. Use a *flexible* federated
+     credential with a claims-matching expression (e.g.
+     `claims['sub'] matches 'repo:tursodatabase/turso:ref:refs/tags/*'`), or
+     scope the job to a GitHub Environment and match
+     `repo:tursodatabase/turso:environment:<name>` instead.
 
    Add a federated credential for each (or scope them to a GitHub Environment).
    See [Configuring OpenID Connect in Azure](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure).


### PR DESCRIPTION
dotnet-publish.yml triggers on pushes to all branches, and the signing steps were gated only on the AZURE_SIGNING_ENABLED repo variable, which is available to every same-repo branch push. The Entra federated credential matches the exact subject refs/heads/main, so every branch push since the variable was enabled on June 25 failed OIDC login with AADSTS7002131 on the Windows matrix legs.

Gate both signing steps on refs/heads/main or workflow_dispatch: dev-branch artifacts don't need signing, and main and manual publish runs keep signing as before. Also correct docs/code-signing.md, which prescribed a refs/heads/* federated credential subject; classic federated credentials are exact-match only, so a literal wildcard never matches. Document the flexible-FIC or environment-scoped alternatives release.yml needs for tag signing.