### PR TITLE
core/vdbe: reject Destroy while other statements are active on the connection

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -467,6 +467,7 @@ pub struct Connection {
     /// (`db->nVdbeActive`) for user statements, excluding internal helpers and
     /// subprogram execution.
     pub(crate) n_active_root_statements: AtomicI32,
+    pub(crate) destroy_in_progress: AtomicBool,
     /// Whether pragma ignore_check_constraints=ON for this connection
     pub(super) check_constraints_pragma: AtomicBool,
     /// Track when each virtual table instance is currently in transaction.

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2142,6 +2142,7 @@ impl Database {
             fk_deferred_violations: AtomicIsize::new(0),
             n_active_writes: AtomicI32::new(0),
             n_active_root_statements: AtomicI32::new(0),
+            destroy_in_progress: AtomicBool::new(false),
             check_constraints_pragma: AtomicBool::new(false),
             vtab_txn_states: RwLock::new(HashSet::default()),
             named_savepoints: RwLock::new(Vec::new()),

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -501,6 +501,16 @@ impl Statement {
     }
 
     fn _step(&mut self, waker: Option<&Waker>) -> Result<StepResult> {
+        if matches!(self.origin, StatementOrigin::Root)
+            && !self.state.holds_destroy_guard
+            && self
+                .program
+                .connection
+                .destroy_in_progress
+                .load(Ordering::SeqCst)
+        {
+            return Err(LimboError::TableLocked);
+        }
         if !self.counted_as_active_root && matches!(self.origin, StatementOrigin::Root) {
             self.program
                 .connection
@@ -1429,6 +1439,14 @@ impl Statement {
                 .n_active_writes
                 .fetch_sub(1, Ordering::SeqCst);
             self.state.is_active_write = false;
+        }
+        if self.state.holds_destroy_guard {
+            assert!(self
+                .program
+                .connection
+                .destroy_in_progress
+                .swap(false, Ordering::SeqCst));
+            self.state.holds_destroy_guard = false;
         }
         if self.counted_as_active_root && !preserve_active_root_count {
             self.release_active_root_if_counted();

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1958,6 +1958,11 @@ impl ProgramBuilder {
             .iter()
             .any(|(insn, _)| matches!(insn, Insn::Program { .. }));
 
+        let contains_destroy = self
+            .insns
+            .iter()
+            .any(|(insn, _)| matches!(insn, Insn::Destroy { .. }));
+
         let prepared = PreparedProgram {
             max_registers: self.next_free_register,
             insns: self.insns,
@@ -1975,6 +1980,7 @@ impl ProgramBuilder {
             trigger: self.trigger.take(),
             is_subprogram: self.flags.is_subprogram(),
             contains_trigger_subprograms,
+            contains_destroy,
             resolve_type: self.resolve_type,
             prepare_context,
             write_databases: self.write_databases,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11397,6 +11397,17 @@ pub fn op_destroy(
     loop {
         match state.active_op_state.destroy() {
             OpDestroyState::CreateCursor => {
+                // Like SQLite's OP_Destroy, refuse to free a root page while any other
+                // statement is active on this connection: active cursors may still
+                // reference pages that would go to the freelist and be recycled.
+                if program
+                    .connection
+                    .n_active_root_statements
+                    .load(Ordering::SeqCst)
+                    > 1
+                {
+                    return Err(LimboError::TableLocked);
+                }
                 // Destroy doesn't do anything meaningful with the table/index distinction so we can just use a
                 // table btree cursor for both.
                 let cursor = BTreeCursor::new(destroy_pager.clone(), *root, 0);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11397,9 +11397,6 @@ pub fn op_destroy(
     loop {
         match state.active_op_state.destroy() {
             OpDestroyState::CreateCursor => {
-                // Like SQLite's OP_Destroy, refuse to free a root page while any other
-                // statement is active on this connection: active cursors may still
-                // reference pages that would go to the freelist and be recycled.
                 if program
                     .connection
                     .n_active_root_statements

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3910,6 +3910,26 @@ pub fn op_transaction_inner(
                 *state.active_op_state.transaction() = OpTransactionState::BeginStatement;
             }
             OpTransactionState::BeginStatement => {
+                if program.contains_destroy
+                    && matches!(tx_mode, TransactionMode::Write)
+                    && program.connection.mv_store_for_db(*db).is_none()
+                {
+                    if program
+                        .connection
+                        .n_active_root_statements
+                        .load(Ordering::SeqCst)
+                        > 1
+                    {
+                        return Err(LimboError::TableLocked);
+                    }
+                    if !state.holds_destroy_guard {
+                        assert!(!program
+                            .connection
+                            .destroy_in_progress
+                            .swap(true, Ordering::SeqCst));
+                        state.holds_destroy_guard = true;
+                    }
+                }
                 let needs_stmt_journal = program.needs_stmt_subtransactions.load(Ordering::Relaxed);
                 let in_explicit_txn = !program.connection.auto_commit.load(Ordering::SeqCst);
                 if *db == crate::MAIN_DB_ID && needs_stmt_journal {
@@ -11404,6 +11424,13 @@ pub fn op_destroy(
                     > 1
                 {
                     return Err(LimboError::TableLocked);
+                }
+                if !state.holds_destroy_guard {
+                    assert!(!program
+                        .connection
+                        .destroy_in_progress
+                        .swap(true, Ordering::SeqCst));
+                    state.holds_destroy_guard = true;
                 }
                 // Destroy doesn't do anything meaningful with the table/index distinction so we can just use a
                 // table btree cursor for both.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -769,6 +769,7 @@ pub struct ProgramState {
     uses_subjournal: bool,
     /// Whether this statement is an active write inside an explicit transaction.
     pub(crate) is_active_write: bool,
+    pub(crate) holds_destroy_guard: bool,
     /// Whether begin_statement was called (savepoint + FK bookkeeping active).
     has_stmt_transaction: bool,
     pub n_change: AtomicI64,
@@ -832,6 +833,7 @@ impl ProgramState {
             ephemeral_temp_files: HashMap::default(),
             uses_subjournal: false,
             is_active_write: false,
+            holds_destroy_guard: false,
             has_stmt_transaction: false,
             attached_savepoint_pagers: Vec::new(),
             n_change: AtomicI64::new(0),
@@ -962,6 +964,7 @@ impl ProgramState {
         self.ephemeral_temp_files.clear();
         self.uses_subjournal = false;
         self.is_active_write = false;
+        assert!(!self.holds_destroy_guard);
         self.has_stmt_transaction = false;
         self.distinct_key_values.clear();
         self.attached_savepoint_pagers.clear();
@@ -1115,6 +1118,10 @@ impl ProgramState {
         if self.is_active_write {
             connection.n_active_writes.fetch_sub(1, Ordering::SeqCst);
             self.is_active_write = false;
+        }
+        if self.holds_destroy_guard {
+            assert!(connection.destroy_in_progress.swap(false, Ordering::SeqCst));
+            self.holds_destroy_guard = false;
         }
         // If begin_statement was never called, no savepoint/FK cleanup needed.
         if !self.has_stmt_transaction {
@@ -1371,6 +1378,7 @@ pub struct PreparedProgram {
     pub is_subprogram: bool,
     /// Whether the program contains any trigger subprograms.
     pub contains_trigger_subprograms: bool,
+    pub contains_destroy: bool,
     pub resolve_type: ResolveType,
     pub prepare_context: PrepareContext,
     /// Set of attached database indices that need write transactions.

--- a/tests/integration/query_processing/test_ddl.rs
+++ b/tests/integration/query_processing/test_ddl.rs
@@ -1,4 +1,92 @@
+use std::sync::Arc;
+
 use crate::common::{ExecRows, TempDatabase};
+use crate::queued_io::QueuedIo;
+use turso_core::{Connection, Database, DatabaseOpts, OpenFlags, StepResult};
+
+fn open_queued_conn(io: Arc<QueuedIo>, path: &str) -> anyhow::Result<Arc<Connection>> {
+    let db =
+        Database::open_file_with_flags(io, path, OpenFlags::default(), DatabaseOpts::new(), None)?;
+    Ok(db.connect()?)
+}
+
+fn collect_rows(stmt: &mut turso_core::Statement) -> anyhow::Result<Vec<(i64, i64)>> {
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::IO => stmt._io().step()?,
+            StepResult::Yield => {}
+            StepResult::Row => {
+                let row = stmt.row().expect("row should be available after Row");
+                rows.push((row.get::<i64>(0)?, row.get::<i64>(1)?));
+            }
+            StepResult::Done => return Ok(rows),
+            StepResult::Interrupt | StepResult::Busy => {
+                anyhow::bail!("unexpected non-progress result while draining statement")
+            }
+        }
+    }
+}
+
+/// SQLite's OP_Destroy refuses to free a root page while any other statement
+/// is active on the connection (SQLITE_LOCKED "database table is locked"),
+/// because active cursors may hold references to pages that DROP TABLE would
+/// send to the freelist for reuse. A SELECT parked at its first I/O yield must
+/// therefore block DROP TABLE, and resume against intact table pages instead
+/// of a recycled root page.
+///
+/// Reference behavior verified against SQLite via rusqlite: with a stepped,
+/// unfinished SELECT on the same connection, DROP TABLE fails with
+/// SQLITE_LOCKED "database table is locked" while CREATE TABLE and INSERT
+/// still succeed, and DROP TABLE succeeds once the reader finishes.
+#[test]
+fn active_table_seek_after_drop_reuse_must_not_use_recycled_root_page() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let dir = tempfile::TempDir::new()?;
+    let path = dir.path().join("table-interior-drop-reuse.db");
+    let path = path.to_str().unwrap();
+    let conn = open_queued_conn(io, path)?;
+
+    conn.execute("PRAGMA page_size=512")?;
+    conn.execute("PRAGMA cache_size=9")?;
+    conn.execute("PRAGMA cache_spill=ON")?;
+    conn.execute("PRAGMA journal_mode='wal'")?;
+    conn.execute("CREATE TABLE u(id INTEGER PRIMARY KEY, b BLOB)")?;
+
+    for id in 1..=32 {
+        conn.execute(format!("INSERT INTO u VALUES({id}, zeroblob(60))"))?;
+    }
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+    let mut select = conn.prepare("SELECT id, length(b) FROM u WHERE id = 16")?;
+    match select.step()? {
+        StepResult::IO => select._io().step()?,
+        other => anyhow::bail!("SELECT did not yield at the root-page read: {other:?}"),
+    }
+
+    let err = conn
+        .execute("DROP TABLE u")
+        .expect_err("DROP TABLE must fail while a statement is active on the connection");
+    assert!(
+        matches!(err, turso_core::LimboError::TableLocked),
+        "expected TableLocked, got {err:?}"
+    );
+    conn.execute("CREATE TABLE reuse(id INTEGER PRIMARY KEY, b BLOB)")?;
+    conn.execute("INSERT INTO reuse VALUES(16, zeroblob(5000))")?;
+
+    let rows = collect_rows(&mut select)?;
+    assert_eq!(rows, vec![(16, 60)]);
+
+    conn.execute("DROP TABLE u")?;
+    let remaining: Vec<(String,)> =
+        conn.exec_rows("SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name");
+    assert_eq!(remaining, vec![("reuse".to_string(),)]);
+    let integrity: Vec<(String,)> = conn.exec_rows("PRAGMA integrity_check");
+    assert_eq!(integrity, vec![("ok".to_string(),)]);
+
+    Ok(())
+}
 
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b);")]
 fn test_fail_drop_indexed_column(tmp_db: TempDatabase) -> anyhow::Result<()> {

--- a/tests/integration/query_processing/test_ddl.rs
+++ b/tests/integration/query_processing/test_ddl.rs
@@ -28,17 +28,6 @@ fn collect_rows(stmt: &mut turso_core::Statement) -> anyhow::Result<Vec<(i64, i6
     }
 }
 
-/// SQLite's OP_Destroy refuses to free a root page while any other statement
-/// is active on the connection (SQLITE_LOCKED "database table is locked"),
-/// because active cursors may hold references to pages that DROP TABLE would
-/// send to the freelist for reuse. A SELECT parked at its first I/O yield must
-/// therefore block DROP TABLE, and resume against intact table pages instead
-/// of a recycled root page.
-///
-/// Reference behavior verified against SQLite via rusqlite: with a stepped,
-/// unfinished SELECT on the same connection, DROP TABLE fails with
-/// SQLITE_LOCKED "database table is locked" while CREATE TABLE and INSERT
-/// still succeed, and DROP TABLE succeeds once the reader finishes.
 #[test]
 fn active_table_seek_after_drop_reuse_must_not_use_recycled_root_page() -> anyhow::Result<()> {
     let io = Arc::new(QueuedIo::new());

--- a/tests/integration/query_processing/test_ddl.rs
+++ b/tests/integration/query_processing/test_ddl.rs
@@ -10,6 +10,20 @@ fn open_queued_conn(io: Arc<QueuedIo>, path: &str) -> anyhow::Result<Arc<Connect
     Ok(db.connect()?)
 }
 
+fn queued_drop_fixture(io: &Arc<QueuedIo>, path: &str) -> anyhow::Result<Arc<Connection>> {
+    let conn = open_queued_conn(io.clone(), path)?;
+    conn.execute("PRAGMA page_size=512")?;
+    conn.execute("PRAGMA cache_size=9")?;
+    conn.execute("PRAGMA cache_spill=ON")?;
+    conn.execute("PRAGMA journal_mode='wal'")?;
+    conn.execute("CREATE TABLE u(id INTEGER PRIMARY KEY, b BLOB)")?;
+    for id in 1..=32 {
+        conn.execute(format!("INSERT INTO u VALUES({id}, zeroblob(60))"))?;
+    }
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    Ok(conn)
+}
+
 fn collect_rows(stmt: &mut turso_core::Statement) -> anyhow::Result<Vec<(i64, i64)>> {
     let mut rows = Vec::new();
     loop {
@@ -33,20 +47,7 @@ fn active_table_seek_after_drop_reuse_must_not_use_recycled_root_page() -> anyho
     let io = Arc::new(QueuedIo::new());
     let dir = tempfile::TempDir::new()?;
     let path = dir.path().join("table-interior-drop-reuse.db");
-    let path = path.to_str().unwrap();
-    let conn = open_queued_conn(io, path)?;
-
-    conn.execute("PRAGMA page_size=512")?;
-    conn.execute("PRAGMA cache_size=9")?;
-    conn.execute("PRAGMA cache_spill=ON")?;
-    conn.execute("PRAGMA journal_mode='wal'")?;
-    conn.execute("CREATE TABLE u(id INTEGER PRIMARY KEY, b BLOB)")?;
-
-    for id in 1..=32 {
-        conn.execute(format!("INSERT INTO u VALUES({id}, zeroblob(60))"))?;
-    }
-
-    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    let conn = queued_drop_fixture(&io, path.to_str().unwrap())?;
 
     let mut select = conn.prepare("SELECT id, length(b) FROM u WHERE id = 16")?;
     match select.step()? {
@@ -61,6 +62,9 @@ fn active_table_seek_after_drop_reuse_must_not_use_recycled_root_page() -> anyho
         matches!(err, turso_core::LimboError::TableLocked),
         "expected TableLocked, got {err:?}"
     );
+    let schema_after_failed_drop: Vec<(i64,)> =
+        conn.exec_rows("SELECT count(*) FROM sqlite_schema WHERE name = 'u'");
+    assert_eq!(schema_after_failed_drop, vec![(1,)]);
     conn.execute("CREATE TABLE reuse(id INTEGER PRIMARY KEY, b BLOB)")?;
     conn.execute("INSERT INTO reuse VALUES(16, zeroblob(5000))")?;
 
@@ -74,6 +78,97 @@ fn active_table_seek_after_drop_reuse_must_not_use_recycled_root_page() -> anyho
     let integrity: Vec<(String,)> = conn.exec_rows("PRAGMA integrity_check");
     assert_eq!(integrity, vec![("ok".to_string(),)]);
 
+    Ok(())
+}
+
+#[test]
+fn statement_started_during_in_flight_destroy_is_locked_out() -> anyhow::Result<()> {
+    let mut saw_locked = false;
+    let mut park_after = 1usize;
+    loop {
+        let io = Arc::new(QueuedIo::new());
+        let dir = tempfile::TempDir::new()?;
+        let path = dir.path().join(format!("drop-parked-{park_after}.db"));
+        let conn = queued_drop_fixture(&io, path.to_str().unwrap())?;
+
+        let mut drop_stmt = conn.prepare("DROP TABLE u")?;
+        let mut yields = 0usize;
+        let parked = loop {
+            match drop_stmt.step()? {
+                StepResult::IO => {
+                    while io.step_one()?.is_some() {}
+                    yields += 1;
+                    if yields == park_after {
+                        break true;
+                    }
+                }
+                StepResult::Yield | StepResult::Row => {}
+                StepResult::Done => break false,
+                other => anyhow::bail!("unexpected result while driving DROP: {other:?}"),
+            }
+        };
+        if !parked {
+            break;
+        }
+
+        match conn.execute("CREATE TABLE reuse(id INTEGER PRIMARY KEY, b BLOB)") {
+            Ok(_) => {
+                conn.execute("INSERT INTO reuse VALUES(16, zeroblob(5000))")?;
+            }
+            Err(err) => {
+                assert!(
+                    matches!(err, turso_core::LimboError::TableLocked),
+                    "park_after={park_after}: write probe must fail with TableLocked, got {err:?}"
+                );
+                saw_locked = true;
+            }
+        }
+
+        match conn.prepare("SELECT id, length(b) FROM u WHERE id = 16") {
+            Ok(mut probe) => match collect_rows(&mut probe) {
+                Ok(rows) => {
+                    assert_eq!(rows, vec![(16, 60)], "park_after={park_after}");
+                }
+                Err(err) => {
+                    let err = err.downcast::<turso_core::LimboError>()?;
+                    assert!(
+                        matches!(err, turso_core::LimboError::TableLocked),
+                        "park_after={park_after}: probe must fail with TableLocked, got {err:?}"
+                    );
+                    saw_locked = true;
+                }
+            },
+            Err(err) => {
+                assert!(
+                    err.to_string().to_lowercase().contains("no such table"),
+                    "park_after={park_after}: unexpected prepare error {err:?}"
+                );
+            }
+        }
+
+        loop {
+            match drop_stmt.step()? {
+                StepResult::IO => while io.step_one()?.is_some() {},
+                StepResult::Yield | StepResult::Row => {}
+                StepResult::Done => break,
+                other => anyhow::bail!("unexpected result while finishing DROP: {other:?}"),
+            }
+        }
+        drop(drop_stmt);
+
+        let remaining: Vec<(i64,)> =
+            conn.exec_rows("SELECT count(*) FROM sqlite_schema WHERE name = 'u'");
+        assert_eq!(remaining, vec![(0,)], "park_after={park_after}");
+        let integrity: Vec<(String,)> = conn.exec_rows("PRAGMA integrity_check");
+        assert_eq!(
+            integrity,
+            vec![("ok".to_string(),)],
+            "park_after={park_after}"
+        );
+
+        park_after += 1;
+    }
+    assert!(saw_locked);
     Ok(())
 }
 


### PR DESCRIPTION
## Description

An in-flight SELECT parked at an IO yield keeps a cursor on its table's root page, which `DROP TABLE` freed unconditionally; once `CREATE TABLE` plus a large `INSERT` recycled the page (e.g. as an overflow page), the resumed SELECT panicked at the `TableInterior` page-type assertion — or could silently return wrong data.

`op_destroy` now fails with `TableLocked` when another root statement is active on the connection, before any page is freed, re-checked at each `Destroy` — mirroring SQLite's `OP_Destroy` (`SQLITE_LOCKED` when `nVdbeRead > nVDestroy+1`). Verified against SQLite via rusqlite: the DROP fails with "database table is locked" while the reader is active and the resumed SELECT returns the real row, so the issue's draft expectation of an empty result was corrected to match SQLite.

## Motivation and context

Fixes #7728.

## Description of AI Usage

Authored autonomously by Claude Code from the issue's reproducer, with SQLite as the behavioral reference.