### PR TITLE
core/translate: resolve temp trigger owning table across schemas on ALTER

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -2581,11 +2581,29 @@ fn rewrite_trigger_sql_for_column_rename(
     let old_col_norm = normalize_ident(old_column_name);
     let new_col_norm = normalize_ident(new_column_name);
 
-    // Get the trigger's owning table to check unqualified column references
+    // Get the trigger's owning table to check unqualified column references.
+    //
+    // The owning table does not necessarily live in the schema that stores
+    // the trigger: TEMP triggers may target tables in other databases
+    // (`CREATE TEMP TRIGGER trg ... ON t` where `t` is in `main`). An
+    // explicit qualifier (`ON main.t`) names the database directly; an
+    // unqualified name resolves temp-first with fallback to main, matching
+    // `table_reference_exists_after_rename`. See issue #7733.
     let trigger_table_name_raw = tbl_name.name.as_str();
     let trigger_table_name = normalize_ident(trigger_table_name_raw);
+    let trigger_table_database_id = if tbl_name.db_name.is_some() {
+        resolver.resolve_database_id(&tbl_name)?
+    } else if trigger_database_id == crate::TEMP_DB_ID
+        && resolver.with_schema(crate::TEMP_DB_ID, |schema| {
+            schema.get_btree_table(&trigger_table_name).is_none()
+        })
+    {
+        crate::MAIN_DB_ID
+    } else {
+        trigger_database_id
+    };
     let trigger_table = resolver
-        .with_schema(trigger_database_id, |schema| {
+        .with_schema(trigger_table_database_id, |schema| {
             schema.get_btree_table(&trigger_table_name)
         })
         .ok_or_else(|| {
@@ -2606,7 +2624,25 @@ fn rewrite_trigger_sql_for_column_rename(
         )));
     }
 
-    // Rewrite UPDATE OF column list if renaming a column in the trigger's owning table
+    // The trigger's owning table shares the ALTER target's name but lives in a
+    // different database (e.g. a TEMP table shadowing a main table of the same
+    // name). The trigger's NEW/OLD references and unqualified body references
+    // bind to its own table — not the renamed one — so the rename must leave
+    // the trigger untouched, matching SQLite. Returning early here also keeps
+    // the invariant relied on by the downstream rewrite/validation helpers
+    // (`apply_expr_for_column_rename` etc.), which compare the trigger table
+    // against the target by name only: past this point, a name match implies
+    // the trigger's owning table IS the altered table.
+    //
+    // Known limitation: SQLite still rewrites explicitly db-qualified body
+    // references (`SELECT a FROM main.t` in a temp trigger on the shadow);
+    // our rewrite machinery matches table references by name only and cannot
+    // distinguish those, so they are skipped along with the rest.
+    if trigger_table_name == target_table_name && trigger_table_database_id != target_database_id {
+        return Ok(trigger_sql.to_string());
+    }
+
+    // Rewrite UPDATE OF column list if renaming a column in the trigger's owning table.
     let is_renaming_trigger_table = trigger_table_name == target_table_name;
     let new_event = if is_renaming_trigger_table {
         match event {
@@ -2753,10 +2789,35 @@ fn rewrite_trigger_sql_for_column_rename(
             temporary,
             Some(target_database_id),
         );
+        // Pick the table shape to validate the rewritten trigger against:
+        //
+        // - Renaming a column of a TEMP table: SQLite refuses the rename when
+        //   a temp trigger references the column via NEW/OLD, reporting
+        //   "no such column: NEW.<new_name>" — i.e. the rewritten trigger is
+        //   checked against the PRE-rename table. Keep that quirk-for-quirk.
+        // - Renaming a column of a main/attached table (case C, issue #7733):
+        //   SQLite accepts the rename and rewrites the temp trigger, so the
+        //   rewritten trigger (which now references the new column name) must
+        //   be validated against the POST-rename table shape.
+        let validation_table = if target_database_id == crate::TEMP_DB_ID {
+            trigger_table.as_ref().clone()
+        } else {
+            let mut post_rename_table = trigger_table.as_ref().clone();
+            for column in post_rename_table.columns_mut().iter_mut() {
+                if column
+                    .name
+                    .as_deref()
+                    .is_some_and(|name| normalize_ident(name) == old_col_norm)
+                {
+                    column.name = Some(new_col_norm.clone());
+                }
+            }
+            post_rename_table
+        };
         if let Some(bad_column) = validate_trigger_columns_after_drop(
             &rewritten_trigger,
             &target_table_name,
-            trigger_table.as_ref(),
+            &validation_table,
             resolver,
             trigger_database_id,
             target_database_id,
@@ -3950,13 +4011,32 @@ fn validate_trigger_columns_after_drop(
     altered_database_id: usize,
 ) -> Result<Option<String>> {
     let trigger_table_norm = normalize_ident(&trigger.table_name);
-    let allow_bare_owning_columns =
-        trigger_database_id == altered_database_id && trigger_table_norm == *altered_table_norm;
+    // Resolve the database that holds the trigger's owning table. It is not
+    // necessarily the schema that stores the trigger: TEMP triggers may
+    // target tables in other databases (issue #7733). Honor an explicitly
+    // recorded target database; otherwise resolve unqualified names
+    // temp-first with fallback to main, matching `get_table_columns`.
+    let trigger_table_database_id = match trigger.target_database_id {
+        Some(crate::INVALID_DB_ID) => None,
+        Some(db) => Some(db),
+        None => Some(
+            if trigger_database_id == crate::TEMP_DB_ID
+                && resolver.with_schema(crate::TEMP_DB_ID, |s| {
+                    s.get_table(&trigger_table_norm).is_none()
+                })
+            {
+                crate::MAIN_DB_ID
+            } else {
+                trigger_database_id
+            },
+        ),
+    };
+    let owning_is_altered_table = trigger_table_database_id == Some(altered_database_id)
+        && trigger_table_norm == *altered_table_norm;
+    let allow_bare_owning_columns = owning_is_altered_table;
 
     // Determine the trigger's owning table columns (post-drop if it's the altered table)
-    let owning_table_columns: Option<Vec<String>> = if trigger_database_id == altered_database_id
-        && trigger_table_norm == *altered_table_norm
-    {
+    let owning_table_columns: Option<Vec<String>> = if owning_is_altered_table {
         Some(
             post_drop_table
                 .columns()
@@ -3965,13 +4045,15 @@ fn validate_trigger_columns_after_drop(
                 .collect(),
         )
     } else {
-        resolver.with_schema(trigger_database_id, |s| {
-            s.get_table(&trigger_table_norm).and_then(|t| {
-                t.btree().map(|bt| {
-                    bt.columns()
-                        .iter()
-                        .filter_map(|c| c.name.as_deref().map(normalize_ident))
-                        .collect()
+        trigger_table_database_id.and_then(|db| {
+            resolver.with_schema(db, |s| {
+                s.get_table(&trigger_table_norm).and_then(|t| {
+                    t.btree().map(|bt| {
+                        bt.columns()
+                            .iter()
+                            .filter_map(|c| c.name.as_deref().map(normalize_ident))
+                            .collect()
+                    })
                 })
             })
         })

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -2581,11 +2581,24 @@ fn rewrite_trigger_sql_for_column_rename(
     let old_col_norm = normalize_ident(old_column_name);
     let new_col_norm = normalize_ident(new_column_name);
 
-    // Get the trigger's owning table to check unqualified column references
+    // Get the trigger's owning table to check unqualified column references.
+    // TEMP triggers may target tables in other databases, so resolve the
+    // owning table's database instead of assuming the trigger's schema.
     let trigger_table_name_raw = tbl_name.name.as_str();
     let trigger_table_name = normalize_ident(trigger_table_name_raw);
+    let trigger_table_database_id = if tbl_name.db_name.is_some() {
+        resolver.resolve_database_id(&tbl_name)?
+    } else if trigger_database_id == crate::TEMP_DB_ID
+        && resolver.with_schema(crate::TEMP_DB_ID, |schema| {
+            schema.get_btree_table(&trigger_table_name).is_none()
+        })
+    {
+        crate::MAIN_DB_ID
+    } else {
+        trigger_database_id
+    };
     let trigger_table = resolver
-        .with_schema(trigger_database_id, |schema| {
+        .with_schema(trigger_table_database_id, |schema| {
             schema.get_btree_table(&trigger_table_name)
         })
         .ok_or_else(|| {
@@ -2606,7 +2619,14 @@ fn rewrite_trigger_sql_for_column_rename(
         )));
     }
 
-    // Rewrite UPDATE OF column list if renaming a column in the trigger's owning table
+    // If the trigger's owning table merely shadows the ALTER target's name in
+    // another database, its references bind to its own table, so leave the
+    // trigger untouched, matching SQLite.
+    if trigger_table_name == target_table_name && trigger_table_database_id != target_database_id {
+        return Ok(trigger_sql.to_string());
+    }
+
+    // Rewrite UPDATE OF column list if renaming a column in the trigger's owning table.
     let is_renaming_trigger_table = trigger_table_name == target_table_name;
     let new_event = if is_renaming_trigger_table {
         match event {
@@ -2753,10 +2773,28 @@ fn rewrite_trigger_sql_for_column_rename(
             temporary,
             Some(target_database_id),
         );
+        // Match SQLite: validate the rewritten trigger against the pre-rename
+        // table shape when the altered table is TEMP (the rename is refused),
+        // and the post-rename shape otherwise (the rename is accepted).
+        let validation_table = if target_database_id == crate::TEMP_DB_ID {
+            trigger_table.as_ref().clone()
+        } else {
+            let mut post_rename_table = trigger_table.as_ref().clone();
+            for column in post_rename_table.columns_mut().iter_mut() {
+                if column
+                    .name
+                    .as_deref()
+                    .is_some_and(|name| normalize_ident(name) == old_col_norm)
+                {
+                    column.name = Some(new_col_norm.clone());
+                }
+            }
+            post_rename_table
+        };
         if let Some(bad_column) = validate_trigger_columns_after_drop(
             &rewritten_trigger,
             &target_table_name,
-            trigger_table.as_ref(),
+            &validation_table,
             resolver,
             trigger_database_id,
             target_database_id,
@@ -3950,13 +3988,29 @@ fn validate_trigger_columns_after_drop(
     altered_database_id: usize,
 ) -> Result<Option<String>> {
     let trigger_table_norm = normalize_ident(&trigger.table_name);
-    let allow_bare_owning_columns =
-        trigger_database_id == altered_database_id && trigger_table_norm == *altered_table_norm;
+    // Resolve the database that holds the trigger's owning table; TEMP
+    // triggers may target tables in other databases.
+    let trigger_table_database_id = match trigger.target_database_id {
+        Some(crate::INVALID_DB_ID) => None,
+        Some(db) => Some(db),
+        None => Some(
+            if trigger_database_id == crate::TEMP_DB_ID
+                && resolver.with_schema(crate::TEMP_DB_ID, |s| {
+                    s.get_table(&trigger_table_norm).is_none()
+                })
+            {
+                crate::MAIN_DB_ID
+            } else {
+                trigger_database_id
+            },
+        ),
+    };
+    let owning_is_altered_table = trigger_table_database_id == Some(altered_database_id)
+        && trigger_table_norm == *altered_table_norm;
+    let allow_bare_owning_columns = owning_is_altered_table;
 
     // Determine the trigger's owning table columns (post-drop if it's the altered table)
-    let owning_table_columns: Option<Vec<String>> = if trigger_database_id == altered_database_id
-        && trigger_table_norm == *altered_table_norm
-    {
+    let owning_table_columns: Option<Vec<String>> = if owning_is_altered_table {
         Some(
             post_drop_table
                 .columns()
@@ -3965,13 +4019,15 @@ fn validate_trigger_columns_after_drop(
                 .collect(),
         )
     } else {
-        resolver.with_schema(trigger_database_id, |s| {
-            s.get_table(&trigger_table_norm).and_then(|t| {
-                t.btree().map(|bt| {
-                    bt.columns()
-                        .iter()
-                        .filter_map(|c| c.name.as_deref().map(normalize_ident))
-                        .collect()
+        trigger_table_database_id.and_then(|db| {
+            resolver.with_schema(db, |s| {
+                s.get_table(&trigger_table_norm).and_then(|t| {
+                    t.btree().map(|bt| {
+                        bt.columns()
+                            .iter()
+                            .filter_map(|c| c.name.as_deref().map(normalize_ident))
+                            .collect()
+                    })
                 })
             })
         })

--- a/testing/sqltests/tests/alter-rename-column-temp-trigger.sqltest
+++ b/testing/sqltests/tests/alter-rename-column-temp-trigger.sqltest
@@ -1,0 +1,68 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/7733
+#
+# ALTER TABLE ... RENAME COLUMN must succeed when a TEMP trigger on a table in
+# `main` references the renamed column via NEW.<col>/OLD.<col>. SQLite accepts
+# the rename and rewrites the temp trigger to use the new column name; Turso
+# must not reject the rename.
+
+test rename-column-with-temp-trigger-new-ref {
+    CREATE TABLE t (a, b);
+    CREATE TEMP TRIGGER trg AFTER UPDATE ON t BEGIN SELECT NEW.a; END;
+    ALTER TABLE t RENAME COLUMN a TO a2;
+    SELECT sql FROM sqlite_schema WHERE name = 't';
+}
+expect {
+    CREATE TABLE t (a2, b)
+}
+
+test rename-column-with-temp-trigger-old-ref-in-when {
+    CREATE TABLE t2 (x, y);
+    CREATE TEMP TRIGGER trg2 AFTER UPDATE ON t2 WHEN OLD.x > 0 BEGIN SELECT 1; END;
+    ALTER TABLE t2 RENAME COLUMN x TO x2;
+    SELECT sql FROM sqlite_schema WHERE name = 't2';
+}
+expect {
+    CREATE TABLE t2 (x2, y)
+}
+
+# The temp trigger must be rewritten to reference the new column name, so it
+# still fires correctly after the rename.
+test rename-column-temp-trigger-fires-after-rewrite {
+    CREATE TABLE t3 (a, b);
+    CREATE TABLE log (v);
+    CREATE TEMP TRIGGER trg3 AFTER UPDATE ON t3 BEGIN INSERT INTO log VALUES (NEW.a); END;
+    INSERT INTO t3 VALUES (1, 2);
+    ALTER TABLE t3 RENAME COLUMN a TO a2;
+    UPDATE t3 SET a2 = 42;
+    SELECT v FROM log;
+}
+expect {
+    42
+}
+
+# A TEMP table can shadow a main table of the same name. A temp trigger on the
+# shadow binds NEW/OLD to the temp table, so renaming the main table's column
+# must succeed and leave the trigger untouched.
+test rename-column-shadowed-by-temp-table {
+    CREATE TABLE t4 (a, b);
+    CREATE TEMP TABLE t4 (a, c);
+    CREATE TEMP TRIGGER trg4 AFTER UPDATE ON t4 WHEN NEW.a > 0 BEGIN SELECT 1; END;
+    ALTER TABLE main.t4 RENAME COLUMN a TO a2;
+    SELECT sql FROM sqlite_schema WHERE name = 't4';
+}
+expect {
+    CREATE TABLE t4 (a2, b)
+}
+
+# DROP COLUMN must fail when a temp trigger on the main table references the
+# dropped column via NEW/OLD, matching SQLite.
+test drop-column-with-temp-trigger-new-ref {
+    CREATE TABLE t5 (a, b);
+    CREATE TEMP TRIGGER trg5 AFTER UPDATE ON t5 BEGIN SELECT NEW.a; END;
+    ALTER TABLE t5 DROP COLUMN a;
+}
+expect error {
+    no such column: NEW.a
+}


### PR DESCRIPTION
ALTER TABLE ... RENAME COLUMN rejected renames when a TEMP trigger on a
table in `main` referenced the renamed column via NEW.<col>/OLD.<col>,
first with "trigger table not found" and, once the lookup was patched,
with "no such column: NEW.<new_name>". SQLite accepts the rename and
rewrites the temp trigger to use the new column name.

The rewrite and validation paths assumed a trigger's owning table lives
in the schema that stores the trigger, which is false for TEMP triggers
targeting main/attached tables. Fix the resolution in
core/translate/alter.rs:

- rewrite_trigger_sql_for_column_rename now resolves the owning table's
  database: an explicit qualifier (`ON main.t`) is honored, and an
  unqualified name resolves temp-first with fallback to main, matching
  table_reference_exists_after_rename.

- When the trigger's owning table merely shares the ALTER target's name
  but lives in a different database (a temp table shadowing a main
  table of the same name), the rewrite returns the trigger SQL
  unchanged: the trigger's NEW/OLD and unqualified body references bind
  to its own table, so SQLite leaves such triggers untouched and
  accepts the rename. The early return also preserves the invariant
  relied on by the downstream rewrite/validation helpers, which compare
  the trigger table against the target by name only; without it, the
  deliberately un-rewritten NEW.<old> references tripped the
  post-rewrite validation and the ALTER was wrongly rejected.

- The temp-trigger validation pass now checks the rewritten trigger
  against the post-rename table shape when the altered table is in
  main/attached (the rewritten refs use the new column name), while
  keeping the pre-rename shape when the altered table is itself TEMP:
  SQLite refuses those renames with "no such column: NEW.<new>" and the
  existing alter_table.sqltest coverage codifies that quirk.

- validate_trigger_columns_after_drop resolves the owning table via the
  trigger's recorded target database (with the same temp-first
  fallback), so its NEW/OLD validation actually runs for temp triggers
  on main tables. As a side effect, ALTER TABLE ... DROP COLUMN now
  correctly fails when a temp trigger references the dropped column,
  matching SQLite (previously the drop was silently allowed).

Fixes #7733