### PR TITLE
core/mvcc: mark recovery delete tombstones for truncated frames btree-resident

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -8120,11 +8120,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                             TxTimestampOrID::Timestamp(commit_ts),
                                         )),
                                         row: tombstone_row.clone(),
-                                        // The version this delete ends was not replayed, so its
-                                        // frame is at or below the durable replay boundary: the
-                                        // deleted row is in the DB file. Mark the tombstone
-                                        // btree-resident so checkpoint applies the delete even
-                                        // though the logged flag predates the row becoming durable.
                                         btree_resident: true,
                                     };
                                     self.insert_version_raw(&mut versions, row_version)?;
@@ -8138,8 +8133,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                         TxTimestampOrID::Timestamp(commit_ts),
                                     )),
                                     row: tombstone_row,
-                                    // Same invariant as above: no replayed version means the
-                                    // deleted row is already durable in the DB file.
                                     btree_resident: true,
                                 };
                                 let versions =
@@ -8237,12 +8230,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     TxTimestampOrID::Timestamp(commit_ts),
                                 )),
                                 row: row.clone(),
-                                // The index entry this delete ends was not replayed, so its
-                                // frame is at or below the durable replay boundary: the entry
-                                // is in the DB file. Mark the tombstone btree-resident so
-                                // checkpoint applies the delete even though the logged flag
-                                // predates the entry becoming durable (e.g. a checkpoint that
-                                // failed after its pager commit).
                                 btree_resident: true,
                             };
                             self.insert_index_version(rowid.table_id, sortable_key, row_version)?;

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -8059,9 +8059,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             allocator.insert_row_id_maybe_update(rowid.row_id.to_int_or_panic());
                         }
                         StreamingResult::DeleteTableRow {
-                            rowid,
-                            commit_ts,
-                            btree_resident,
+                            rowid, commit_ts, ..
                         } => {
                             max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
                             if commit_ts <= replay_cutoff_ts {
@@ -8122,7 +8120,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                             TxTimestampOrID::Timestamp(commit_ts),
                                         )),
                                         row: tombstone_row.clone(),
-                                        btree_resident,
+                                        // The version this delete ends was not replayed, so its
+                                        // frame is at or below the durable replay boundary: the
+                                        // deleted row is in the DB file. Mark the tombstone
+                                        // btree-resident so checkpoint applies the delete even
+                                        // though the logged flag predates the row becoming durable.
+                                        btree_resident: true,
                                     };
                                     self.insert_version_raw(&mut versions, row_version)?;
                                 }
@@ -8135,7 +8138,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                         TxTimestampOrID::Timestamp(commit_ts),
                                     )),
                                     row: tombstone_row,
-                                    btree_resident,
+                                    // Same invariant as above: no replayed version means the
+                                    // deleted row is already durable in the DB file.
+                                    btree_resident: true,
                                 };
                                 let versions =
                                     self.get_or_create_table_row_versions(rowid.clone())?;
@@ -8201,7 +8206,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             row,
                             rowid,
                             commit_ts,
-                            btree_resident,
+                            ..
                         } => {
                             max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
                             if commit_ts <= replay_cutoff_ts {
@@ -8232,7 +8237,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     TxTimestampOrID::Timestamp(commit_ts),
                                 )),
                                 row: row.clone(),
-                                btree_resident,
+                                // The index entry this delete ends was not replayed, so its
+                                // frame is at or below the durable replay boundary: the entry
+                                // is in the DB file. Mark the tombstone btree-resident so
+                                // checkpoint applies the delete even though the logged flag
+                                // predates the entry becoming durable (e.g. a checkpoint that
+                                // failed after its pager commit).
+                                btree_resident: true,
                             };
                             self.insert_index_version(rowid.table_id, sortable_key, row_version)?;
                         }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -3397,13 +3397,6 @@ fn test_checkpoint_stale_boundary_does_not_replay_checkpointed_create_table_afte
     assert_eq!(&rows[0][1].to_string(), "persisted");
 }
 
-/// What this test checks: a checkpoint failure after the durable boundary advanced must not
-/// leave a stale unique-index entry behind after restart recovery plus a later checkpoint.
-/// Why this matters: the torn checkpoint makes the 'old'->'mid' UPDATE durable in the B-tree
-/// but fails before truncating the logical log. On restart that frame is (correctly) skipped
-/// at the replay boundary, so the later 'mid'->'new' UPDATE replays its index delete as a
-/// standalone tombstone; the next checkpoint must still apply that delete to the B-tree, or
-/// the 'mid' autoindex entry survives alongside 'new' for the same rowid.
 #[test]
 fn test_checkpoint_post_durable_failure_then_unique_update_removes_stale_autoindex_entry() {
     let mut db = MvccTestDbNoConn::new_with_random_db();
@@ -3458,10 +3451,6 @@ fn test_checkpoint_post_durable_failure_then_unique_update_removes_stale_autoind
     assert_integrity_ok(&conn);
 }
 
-/// What this test checks: the table-row flavor of the same torn-checkpoint bug. A row insert
-/// made durable by a failed checkpoint must still be deletable after restart: recovery creates
-/// a standalone tombstone for the row, and the next checkpoint must apply that delete to the
-/// B-tree even though the tombstone's inserting frame was truncated from replay.
 #[test]
 fn test_checkpoint_post_durable_failure_then_delete_removes_stale_table_row() {
     let mut db = MvccTestDbNoConn::new_with_random_db();

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -3397,6 +3397,113 @@ fn test_checkpoint_stale_boundary_does_not_replay_checkpointed_create_table_afte
     assert_eq!(&rows[0][1].to_string(), "persisted");
 }
 
+/// What this test checks: a checkpoint failure after the durable boundary advanced must not
+/// leave a stale unique-index entry behind after restart recovery plus a later checkpoint.
+/// Why this matters: the torn checkpoint makes the 'old'->'mid' UPDATE durable in the B-tree
+/// but fails before truncating the logical log. On restart that frame is (correctly) skipped
+/// at the replay boundary, so the later 'mid'->'new' UPDATE replays its index delete as a
+/// standalone tombstone; the next checkpoint must still apply that delete to the B-tree, or
+/// the 'mid' autoindex entry survives alongside 'new' for the same rowid.
+#[test]
+fn test_checkpoint_post_durable_failure_then_unique_update_removes_stale_autoindex_entry() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
+        conn.execute("CREATE TABLE t(a TEXT UNIQUE, b REAL, c NUMERIC NOT NULL PRIMARY KEY)")
+            .unwrap();
+
+        conn.execute("INSERT INTO t VALUES ('old', 1.0, 1)")
+            .unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+        conn.execute("UPDATE t SET a = 'mid', b = 2.0 WHERE c = 1")
+            .unwrap();
+
+        let checkpoint_conn = db.connect();
+        let failure_injector = FixedFailureInjector::new([(
+            CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
+            LimboError::TxError("synthetic checkpoint failure after pager commit".to_string()),
+        )]);
+        checkpoint_conn.set_failure_injector(Some(failure_injector.clone()));
+        checkpoint_conn
+            .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            .expect_err("checkpoint should fail after pager commit");
+        checkpoint_conn.set_failure_injector(None);
+
+        conn.execute("UPDATE t SET a = 'new', b = 3.0 WHERE c = 1")
+            .unwrap();
+        assert_integrity_ok(&conn);
+    }
+
+    db.restart();
+    let conn = db.connect();
+    assert_integrity_ok(&conn);
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT rowid, a, b, c FROM t INDEXED BY sqlite_autoindex_t_1 WHERE c = 1",
+    );
+    assert_eq!(
+        rows.len(),
+        1,
+        "stale autoindex entries after checkpoint: {rows:?}"
+    );
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "new");
+    assert_eq!(rows[0][3].as_int().unwrap(), 1);
+    assert_integrity_ok(&conn);
+}
+
+/// What this test checks: the table-row flavor of the same torn-checkpoint bug. A row insert
+/// made durable by a failed checkpoint must still be deletable after restart: recovery creates
+/// a standalone tombstone for the row, and the next checkpoint must apply that delete to the
+/// B-tree even though the tombstone's inserting frame was truncated from replay.
+#[test]
+fn test_checkpoint_post_durable_failure_then_delete_removes_stale_table_row() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'keep')").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+        conn.execute("INSERT INTO t VALUES (2, 'doomed')").unwrap();
+
+        let checkpoint_conn = db.connect();
+        let failure_injector = FixedFailureInjector::new([(
+            CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
+            LimboError::TxError("synthetic checkpoint failure after pager commit".to_string()),
+        )]);
+        checkpoint_conn.set_failure_injector(Some(failure_injector.clone()));
+        checkpoint_conn
+            .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            .expect_err("checkpoint should fail after pager commit");
+        checkpoint_conn.set_failure_injector(None);
+
+        conn.execute("DELETE FROM t WHERE id = 2").unwrap();
+        assert_integrity_ok(&conn);
+    }
+
+    db.restart();
+    let conn = db.connect();
+    assert_integrity_ok(&conn);
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(&conn, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(rows.len(), 1, "stale table rows after checkpoint: {rows:?}");
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "keep");
+    assert_integrity_ok(&conn);
+}
+
 /// What this test checks: Replay gate uses metadata boundary and never applies frames at or below it.
 /// Why this matters: This enforces exactly-once effects at the DB-file apply boundary.
 #[test]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -3402,7 +3402,7 @@ fn test_checkpoint_post_durable_failure_then_unique_update_removes_stale_autoind
     let mut db = MvccTestDbNoConn::new_with_random_db();
     {
         let conn = db.connect();
-        vec![
+        [
             "PRAGMA mvcc_checkpoint_threshold = -1",
             "CREATE TABLE t(a UNIQUE, b, c PRIMARY KEY)",
             "INSERT INTO t VALUES ('old', 1.0, 1)",

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -3426,7 +3426,7 @@ fn test_checkpoint_post_durable_failure_then_unique_update_removes_stale_autoind
             CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
             LimboError::TxError("synthetic checkpoint failure after pager commit".to_string()),
         )]);
-        checkpoint_conn.set_failure_injector(Some(failure_injector.clone()));
+        checkpoint_conn.set_failure_injector(Some(failure_injector));
         checkpoint_conn
             .execute("PRAGMA wal_checkpoint(TRUNCATE)")
             .expect_err("checkpoint should fail after pager commit");
@@ -3481,7 +3481,7 @@ fn test_checkpoint_post_durable_failure_then_delete_removes_stale_table_row() {
             CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
             LimboError::TxError("synthetic checkpoint failure after pager commit".to_string()),
         )]);
-        checkpoint_conn.set_failure_injector(Some(failure_injector.clone()));
+        checkpoint_conn.set_failure_injector(Some(failure_injector));
         checkpoint_conn
             .execute("PRAGMA wal_checkpoint(TRUNCATE)")
             .expect_err("checkpoint should fail after pager commit");

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -3402,17 +3402,15 @@ fn test_checkpoint_post_durable_failure_then_unique_update_removes_stale_autoind
     let mut db = MvccTestDbNoConn::new_with_random_db();
     {
         let conn = db.connect();
-        conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
-            .unwrap();
-        conn.execute("CREATE TABLE t(a TEXT UNIQUE, b REAL, c NUMERIC NOT NULL PRIMARY KEY)")
-            .unwrap();
-
-        conn.execute("INSERT INTO t VALUES ('old', 1.0, 1)")
-            .unwrap();
-        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
-
-        conn.execute("UPDATE t SET a = 'mid', b = 2.0 WHERE c = 1")
-            .unwrap();
+        vec![
+            "PRAGMA mvcc_checkpoint_threshold = -1",
+            "CREATE TABLE t(a UNIQUE, b, c PRIMARY KEY)",
+            "INSERT INTO t VALUES ('old', 1.0, 1)",
+            "PRAGMA wal_checkpoint(TRUNCATE)",
+            "UPDATE t SET a = 'mid', b = 2.0 WHERE c = 1",
+        ]
+        .iter()
+        .for_each(|sql| conn.execute(sql).unwrap());
 
         let checkpoint_conn = db.connect();
         let failure_injector = FixedFailureInjector::new([(
@@ -3423,7 +3421,6 @@ fn test_checkpoint_post_durable_failure_then_unique_update_removes_stale_autoind
         checkpoint_conn
             .execute("PRAGMA wal_checkpoint(TRUNCATE)")
             .expect_err("checkpoint should fail after pager commit");
-        checkpoint_conn.set_failure_injector(None);
 
         conn.execute("UPDATE t SET a = 'new', b = 3.0 WHERE c = 1")
             .unwrap();


### PR DESCRIPTION
## Description

An MVCC checkpoint that fails after its pager commit advances the durable boundary but leaves the logical log untruncated and in-memory versions carrying stale `btree_resident=false`. A later delete of an entry made durable by that torn checkpoint logs the stale flag; on restart, replay correctly skips the entry's creating frame and materializes the delete as a standalone tombstone, so the next checkpoint computes `exists_in_db_file=false` and skips the B-tree delete — resurrecting the previous unique-index entry (`wrong # of entries in index`) or a deleted row.

`recover_process_frame` now marks such tombstones `btree_resident: true`: an un-replayed frame is by construction already durable, so the durable B-tree state — not the write-time flag the torn checkpoint invalidated — drives the delete.

## Motivation and context

Fixes #7740.

## Description of AI Usage

Authored autonomously by Claude Code from the issue's reproducer and analysis.