### PR TITLE
core: store TEXT as raw bytes to allow non-UTF-8 values

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -1922,7 +1922,7 @@ pub unsafe extern "C" fn sqlite3_column_bytes(
         None => return 0,
     };
     match row.get::<&Value>(idx as usize) {
-        Ok(turso_core::Value::Text(text)) => text.as_str().len() as ffi::c_int,
+        Ok(turso_core::Value::Text(text)) => text.as_bytes().len() as ffi::c_int,
         Ok(turso_core::Value::Blob(blob)) => blob.len() as ffi::c_int,
         _ => 0,
     }
@@ -2065,7 +2065,7 @@ pub unsafe extern "C" fn sqlite3_column_text(
     match row.get::<&Value>(i) {
         Ok(turso_core::Value::Text(text)) => {
             let buf = &mut stmt.text_cache[i];
-            buf.extend(text.as_str().as_bytes());
+            buf.extend(text.as_bytes());
             buf.push(0);
             buf.as_ptr() as *const ffi::c_uchar
         }
@@ -2106,7 +2106,7 @@ pub unsafe extern "C" fn sqlite3_column_value(
         Ok(turso_core::Value::Numeric(turso_core::Numeric::Float(f))) => {
             ExtValue::from_float(f64::from(*f))
         }
-        Ok(turso_core::Value::Text(t)) => ExtValue::from_text(t.value.to_string()),
+        Ok(turso_core::Value::Text(t)) => ExtValue::from_text(t.to_str_lossy().into_owned()),
         Ok(turso_core::Value::Blob(b)) => ExtValue::from_blob(b.clone()),
         _ => ExtValue::null(),
     };
@@ -2968,14 +2968,14 @@ pub unsafe extern "C" fn sqlite3_table_column_metadata(
                 Ok(rows) => {
                     let mut found_column = false;
                     for row in rows {
-                        let col_name: &str = match &row[1] {
-                            turso_core::Value::Text(text) => text.as_str(),
+                        let col_name = match &row[1] {
+                            turso_core::Value::Text(text) => text.to_str_lossy(),
                             _ => return SQLITE_ERROR,
                         }; // name column
-                        if col_name == column_name {
+                        if &*col_name == column_name {
                             // Found the column, extract metadata
                             let col_type: String = match &row[2] {
-                                turso_core::Value::Text(text) => text.as_str().to_string(),
+                                turso_core::Value::Text(text) => text.to_str_lossy().into_owned(),
                                 _ => return SQLITE_ERROR,
                             }; // type column
                             let col_notnull: i64 = row[3].as_int().unwrap(); // notnull column

--- a/bindings/java/rs_src/turso_statement.rs
+++ b/bindings/java/rs_src/turso_statement.rs
@@ -110,7 +110,7 @@ fn row_to_obj_array<'local>(
             turso_core::Value::Numeric(turso_core::Numeric::Float(f)) => {
                 env.new_object("java/lang/Double", "(D)V", &[JValue::Double(f64::from(*f))])?
             }
-            turso_core::Value::Text(s) => env.new_string(s.as_str())?.into(),
+            turso_core::Value::Text(s) => env.new_string(&*s.to_str_lossy())?.into(),
             turso_core::Value::Blob(b) => env.byte_array_from_slice(b.as_slice())?.into(),
         };
         if let Err(e) = env.set_object_array_element(&obj_array, i as i32, obj) {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -1006,7 +1006,7 @@ fn to_js_value<'a>(
         turso_core::Value::Numeric(turso_core::Numeric::Float(f)) => {
             ToNapiValue::into_unknown(f64::from(*f), env)
         }
-        turso_core::Value::Text(s) => ToNapiValue::into_unknown(s.as_str(), env),
+        turso_core::Value::Text(s) => ToNapiValue::into_unknown(s.to_str_lossy().into_owned(), env),
         turso_core::Value::Blob(b) => {
             #[cfg(not(feature = "browser"))]
             {

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -76,7 +76,7 @@ fn core_value_to_js(value: turso_core::Value) -> Either5<Null, i64, f64, String,
             Either5::<Null, i64, f64, String, Vec<u8>>::C(f64::from(value))
         }
         turso_core::Value::Text(value) => {
-            Either5::<Null, i64, f64, String, Vec<u8>>::D(value.as_str().to_string())
+            Either5::<Null, i64, f64, String, Vec<u8>>::D(value.to_str_lossy().into_owned())
         }
         turso_core::Value::Blob(value) => Either5::<Null, i64, f64, String, Vec<u8>>::E(value),
     }

--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -405,7 +405,7 @@ fn db_value_to_py(py: Python, value: Value) -> PyResult<Py<PyAny>> {
         Value::Null => Ok(py.None()),
         Value::Numeric(Numeric::Integer(i)) => Ok(i.into_pyobject(py)?.into()),
         Value::Numeric(Numeric::Float(f)) => Ok(f64::from(f).into_pyobject(py)?.into()),
-        Value::Text(s) => Ok(s.value.as_ref().into_pyobject(py)?.into()),
+        Value::Text(s) => Ok(s.to_str_lossy().into_owned().into_pyobject(py)?.into()),
         Value::Blob(b) => Ok(PyBytes::new(py, &b).into()),
     }
 }

--- a/bindings/rust/src/rows.rs
+++ b/bindings/rust/src/rows.rs
@@ -89,7 +89,7 @@ impl Row {
             }
             turso_sdk_kit::rsapi::Value::Null => Ok(Value::Null),
             turso_sdk_kit::rsapi::Value::Text(text) => {
-                Ok(Value::Text(text.value.clone().into_owned()))
+                Ok(Value::Text(text.to_str_lossy().into_owned()))
             }
             turso_sdk_kit::rsapi::Value::Blob(items) => Ok(Value::Blob(items.to_vec())),
         }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1402,12 +1402,12 @@ impl Limbo {
             row.get::<&Value>(2),
         ) {
             let modified_schema = if db_display_name == "main" {
-                schema.as_str().to_string()
+                schema.to_str_lossy().into_owned()
             } else {
                 // We need to modify the SQL to include the database prefix in table names
                 // This is a simple approach - for CREATE TABLE statements, insert db name after "TABLE "
                 // For CREATE INDEX statements, insert db name after "ON "
-                let schema_str = schema.as_str();
+                let schema_str = schema.to_str_lossy();
                 if schema_str.to_uppercase().contains("CREATE TABLE ") {
                     // Find "CREATE TABLE " and insert database name after it
                     if let Some(pos) = schema_str.to_uppercase().find("CREATE TABLE ") {
@@ -1432,11 +1432,15 @@ impl Limbo {
             };
             let _ = self.writeln_fmt(format_args!("{modified_schema};"));
             // For views, add the column comment like SQLite does
-            if obj_type.as_str() == "view" {
+            if obj_type.as_bytes() == b"view" {
                 let columns = self
-                    .get_view_columns(obj_name.as_str())
+                    .get_view_columns(&obj_name.to_str_lossy())
                     .unwrap_or_else(|_| "x".to_string());
-                let _ = self.writeln_fmt(format_args!("/* {}({}) */", obj_name.as_str(), columns));
+                let _ = self.writeln_fmt(format_args!(
+                    "/* {}({}) */",
+                    obj_name.to_str_lossy(),
+                    columns
+                ));
             }
             true
         } else {
@@ -1453,7 +1457,7 @@ impl Limbo {
         let handler = |row: &turso_core::Row| {
             // Column name is in the second column (index 1) of PRAGMA table_info
             if let Ok(Value::Text(col_name)) = row.get::<&Value>(1) {
-                columns.push(col_name.as_str().to_string());
+                columns.push(col_name.to_str_lossy().into_owned());
             }
             Ok(())
         };
@@ -1610,7 +1614,7 @@ impl Limbo {
                         indexes.push_str(prefix);
                         indexes.push('.');
                     }
-                    indexes.push_str(idx.as_str());
+                    indexes.push_str(&idx.to_str_lossy());
                     indexes.push(' ');
                 }
                 Ok(())
@@ -1648,7 +1652,7 @@ impl Limbo {
                         tables.push_str(prefix);
                         tables.push('.');
                     }
-                    tables.push_str(table.as_str());
+                    tables.push_str(&table.to_str_lossy());
                     tables.push(' ');
                 }
                 Ok(())
@@ -1731,9 +1735,9 @@ impl Limbo {
                 row.get::<&Value>(2),
             ) {
                 let file = match file_value {
-                    Value::Text(path) => path.as_str(),
-                    Value::Null => "",
-                    _ => "",
+                    Value::Text(path) => path.to_str_lossy(),
+                    Value::Null => std::borrow::Cow::Borrowed(""),
+                    _ => std::borrow::Cow::Borrowed(""),
                 };
 
                 // Format like SQLite: "main: /path/to/file r/w"
@@ -1750,7 +1754,12 @@ impl Limbo {
                     "r/w"
                 };
 
-                databases.push(format!("{}: {} {}", name.as_str(), file_display, mode));
+                databases.push(format!(
+                    "{}: {} {}",
+                    name.to_str_lossy(),
+                    file_display,
+                    mode
+                ));
             }
             Ok(())
         })?;
@@ -1984,7 +1993,7 @@ impl Limbo {
             Value::Numeric(Numeric::Float(f)) => write!(out, "{}", f64::from(*f)).map(|_| ()),
             Value::Text(s) => {
                 out.write_all(b"'")?;
-                let bytes = s.value.as_bytes();
+                let bytes = s.as_bytes();
                 let mut i = 0;
                 while i < bytes.len() {
                     let b = bytes[i];

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -678,10 +678,7 @@ fn convert_value_to_core(value: &Value) -> CoreValue {
         Value::None | Value::Null => CoreValue::Null,
         Value::Integer { value } => CoreValue::from_i64(*value),
         Value::Float { value } => CoreValue::from_f64(*value),
-        Value::Text { value } => CoreValue::Text(turso_core::types::Text {
-            value: std::borrow::Cow::Owned(value.clone()),
-            subtype: turso_core::types::TextSubtype::Text,
-        }),
+        Value::Text { value } => CoreValue::Text(turso_core::types::Text::new(value.clone())),
         Value::Blob { value } => CoreValue::Blob(value.to_vec()),
     }
 }
@@ -694,7 +691,7 @@ fn convert_core_to_value(value: CoreValue) -> Value {
             value: f64::from(v),
         },
         CoreValue::Text(t) => Value::Text {
-            value: t.value.to_string(),
+            value: t.to_str_lossy().into_owned(),
         },
         CoreValue::Blob(b) => Value::Blob {
             value: Bytes::from(b),

--- a/core/btree_dump.rs
+++ b/core/btree_dump.rs
@@ -157,11 +157,11 @@ impl InternalVirtualTableCursor for BtreeDumpCursor {
         }
 
         let name = match args.first() {
-            Some(Value::Text(s)) => s.as_str(),
+            Some(Value::Text(s)) => s.to_str_lossy(),
             _ => return Ok(false),
         };
 
-        let root_page = match self.find_root_page(name) {
+        let root_page = match self.find_root_page(&name) {
             Some(rp) if rp > 0 => rp,
             Some(_) => {
                 return Err(crate::LimboError::InternalError(format!(

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -4095,8 +4095,8 @@ impl Connection {
 
     pub(crate) fn custom_collation_compare(
         external: &function::ExternalCollation,
-        left: &str,
-        right: &str,
+        left: &[u8],
+        right: &[u8],
     ) -> CmpOrdering {
         let result = unsafe {
             (external.callback)(
@@ -4116,7 +4116,7 @@ impl Connection {
         Arc::new(move |left, right| {
             Ok(match (left, right) {
                 (crate::ValueRef::Text(left), crate::ValueRef::Text(right)) => {
-                    Self::custom_collation_compare(&external, left.as_str(), right.as_str())
+                    Self::custom_collation_compare(&external, left.as_bytes(), right.as_bytes())
                 }
                 _ => left.partial_cmp(right).unwrap_or(CmpOrdering::Equal),
             })
@@ -4138,7 +4138,11 @@ impl Connection {
         right: &str,
     ) -> Result<CmpOrdering> {
         let external = self.get_external_collation(collation)?;
-        Ok(Self::custom_collation_compare(&external, left, right))
+        Ok(Self::custom_collation_compare(
+            &external,
+            left.as_bytes(),
+            right.as_bytes(),
+        ))
     }
 
     pub(crate) fn database_ptr(&self) -> usize {
@@ -4781,9 +4785,9 @@ mod tests {
         }
     }
 
-    fn text_value(value: &Value) -> &str {
+    fn text_value(value: &Value) -> String {
         match value {
-            Value::Text(text) => text.as_str(),
+            Value::Text(text) => text.to_str_lossy().into_owned(),
             other => panic!("expected text value, got {other:?}"),
         }
     }

--- a/core/dbpage.rs
+++ b/core/dbpage.rs
@@ -155,7 +155,7 @@ impl InternalVirtualTableCursor for DbPageCursor {
 
         if (idx_num & 2) != 0 {
             if let Some(Value::Text(schema)) = args.get(arg_idx) {
-                if schema.as_str() != "main" {
+                if schema.as_bytes() != b"main" {
                     self.schema_mismatch = true;
                     return Ok(false);
                 }
@@ -219,10 +219,10 @@ fn parse_rowid(value: &Value) -> Result<Option<i64>> {
 fn ensure_main_schema(value: &Value) -> Result<()> {
     match value {
         Value::Null => Ok(()),
-        Value::Text(schema) if schema.as_str() == "main" => Ok(()),
+        Value::Text(schema) if schema.as_bytes() == b"main" => Ok(()),
         Value::Text(schema) => Err(LimboError::InvalidArgument(format!(
             "sqlite_dbpage only supports main schema (got {})",
-            schema.as_str()
+            schema.to_str_lossy()
         ))),
         _ => Err(LimboError::InvalidArgument(
             "sqlite_dbpage schema must be text or null".to_string(),

--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -872,7 +872,7 @@ where
         let first = values.next().unwrap();
         match first.as_value_ref() {
             ValueRef::Text(s) => {
-                if parse_date_or_time(s.as_str(), &mut p).is_err() {
+                if parse_date_or_time(&s.to_str_lossy(), &mut p).is_err() {
                     return Value::Null;
                 }
             }
@@ -899,7 +899,7 @@ where
     for (i, val) in values.enumerate() {
         has_modifier = true;
         if let ValueRef::Text(s) = val.as_value_ref() {
-            if parse_modifier(&mut p, s.as_str(), i).is_err() {
+            if parse_modifier(&mut p, &s.to_str_lossy(), i).is_err() {
                 return Value::Null;
             }
         } else {
@@ -1042,7 +1042,7 @@ where
     let val1 = values.next().unwrap();
     match val1.as_value_ref() {
         ValueRef::Text(s) => {
-            if parse_date_or_time(s.as_str(), &mut d1).is_err() {
+            if parse_date_or_time(&s.to_str_lossy(), &mut d1).is_err() {
                 return Value::Null;
             }
         }
@@ -1069,7 +1069,7 @@ where
     let val2 = values.next().unwrap();
     match val2.as_value_ref() {
         ValueRef::Text(s) => {
-            if parse_date_or_time(s.as_str(), &mut d2).is_err() {
+            if parse_date_or_time(&s.to_str_lossy(), &mut d2).is_err() {
                 return Value::Null;
             }
         }
@@ -1190,7 +1190,7 @@ where
 
     let fmt_val = values.next().unwrap();
     let fmt_str = match fmt_val.as_value_ref() {
-        ValueRef::Text(s) => Cow::Borrowed(s.as_str()),
+        ValueRef::Text(s) => s.to_str_lossy(),
         ValueRef::Null => return Value::Null,
         val => Cow::Owned(val.to_string()),
     };
@@ -1202,7 +1202,7 @@ where
         let init_val = values.next().unwrap();
         match init_val.as_value_ref() {
             ValueRef::Text(s) => {
-                let s_str = s.as_str();
+                let s_str = s.to_str_lossy();
                 if s_str.eq_ignore_ascii_case("now") {
                     set_to_current(&mut p);
                 } else if let Ok(val) = s_str.parse::<f64>() {
@@ -1214,7 +1214,7 @@ where
                     }
                 } else {
                     let mut temp_p = DateTime::default();
-                    if parse_date_or_time(s_str, &mut temp_p).is_ok() {
+                    if parse_date_or_time(&s_str, &mut temp_p).is_ok() {
                         p = temp_p;
                     } else {
                         return Value::Null;
@@ -1242,7 +1242,7 @@ where
 
         for (i, val) in values.enumerate() {
             if let ValueRef::Text(s) = val.as_value_ref() {
-                if parse_modifier(&mut p, s.as_str(), i).is_err() {
+                if parse_modifier(&mut p, &s.to_str_lossy(), i).is_err() {
                     return Value::Null;
                 }
             } else {
@@ -1633,7 +1633,7 @@ mod tests {
         for (input, expected) in test_cases {
             let result = exec_time(&[input]);
             if let Value::Text(result_str) = result {
-                assert_eq!(result_str.as_str(), expected);
+                assert_eq!(&*result_str.to_str_lossy(), expected);
             } else {
                 panic!("Expected Value::Text, but got: {result:?}");
             }
@@ -1837,7 +1837,7 @@ mod tests {
                 Value::build_text(modifier.to_string()),
             ];
             let val = exec_datetime_full(args);
-            val.to_text().unwrap().to_string()
+            val.to_text_str_lossy().unwrap().to_string()
         };
 
         assert_eq!(run("+2023-05-15"), "4023-06-16 00:00:00");
@@ -1852,7 +1852,7 @@ mod tests {
                 Value::build_text(modifier.to_string()),
             ];
             let val = exec_datetime_full(args);
-            val.to_text().unwrap().to_string()
+            val.to_text_str_lossy().unwrap().to_string()
         };
 
         assert_eq!(run("+2023-05-15 14:30"), "4023-06-16 14:30:00");
@@ -1889,7 +1889,7 @@ mod tests {
                 Value::build_text(modifier.to_string()),
             ];
             let val = exec_datetime_full(args);
-            val.to_text().unwrap().to_string()
+            val.to_text_str_lossy().unwrap().to_string()
         };
 
         let base = "2023-06-15 12:30:45";
@@ -1928,7 +1928,7 @@ mod tests {
                 Value::build_text(modifier.to_string()),
             ];
             let val = exec_date(args);
-            val.to_text().unwrap().to_string()
+            val.to_text_str_lossy().unwrap().to_string()
         };
 
         // 2023-01-01 was a Sunday (0)
@@ -1994,7 +1994,10 @@ mod tests {
                 Value::build_text("2023-06-15 12:30:45".to_string()),
                 Value::build_text(mod_str.to_string()),
             ];
-            exec_datetime_full(args).to_text().unwrap().to_string()
+            exec_datetime_full(args)
+                .to_text_str_lossy()
+                .unwrap()
+                .to_string()
         };
 
         assert_eq!(run("5 days"), "2023-06-20 12:30:45");
@@ -2008,7 +2011,10 @@ mod tests {
                 Value::build_text("2023-06-15 12:30:45".to_string()),
                 Value::build_text(mod_str.to_string()),
             ];
-            exec_datetime_full(args).to_text().unwrap().to_string()
+            exec_datetime_full(args)
+                .to_text_str_lossy()
+                .unwrap()
+                .to_string()
         };
 
         assert_eq!(run("6 hours"), "2023-06-15 18:30:45");
@@ -2022,7 +2028,10 @@ mod tests {
                 Value::build_text("2023-06-15 12:30:45".to_string()),
                 Value::build_text(mod_str.to_string()),
             ];
-            exec_datetime_full(args).to_text().unwrap().to_string()
+            exec_datetime_full(args)
+                .to_text_str_lossy()
+                .unwrap()
+                .to_string()
         };
 
         assert_eq!(run("45 minutes"), "2023-06-15 13:15:45");
@@ -2036,7 +2045,10 @@ mod tests {
                 Value::build_text("2023-06-15 12:30:45".to_string()),
                 Value::build_text(mod_str.to_string()),
             ];
-            exec_datetime_full(args).to_text().unwrap().to_string()
+            exec_datetime_full(args)
+                .to_text_str_lossy()
+                .unwrap()
+                .to_string()
         };
 
         assert_eq!(run("30 seconds"), "2023-06-15 12:31:15");
@@ -2116,7 +2128,10 @@ mod tests {
                 Value::build_text("2023-06-15 12:30:45".to_string()),
                 Value::build_text(mod_str.to_string()),
             ];
-            exec_datetime_full(args).to_text().unwrap().to_string()
+            exec_datetime_full(args)
+                .to_text_str_lossy()
+                .unwrap()
+                .to_string()
         };
 
         assert_eq!(run("+01:30"), "2023-06-15 14:00:45");
@@ -2130,7 +2145,10 @@ mod tests {
                 Value::build_text("2023-06-15 12:30:45".to_string()),
                 Value::build_text(mod_str.to_string()),
             ];
-            exec_datetime_full(args).to_text().unwrap().to_string()
+            exec_datetime_full(args)
+                .to_text_str_lossy()
+                .unwrap()
+                .to_string()
         };
 
         assert_eq!(run("+0001-01-01 01:01"), "2024-07-16 13:31:45");
@@ -2145,7 +2163,7 @@ mod tests {
             Value::build_text("2023-06-15 12:30:45"),
             Value::build_text("start of year"),
         ]);
-        assert_eq!(res.to_text().unwrap(), "2023-01-01 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-01-01 00:00:00");
     }
 
     #[test]
@@ -2154,7 +2172,7 @@ mod tests {
             Value::build_text("2023-06-15 12:30:45"),
             Value::build_text("start of day"),
         ]);
-        assert_eq!(res.to_text().unwrap(), "2023-06-15 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-15 00:00:00");
     }
 
     #[test]
@@ -2163,7 +2181,7 @@ mod tests {
             Value::build_text("2023-06-15 12:30:45"),
             Value::build_text("-1 day"),
         ]);
-        assert_eq!(res.to_text().unwrap(), "2023-06-14 12:30:45");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-14 12:30:45");
     }
 
     #[test]
@@ -2173,7 +2191,7 @@ mod tests {
             Value::build_text("-1 day"),
             Value::build_text("+3 hours"),
         ]);
-        assert_eq!(res.to_text().unwrap(), "2023-06-14 15:30:45");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-14 15:30:45");
     }
 
     #[test]
@@ -2185,7 +2203,7 @@ mod tests {
             ],
             "time",
         );
-        assert_eq!(res.to_text().unwrap(), "12:30:45.000");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "12:30:45.000");
     }
 
     #[test]
@@ -2195,7 +2213,7 @@ mod tests {
             Value::build_text("start of day"),
             Value::build_text("-1 day"),
         ]);
-        assert_eq!(res.to_text().unwrap(), "2023-06-14 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-14 00:00:00");
     }
 
     #[test]
@@ -2205,7 +2223,7 @@ mod tests {
             Value::build_text("start of month"),
             Value::build_text("+1 day"),
         ]);
-        assert_eq!(res.to_text().unwrap(), "2023-06-02 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-02 00:00:00");
     }
 
     #[test]
@@ -2216,7 +2234,7 @@ mod tests {
             Value::build_text("+30 days"),
             Value::build_text("+5 hours"),
         ]);
-        assert_eq!(res.to_text().unwrap(), "2023-01-31 05:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-01-31 05:00:00");
     }
 
     #[test]
@@ -2242,7 +2260,7 @@ mod tests {
             .to_string();
 
         assert_eq!(
-            res_local.to_text().unwrap(),
+            res_local.to_text_str_lossy().unwrap(),
             expected_local,
             "localtime modifier mismatch"
         );
@@ -2263,7 +2281,7 @@ mod tests {
                     .format("%Y-%m-%d %H:%M:%S")
                     .to_string();
                 assert_eq!(
-                    res_utc.to_text().unwrap(),
+                    res_utc.to_text_str_lossy().unwrap(),
                     expected_utc,
                     "utc modifier mismatch"
                 );
@@ -2271,7 +2289,7 @@ mod tests {
             _ => {
                 // Fallback if local time is ambiguous/invalid in test environment
                 // Ensure result is at least a valid string and not Null
-                assert!(res_utc.to_text().is_some());
+                assert!(res_utc.to_text_str_lossy().is_some());
                 assert_ne!(res_utc, Value::Null);
             }
         }
@@ -2288,14 +2306,17 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "1999-12-31 05:30:15.000");
+        assert_eq!(
+            result.to_text_str_lossy().unwrap(),
+            "1999-12-31 05:30:15.000"
+        );
     }
 
     #[test]
     fn test_max_datetime_limit() {
         let args = vec![Value::build_text("9999-12-31 23:59:59".to_string())];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "9999-12-31 23:59:59");
+        assert_eq!(result.to_text_str_lossy().unwrap(), "9999-12-31 23:59:59");
     }
 
     #[test]
@@ -2312,7 +2333,7 @@ mod tests {
             Value::build_text("weekday 0".to_string()),
         ];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "2023-01-01 12:00:00");
+        assert_eq!(result.to_text_str_lossy().unwrap(), "2023-01-01 12:00:00");
     }
 
     #[test]
@@ -2322,14 +2343,14 @@ mod tests {
             Value::build_text("weekday 1".to_string()),
         ];
         let res1 = exec_datetime_full(args1);
-        assert_eq!(res1.to_text().unwrap(), "2023-01-02 12:00:00");
+        assert_eq!(res1.to_text_str_lossy().unwrap(), "2023-01-02 12:00:00");
 
         let args2 = vec![
             Value::build_text("2023-01-03 12:00:00".to_string()),
             Value::build_text("weekday 5".to_string()),
         ];
         let res2 = exec_datetime_full(args2);
-        assert_eq!(res2.to_text().unwrap(), "2023-01-06 12:00:00");
+        assert_eq!(res2.to_text_str_lossy().unwrap(), "2023-01-06 12:00:00");
     }
 
     #[test]
@@ -2339,14 +2360,14 @@ mod tests {
             Value::build_text("weekday 0".to_string()),
         ];
         let res1 = exec_datetime_full(args1);
-        assert_eq!(res1.to_text().unwrap(), "2023-01-08 12:00:00");
+        assert_eq!(res1.to_text_str_lossy().unwrap(), "2023-01-08 12:00:00");
 
         let args2 = vec![
             Value::build_text("2023-01-08 12:00:00".to_string()),
             Value::build_text("weekday 0".to_string()),
         ];
         let res2 = exec_datetime_full(args2);
-        assert_eq!(res2.to_text().unwrap(), "2023-01-08 12:00:00");
+        assert_eq!(res2.to_text_str_lossy().unwrap(), "2023-01-08 12:00:00");
     }
 
     #[test]
@@ -2356,7 +2377,7 @@ mod tests {
             Value::build_text("weekday 4".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-01-05 12:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-01-05 12:00:00");
     }
 
     #[test]
@@ -2366,7 +2387,7 @@ mod tests {
             Value::build_text("weekday 5".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-01-06 12:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-01-06 12:00:00");
     }
 
     #[test]
@@ -2376,7 +2397,7 @@ mod tests {
 
         let dt_args = vec![jd_val, Value::build_text("auto".to_string())];
         let dt_res = exec_datetime_full(dt_args);
-        assert_eq!(dt_res.to_text().unwrap(), "2000-01-01 12:00:00");
+        assert_eq!(dt_res.to_text_str_lossy().unwrap(), "2000-01-01 12:00:00");
     }
 
     #[test]
@@ -2386,7 +2407,7 @@ mod tests {
             Value::build_text("start of month".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-06-01 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-01 00:00:00");
     }
 
     #[test]
@@ -2396,7 +2417,7 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let res = exec_datetime_general(args, "datetime");
-        assert_eq!(res.to_text().unwrap(), "2023-06-15 12:30:45.000");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-15 12:30:45.000");
     }
 
     #[test]
@@ -2407,7 +2428,7 @@ mod tests {
             Value::build_text("floor".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-02-28 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-02-28 00:00:00");
     }
 
     #[test]
@@ -2418,7 +2439,7 @@ mod tests {
             Value::build_text("floor".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-02-15 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-02-15 00:00:00");
     }
 
     #[test]
@@ -2429,7 +2450,7 @@ mod tests {
             Value::build_text("+1 month".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-03-03 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-03-03 00:00:00");
     }
 
     #[test]
@@ -2439,7 +2460,7 @@ mod tests {
             Value::build_text("start of month".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-06-01 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-01 00:00:00");
     }
 
     #[test]
@@ -2449,7 +2470,7 @@ mod tests {
             Value::build_text("start of month".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-06-01 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-01 00:00:00");
     }
 
     #[test]
@@ -2459,7 +2480,7 @@ mod tests {
             Value::build_text("start of month".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-07-01 00:00:00");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-07-01 00:00:00");
     }
 
     #[test]
@@ -2469,7 +2490,7 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2023-06-15 12:30:45.123");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2023-06-15 12:30:45.123");
     }
 
     #[test]
@@ -2479,7 +2500,7 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2025-01-02 04:12:21.891");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2025-01-02 04:12:21.891");
     }
 
     #[test]
@@ -2489,7 +2510,7 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2025-01-02 04:12:21.000");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2025-01-02 04:12:21.000");
     }
 
     #[test]
@@ -2499,7 +2520,7 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let res = exec_datetime_full(args);
-        assert_eq!(res.to_text().unwrap(), "2025-01-02 04:12:21.891");
+        assert_eq!(res.to_text_str_lossy().unwrap(), "2025-01-02 04:12:21.891");
     }
 
     #[test]
@@ -2626,7 +2647,10 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "2024-01-01 12:00:00.000");
+        assert_eq!(
+            result.to_text_str_lossy().unwrap(),
+            "2024-01-01 12:00:00.000"
+        );
     }
 
     #[test]
@@ -2636,7 +2660,10 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "2024-01-01 00:00:00.000");
+        assert_eq!(
+            result.to_text_str_lossy().unwrap(),
+            "2024-01-01 00:00:00.000"
+        );
     }
 
     #[test]
@@ -2646,7 +2673,10 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "2024-01-01 15:30:00.000");
+        assert_eq!(
+            result.to_text_str_lossy().unwrap(),
+            "2024-01-01 15:30:00.000"
+        );
     }
 
     #[test]
@@ -2657,7 +2687,10 @@ mod tests {
             Value::build_text("+1 hour".to_string()),
         ];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "2024-01-01 13:00:00.000");
+        assert_eq!(
+            result.to_text_str_lossy().unwrap(),
+            "2024-01-01 13:00:00.000"
+        );
     }
 
     #[test]
@@ -2668,7 +2701,10 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "2024-01-01 13:00:00.000");
+        assert_eq!(
+            result.to_text_str_lossy().unwrap(),
+            "2024-01-01 13:00:00.000"
+        );
     }
 
     #[test]
@@ -2679,7 +2715,10 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "2024-01-01 12:00:01.999");
+        assert_eq!(
+            result.to_text_str_lossy().unwrap(),
+            "2024-01-01 12:00:01.999"
+        );
     }
 
     #[test]
@@ -2689,7 +2728,10 @@ mod tests {
             Value::build_text("SuBsEc".to_string()),
         ];
         let result = exec_datetime_full(args);
-        assert_eq!(result.to_text().unwrap(), "2024-01-01 12:00:00.000");
+        assert_eq!(
+            result.to_text_str_lossy().unwrap(),
+            "2024-01-01 12:00:00.000"
+        );
     }
 
     #[test]
@@ -2877,31 +2919,31 @@ mod tests {
     fn test_fast_path_date_only() {
         assert_eq!(
             exec_date(vec![Value::build_text("2024-01-01".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "2024-01-01"
         );
         assert_eq!(
             exec_date(vec![Value::build_text("0001-01-01".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "0001-01-01"
         );
         assert_eq!(
             exec_date(vec![Value::build_text("9999-12-31".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "9999-12-31"
         );
         assert_eq!(
             exec_date(vec![Value::build_text("2024-02-29".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "2024-02-29"
         );
         assert_eq!(
             exec_date(vec![Value::build_text("2023-02-29".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "2023-03-01"
         );
@@ -2946,13 +2988,13 @@ mod tests {
     fn test_fast_path_datetime_formats() {
         assert_eq!(
             exec_datetime_full(vec![Value::build_text("2024-01-15 10:30".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "2024-01-15 10:30:00"
         );
         assert_eq!(
             exec_datetime_full(vec![Value::build_text("2024-01-15T10:30".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "2024-01-15 10:30:00"
         );
@@ -2962,13 +3004,13 @@ mod tests {
         );
         assert_eq!(
             exec_datetime_full(vec![Value::build_text("2024-01-15 10:30:45".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "2024-01-15 10:30:45"
         );
         assert_eq!(
             exec_datetime_full(vec![Value::build_text("2024-01-15T10:30:45".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "2024-01-15 10:30:45"
         );
@@ -2991,25 +3033,25 @@ mod tests {
     fn test_fast_path_time_only() {
         assert_eq!(
             exec_time(vec![Value::build_text("10:30".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "10:30:00"
         );
         assert_eq!(
             exec_time(vec![Value::build_text("00:00".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "00:00:00"
         );
         assert_eq!(
             exec_time(vec![Value::build_text("23:59".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "23:59:00"
         );
         assert_eq!(
             exec_time(vec![Value::build_text("24:00".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "24:00:00"
         );
@@ -3020,19 +3062,19 @@ mod tests {
 
         assert_eq!(
             exec_time(vec![Value::build_text("10:30:45".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "10:30:45"
         );
         assert_eq!(
             exec_time(vec![Value::build_text("00:00:00".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "00:00:00"
         );
         assert_eq!(
             exec_time(vec![Value::build_text("23:59:59".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "23:59:59"
         );
@@ -3044,7 +3086,7 @@ mod tests {
             ],
             "time",
         );
-        assert_eq!(res1.to_text().unwrap(), "10:30:45.123");
+        assert_eq!(res1.to_text_str_lossy().unwrap(), "10:30:45.123");
 
         let res2 = exec_datetime_general(
             vec![
@@ -3053,14 +3095,14 @@ mod tests {
             ],
             "time",
         );
-        assert_eq!(res2.to_text().unwrap(), "10:30:45.100");
+        assert_eq!(res2.to_text_str_lossy().unwrap(), "10:30:45.100");
     }
 
     #[test]
     fn test_fast_path_skips_timezone_strings() {
         assert_eq!(
             exec_datetime_full(vec![Value::build_text("2024-01-15 10:30:45Z".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "2024-01-15 10:30:45"
         );
@@ -3068,7 +3110,7 @@ mod tests {
             exec_datetime_full(vec![Value::build_text(
                 "2024-01-15 10:30:45+02:00".to_string()
             )])
-            .to_text()
+            .to_text_str_lossy()
             .unwrap(),
             "2024-01-15 08:30:45"
         );
@@ -3076,13 +3118,13 @@ mod tests {
             exec_datetime_full(vec![Value::build_text(
                 "2024-01-15 10:30:45-05:00".to_string()
             )])
-            .to_text()
+            .to_text_str_lossy()
             .unwrap(),
             "2024-01-15 15:30:45"
         );
         assert_eq!(
             exec_time(vec![Value::build_text("10:30:45+02:00".to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap(),
             "08:30:45"
         );
@@ -3095,7 +3137,7 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         assert_eq!(
-            exec_datetime_full(args1).to_text().unwrap(),
+            exec_datetime_full(args1).to_text_str_lossy().unwrap(),
             "2024-01-15 10:30:45.123"
         );
 
@@ -3104,7 +3146,7 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         assert_eq!(
-            exec_datetime_full(args2).to_text().unwrap(),
+            exec_datetime_full(args2).to_text_str_lossy().unwrap(),
             "2024-01-15 10:30:45.100"
         );
 
@@ -3113,7 +3155,7 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         assert_eq!(
-            exec_datetime_full(args3).to_text().unwrap(),
+            exec_datetime_full(args3).to_text_str_lossy().unwrap(),
             "2024-01-15 10:30:45.100"
         );
 
@@ -3122,7 +3164,7 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         assert_eq!(
-            exec_datetime_full(args4).to_text().unwrap(),
+            exec_datetime_full(args4).to_text_str_lossy().unwrap(),
             "2024-01-15 10:30:45.000"
         );
     }
@@ -3131,7 +3173,7 @@ mod tests {
     fn test_fast_path_month_day_boundaries() {
         let run = |s: &str| -> String {
             exec_datetime_full(&[Value::build_text(s.to_string())])
-                .to_text()
+                .to_text_str_lossy()
                 .unwrap()
                 .to_string()
         };
@@ -3151,7 +3193,7 @@ mod tests {
         let run = |s: &str| -> Value { exec_datetime_full(&[Value::build_text(s.to_string())]) };
 
         // Helper for cases expected to succeed (return String)
-        let run_str = |s: &str| -> String { run(s).to_text().unwrap().to_string() };
+        let run_str = |s: &str| -> String { run(s).to_text_str_lossy().unwrap().to_string() };
 
         assert_eq!(run(""), Value::Null);
         assert_eq!(run("a"), Value::Null);
@@ -3176,7 +3218,9 @@ mod tests {
             Value::build_text("subsec".to_string()),
         ];
         assert_eq!(
-            exec_datetime_general(dt_args, "time").to_text().unwrap(),
+            exec_datetime_general(dt_args, "time")
+                .to_text_str_lossy()
+                .unwrap(),
             "10:30:45.120"
         );
     }

--- a/core/functions/math.rs
+++ b/core/functions/math.rs
@@ -84,7 +84,7 @@ fn value_as_i64(v: &Value) -> Option<i64> {
                 None
             }
         }
-        Value::Text(t) => t.as_str().parse::<i64>().ok(),
+        Value::Text(t) => t.to_str_lossy().parse::<i64>().ok(),
         _ => None,
     }
 }

--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -164,7 +164,7 @@ fn coerce_to_i64(value: &Value) -> i64 {
     match value {
         Value::Numeric(Numeric::Integer(i)) => *i,
         Value::Numeric(Numeric::Float(f)) => f64::from(*f) as i64,
-        Value::Text(t) => str_to_i64(t.as_str()).unwrap_or(0),
+        Value::Text(t) => str_to_i64(t.to_str_lossy()).unwrap_or(0),
         Value::Blob(b) => {
             let s = String::from_utf8_lossy(b);
             str_to_i64(s.as_ref()).unwrap_or(0)
@@ -191,7 +191,7 @@ fn coerce_to_string(value: &Value) -> String {
         Value::Null => String::new(),
         Value::Numeric(Numeric::Integer(i)) => i.to_string(),
         Value::Numeric(Numeric::Float(f)) => format_float(f64::from(*f)),
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.to_str_lossy().into_owned(),
         Value::Blob(b) => String::from_utf8_lossy(b).to_string(),
     }
 }
@@ -1073,7 +1073,7 @@ fn format_string(output: &mut String, value: &Value, spec: &FormatSpec) {
 fn format_char(output: &mut String, value: &Value, spec: &FormatSpec) {
     // In SQLite SQL context, %c takes the first character of the string representation
     let c = match value {
-        Value::Text(t) => t.value.chars().next().unwrap_or('\0'),
+        Value::Text(t) => t.to_str_lossy().chars().next().unwrap_or('\0'),
         _ => {
             let s = coerce_to_string(value);
             s.chars().next().unwrap_or('\0')
@@ -1255,7 +1255,10 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
     let format_value = values[0].get_value();
     let fmt_owned: String;
     let format_str = match &format_value {
-        Value::Text(t) => t.as_str(),
+        Value::Text(t) => {
+            fmt_owned = t.to_str_lossy().into_owned();
+            fmt_owned.as_str()
+        }
         Value::Null => return Ok(Value::Null),
         Value::Numeric(Numeric::Integer(i)) => {
             fmt_owned = i.to_string();
@@ -1475,7 +1478,7 @@ mod tests {
         // Huge finite float must not overflow rounding to produce "inf"
         let huge = exec_printf(&[text("%f"), float(1e308)]).unwrap();
         let huge_str = match &huge {
-            Value::Text(t) => t.as_str().to_string(),
+            Value::Text(t) => t.to_str_lossy().into_owned(),
             _ => panic!("expected text"),
         };
         assert!(huge_str.starts_with("9999999999999999"));
@@ -1785,7 +1788,7 @@ mod tests {
         // infinity without flag_zeropad → "Inf"
         let inf_f = exec_printf(&[text("%020f"), float(f64::INFINITY)]).unwrap();
         let inf_str = match &inf_f {
-            Value::Text(t) => t.as_str().to_string(),
+            Value::Text(t) => t.to_str_lossy().into_owned(),
             _ => panic!("expected text"),
         };
         assert!(inf_str.starts_with("9000"));
@@ -1843,7 +1846,7 @@ mod tests {
         // ! flag with %f infinity: strips trailing fractional zeros
         let inf_bang_f = exec_printf(&[text("%!0f"), float(f64::INFINITY)]).unwrap();
         let inf_bang_str = match &inf_bang_f {
-            Value::Text(t) => t.as_str().to_string(),
+            Value::Text(t) => t.to_str_lossy().into_owned(),
             _ => panic!("expected text"),
         };
         assert!(

--- a/core/functions/string.rs
+++ b/core/functions/string.rs
@@ -12,7 +12,7 @@ use crate::types::Value;
 pub fn exec_repeat(input: &Value, count: &Value) -> Value {
     let s = match input {
         Value::Null => return Value::Null,
-        Value::Text(t) => t.as_str().to_owned(),
+        Value::Text(t) => t.to_str_lossy().into_owned(),
         v => v.to_string(),
     };
     let n = match count {
@@ -22,7 +22,7 @@ pub fn exec_repeat(input: &Value, count: &Value) -> Value {
             let f: f64 = (*f).into();
             f as i64
         }
-        Value::Text(t) => t.as_str().parse::<i64>().unwrap_or(0),
+        Value::Text(t) => t.to_str_lossy().parse::<i64>().unwrap_or(0),
         _ => return Value::Null,
     };
     if n <= 0 {
@@ -51,7 +51,7 @@ pub fn exec_rpad(input: &Value, length: &Value, fill: Option<&Value>) -> Value {
 fn pad(input: &Value, length: &Value, fill: Option<&Value>, on_left: bool) -> Value {
     let s = match input {
         Value::Null => return Value::Null,
-        Value::Text(t) => t.as_str().to_owned(),
+        Value::Text(t) => t.to_str_lossy().into_owned(),
         v => v.to_string(),
     };
     let target_len = match length {
@@ -61,7 +61,7 @@ fn pad(input: &Value, length: &Value, fill: Option<&Value>, on_left: bool) -> Va
             let f: f64 = (*f).into();
             f as i64
         }
-        Value::Text(t) => t.as_str().parse::<i64>().unwrap_or(0),
+        Value::Text(t) => t.to_str_lossy().parse::<i64>().unwrap_or(0),
         _ => return Value::Null,
     };
     if target_len <= 0 {
@@ -78,7 +78,7 @@ fn pad(input: &Value, length: &Value, fill: Option<&Value>, on_left: bool) -> Va
     let fill_str = match fill {
         None => " ".to_string(),
         Some(Value::Null) => return Value::Null,
-        Some(Value::Text(t)) => t.as_str().to_owned(),
+        Some(Value::Text(t)) => t.to_str_lossy().into_owned(),
         Some(v) => v.to_string(),
     };
     let fill_chars: Vec<char> = fill_str.chars().collect();

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -3108,9 +3108,9 @@ mod tests {
             if let (Value::Text(name), Value::Numeric(Numeric::Float(sum))) =
                 (&row.values[0], &row.values[1])
             {
-                if name.as_str() == "Alice" {
+                if name.as_bytes() == b"Alice" {
                     assert_eq!(*sum, 55.0, "Alice should have sum 55");
-                } else if name.as_str() == "Bob" {
+                } else if name.as_bytes() == b"Bob" {
                     assert_eq!(*sum, 20.0, "Bob should have sum 20");
                 }
             }
@@ -3778,7 +3778,7 @@ mod tests {
             .iter()
             .map(|(row, _)| {
                 if let Value::Text(name) = &row.values[1] {
-                    name.as_str().to_string()
+                    name.to_str_lossy().into_owned()
                 } else {
                     panic!("Expected text value");
                 }
@@ -5028,7 +5028,7 @@ mod tests {
                 Value::Numeric(Numeric::Float(total)),
             ) = (&row.values[0], &row.values[1], &row.values[2])
             {
-                let key = format!("{}-{}", name.as_ref(), product.as_ref());
+                let key = format!("{}-{}", name.to_str_lossy(), product.to_str_lossy());
                 found_results.insert(key.clone());
 
                 match key.as_str() {
@@ -5626,10 +5626,10 @@ mod tests {
 
             // Check the aggregated values
             if let Value::Text(name) = &row.values[0] {
-                if name.as_ref() == "Alice" {
+                if name.as_bytes() == b"Alice" {
                     // Alice should have total quantity of 8 (5 + 3)
                     assert_eq!(row.values[1], Value::from_i64(8));
-                } else if name.as_ref() == "Bob" {
+                } else if name.as_bytes() == b"Bob" {
                     // Bob should have total quantity of 7
                     assert_eq!(row.values[1], Value::from_i64(7));
                 }

--- a/core/incremental/dbsp.rs
+++ b/core/incremental/dbsp.rs
@@ -60,7 +60,7 @@ impl Hash128 {
                 }
                 Value::Text(t) => {
                     s.push_str("T:");
-                    s.push_str(t.as_str());
+                    s.push_str(&t.to_str_lossy());
                 }
                 Value::Blob(b) => {
                     s.push_str("B:");

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -593,9 +593,9 @@ mod tests {
         for (row, weight) in &state.changes {
             assert_eq!(*weight, 1);
             if let Value::Text(team) = &row.values[0] {
-                if team.as_str() == "red" {
+                if team.as_bytes() == b"red" {
                     red_sum = Some(&row.values[1]);
-                } else if team.as_str() == "blue" {
+                } else if team.as_bytes() == b"blue" {
                     blue_sum = Some(&row.values[1]);
                 }
             }
@@ -645,7 +645,7 @@ mod tests {
 
         for (row, weight) in &output_delta.changes {
             if let Value::Text(team) = &row.values[0] {
-                assert_eq!(team.as_str(), "red", "Only red team should have changes");
+                assert_eq!(team.as_bytes(), b"red", "Only red team should have changes");
 
                 if *weight == -1 {
                     // Retraction of old value
@@ -3714,7 +3714,7 @@ mod tests {
 
             // Extract name (column 1 from left) and quantity (column 3 from right)
             let name = match &row.values[1] {
-                Value::Text(t) => t.as_str().to_string(),
+                Value::Text(t) => t.to_str_lossy().into_owned(),
                 _ => panic!("Expected text value for name"),
             };
             let quantity = match &row.values[4] {
@@ -4546,7 +4546,7 @@ mod tests {
             .iter()
             .map(|(row, _)| {
                 let category = match &row.values[0] {
-                    Value::Text(s) => s.value.clone().into_owned(),
+                    Value::Text(s) => s.to_str_lossy().into_owned(),
                     _ => panic!("Expected text for category"),
                 };
                 let value = match &row.values[1] {

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -784,7 +784,9 @@ impl HybridBTreeDirectory {
 
             // Extract and validate
             let found_path = record.get_value_opt(0).and_then(|v| match v {
-                crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
+                crate::types::ValueRef::Text(t) => {
+                    Some(String::from_utf8_lossy(t.value).into_owned())
+                }
                 _ => None,
             });
             let found_chunk = record.get_value_opt(1).and_then(|v| match v {
@@ -2083,7 +2085,9 @@ impl FtsCursor {
                     let record = return_if_io!(cursor.record());
                     let current_path = record.as_ref().and_then(|r| {
                         r.get_value_opt(0).and_then(|v| match v {
-                            crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
+                            crate::types::ValueRef::Text(t) => {
+                                Some(String::from_utf8_lossy(t.value).into_owned())
+                            }
                             _ => None,
                         })
                     });
@@ -2309,7 +2313,7 @@ impl FtsCursor {
                     let record = return_if_io!(cursor.record());
                     let matches = if let Some(record) = record {
                         match record.get_value_opt(0) {
-                            Some(crate::types::ValueRef::Text(t)) => t.value == path_str,
+                            Some(crate::types::ValueRef::Text(t)) => t.value == path_str.as_bytes(),
                             _ => false,
                         }
                     } else {
@@ -2752,7 +2756,9 @@ impl IndexMethodCursor for FtsCursor {
                     let record = return_if_io!(cursor.record());
                     if let Some(record) = record {
                         let path_str = record.get_value_opt(0).and_then(|v| match v {
-                            crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
+                            crate::types::ValueRef::Text(t) => {
+                                Some(String::from_utf8_lossy(t.value).into_owned())
+                            }
                             _ => None,
                         });
                         let chunk_no = record.get_value_opt(1).and_then(|v| match v {
@@ -3024,7 +3030,7 @@ impl IndexMethodCursor for FtsCursor {
         for ((_col, field), reg) in self.text_fields.iter().zip(&values[..values.len() - 1]) {
             match reg {
                 Register::Value(Value::Text(t)) => {
-                    doc.add_text(*field, t.as_str());
+                    doc.add_text(*field, &*t.to_str_lossy());
                 }
                 Register::Value(Value::Null) => continue,
                 _ => continue,
@@ -3102,7 +3108,7 @@ impl IndexMethodCursor for FtsCursor {
 
         // values[1] = query string
         let query_str = match &values[1] {
-            Register::Value(Value::Text(t)) => t.as_str().to_string(),
+            Register::Value(Value::Text(t)) => t.to_str_lossy().into_owned(),
             _ => return Err(LimboError::InternalError("FTS query must be text".into())),
         };
 

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -367,10 +367,10 @@ impl VectorSparseInvertedIndexMethodCursor {
             _ => 1.0,
         };
         let scan_order = match configuration.parameters.get("scan_order") {
-            Some(Value::Text(scan_order)) if scan_order.as_str() == "dataset_frequency_asc" => {
+            Some(Value::Text(scan_order)) if scan_order.as_bytes() == b"dataset_frequency_asc" => {
                 ScanOrder::DatasetFrequencyAsc
             }
-            Some(Value::Text(scan_order)) if scan_order.as_str() == "query_weight_desc" => {
+            Some(Value::Text(scan_order)) if scan_order.as_bytes() == b"query_weight_desc" => {
                 ScanOrder::QueryWeightDesc
             }
             _ => ScanOrder::QueryWeightDesc,

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -130,12 +130,13 @@ fn is_jsonb_blob(slice: &[u8]) -> bool {
 pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Result<Jsonb> {
     match val {
         ValueRef::Text(text) => {
+            let text_str = text.to_str_lossy();
             let res = if text.subtype == TextSubtype::Json || matches!(strict, Conv::Strict) {
-                Jsonb::from_str_with_mode(&text, strict)
+                Jsonb::from_str_with_mode(&text_str, strict)
             } else {
                 // Handle as a string literal otherwise
                 // Escape backslashes first, then double quotes
-                let mut str = text.replace('\\', "\\\\").replace('"', "\\\"");
+                let mut str = text_str.replace('\\', "\\\\").replace('"', "\\\"");
                 // Quote the string to make it a JSON string
                 str.insert(0, '"');
                 str.push('"');
@@ -687,20 +688,28 @@ fn json_path_from_db_value<'a>(
     let path = path.as_value_ref();
     let json_path = if strict {
         match path {
-            ValueRef::Text(t) => json_path(t.as_str())?,
+            ValueRef::Text(t) => {
+                let Ok(s) = std::str::from_utf8(t.value) else {
+                    crate::bail_constraint_error!("JSON path error near: {:?}", path.to_string());
+                };
+                json_path(s)?
+            }
             ValueRef::Null => return Ok(None),
             _ => crate::bail_constraint_error!("JSON path error near: {:?}", path.to_string()),
         }
     } else {
         match path {
             ValueRef::Text(t) => {
-                if t.as_str().starts_with("$") {
-                    json_path(t.as_str())?
+                let Ok(s) = std::str::from_utf8(t.value) else {
+                    crate::bail_constraint_error!("JSON path error near: {:?}", path.to_string());
+                };
+                if s.starts_with("$") {
+                    json_path(s)?
                 } else {
                     JsonPath {
                         elements: vec![
                             PathElement::Root(),
-                            PathElement::Key(Cow::Borrowed(t.as_str()), false),
+                            PathElement::Key(Cow::Borrowed(s), false),
                         ],
                     }
                 }
@@ -727,7 +736,7 @@ fn json_path_from_db_value<'a>(
 
 pub fn json_error_position(json: impl AsValueRef) -> crate::Result<Value> {
     match json.as_value_ref() {
-        ValueRef::Text(t) => match Jsonb::from_str(t.as_str()) {
+        ValueRef::Text(t) => match Jsonb::from_str(&t.to_str_lossy()) {
             Ok(_) => Ok(Value::from_i64(0)),
             Err(JsonError::Message { location, .. }) => {
                 if let Some(loc) = location {
@@ -871,7 +880,7 @@ pub fn json_quote(value: impl AsValueRef) -> crate::Result<Value> {
             let mut escaped_value = String::with_capacity(t.value.len() + 4);
             escaped_value.push('"');
 
-            for c in t.as_str().chars() {
+            for c in t.to_str_lossy().chars() {
                 match c {
                     '"' | '\\' | '\n' | '\r' | '\t' | '\u{0008}' | '\u{000c}' => {
                         escaped_value.push('\\');
@@ -908,7 +917,7 @@ mod tests {
         let input = Value::build_text("{ key: 'value' }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("\"key\":\"value\""));
+            assert!(result_str.to_str_lossy().contains("\"key\":\"value\""));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -920,7 +929,7 @@ mod tests {
         let input = Value::build_text("{ \"key\": Infinity }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("{\"key\":9e999}"));
+            assert!(result_str.to_str_lossy().contains("{\"key\":9e999}"));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -932,7 +941,7 @@ mod tests {
         let input = Value::build_text("{ \"key\": -Infinity }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("{\"key\":-9e999}"));
+            assert!(result_str.to_str_lossy().contains("{\"key\":-9e999}"));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -944,7 +953,7 @@ mod tests {
         let input = Value::build_text("{ \"key\": NaN }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("{\"key\":null}"));
+            assert!(result_str.to_str_lossy().contains("{\"key\":null}"));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -966,7 +975,7 @@ mod tests {
         let input = Value::build_text("{\"key\":\"value\"}");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("\"key\":\"value\""));
+            assert!(result_str.to_str_lossy().contains("\"key\":\"value\""));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -989,7 +998,7 @@ mod tests {
         let input = Value::Blob(binary_json);
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains(r#"{"hey":"yo"}"#));
+            assert!(result_str.to_str_lossy().contains(r#"{"hey":"yo"}"#));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1027,7 +1036,7 @@ mod tests {
 
         let result = json_array(&input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "[\"value1\",\"value2\",1,1.1]");
+            assert_eq!(res.to_str_lossy(), "[\"value1\",\"value2\",1,1.1]");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1042,7 +1051,7 @@ mod tests {
 
         let result = json_array(&input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "[1,9.0e+999,-9.0e+999]");
+            assert_eq!(res.to_str_lossy(), "[1,9.0e+999,-9.0e+999]");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1057,7 +1066,7 @@ mod tests {
 
         let result = json_object(&input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), r#"{"k":9.0e+999}"#);
+            assert_eq!(res.to_str_lossy(), r#"{"k":9.0e+999}"#);
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1072,7 +1081,7 @@ mod tests {
 
         let result = json_object(&input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), r#"{"k":-9.0e+999}"#);
+            assert_eq!(res.to_str_lossy(), r#"{"k":-9.0e+999}"#);
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1084,7 +1093,7 @@ mod tests {
         let infinity = Value::from_f64(f64::INFINITY);
         let result = get_json(&infinity, None).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "9e999");
+            assert_eq!(res.to_str_lossy(), "9e999");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text, got {result:?}");
@@ -1096,7 +1105,7 @@ mod tests {
         let neg_infinity = Value::from_f64(f64::NEG_INFINITY);
         let result = get_json(&neg_infinity, None).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "-9e999");
+            assert_eq!(res.to_str_lossy(), "-9e999");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text, got {result:?}");
@@ -1109,7 +1118,7 @@ mod tests {
 
         let result = json_array(input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "[]");
+            assert_eq!(res.to_str_lossy(), "[]");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1347,7 +1356,7 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"key":"value"}"#);
+        assert_eq!(json_text.to_str_lossy(), r#"{"key":"value"}"#);
     }
 
     #[test]
@@ -1381,7 +1390,7 @@ mod tests {
             panic!("Expected Value::Text");
         };
         assert_eq!(
-            json_text.as_str(),
+            json_text.to_str_lossy(),
             r#"{"text_key":"text_value","json_key":{"json":"value","number":1},"integer_key":1,"float_key":1.1,"null_key":null}"#
         );
     }
@@ -1396,7 +1405,7 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"key":{"json":"value"}}"#);
+        assert_eq!(json_text.to_str_lossy(), r#"{"key":{"json":"value"}}"#);
     }
 
     #[test]
@@ -1409,7 +1418,10 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"key":"{\"json\":\"value\"}"}"#);
+        assert_eq!(
+            json_text.to_str_lossy(),
+            r#"{"key":"{\"json\":\"value\"}"}"#
+        );
     }
 
     #[test]
@@ -1427,7 +1439,10 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"parent_key":{"key":"value"}}"#);
+        assert_eq!(
+            json_text.to_str_lossy(),
+            r#"{"parent_key":{"key":"value"}}"#
+        );
     }
 
     #[test]
@@ -1440,7 +1455,7 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"key":"value","key":"value"}"#);
+        assert_eq!(json_text.to_str_lossy(), r#"{"key":"value","key":"value"}"#);
     }
 
     #[test]
@@ -1451,7 +1466,7 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{}"#);
+        assert_eq!(json_text.to_str_lossy(), r#"{}"#);
     }
 
     #[test]
@@ -1499,7 +1514,7 @@ mod tests {
                 panic!("Expected Value::Text");
             };
             assert_eq!(
-                json_text.as_str(),
+                json_text.to_str_lossy(),
                 expected,
                 "Failed for key={key:?}, value={value:?}"
             );
@@ -1647,7 +1662,10 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_eq!(result.unwrap().to_text().unwrap(), r#"{"field":"value"}"#);
+        assert_eq!(
+            result.unwrap().to_text_str_lossy().unwrap(),
+            r#"{"field":"value"}"#
+        );
     }
 
     #[test]
@@ -1665,7 +1683,7 @@ mod tests {
         assert!(result.is_ok());
 
         assert_eq!(
-            result.unwrap().to_text().unwrap(),
+            result.unwrap().to_text_str_lossy().unwrap(),
             r#"{"field":"new_value"}"#
         );
     }
@@ -1685,7 +1703,7 @@ mod tests {
         assert!(result.is_ok());
 
         assert_eq!(
-            result.unwrap().to_text().unwrap(),
+            result.unwrap().to_text_str_lossy().unwrap(),
             r#"{"object":{"doesnt":{"exist":"value"}}}"#
         );
     }
@@ -1704,7 +1722,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_eq!(result.unwrap().to_text().unwrap(), r#"["value"]"#);
+        assert_eq!(result.unwrap().to_text_str_lossy().unwrap(), r#"["value"]"#);
     }
 
     #[test]
@@ -1722,7 +1740,7 @@ mod tests {
         assert!(result.is_ok());
 
         assert_eq!(
-            result.unwrap().to_text().unwrap(),
+            result.unwrap().to_text_str_lossy().unwrap(),
             r#"{"some_array":[123]}"#
         );
     }
@@ -1741,7 +1759,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_eq!(result.unwrap().to_text().unwrap(), "[123,456]");
+        assert_eq!(result.unwrap().to_text_str_lossy().unwrap(), "[123,456]");
     }
 
     #[test]
@@ -1758,7 +1776,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_eq!(result.unwrap().to_text().unwrap(), "[123]");
+        assert_eq!(result.unwrap().to_text_str_lossy().unwrap(), "[123]");
     }
 
     #[test]
@@ -1775,7 +1793,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_eq!(result.unwrap().to_text().unwrap(), "[456]");
+        assert_eq!(result.unwrap().to_text_str_lossy().unwrap(), "[456]");
     }
 
     #[test]
@@ -1788,7 +1806,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_eq!(result.unwrap().to_text().unwrap(), "{}");
+        assert_eq!(result.unwrap().to_text_str_lossy().unwrap(), "{}");
     }
 
     #[test]
@@ -1807,7 +1825,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_eq!(result.unwrap().to_text().unwrap(), "[456,789]");
+        assert_eq!(result.unwrap().to_text_str_lossy().unwrap(), "[456,789]");
     }
 
     #[test]
@@ -1825,7 +1843,7 @@ mod tests {
         assert!(result.is_ok());
 
         assert_eq!(
-            result.unwrap().to_text().unwrap(),
+            result.unwrap().to_text_str_lossy().unwrap(),
             r#"{"object":[{"field":123}]}"#
         );
     }
@@ -1844,7 +1862,10 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_eq!(result.unwrap().to_text().unwrap(), r#"{"object":[[123]]}"#);
+        assert_eq!(
+            result.unwrap().to_text_str_lossy().unwrap(),
+            r#"{"object":[[123]]}"#
+        );
     }
 
     #[test]
@@ -1863,7 +1884,10 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_eq!(result.unwrap().to_text().unwrap(), r#"{"field":"value"}"#,);
+        assert_eq!(
+            result.unwrap().to_text_str_lossy().unwrap(),
+            r#"{"field":"value"}"#,
+        );
     }
 
     #[test]

--- a/core/json/ops.rs
+++ b/core/json/ops.rs
@@ -28,7 +28,7 @@ pub fn json_patch(
         // Explicit handling for the case json_path('{}', 'null') case. If the patch value is
         // the text null, the result will also be the text null. No extra parsing required.
         (_, ValueRef::Text(t)) => {
-            if t.value == "null" {
+            if t.value == b"null" {
                 return Ok(Value::Text(Text::new("null")));
             }
         }
@@ -103,7 +103,7 @@ where
     let mut json = json_cache.get_or_insert_with(first_arg, make_jsonb_fn)?;
     for arg in args {
         if let ValueRef::Text(s) = arg.as_value_ref() {
-            if s.as_str() == "$" {
+            if s.value == b"$" {
                 return Ok(Value::Null);
             }
         }
@@ -136,7 +136,7 @@ where
     let mut json = json_cache.get_or_insert_with(first_arg, make_jsonb_fn)?;
     for arg in args {
         if let ValueRef::Text(s) = arg.as_value_ref() {
-            if s.as_str() == "$" {
+            if s.value == b"$" {
                 return Ok(Value::Null);
             }
         }
@@ -432,7 +432,7 @@ mod tests {
         let json_cache = JsonCacheCell::new();
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
-            Value::Text(t) => assert_eq!(t.as_str(), "[1,2,4,5]"),
+            Value::Text(t) => assert_eq!(t.to_str_lossy(), "[1,2,4,5]"),
             _ => panic!("Expected Text value"),
         }
     }
@@ -448,7 +448,7 @@ mod tests {
         let json_cache = JsonCacheCell::new();
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
-            Value::Text(t) => assert_eq!(t.as_str(), r#"{"b":2}"#),
+            Value::Text(t) => assert_eq!(t.to_str_lossy(), r#"{"b":2}"#),
             _ => panic!("Expected Text value"),
         }
     }
@@ -463,7 +463,7 @@ mod tests {
         let json_cache = JsonCacheCell::new();
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
-            Value::Text(t) => assert_eq!(t.as_str(), r#"{"a":{"b":{"d":2}}}"#),
+            Value::Text(t) => assert_eq!(t.to_str_lossy(), r#"{"a":{"b":{"d":2}}}"#),
             _ => panic!("Expected Text value"),
         }
     }
@@ -478,7 +478,7 @@ mod tests {
         let json_cache = JsonCacheCell::new();
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
-            Value::Text(t) => assert_eq!(t.as_str(), r#"{"a":2,"a":3}"#),
+            Value::Text(t) => assert_eq!(t.to_str_lossy(), r#"{"a":2,"a":3}"#),
             _ => panic!("Expected Text value"),
         }
     }
@@ -507,7 +507,7 @@ mod tests {
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
             Value::Text(t) => {
-                let value = t.as_str();
+                let value = t.to_str_lossy();
                 assert!(value.contains(r#"[1,3]"#));
                 assert!(value.contains(r#"{"x":2}"#));
             }

--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -258,13 +258,7 @@ impl InternalVirtualTableCursor for JsonEachCursor {
         }
         if args.len() == 2 && matches!(self.traversal_mode, JsonTraversalMode::Tree) {
             if let Value::Text(ref text) = args[1] {
-                if !text.value.is_empty()
-                    && text
-                        .value
-                        .as_bytes()
-                        .windows(3)
-                        .any(|chars| chars == b"[#-")
-                {
+                if !text.value.is_empty() && text.value.windows(3).any(|chars| chars == b"[#-") {
                     return Err(LimboError::InvalidArgument(
                         "Json paths with negative indices in json_tree are not supported yet"
                             .to_owned(),
@@ -284,12 +278,15 @@ impl InternalVirtualTableCursor for JsonEachCursor {
                     "root path should be text".to_owned(),
                 ));
             };
+            let path = std::str::from_utf8(&path.value).map_err(|_| {
+                LimboError::InvalidArgument("root path should be valid UTF-8".to_owned())
+            })?;
             let root_json = if let Some(json) = navigate_to_path(&mut jsonb, &args[1])? {
                 json
             } else {
                 return Ok(false);
             };
-            (path.as_str(), root_json)
+            (path, root_json)
         };
 
         self.json = root_json;

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -369,9 +369,9 @@ pub fn sqlite_schema_btree_identity(version: &RowVersion) -> Option<SqliteSchema
     };
 
     let kind = match col0 {
-        ValueRef::Text(type_str) => match type_str.as_str() {
-            "table" => SqliteSchemaBtreeKind::Table,
-            "index" => SqliteSchemaBtreeKind::Index,
+        ValueRef::Text(type_str) => match type_str.as_bytes() {
+            b"table" => SqliteSchemaBtreeKind::Table,
+            b"index" => SqliteSchemaBtreeKind::Index,
             _ => return None,
         },
         _ => panic!("sqlite_schema.type column must be TEXT, got {col0:?}"),

--- a/core/mvcc/database/hermitage_tests.rs
+++ b/core/mvcc/database/hermitage_tests.rs
@@ -41,7 +41,7 @@ impl FromValue for i64 {
 
 impl FromValue for String {
     fn from_value(v: &Value) -> Self {
-        v.to_text().unwrap().to_string()
+        String::from_utf8_lossy(v.to_text().unwrap()).into_owned()
     }
 }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -7952,7 +7952,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                         "sqlite_schema type must be text".to_string(),
                                     ));
                                 };
-                                let row_type = row_type.as_str();
+                                let row_type = row_type.as_bytes();
                                 let val = match record.get_value_opt(3) {
                                     Some(v) => v,
                                     None => {
@@ -7968,25 +7968,23 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     panic!("Expected integer value for root page, got {val:?}");
                                 };
                                 let sql = match record.get_value_opt(4) {
-                                    Some(ValueRef::Text(v)) => Some(v.as_str()),
+                                    Some(ValueRef::Text(v)) => Some(v.as_bytes()),
                                     _ => None,
                                 };
-                                let is_virtual_table = row_type == "table"
+                                let is_virtual_table = row_type == b"table"
                                     && sql.is_some_and(|sql| {
-                                        contains_ignore_ascii_case!(
-                                            sql.as_bytes(),
-                                            b"create virtual"
-                                        )
+                                        contains_ignore_ascii_case!(sql, b"create virtual")
                                     });
                                 let has_btree = match row_type {
-                                    "index" => true,
-                                    "table" => !is_virtual_table,
+                                    b"index" => true,
+                                    b"table" => !is_virtual_table,
                                     _ => false,
                                 };
                                 if has_btree {
                                     if root_page == 0 {
                                         return Err(LimboError::Corrupt(format!(
-                                            "sqlite_schema root_page=0 for btree {row_type}"
+                                            "sqlite_schema root_page=0 for btree {}",
+                                            String::from_utf8_lossy(row_type)
                                         )));
                                     }
                                     if root_page < 0 {
@@ -8019,7 +8017,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     }
                                 } else if root_page != 0 {
                                     return Err(LimboError::Corrupt(format!(
-                                        "sqlite_schema root_page must be 0 for {row_type}, got {root_page}"
+                                        "sqlite_schema root_page must be 0 for {}, got {root_page}",
+                                        String::from_utf8_lossy(row_type)
                                     )));
                                 }
                                 let rowid_int = rowid.row_id.to_int_or_panic();
@@ -8165,8 +8164,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                             .to_string(),
                                     ));
                                 };
-                                let row_type = row_type.as_str();
-                                if (row_type == "table" || row_type == "index") && root_page > 0 {
+                                let row_type = row_type.as_bytes();
+                                if (row_type == b"table" || row_type == b"index") && root_page > 0 {
                                     dropped_root_pages.insert(root_page);
                                 }
                                 schema_rows.remove(&rowid_int);
@@ -8312,7 +8311,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         for rowid in &sorted_rowids {
             let record = &schema_rows[rowid];
             let ty = match record.get_value_opt(0) {
-                Some(ValueRef::Text(v)) => v.as_str(),
+                Some(ValueRef::Text(v)) => v.to_str_lossy(),
                 _ => {
                     return Err(LimboError::Corrupt(
                         "sqlite_schema type must be text".to_string(),
@@ -8320,7 +8319,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 }
             };
             let name = match record.get_value_opt(1) {
-                Some(ValueRef::Text(v)) => v.as_str(),
+                Some(ValueRef::Text(v)) => v.to_str_lossy(),
                 _ => {
                     return Err(LimboError::Corrupt(
                         "sqlite_schema name must be text".to_string(),
@@ -8328,7 +8327,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 }
             };
             let table_name = match record.get_value_opt(2) {
-                Some(ValueRef::Text(v)) => v.as_str(),
+                Some(ValueRef::Text(v)) => v.to_str_lossy(),
                 _ => {
                     return Err(LimboError::Corrupt(
                         "sqlite_schema tbl_name must be text".to_string(),
@@ -8344,7 +8343,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 }
             };
             let sql = match record.get_value_opt(4) {
-                Some(ValueRef::Text(v)) => Some(v.as_str()),
+                Some(ValueRef::Text(v)) => Some(v.to_str_lossy()),
                 _ => None,
             };
             let attached_resolver = |alias: &str| -> Option<usize> {
@@ -8355,11 +8354,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     .map(|(idx, _)| idx)
             };
             fresh.handle_schema_row(
-                ty,
-                name,
-                table_name,
+                &ty,
+                &name,
+                &table_name,
                 root_page,
-                sql,
+                sql.as_deref(),
                 &syms,
                 &mut from_sql_indexes,
                 &mut automatic_indices,

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -988,7 +988,7 @@ fn tamper_db_metadata_row_value(db_path: &str, metadata_root_page: u32, new_valu
     };
     let new_record = ImmutableRecord::from_values(
         &[
-            Value::Text(Text::new(key.as_str().to_string())),
+            Value::Text(Text::from_bytes(key.as_bytes().to_vec())),
             Value::from_i64(new_value),
         ],
         2,
@@ -1016,7 +1016,7 @@ fn tamper_db_metadata_row_value_by_key(
         let ValueRef::Text(key) = key else {
             panic!("metadata key must be text");
         };
-        if key.as_str() != target_key {
+        if key.as_bytes() != target_key.as_bytes() {
             continue;
         }
         let new_record = ImmutableRecord::from_values(
@@ -5427,7 +5427,7 @@ fn test_commit_dep_threaded_abort_cascades() {
     assert_eq!(rows.len(), 1);
     assert_eq!(
         rows[0][0].to_text().unwrap(),
-        "modified",
+        b"modified",
         "reader should have speculatively read the Preparing writer's value"
     );
 
@@ -5445,7 +5445,7 @@ fn test_commit_dep_threaded_abort_cascades() {
         let mut stmt = conn.prepare("SELECT value FROM t WHERE id = 1").unwrap();
         let rows = stmt.run_collect_rows().unwrap();
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0][0].to_text().unwrap(), "initial");
+        assert_eq!(rows[0][0].to_text().unwrap(), b"initial");
 
         // Reader's INSERT must not be visible (cascade-aborted)
         let mut stmt = conn.prepare("SELECT * FROM t WHERE id = 2").unwrap();
@@ -5533,7 +5533,7 @@ fn test_commit_dep_threaded_multiple_dependents_abort() {
     for handle in handles {
         let (rows, commit_result) = handle.join().unwrap();
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0][0].to_text().unwrap(), "modified");
+        assert_eq!(rows[0][0].to_text().unwrap(), b"modified");
         assert!(
             matches!(commit_result, Err(LimboError::CommitDependencyAborted)),
             "expected CommitDependencyAborted, got: {commit_result:?}",
@@ -5646,7 +5646,7 @@ fn test_commit_dep_threaded_commit_resolves() {
 
     // Reader speculatively read the writer's value
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0][0].to_text().unwrap(), "committed");
+    assert_eq!(rows[0][0].to_text().unwrap(), b"committed");
 
     // Reader's COMMIT succeeds: dependency resolved by writer's commit
     assert!(
@@ -5660,8 +5660,8 @@ fn test_commit_dep_threaded_commit_resolves() {
         let mut stmt = conn.prepare("SELECT value FROM t ORDER BY id").unwrap();
         let rows = stmt.run_collect_rows().unwrap();
         assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0][0].to_text().unwrap(), "committed");
-        assert_eq!(rows[1][0].to_text().unwrap(), "reader_data");
+        assert_eq!(rows[0][0].to_text().unwrap(), b"committed");
+        assert_eq!(rows[1][0].to_text().unwrap(), b"reader_data");
     }
 }
 
@@ -5734,7 +5734,7 @@ fn test_commit_dep_threaded_readonly_abort_cascades() {
     let (rows, commit_result) = reader_handle.join().unwrap();
 
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0][0].to_text().unwrap(), "modified");
+    assert_eq!(rows[0][0].to_text().unwrap(), b"modified");
 
     // Read-only tx must still fail when its dependency aborts
     assert!(
@@ -6135,7 +6135,7 @@ fn test_exclusive_tx_does_not_deadlock_behind_preparing_concurrent_commit() {
 
     let rows = get_rows(&conn_a, "SELECT key FROM t ORDER BY key");
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0][0].to_text().unwrap(), "a");
+    assert_eq!(rows[0][0].to_text().unwrap(), b"a");
 
     conn_a.close().unwrap();
     conn_b.close().unwrap();
@@ -6223,7 +6223,7 @@ fn test_restart() {
         let record = get_record_value(&row);
         match record.get_value(0).unwrap() {
             ValueRef::Text(text) => {
-                assert_eq!(text.as_str(), "bar");
+                assert_eq!(text.as_bytes(), b"bar");
             }
             _ => panic!("Expected Text value"),
         }
@@ -6250,7 +6250,7 @@ fn test_connection_sees_other_connection_changes() {
     let mut stmt = conn1.query("SELECT * FROM test_table").unwrap().unwrap();
     stmt.run_with_row_callback(|row| {
         let text = row.get_value(1).to_text().unwrap();
-        assert_eq!(text, "text_877");
+        assert_eq!(text, b"text_877");
         Ok(())
     })
     .unwrap();
@@ -12877,7 +12877,7 @@ fn test_mvcc_encrypted_log_recovery_and_wrong_key() {
             .unwrap();
         let record = get_record_value(&row);
         match record.get_value(0).unwrap() {
-            ValueRef::Text(text) => assert_eq!(text.as_str(), "encrypted_value"),
+            ValueRef::Text(text) => assert_eq!(text.as_bytes(), b"encrypted_value"),
             other => panic!("Expected Text, got {other:?}"),
         }
         conn.close().unwrap();

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -4461,7 +4461,7 @@ mod tests {
         let ValueRef::Text(foo) = foo else {
             unreachable!()
         };
-        assert_eq!(foo.as_str(), "foo");
+        assert_eq!(foo.as_bytes(), b"foo");
     }
 
     /// What this test checks: A long sequence of committed frames is replayed in order without dropping or reordering transactions.
@@ -4541,7 +4541,7 @@ mod tests {
             let ValueRef::Text(foo) = foo else {
                 unreachable!()
             };
-            assert_eq!(foo.as_str(), value.as_str());
+            assert_eq!(foo.as_bytes(), value.as_bytes());
         }
     }
 
@@ -4664,8 +4664,8 @@ mod tests {
             };
 
             assert_eq!(
-                foo.as_str(),
-                format!("row_{}", present_rowid.row_id.to_int_or_panic())
+                foo.as_bytes(),
+                format!("row_{}", present_rowid.row_id.to_int_or_panic()).as_bytes()
             );
         }
 
@@ -4743,7 +4743,7 @@ mod tests {
             let ValueRef::Text(data_text) = data_value else {
                 panic!("Data column should be text");
             };
-            assert_eq!(data_text.as_str(), expected_data);
+            assert_eq!(data_text.as_bytes(), expected_data.as_bytes());
         }
 
         // Verify index rows can be read
@@ -4791,7 +4791,11 @@ mod tests {
             let ValueRef::Text(index_data) = values[0] else {
                 panic!("First index column should be text");
             };
-            assert_eq!(index_data.as_str(), data_value, "Index data should match");
+            assert_eq!(
+                index_data.as_bytes(),
+                data_value.as_bytes(),
+                "Index data should match"
+            );
             let ValueRef::Numeric(crate::numeric::Numeric::Integer(index_rowid_val)) = values[1]
             else {
                 panic!("Second index column should be integer (rowid)");

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -82,7 +82,7 @@ pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<Por
 
     let text = |value: ValueRef<'_>, field: &str| -> Result<String> {
         match value {
-            ValueRef::Text(text) => Ok(text.as_str().to_string()),
+            ValueRef::Text(text) => Ok(text.to_str_lossy().into_owned()),
             other => Err(LimboError::Corrupt(format!(
                 "{field} must be text in sqlite_schema record, got {other:?}"
             ))),

--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -53,7 +53,7 @@ impl Numeric {
         match value {
             ValueRef::Null => None,
             ValueRef::Numeric(v) => Some(v),
-            ValueRef::Text(text) => Some(Numeric::from(text.as_str())),
+            ValueRef::Text(text) => Some(Numeric::from(text.to_str_lossy())),
             ValueRef::Blob(blob) => {
                 let text = String::from_utf8_lossy(blob);
                 Some(Numeric::from(&text))
@@ -67,14 +67,14 @@ impl Numeric {
             Value::Null | Value::Blob(_) => None,
             Value::Numeric(n) => Some(*n),
             Value::Text(text) => {
-                let s = text.as_str();
+                let s = text.to_str_lossy();
 
-                match str_to_f64(s) {
+                match str_to_f64(&s) {
                     None
                     | Some(StrToF64::FractionalPrefix(_))
                     | Some(StrToF64::DecimalPrefix(_)) => None,
                     Some(StrToF64::Fractional(value)) => Some(Self::Float(value)),
-                    Some(StrToF64::Decimal(real)) => Some(match str_to_i64_checked(s) {
+                    Some(StrToF64::Decimal(real)) => Some(match str_to_i64_checked(&s) {
                         Ok(integer) => Self::Integer(integer),
                         Err(_) => Self::Float(real),
                     }),
@@ -212,7 +212,7 @@ impl From<&Value> for Option<Numeric> {
         match value {
             Value::Null => None,
             Value::Numeric(n) => Some(*n),
-            Value::Text(text) => Some(Numeric::from(text.as_str())),
+            Value::Text(text) => Some(Numeric::from(text.to_str_lossy())),
             Value::Blob(blob) => {
                 let text = String::from_utf8_lossy(blob.as_slice());
                 Some(Numeric::from(&text))
@@ -335,7 +335,7 @@ impl From<&Value> for NullableInteger {
             Value::Null => Self::Null,
             Value::Numeric(Numeric::Integer(v)) => Self::Integer(*v),
             Value::Numeric(Numeric::Float(v)) => Self::Integer(f64::from(*v) as i64),
-            Value::Text(text) => Self::from(text.as_str()),
+            Value::Text(text) => Self::from(text.to_str_lossy()),
             Value::Blob(blob) => {
                 let text = String::from_utf8_lossy(blob.as_slice());
                 Self::from(text)

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -426,7 +426,7 @@ impl PragmaVirtualTableCursor {
             )));
         }
 
-        let to_text = |v: &Value| v.to_text().map(str::to_owned);
+        let to_text = |v: &Value| v.to_text_str_lossy().map(|s| s.into_owned());
         let (arg, schema) = match args.as_slice() {
             [arg0] if self.has_pragma_arg => (to_text(arg0), None),
             [arg0] => (None, to_text(arg0)),

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1624,7 +1624,7 @@ impl Schema {
                         ValueRef::Text(sql) => Some(sql),
                         _ => None,
                     };
-                    let sql = sql_textref.map(|s| s.as_str());
+                    let sql = sql_textref.map(|s| s.to_str_lossy());
 
                     let acc = state
                         .accumulators
@@ -1636,11 +1636,11 @@ impl Schema {
                     // maps to `Some(INVALID_DB_ID)` until a connection-scoped
                     // reparse runs with a real resolver.
                     self.handle_schema_row(
-                        &ty,
-                        &name,
-                        &table_name,
+                        &ty.to_str_lossy(),
+                        &name.to_str_lossy(),
+                        &table_name.to_str_lossy(),
                         root_page,
-                        sql,
+                        sql.as_deref(),
                         syms,
                         &mut acc.from_sql_indexes,
                         &mut acc.automatic_indices,

--- a/core/stats.rs
+++ b/core/stats.rs
@@ -222,11 +222,11 @@ fn load_sqlite_stat1_row(
 
     let idx_name = match idx_value {
         Value::Null => None,
-        Value::Text(s) => Some(s.as_str()),
+        Value::Text(s) => Some(s.to_str_lossy()),
         _ => None,
     };
     let stat = match stat_value {
-        Value::Text(s) => s.as_str(),
+        Value::Text(s) => s.to_str_lossy(),
         _ => return Ok(()),
     };
 
@@ -234,7 +234,7 @@ fn load_sqlite_stat1_row(
     if schema.get_btree_table(table_name).is_none() {
         return Ok(());
     }
-    let Some(numbers) = parse_stat_numbers(stat) else {
+    let Some(numbers) = parse_stat_numbers(&stat) else {
         return Ok(());
     };
     if numbers.is_empty() {
@@ -248,7 +248,7 @@ fn load_sqlite_stat1_row(
     }
 
     // Index-level entry: only keep if the index exists on this table.
-    let idx_name = normalize_ident(idx_name.unwrap());
+    let idx_name = normalize_ident(&idx_name.unwrap());
     if schema.get_index(table_name, &idx_name).is_none() {
         return Ok(());
     }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1088,10 +1088,11 @@ pub fn read_value<'a>(buf: &'a [u8], serial_type: SerialType) -> Result<(ValueRe
                     content_size
                 ))
             })?;
-            // SAFETY: SerialTypeKind is Text so this buffer is a valid string
-            let val = unsafe { std::str::from_utf8_unchecked(data) };
+            // TEXT is stored as raw bytes; it is not required to be valid UTF-8
+            // (SQLite permits e.g. CAST(X'FF' AS TEXT)). Codepoint semantics are
+            // applied lazily by the consumer via TextRef::to_str_lossy.
             Ok((
-                ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
+                ValueRef::Text(TextRef::new(data, TextSubtype::Text)),
                 content_size,
             ))
         }
@@ -1216,10 +1217,10 @@ pub fn read_value_serial_type<'a>(
                         content_size
                     ))
                 })?;
-                // SAFETY: SerialTypeKind is Text so this buffer is a valid string
-                let val = unsafe { std::str::from_utf8_unchecked(data) };
+                // TEXT is stored as raw bytes; see read_value for why it is not
+                // validated as UTF-8 here.
                 Ok((
-                    ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
+                    ValueRef::Text(TextRef::new(data, TextSubtype::Text)),
                     content_size,
                 ))
             }

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -149,13 +149,21 @@ impl CollationSeq {
         }
     }
 
+    /// Compare two TEXT payloads. TEXT is stored as raw bytes (not required to be
+    /// valid UTF-8), and SQLite's built-in collations are byte-wise, so these
+    /// operate on bytes directly. Locale collations require Unicode and decode
+    /// lossily.
     #[inline(always)]
-    pub fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
+    pub fn compare_strings(&self, lhs: &[u8], rhs: &[u8]) -> Ordering {
         match *self {
             Self::Unset | Self::Binary => Self::binary_cmp(lhs, rhs),
             Self::NoCase => Self::nocase_cmp(lhs, rhs),
             Self::Rtrim => Self::rtrim_cmp(lhs, rhs),
-            Self::Locale(id) => LocaleCollationRegistry::global().compare(id, lhs, rhs),
+            Self::Locale(id) => LocaleCollationRegistry::global().compare(
+                id,
+                &String::from_utf8_lossy(lhs),
+                &String::from_utf8_lossy(rhs),
+            ),
             // Immutable comparison paths have no connection to fetch the external
             // callback from. Runtime VDBE paths dispatch custom collations via
             // `Connection`; schema/index paths reject them before storage.
@@ -164,13 +172,13 @@ impl CollationSeq {
     }
 
     #[inline(always)]
-    fn binary_cmp(lhs: &str, rhs: &str) -> Ordering {
+    fn binary_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
         lhs.cmp(rhs)
     }
 
     #[inline(always)]
-    fn nocase_cmp(lhs: &str, rhs: &str) -> Ordering {
-        for (left, right) in lhs.bytes().zip(rhs.bytes()) {
+    fn nocase_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        for (left, right) in lhs.iter().copied().zip(rhs.iter().copied()) {
             let left = left.to_ascii_lowercase();
             let right = right.to_ascii_lowercase();
             if left != right {
@@ -184,8 +192,15 @@ impl CollationSeq {
     }
 
     #[inline(always)]
-    fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
-        lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' '))
+    fn rtrim_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        fn trim_trailing_spaces(s: &[u8]) -> &[u8] {
+            let mut end = s.len();
+            while end > 0 && s[end - 1] == b' ' {
+                end -= 1;
+            }
+            &s[..end]
+        }
+        trim_trailing_spaces(lhs).cmp(trim_trailing_spaces(rhs))
     }
 
     pub fn hash_key(&self, text: &str) -> Vec<u8> {
@@ -556,15 +571,15 @@ mod tests {
     fn test_locale_collation_compare() {
         let traditional_spanish = CollationSeq::new("es-u-co-trad").unwrap();
         assert_eq!(
-            traditional_spanish.compare_strings("pollo", "polvo"),
+            traditional_spanish.compare_strings(b"pollo", b"polvo"),
             Ordering::Greater
         );
 
         let upper_first = CollationSeq::new("en-u-kf-upper").unwrap();
-        assert_eq!(upper_first.compare_strings("A", "a"), Ordering::Less);
+        assert_eq!(upper_first.compare_strings(b"A", b"a"), Ordering::Less);
 
         let upper_first_us = CollationSeq::new("en-US-u-kf-upper").unwrap();
-        assert_eq!(upper_first_us.compare_strings("A", "a"), Ordering::Less);
+        assert_eq!(upper_first_us.compare_strings(b"A", b"a"), Ordering::Less);
     }
 
     #[test]

--- a/core/types.rs
+++ b/core/types.rs
@@ -66,69 +66,105 @@ pub enum TextSubtype {
     Json,
 }
 
+/// Reinterpret a borrowed/owned `str` `Cow` as bytes without copying.
+#[inline]
+fn str_cow_into_bytes(value: Cow<'static, str>) -> Cow<'static, [u8]> {
+    match value {
+        Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
+        Cow::Owned(s) => Cow::Owned(s.into_bytes()),
+    }
+}
+
+/// A TEXT value. SQLite does not require TEXT to be valid UTF-8 (e.g.
+/// `CAST(X'FF' AS TEXT)`), and reading a database written by SQLite can surface
+/// such values, so the payload is stored as raw bytes. Codepoint semantics are
+/// applied lazily via [`Text::to_str_lossy`], matching SQLite's lenient decode.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Text {
-    pub value: Cow<'static, str>,
+    pub value: Cow<'static, [u8]>,
     pub subtype: TextSubtype,
 }
 
 impl Display for Text {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
+        write!(f, "{}", self.to_str_lossy())
     }
 }
 
 impl Text {
     pub fn new(value: impl Into<Cow<'static, str>>) -> Self {
         Self {
+            value: str_cow_into_bytes(value.into()),
+            subtype: TextSubtype::Text,
+        }
+    }
+
+    /// Build a TEXT value from raw bytes that are not required to be valid UTF-8.
+    pub fn from_bytes(value: impl Into<Cow<'static, [u8]>>) -> Self {
+        Self {
             value: value.into(),
             subtype: TextSubtype::Text,
         }
     }
+
     #[cfg(feature = "json")]
     pub fn json(value: String) -> Self {
         Self {
-            value: value.into(),
+            value: Cow::Owned(value.into_bytes()),
             subtype: TextSubtype::Json,
         }
     }
 
-    pub fn as_str(&self) -> &str {
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
         &self.value
+    }
+
+    /// Decode the payload as UTF-8, substituting U+FFFD for invalid sequences.
+    /// Borrows when the bytes are already valid UTF-8; allocates only otherwise.
+    #[inline]
+    pub fn to_str_lossy(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(&self.value)
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct TextRef<'a> {
-    pub value: &'a str,
+    pub value: &'a [u8],
     pub subtype: TextSubtype,
 }
 
 impl<'a> TextRef<'a> {
-    pub fn new(value: &'a str, subtype: TextSubtype) -> Self {
+    pub fn new(value: &'a [u8], subtype: TextSubtype) -> Self {
         Self { value, subtype }
     }
 
     #[inline]
-    pub fn as_str(&self) -> &'a str {
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.value
+    }
+
+    /// See [`Text::to_str_lossy`].
+    #[inline]
+    pub fn to_str_lossy(&self) -> Cow<'a, str> {
+        String::from_utf8_lossy(self.value)
+    }
+}
+
+impl<'a> Borrow<[u8]> for TextRef<'a> {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
         self.value
     }
 }
 
-impl<'a> Borrow<str> for TextRef<'a> {
-    #[inline]
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
-
 impl<'a> Deref for TextRef<'a> {
-    type Target = str;
+    type Target = [u8];
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.as_str()
+        self.value
     }
 }
 
@@ -139,27 +175,14 @@ pub trait Extendable<T> {
 impl<T: AnyText> Extendable<T> for Text {
     #[inline(always)]
     fn do_extend(&mut self, other: &T) -> Result<()> {
-        let other_str = other.as_ref();
+        let other_bytes = other.as_text_bytes();
         match &mut self.value {
             Cow::Owned(s) => {
-                let needed = other_str.len();
-                if s.capacity() >= needed {
-                    // SAFETY: capacity >= needed, source is valid UTF-8
-                    turso_debug_assert!(
-                        s.as_ptr().wrapping_add(s.len()) <= other_str.as_ptr()
-                            || other_str.as_ptr().wrapping_add(other_str.len()) <= s.as_ptr(),
-                        "source and destination ranges must not overlap"
-                    );
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(other_str.as_ptr(), s.as_mut_ptr(), needed);
-                        s.as_mut_vec().set_len(needed);
-                    }
-                } else {
-                    other_str.clone_into(s);
-                }
+                s.clear();
+                s.extend_from_slice(other_bytes);
             }
             Cow::Borrowed(_) => {
-                self.value = Cow::Owned(other_str.to_owned());
+                self.value = Cow::Owned(other_bytes.to_vec());
             }
         }
         self.subtype = other.subtype();
@@ -193,17 +216,33 @@ impl<T: AnyBlob> Extendable<T> for std::vec::Vec<u8> {
     }
 }
 
-pub trait AnyText: AsRef<str> {
+pub trait AnyText {
+    fn as_text_bytes(&self) -> &[u8];
     fn subtype(&self) -> TextSubtype;
 }
 
 impl AnyText for Text {
+    fn as_text_bytes(&self) -> &[u8] {
+        &self.value
+    }
+    fn subtype(&self) -> TextSubtype {
+        self.subtype
+    }
+}
+
+impl AnyText for TextRef<'_> {
+    fn as_text_bytes(&self) -> &[u8] {
+        self.value
+    }
     fn subtype(&self) -> TextSubtype {
         self.subtype
     }
 }
 
 impl AnyText for &str {
+    fn as_text_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
     fn subtype(&self) -> TextSubtype {
         TextSubtype::Text
     }
@@ -225,16 +264,16 @@ impl AnyBlob for &[u8] {
     }
 }
 
-impl AsRef<str> for Text {
-    fn as_ref(&self) -> &str {
-        self.as_str()
+impl AsRef<[u8]> for Text {
+    fn as_ref(&self) -> &[u8] {
+        &self.value
     }
 }
 
 impl From<&str> for Text {
     fn from(value: &str) -> Self {
         Text {
-            value: value.to_owned().into(),
+            value: Cow::Owned(value.as_bytes().to_vec()),
             subtype: TextSubtype::Text,
         }
     }
@@ -243,7 +282,7 @@ impl From<&str> for Text {
 impl From<String> for Text {
     fn from(value: String) -> Self {
         Text {
-            value: Cow::from(value),
+            value: Cow::Owned(value.into_bytes()),
             subtype: TextSubtype::Text,
         }
     }
@@ -251,7 +290,10 @@ impl From<String> for Text {
 
 impl From<Text> for String {
     fn from(value: Text) -> Self {
-        value.value.into_owned()
+        match value.value {
+            Cow::Borrowed(b) => String::from_utf8_lossy(b).into_owned(),
+            Cow::Owned(v) => String::from_utf8_lossy(&v).into_owned(),
+        }
     }
 }
 
@@ -289,7 +331,7 @@ impl Debug for ValueRef<'_> {
             }
             ValueRef::Text(text_ref) => {
                 // truncate string to at most 256 chars
-                let text = text_ref.as_str();
+                let text = text_ref.to_str_lossy();
                 let max_len = text.len().min(256);
                 f.debug_struct("Text")
                     .field("data", &&text[0..max_len])
@@ -395,9 +437,17 @@ impl Value {
         Value::Blob(data)
     }
 
-    pub fn to_text(&self) -> Option<&str> {
+    pub fn to_text(&self) -> Option<&[u8]> {
         match self {
-            Value::Text(t) => Some(t.as_str()),
+            Value::Text(t) => Some(&t.value),
+            _ => None,
+        }
+    }
+
+    /// Decode a TEXT value as UTF-8, substituting U+FFFD for invalid sequences.
+    pub fn to_text_str_lossy(&self) -> Option<Cow<'_, str>> {
+        match self {
+            Value::Text(t) => Some(t.to_str_lossy()),
             _ => None,
         }
     }
@@ -477,7 +527,7 @@ impl Value {
                 let fval: f64 = (*f).into();
                 out.extend_from_slice(&fval.to_be_bytes());
             }
-            Value::Text(t) => out.extend_from_slice(t.value.as_bytes()),
+            Value::Text(t) => out.extend_from_slice(&t.value),
             Value::Blob(b) => out.extend_from_slice(b),
         };
     }
@@ -518,7 +568,7 @@ impl Display for Value {
             Self::Null => write!(f, ""),
             Self::Numeric(Numeric::Integer(i)) => write!(f, "{i}"),
             Self::Numeric(Numeric::Float(fl)) => f.write_str(&format_float(f64::from(*fl))),
-            Self::Text(s) => write!(f, "{}", s.as_str()),
+            Self::Text(s) => write!(f, "{}", s.to_str_lossy()),
             Self::Blob(b) => write!(f, "{}", String::from_utf8_lossy(b)),
         }
     }
@@ -530,7 +580,7 @@ impl Value {
             Self::Null => ExtValue::null(),
             Self::Numeric(Numeric::Integer(i)) => ExtValue::from_integer(*i),
             Self::Numeric(Numeric::Float(fl)) => ExtValue::from_float(f64::from(*fl)),
-            Self::Text(text) => ExtValue::from_text(text.as_str().to_string()),
+            Self::Text(text) => ExtValue::from_text(text.to_str_lossy().into_owned()),
             Self::Blob(blob) => ExtValue::from_blob(blob.to_vec()),
         }
     }
@@ -849,26 +899,37 @@ impl std::ops::AddAssign for Value {
                 *self = sum.into();
             }
             (Self::Text(string_left), Self::Text(string_right)) => {
-                string_left.value.to_mut().push_str(&string_right.value);
+                string_left
+                    .value
+                    .to_mut()
+                    .extend_from_slice(&string_right.value);
                 string_left.subtype = TextSubtype::Text;
             }
             (Self::Text(string_left), Self::Numeric(Numeric::Integer(int_right))) => {
                 let string_right = int_right.to_string();
-                string_left.value.to_mut().push_str(&string_right);
+                string_left
+                    .value
+                    .to_mut()
+                    .extend_from_slice(string_right.as_bytes());
                 string_left.subtype = TextSubtype::Text;
             }
             (Self::Numeric(Numeric::Integer(int_left)), Self::Text(string_right)) => {
-                let string_left = int_left.to_string();
-                *self = Self::build_text(string_left + string_right.as_str());
+                let mut bytes = int_left.to_string().into_bytes();
+                bytes.extend_from_slice(&string_right.value);
+                *self = Self::Text(Text::from_bytes(bytes));
             }
             (Self::Text(string_left), Self::Numeric(Numeric::Float(_))) => {
                 let string_right = rhs.to_string();
-                string_left.value.to_mut().push_str(&string_right);
+                string_left
+                    .value
+                    .to_mut()
+                    .extend_from_slice(string_right.as_bytes());
                 string_left.subtype = TextSubtype::Text;
             }
             (Self::Numeric(Numeric::Float(_)), Self::Text(string_right)) => {
-                let string_left = self.to_string();
-                *self = Self::build_text(string_left + string_right.as_str());
+                let mut bytes = self.to_string().into_bytes();
+                bytes.extend_from_slice(&string_right.value);
+                *self = Self::Text(Text::from_bytes(bytes));
             }
             (_, Self::Null) => {}
             (Self::Null, _) => *self = rhs,
@@ -951,7 +1012,8 @@ impl<'a> TryFrom<ValueRef<'a>> for &'a str {
     #[inline]
     fn try_from(value: ValueRef<'a>) -> Result<Self, Self::Error> {
         match value {
-            ValueRef::Text(s) => Ok(s.as_str()),
+            ValueRef::Text(s) => std::str::from_utf8(s.value)
+                .map_err(|_| LimboError::ConversionError("Expected valid UTF-8 text".into())),
             _ => Err(LimboError::ConversionError("Expected text value".into())),
         }
     }
@@ -1018,7 +1080,7 @@ mod immutable_record {
                     write!(f, "ImmutableRecord {{ payload: {preview} }}")
                 }
                 Value::Text(s) => {
-                    let string = s.as_str();
+                    let string = s.to_str_lossy();
                     let preview = if string.len() > 20 {
                         format!("{:?} ... ({} chars total)", &string[..20], string.len())
                     } else {
@@ -1489,7 +1551,7 @@ mod immutable_record {
                         writer.extend_from_slice(&fval.to_be_bytes());
                     }
                     ValueRef::Text(t) => {
-                        writer.extend_from_slice(t.value.as_bytes());
+                        writer.extend_from_slice(t.value);
                     }
                     ValueRef::Blob(b) => {
                         writer.extend_from_slice(b);
@@ -1853,7 +1915,7 @@ impl<'a> ValueRef<'a> {
             Self::Null => ExtValue::null(),
             Self::Numeric(Numeric::Integer(i)) => ExtValue::from_integer(*i),
             Self::Numeric(Numeric::Float(fl)) => ExtValue::from_float(f64::from(*fl)),
-            Self::Text(text) => ExtValue::from_text(text.as_str().to_string()),
+            Self::Text(text) => ExtValue::from_text(text.to_str_lossy().into_owned()),
             Self::Blob(blob) => ExtValue::from_blob(blob.to_vec()),
         }
     }
@@ -1865,9 +1927,17 @@ impl<'a> ValueRef<'a> {
         }
     }
 
-    pub fn to_text(&self) -> Option<&'a str> {
+    pub fn to_text(&self) -> Option<&'a [u8]> {
         match self {
-            Self::Text(t) => Some(t.as_str()),
+            Self::Text(t) => Some(t.value),
+            _ => None,
+        }
+    }
+
+    /// Decode a TEXT value as UTF-8, substituting U+FFFD for invalid sequences.
+    pub fn to_text_str_lossy(&self) -> Option<Cow<'a, str>> {
+        match self {
+            Self::Text(t) => Some(t.to_str_lossy()),
             _ => None,
         }
     }
@@ -1907,7 +1977,7 @@ impl<'a> ValueRef<'a> {
             ValueRef::Null => Value::Null,
             ValueRef::Numeric(n) => Value::from(*n),
             ValueRef::Text(text) => Value::Text(Text {
-                value: text.value.to_string().into(),
+                value: Cow::Owned(text.value.to_vec()),
                 subtype: text.subtype,
             }),
             ValueRef::Blob(b) => Value::Blob(b.to_vec()),
@@ -1934,7 +2004,7 @@ impl Display for ValueRef<'_> {
                 let fval: f64 = (*fl).into();
                 write!(f, "{fval:?}")
             }
-            Self::Text(s) => write!(f, "{}", s.as_str()),
+            Self::Text(s) => write!(f, "{}", s.to_str_lossy()),
             Self::Blob(b) => write!(f, "{}", String::from_utf8_lossy(b)),
         }
     }
@@ -1945,9 +2015,7 @@ impl<'a> PartialEq<ValueRef<'a>> for ValueRef<'a> {
         match (self, other) {
             (Self::Null, Self::Null) => true,
             (Self::Numeric(a), Self::Numeric(b)) => a == b,
-            (Self::Text(text_left), Self::Text(text_right)) => {
-                text_left.value.as_bytes() == text_right.value.as_bytes()
-            }
+            (Self::Text(text_left), Self::Text(text_right)) => text_left.value == text_right.value,
             (Self::Blob(blob_left), Self::Blob(blob_right)) => blob_left.eq(blob_right),
             _ => false,
         }
@@ -1983,7 +2051,7 @@ impl<'a> Ord for ValueRef<'a> {
             (_, Self::Numeric(_)) => std::cmp::Ordering::Greater,
 
             (Self::Text(text_left), Self::Text(text_right)) => {
-                text_left.value.as_bytes().cmp(text_right.value.as_bytes())
+                text_left.value.cmp(text_right.value)
             }
             (Self::Text(_), Self::Blob(_)) => std::cmp::Ordering::Less,
             (Self::Blob(_), Self::Text(_)) => std::cmp::Ordering::Greater,
@@ -2207,7 +2275,9 @@ where
     let l = l.as_value_ref();
     let r = r.as_value_ref();
     match (l, r) {
-        (ValueRef::Text(left), ValueRef::Text(right)) => collation.compare_strings(&left, &right),
+        (ValueRef::Text(left), ValueRef::Text(right)) => {
+            collation.compare_strings(left.value, right.value)
+        }
         _ => l.cmp(&r),
     }
 }
@@ -2471,7 +2541,7 @@ where
     };
 
     let collation = index_info.key_info[0].collation;
-    let comparison = collation.compare_strings(&lhs_text, &rhs_text);
+    let comparison = collation.compare_strings(lhs_text.value, rhs_text.value);
 
     let final_comparison = match index_info.key_info[0].sort_order {
         SortOrder::Asc => comparison,
@@ -2598,7 +2668,7 @@ where
         let comparison = match (&lhs_value, rhs_value) {
             (ValueRef::Text(lhs_text), ValueRef::Text(rhs_text)) => index_info.key_info[field_idx]
                 .collation
-                .compare_strings(lhs_text, rhs_text),
+                .compare_strings(lhs_text.value, rhs_text.value),
 
             _ => lhs_value.cmp(rhs_value),
         };
@@ -2903,7 +2973,7 @@ impl Record {
                 Value::Numeric(Numeric::Float(f)) => {
                     buf.extend_from_slice(&f64::from(*f).to_be_bytes())
                 }
-                Value::Text(t) => buf.extend_from_slice(t.value.as_bytes()),
+                Value::Text(t) => buf.extend_from_slice(&t.value),
                 Value::Blob(b) => buf.extend_from_slice(b),
             };
         }
@@ -3320,7 +3390,7 @@ mod tests {
         let val = iter.next().unwrap().unwrap();
         assert_eq!(
             val,
-            ValueRef::Text(TextRef::new("hello", TextSubtype::Text))
+            ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text))
         );
 
         assert!(iter.next().is_none());
@@ -3361,7 +3431,7 @@ mod tests {
         assert_eq!(values[2], ValueRef::from_f64(std::f64::consts::PI));
         assert_eq!(
             values[3],
-            ValueRef::Text(TextRef::new("test", TextSubtype::Text))
+            ValueRef::Text(TextRef::new(b"test", TextSubtype::Text))
         );
         assert_eq!(values[4], ValueRef::Blob(&[1, 2, 3]));
         assert_eq!(values[5], ValueRef::from_i64(0));
@@ -3416,7 +3486,7 @@ mod tests {
 
             let cmp = match (&l[i], &r[i]) {
                 (ValueRef::Text(left), ValueRef::Text(right)) => {
-                    collation.compare_strings(left, right)
+                    collation.compare_strings(left.value, right.value)
                 }
                 _ => l[i].partial_cmp(&r[i]).unwrap_or(std::cmp::Ordering::Equal),
             };
@@ -3628,7 +3698,7 @@ mod tests {
                 vec![Value::from_i64(42), Value::Text(Text::new("hello"))],
                 vec![
                     ValueRef::from_i64(42),
-                    ValueRef::Text(TextRef::new("hello", TextSubtype::Text)),
+                    ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text)),
                 ],
                 "integer_text_equal",
             ),
@@ -3636,7 +3706,7 @@ mod tests {
                 vec![Value::from_i64(42), Value::Text(Text::new("hello"))],
                 vec![
                     ValueRef::from_i64(42),
-                    ValueRef::Text(TextRef::new("world", TextSubtype::Text)),
+                    ValueRef::Text(TextRef::new(b"world", TextSubtype::Text)),
                 ],
                 "integer_equal_text_different",
             ),
@@ -3666,34 +3736,34 @@ mod tests {
         let test_cases = vec![
             (
                 vec![Value::Text(Text::new("hello"))],
-                vec![ValueRef::Text(TextRef::new("hello", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text))],
                 "equal_strings",
             ),
             (
                 vec![Value::Text(Text::new("abc"))],
-                vec![ValueRef::Text(TextRef::new("def", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"def", TextSubtype::Text))],
                 "less_than_strings",
             ),
             (
                 vec![Value::Text(Text::new("xyz"))],
-                vec![ValueRef::Text(TextRef::new("abc", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"abc", TextSubtype::Text))],
                 "greater_than_strings",
             ),
             (
                 vec![Value::Text(Text::new(""))],
-                vec![ValueRef::Text(TextRef::new("", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"", TextSubtype::Text))],
                 "empty_strings",
             ),
             (
                 vec![Value::Text(Text::new("a"))],
-                vec![ValueRef::Text(TextRef::new("aa", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"aa", TextSubtype::Text))],
                 "prefix_strings",
             ),
             // Multi-field with string first
             (
                 vec![Value::Text(Text::new("hello")), Value::from_i64(42)],
                 vec![
-                    ValueRef::Text(TextRef::new("hello", TextSubtype::Text)),
+                    ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text)),
                     ValueRef::from_i64(42),
                 ],
                 "string_integer_equal",
@@ -3701,7 +3771,7 @@ mod tests {
             (
                 vec![Value::Text(Text::new("hello")), Value::from_i64(42)],
                 vec![
-                    ValueRef::Text(TextRef::new("hello", TextSubtype::Text)),
+                    ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text)),
                     ValueRef::from_i64(99),
                 ],
                 "string_equal_integer_different",
@@ -3737,7 +3807,7 @@ mod tests {
             ),
             (
                 vec![Value::Null],
-                vec![ValueRef::Text(TextRef::new("hello", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text))],
                 "null_vs_text",
             ),
             (
@@ -3748,12 +3818,12 @@ mod tests {
             // Numbers vs Text/Blob
             (
                 vec![Value::from_i64(42)],
-                vec![ValueRef::Text(TextRef::new("hello", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text))],
                 "integer_vs_text",
             ),
             (
                 vec![Value::from_f64(64.4)],
-                vec![ValueRef::Text(TextRef::new("hello", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text))],
                 "float_vs_text",
             ),
             (
@@ -3817,7 +3887,7 @@ mod tests {
             ),
             (
                 vec![Value::Text(Text::new("abc"))],
-                vec![ValueRef::Text(TextRef::new("def", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"def", TextSubtype::Text))],
                 "desc_string_reversed",
             ),
             // Mixed sort orders
@@ -3825,7 +3895,7 @@ mod tests {
                 vec![Value::from_i64(10), Value::Text(Text::new("hello"))],
                 vec![
                     ValueRef::from_i64(20),
-                    ValueRef::Text(TextRef::new("hello", TextSubtype::Text)),
+                    ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text)),
                 ],
                 "desc_first_asc_second",
             ),
@@ -3851,7 +3921,7 @@ mod tests {
                 vec![Value::from_i64(42)],
                 vec![
                     ValueRef::from_i64(42),
-                    ValueRef::Text(TextRef::new("extra", TextSubtype::Text)),
+                    ValueRef::Text(TextRef::new(b"extra", TextSubtype::Text)),
                 ],
                 "fewer_serialized_fields",
             ),
@@ -3874,13 +3944,13 @@ mod tests {
             ),
             (
                 vec![Value::Text(Text::new("hello")), Value::from_i64(5)],
-                vec![ValueRef::Text(TextRef::new("hello", TextSubtype::Text))],
+                vec![ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text))],
                 "equal_text_prefix_but_more_serialized_fields",
             ),
             (
                 vec![Value::Text(Text::new("same")), Value::from_i64(5)],
                 vec![
-                    ValueRef::Text(TextRef::new("same", TextSubtype::Text)),
+                    ValueRef::Text(TextRef::new(b"same", TextSubtype::Text)),
                     ValueRef::from_i64(5),
                 ],
                 "equal_text_then_equal_int",
@@ -3942,7 +4012,7 @@ mod tests {
 
         let int_values = [
             ValueRef::from_i64(42),
-            ValueRef::Text(TextRef::new("hello", TextSubtype::Text)),
+            ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text)),
         ];
         assert!(matches!(
             find_compare(int_values.iter().peekable(), &index_info_small),
@@ -3950,7 +4020,7 @@ mod tests {
         ));
 
         let string_values = [
-            ValueRef::Text(TextRef::new("hello", TextSubtype::Text)),
+            ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text)),
             ValueRef::from_i64(42),
         ];
         assert!(matches!(
@@ -4259,8 +4329,8 @@ mod tests {
             ValueRef::from_f64(f64::INFINITY),
             ValueRef::from_f64(f64::NEG_INFINITY),
             ValueRef::from_f64(f64::NAN), // becomes Null
-            ValueRef::Text(TextRef::new("hello", TextSubtype::Text)),
-            ValueRef::Text(TextRef::new("", TextSubtype::Text)),
+            ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text)),
+            ValueRef::Text(TextRef::new(b"", TextSubtype::Text)),
             ValueRef::Blob(&[1, 2, 3]),
             ValueRef::Blob(&[]),
         ];

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -630,8 +630,8 @@ pub fn apply_numeric_affinity(val: ValueRef, try_for_int: bool) -> Option<ValueR
         return None; // Only apply to text values
     };
 
-    let text_str = text.as_str();
-    let (parse_result, parsed_value) = try_for_float(text_str.as_bytes());
+    let text_bytes = text.as_bytes();
+    let (parse_result, parsed_value) = try_for_float(text_bytes);
 
     // Only convert if we have a complete valid number (not just a prefix)
     match parse_result {

--- a/core/vdbe/array.rs
+++ b/core/vdbe/array.rs
@@ -23,7 +23,7 @@ pub(crate) fn array_values_from_blob(blob: &[u8]) -> Result<Vec<Value>> {
 pub(crate) fn array_values_from_any(arr: &Value) -> Option<Vec<Value>> {
     match arr {
         Value::Blob(blob) => array_values_from_blob(blob).ok(),
-        Value::Text(text) => parse_text_array(text.as_str()),
+        Value::Text(text) => parse_text_array(&text.to_str_lossy()),
         Value::Null => Some(Vec::new()),
         _ => None,
     }
@@ -188,7 +188,7 @@ fn write_value_ref_pg(result: &mut String, val: &crate::ValueRef<'_>) {
             }
         }
         crate::ValueRef::Text(t) => {
-            write_pg_text_element(result, t.as_str());
+            write_pg_text_element(result, &t.to_str_lossy());
         }
         crate::ValueRef::Blob(b) => {
             result.push_str("\"X'");
@@ -245,7 +245,7 @@ pub(crate) fn compute_array_length(val: &Value) -> Option<i64> {
             Ok(iter) => Some(iter.count() as i64),
             Err(_) => None,
         },
-        Value::Text(t) => parse_text_array(t.as_str()).map(|v| v.len() as i64),
+        Value::Text(t) => parse_text_array(&t.to_str_lossy()).map(|v| v.len() as i64),
         _ => None,
     }
 }
@@ -404,13 +404,13 @@ pub(crate) fn exec_string_to_array(
     null_str: Option<&Value>,
 ) -> Result<Value> {
     let text_str = match text {
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.to_str_lossy().into_owned(),
         Value::Null => return Ok(Value::Null),
         other => other.to_string(),
     };
 
     let null_match: Option<String> = match null_str {
-        Some(Value::Text(t)) => Some(t.as_str().to_string()),
+        Some(Value::Text(t)) => Some(t.to_str_lossy().into_owned()),
         Some(Value::Null) | None => None,
         Some(other) => Some(other.to_string()),
     };
@@ -433,7 +433,7 @@ pub(crate) fn exec_string_to_array(
     }
 
     let delim_str = match delimiter {
-        Value::Text(d) => d.as_str().to_string(),
+        Value::Text(d) => d.to_str_lossy().into_owned(),
         other => other.to_string(),
     };
 
@@ -472,13 +472,13 @@ pub(crate) fn exec_array_to_string(
     }
 
     let delim = match delimiter {
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.to_str_lossy().into_owned(),
         Value::Null => return Value::Null,
         other => other.to_string(),
     };
 
     let null_replacement: Option<String> = match null_str {
-        Some(Value::Text(t)) => Some(t.as_str().to_string()),
+        Some(Value::Text(t)) => Some(t.to_str_lossy().into_owned()),
         Some(Value::Null) | None => None,
         Some(other) => Some(other.to_string()),
     };
@@ -500,7 +500,7 @@ pub(crate) fn exec_array_to_string(
                             continue;
                         }
                     }
-                    crate::ValueRef::Text(t) => t.as_str().to_string(),
+                    crate::ValueRef::Text(t) => t.to_str_lossy().into_owned(),
                     other => format!("{other}"),
                 };
                 if !first {
@@ -528,7 +528,7 @@ pub(crate) fn exec_array_to_string(
                     continue;
                 }
             }
-            Value::Text(t) => t.as_str().to_string(),
+            Value::Text(t) => t.to_str_lossy().into_owned(),
             other => other.to_string(),
         };
         if !first {

--- a/core/vdbe/bloom_filter.rs
+++ b/core/vdbe/bloom_filter.rs
@@ -161,7 +161,7 @@ fn hash_value<H: Hasher>(hasher: &mut H, value: &ValueRef) {
         }
         ValueRef::Text(s) => {
             3u8.hash(hasher);
-            s.as_str().hash(hasher);
+            s.as_bytes().hash(hasher);
         }
         ValueRef::Blob(b) => {
             4u8.hash(hasher);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -212,8 +212,9 @@ fn value_to_bigdecimal(val: &Value) -> Result<bigdecimal::BigDecimal> {
         Value::Numeric(Numeric::Integer(i)) => Ok(BigDecimal::from(*i)),
         Value::Numeric(Numeric::Float(f)) => BigDecimal::from_str(&f.to_string())
             .map_err(|_| LimboError::Constraint(format!("invalid numeric value: {f}"))),
-        Value::Text(t) => BigDecimal::from_str(&t.value)
-            .map_err(|_| LimboError::Constraint(format!("invalid numeric value: \"{}\"", t.value))),
+        Value::Text(t) => BigDecimal::from_str(&t.to_str_lossy()).map_err(|_| {
+            LimboError::Constraint(format!("invalid numeric value: \"{}\"", t.to_str_lossy()))
+        }),
         Value::Blob(b) => crate::numeric::decimal::blob_to_bigdecimal(b),
         _ => Err(LimboError::Constraint(format!(
             "cannot convert to numeric: \"{val}\""
@@ -250,7 +251,7 @@ fn make_sort_comparator(
             std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Result<Ordering> {
                 fn reverse_str(v: &ValueRef) -> String {
                     match v {
-                        ValueRef::Text(t) => t.to_string().chars().rev().collect(),
+                        ValueRef::Text(t) => t.to_str_lossy().chars().rev().collect(),
                         _ => String::new(),
                     }
                 }
@@ -275,7 +276,7 @@ fn make_sort_comparator(
                                 None
                             }
                         }
-                        ValueRef::Text(t) => t.to_string().parse::<u64>().ok(),
+                        ValueRef::Text(t) => t.to_str_lossy().parse::<u64>().ok(),
                         _ => None,
                     }
                 }
@@ -302,8 +303,8 @@ fn make_sort_comparator(
                             .unwrap_or(Ordering::Equal)
                     }
                     (ValueRef::Text(a_text), ValueRef::Text(b_text)) => {
-                        let a_vals = crate::vdbe::array::parse_text_array(a_text);
-                        let b_vals = crate::vdbe::array::parse_text_array(b_text);
+                        let a_vals = crate::vdbe::array::parse_text_array(&a_text.to_str_lossy());
+                        let b_vals = crate::vdbe::array::parse_text_array(&b_text.to_str_lossy());
                         match (a_vals, b_vals) {
                             (Some(av), Some(bv)) => {
                                 let a_blob = crate::vdbe::array::values_to_record_blob(&av)?;
@@ -340,7 +341,7 @@ fn compare_with_collation(
             if let Some(comparator) = collation_comparator {
                 comparator(&lhs.as_ref(), &rhs.as_ref())?
             } else if let Some(coll) = collation {
-                coll.compare_strings(lhs_text.as_str(), rhs_text.as_str())
+                coll.compare_strings(lhs_text.as_bytes(), rhs_text.as_bytes())
             } else {
                 lhs.cmp(rhs)
             }
@@ -365,8 +366,8 @@ where
         if let (ValueRef::Text(lhs_text), ValueRef::Text(rhs_text)) = (lhs, rhs) {
             return program.connection.compare_external_collation(
                 collation,
-                lhs_text.as_str(),
-                rhs_text.as_str(),
+                &lhs_text.to_str_lossy(),
+                &rhs_text.to_str_lossy(),
             );
         }
     }
@@ -2152,7 +2153,7 @@ pub fn op_array_encode(
     // Extract elements from either blob (MakeArray) or text (JSON literal)
     let raw_elements = match val {
         Value::Blob(b) => array_values_from_blob(b).ok(),
-        Value::Text(text) => parse_text_array(text.as_str()),
+        Value::Text(text) => parse_text_array(&text.to_str_lossy()),
         _ => None,
     };
     let Some(raw_elements) = raw_elements else {
@@ -2290,10 +2291,10 @@ pub fn op_array_element(
                     // contain invalid UTF-8 (from_utf8_unchecked in the
                     // record decoder). Validate and demote to blob if needed.
                     if let ValueRef::Text(t) = &vref {
-                        if t.value.as_bytes().iter().any(|&b| b > 0x7F)
-                            && std::str::from_utf8(t.value.as_bytes()).is_err()
+                        if t.value.iter().any(|&b| b > 0x7F)
+                            && std::str::from_utf8(t.value).is_err()
                         {
-                            return Value::Blob(t.value.as_bytes().to_vec());
+                            return Value::Blob(t.value.to_vec());
                         }
                     }
                     vref.to_owned()
@@ -5977,7 +5978,7 @@ fn update_agg_payload(
                     apply_kbn_step(sum_val, f64::from(*f), &mut sum_state);
                 }
                 Value::Text(t) => {
-                    let (parse_result, parsed_number) = try_for_float(t.as_str().as_bytes());
+                    let (parse_result, parsed_number) = try_for_float(t.as_bytes());
                     match parsed_number {
                         ParsedNumber::Integer(i) => {
                             if matches!(parse_result, NumericParseResult::ValidPrefixOnly) {
@@ -6072,7 +6073,7 @@ fn update_agg_payload(
                     _ => unreachable!("Sum/Total accumulator initialized to Null/Integer/Float"),
                 },
                 Value::Text(t) => {
-                    let (parse_result, parsed_number) = try_for_float(t.as_str().as_bytes());
+                    let (parse_result, parsed_number) = try_for_float(t.as_bytes());
                     handle_text_sum(acc, &mut sum_state, parsed_number, parse_result, false);
                 }
                 Value::Blob(b) => {
@@ -6360,7 +6361,7 @@ fn finalize_agg_payload(func: &AggFunc, payload: &[Value]) -> Result<Value> {
 fn ordered_set_compare(a: &Value, b: &Value, collation: CollationSeq) -> std::cmp::Ordering {
     match (a, b) {
         (Value::Text(lhs), Value::Text(rhs)) => {
-            collation.compare_strings(lhs.as_str(), rhs.as_str())
+            collation.compare_strings(lhs.as_bytes(), rhs.as_bytes())
         }
         _ => a.cmp(b),
     }
@@ -7408,19 +7409,19 @@ pub fn op_function(
                 // However, Rust strings uses utf-8
                 // so the behavior at the moment is slightly different
                 // To the way blobs are parsed here in SQLite.
-                let indent = match indent {
+                let indent: String = match indent {
                     Some(value) => match value.get_value() {
-                        Value::Text(text) => text.as_str(),
-                        Value::Numeric(Numeric::Integer(val)) => &val.to_string(),
-                        Value::Numeric(Numeric::Float(val)) => &f64::from(*val).to_string(),
-                        Value::Blob(val) => &String::from_utf8_lossy(val),
-                        _ => "    ",
+                        Value::Text(text) => text.to_str_lossy().into_owned(),
+                        Value::Numeric(Numeric::Integer(val)) => val.to_string(),
+                        Value::Numeric(Numeric::Float(val)) => f64::from(*val).to_string(),
+                        Value::Blob(val) => String::from_utf8_lossy(val).into_owned(),
+                        _ => "    ".to_string(),
                     },
                     // If the second argument is omitted or is NULL, then indentation is four spaces per level
-                    None => "    ",
+                    None => "    ".to_string(),
                 };
 
-                let json_str = get_json(json_value.get_value(), Some(indent))?;
+                let json_str = get_json(json_value.get_value(), Some(indent.as_str()))?;
                 state.registers[*dest].set_value(json_str);
             }
             JsonFunc::JsonSet => {
@@ -7475,7 +7476,7 @@ pub fn op_function(
                 };
                 let result = reg_value_argument
                     .get_value()
-                    .exec_cast(reg_value_type.as_str());
+                    .exec_cast(&reg_value_type.to_str_lossy());
                 state.registers[*dest].set_value(result);
             }
             ScalarFunc::Changes => {
@@ -7518,7 +7519,7 @@ pub fn op_function(
                     state.registers[*dest].set_null();
                 } else {
                     let pattern_cow = match pattern_value {
-                        Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                        Value::Text(s) => s.to_str_lossy(),
                         v => match v.exec_cast("TEXT") {
                             Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                             _ => unreachable!("Cast to TEXT should yield Text"),
@@ -7526,7 +7527,7 @@ pub fn op_function(
                     };
 
                     let match_cow = match match_value {
-                        Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                        Value::Text(s) => s.to_str_lossy(),
                         v => match v.exec_cast("TEXT") {
                             Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                             _ => unreachable!("Cast to TEXT should yield Text"),
@@ -7573,7 +7574,7 @@ pub fn op_function(
                             }
                             _ => {
                                 let escape_cow = match escape_value {
-                                    Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                                    Value::Text(s) => s.to_str_lossy(),
                                     v => match v.exec_cast("TEXT") {
                                         Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                                         _ => unreachable!("Cast to TEXT should yield Text"),
@@ -7597,7 +7598,7 @@ pub fn op_function(
                     } else {
                         // 3. Prepare Pattern and Text
                         let pattern_cow = match pattern_value {
-                            Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                            Value::Text(s) => s.to_str_lossy(),
                             v => match v.exec_cast("TEXT") {
                                 Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                                 _ => unreachable!("Cast to TEXT should yield Text"),
@@ -7605,7 +7606,7 @@ pub fn op_function(
                         };
 
                         let match_cow = match match_value {
-                            Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                            Value::Text(s) => s.to_str_lossy(),
                             v => match v.exec_cast("TEXT") {
                                 Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                                 _ => unreachable!("Cast to TEXT should yield Text"),
@@ -7631,7 +7632,7 @@ pub fn op_function(
             }
             ScalarFunc::CurrVal => {
                 let seq_name = match state.registers[*start_reg].get_value() {
-                    Value::Text(t) => t.as_str().to_string(),
+                    Value::Text(t) => t.to_str_lossy().into_owned(),
                     _ => {
                         return Err(crate::LimboError::ParseError(
                             "currval() requires a text argument".to_string(),
@@ -7671,7 +7672,7 @@ pub fn op_function(
                 // requirement. The autonomous-tx mechanism (planned for MVCC
                 // concurrency in a follow-up) will subsume serialization.
                 let seq_name = match state.registers[*start_reg].get_value() {
-                    Value::Text(t) => t.as_str().to_string(),
+                    Value::Text(t) => t.to_str_lossy().into_owned(),
                     _ => {
                         return Err(crate::LimboError::ParseError(
                             "setval() requires a text argument".to_string(),
@@ -7977,7 +7978,7 @@ pub fn op_function(
                     };
                     let table = {
                         let schema = program.connection.schema.read();
-                        match schema.get_table(table.as_str()) {
+                        match schema.get_table(&table.to_str_lossy()) {
                             Some(table) => table,
                             None => {
                                 return Err(LimboError::InvalidArgument(format!(
@@ -7993,7 +7994,7 @@ pub fn op_function(
 
                         let name = column.name.as_ref().expect("column should have a name");
                         let name_json = json::convert_ref_dbtype_to_jsonb(
-                            ValueRef::Text(TextRef::new(name, TextSubtype::Text)),
+                            ValueRef::Text(TextRef::new(name.as_bytes(), TextSubtype::Text)),
                             json::Conv::ToString,
                         )?;
                         json.append_jsonb_to_end(name_json.data());
@@ -8039,7 +8040,7 @@ pub fn op_function(
                         ));
                     };
                     let mut columns_json_array =
-                        json::jsonb::Jsonb::from_str(columns_str.as_str())?;
+                        json::jsonb::Jsonb::from_str(&columns_str.to_str_lossy())?;
                     let columns_len = columns_json_array.array_len()?;
 
                     let mut payload_iterator = ValueIterator::new(bin_record.as_slice())?;
@@ -8105,8 +8106,8 @@ pub fn op_function(
                 };
 
                 return_if_io!(program.connection.attach_database(
-                    filename_str.as_str(),
-                    dbname_str.as_str(),
+                    &filename_str.to_str_lossy(),
+                    &dbname_str.to_str_lossy(),
                     state.active_op_state.attach(),
                 ));
                 // Sequence descriptors for the attached database are
@@ -8131,7 +8132,9 @@ pub fn op_function(
                 };
 
                 // Call the detach_database method on the connection
-                program.connection.detach_database(dbname_str.as_str())?;
+                program
+                    .connection
+                    .detach_database(&dbname_str.to_str_lossy())?;
 
                 // Set result to NULL (detach doesn't return a value)
                 state.registers[*dest].set_null();
@@ -8222,7 +8225,7 @@ pub fn op_function(
             ScalarFunc::SequenceWatermark => {
                 assert_eq!(arg_count, 1);
                 let sequence_name = match state.registers[*start_reg].get_value() {
-                    Value::Text(text) => text.as_str(),
+                    Value::Text(text) => text.to_str_lossy(),
                     Value::Null => {
                         state.registers[*dest].set_value(Value::Null);
                         return Ok(InsnFunctionStepResult::Step);
@@ -8240,9 +8243,9 @@ pub fn op_function(
                             crate::util::normalize_ident(sequence_name),
                         )
                     } else {
-                        (MAIN_DB_ID, crate::util::normalize_ident(sequence_name))
+                        (MAIN_DB_ID, crate::util::normalize_ident(&sequence_name))
                     };
-                program.connection.find_sequence(sequence_name)?;
+                program.connection.find_sequence(&sequence_name)?;
                 let watermark = program
                     .connection
                     .mv_store_for_db(db_id)
@@ -8424,7 +8427,7 @@ pub fn op_function(
                         }
                     },
                     Value::Text(t) => {
-                        let v = &t.value;
+                        let v = t.to_str_lossy();
                         match v.to_ascii_lowercase().as_str() {
                             "true" | "t" | "yes" | "on" | "1" => Value::from_i64(1),
                             "false" | "f" | "no" | "off" | "0" => Value::from_i64(0),
@@ -8459,7 +8462,7 @@ pub fn op_function(
                 let result = match val.get_value() {
                     Value::Null => Value::Null,
                     Value::Text(t) => {
-                        let v = &t.value;
+                        let v = t.to_str_lossy();
                         v.parse::<std::net::IpAddr>().map_err(|_| {
                             LimboError::Constraint(format!("invalid input for type inet: \"{v}\""))
                         })?;
@@ -8506,7 +8509,7 @@ pub fn op_function(
                         let text = match other {
                             Value::Numeric(Numeric::Integer(i)) => i.to_string(),
                             Value::Numeric(Numeric::Float(f)) => f.to_string(),
-                            Value::Text(t) => t.value.to_string(),
+                            Value::Text(t) => t.to_str_lossy().into_owned(),
                             _ => {
                                 return Err(LimboError::Constraint(format!(
                                     "invalid input for type numeric: \"{other}\""
@@ -8878,7 +8881,9 @@ pub fn op_function(
                 AlterTableFunc::RenameTable => {
                     let rename_from = {
                         match &state.registers[*start_reg + 5].get_value() {
-                            Value::Text(rename_from) => normalize_ident(rename_from.as_str()),
+                            Value::Text(rename_from) => {
+                                normalize_ident(&rename_from.to_str_lossy())
+                            }
                             _ => panic!("rename_from parameter should be TEXT"),
                         }
                     };
@@ -8889,7 +8894,7 @@ pub fn op_function(
                             _ => panic!("rename_to parameter should be TEXT"),
                         }
                     };
-                    let rename_to = normalize_ident(original_rename_to.as_str());
+                    let rename_to = normalize_ident(&original_rename_to.to_str_lossy());
 
                     let new_name = if let Some(column) =
                         &name.strip_prefix(&format!("sqlite_autoindex_{rename_from}_"))
@@ -8912,7 +8917,7 @@ pub fn op_function(
                             break 'sql None;
                         };
 
-                        let mut parser = Parser::new(sql.as_str().as_bytes());
+                        let mut parser = Parser::new(sql.as_bytes());
                         let ast::Cmd::Stmt(stmt) =
                             parser.next().expect("parser should have next item")?
                         else {
@@ -8983,7 +8988,7 @@ pub fn op_function(
                                         any_change |= rewrite_fk_parent_table_if_needed(
                                             clause,
                                             &rename_from,
-                                            original_rename_to.as_str(),
+                                            &original_rename_to.to_str_lossy(),
                                         );
                                     }
                                 }
@@ -8991,7 +8996,7 @@ pub fn op_function(
                                     any_change |= rewrite_inline_col_fk_target_if_needed(
                                         col,
                                         &rename_from,
-                                        original_rename_to.as_str(),
+                                        &original_rename_to.to_str_lossy(),
                                     );
                                 }
 
@@ -9116,7 +9121,7 @@ pub fn op_function(
                                     rewrite_check_expr_table_refs(
                                         when,
                                         &rename_from,
-                                        original_rename_to.as_str(),
+                                        &original_rename_to.to_str_lossy(),
                                     );
                                 }
 
@@ -9125,7 +9130,7 @@ pub fn op_function(
                                     rewrite_trigger_cmd_table_refs(
                                         cmd,
                                         &rename_from,
-                                        original_rename_to.as_str(),
+                                        &original_rename_to.to_str_lossy(),
                                     );
                                 }
 
@@ -9153,7 +9158,7 @@ pub fn op_function(
                 AlterTableFunc::AlterColumn | AlterTableFunc::RenameColumn => {
                     let table = {
                         match &state.registers[*start_reg + 5].get_value() {
-                            Value::Text(rename_to) => normalize_ident(rename_to.as_str()),
+                            Value::Text(rename_to) => normalize_ident(&rename_to.to_str_lossy()),
                             _ => panic!("table parameter should be TEXT"),
                         }
                     };
@@ -9164,11 +9169,11 @@ pub fn op_function(
                             _ => panic!("rename_from parameter should be TEXT"),
                         }
                     };
-                    let rename_from = normalize_ident(original_rename_from.as_str());
+                    let rename_from = normalize_ident(&original_rename_from.to_str_lossy());
 
                     let column_def = {
                         match &state.registers[*start_reg + 7].get_value() {
-                            Value::Text(column_def) => column_def.as_str(),
+                            Value::Text(column_def) => column_def.to_str_lossy(),
                             _ => panic!("rename_to parameter should be TEXT"),
                         }
                     };
@@ -9183,7 +9188,7 @@ pub fn op_function(
                             break 'sql None;
                         };
 
-                        let mut parser = Parser::new(sql.as_str().as_bytes());
+                        let mut parser = Parser::new(sql.as_bytes());
                         let ast::Cmd::Stmt(stmt) =
                             parser.next().expect("parser should have next item")?
                         else {
@@ -10774,7 +10779,7 @@ fn coerce_register_to_integer(state: &mut ProgramState, reg: usize) -> Result<bo
     let converted = match state.registers[reg].get_value() {
         Value::Numeric(Numeric::Integer(_)) => return Ok(true),
         Value::Numeric(Numeric::Float(f)) => cast_real_to_integer(f64::from(*f)).ok(),
-        Value::Text(text) => match checked_cast_text_to_numeric(text.as_str(), true) {
+        Value::Text(text) => match checked_cast_text_to_numeric(&text.to_str_lossy(), true) {
             Ok(Value::Numeric(Numeric::Integer(i))) => Some(i),
             Ok(Value::Numeric(Numeric::Float(f))) => cast_real_to_integer(f64::from(f)).ok(),
             _ => None,
@@ -11708,7 +11713,7 @@ pub fn op_sequence_compute_next(
     );
 
     let seq_name = match state.registers[*seq_name_reg].get_value() {
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.to_str_lossy().into_owned(),
         _ => {
             return Err(crate::LimboError::ParseError(
                 "SequenceComputeNext: seq_name_reg must be text".to_string(),
@@ -11824,7 +11829,7 @@ pub fn op_set_sequence_currval(
     );
 
     let seq_name = match state.registers[*seq_name_reg].get_value() {
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.to_str_lossy().into_owned(),
         _ => {
             return Err(crate::LimboError::ParseError(
                 "SetSequenceCurrval: seq_name_reg must be text".to_string(),
@@ -11867,7 +11872,7 @@ pub fn op_sequence_track_allocation(
     );
 
     let seq_name = match state.registers[*seq_name_reg].get_value() {
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.to_str_lossy().into_owned(),
         _ => {
             return Err(crate::LimboError::ParseError(
                 "SequenceTrackAllocation: seq_name_reg must be text".to_string(),
@@ -11959,7 +11964,7 @@ pub fn op_sequence_register_allocation(
     };
 
     let seq_name = match state.registers[*seq_name_reg].get_value() {
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.to_str_lossy().into_owned(),
         _ => {
             return Err(crate::LimboError::ParseError(
                 "SequenceRegisterAllocation: seq_name_reg must be text".to_string(),
@@ -13121,7 +13126,7 @@ pub fn op_add_imm(
     let lhs = match current_value {
         Value::Numeric(Numeric::Integer(i)) => *i,
         Value::Numeric(Numeric::Float(f)) => real_to_i64(f64::from(*f)),
-        Value::Text(s) => crate::numeric::str_to_i64(s.as_str()).unwrap_or(0),
+        Value::Text(s) => crate::numeric::str_to_i64(s.to_str_lossy()).unwrap_or(0),
         Value::Blob(b) => {
             crate::numeric::str_to_i64(String::from_utf8_lossy(b).as_ref()).unwrap_or(0)
         }
@@ -15663,7 +15668,8 @@ fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
                 }
 
                 if let Value::Text(t) = value {
-                    let text = trim_ascii_whitespace(t.as_str());
+                    let text_lossy = t.to_str_lossy();
+                    let text = trim_ascii_whitespace(&text_lossy);
 
                     // Handle hex numbers - they shouldn't be converted
                     if text.starts_with("0x") {
@@ -15715,7 +15721,8 @@ fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
                     return true;
                 }
                 Value::Text(t) => {
-                    let text = trim_ascii_whitespace(t.as_str());
+                    let text_lossy = t.to_str_lossy();
+                    let text = trim_ascii_whitespace(&text_lossy);
                     if text.starts_with("0x") {
                         return false;
                     }
@@ -15807,7 +15814,7 @@ pub fn extract_int_value<V: AsValueRef>(value: V) -> i64 {
     match value {
         ValueRef::Numeric(Numeric::Integer(i)) => i,
         ValueRef::Numeric(Numeric::Float(f)) => real_to_i64(f64::from(f)),
-        ValueRef::Text(t) => crate::numeric::str_to_i64(t.as_str()).unwrap_or(0),
+        ValueRef::Text(t) => crate::numeric::str_to_i64(t.to_str_lossy()).unwrap_or(0),
         ValueRef::Blob(b) => {
             crate::numeric::str_to_i64(String::from_utf8_lossy(b).as_ref()).unwrap_or(0)
         }
@@ -17173,7 +17180,7 @@ mod tests {
             match register {
                 Register::Value(Value::Text(t)) => {
                     assert_eq!(
-                        t.as_str().chars().count(),
+                        t.to_str_lossy().chars().count(),
                         expected_len,
                         "String '{input}' should have {expected_len} characters",
                     );
@@ -17195,7 +17202,11 @@ mod tests {
             apply_affinity_char(&mut register, Affinity::Integer);
             match register {
                 Register::Value(Value::Text(t)) => {
-                    assert_eq!(t.as_str(), input, "Unexpected conversion for '{input}'");
+                    assert_eq!(
+                        t.as_bytes(),
+                        input.as_bytes(),
+                        "Unexpected conversion for '{input}'"
+                    );
                 }
                 other => {
                     panic!("'{input}' should remain text, got {other:?}");
@@ -17206,7 +17217,11 @@ mod tests {
             apply_affinity_char(&mut register, Affinity::Numeric);
             match register {
                 Register::Value(Value::Text(t)) => {
-                    assert_eq!(t.as_str(), input, "Unexpected conversion for '{input}'");
+                    assert_eq!(
+                        t.as_bytes(),
+                        input.as_bytes(),
+                        "Unexpected conversion for '{input}'"
+                    );
                 }
                 other => {
                     panic!("'{input}' should remain text, got {other:?}");

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -44,9 +44,9 @@ const BLOB_HASH: u8 = 4;
 #[inline]
 /// Hash text case-insensitively without allocation (ASCII-only for SQLite NOCASE).
 /// SQLite's NOCASE collation only considers ASCII case, so to_ascii_lowercase() is correct.
-fn hash_text_nocase(hasher: &mut impl Hasher, text: &str) {
+fn hash_text_nocase(hasher: &mut impl Hasher, text: &[u8]) {
     hasher.write_usize(text.len());
-    for byte in text.bytes() {
+    for &byte in text {
         hasher.write_u8(byte.to_ascii_lowercase());
         if byte == 0 {
             break;
@@ -87,17 +87,18 @@ fn hash_join_key(key_values: &[ValueRef], collations: &[CollationSeq]) -> u64 {
                 hasher.write_u8(TEXT_HASH);
                 match *collation {
                     CollationSeq::NoCase => {
-                        hash_text_nocase(&mut hasher, text.as_str());
+                        hash_text_nocase(&mut hasher, text.as_bytes());
                     }
                     CollationSeq::Rtrim => {
-                        let trimmed = text.as_str().trim_end_matches(' ');
-                        hasher.write(trimmed.as_bytes());
+                        let bytes = text.as_bytes();
+                        let end = bytes.iter().rposition(|&b| b != b' ').map_or(0, |i| i + 1);
+                        hasher.write(&bytes[..end]);
                     }
                     CollationSeq::Binary | CollationSeq::Unset => {
                         hasher.write(text.as_bytes());
                     }
                     CollationSeq::Locale(_) => {
-                        hasher.write(&collation.hash_key(text.as_str()));
+                        hasher.write(&collation.hash_key(&text.to_str_lossy()));
                     }
                     CollationSeq::Custom(_) => {
                         unreachable!(
@@ -162,7 +163,7 @@ fn values_equal(v1: ValueRef, v2: ValueRef, collation: CollationSeq) -> bool {
         (ValueRef::Blob(b1), ValueRef::Blob(b2)) => b1 == b2,
         (ValueRef::Text(t1), ValueRef::Text(t2)) => {
             // Use collation for text comparison
-            collation.compare_strings(t1.as_str(), t2.as_str()) == Ordering::Equal
+            collation.compare_strings(t1.as_bytes(), t2.as_bytes()) == Ordering::Equal
         }
         _ => false,
     }
@@ -281,7 +282,7 @@ impl HashEntry {
         let value_size = |v: &Value| match v {
             Value::Null => 1,
             Value::Numeric(_) => 8,
-            Value::Text(t) => t.as_str().len(),
+            Value::Text(t) => t.as_bytes().len(),
             Value::Blob(b) => b.len(),
         };
         let key_size: usize = key_values.iter().map(value_size).sum();
@@ -296,7 +297,7 @@ impl HashEntry {
             Value::Null => 0,
             Value::Numeric(_) => 8,
             Value::Text(t) => {
-                let len = t.as_str().len();
+                let len = t.as_bytes().len();
                 varint_len(len as u64) + len
             }
             Value::Blob(b) => varint_len(b.len() as u64) + b.len(),
@@ -362,7 +363,7 @@ impl HashEntry {
             Value::Text(t) => {
                 buf[offset] = TEXT_HASH;
                 offset += 1;
-                let bytes = t.as_str().as_bytes();
+                let bytes = t.as_bytes();
                 offset += write_varint(&mut buf[offset..], bytes.len() as u64);
                 buf[offset..offset + bytes.len()].copy_from_slice(bytes);
                 offset += bytes.len();
@@ -419,7 +420,7 @@ impl HashEntry {
             }
             Value::Text(t) => {
                 buf.push(TEXT_HASH);
-                let bytes = t.as_str().as_bytes();
+                let bytes = t.as_bytes();
                 let len = write_varint(varint_buf, bytes.len() as u64);
                 buf.extend_from_slice(&varint_buf[..len]);
                 buf.extend_from_slice(bytes);
@@ -524,13 +525,9 @@ impl HashEntry {
                         "HashEntry: buffer too small for text".to_string(),
                     ));
                 }
-                // SAFETY: We serialized this data ourselves, so it should be valid UTF-8.
-                // Skipping validation here for performance in the spill/reload path.
-                // Doing checked utf8 construction here is a massive performance hit.
                 let bytes = buf[offset..offset + str_len as usize].to_vec();
-                let s = unsafe { String::from_utf8_unchecked(bytes) };
                 offset += str_len as usize;
-                Value::Text(s.into())
+                Value::Text(crate::types::Text::from_bytes(bytes))
             }
             BLOB_HASH => {
                 let (blob_len, varint_len) = read_varint(&buf[offset..])?;
@@ -3303,21 +3300,21 @@ mod hashtests {
         let keys1 = vec![
             ValueRef::from_i64(42),
             ValueRef::Text(crate::types::TextRef::new(
-                "hello",
+                b"hello",
                 crate::types::TextSubtype::Text,
             )),
         ];
         let keys2 = vec![
             ValueRef::from_i64(42),
             ValueRef::Text(crate::types::TextRef::new(
-                "hello",
+                b"hello",
                 crate::types::TextSubtype::Text,
             )),
         ];
         let keys3 = vec![
             ValueRef::from_i64(43),
             ValueRef::Text(crate::types::TextRef::new(
-                "hello",
+                b"hello",
                 crate::types::TextSubtype::Text,
             )),
         ];
@@ -3361,14 +3358,14 @@ mod hashtests {
         let key2 = vec![
             ValueRef::from_i64(42),
             ValueRef::Text(crate::types::TextRef::new(
-                "hello",
+                b"hello",
                 crate::types::TextSubtype::Text,
             )),
         ];
         let key3 = vec![
             ValueRef::from_i64(43),
             ValueRef::Text(crate::types::TextRef::new(
-                "hello",
+                b"hello",
                 crate::types::TextSubtype::Text,
             )),
         ];
@@ -3521,7 +3518,7 @@ mod hashtests {
                 (Value::Numeric(Numeric::Integer(i1)), Value::Numeric(Numeric::Integer(i2))) => {
                     assert_eq!(i1, i2)
                 }
-                (Value::Text(t1), Value::Text(t2)) => assert_eq!(t1.as_str(), t2.as_str()),
+                (Value::Text(t1), Value::Text(t2)) => assert_eq!(t1.as_bytes(), t2.as_bytes()),
                 (Value::Numeric(Numeric::Float(f1)), Value::Numeric(Numeric::Float(f2))) => {
                     assert!((f64::from(*f1) - f64::from(*f2)).abs() < 1e-10)
                 }
@@ -3825,8 +3822,8 @@ mod hashtests {
     fn test_hash_function_respects_collation_nocase() {
         use crate::types::{TextRef, TextSubtype};
 
-        let keys1 = vec![ValueRef::Text(TextRef::new("Hello", TextSubtype::Text))];
-        let keys2 = vec![ValueRef::Text(TextRef::new("hello", TextSubtype::Text))];
+        let keys1 = vec![ValueRef::Text(TextRef::new(b"Hello", TextSubtype::Text))];
+        let keys2 = vec![ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text))];
 
         // Under BINARY: hashes must differ
         let bin_coll = vec![CollationSeq::Binary];
@@ -3847,8 +3844,14 @@ mod hashtests {
 
         // SQLite NOCASE only affects ASCII a-z/A-Z.
         // Non-ASCII characters like ü should hash identically regardless of case conversion.
-        let keys1 = vec![ValueRef::Text(TextRef::new("über", TextSubtype::Text))];
-        let keys2 = vec![ValueRef::Text(TextRef::new("ÜBER", TextSubtype::Text))];
+        let keys1 = vec![ValueRef::Text(TextRef::new(
+            "über".as_bytes(),
+            TextSubtype::Text,
+        ))];
+        let keys2 = vec![ValueRef::Text(TextRef::new(
+            "ÜBER".as_bytes(),
+            TextSubtype::Text,
+        ))];
 
         // Under NOCASE: ASCII portion differs (b/B), so hashes should differ
         // (because SQLite NOCASE doesn't handle Unicode case folding)
@@ -3870,9 +3873,9 @@ mod hashtests {
         use crate::types::{TextRef, TextSubtype};
 
         let nocase_coll = vec![CollationSeq::NoCase];
-        let keys1 = vec![ValueRef::Text(TextRef::new("A\0x", TextSubtype::Text))];
-        let keys2 = vec![ValueRef::Text(TextRef::new("a\0y", TextSubtype::Text))];
-        let keys3 = vec![ValueRef::Text(TextRef::new("a\0yz", TextSubtype::Text))];
+        let keys1 = vec![ValueRef::Text(TextRef::new(b"A\0x", TextSubtype::Text))];
+        let keys2 = vec![ValueRef::Text(TextRef::new(b"a\0y", TextSubtype::Text))];
+        let keys3 = vec![ValueRef::Text(TextRef::new(b"a\0yz", TextSubtype::Text))];
 
         assert!(values_equal(keys1[0], keys2[0], CollationSeq::NoCase));
         assert_eq!(
@@ -3891,8 +3894,8 @@ mod hashtests {
     fn test_values_equal_with_collations() {
         use crate::types::{TextRef, TextSubtype};
 
-        let h1 = ValueRef::Text(TextRef::new("Hello  ", TextSubtype::Text));
-        let h2 = ValueRef::Text(TextRef::new("hello", TextSubtype::Text));
+        let h1 = ValueRef::Text(TextRef::new(b"Hello  ", TextSubtype::Text));
+        let h2 = ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text));
 
         // Binary: case / trailing spaces matter
         assert!(!values_equal(h1, h2, CollationSeq::Binary));
@@ -3901,7 +3904,7 @@ mod hashtests {
         assert!(!values_equal(h1, h2, CollationSeq::NoCase));
 
         // RTRIM: ignore trailing spaces, but case is still significant
-        let h3 = ValueRef::Text(TextRef::new("Hello", TextSubtype::Text));
+        let h3 = ValueRef::Text(TextRef::new(b"Hello", TextSubtype::Text));
         assert!(values_equal(h1, h3, CollationSeq::Rtrim));
     }
 
@@ -3910,7 +3913,7 @@ mod hashtests {
         use crate::types::{TextRef, TextSubtype};
 
         let key1 = vec![Value::Text("Hello".into())];
-        let key2 = vec![ValueRef::Text(TextRef::new("hello", TextSubtype::Text))];
+        let key2 = vec![ValueRef::Text(TextRef::new(b"hello", TextSubtype::Text))];
 
         // Binary: not equal
         assert!(!keys_equal(&key1, &key2, &[CollationSeq::Binary]));
@@ -4737,7 +4740,7 @@ mod hashtests {
                     let expected_payload = format!("payload_{}", build_entry.rowid);
                     assert_eq!(build_entry.payload_values.len(), 1);
                     match &build_entry.payload_values[0] {
-                        Value::Text(t) => assert_eq!(t.as_str(), expected_payload.as_str()),
+                        Value::Text(t) => assert_eq!(t.as_bytes(), expected_payload.as_bytes()),
                         other => panic!("expected text payload, got {other:?}"),
                     }
                     match_count += 1;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2739,7 +2739,7 @@ impl<'a> FromValueRow<'a> for f64 {
 impl<'a> FromValueRow<'a> for String {
     fn from_value(value: &'a Value) -> Result<Self> {
         match value {
-            Value::Text(s) => Ok(s.as_str().to_string()),
+            Value::Text(s) => Ok(s.to_str_lossy().into_owned()),
             _ => Err(LimboError::ConversionError("Expected text value".into())),
         }
     }
@@ -2748,7 +2748,8 @@ impl<'a> FromValueRow<'a> for String {
 impl<'a> FromValueRow<'a> for &'a str {
     fn from_value(value: &'a Value) -> Result<Self> {
         match value {
-            Value::Text(s) => Ok(s.as_str()),
+            Value::Text(s) => std::str::from_utf8(s.as_bytes())
+                .map_err(|_| LimboError::ConversionError("Expected valid UTF-8 text value".into())),
             _ => Err(LimboError::ConversionError("Expected text value".into())),
         }
     }
@@ -2992,27 +2993,16 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 }
                 self.set_data_section(&data[content_size..]);
                 let text_data = &data[..content_size];
-                // SAFETY: TEXT serial type contains valid UTF-8
-                let text_str = if cfg!(debug_assertions) {
-                    match std::str::from_utf8(text_data) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            return Some(Err(LimboError::InternalError(format!(
-                                "Invalid UTF-8 in TEXT serial type: {e}"
-                            ))));
-                        }
-                    }
-                } else {
-                    unsafe { std::str::from_utf8_unchecked(text_data) }
-                };
                 match dest {
                     Register::Value(Value::Text(existing_text)) => {
-                        if let Err(err) = existing_text.do_extend(&text_str) {
+                        let text_ref =
+                            crate::types::TextRef::new(text_data, crate::types::TextSubtype::Text);
+                        if let Err(err) = existing_text.do_extend(&text_ref) {
                             return Some(Err(err));
                         }
                     }
                     _ => {
-                        if let Err(err) = dest.set_text(Text::new(text_str.to_string())) {
+                        if let Err(err) = dest.set_text(Text::from_bytes(text_data.to_vec())) {
                             return Some(Err(err));
                         }
                     }
@@ -3120,7 +3110,7 @@ mod shuttle_tests {
                         Register::Value(Value::Numeric(Numeric::Integer(42)))
                     ));
                     if let Register::Value(Value::Text(t)) = &state.registers[1] {
-                        assert_eq!(t.as_str(), "test");
+                        assert_eq!(t.as_bytes(), b"test");
                     } else {
                         panic!("Expected text value");
                     }

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -183,6 +183,70 @@ fn sqlite_text_prefix(s: &str) -> &str {
     }
 }
 
+/// Number of codepoints in a TEXT payload under lenient READ_UTF8 rules: a lead
+/// byte plus its trailing continuation bytes is one codepoint, and a lone
+/// continuation or short byte counts as its own. Matches SQLite's character
+/// counting for `length()`/`substr()` over non-UTF-8 bytes.
+fn utf8_char_count(bytes: &[u8]) -> usize {
+    let mut n = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        n += 1;
+        i += 1;
+        while i < bytes.len() && (bytes[i] & 0xc0) == 0x80 {
+            i += 1;
+        }
+    }
+    n
+}
+
+/// Byte offset reached after skipping `chars` codepoints (see [`utf8_char_count`]).
+fn utf8_char_byte_offset(bytes: &[u8], mut chars: usize) -> usize {
+    let mut i = 0;
+    while chars > 0 && i < bytes.len() {
+        i += 1;
+        while i < bytes.len() && (bytes[i] & 0xc0) == 0x80 {
+            i += 1;
+        }
+        chars -= 1;
+    }
+    i
+}
+
+/// Decode the first codepoint of a TEXT payload using SQLite's lenient
+/// `READ_UTF8` semantics (see SQLite's `utf.c`). A byte below 0xC0 (ASCII or a
+/// lone continuation byte) is returned as its own value; a lead byte greedily
+/// consumes the following continuation bytes, and only an overlong, surrogate,
+/// or noncharacter result folds to U+FFFD. This intentionally differs from
+/// `str::from_utf8` / `from_utf8_lossy`, which would fold a bare 0xFF/0x80 to
+/// U+FFFD. Returns `None` when the payload is empty.
+fn read_utf8_first_codepoint(bytes: &[u8]) -> Option<u32> {
+    let mut iter = bytes.iter();
+    let first = *iter.next()? as u32;
+    if first < 0xc0 {
+        // ASCII byte or a lone continuation byte: value is the byte itself.
+        return Some(first);
+    }
+    // Initial data bits by lead-byte class (2-, 3-, or 4+-byte start).
+    let mut c = if first < 0xe0 {
+        first & 0x1f
+    } else if first < 0xf0 {
+        first & 0x0f
+    } else {
+        first & 0x07
+    };
+    for &b in iter {
+        if b & 0xc0 != 0x80 {
+            break;
+        }
+        c = (c << 6) + (0x3f & b as u32);
+    }
+    if c < 0x80 || (c & 0xffff_f800) == 0xd800 || (c & 0xffff_fffe) == 0xfffe {
+        c = 0xfffd;
+    }
+    Some(c)
+}
+
 enum TrimType {
     All,
     Left,
@@ -191,14 +255,27 @@ enum TrimType {
 
 impl Value {
     pub fn exec_lower(&self) -> Option<Self> {
-        self.cast_text()
-            .map(|s| Value::build_text(s.to_ascii_lowercase()))
+        match self {
+            // Case-fold only ASCII, preserving other (possibly non-UTF-8) bytes,
+            // matching SQLite's byte-wise lower().
+            Value::Text(t) => Some(Value::Text(crate::types::Text::from_bytes(
+                t.as_bytes().to_ascii_lowercase(),
+            ))),
+            _ => self
+                .cast_text()
+                .map(|s| Value::build_text(s.to_ascii_lowercase())),
+        }
     }
 
     pub fn exec_length(&self) -> Self {
         match self {
             Value::Text(t) => {
-                Value::from_i64(sqlite_text_prefix(t.as_str()).chars().count() as i64)
+                let bytes = t.as_bytes();
+                let bytes = match bytes.iter().position(|&b| b == 0) {
+                    Some(i) => &bytes[..i],
+                    None => bytes,
+                };
+                Value::from_i64(utf8_char_count(bytes) as i64)
             }
             Value::Numeric(_) => {
                 // For numbers, SQLite returns the length of the string representation
@@ -211,7 +288,7 @@ impl Value {
 
     pub fn exec_octet_length(&self) -> Self {
         match self {
-            Value::Text(s) => Value::from_i64(s.as_str().len() as i64),
+            Value::Text(s) => Value::from_i64(s.as_bytes().len() as i64),
             Value::Blob(blob) => Value::from_i64(blob.len() as i64),
             Value::Numeric(_) => Value::from_i64(self.to_string().len() as i64),
             _ => self.to_owned(),
@@ -219,8 +296,15 @@ impl Value {
     }
 
     pub fn exec_upper(&self) -> Option<Self> {
-        self.cast_text()
-            .map(|s| Value::build_text(s.to_ascii_uppercase()))
+        match self {
+            // Case-fold only ASCII, preserving other (possibly non-UTF-8) bytes.
+            Value::Text(t) => Some(Value::Text(crate::types::Text::from_bytes(
+                t.as_bytes().to_ascii_uppercase(),
+            ))),
+            _ => self
+                .cast_text()
+                .map(|s| Value::build_text(s.to_ascii_uppercase())),
+        }
     }
 
     pub fn exec_sign(&self) -> Option<Value> {
@@ -238,7 +322,7 @@ impl Value {
     /// Generates the Soundex code for a given word
     pub fn exec_soundex(&self) -> Value {
         let s = match self {
-            Value::Text(s) => s.as_str(),
+            Value::Text(s) => s.to_str_lossy(),
             Value::Null => return Value::build_text("?000"),
             _ => return Value::build_text("?000"),
         };
@@ -306,7 +390,7 @@ impl Value {
             Value::Numeric(Numeric::Float(non_nan)) => Value::from_f64(f64::from(*non_nan).abs()),
             _ => {
                 let s = match self {
-                    Value::Text(text) => std::borrow::Cow::Borrowed(text.as_str()),
+                    Value::Text(text) => text.to_str_lossy(),
                     Value::Blob(blob) => String::from_utf8_lossy(blob),
                     _ => unreachable!(),
                 };
@@ -335,7 +419,7 @@ impl Value {
         let length = match self {
             Value::Numeric(Numeric::Integer(i)) => *i,
             Value::Numeric(Numeric::Float(f)) => f64::from(*f) as i64,
-            Value::Text(t) => t.as_str().parse().unwrap_or(1),
+            Value::Text(t) => t.to_str_lossy().parse().unwrap_or(1),
             _ => 1,
         }
         .max(1);
@@ -368,9 +452,10 @@ impl Value {
                 Value::build_text(quoted)
             }
             Value::Text(s) => {
-                let mut quoted = String::with_capacity(s.as_str().len() + 2);
+                let s = s.to_str_lossy();
+                let mut quoted = String::with_capacity(s.len() + 2);
                 quoted.push('\'');
-                for c in s.as_str().chars() {
+                for c in s.chars() {
                     if c == '\0' {
                         break;
                     } else if c == '\'' {
@@ -391,7 +476,7 @@ impl Value {
 
         match self {
             Value::Text(s) => {
-                let s = s.as_str();
+                let s = s.to_str_lossy();
                 let mut end = s.len();
                 let mut has_ctrl = false;
 
@@ -551,6 +636,22 @@ impl Value {
                 let (start, end) = calculate_postions(start, b.len(), length_value.as_ref());
                 Value::from_blob(b[start..end].to_vec())
             }
+            (Value::Text(t), Value::Numeric(Numeric::Integer(start))) => {
+                // substr on TEXT indexes by codepoint (lenient READ_UTF8) but
+                // returns the underlying bytes, so non-UTF-8 content survives.
+                let bytes = t.as_bytes();
+                let bytes = match bytes.iter().position(|&b| b == 0) {
+                    Some(i) => &bytes[..i],
+                    None => bytes,
+                };
+                let char_count = utf8_char_count(bytes);
+                let (start, end) = calculate_postions(start, char_count, length_value.as_ref());
+                let start_byte = utf8_char_byte_offset(bytes, start);
+                let end_byte = utf8_char_byte_offset(bytes, end);
+                Value::Text(crate::types::Text::from_bytes(
+                    bytes[start_byte..end_byte].to_vec(),
+                ))
+            }
             (value, Value::Numeric(Numeric::Integer(start))) => {
                 if let Some(text) = value.cast_text() {
                     let s = sqlite_text_prefix(text.as_str());
@@ -599,19 +700,25 @@ impl Value {
 
         let reg_str;
         let reg = match self {
-            Value::Text(s) => s.as_str(),
+            Value::Text(s) => {
+                reg_str = s.to_str_lossy();
+                reg_str.as_ref()
+            }
             _ => {
-                reg_str = self.to_string();
-                reg_str.as_str()
+                reg_str = std::borrow::Cow::Owned(self.to_string());
+                reg_str.as_ref()
             }
         };
 
         let pattern_str;
         let pattern = match pattern {
-            Value::Text(s) => s.as_str(),
+            Value::Text(s) => {
+                pattern_str = s.to_str_lossy();
+                pattern_str.as_ref()
+            }
             _ => {
-                pattern_str = pattern.to_string();
-                pattern_str.as_str()
+                pattern_str = std::borrow::Cow::Owned(pattern.to_string());
+                pattern_str.as_ref()
             }
         };
 
@@ -637,10 +744,10 @@ impl Value {
 
     pub fn exec_hex(&self) -> Value {
         match self {
-            Value::Text(_) | Value::Numeric(_) => {
-                let text = self.to_string();
-                Value::build_text(hex::encode_upper(text))
-            }
+            // TEXT hexes its raw bytes (not a lossy UTF-8 rendering), matching
+            // SQLite; a lossy conversion would turn X'FF' into EF BF BD.
+            Value::Text(t) => Value::build_text(hex::encode_upper(t.as_bytes())),
+            Value::Numeric(_) => Value::build_text(hex::encode_upper(self.to_string())),
             Value::Blob(blob_bytes) => Value::build_text(hex::encode_upper(blob_bytes)),
             Value::Null => Value::build_text(""),
         }
@@ -700,7 +807,17 @@ impl Value {
 
     pub fn exec_unicode(&self) -> Value {
         match self {
-            Value::Text(_) | Value::Numeric(_) | Value::Blob(_) => {
+            // TEXT is stored as raw bytes and is not required to be valid UTF-8.
+            // Decode the first codepoint with SQLite's lenient READ_UTF8 rules
+            // (see utf.c): a lone continuation/short byte is returned as its raw
+            // value, and only a malformed *multi-byte* sequence folds to U+FFFD.
+            // This differs from `from_utf8_lossy`, which would yield U+FFFD for a
+            // bare 0xFF/0x80.
+            Value::Text(t) => match read_utf8_first_codepoint(t.as_bytes()) {
+                None | Some(0) => Value::Null,
+                Some(c) => Value::from_i64(c as i64),
+            },
+            Value::Numeric(_) | Value::Blob(_) => {
                 let text = self.to_string();
                 if let Some(first_char) = text.chars().next() {
                     if first_char == '\0' {
@@ -717,7 +834,7 @@ impl Value {
 
     pub fn exec_unistr(&self) -> Result<Value> {
         let text = match self {
-            Value::Text(t) => std::borrow::Cow::Borrowed(t.as_str()),
+            Value::Text(t) => t.to_str_lossy(),
             Value::Numeric(_) | Value::Blob(_) => std::borrow::Cow::Owned(self.to_string()),
             _ => return Ok(Value::Null),
         };
@@ -806,7 +923,7 @@ impl Value {
 
     fn _exec_trim(&self, pattern: Option<&Value>, trim_type: TrimType) -> Value {
         let text_cow = match self {
-            Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+            Value::Text(s) => s.to_str_lossy(),
             Value::Null => return Value::Null,
             _ => std::borrow::Cow::Owned(self.to_string()),
         };
@@ -816,7 +933,7 @@ impl Value {
                     return Value::Null;
                 }
                 let pat_cow = match p {
-                    Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                    Value::Text(s) => s.to_str_lossy(),
                     _ => std::borrow::Cow::Owned(p.to_string()),
                 };
                 let p_str = pat_cow.as_ref();
@@ -853,7 +970,7 @@ impl Value {
         let length: i64 = match self {
             Value::Numeric(Numeric::Integer(i)) => *i,
             Value::Numeric(Numeric::Float(f)) => f64::from(*f) as i64,
-            Value::Text(s) => s.as_str().parse().unwrap_or(0),
+            Value::Text(s) => s.to_str_lossy().parse().unwrap_or(0),
             _ => 0,
         }
         .max(0);
@@ -891,11 +1008,18 @@ impl Value {
             }
             // TEXT To cast a BLOB value to TEXT, the sequence of bytes that make up the BLOB is interpreted as text encoded using the database encoding.
             // Casting an INTEGER or REAL value into TEXT renders the value as if via sqlite3_snprintf() except that the resulting TEXT uses the encoding of the database connection.
-            Affinity::Text => {
-                // Convert everything to text representation
-                // TODO: handle encoding and whatever sqlite3_snprintf does
-                Value::build_text(self.to_string())
-            }
+            Affinity::Text => match self {
+                // Casting a BLOB to TEXT reinterprets the raw bytes as text
+                // without conversion; the bytes need not be valid UTF-8 (SQLite:
+                // "the sequence of bytes that make up the BLOB is interpreted as
+                // text"). A lossy conversion here would corrupt e.g. X'FF'.
+                Value::Blob(b) => Value::Text(crate::types::Text::from_bytes(b.clone())),
+                Value::Text(t) => {
+                    Value::Text(crate::types::Text::from_bytes(t.as_bytes().to_vec()))
+                }
+                // Numeric/other: render via snprintf-equivalent (always UTF-8).
+                _ => Value::build_text(self.to_string()),
+            },
             Affinity::Real => match self {
                 Value::Blob(b) => {
                     let text = String::from_utf8_lossy(b);
@@ -905,9 +1029,11 @@ impl Value {
                             .unwrap_or(0.0),
                     )
                 }
-                Value::Text(t) => {
-                    Value::from_f64(crate::numeric::str_to_f64(t).map(f64::from).unwrap_or(0.0))
-                }
+                Value::Text(t) => Value::from_f64(
+                    crate::numeric::str_to_f64(t.to_str_lossy())
+                        .map(f64::from)
+                        .unwrap_or(0.0),
+                ),
                 Value::Numeric(Numeric::Integer(i)) => Value::from_f64(*i as f64),
                 Value::Numeric(Numeric::Float(f)) => Value::Numeric(Numeric::Float(*f)),
                 _ => Value::from_f64(0.0),
@@ -918,7 +1044,9 @@ impl Value {
                     let text = String::from_utf8_lossy(b);
                     Value::from_i64(crate::numeric::str_to_i64(&text).unwrap_or(0))
                 }
-                Value::Text(t) => Value::from_i64(crate::numeric::str_to_i64(t).unwrap_or(0)),
+                Value::Text(t) => {
+                    Value::from_i64(crate::numeric::str_to_i64(t.to_str_lossy()).unwrap_or(0))
+                }
                 Value::Numeric(Numeric::Integer(i)) => Value::from_i64(*i),
                 // A cast of a REAL value into an INTEGER follows SQLite's sqlite3RealToI64:
                 // truncate toward zero and clamp to i64::MIN/MAX if outside the safe range.
@@ -931,7 +1059,7 @@ impl Value {
                 Value::Numeric(Numeric::Float(v)) => Value::Numeric(Numeric::Float(*v)),
                 _ => {
                     let s = match self {
-                        Value::Text(text) => text.as_str().into(),
+                        Value::Text(text) => text.to_str_lossy(),
                         Value::Blob(blob) => String::from_utf8_lossy(blob.as_slice()),
                         _ => unreachable!(),
                     };
@@ -963,13 +1091,14 @@ impl Value {
         // If any of the casts failed, panic as text casting is not expected to fail.
         match (&source, &pattern, &replacement) {
             (Value::Text(source), Value::Text(pattern), Value::Text(replacement)) => {
-                if pattern.as_str().is_empty() || pattern.as_str().starts_with('\0') {
+                let pattern_str = pattern.to_str_lossy();
+                if pattern_str.is_empty() || pattern_str.starts_with('\0') {
                     return Value::Text(source.clone());
                 }
 
                 let result = source
-                    .as_str()
-                    .replace(pattern.as_str(), replacement.as_str());
+                    .to_str_lossy()
+                    .replace(pattern_str.as_ref(), &replacement.to_str_lossy());
                 Value::build_text(result)
             }
             _ => unreachable!("text cast should never fail"),
@@ -1149,15 +1278,25 @@ impl Value {
             return Value::Blob([lhs.as_slice(), rhs.as_slice()].concat());
         }
 
-        let Some(lhs) = self.cast_text() else {
+        // `||` converts both operands to TEXT and concatenates the raw byte
+        // sequences (SQLite). TEXT bytes are carried through verbatim so that
+        // non-UTF-8 content is preserved.
+        fn concat_bytes(v: &Value) -> Option<std::borrow::Cow<'_, [u8]>> {
+            match v {
+                Value::Null => None,
+                Value::Text(t) => Some(std::borrow::Cow::Borrowed(t.as_bytes())),
+                Value::Blob(b) => Some(std::borrow::Cow::Borrowed(b.as_slice())),
+                Value::Numeric(_) => Some(std::borrow::Cow::Owned(v.to_string().into_bytes())),
+            }
+        }
+
+        let (Some(lhs), Some(rhs)) = (concat_bytes(self), concat_bytes(rhs)) else {
             return Value::Null;
         };
-
-        let Some(rhs) = rhs.cast_text() else {
-            return Value::Null;
-        };
-
-        Value::build_text(lhs + &rhs)
+        let mut out = Vec::with_capacity(lhs.len() + rhs.len());
+        out.extend_from_slice(&lhs);
+        out.extend_from_slice(&rhs);
+        Value::Text(crate::types::Text::from_bytes(out))
     }
 
     pub fn exec_and(&self, rhs: &Value) -> Value {
@@ -1302,7 +1441,9 @@ impl Value {
         let Value::Text(text) = self else {
             panic!("concat_to_text must be called only on Value::Text");
         };
-        text.value.to_mut().push_str(&other.to_string());
+        text.value
+            .to_mut()
+            .extend_from_slice(other.to_string().as_bytes());
     }
 
     pub fn exec_concat_strings<'a, T: Iterator<Item = &'a Self>>(registers: T) -> Self {
@@ -1310,7 +1451,7 @@ impl Value {
         for val in registers {
             match val {
                 Value::Null => continue,
-                Value::Text(s) => result.push_str(s.as_str()),
+                Value::Text(s) => result.push_str(&s.to_str_lossy()),
                 Value::Blob(b) => result.push_str(&String::from_utf8_lossy(b)),
                 Value::Numeric(Numeric::Integer(i)) => result.push_str(&i.to_string()),
                 Value::Numeric(Numeric::Float(f)) => result.push_str(&format_float(f64::from(*f))),

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -18,7 +18,7 @@ pub fn parse_vector<'a>(
     match value.value_type() {
         ValueType::Text => operations::text::vector_from_text(
             type_hint.unwrap_or(VectorType::Float32Dense),
-            value.to_text().expect("value must be text"),
+            &value.to_text_str_lossy().expect("value must be text"),
         ),
         ValueType::Blob => {
             let Some(blob) = value.to_blob() else {

--- a/core/vector/operations/text.rs
+++ b/core/vector/operations/text.rs
@@ -64,7 +64,7 @@ fn format_text<T: std::string::ToString>(values: impl Iterator<Item = T>) -> Str
 /// ```console
 /// [1.0, 2.0, 3.0]
 /// ```
-pub fn vector_from_text(vector_type: VectorType, text: &str) -> Result<Vector> {
+pub fn vector_from_text(vector_type: VectorType, text: &str) -> Result<Vector<'static>> {
     let text = text.trim();
     let mut chars = text.chars();
     if chars.next() != Some('[') || chars.last() != Some(']') {

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -710,7 +710,7 @@ mod tests {
             .into_iter()
             .map(|cols| {
                 let key = match &cols[0] {
-                    Value::Text(t) => t.as_str().to_string(),
+                    Value::Text(t) => t.to_str_lossy().into_owned(),
                     other => panic!("unexpected key type {other:?}"),
                 };
                 let value = match &cols[1] {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -2062,7 +2062,10 @@ mod tests {
                     .unwrap();
                 assert_eq!(stmt.step(None).unwrap(), TursoStatusCode::Row);
                 assert_integer(stmt.row_value(0).unwrap(), 1);
-                assert_eq!(stmt.row_value(1).unwrap().to_text(), Some("secret_data"));
+                assert_eq!(
+                    stmt.row_value(1).unwrap().to_text(),
+                    Some("secret_data".as_bytes())
+                );
             }
 
             // 4. Verify opening with wrong key fails

--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -205,7 +205,11 @@ impl DatabaseReplayGenerator {
                             before.get(1)
                         );
                     };
-                    let query = format!("DROP {} {}", entity_type.as_str(), entity_name.as_str());
+                    let query = format!(
+                        "DROP {} {}",
+                        entity_type.to_str_lossy(),
+                        entity_name.to_str_lossy()
+                    );
                     let delete = ReplayInfo {
                         change_type: DatabaseChangeType::Delete,
                         query,
@@ -223,26 +227,26 @@ impl DatabaseReplayGenerator {
                             after.last()
                         )));
                     };
-                    let mut parser = Parser::new(sql.as_str().as_bytes());
+                    let mut parser = Parser::new(sql.as_bytes());
                     let mut ast = parser
                         .next()
                         .ok_or_else(|| {
                             Error::DatabaseTapeError(format!(
                                 "unexpected DDL query: {}",
-                                sql.as_str()
+                                sql.to_str_lossy()
                             ))
                         })?
                         .map_err(|e| {
                             Error::DatabaseTapeError(format!(
                                 "unexpected DDL query {}: {}",
                                 e,
-                                sql.as_str()
+                                sql.to_str_lossy()
                             ))
                         })?;
                     let turso_parser::ast::Cmd::Stmt(stmt) = &mut ast else {
                         return Err(Error::DatabaseTapeError(format!(
                             "unexpected DDL query: {}",
-                            sql.as_str()
+                            sql.to_str_lossy()
                         )));
                     };
                     match stmt {
@@ -282,7 +286,7 @@ impl DatabaseReplayGenerator {
                     };
                     let update = ReplayInfo {
                         change_type: DatabaseChangeType::Update,
-                        query: ddl_stmt.as_str().to_string(),
+                        query: ddl_stmt.to_str_lossy().into_owned(),
                         pk_column_indices: None,
                         column_names: Vec::new(),
                         is_ddl_replay: true,
@@ -542,7 +546,7 @@ impl DatabaseReplayGenerator {
             if *pk == 1 {
                 pk_column_indices.push(*column_id as usize);
             }
-            column_names.push(name.as_str().to_string());
+            column_names.push(name.to_str_lossy().into_owned());
         }
         Ok((column_names, pk_column_indices))
     }

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -673,7 +673,7 @@ fn convert_to_args(
                 value: f64::from(value),
             },
             Value::Text(value) => server_proto::Value::Text {
-                value: value.as_str().to_string(),
+                value: value.to_str_lossy().into_owned(),
             },
             Value::Blob(value) => server_proto::Value::Blob {
                 value: value.into(),

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -1569,7 +1569,9 @@ mod tests {
                 let mut rows = Vec::new();
                 let mut stmt = conn3.prepare("SELECT name FROM sqlite_master").unwrap();
                 while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
-                    rows.push(row.get_value(0).to_text().unwrap().to_string());
+                    rows.push(
+                        String::from_utf8_lossy(row.get_value(0).to_text().unwrap()).into_owned(),
+                    );
                 }
                 assert_eq!(
                     rows,
@@ -1661,7 +1663,7 @@ mod tests {
                     .prepare("SELECT sql FROM sqlite_schema WHERE name = 't'")
                     .unwrap();
                 let row = run_stmt_once(&coro, &mut stmt).await.unwrap().unwrap();
-                let sql = row.get_value(0).to_text().unwrap().to_string();
+                let sql = String::from_utf8_lossy(row.get_value(0).to_text().unwrap()).into_owned();
                 assert!(
                     sql.contains("z"),
                     "schema should contain z column after ALTER TABLE: {sql}"
@@ -2235,7 +2237,7 @@ mod tests {
                     .prepare("SELECT sql FROM sqlite_schema WHERE name = 't'")
                     .unwrap();
                 let row = run_stmt_once(&coro, &mut stmt).await.unwrap().unwrap();
-                let sql = row.get_value(0).to_text().unwrap().to_string();
+                let sql = String::from_utf8_lossy(row.get_value(0).to_text().unwrap()).into_owned();
                 assert!(
                     sql.contains("z"),
                     "schema should still contain z column: {sql}"

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -281,9 +281,11 @@ impl Property for IntegrityCheckProperty {
                     );
                 }
                 match &row[0] {
-                    Value::Text(text) if text.as_str() == "ok" => Ok(()),
+                    Value::Text(text) if text.as_bytes() == b"ok" => Ok(()),
                     // "Page N: never used" is informational in MVCC mode, not corruption
-                    Value::Text(text) if is_integrity_check_informational(text.as_str()) => Ok(()),
+                    Value::Text(text) if is_integrity_check_informational(&text.to_str_lossy()) => {
+                        Ok(())
+                    }
                     other => {
                         bail!(
                             "step {step}, fiber {fiber_id}: integrity_check returned {:?}, expected \"ok\"",
@@ -2182,7 +2184,7 @@ fn parse_read_result(result: &OpResult) -> Option<Vec<i64>> {
         } else if let Some(row) = rows.first() {
             if let Some(value) = row.first() {
                 match value {
-                    Value::Text(csv_str) => parse_comma_separated_ints(csv_str.as_str()),
+                    Value::Text(csv_str) => parse_comma_separated_ints(&csv_str.to_str_lossy()),
                     Value::Null => Some(vec![]),
                     _ => Some(vec![]),
                 }

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -292,7 +292,7 @@ fn assert_integrity_check_ok(whopper: &mut MultiprocessWhopper, worker_idx: usiz
     );
     assert_eq!(
         rows[0][0].to_text(),
-        Some("ok"),
+        Some(b"ok".as_slice()),
         "integrity_check should report ok"
     );
 }

--- a/testing/differential-oracle/fuzzer/custom_types_fuzzer.rs
+++ b/testing/differential-oracle/fuzzer/custom_types_fuzzer.rs
@@ -3912,7 +3912,7 @@ fn execute_turso_rows(conn: &Arc<turso_core::Connection>, sql: &str) -> Result<V
                     turso_core::Value::Numeric(turso_core::Numeric::Float(f)) => {
                         values.push(f.to_string())
                     }
-                    turso_core::Value::Text(s) => values.push(s.as_str().to_string()),
+                    turso_core::Value::Text(s) => values.push(s.to_str_lossy().into_owned()),
                     turso_core::Value::Blob(b) => {
                         let hex: String = b.iter().map(|byte| format!("{byte:02x}")).collect();
                         values.push(format!("x'{hex}'"));

--- a/testing/differential-oracle/fuzzer/oracle.rs
+++ b/testing/differential-oracle/fuzzer/oracle.rs
@@ -282,7 +282,7 @@ impl DifferentialOracle {
             Value::Null => SqlValue::Null,
             Value::Numeric(Numeric::Integer(i)) => SqlValue::Integer(i),
             Value::Numeric(Numeric::Float(f)) => SqlValue::Real(f64::from(f)),
-            Value::Text(s) => SqlValue::Text(s.as_str().to_string()),
+            Value::Text(s) => SqlValue::Text(s.to_str_lossy().into_owned()),
             Value::Blob(b) => SqlValue::Blob(b),
         }
     }

--- a/testing/differential-oracle/fuzzer/schema.rs
+++ b/testing/differential-oracle/fuzzer/schema.rs
@@ -44,10 +44,10 @@ impl SchemaIntrospector {
         rows.run_with_row_callback(|row| {
             if let turso_core::Value::Text(name) = row.get_value(0) {
                 let strict = match row.get_value(1) {
-                    turso_core::Value::Text(sql) => Self::sql_is_strict(sql.as_str()),
+                    turso_core::Value::Text(sql) => Self::sql_is_strict(&sql.to_str_lossy()),
                     _ => false,
                 };
-                tables.push((name.as_str().to_string(), strict));
+                tables.push((name.to_str_lossy().into_owned(), strict));
             }
             Ok(())
         })
@@ -140,9 +140,8 @@ impl SchemaIntrospector {
 
         rows.run_with_row_callback(|row| {
             if let turso_core::Value::Text(name) = row.get_value(1) {
-                let name = name.as_str();
-                if name != "main" {
-                    databases.push(name.to_string());
+                if name.as_bytes() != b"main" {
+                    databases.push(name.to_str_lossy().into_owned());
                 }
             }
             Ok(())
@@ -181,12 +180,12 @@ impl SchemaIntrospector {
 
         rows.run_with_row_callback(|row| {
             let name = match row.get_value(1) {
-                turso_core::Value::Text(s) => s.as_str().to_string(),
+                turso_core::Value::Text(s) => s.to_str_lossy().into_owned(),
                 _ => return Ok(()),
             };
 
             let type_str = match row.get_value(2) {
-                turso_core::Value::Text(s) => s.as_str().to_uppercase(),
+                turso_core::Value::Text(s) => s.to_str_lossy().to_uppercase(),
                 _ => "TEXT".to_string(),
             };
 
@@ -349,7 +348,7 @@ impl SchemaIntrospector {
 
         rows.run_with_row_callback(|row| {
             let name = match row.get_value(1) {
-                turso_core::Value::Text(s) => s.as_str().to_string(),
+                turso_core::Value::Text(s) => s.to_str_lossy().into_owned(),
                 _ => return Ok(()),
             };
             let unique = match row.get_value(2) {
@@ -357,7 +356,7 @@ impl SchemaIntrospector {
                 _ => false,
             };
             let origin = match row.get_value(3) {
-                turso_core::Value::Text(s) => Some(s.as_str().to_string()),
+                turso_core::Value::Text(s) => Some(s.to_str_lossy().into_owned()),
                 _ => None,
             };
             if origin.as_deref().is_some_and(|origin| origin != "c")
@@ -454,7 +453,7 @@ impl SchemaIntrospector {
                 return Ok(());
             }
             if let turso_core::Value::Text(name) = row.get_value(2) {
-                columns.push(name.as_str().to_string());
+                columns.push(name.to_str_lossy().into_owned());
             }
             Ok(())
         })

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -1616,7 +1616,7 @@ fn run_integrity_check(
             rows.run_with_row_callback(|row| {
                 let value = row
                     .get_value(0)
-                    .to_text()
+                    .to_text_str_lossy()
                     .ok_or_else(|| {
                         LimboError::InternalError(
                             "integrity_check returned a non-text value".to_string(),

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -353,7 +353,7 @@ fn limbo_integrity_check(conn: &Arc<Connection>) -> Result<()> {
 
     rows.run_with_row_callback(|row| {
         let val = match row.get_value(0) {
-            turso_core::Value::Text(text) => text.as_str().to_string(),
+            turso_core::Value::Text(text) => text.to_str_lossy().into_owned(),
             _ => unreachable!(),
         };
         result.push(val);

--- a/testing/sqltests/tests/non-utf8-text.sqltest
+++ b/testing/sqltests/tests/non-utf8-text.sqltest
@@ -1,0 +1,199 @@
+@database :memory:
+
+# TEXT values are not required to be valid UTF-8. SQLite stores the raw bytes
+# with a TEXT serial type (e.g. via CAST(X'FF' AS TEXT)), keeps typeof() = 'text',
+# compares them byte-wise, and only interprets them as codepoints when a function
+# forces a decode. Turso previously called from_utf8_unchecked in the record
+# decoder, which was undefined behavior (SIGSEGV in release, error in debug) on
+# such values. Regression for https://github.com/tursodatabase/turso/issues/5164.
+#
+# Fixtures cover: a lone lead byte (FF), an invalid byte between valid ASCII
+# (a FF b), a lone continuation byte (80), a truncated 2-byte sequence (C3),
+# a noncharacter/invalid pair (FF FE), and a valid ASCII control ('abc').
+setup data {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES
+        (CAST(X'FF'     AS TEXT)),
+        (CAST(X'61FF62' AS TEXT)),
+        (CAST(X'80'     AS TEXT)),
+        (CAST(X'C3'     AS TEXT)),
+        (CAST(X'FFFE'   AS TEXT)),
+        ('abc');
+}
+
+# ---------------------------------------------------------------------------
+# Byte-level behavior: no decode happens, so these hold for any conforming
+# implementation of the bytes-backed Text type.
+# ---------------------------------------------------------------------------
+
+# Invalid UTF-8 stays TEXT — it is never demoted to BLOB.
+@setup data
+test non-utf8-typeof-stays-text {
+    SELECT typeof(x) FROM t ORDER BY rowid;
+}
+expect {
+    text
+    text
+    text
+    text
+    text
+    text
+}
+
+# Raw bytes survive a store + read round-trip through the b-tree unchanged.
+@setup data
+test non-utf8-hex-roundtrip {
+    SELECT hex(x) FROM t ORDER BY rowid;
+}
+expect {
+    FF
+    61FF62
+    80
+    C3
+    FFFE
+    616263
+}
+
+# length() is byte/char length; for these inputs it matches the byte count of
+# maximal decode attempts and is decoder-agnostic.
+@setup data
+test non-utf8-length {
+    SELECT length(x) FROM t ORDER BY rowid;
+}
+expect {
+    1
+    3
+    1
+    1
+    2
+    3
+}
+
+# LIKE compares bytes; the invalid bytes never spuriously match 'a'.
+@setup data
+test non-utf8-like {
+    SELECT x LIKE '%a%' FROM t ORDER BY rowid;
+}
+expect {
+    0
+    1
+    0
+    0
+    0
+    1
+}
+
+# GLOB is likewise byte-wise.
+@setup data
+test non-utf8-glob {
+    SELECT x GLOB '*a*' FROM t ORDER BY rowid;
+}
+expect {
+    0
+    1
+    0
+    0
+    0
+    1
+}
+
+# ORDER BY on TEXT with BINARY collation is an unsigned byte comparison.
+@setup data
+test non-utf8-order-byte-wise {
+    SELECT hex(x) FROM t ORDER BY x;
+}
+expect {
+    616263
+    61FF62
+    80
+    C3
+    FF
+    FFFE
+}
+
+# Equality is byte equality: only the identical FF value matches.
+@setup data
+test non-utf8-equality {
+    SELECT x = CAST(X'FF' AS TEXT) FROM t ORDER BY rowid;
+}
+expect {
+    1
+    0
+    0
+    0
+    0
+    0
+}
+
+# substr slices bytes and preserves invalid bytes verbatim.
+@setup data
+test non-utf8-substr-preserves-bytes {
+    SELECT hex(substr(x, 1, 1)) FROM t ORDER BY rowid;
+}
+expect {
+    FF
+    61
+    80
+    C3
+    FF
+    61
+}
+
+# Concatenation carries invalid bytes through untouched.
+@setup data
+test non-utf8-concat-preserves-bytes {
+    SELECT hex('[' || x || ']') FROM t ORDER BY rowid;
+}
+expect {
+    5BFF5D
+    5B61FF625D
+    5B805D
+    5BC35D
+    5BFFFE5D
+    5B6162635D
+}
+
+# Case folding leaves bytes that are not decodable ASCII untouched, and folds
+# only the valid ASCII (a FF b -> A FF B).
+@setup data
+test non-utf8-upper-preserves-invalid-bytes {
+    SELECT hex(upper(x)) FROM t ORDER BY rowid;
+}
+expect {
+    FF
+    41FF42
+    80
+    C3
+    FFFE
+    414243
+}
+
+# ---------------------------------------------------------------------------
+# Codepoint decode behavior: these pin SQLite's lenient READ_UTF8 semantics.
+# A from_utf8_lossy-based decoder DIVERGES on the lone continuation byte below
+# (it would yield 65533 instead of 128), so these guard the decoder choice.
+# ---------------------------------------------------------------------------
+
+# unicode() decodes the first codepoint. Malformed lead/pair bytes fold to the
+# replacement character U+FFFD (65533); a bare ASCII stays itself.
+@setup data
+test non-utf8-unicode-first-char {
+    SELECT unicode(x) FROM t ORDER BY rowid;
+}
+expect {
+    65533
+    97
+    128
+    65533
+    65533
+    97
+}
+
+# A lone continuation byte (0x80) is returned as its raw value 128, NOT U+FFFD.
+# This is the case where from_utf8_lossy would be wrong.
+test non-utf8-unicode-lone-continuation-byte {
+    SELECT unicode(CAST(X'80' AS TEXT));
+}
+expect {
+    128
+}

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -411,7 +411,9 @@ pub fn limbo_exec_rows(
                 turso_core::Value::Numeric(turso_core::Numeric::Float(x)) => {
                     rusqlite::types::Value::Real(f64::from(*x))
                 }
-                turso_core::Value::Text(x) => rusqlite::types::Value::Text(x.as_str().to_string()),
+                turso_core::Value::Text(x) => {
+                    rusqlite::types::Value::Text(x.to_str_lossy().into_owned())
+                }
                 turso_core::Value::Blob(x) => rusqlite::types::Value::Blob(x.to_vec()),
             })
             .collect();
@@ -444,7 +446,9 @@ pub fn try_limbo_exec_rows(
                 turso_core::Value::Numeric(turso_core::Numeric::Float(x)) => {
                     rusqlite::types::Value::Real(f64::from(*x))
                 }
-                turso_core::Value::Text(x) => rusqlite::types::Value::Text(x.as_str().to_string()),
+                turso_core::Value::Text(x) => {
+                    rusqlite::types::Value::Text(x.to_str_lossy().into_owned())
+                }
                 turso_core::Value::Blob(x) => rusqlite::types::Value::Blob(x.to_vec()),
             })
             .collect();
@@ -488,7 +492,9 @@ pub fn limbo_exec_rows_fallible(
                 turso_core::Value::Numeric(turso_core::Numeric::Float(x)) => {
                     rusqlite::types::Value::Real(f64::from(*x))
                 }
-                turso_core::Value::Text(x) => rusqlite::types::Value::Text(x.as_str().to_string()),
+                turso_core::Value::Text(x) => {
+                    rusqlite::types::Value::Text(x.to_str_lossy().into_owned())
+                }
                 turso_core::Value::Blob(x) => rusqlite::types::Value::Blob(x.to_vec()),
             })
             .collect();

--- a/tests/integration/integrity_check.rs
+++ b/tests/integration/integrity_check.rs
@@ -28,7 +28,7 @@ fn run_integrity_check(conn: &Arc<turso_core::Connection>) -> String {
         .filter_map(|row| {
             row.into_iter().next().and_then(|v| {
                 if let Value::Text(text) = v {
-                    Some(text.as_str().to_string())
+                    Some(text.to_str_lossy().into_owned())
                 } else {
                     None
                 }
@@ -48,7 +48,7 @@ fn run_quick_check(conn: &Arc<turso_core::Connection>) -> String {
         .filter_map(|row| {
             row.into_iter().next().and_then(|v| {
                 if let Value::Text(text) = v {
-                    Some(text.as_str().to_string())
+                    Some(text.to_str_lossy().into_owned())
                 } else {
                     None
                 }
@@ -97,7 +97,7 @@ fn run_integrity_check_or_error(conn: &Arc<turso_core::Connection>) -> Result<St
                 .filter_map(|row| {
                     row.into_iter().next().and_then(|v| {
                         if let Value::Text(text) = v {
-                            Some(text.as_str().to_string())
+                            Some(text.to_str_lossy().into_owned())
                         } else {
                             None
                         }
@@ -213,7 +213,7 @@ fn test_integrity_check_max_errors(db: TempDatabase) {
         .filter_map(|row| {
             row.into_iter().next().and_then(|v| {
                 if let Value::Text(text) = v {
-                    Some(text.as_str().to_string())
+                    Some(text.to_str_lossy().into_owned())
                 } else {
                     None
                 }

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -46,7 +46,7 @@ fn test_pragma_module_list_generate_series(db: TempDatabase) {
         while let StepResult::Row = rows.step().unwrap() {
             let row = rows.row().unwrap();
             if let Value::Text(name) = row.get_value(0) {
-                if name.as_str() == "generate_series" {
+                if name.as_bytes() == b"generate_series" {
                     found = true;
                     break;
                 }
@@ -150,7 +150,7 @@ fn test_pragma_page_sizes_with_writes_persists(db: TempDatabase) {
                 let Value::Text(value) = row.get_value(0) else {
                     panic!("expected text value");
                 };
-                assert_eq!(value.as_str(), "test data");
+                assert_eq!(value.as_bytes(), b"test data");
                 Ok(())
             })
             .unwrap();

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -54,11 +54,11 @@ fn test_statement_bind(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
     stmt.run_with_row_callback(|row| {
         if let turso_core::Value::Text(s) = row.get::<&Value>(0).unwrap() {
-            assert_eq!(s.as_str(), "hello")
+            assert_eq!(s.as_bytes(), b"hello")
         }
 
         if let turso_core::Value::Text(s) = row.get::<&Value>(1).unwrap() {
-            assert_eq!(s.as_str(), "hello")
+            assert_eq!(s.as_bytes(), b"hello")
         }
 
         if let turso_core::Value::Numeric(Numeric::Integer(i)) = row.get::<&Value>(2).unwrap() {

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -399,7 +399,7 @@ fn test_mvcc_update_same_row_twice(tmp_db: TempDatabase) {
     let Value::Text(value) = &row[0] else {
         panic!("expected text value");
     };
-    assert_eq!(value.as_str(), "second");
+    assert_eq!(value.as_bytes(), b"second");
 
     conn1
         .execute("UPDATE test SET value = 'third' WHERE id = 1")
@@ -413,7 +413,7 @@ fn test_mvcc_update_same_row_twice(tmp_db: TempDatabase) {
     let Value::Text(value) = &row[0] else {
         panic!("expected text value");
     };
-    assert_eq!(value.as_str(), "third");
+    assert_eq!(value.as_bytes(), b"third");
 }
 
 #[test]
@@ -1584,8 +1584,8 @@ fn test_wal_savepoint_rollback_on_constraint_violation() {
         panic!("Expected text value");
     };
     assert_eq!(
-        val.as_str(),
-        &padding,
+        val.as_bytes(),
+        padding.as_bytes(),
         "Row should have original value after failed UPDATE rollback"
     );
 

--- a/tests/integration/statement_reset.rs
+++ b/tests/integration/statement_reset.rs
@@ -71,7 +71,7 @@ fn query_rows_with_reset(
                     rusqlite::types::Value::Real(f64::from(*value))
                 }
                 turso_core::Value::Text(value) => {
-                    rusqlite::types::Value::Text(value.as_str().to_string())
+                    rusqlite::types::Value::Text(value.to_str_lossy().into_owned())
                 }
                 turso_core::Value::Blob(value) => rusqlite::types::Value::Blob(value.to_vec()),
             })
@@ -101,7 +101,7 @@ fn collect_limbo_prepared_rows(
                     rusqlite::types::Value::Real(f64::from(*value))
                 }
                 turso_core::Value::Text(value) => {
-                    rusqlite::types::Value::Text(value.as_str().to_string())
+                    rusqlite::types::Value::Text(value.to_str_lossy().into_owned())
                 }
                 turso_core::Value::Blob(value) => rusqlite::types::Value::Blob(value.to_vec()),
             })

--- a/tools/dbhash/src/encoder.rs
+++ b/tools/dbhash/src/encoder.rs
@@ -29,7 +29,7 @@ pub fn encode_value(value: &Value, output: &mut Vec<u8>) {
         }
         Value::Text(text) => {
             output.push(b'3');
-            output.extend_from_slice(text.as_str().as_bytes());
+            output.extend_from_slice(text.as_bytes());
         }
         Value::Blob(b) => {
             output.push(b'4');

--- a/tools/dbhash/src/lib.rs
+++ b/tools/dbhash/src/lib.rs
@@ -123,7 +123,7 @@ fn get_table_names(
             StepResult::Row => {
                 let row = stmt.row().unwrap();
                 let name = row.get_value(0).to_text().expect("table name must be text");
-                names.push(name.to_string());
+                names.push(String::from_utf8_lossy(name).into_owned());
             }
             StepResult::IO => io.step()?,
             StepResult::Yield => continue,


### PR DESCRIPTION
TEXT values are not required to be valid UTF-8 (e.g. CAST(X'FF' AS TEXT), or a database written by SQLite). The record decoders reinterpreted such payloads with from_utf8_unchecked, which is undefined behavior: release builds segfaulted and debug builds raised an internal error.

Represent TEXT as bytes instead of str: Text now holds Cow<'static, [u8]> and TextRef holds &[u8], mirroring SQLite's byte-plus-encoding value model. The decoders become zero-copy byte borrows, so invalid UTF-8 can no longer trigger undefined behavior. Codepoint semantics are applied lazily at the boundary via as_bytes() for byte-level work (comparison, LIKE/GLOB, ordering, hashing, hex, serialization) and to_str_lossy() (substituting U+FFFD) only where a &str is genuinely required.

CAST(blob AS TEXT) now reinterprets the raw bytes rather than producing a lossy rendering, and hex/upper/lower/substr/length and the || operator work on the underlying bytes so non-UTF-8 content is preserved end to end. unicode() decodes the first codepoint with SQLite's lenient READ_UTF8 rules, so unicode(X'80') returns 128 rather than the U+FFFD replacement character.

Tests: testing/sqltests/tests/non-utf8-text.sqltest exercises each behavior against both Turso and SQLite; the full sqltest corpus and the core_tester integration suite pass with no regressions.

Fixes #5164