### PR TITLE
core: make schema cloning fallible

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,12 @@ jobs:
     timeout-minutes: ${{ matrix.os == 'windows-latest' && 120 || 30 }}
     strategy:
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2404, blacksmith-6vcpu-macos-latest, windows-latest]
+        os:
+          [
+            blacksmith-4vcpu-ubuntu-2404,
+            blacksmith-6vcpu-macos-latest,
+            windows-latest,
+          ]
 
     runs-on: ${{ matrix.os }}
 
@@ -372,6 +377,9 @@ jobs:
           - name: in-process-mvcc
             iterations: 25
             args: "--mode fast --reopen-probability 0.01 --enable-mvcc --allocation-fault-probability 0.01"
+          - name: schema-clone-faults
+            iterations: 10
+            args: "--mode schema-clone-faults --reopen-probability 0.0001 --allocation-fault-probability 0.01"
           - name: btree-rebalance
             iterations: 5
             args: "--mode btree-rebalance --allocation-fault-probability 0"

--- a/core/alloc/allocation_site.rs
+++ b/core/alloc/allocation_site.rs
@@ -4,6 +4,7 @@ use std::cell::Cell;
 pub enum AllocationSite {
     MvStore(MvStoreAllocationSite),
     MvccCheckpoint(MvccCheckpointAllocationSite),
+    Schema(SchemaAllocationSite),
     NoFaultInjection,
 }
 
@@ -18,6 +19,11 @@ pub enum MvStoreAllocationSite {
     RowVersionReserve,
     RowPayload,
     SchemaRowPayload,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum SchemaAllocationSite {
+    MakeMut,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -37,6 +43,12 @@ impl From<MvStoreAllocationSite> for AllocationSite {
 impl From<MvccCheckpointAllocationSite> for AllocationSite {
     fn from(site: MvccCheckpointAllocationSite) -> Self {
         Self::MvccCheckpoint(site)
+    }
+}
+
+impl From<SchemaAllocationSite> for AllocationSite {
+    fn from(site: SchemaAllocationSite) -> Self {
+        Self::Schema(site)
     }
 }
 

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -14,7 +14,7 @@ mod collections;
 
 pub use allocation_site::{
     current_allocation_site, enter_allocation_site, AllocationSite, AllocationSiteGuard,
-    MvStoreAllocationSite, MvccCheckpointAllocationSite,
+    MvStoreAllocationSite, MvccCheckpointAllocationSite, SchemaAllocationSite,
 };
 /// The underlying allocator trait: `allocator_api2::alloc::Allocator` on
 /// stable, `std::alloc::Allocator` on `--cfg nightly` builds.

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -31,7 +31,7 @@ pub use collections::{
     TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt, TursoVecInExt,
 };
 
-pub const ALLOC_ERR_MSG: &str = "TODO: fallible allocations";
+pub const ALLOC_ERR_MSG: &str = "fallible allocations";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TryReserveError;

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1,3 +1,4 @@
+use crate::alloc::TryClone;
 use crate::error::io_error;
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_points::{FailureInjector, YieldInjector};
@@ -1333,8 +1334,9 @@ impl Connection {
         // But in this occasion it will always reprepare, and we get an error. So we trick the statement by swapping our schema
         // with a new clean schema that has the same header cookie.
         self.with_schema_mut(|schema| {
-            *schema = fresh.clone();
-        });
+            *schema = fresh.try_clone()?;
+            Ok::<_, crate::alloc::TryReserveError>(())
+        })??;
 
         let stmt = self.prepare("SELECT * FROM sqlite_schema")?;
 
@@ -1423,8 +1425,9 @@ impl Connection {
                             let work = inner.fresh.sequence_backing_table_names();
                             if !work.is_empty() {
                                 self.with_schema_mut(|schema| {
-                                    *schema = inner.fresh.clone();
-                                });
+                                    *schema = inner.fresh.try_clone()?;
+                                    Ok::<_, crate::alloc::TryReserveError>(())
+                                })??;
                             }
                             *pending = Some(work);
                         }
@@ -1502,8 +1505,9 @@ impl Connection {
                     {
                         // Temporarily install the schema so we can query against it.
                         self.with_schema_mut(|schema| {
-                            *schema = inner.fresh.clone();
-                        });
+                            *schema = inner.fresh.try_clone()?;
+                            Ok::<_, crate::alloc::TryReserveError>(())
+                        })??;
                         let stmt = self.prepare_internal(format!(
                             "SELECT name, sql FROM {}",
                             crate::schema::TURSO_TYPES_TABLE_NAME
@@ -1563,7 +1567,7 @@ impl Connection {
                     );
                     self.with_schema_mut(|schema| {
                         *schema = fresh;
-                    });
+                    })?;
                     return Ok(IOResult::Done(()));
                 }
             }
@@ -2284,12 +2288,10 @@ impl Connection {
         }
 
         let schema = self.schema.read().clone();
-        self.db
-            .with_schema_mut(|current| {
-                *current = schema.as_ref().clone();
-                Ok(())
-            })
-            .expect("external restore schema replacement should be infallible");
+        self.db.with_schema_mut(|current| {
+            *current = schema.as_ref().try_clone()?;
+            Ok(())
+        })?;
         Ok(())
     }
 
@@ -2688,7 +2690,7 @@ impl Connection {
                 Err(e) => return Err(e),
             }
             Ok(())
-        })
+        })?
     }
 
     // Clearly there is something to improve here, Vec<Vec<Value>> isn't a couple of tea
@@ -2867,10 +2869,10 @@ impl Connection {
     }
 
     #[inline]
-    pub fn with_schema_mut<T>(&self, f: impl FnOnce(&mut Schema) -> T) -> T {
+    pub fn with_schema_mut<T>(&self, f: impl FnOnce(&mut Schema) -> T) -> Result<T> {
         let mut schema_ref = self.schema.write();
-        let schema = Arc::make_mut(&mut *schema_ref);
-        f(schema)
+        let schema = Schema::try_make_mut(&mut *schema_ref)?;
+        Ok(f(schema))
     }
 
     /// Mutate the schema for a specific database (main or attached).
@@ -2878,7 +2880,7 @@ impl Connection {
         &self,
         database_id: usize,
         f: impl FnOnce(&mut Schema) -> T,
-    ) -> T {
+    ) -> Result<T> {
         match database_id {
             crate::MAIN_DB_ID => self.with_schema_mut(f),
             crate::TEMP_DB_ID => {
@@ -2890,10 +2892,10 @@ impl Connection {
                     .as_ref()
                     .expect("temp database should be initialized before schema mutation");
                 let mut schema_guard = temp_db.db.schema.lock();
-                let schema = Arc::make_mut(&mut schema_guard);
+                let schema = Schema::try_make_mut(&mut schema_guard)?;
                 let result = f(schema);
                 self.bump_prepare_context_generation();
-                result
+                Ok(result)
             }
             _ => {
                 // For attached databases, update a connection-local copy of the schema.
@@ -2910,10 +2912,10 @@ impl Connection {
                     let schema = db.schema.lock().clone();
                     schema
                 });
-                let schema = Arc::make_mut(schema_arc);
+                let schema = Schema::try_make_mut(schema_arc)?;
                 let result = f(schema);
                 self.bump_prepare_context_generation();
-                result
+                Ok(result)
             }
         }
     }
@@ -3828,7 +3830,7 @@ impl Connection {
                         schema
                             .sequences
                             .insert(normalized.clone(), Arc::new(sequence));
-                    });
+                    })?;
                     *idx += 1;
                     *stmt = None;
                     *meta = None;

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1941,13 +1941,15 @@ impl Connection {
                     header.schema_cookie.get() < version,
                     "cookie can't go back in time"
                 );
-                self.set_tx_state(TransactionState::Write {
-                    schema_did_change: true,
-                });
-                self.with_schema_mut(|schema| schema.schema_version = version);
-                header.schema_cookie = version.into();
+                self.with_schema_mut(|schema| schema.schema_version = version)
+                    .map(|()| {
+                        self.set_tx_state(TransactionState::Write {
+                            schema_did_change: true,
+                        });
+                        header.schema_cookie = version.into();
+                    })
             })
-        })?;
+        })??;
         self.reparse_schema()?;
         Ok(())
     }
@@ -2871,7 +2873,7 @@ impl Connection {
     #[inline]
     pub fn with_schema_mut<T>(&self, f: impl FnOnce(&mut Schema) -> T) -> Result<T> {
         let mut schema_ref = self.schema.write();
-        let schema = Schema::try_make_mut(&mut *schema_ref)?;
+        let schema = Schema::try_make_mut(&mut schema_ref)?;
         Ok(f(schema))
     }
 

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -79,7 +79,7 @@ pub(crate) unsafe extern "C" fn register_vtab_module(
                 let table = Arc::new(Table::Virtual(vtab));
                 let mutex = &*(ext_ctx.schema as *mut Mutex<Arc<Schema>>);
                 let mut guard = mutex.lock();
-                let Ok(schema) = Schema::try_make_mut(&mut *guard) else {
+                let Ok(schema) = Schema::try_make_mut(&mut guard) else {
                     return ResultCode::Error;
                 };
                 schema.tables.insert(name_str, table);

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -79,7 +79,9 @@ pub(crate) unsafe extern "C" fn register_vtab_module(
                 let table = Arc::new(Table::Virtual(vtab));
                 let mutex = &*(ext_ctx.schema as *mut Mutex<Arc<Schema>>);
                 let mut guard = mutex.lock();
-                let schema = Arc::make_mut(&mut *guard);
+                let Ok(schema) = Schema::try_make_mut(&mut *guard) else {
+                    return ResultCode::Error;
+                };
                 schema.tables.insert(name_str, table);
             } else {
                 return ResultCode::Error;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1459,7 +1459,7 @@ impl Database {
                     // internally, so we can't use get_mut here.
                     //
                     // it's not ideal but correctness is OK - before prepare connection call maybe_update_schema and in case of divergence update schema ref from the db + we always check connection cookie in the VDBE program itself
-                    let schema = Arc::make_mut(&mut **guard);
+                    let schema = Schema::try_make_mut(&mut **guard)?;
                     schema.schema_version = header_schema_cookie;
 
                     state.phase = OpenDbAsyncPhase::LoadingSchema;
@@ -1485,7 +1485,7 @@ impl Database {
                     // so, we can't use get_mut here for now
                     //
                     // it's not ideal but correctness is OK - before prepare connection call maybe_update_schema and in case of divergence update schema ref from the db + we always check connection cookie in the VDBE program itself
-                    let schema = Arc::make_mut(&mut **guard);
+                    let schema = Schema::try_make_mut(&mut **guard)?;
 
                     let result = schema.make_from_btree(
                         &mut state.make_from_btree_state,
@@ -2845,8 +2845,12 @@ impl Database {
     #[inline]
     pub(crate) fn with_schema_mut<T>(&self, f: impl FnOnce(&mut Schema) -> Result<T>) -> Result<T> {
         let mut schema_ref = self.schema.lock();
-        let schema = Arc::make_mut(&mut *schema_ref);
+        let schema = Schema::try_make_mut(&mut *schema_ref)?;
         f(schema)
+    }
+
+    pub(crate) fn replace_schema(&self, schema: Arc<Schema>) {
+        *self.schema.lock() = schema;
     }
 
     /// Register an `InternalVirtualTable` into this database's catalog. The

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1459,7 +1459,7 @@ impl Database {
                     // internally, so we can't use get_mut here.
                     //
                     // it's not ideal but correctness is OK - before prepare connection call maybe_update_schema and in case of divergence update schema ref from the db + we always check connection cookie in the VDBE program itself
-                    let schema = Schema::try_make_mut(&mut **guard)?;
+                    let schema = Schema::try_make_mut(guard)?;
                     schema.schema_version = header_schema_cookie;
 
                     state.phase = OpenDbAsyncPhase::LoadingSchema;
@@ -1485,7 +1485,7 @@ impl Database {
                     // so, we can't use get_mut here for now
                     //
                     // it's not ideal but correctness is OK - before prepare connection call maybe_update_schema and in case of divergence update schema ref from the db + we always check connection cookie in the VDBE program itself
-                    let schema = Schema::try_make_mut(&mut **guard)?;
+                    let schema = Schema::try_make_mut(guard)?;
 
                     let result = schema.make_from_btree(
                         &mut state.make_from_btree_state,
@@ -2845,7 +2845,7 @@ impl Database {
     #[inline]
     pub(crate) fn with_schema_mut<T>(&self, f: impl FnOnce(&mut Schema) -> Result<T>) -> Result<T> {
         let mut schema_ref = self.schema.lock();
-        let schema = Schema::try_make_mut(&mut *schema_ref)?;
+        let schema = Schema::try_make_mut(&mut schema_ref)?;
         f(schema)
     }
 

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -11,7 +11,7 @@ use crate::mvcc::database::{
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
 use crate::mvcc::yield_points::{inject_transition_failure, inject_transition_yield};
-use crate::schema::Index;
+use crate::schema::{Index, Schema};
 use crate::state_machine::{StateMachine, StateTransition, TransitionResult};
 use crate::storage::btree::{BTreeCursor, CursorTrait};
 use crate::storage::pager::CreateBTreeFlags;
@@ -1269,14 +1269,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         // pager commit succeeds because the committed root pages are then visible
         // through WAL even if the later WAL checkpoint/log truncation is busy.
         let mut schema_ref = self.connection.db.schema.lock();
-        let schema = Arc::make_mut(&mut *schema_ref);
+        let schema = Schema::try_make_mut(&mut *schema_ref)?;
         for (name, table) in schema.tables.iter_mut() {
+            #[cfg(not(feature = "conn_raw_api"))]
+            let _ = name;
             let table = Arc::get_mut(table).expect("this should be the only reference");
             let Some(btree_table) = table.btree_mut() else {
                 continue;
             };
             let btree_table = Arc::make_mut(btree_table);
             if btree_table.root_page < 0 {
+                #[cfg(feature = "conn_raw_api")]
                 let old_root_page = btree_table.root_page;
                 let table_id = MVTableId::from(btree_table.root_page);
                 let entry = self

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1269,7 +1269,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         // pager commit succeeds because the committed root pages are then visible
         // through WAL even if the later WAL checkpoint/log truncation is busy.
         let mut schema_ref = self.connection.db.schema.lock();
-        let schema = Schema::try_make_mut(&mut *schema_ref)?;
+        let schema = Schema::try_make_mut(&mut schema_ref)?;
         for (name, table) in schema.tables.iter_mut() {
             #[cfg(not(feature = "conn_raw_api"))]
             let _ = name;

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3988,11 +3988,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         table_valued_functions: &[Arc<crate::vtab::VirtualTable>],
-    ) {
+    ) -> Result<()> {
         connection.with_schema_mut(|schema| {
             Self::rehydrate_table_valued_functions(schema, table_valued_functions);
-        });
+        })?;
         *connection.db.schema.lock() = connection.schema.read().clone();
+        Ok(())
     }
 
     /// Creates a new database whose skiplists allocate through `alloc`.
@@ -4363,7 +4364,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 }
                 BootstrapState::PreReparse { tvfs, reparse_st } => {
                     return_if_io!(bootstrap_conn.reparse_schema_nonblock(reparse_st));
-                    self.rehydrate_connection_table_valued_functions(bootstrap_conn, tvfs);
+                    self.rehydrate_connection_table_valued_functions(bootstrap_conn, tvfs)?;
                     // pre_metadata done. Decide whether metadata bootstrap IO is needed.
                     if !self.uses_durable_mvcc_metadata(bootstrap_conn) {
                         self.bootstrap_map_root_pages(bootstrap_conn)?;
@@ -7728,11 +7729,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     );
                     connection.with_schema_mut(|schema| {
                         schema.dropped_root_pages = dropped_root_pages;
-                    });
+                    })?;
                     if let Some(header) = self.global_header.read().as_ref() {
                         connection.with_schema_mut(|schema| {
                             schema.schema_version = header.schema_cookie.get();
-                        });
+                        })?;
                     }
                     *connection.db.schema.lock() = connection.schema.read().clone();
                     self.clock.reset(max_commit_ts_seen + 1);

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -14940,7 +14940,8 @@ fn test_integrity_check_ignores_dropped_root_that_is_live_after_recovery() {
 
     conn.with_schema_mut(|schema| {
         schema.dropped_root_pages.insert(root_page);
-    });
+    })
+    .unwrap();
 
     let rows = get_rows(&conn, "PRAGMA integrity_check");
     assert_eq!(rows.len(), 1);

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4372,15 +4372,15 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                             }
                         };
                         primary_key_columns
-                            .push((col_name, column.order.unwrap_or(SortOrder::Asc)));
-                        pk_collations.push(collation);
+                            .try_push((col_name, column.order.unwrap_or(SortOrder::Asc)))?;
+                        pk_collations.try_push(collation)?;
                     }
-                    unique_sets_constraints.push(UniqueSet {
-                        columns: primary_key_columns.clone(),
+                    unique_sets_constraints.try_push(UniqueSet {
+                        columns: primary_key_columns.try_clone()?,
                         collations: pk_collations,
                         is_primary_key: true,
                         conflict_clause: *conflict_clause,
-                    });
+                    })?;
                 } else if let ast::TableConstraint::Unique {
                     columns,
                     conflict_clause,
@@ -4390,21 +4390,20 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     let mut unique_collations = Vec::try_with_capacity_ext(columns.len())?;
                     for column in columns {
                         let (expr, collation) = constraint_column_collation(column.expr.as_ref())?;
-                        // preallocated enough to not need try_push
                         match expr {
-                            Expr::Id(id) => unique_columns.push((
+                            Expr::Id(id) => unique_columns.try_push((
                                 id.as_str().to_string(),
                                 column.order.unwrap_or(SortOrder::Asc),
-                            )),
-                            Expr::Literal(Literal::String(value)) => unique_columns.push((
+                            ))?,
+                            Expr::Literal(Literal::String(value)) => unique_columns.try_push((
                                 value.trim_matches('\'').to_owned(),
                                 column.order.unwrap_or(SortOrder::Asc),
-                            )),
+                            ))?,
                             expr => {
                                 bail_parse_error!("unsupported unique key expression: {}", expr)
                             }
                         }
-                        unique_collations.push(collation);
+                        unique_collations.try_push(collation)?;
                     }
                     let unique_set = UniqueSet {
                         columns: unique_columns,
@@ -4412,7 +4411,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                         is_primary_key: false,
                         conflict_clause: *conflict_clause,
                     };
-                    unique_sets_constraints.push(unique_set);
+                    unique_sets_constraints.try_push(unique_set)?;
                 } else if let ast::TableConstraint::ForeignKey {
                     columns,
                     clause,
@@ -4480,10 +4479,14 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                         deferred,
                         decl_order: table_fk_order,
                     };
+                    foreign_keys.try_push(Arc::new(fk))?;
                     table_fk_order += 1;
-                    foreign_keys.push(Arc::new(fk));
                 } else if let ast::TableConstraint::Check(expr) = &c.constraint {
-                    check_constraints.push(CheckConstraint::new(c.name.as_ref(), expr, None));
+                    check_constraints.try_push(CheckConstraint::new(
+                        c.name.as_ref(),
+                        expr,
+                        None,
+                    ))?;
                 }
             }
 
@@ -4548,11 +4551,11 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 for c_def in constraints {
                     match &c_def.constraint {
                         ast::ColumnConstraint::Check(expr) => {
-                            check_constraints.push(CheckConstraint::new(
+                            check_constraints.try_push(CheckConstraint::new(
                                 c_def.name.as_ref(),
                                 expr,
                                 Some(&name),
-                            ));
+                            ))?;
                         }
                         ast::ColumnConstraint::Generated { expr, typ } => {
                             if typ
@@ -4583,12 +4586,12 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                             if let Some(o) = o {
                                 order = *o;
                             }
-                            unique_sets_columns.push(UniqueSet {
-                                columns: vec![(name.clone(), order)],
-                                collations: vec![None],
+                            unique_sets_columns.try_push(UniqueSet {
+                                columns: try_vec![(name.clone(), order)]?,
+                                collations: try_vec![None]?,
                                 is_primary_key: true,
                                 conflict_clause: *conflict_clause,
-                            });
+                            })?;
                         }
                         ast::ColumnConstraint::NotNull {
                             nullable,
@@ -4607,12 +4610,12 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                         }
                         ast::ColumnConstraint::Unique(conflict) => {
                             unique = true;
-                            unique_sets_columns.push(UniqueSet {
-                                columns: vec![(name.clone(), order)],
-                                collations: vec![None],
+                            unique_sets_columns.try_push(UniqueSet {
+                                columns: try_vec![(name.clone(), order)]?,
+                                collations: try_vec![None]?,
                                 is_primary_key: false,
                                 conflict_clause: *conflict,
-                            });
+                            })?;
                         }
                         ast::ColumnConstraint::Collate { ref collation_name } => {
                             let collation_seq = CollationSeq::new(collation_name.as_str())?;
@@ -4676,8 +4679,8 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                                 },
                                 decl_order: column_fk_order,
                             };
+                            foreign_keys.try_push(Arc::new(fk))?;
                             column_fk_order += 1;
-                            foreign_keys.push(Arc::new(fk));
                         }
                     }
                 }
@@ -4705,7 +4708,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 }
 
                 if primary_key {
-                    primary_key_columns.push((name.clone(), order));
+                    primary_key_columns.try_push((name.clone(), order))?;
                     if order == SortOrder::Desc {
                         primary_key_desc_columns_constraint = true;
                     }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -157,7 +157,6 @@ use bitflags::bitflags;
 use core::fmt;
 use rustc_hash::{FxBuildHasher, FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::VecDeque;
-use std::ops::Deref;
 use std::sync::OnceLock;
 use tracing::trace;
 use turso_parser::ast::{
@@ -2627,71 +2626,160 @@ crate::alloc::impl_try_clone_via_clone!(
 // fallible impls when their fields become allocator-aware.
 crate::alloc::impl_try_clone_via_clone!(Column, IndexColumn, CheckConstraint);
 
-impl Clone for Schema {
-    /// Cloning a `Schema` requires deep cloning of all internal tables and indexes, even though they are wrapped in `Arc`.
+impl Schema {
+    pub(crate) fn try_make_mut(schema: &mut Arc<Self>) -> Result<&mut Self, TryReserveError> {
+        if Arc::get_mut(schema).is_none() {
+            *schema = Arc::new(schema.as_ref().try_clone()?);
+        }
+        Ok(Arc::get_mut(schema).expect("schema was made unique above"))
+    }
+}
+
+impl TryClone for View {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            name: self.name.clone(),
+            sql: self.sql.clone(),
+            select_stmt: self.select_stmt.clone(),
+            columns: self.columns.try_clone()?,
+            state: AtomicViewState::new(ViewState::Ready),
+        })
+    }
+}
+
+impl TryClone for VirtualTable {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            name: self.name.clone(),
+            columns: self.columns.try_clone()?,
+            kind: self.kind,
+            vtab_type: self.vtab_type.clone(),
+            vtab_id: self.vtab_id,
+            innocuous: self.innocuous,
+        })
+    }
+}
+
+impl TryClone for BTreeTable {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            root_page: self.root_page,
+            name: self.name.clone(),
+            primary_key_columns: self.primary_key_columns.try_clone()?,
+            columns: self.columns.try_clone()?,
+            has_rowid: self.has_rowid,
+            is_strict: self.is_strict,
+            has_autoincrement: self.has_autoincrement,
+            unique_sets: self.unique_sets.try_clone()?,
+            foreign_keys: self.foreign_keys.try_clone()?,
+            check_constraints: self.check_constraints.try_clone()?,
+            rowid_alias_conflict_clause: self.rowid_alias_conflict_clause,
+            has_virtual_columns: self.has_virtual_columns,
+            logical_to_physical_map: self.logical_to_physical_map.try_clone()?,
+            column_dependencies: Default::default(),
+        })
+    }
+}
+
+impl TryClone for FromClauseSubquery {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            name: self.name.clone(),
+            plan: self.plan.clone(),
+            columns: self.columns.try_clone()?,
+            result_columns_start_reg: self.result_columns_start_reg,
+            materialized_cursor_id: self.materialized_cursor_id,
+            cte: self.cte,
+        })
+    }
+}
+
+impl TryClone for Table {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(match self {
+            Table::BTree(table) => Table::BTree(Arc::new(table.as_ref().try_clone()?)),
+            Table::Virtual(table) => Table::Virtual(Arc::new(table.as_ref().try_clone()?)),
+            Table::FromClauseSubquery(from_clause_subquery) => {
+                Table::FromClauseSubquery(Arc::new(from_clause_subquery.as_ref().try_clone()?))
+            }
+        })
+    }
+}
+
+impl TryClone for Index {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            name: self.name.clone(),
+            table_name: self.table_name.clone(),
+            root_page: self.root_page,
+            columns: self.columns.try_clone()?,
+            unique: self.unique,
+            ephemeral: self.ephemeral,
+            has_rowid: self.has_rowid,
+            where_clause: self.where_clause.clone(),
+            index_method: self.index_method.clone(),
+            on_conflict: self.on_conflict,
+        })
+    }
+}
+
+impl TryClone for Schema {
+    /// Copying a `Schema` requires deep cloning of all internal tables and indexes, even though they are wrapped in `Arc`.
     /// Simply copying the `Arc` pointers would result in multiple `Schema` instances sharing the same underlying tables and indexes,
     /// which could lead to panics or data races if any instance attempts to modify them.
     /// To ensure each `Schema` is independent and safe to modify, we clone the underlying data for all tables and indexes.
-    fn clone(&self) -> Self {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
         let tables = self
             .tables
             .iter()
-            .map(|(name, table)| match table.deref() {
-                Table::BTree(table) => {
-                    let table = Arc::deref(table);
-                    (
-                        name.clone(),
-                        Arc::new(Table::BTree(Arc::new(table.clone()))),
-                    )
-                }
-                Table::Virtual(table) => {
-                    let table = Arc::deref(table);
-                    (
-                        name.clone(),
-                        Arc::new(Table::Virtual(Arc::new(table.clone()))),
-                    )
-                }
-                Table::FromClauseSubquery(from_clause_subquery) => (
-                    name.clone(),
-                    Arc::new(Table::FromClauseSubquery(Arc::new(
-                        (**from_clause_subquery).clone(),
-                    ))),
-                ),
+            .map(|(name, table)| {
+                Ok::<_, TryReserveError>((name.clone(), Arc::new(table.as_ref().try_clone()?)))
             })
-            .try_collect()
-            .expect("TODO: Clone is supposed to be fallible");
+            .try_collect::<Result<_, TryReserveError>>()??;
         let indexes = self
             .indexes
             .iter()
             .map(|(name, indexes)| {
                 let indexes = indexes
                     .iter()
-                    .map(|index| Arc::new((**index).clone()))
-                    .try_collect()?;
-                Ok::<_, LimboError>((name.clone(), indexes))
+                    .map(|index| index.as_ref().try_clone().map(Arc::new))
+                    .try_collect::<Result<VecDeque<_>, TryReserveError>>()??;
+                Ok::<_, TryReserveError>((name.clone(), indexes))
             })
-            .try_collect::<Result<_>>()
-            .expect("TODO: Clone is supposed to be fallible")
-            .unwrap();
-        let materialized_view_names = self.materialized_view_names.clone();
-        let materialized_view_sql = self.materialized_view_sql.clone();
+            .try_collect::<Result<_, TryReserveError>>()??;
+        let materialized_view_names = self.materialized_view_names.try_clone()?;
+        let materialized_view_sql = self.materialized_view_sql.try_clone()?;
         let incremental_views = self
             .incremental_views
             .iter()
             .map(|(name, view)| (name.clone(), view.clone()))
-            .try_collect()
-            .expect("TODO: Clone is supposed to be fallible");
+            .try_collect()?;
         let views = self
             .views
             .iter()
-            .map(|(name, view)| (name.clone(), Arc::new((**view).clone())))
-            .try_collect()
-            .expect("TODO: Clone is supposed to be fallible");
+            .map(|(name, view)| {
+                Ok::<_, TryReserveError>((name.clone(), Arc::new(view.as_ref().try_clone()?)))
+            })
+            .try_collect::<Result<_, TryReserveError>>()??;
         let triggers = self
             .triggers
             .iter()
             .map(|(table_name, triggers)| {
-                Ok::<_, LimboError>((
+                Ok::<_, TryReserveError>((
                     table_name.clone(),
                     triggers
                         .iter()
@@ -2699,31 +2787,29 @@ impl Clone for Schema {
                         .try_collect()?,
                 ))
             })
-            .try_collect::<Result<_>>()
-            .expect("TODO: Clone is supposed to be fallible")
-            .unwrap();
-        let incompatible_views = self.incompatible_views.clone();
-        Self {
+            .try_collect::<Result<_, TryReserveError>>()??;
+        let incompatible_views = self.incompatible_views.try_clone()?;
+        Ok(Self {
             tables,
             #[cfg(feature = "conn_raw_api")]
-            table_names_by_root_page: self.table_names_by_root_page.clone(),
+            table_names_by_root_page: self.table_names_by_root_page.try_clone()?,
             materialized_view_names,
             materialized_view_sql,
             incremental_views,
             views,
             triggers,
             indexes,
-            has_indexes: self.has_indexes.clone(),
+            has_indexes: self.has_indexes.try_clone()?,
             schema_version: self.schema_version,
             analyze_stats: self.analyze_stats.clone(),
-            table_to_materialized_views: self.table_to_materialized_views.clone(),
+            table_to_materialized_views: self.table_to_materialized_views.try_clone()?,
             incompatible_views,
-            broken_views: self.broken_views.clone(),
-            dropped_root_pages: self.dropped_root_pages.clone(),
-            type_registry: self.type_registry.clone(),
+            broken_views: self.broken_views.try_clone()?,
+            dropped_root_pages: self.dropped_root_pages.try_clone()?,
+            type_registry: self.type_registry.try_clone()?,
             generated_columns_enabled: self.generated_columns_enabled,
-            sequences: self.sequences.clone(),
-        }
+            sequences: self.sequences.try_clone()?,
+        })
     }
 }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2627,6 +2627,7 @@ crate::alloc::impl_try_clone_via_clone!(
 crate::alloc::impl_try_clone_via_clone!(Column, IndexColumn, CheckConstraint);
 
 impl Schema {
+    #[turso_macros::allocation_site(crate::alloc::SchemaAllocationSite::MakeMut)]
     pub(crate) fn try_make_mut(schema: &mut Arc<Self>) -> Result<&mut Self, TryReserveError> {
         if Arc::get_mut(schema).is_none() {
             *schema = Arc::new(schema.as_ref().try_clone()?);

--- a/core/stats.rs
+++ b/core/stats.rs
@@ -120,9 +120,11 @@ pub fn refresh_analyze_stats(conn: &Arc<Connection>) {
 
     let mv_tx = conn.get_mv_tx();
     if let Ok(stats) = gather_sqlite_stat1(conn, &schema_snapshot, mv_tx) {
-        conn.with_schema_mut(|schema| {
+        if let Err(e) = conn.with_schema_mut(|schema| {
             schema.analyze_stats = stats;
-        });
+        }) {
+            tracing::warn!("Failed to refresh analyze stats: {e}");
+        }
     }
 }
 
@@ -179,9 +181,11 @@ pub fn refresh_analyze_stats_nonblock(
                     Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
                     Ok(IOResult::Done(())) => {
                         let stats = std::mem::take(stats);
-                        conn.with_schema_mut(|schema| {
+                        if let Err(e) = conn.with_schema_mut(|schema| {
                             schema.analyze_stats = stats;
-                        });
+                        }) {
+                            tracing::warn!("Failed to refresh analyze stats: {e}");
+                        }
                         *st = RefreshAnalyzeStatsState::Start;
                         return Ok(IOResult::Done(()));
                     }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -507,6 +507,7 @@ fn stmt_kind(stmt: &ast::Stmt) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alloc::TryClone;
     use crate::io::MemoryIO;
     use crate::schema::{BTreeTable, Table, SQLITE_SEQUENCE_TABLE_NAME};
     use crate::Database;
@@ -553,7 +554,7 @@ mod tests {
         conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)")
             .unwrap();
 
-        let mut schema = db.schema.lock().as_ref().clone();
+        let mut schema = db.schema.lock().as_ref().try_clone().unwrap();
         let seq_root_page = schema
             .get_btree_table(SQLITE_SEQUENCE_TABLE_NAME)
             .expect("sqlite_sequence should exist after creating AUTOINCREMENT table")
@@ -597,7 +598,7 @@ mod tests {
         conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)")
             .unwrap();
 
-        let mut schema = db.schema.lock().as_ref().clone();
+        let mut schema = db.schema.lock().as_ref().try_clone().unwrap();
         schema.tables.remove(SQLITE_SEQUENCE_TABLE_NAME);
 
         let pager = conn.pager.load().clone();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -495,7 +495,7 @@ pub fn op_drop_index(
             schema.dropped_root_pages.insert(index.root_page);
         }
         schema.remove_index(index);
-    });
+    })?;
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -11565,7 +11565,7 @@ pub fn op_drop_table(
             schema.remove_indices_for_table(table_name);
             schema.remove_triggers_for_table(table_name);
             schema.remove_table(table_name);
-        });
+        })?;
         // SQLite also removes temp triggers that target the dropped table.
         // Only needed when dropping from a non-temp database. We must
         // scope the removal to triggers whose `target_database_id`
@@ -11575,7 +11575,7 @@ pub fn op_drop_table(
             let dropped_db = *db;
             conn.with_database_schema_mut(crate::TEMP_DB_ID, |temp_schema| {
                 temp_schema.remove_triggers_for_table_with_db(table_name, dropped_db);
-            });
+            })?;
         }
     }
     state.pc += 1;
@@ -11593,7 +11593,7 @@ pub fn op_drop_view(
     conn.with_database_schema_mut(*db, |schema| {
         schema.remove_view(view_name).ok();
         schema.broken_views.remove(view_name);
-    });
+    })?;
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -11608,7 +11608,6 @@ pub fn op_drop_type(
     let conn = program.connection.clone();
     conn.with_database_schema_mut(*db, |schema| {
         schema.remove_type(type_name);
-        Ok::<(), crate::LimboError>(())
     })?;
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -11645,7 +11644,7 @@ pub fn op_add_sequence(
         schema
             .sequences
             .insert(crate::util::normalize_ident(name), std::sync::Arc::new(seq));
-    });
+    })?;
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -11660,7 +11659,7 @@ pub fn op_drop_sequence(
     let conn = program.connection.clone();
     conn.with_database_schema_mut(*db, |schema| {
         schema.remove_sequence(seq_name);
-    });
+    })?;
     // Drop this connection's stale currval. Otherwise a same-session
     // DROP SEQUENCE + CREATE SEQUENCE <same name> would let currval()
     // return the prior sequence's last value instead of erroring with
@@ -11680,7 +11679,7 @@ pub fn op_add_type(
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(AddType { db, sql }, insn);
     let conn = program.connection.clone();
-    conn.with_database_schema_mut(*db, |schema| schema.add_type_from_sql(sql))?;
+    conn.with_database_schema_mut(*db, |schema| schema.add_type_from_sql(sql))??;
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -12294,7 +12293,7 @@ pub fn op_drop_trigger(
     let conn = program.connection.clone();
     conn.with_database_schema_mut(*db, |schema| {
         schema.remove_trigger(trigger_name).ok();
-    });
+    })?;
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -12522,7 +12521,7 @@ fn op_parse_schema_step(
                 let table_name = row.get::<&str>(2)?;
                 let root_page = row.get::<i64>(3)?;
                 let sql = row.get::<&str>(4).ok();
-                let schema = Arc::make_mut(&mut inner.schema_arc);
+                let schema = Schema::try_make_mut(&mut inner.schema_arc)?;
                 let syms = conn.syms.read();
                 let attached_resolver = |alias: &str| -> Option<usize> {
                     conn.attached_databases()
@@ -12563,7 +12562,7 @@ fn op_parse_schema_step(
                     .parse_schema()
                     .take()
                     .expect("parse schema state should exist");
-                let schema = Arc::make_mut(&mut schema_arc);
+                let schema = Schema::try_make_mut(&mut schema_arc)?;
                 let mv_store = stmt.mv_store();
                 let syms = conn.syms.read();
 
@@ -13057,9 +13056,9 @@ pub fn op_set_cookie(
                     // snapshot on the connection. Flag that it needs updating.
                     program.connection.mark_temp_schema_did_change();
                 }
-                program
-                    .connection
-                    .with_database_schema_mut(*db, |schema| schema.schema_version = *value as u32);
+                program.connection.with_database_schema_mut(*db, |schema| {
+                    schema.schema_version = *value as u32
+                })?;
                 header.schema_cookie = (*value as u32).into();
             }
         };
@@ -14001,9 +14000,9 @@ fn with_relevant_trigger_schemas_mut(
     table_db_id: usize,
     mut f: impl FnMut(&mut Schema) -> crate::Result<()>,
 ) -> crate::Result<()> {
-    conn.with_database_schema_mut(table_db_id, |schema| f(schema))?;
+    conn.with_database_schema_mut(table_db_id, |schema| f(schema))??;
     if table_db_id != crate::TEMP_DB_ID && conn.temp.database.read().is_some() {
-        conn.with_database_schema_mut(crate::TEMP_DB_ID, |schema| f(schema))?;
+        conn.with_database_schema_mut(crate::TEMP_DB_ID, |schema| f(schema))??;
     }
     Ok(())
 }
@@ -14207,7 +14206,7 @@ pub fn op_rename_table(
         }
 
         Ok(())
-    })?;
+    })??;
 
     if *db != crate::TEMP_DB_ID && conn.temp.database.read().is_some() {
         conn.with_database_schema_mut(crate::TEMP_DB_ID, |schema| -> crate::Result<()> {
@@ -14221,7 +14220,7 @@ pub fn op_rename_table(
                 }
             }
             Ok(())
-        })?;
+        })??;
     }
 
     state.pc += 1;
@@ -14285,7 +14284,7 @@ pub fn op_drop_column(
 
         btree.shift_generated_column_indices_after_drop(*column_index)?;
         Ok(())
-    })?;
+    })??;
 
     conn.with_schema(*db, |schema| -> crate::Result<()> {
         if let Some(indexes) = schema.indexes.get(&normalized_table_name) {
@@ -14334,7 +14333,7 @@ pub fn op_drop_column(
             }
         }
         Ok(())
-    })?;
+    })??;
 
     conn.with_schema(*db, |schema| -> crate::Result<()> {
         for (view_name, view) in schema.views.iter() {
@@ -14397,7 +14396,7 @@ pub fn op_add_column(
         // Resolve generated column expressions and update virtual column metadata
         btree.prepare_generated_columns()?;
         Ok(())
-    })?;
+    })??;
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -14634,7 +14633,7 @@ pub fn op_alter_column(
             }
         }
         Ok(())
-    })?;
+    })??;
 
     if *rename {
         // Update in-memory trigger objects for the renamed column in both the
@@ -14663,7 +14662,7 @@ pub fn op_alter_column(
                     view.columns = rewritten.columns;
                 }
                 Ok(())
-            })?;
+            })??;
         }
 
         if *db != crate::MAIN_DB_ID {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12394,6 +12394,14 @@ pub struct OpParseSchemaInner {
 
 pub type OpParseSchemaState = Option<Box<OpParseSchemaInner>>;
 
+impl OpParseSchemaInner {
+    /// The connection's `auto_commit` value saved at ParseSchema entry, so
+    /// abort paths can restore it when the op never reached its Done arm.
+    pub(crate) fn previous_auto_commit(&self) -> bool {
+        self.previous_auto_commit
+    }
+}
+
 pub fn op_parse_schema(
     program: &Program,
     state: &mut ProgramState,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -621,6 +621,19 @@ impl ActiveOpStateSlot {
         None
     );
 
+    /// Take the ParseSchema op state if it is the active one, without
+    /// touching (or panicking on) any other live op state. Used by abort
+    /// cleanup, which runs regardless of which opcode was executing.
+    fn take_parse_schema_if_active(&mut self) -> execute::OpParseSchemaState {
+        if let ActiveOpState::ParseSchema(inner) = &mut self.state {
+            let taken = inner.take();
+            self.state = ActiveOpState::None;
+            taken
+        } else {
+            None
+        }
+    }
+
     fn program_ref(&self) -> Option<&OpProgramState> {
         match &self.state {
             ActiveOpState::Program(state) => Some(state),
@@ -2398,6 +2411,22 @@ impl Program {
         state
             .commit_state
             .cleanup_abandoned_mvcc_commit(&self.connection);
+
+        // ParseSchema owns a nested helper statement on this connection and
+        // stores `auto_commit=false` for its duration. If the program aborts
+        // while that state is live (error mid-schema-row), release it here:
+        // restore the saved auto_commit and drop the inner statement so its
+        // nested guard is released BEFORE the `is_nested_stmt()` check below.
+        // Otherwise this top-level statement misclassifies itself as nested,
+        // skips transaction rollback, and leaks the DDL's exclusive MVCC tx
+        // (and the cleared auto_commit) into subsequent statements — which
+        // then appear to succeed without ever committing.
+        if let Some(inner) = state.active_op_state.take_parse_schema_if_active() {
+            self.connection
+                .auto_commit
+                .store(inner.previous_auto_commit(), Ordering::SeqCst);
+            drop(inner);
+        }
 
         // VACUUM (and VACUUM INTO) state can own internal helper statements whose drop path
         // releases nested guards. Clean it before checking whether this program

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -545,7 +545,7 @@ pub(crate) fn vacuum_target_build_step(
                         for (name, td) in &config.source_custom_types {
                             target_schema.type_registry.insert(name.clone(), td.clone());
                         }
-                    });
+                    })?;
                 }
 
                 // Auto-vacuum must be installed before MVCC bootstrap creates
@@ -1554,12 +1554,7 @@ struct VacuumCommittedImageMeta {
 }
 
 fn replace_shared_schema_after_vacuum(source_db: &Database, schema: Arc<Schema>) {
-    source_db
-        .with_schema_mut(|current| {
-            *current = schema.as_ref().clone();
-            Ok(())
-        })
-        .expect("VACUUM shared schema replacement should be infallible");
+    source_db.replace_schema(schema);
 }
 
 fn install_mvcc_state_after_vacuum_commit(
@@ -2731,7 +2726,7 @@ mod tests {
 
         conn.with_schema_mut(|schema| {
             schema.schema_version = 1;
-        });
+        })?;
         db.with_schema_mut(|schema| {
             schema.schema_version = 1;
             Ok(())
@@ -2767,7 +2762,7 @@ mod tests {
 
         conn.with_schema_mut(|schema| {
             schema.schema_version = 1;
-        });
+        })?;
         db.with_schema_mut(|schema| {
             schema.schema_version = 1;
             Ok(())

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use turso_core::alloc::{
     AllocError, AllocationSite, ApiAllocator, Global, Layout, MvStoreAllocationSite,
-    MvccCheckpointAllocationSite, SetAllocatorError, TursoAllocBackend,
+    MvccCheckpointAllocationSite, SchemaAllocationSite, SetAllocatorError, TursoAllocBackend,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -216,6 +216,9 @@ fn allocation_site_id(site: AllocationSite) -> u64 {
             MvccCheckpointAllocationSite::CheckpointIndexWriteSet => 9,
             MvccCheckpointAllocationSite::CheckpointMetadataPayload => 10,
             MvccCheckpointAllocationSite::CheckpointSequenceCompactions => 11,
+        },
+        AllocationSite::Schema(site) => match site {
+            SchemaAllocationSite::MakeMut => 14,
         },
     }
 }

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -393,6 +393,21 @@ impl WhopperOpts {
         }
     }
 
+    pub fn schema_clone_faults() -> Self {
+        Self {
+            max_steps: 200_000,
+            schema_bias: SchemaBias {
+                non_rowid_pk_prob: 0.4,
+                unique_col_prob: 0.8,
+                num_tables_range: 6..=12,
+                num_columns_range: 8..=16,
+                initial_rows_per_table: 2,
+            },
+            reopen_probability: 0.05,
+            ..Default::default()
+        }
+    }
+
     pub fn btree_rebalance() -> Self {
         Self {
             max_steps: 500_000,

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -31,7 +31,7 @@ struct Args {
     #[command(subcommand)]
     subcommand: Option<SubCmd>,
 
-    /// Simulation mode (fast, chaos, btree-rebalance/btree-rekey, recovery-heavy, ragnarök/ragnarok)
+    /// Simulation mode (fast, chaos, schema-clone-faults, btree-rebalance/btree-rekey, recovery-heavy, ragnarök/ragnarok)
     #[arg(long, default_value = "fast")]
     mode: String,
     /// Max connections
@@ -163,6 +163,7 @@ fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
     let base_max_steps = match args.mode.as_str() {
         "fast" => 100_000,
         "chaos" => 10_000_000,
+        "schema-clone-faults" => 10_000,
         "btree-rebalance" | "btree-rekey" => 500_000,
         "ragnarök" | "ragnarok" => 1_000_000,
         mode => return Err(anyhow::anyhow!("Unknown mode: {}", mode)),
@@ -401,6 +402,19 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
         )];
 
         (w, p, vec![], chaotic)
+    } else if is_schema_clone_fault_mode(&args.mode) {
+        let w: Vec<(u32, Box<dyn Workload>)> = vec![
+            (45, Box::new(SchemaChurnWorkload)),
+            (20, Box::new(TruncateCheckpointWorkload)),
+            (20, Box::new(BeginWorkload)),
+            (10, Box::new(CommitWorkload)),
+            (15, Box::new(RollbackWorkload)),
+            (10, Box::new(IntegrityCheckWorkload)),
+            (8, Box::new(SelectWorkload)),
+        ];
+        let p: Vec<Box<dyn Property>> = vec![Box::new(IntegrityCheckProperty)];
+
+        (w, p, vec![], vec![])
     } else {
         let w: Vec<(u32, Box<dyn Workload>)> = vec![
             (10, Box::new(IntegrityCheckWorkload)),
@@ -448,6 +462,7 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
     let mut base_opts = match args.mode.as_str() {
         "fast" => WhopperOpts::fast(),
         "chaos" => WhopperOpts::chaos(),
+        "schema-clone-faults" => WhopperOpts::schema_clone_faults(),
         "btree-rebalance" | "btree-rekey" => WhopperOpts::btree_rebalance(),
         "ragnarök" | "ragnarok" => WhopperOpts::ragnarok(),
         "recovery-heavy" => WhopperOpts::recovery_heavy(),
@@ -468,7 +483,7 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         .with_seed(seed)
         .with_max_connections(args.max_connections)
         .with_keep_files(args.keep)
-        .with_enable_mvcc(args.enable_mvcc)
+        .with_enable_mvcc(args.enable_mvcc || is_schema_clone_fault_mode(&args.mode))
         .with_enable_encryption(args.enable_encryption)
         .with_elle_tables(elle_tables)
         .with_workloads(workloads)
@@ -481,6 +496,10 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
 
 fn is_btree_rebalance_mode(mode: &str) -> bool {
     matches!(mode, "btree-rebalance" | "btree-rekey")
+}
+
+fn is_schema_clone_fault_mode(mode: &str) -> bool {
+    mode == "schema-clone-faults"
 }
 
 fn format_stats(stats: &turso_whopper::Stats, elle_mode: bool) -> String {

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -252,6 +252,118 @@ impl Workload for WalCheckpointWorkload {
     }
 }
 
+/// Run the checkpoint mode that is valid for both WAL and MVCC.
+pub struct TruncateCheckpointWorkload;
+
+impl Workload for TruncateCheckpointWorkload {
+    fn generate(&self, ctx: &WorkloadContext, _rng: &mut ChaCha8Rng) -> Option<Operation> {
+        if *ctx.fiber_state != FiberState::Idle {
+            return None;
+        }
+        Some(Operation::WalCheckpoint {
+            mode: "TRUNCATE".to_string(),
+        })
+    }
+}
+
+/// Churn schema objects to force schema copy-on-write under allocation faults.
+pub struct SchemaChurnWorkload;
+
+impl Workload for SchemaChurnWorkload {
+    fn generate(&self, ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        if *ctx.fiber_state == FiberState::InConcurrentTx {
+            return None;
+        }
+
+        let table_id = rng.random_range(0..64);
+        let index_id = rng.random_range(0..256);
+        let sql = match rng.random_range(0..12) {
+            0..=2 => schema_churn_create_table_sql(table_id),
+            3..=4 => schema_churn_create_index_sql(table_id, index_id),
+            5 => schema_churn_create_view_sql(table_id),
+            6 => schema_churn_create_trigger_sql(table_id),
+            7 => schema_churn_drop_index_sql(table_id, index_id),
+            8 => schema_churn_drop_view_sql(table_id),
+            9 => schema_churn_schema_read_sql(table_id),
+            10 => existing_table_index_sql(&ctx.tables_vec, index_id, rng)
+                .unwrap_or_else(|| schema_churn_create_table_sql(table_id)),
+            _ => "SELECT name, sql FROM sqlite_schema WHERE name LIKE 'schema_clone_%' ORDER BY name LIMIT 8".to_string(),
+        };
+        Some(Operation::Execute { sql })
+    }
+}
+
+fn schema_churn_table_name(table_id: u32) -> String {
+    format!("schema_clone_t_{table_id}")
+}
+
+fn schema_churn_create_table_sql(table_id: u32) -> String {
+    let table_name = schema_churn_table_name(table_id);
+    format!(
+        "CREATE TABLE IF NOT EXISTS {table_name} (\
+         id INTEGER PRIMARY KEY, \
+         k TEXT NOT NULL DEFAULT 'k', \
+         v INTEGER NOT NULL DEFAULT 0, \
+         payload BLOB, \
+         CHECK (v >= 0), \
+         UNIQUE (k, v))"
+    )
+}
+
+fn schema_churn_create_index_sql(table_id: u32, index_id: u32) -> String {
+    let table_name = schema_churn_table_name(table_id);
+    format!(
+        "CREATE INDEX IF NOT EXISTS schema_clone_idx_{table_id}_{index_id} \
+         ON {table_name}(k, v) WHERE v >= 0"
+    )
+}
+
+fn schema_churn_create_view_sql(table_id: u32) -> String {
+    let table_name = schema_churn_table_name(table_id);
+    format!(
+        "CREATE VIEW IF NOT EXISTS schema_clone_v_{table_id} AS \
+         SELECT id, k, v FROM {table_name} WHERE v >= 0"
+    )
+}
+
+fn schema_churn_create_trigger_sql(table_id: u32) -> String {
+    let table_name = schema_churn_table_name(table_id);
+    format!(
+        "CREATE TRIGGER IF NOT EXISTS schema_clone_tr_{table_id} \
+         AFTER INSERT ON {table_name} \
+         WHEN new.v > 100 \
+         BEGIN \
+             UPDATE {table_name} SET v = new.v WHERE id = new.id; \
+         END"
+    )
+}
+
+fn schema_churn_drop_index_sql(table_id: u32, index_id: u32) -> String {
+    format!("DROP INDEX IF EXISTS schema_clone_idx_{table_id}_{index_id}")
+}
+
+fn schema_churn_drop_view_sql(table_id: u32) -> String {
+    format!("DROP VIEW IF EXISTS schema_clone_v_{table_id}")
+}
+
+fn schema_churn_schema_read_sql(table_id: u32) -> String {
+    let table_name = schema_churn_table_name(table_id);
+    format!("PRAGMA table_info('{table_name}')")
+}
+
+fn existing_table_index_sql(
+    tables: &[Table],
+    index_id: u32,
+    rng: &mut ChaCha8Rng,
+) -> Option<String> {
+    let table = tables.choose(rng)?;
+    let column = table.columns.choose(rng)?;
+    Some(format!(
+        "CREATE INDEX IF NOT EXISTS schema_clone_existing_idx_{}_{} ON {}({})",
+        table.name, index_id, table.name, column.name
+    ))
+}
+
 /// Commit the current transaction.
 pub struct CommitWorkload;
 
@@ -619,5 +731,74 @@ impl Workload for AutoincDeleteWorkload {
     fn generate(&self, _ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
         let id = rng.random_range(1..10_000i64);
         Some(Operation::AutoincDelete { id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng;
+    use sql_generation::{
+        generation::Opts,
+        model::table::{Column, ColumnType, Table},
+    };
+
+    use super::*;
+
+    #[test]
+    fn schema_churn_create_table_uses_schema_features() {
+        let sql = schema_churn_create_table_sql(7);
+
+        assert!(sql.contains("schema_clone_t_7"));
+        assert!(sql.contains("UNIQUE"));
+        assert!(sql.contains("CHECK"));
+    }
+
+    #[test]
+    fn schema_churn_skips_concurrent_transactions() {
+        let table = Table {
+            name: "table_0".to_string(),
+            columns: vec![Column {
+                name: "id".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![],
+            }],
+            rows: vec![],
+            indexes: vec![],
+        };
+        let state = SimulatorState::new(vec![table.clone()], vec![]);
+        let opts = Opts::default();
+        let tables_vec = vec![table];
+        let ctx = WorkloadContext {
+            fiber_state: &FiberState::InConcurrentTx,
+            sim_state: &state,
+            opts: &opts,
+            enable_mvcc: true,
+            tables_vec,
+        };
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+
+        assert!(SchemaChurnWorkload.generate(&ctx, &mut rng).is_none());
+    }
+
+    #[test]
+    fn existing_table_index_targets_generated_schema() {
+        let table = Table {
+            name: "table_0".to_string(),
+            columns: vec![Column {
+                name: "col_0".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![],
+            }],
+            rows: vec![],
+            indexes: vec![],
+        };
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+
+        let sql = existing_table_index_sql(&[table], 9, &mut rng).unwrap();
+
+        assert_eq!(
+            sql,
+            "CREATE INDEX IF NOT EXISTS schema_clone_existing_idx_table_0_9 ON table_0(col_0)"
+        );
     }
 }


### PR DESCRIPTION
## Description
- replace the infallible deep Schema clone with TryClone
- route schema copy-on-write through Schema::try_make_mut
- propagate schema mutation allocation failures through connection, VDBE, MVCC, and extension paths
- added an additional whopper workload and fallible allocation site to stress the DDL path schema allocation failures

## Context
Arc::make_mut on Arc<Schema> could deep-clone schema tables and indexes with infallible Clone. Under allocation pressure this could abort while cloning allocator-aware vectors such as table columns.
