### PR TITLE
allow picking emails to notify in Antithesis Experiment workflow

### DIFF
--- a/.github/workflows/antithesis-schedule.yml
+++ b/.github/workflows/antithesis-schedule.yml
@@ -11,4 +11,5 @@ jobs:
     with:
       duration: ${{ github.event.schedule == '0 0 * * 6' && 1440 || 240 }}
       test_name: ${{ github.event.schedule == '0 0 * * 6' && 'weekend run' || 'scheduled run' }}
+      notify_everyone: true
     secrets: inherit

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -24,6 +24,11 @@ on:
         required: false
         default: false
         type: boolean
+      notify_email:
+        description: "Email to notify (ignored if 'notify everyone' is checked)"
+        required: false
+        default: ""
+        type: string
   workflow_call:
     inputs:
       test_name:
@@ -40,6 +45,10 @@ on:
         required: false
         default: false
         type: boolean
+      notify_email:
+        required: false
+        default: ""
+        type: string
 
 env:
   ANTITHESIS_DOCKER_HOST: us-central1-docker.pkg.dev
@@ -91,7 +100,7 @@ jobs:
           Turso - ${{ github.event_name }}
           on ${{ github.ref_name }} (${{ github.sha }})
           by ${{ github.actor }}${{ inputs.test_name && format(' ({0})', inputs.test_name) || '' }}${{ inputs.diff_base && format(' diff vs {0}', inputs.diff_base) || '' }}
-        email_recipients: ${{ inputs.notify_everyone && secrets.ANTITHESIS_EMAIL || '' }}
+        email_recipients: ${{ inputs.notify_everyone && secrets.ANTITHESIS_EMAIL || inputs.notify_email }}
         test_name: ${{ inputs.test_name }}
         additional_parameters: |-
           antithesis.duration=${{ inputs.duration }}

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -25,7 +25,7 @@ on:
         default: false
         type: boolean
       notify_email:
-        description: "Email to notify (ignored if 'notify everyone' is checked)"
+        description: "Email to notify of test results (combined with 'notify everyone' if both are set)"
         required: false
         default: ""
         type: string
@@ -100,7 +100,9 @@ jobs:
           Turso - ${{ github.event_name }}
           on ${{ github.ref_name }} (${{ github.sha }})
           by ${{ github.actor }}${{ inputs.test_name && format(' ({0})', inputs.test_name) || '' }}${{ inputs.diff_base && format(' diff vs {0}', inputs.diff_base) || '' }}
-        email_recipients: ${{ inputs.notify_everyone && secrets.ANTITHESIS_EMAIL || inputs.notify_email }}
+        # Report recipients: the shared list when "notify everyone" is set, plus
+        # any custom address, joined with ';' (the action's delimiter) when both.
+        email_recipients: ${{ inputs.notify_everyone && secrets.ANTITHESIS_EMAIL || '' }}${{ (inputs.notify_everyone && secrets.ANTITHESIS_EMAIL != '' && inputs.notify_email != '') && ';' || '' }}${{ inputs.notify_email }}
         test_name: ${{ inputs.test_name }}
         additional_parameters: |-
           antithesis.duration=${{ inputs.duration }}

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -19,16 +19,16 @@ on:
         required: false
         default: ""
         type: string
+      notify_email:
+        description: "Custom email to notify of test results"
+        required: false
+        default: ""
+        type: string
       notify_everyone:
         description: "Notify everyone of test results"
         required: false
         default: false
         type: boolean
-      notify_email:
-        description: "Email to notify of test results (combined with 'notify everyone' if both are set)"
-        required: false
-        default: ""
-        type: string
   workflow_call:
     inputs:
       test_name:
@@ -41,14 +41,14 @@ on:
         required: false
         default: ""
         type: string
-      notify_everyone:
-        required: false
-        default: false
-        type: boolean
       notify_email:
         required: false
         default: ""
         type: string
+      notify_everyone:
+        required: false
+        default: false
+        type: boolean
 
 env:
   ANTITHESIS_DOCKER_HOST: us-central1-docker.pkg.dev

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: ""
         type: string
+      notify_everyone:
+        description: "Notify everyone of test results"
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       test_name:
@@ -31,6 +36,10 @@ on:
         required: false
         default: ""
         type: string
+      notify_everyone:
+        required: false
+        default: false
+        type: boolean
 
 env:
   ANTITHESIS_DOCKER_HOST: us-central1-docker.pkg.dev
@@ -82,7 +91,7 @@ jobs:
           Turso - ${{ github.event_name }}
           on ${{ github.ref_name }} (${{ github.sha }})
           by ${{ github.actor }}${{ inputs.test_name && format(' ({0})', inputs.test_name) || '' }}${{ inputs.diff_base && format(' diff vs {0}', inputs.diff_base) || '' }}
-        email_recipients: ${{ secrets.ANTITHESIS_EMAIL }}
+        email_recipients: ${{ inputs.notify_everyone && secrets.ANTITHESIS_EMAIL || '' }}
         test_name: ${{ inputs.test_name }}
         additional_parameters: |-
           antithesis.duration=${{ inputs.duration }}

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -100,8 +100,6 @@ jobs:
           Turso - ${{ github.event_name }}
           on ${{ github.ref_name }} (${{ github.sha }})
           by ${{ github.actor }}${{ inputs.test_name && format(' ({0})', inputs.test_name) || '' }}${{ inputs.diff_base && format(' diff vs {0}', inputs.diff_base) || '' }}
-        # Report recipients: the shared list when "notify everyone" is set, plus
-        # any custom address, joined with ';' (the action's delimiter) when both.
         email_recipients: ${{ inputs.notify_everyone && secrets.ANTITHESIS_EMAIL || '' }}${{ (inputs.notify_everyone && secrets.ANTITHESIS_EMAIL != '' && inputs.notify_email != '') && ';' || '' }}${{ inputs.notify_email }}
         test_name: ${{ inputs.test_name }}
         additional_parameters: |-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -459,11 +459,6 @@ And launch an Antithesis test run with:
 scripts/antithesis/launch.sh
 ```
 
-By default the launch script does not email anyone the results. Set
-`NOTIFY_EVERYONE=true` to notify everyone on `$ANTITHESIS_EMAIL`, set
-`NOTIFY_EMAIL=you@turso.tech` to notify a single custom address, or set both to
-notify everyone plus that address.
-
 ## Annotating intent with Aristo
 
 Turso uses [Aristo](https://github.com/aretta-ai/aristo) to capture design intent that the code alone doesn't spell out — invariants a refactor could silently break — as `#[aristo::intent("...")]` annotations attached to the code. They're optional; reach for one only when a property is invisible from the signature and not already guarded by a test. For example, on the WAL trait in `core/storage/wal.rs`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -459,6 +459,9 @@ And launch an Antithesis test run with:
 scripts/antithesis/launch.sh
 ```
 
+By default the launch script does not email anyone the results. To notify
+everyone on `$ANTITHESIS_EMAIL`, run it with `NOTIFY_EVERYONE=true`.
+
 ## Annotating intent with Aristo
 
 Turso uses [Aristo](https://github.com/aretta-ai/aristo) to capture design intent that the code alone doesn't spell out — invariants a refactor could silently break — as `#[aristo::intent("...")]` annotations attached to the code. They're optional; reach for one only when a property is invisible from the signature and not already guarded by a test. For example, on the WAL trait in `core/storage/wal.rs`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -460,7 +460,9 @@ scripts/antithesis/launch.sh
 ```
 
 By default the launch script does not email anyone the results. To notify
-everyone on `$ANTITHESIS_EMAIL`, run it with `NOTIFY_EVERYONE=true`.
+everyone on `$ANTITHESIS_EMAIL`, run it with `NOTIFY_EVERYONE=true`; to notify a
+single custom address instead, run it with `NOTIFY_EMAIL=you@turso.tech`
+(`NOTIFY_EVERYONE` takes precedence when both are set).
 
 ## Annotating intent with Aristo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -459,10 +459,10 @@ And launch an Antithesis test run with:
 scripts/antithesis/launch.sh
 ```
 
-By default the launch script does not email anyone the results. To notify
-everyone on `$ANTITHESIS_EMAIL`, run it with `NOTIFY_EVERYONE=true`; to notify a
-single custom address instead, run it with `NOTIFY_EMAIL=you@turso.tech`
-(`NOTIFY_EVERYONE` takes precedence when both are set).
+By default the launch script does not email anyone the results. Set
+`NOTIFY_EVERYONE=true` to notify everyone on `$ANTITHESIS_EMAIL`, set
+`NOTIFY_EMAIL=you@turso.tech` to notify a single custom address, or set both to
+notify everyone plus that address.
 
 ## Annotating intent with Aristo
 

--- a/scripts/antithesis/launch.sh
+++ b/scripts/antithesis/launch.sh
@@ -9,10 +9,6 @@ else
   TEST_TYPE="scheduled test"
 fi
 
-# Decide who receives the test report. NOTIFY_EVERYONE adds the shared recipient
-# list and NOTIFY_EMAIL adds a single custom address; when both are set the two
-# are combined into the semicolon-delimited list the API expects. When neither is
-# set the report is not emailed, so ad-hoc runs stay quiet by default.
 RECIPIENTS=""
 if [ "$NOTIFY_EVERYONE" = "true" ] && [ -n "$ANTITHESIS_EMAIL" ]; then
   RECIPIENTS="$ANTITHESIS_EMAIL"

--- a/scripts/antithesis/launch.sh
+++ b/scripts/antithesis/launch.sh
@@ -9,13 +9,16 @@ else
   TEST_TYPE="scheduled test"
 fi
 
-# Decide who receives the test report. NOTIFY_EVERYONE uses the shared recipient
-# list; otherwise fall back to a single custom NOTIFY_EMAIL. When neither is set
-# the report is not emailed, so ad-hoc runs stay quiet by default.
-if [ "$NOTIFY_EVERYONE" = "true" ]; then
+# Decide who receives the test report. NOTIFY_EVERYONE adds the shared recipient
+# list and NOTIFY_EMAIL adds a single custom address; when both are set the two
+# are combined into the semicolon-delimited list the API expects. When neither is
+# set the report is not emailed, so ad-hoc runs stay quiet by default.
+RECIPIENTS=""
+if [ "$NOTIFY_EVERYONE" = "true" ] && [ -n "$ANTITHESIS_EMAIL" ]; then
   RECIPIENTS="$ANTITHESIS_EMAIL"
-else
-  RECIPIENTS="$NOTIFY_EMAIL"
+fi
+if [ -n "$NOTIFY_EMAIL" ]; then
+  RECIPIENTS="${RECIPIENTS:+$RECIPIENTS;}$NOTIFY_EMAIL"
 fi
 
 REPORT_RECIPIENTS=""

--- a/scripts/antithesis/launch.sh
+++ b/scripts/antithesis/launch.sh
@@ -9,12 +9,19 @@ else
   TEST_TYPE="scheduled test"
 fi
 
-# Only notify everyone of the test results when explicitly opted in, so that
-# ad-hoc runs don't email the whole recipient list by default.
+# Decide who receives the test report. NOTIFY_EVERYONE uses the shared recipient
+# list; otherwise fall back to a single custom NOTIFY_EMAIL. When neither is set
+# the report is not emailed, so ad-hoc runs stay quiet by default.
+if [ "$NOTIFY_EVERYONE" = "true" ]; then
+  RECIPIENTS="$ANTITHESIS_EMAIL"
+else
+  RECIPIENTS="$NOTIFY_EMAIL"
+fi
+
 REPORT_RECIPIENTS=""
-if [ "$NOTIFY_EVERYONE" = "true" ] && [ -n "$ANTITHESIS_EMAIL" ]; then
+if [ -n "$RECIPIENTS" ]; then
   REPORT_RECIPIENTS=",
-      \"antithesis.report.recipients\":\"$ANTITHESIS_EMAIL\""
+      \"antithesis.report.recipients\":\"$RECIPIENTS\""
 fi
 
 curl --fail -u "$ANTITHESIS_USER:$ANTITHESIS_PASSWD" \

--- a/scripts/antithesis/launch.sh
+++ b/scripts/antithesis/launch.sh
@@ -9,11 +9,18 @@ else
   TEST_TYPE="scheduled test"
 fi
 
+# Only notify everyone of the test results when explicitly opted in, so that
+# ad-hoc runs don't email the whole recipient list by default.
+REPORT_RECIPIENTS=""
+if [ "$NOTIFY_EVERYONE" = "true" ] && [ -n "$ANTITHESIS_EMAIL" ]; then
+  REPORT_RECIPIENTS=",
+      \"antithesis.report.recipients\":\"$ANTITHESIS_EMAIL\""
+fi
+
 curl --fail -u "$ANTITHESIS_USER:$ANTITHESIS_PASSWD" \
   -X POST https://$ANTITHESIS_TENANT.antithesis.com/api/v1/launch/limbo \
   -d "{\"params\": { \"antithesis.description\":\"$TEST_TYPE on $BRANCH @ $COMMIT\",
       \"custom.duration\":\"4\",
       \"antithesis.config_image\":\"$ANTITHESIS_DOCKER_REPO/limbo-config:antithesis-latest\",
-      \"antithesis.images\":\"$ANTITHESIS_DOCKER_REPO/limbo-workload:antithesis-latest\",
-      \"antithesis.report.recipients\":\"$ANTITHESIS_EMAIL\"
+      \"antithesis.images\":\"$ANTITHESIS_DOCKER_REPO/limbo-workload:antithesis-latest\"$REPORT_RECIPIENTS
       } }"


### PR DESCRIPTION
## Description

Often times, when we launch an Antithesis Experiment, we don't want everyone to be notified of the test results, because (1) it's spammy, and (2) people can get confused by weird errors that might exist only on tests run from branches.

This PR lets people choose who to notify. I tested by entering my turso email. Gmail is smart enough to decuplicate emails if you select "notify everyone" and add your own turso email. I then added my personal email, and I got notified there, too.

The script concatenates emails with semicolons. This is the [documented format](https://github.com/antithesishq/antithesis-trigger-action).

## Result

<img width="471" height="721" alt="image" src="https://github.com/user-attachments/assets/665845cb-6cdb-494f-be77-a8ab2d67121b" />