### PR TITLE
Drop the beta warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@
 
 ## About
 
-Turso Database is an in-process SQL database written in Rust, compatible with SQLite.
-
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database is an in-process SQL database written in Rust, compatible with SQLite. It runs in production today at multiple organizations — see the [FAQ](#faq) for where the project stands on its way to 1.0.
 
 ## Features and Roadmap
 
@@ -426,13 +424,19 @@ We'd love to have you contribute to Turso Database! Please check out the [contri
 
 ### Is Turso Database ready for production use?
 
-Turso powers production apps today. That includes [Turso Cloud](https://turso.tech/signup), the [Kin AI assistant](https://mykin.ai/), and [Spice.ai](https://github.com/spiceai/spiceai). However, it is still under active development and for mission-critical applications, caution is advised. Independent backups are encouraged. Turso is extensively tested by a collection of tools including a native Deterministic Simulation Testing suite and [Antithesis](https://antithesis.com), so we are generally confident in the end result. But our bar is SQLite-level reliability, and we will still recommend caution until we are confident it meets that bar.
+Yes — Turso powers production applications today at multiple organizations, including [Turso Cloud](https://turso.tech/signup), the [Kin AI assistant](https://mykin.ai/), and [Spice.ai](https://github.com/spiceai/spiceai). Reliability is our top priority: Turso is extensively tested by a collection of tools including a native Deterministic Simulation Testing suite and [Antithesis](https://antithesis.com).
+
+That said, we have not yet reached 1.0. The project is under active development, and some features are explicitly marked experimental. Our bar is SQLite-level reliability — one of the most rigorously tested pieces of software in the world — and until we declare 1.0, we recommend the same discipline you would apply to any database: keep independent backups.
+
+### How compatible is Turso Database with SQLite?
+
+Turso is compatible with SQLite at the SQL dialect, file format, and C API levels, and existing SQLite database files work as-is. We are not at 100% yet, so some differences are still expected — [COMPAT.md](COMPAT.md) tracks the details — but the gap is closing quickly, and full compatibility is a requirement for 1.0.
 
 ### How is Turso Database different from Turso's libSQL?
 
 Turso Database is a project to build the next evolution of SQLite in Rust, with a strong open contribution focus and features like native async support, vector search, and more. The libSQL project is also an attempt to evolve SQLite in a similar direction, but through a fork rather than a rewrite.
 
-Rewriting SQLite in Rust started as an unassuming experiment, and due to its incredible success, replaces libSQL as our intended direction. At this point, libSQL is production ready, Turso Database is not - although it is evolving rapidly. More details [here](https://turso.tech/blog/we-will-rewrite-sqlite-and-we-are-going-all-in).
+Rewriting SQLite in Rust started as an unassuming experiment, and due to its incredible success, replaces libSQL as our intended direction. Both run in production today: libSQL has been battle-tested for longer, while Turso Database is where our development effort is focused and is evolving rapidly. More details [here](https://turso.tech/blog/we-will-rewrite-sqlite-and-we-are-going-all-in).
 
 ## Publications
 

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -14,7 +14,7 @@
 
 ## About
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 
 ## Features
 

--- a/bindings/javascript/README.md
+++ b/bindings/javascript/README.md
@@ -16,7 +16,7 @@
 
 This package is the Turso in-memory database library for JavaScript.
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 
 ## Features
 

--- a/bindings/javascript/packages/common/README.md
+++ b/bindings/javascript/packages/common/README.md
@@ -4,5 +4,5 @@ This package is the Turso embedded database common JS library which is shared be
 
 Do not use this package directly - instead you must use `@tursodatabase/database` or `@tursodatabase/database-wasm`.
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 

--- a/bindings/javascript/packages/native/README.md
+++ b/bindings/javascript/packages/native/README.md
@@ -16,7 +16,7 @@
 
 This package is the Turso embedded database library for JavaScript in Node.
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 
 ## Features
 

--- a/bindings/javascript/packages/wasm-common/README.md
+++ b/bindings/javascript/packages/wasm-common/README.md
@@ -4,5 +4,5 @@ This package is the Turso embedded database common JS library which is shared be
 
 Do not use this package directly - instead you must use `@tursodatabase/database` or `@tursodatabase/database-wasm`.
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 

--- a/bindings/javascript/packages/wasm/README.md
+++ b/bindings/javascript/packages/wasm/README.md
@@ -16,7 +16,7 @@
 
 This package is the Turso embedded database library for JavaScript in Browser.
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 
 ## Features
 

--- a/bindings/javascript/sync/README.md
+++ b/bindings/javascript/sync/README.md
@@ -16,7 +16,7 @@
 
 This package is for syncing local Turso databases to the Turso Cloud and back.
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 
 ## Installation
 

--- a/bindings/javascript/sync/packages/common/README.md
+++ b/bindings/javascript/sync/packages/common/README.md
@@ -4,5 +4,5 @@ This package is the Turso Sync common JS library which is shared between final b
 
 Do not use this package directly - instead you must use `@tursodatabase/sync` or `@tursodatabase/sync-wasm`.
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 

--- a/bindings/javascript/sync/packages/native/README.md
+++ b/bindings/javascript/sync/packages/native/README.md
@@ -16,7 +16,7 @@
 
 This package is the Turso embedded database library for JavaScript in Node.
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 
 ## Features
 

--- a/bindings/javascript/sync/packages/wasm/README.md
+++ b/bindings/javascript/sync/packages/wasm/README.md
@@ -16,7 +16,7 @@
 
 This package is the Turso embedded database library for JavaScript in Browser.
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 
 ## Features
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -14,7 +14,7 @@
 
 ## About
 
-> **⚠️ Warning:** This software is in BETA. It may still contain bugs and unexpected behavior. Use caution with production data and ensure you have backups.
+Turso Database runs in production today at multiple organizations. It has not yet reached 1.0, so as with any database we recommend keeping backups — see the [FAQ](https://github.com/tursodatabase/turso#faq) for where the project stands.
 
 ## Features
 

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -343,9 +343,6 @@ impl Limbo {
                 self.writeln(&hint).map_err(|e| io_error(e, "write"))?;
             }
 
-            self.writeln(
-                "This software is in BETA, use caution with production data and ensure you have backups."
-            ).map_err(|e| io_error(e, "write"))?;
             self.display_in_memory().map_err(|e| io_error(e, "write"))?;
         }
         Ok(())


### PR DESCRIPTION
0.7 ships next week, and Turso now runs in production at multiple organizations — the top-of-page "this software is in BETA, use caution with production data" warning no longer reflects reality, and it's the first thing every visitor reads.

## What changed

- **About**: the ⚠️ BETA warning blockquote is gone. In its place, a one-line status note: Turso runs in production today, with a pointer to the FAQ for where the project stands on the way to 1.0.
- **FAQ "Is Turso Database ready for production use?"**: now opens with "Yes" and the production users, followed by the testing story (DST, Antithesis). The honest caveats stay, but softened: not yet 1.0, some features explicitly experimental, and backups recommended as "the same discipline you would apply to any database" rather than as a data-loss threat.
- **New FAQ "How compatible is Turso Database with SQLite?"**: we're not at 100% yet, COMPAT.md tracks the details, the gap is closing quickly, and full compatibility is a requirement for 1.0.
- **libSQL FAQ**: still flatly said "libSQL is production ready, Turso Database is not", contradicting the rest of the page. Now: both run in production; libSQL is more battle-tested, Turso Database is where development effort is focused.

The goal is to neither scare nor oversell: no data-loss warning up top, but the README still says clearly that we are pre-1.0 and that some SQLite differences remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)