### PR TITLE
perf/prepare: add phase benchmark and drop redundant utf-8 revalidation

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -253,3 +253,7 @@ harness = false
 [[bench]]
 name = "prepare_params_benchmark"
 harness = false
+
+[[bench]]
+name = "prepare_benchmark"
+harness = false

--- a/core/benches/prepare_benchmark.rs
+++ b/core/benches/prepare_benchmark.rs
@@ -1,0 +1,102 @@
+//! Prepare-time cost of common statement shapes (issue #220).
+//!
+//! `Connection::prepare` has historically been ~3-4x slower than SQLite's
+//! `sqlite3_prepare_v2` and the gap was not tracked by CI, so it regressed
+//! silently. This benchmark times ONLY `prepare` (no execution) for a small
+//! fixed set of statement shapes against a two-table schema.
+//!
+//! A parse-only group measures the same statements through `turso_parser`
+//! alone, so the parse vs translate/emit split stays visible over time:
+//! as of 2026-07 parsing is ~12-20% of prepare and translation dominates.
+//!
+//! Run with:
+//!   cargo bench --bench prepare_benchmark
+
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
+
+use std::sync::Arc;
+use turso_core::{Database, MemoryIO, StepResult};
+use turso_parser::parser::Parser;
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+const STATEMENTS: &[(&str, &str)] = &[
+    ("select_1", "SELECT 1"),
+    ("select_by_pk", "SELECT * FROM users WHERE id = ?"),
+    (
+        "select_join_group_order",
+        "SELECT u.name, COUNT(o.id), SUM(o.amount) AS total FROM users u \
+         JOIN orders o ON o.user_id = u.id WHERE o.amount > 10.0 \
+         GROUP BY u.name ORDER BY total DESC",
+    ),
+    (
+        "insert_params",
+        "INSERT INTO users (id, name) VALUES (?, ?)",
+    ),
+];
+
+fn run_to_completion(stmt: &mut turso_core::Statement, db: &Arc<Database>) {
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::IO | StepResult::Yield => db.io.step().unwrap(),
+            StepResult::Done => break,
+            StepResult::Row => {}
+            StepResult::Interrupt | StepResult::Busy => panic!("unexpected step result"),
+        }
+    }
+}
+
+fn open_with_schema() -> (Arc<Database>, Arc<turso_core::Connection>) {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:").unwrap();
+    let conn = db.connect().unwrap();
+    for sql in [
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)",
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, \
+         amount REAL, created_at TEXT)",
+        "CREATE INDEX idx_orders_user_id ON orders (user_id)",
+    ] {
+        let mut stmt = conn.query(sql).unwrap().unwrap();
+        run_to_completion(&mut stmt, &db);
+    }
+    (db, conn)
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_prepare(c: &mut Criterion) {
+    let (_db, conn) = open_with_schema();
+
+    let mut group = c.benchmark_group("prepare_statement");
+    for (name, sql) in STATEMENTS {
+        group.bench_function(*name, |b| {
+            b.iter(|| {
+                let stmt = conn.prepare(black_box(sql)).unwrap();
+                black_box(stmt);
+            });
+        });
+    }
+    group.finish();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_parse_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_statement");
+    for (name, sql) in STATEMENTS {
+        group.bench_function(*name, |b| {
+            b.iter(|| {
+                let cmd = Parser::new(black_box(sql.as_bytes())).next_cmd();
+                black_box(cmd).unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(prepare_benches, bench_prepare, bench_parse_only);
+criterion_main!(prepare_benches);

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -982,9 +982,10 @@ impl Connection {
                 };
                 (cmd, parser.offset())
             };
-            let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
-                .unwrap()
-                .trim();
+            // The parser only stops on token boundaries, so slicing the
+            // already-valid &str directly avoids re-validating UTF-8 on
+            // every prepare.
+            let input = sql[..byte_offset_end].trim();
             let (program, pager, mode) = self.compile_cmd(cmd, input)?;
 
             Ok(Statement::new_with_origin(
@@ -1543,9 +1544,7 @@ impl Connection {
         let mut parser = Parser::new(sql.as_bytes());
         while let Some(cmd) = parser.next_cmd()? {
             let byte_offset_end = parser.offset();
-            let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
-                .unwrap()
-                .trim();
+            let input = sql[..byte_offset_end].trim();
             let (program, pager, mode) = self.compile_cmd(cmd, input)?;
             Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
         }
@@ -1562,9 +1561,7 @@ impl Connection {
         let mut parser = Parser::new(sql.as_bytes());
         let cmd = parser.next_cmd()?;
         let byte_offset_end = parser.offset();
-        let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
-            .unwrap()
-            .trim();
+        let input = sql[..byte_offset_end].trim();
         match cmd {
             Some(cmd) => self.run_cmd(cmd, input),
             None => Ok(None),
@@ -1601,9 +1598,7 @@ impl Connection {
         let mut parser = Parser::new(sql.as_bytes());
         while let Some(cmd) = parser.next_cmd()? {
             let byte_offset_end = parser.offset();
-            let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
-                .unwrap()
-                .trim();
+            let input = sql[..byte_offset_end].trim();
             let (program, pager, mode) = self.compile_cmd(cmd, input)?;
             {
                 crate::stack::trace_stack!("run");
@@ -1623,9 +1618,7 @@ impl Connection {
             return Ok(None);
         };
         let byte_offset_end = parser.offset();
-        let input = str::from_utf8(&sql.as_ref().as_bytes()[..byte_offset_end])
-            .unwrap()
-            .trim();
+        let input = sql.as_ref()[..byte_offset_end].trim();
         let (program, pager, mode) = self.compile_cmd(cmd, input)?;
         let stmt = Statement::new(program, pager, mode, 0);
         Ok(Some((stmt, parser.offset())))


### PR DESCRIPTION
Prepare is still ~3.6-4.4x slower than SQLite on current main (measured against rusqlite on an identical in-memory schema: `SELECT 1` 895ns vs 248ns, pk lookup 2.25us vs 566ns, 2-table JOIN+GROUP BY 8.6us vs 2.2us, INSERT 1.5us vs 347ns). The interesting part: the profiling in #220 predates the parser rewrite — on today's main parsing is only 12-20% of prepare and translate/emit is the rest, so the remaining work lives in the translator, not the parser.

Two commits:

- a prepare-only benchmark with a parse-only group, so the parse vs translate split stays visible over time (`bench_prepare_query` compares end-to-end against rusqlite but doesn't isolate the phases)
- drop the `str::from_utf8` re-validation of already-valid `&str` statement text on every prepare/query/execute/batch (5 sites); also makes validation in the batch loops linear instead of quadratic. ~1-2% on longer statements.

Refs #220