### PR TITLE
core/translate: report qualified column refs in ALTER TABLE trigger errors

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -2793,8 +2793,8 @@ enum ColumnRenameExprTraversal {
     RewriteResultExpr,
 }
 
-fn no_such_column_error(old_col_norm: &str) -> LimboError {
-    LimboError::ParseError(format!("no such column: {old_col_norm}"))
+fn no_such_column_error(column_ref: &str) -> LimboError {
+    LimboError::ParseError(format!("no such column: {column_ref}"))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2809,13 +2809,26 @@ fn apply_expr_column_ref_with_context(
     from_target_qualifiers: &[String],
 ) -> Result<()> {
     match e {
-        ast::Expr::Qualified(ns, col) | ast::Expr::DoublyQualified(_, ns, col) => {
+        ast::Expr::Qualified(..) | ast::Expr::DoublyQualified(..) => {
+            let (db, ns, col) = match e {
+                ast::Expr::Qualified(ns, col) => (None, &*ns, col),
+                ast::Expr::DoublyQualified(db, ns, col) => (Some(&*db), &*ns, col),
+                _ => unreachable!("outer match arm only admits (Doubly)Qualified"),
+            };
             let ns_norm = normalize_ident(ns.as_str());
             let col_norm = normalize_ident(col.as_str());
 
             if col_norm != *old_col_norm {
                 return Ok(());
             }
+
+            // SQLite reports unresolvable references as written in the
+            // original expression (e.g. "no such column: t.b"), so keep
+            // the qualifier(s) when building validation error messages.
+            let error_column_ref = match db {
+                Some(db) => format!("{}.{}.{}", db.as_str(), ns.as_str(), col.as_str()),
+                None => format!("{}.{}", ns.as_str(), col.as_str()),
+            };
 
             // These branches are mutually exclusive — a qualifier can
             // match at most one of: NEW/OLD (the trigger table), the
@@ -2831,7 +2844,7 @@ fn apply_expr_column_ref_with_context(
                     if let Some(new_col_norm) = mode.rewritten_name() {
                         *col = ast::Name::from_string(new_col_norm);
                     } else {
-                        return Err(no_such_column_error(old_col_norm));
+                        return Err(no_such_column_error(&error_column_ref));
                     }
                 }
                 return Ok(());
@@ -2846,7 +2859,7 @@ fn apply_expr_column_ref_with_context(
                 if let Some(new_col_norm) = mode.rewritten_name() {
                     *col = ast::Name::from_string(new_col_norm);
                 } else {
-                    return Err(no_such_column_error(old_col_norm));
+                    return Err(no_such_column_error(&error_column_ref));
                 }
             } else if is_renaming_trigger_table
                 && ns_norm.eq_ignore_ascii_case(trigger_table_name)
@@ -2858,19 +2871,17 @@ fn apply_expr_column_ref_with_context(
                         .as_ref()
                         .is_some_and(|(_, ctx_name, _)| *ctx_name != trigger_table_name_norm);
                     if ctx_is_different_table {
-                        return Err(LimboError::ParseError(format!(
-                            "no such column: {trigger_table_name}.{col_norm}"
-                        )));
+                        return Err(no_such_column_error(&error_column_ref));
                     }
                     *col = ast::Name::from_string(new_col_norm);
                 } else {
-                    return Err(no_such_column_error(old_col_norm));
+                    return Err(no_such_column_error(&error_column_ref));
                 }
             } else if from_target_qualifiers.contains(&ns_norm) {
                 if let Some(new_col_norm) = mode.rewritten_name() {
                     *col = ast::Name::from_string(new_col_norm);
                 } else {
-                    return Err(no_such_column_error(old_col_norm));
+                    return Err(no_such_column_error(&error_column_ref));
                 }
             }
         }

--- a/testing/sqltests/tests/alter-rename-column-qualified-trigger-error.sqltest
+++ b/testing/sqltests/tests/alter-rename-column-qualified-trigger-error.sqltest
@@ -1,0 +1,39 @@
+@database :memory:
+
+# Regression tests for https://github.com/tursodatabase/turso/issues/7737
+#
+# When ALTER TABLE RENAME COLUMN is rejected because a trigger still references
+# the renamed column, SQLite reports the reference as written in the expression
+# ("no such column: t.b"), not the normalized bare column name ("no such
+# column: b"). This includes doubly-qualified (db.table.column) references and
+# quoted identifiers, which report the dequoted, case-preserved spelling.
+
+@cross-check-integrity
+test rename-column-trigger-when-qualified-ref-error-message {
+    CREATE TABLE t (a, b);
+    CREATE TRIGGER tr BEFORE UPDATE ON t WHEN t.b > 0 BEGIN SELECT 1; END;
+    ALTER TABLE t RENAME COLUMN b TO c;
+}
+expect error {
+    no such column: t\.b
+}
+
+@cross-check-integrity
+test rename-column-trigger-when-doubly-qualified-ref-error-message {
+    CREATE TABLE t (a, b);
+    CREATE TRIGGER tr BEFORE UPDATE ON t WHEN main.t.b > 0 BEGIN SELECT 1; END;
+    ALTER TABLE t RENAME COLUMN b TO c;
+}
+expect error {
+    no such column: main\.t\.b
+}
+
+@cross-check-integrity
+test rename-column-trigger-when-quoted-qualified-ref-error-message {
+    CREATE TABLE t (a, b);
+    CREATE TRIGGER tr BEFORE UPDATE ON t WHEN "T"."B" > 0 BEGIN SELECT 1; END;
+    ALTER TABLE t RENAME COLUMN b TO c;
+}
+expect error {
+    no such column: T\.B
+}


### PR DESCRIPTION
When ALTER TABLE RENAME COLUMN is rejected because a trigger still
references the renamed column through a table-qualified name (e.g.
`WHEN t.b > 0`), the post-rewrite validation pass reported only the
normalized bare column name ("no such column: b"). SQLite reports
the reference as written in the expression ("no such column: t.b").

Restructure the Qualified/DoublyQualified arm of
apply_expr_column_ref_with_context so it captures the optional
database qualifier and builds the reference string as written, then
use that string for every Validate-mode "no such column" error in
that arm. DoublyQualified refs now report the full db.table.column
name, matching SQLite's name resolver, and the pre-existing
ctx_is_different_table error is unified onto the same helper instead
of hand-formatting a normalized variant. Bare identifier references
keep reporting the bare name, which already matched SQLite.

Verified against sqlite3, which reports "no such column: t.b" for
the reproducer; full sqltest suite (1418 tests), trigger/alter
integration tests, and core unit tests all pass.

Fixes #7737