### PR TITLE
core/storage: remove leftover whopper debug probes from wal

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -905,20 +905,6 @@ impl WalCoordination for InProcessWalCoordination {
                 .rfind(|&&frame| range.contains(&frame))
                 .copied()
         });
-        if page_id == 12075 || result == Some(5161) {
-            let frames = frame_cache.get(&page_id).cloned().unwrap_or_default();
-            let checkpoint_seq = shared.metadata.wal_header.lock().checkpoint_seq;
-            let shared_snapshot = WalSnapshot {
-                max_frame: shared.metadata.max_frame.load(Ordering::Acquire),
-                nbackfills: shared.metadata.nbackfills.load(Ordering::Acquire),
-                last_checksum: shared.metadata.last_checksum,
-                checkpoint_seq,
-                transaction_count: shared.metadata.transaction_count.load(Ordering::Acquire),
-            };
-            eprintln!(
-                "[WHOPPER_FIND_FRAME_PROBE] page_id={page_id} result={result:?} min_frame={min_frame} max_frame={max_frame} frame_watermark={frame_watermark:?} shared_snapshot={shared_snapshot:?} frames={frames:?}"
-            );
-        }
         result
     }
 
@@ -4352,14 +4338,6 @@ impl Wal for WalFile {
                 frame_db_size,
                 &data_to_write,
             );
-            if page_id == 12075 || page_id == 11505 || next_frame_id == 5161 {
-                let frame = frame_bytes.as_slice();
-                let page_prefix = &frame[WAL_FRAME_HEADER_SIZE
-                    ..WAL_FRAME_HEADER_SIZE + 8.min(shared_page_size as usize)];
-                eprintln!(
-                    "[WHOPPER_WAL_APPEND_PROBE] build frame_id={next_frame_id} page_id={page_id} page_prefix={page_prefix:02x?}"
-                );
-            }
             iovecs.push(frame_bytes);
 
             // (page, assigned_frame_id, cumulative_checksum_at_this_frame)
@@ -4406,14 +4384,6 @@ impl Wal for WalFile {
 
         for (page, fid, csum) in &page_frame_and_checksum {
             self.complete_append_frame(page.get().id as u64, *fid, *csum);
-            if page.get().id == 12075 || page.get().id == 11505 || *fid == 5161 {
-                eprintln!(
-                    "[WHOPPER_WAL_APPEND_PROBE] index frame_id={fid} current_page_id={} wal_tag={:?} has_unpublished_frames={}",
-                    page.get().id,
-                    page.wal_tag_pair(),
-                    self.has_unpublished_frames.load(Ordering::Acquire)
-                );
-            }
         }
 
         Ok(c)


### PR DESCRIPTION
Three eprintln probes gated on hardcoded page ids (12075/11505) and frame id 5161 survived a whopper debugging session, one of them in the `find_frame` read hot path — any database that happens to touch those page numbers spams stderr. The anomaly-gated probe in `prepare_frames` is left alone since it fires on a real inconsistency rather than magic constants.