### PR TITLE
core/storage: reject stale publish_backfill after wal restart

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -7275,7 +7275,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         }
                         *st = CompleteCheckpointState::DriveEarlyTruncate {
                             header_result,
-                            checkpoint_result: CheckpointResult::new(0, 0, 0),
+                            checkpoint_result: CheckpointResult::new(0, 0, 0, 0),
                         };
                         continue;
                     }
@@ -7376,7 +7376,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         io_yield_one!(c);
                     }
                     let checkpoint_result =
-                        std::mem::replace(checkpoint_result, CheckpointResult::new(0, 0, 0));
+                        std::mem::replace(checkpoint_result, CheckpointResult::new(0, 0, 0, 0));
                     *st = CompleteCheckpointState::RetryHeader {
                         checkpoint_result,
                         retried_crc: false,
@@ -7435,7 +7435,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         if crc_valid {
                             let checkpoint_result = std::mem::replace(
                                 checkpoint_result,
-                                CheckpointResult::new(0, 0, 0),
+                                CheckpointResult::new(0, 0, 0, 0),
                             );
                             *st = CompleteCheckpointState::DriveFinalTruncate { checkpoint_result };
                         } else {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1026,6 +1026,7 @@ struct CheckpointState {
 #[derive(Clone, Debug)]
 struct PendingCheckpointDbIdentityRead {
     max_frame: u64,
+    checkpoint_seq: u32,
     header_buf: Arc<Buffer>,
     bytes_read: Arc<AtomicUsize>,
     read_sent: bool,
@@ -1059,11 +1060,13 @@ enum CheckpointPhase {
     SyncBackfillProof {
         clear_page_cache: bool,
         max_frame: u64,
+        checkpoint_seq: u32,
     },
     /// Publish the durable backfill progress after the proof is installed and synced.
     PublishBackfill {
         clear_page_cache: bool,
         max_frame: u64,
+        checkpoint_seq: u32,
     },
     /// Truncate the WAL file after DB file is safely synced (only for TRUNCATE checkpoint mode).
     /// This must happen AFTER SyncDbFile to ensure data durability.
@@ -4426,6 +4429,7 @@ impl Pager {
                 clear_page_cache,
                 read: PendingCheckpointDbIdentityRead {
                     max_frame: result.wal_total_backfilled,
+                    checkpoint_seq: result.checkpoint_seq,
                     header_buf: Arc::new(Buffer::new_temporary(PageSize::MIN as usize)),
                     bytes_read: Arc::new(AtomicUsize::new(usize::MAX)),
                     read_sent: false,
@@ -4692,30 +4696,35 @@ impl Pager {
                         self.checkpoint_state.write().phase = CheckpointPhase::SyncBackfillProof {
                             clear_page_cache,
                             max_frame: read.max_frame,
+                            checkpoint_seq: read.checkpoint_seq,
                         };
                         io_yield_one!(c);
                     }
                     self.checkpoint_state.write().phase = CheckpointPhase::PublishBackfill {
                         clear_page_cache,
                         max_frame: read.max_frame,
+                        checkpoint_seq: read.checkpoint_seq,
                     };
                     continue;
                 }
                 CheckpointPhase::SyncBackfillProof {
                     clear_page_cache,
                     max_frame,
+                    checkpoint_seq,
                 } => {
                     self.checkpoint_state.write().phase = CheckpointPhase::PublishBackfill {
                         clear_page_cache,
                         max_frame,
+                        checkpoint_seq,
                     };
                     continue;
                 }
                 CheckpointPhase::PublishBackfill {
                     clear_page_cache,
                     max_frame,
+                    checkpoint_seq,
                 } => {
-                    wal.publish_backfill(max_frame);
+                    wal.publish_backfill(max_frame, checkpoint_seq);
                     let next_phase = {
                         let state = self.checkpoint_state.read();
                         if matches!(state.mode, Some(CheckpointMode::Truncate { .. })) {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -62,6 +62,7 @@ pub struct CheckpointResult {
     pub wal_total_backfilled: u64,
     /// amount of new frames backfilled to the DB file during this checkpoint procedure
     pub wal_checkpoint_backfilled: u64,
+    pub checkpoint_seq: u32,
     /// In the case of everything backfilled, we need to hold the locks until the db
     /// file is truncated.
     maybe_guard: Option<CheckpointLocks>,
@@ -84,11 +85,13 @@ impl CheckpointResult {
         wal_max_frame: u64,
         wal_total_backfilled: u64,
         wal_checkpoint_backfilled: u64,
+        checkpoint_seq: u32,
     ) -> Self {
         Self {
             wal_max_frame,
             wal_total_backfilled,
             wal_checkpoint_backfilled,
+            checkpoint_seq,
             maybe_guard: None,
             db_sync_sent: false,
             db_truncate_sent: false,
@@ -479,7 +482,7 @@ trait WalCoordination: Debug + Send + Sync {
     fn publish_commit(&self, commit: WalCommitState);
 
     /// Publish the highest frame durably backfilled during checkpoint.
-    fn publish_backfill(&self, max_frame: u64);
+    fn publish_backfill(&self, max_frame: u64, checkpoint_seq: u32);
 
     /// Install any backend-specific durable proof before publishing backfill.
     /// Returns an optional completion that must finish before `publish_backfill`.
@@ -718,7 +721,7 @@ pub trait Wal: Debug + Send + Sync {
         db_header_crc32c: u32,
         sync_type: FileSyncType,
     ) -> Result<Option<Completion>>;
-    fn publish_backfill(&self, max_frame: u64);
+    fn publish_backfill(&self, max_frame: u64, checkpoint_seq: u32);
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion>;
     fn is_syncing(&self) -> bool;
     fn get_max_frame_in_wal(&self) -> u64;
@@ -869,12 +872,25 @@ impl WalCoordination for InProcessWalCoordination {
             .store(commit.transaction_count, Ordering::Release);
     }
 
-    fn publish_backfill(&self, max_frame: u64) {
-        self.shared
-            .write()
+    fn publish_backfill(&self, max_frame: u64, checkpoint_seq: u32) {
+        let shared = self.shared.write();
+        let current_seq = shared.metadata.wal_header.lock().checkpoint_seq;
+        if current_seq != checkpoint_seq {
+            tracing::debug!(
+                "publish_backfill: rejecting stale publish from checkpoint_seq={checkpoint_seq} (current_seq={current_seq}, max_frame={max_frame})"
+            );
+            return;
+        }
+        let shared_max_frame = shared.metadata.max_frame.load(Ordering::Acquire);
+        turso_assert!(
+            max_frame <= shared_max_frame,
+            "nbackfills must never exceed max_frame",
+            { "nbackfills": max_frame, "max_frame": shared_max_frame, "checkpoint_seq": checkpoint_seq }
+        );
+        shared
             .metadata
             .nbackfills
-            .store(max_frame, Ordering::Release);
+            .fetch_max(max_frame, Ordering::AcqRel);
     }
 
     fn install_durable_backfill_proof(
@@ -1883,12 +1899,25 @@ impl WalCoordination for ShmWalCoordination {
         }
     }
 
-    fn publish_backfill(&self, max_frame: u64) {
-        self.shared
-            .write()
+    fn publish_backfill(&self, max_frame: u64, checkpoint_seq: u32) {
+        let shared = self.shared.write();
+        let authority_snapshot = self.authority.snapshot();
+        if authority_snapshot.checkpoint_seq != checkpoint_seq {
+            tracing::debug!(
+                "publish_backfill: rejecting stale publish from checkpoint_seq={checkpoint_seq} (current_seq={}, max_frame={max_frame})",
+                authority_snapshot.checkpoint_seq
+            );
+            return;
+        }
+        turso_assert!(
+            max_frame <= authority_snapshot.max_frame,
+            "nbackfills must never exceed max_frame",
+            { "nbackfills": max_frame, "max_frame": authority_snapshot.max_frame, "checkpoint_seq": checkpoint_seq }
+        );
+        shared
             .metadata
             .nbackfills
-            .store(max_frame, Ordering::Release);
+            .fetch_max(max_frame, Ordering::AcqRel);
         self.authority.publish_backfill(max_frame);
     }
 
@@ -3834,8 +3863,9 @@ impl Wal for WalFile {
         )
     }
 
-    fn publish_backfill(&self, max_frame: u64) {
-        self.coordination.publish_backfill(max_frame);
+    fn publish_backfill(&self, max_frame: u64, checkpoint_seq: u32) {
+        self.coordination
+            .publish_backfill(max_frame, checkpoint_seq);
     }
 
     #[instrument(err, skip_all, level = Level::DEBUG)]
@@ -4606,7 +4636,10 @@ impl WalFile {
                         // there are no frames to copy over and we don't need to reset
                         // the log so we can return early success.
                         return Ok(IOResult::Done(CheckpointResult::new(
-                            max_frame, nbackfills, 0,
+                            max_frame,
+                            nbackfills,
+                            0,
+                            snapshot.checkpoint_seq,
                         )));
                     }
                     // acquire the appropriate exclusive locks depending on the checkpoint mode
@@ -4777,7 +4810,8 @@ impl WalFile {
                         ongoing_chkpt.complete(),
                         "checkpoint pending flush must have finished"
                     );
-                    let wal_max_frame = self.load_coordination_snapshot().max_frame;
+                    let snapshot = self.load_coordination_snapshot();
+                    let wal_max_frame = snapshot.max_frame;
                     let wal_total_backfilled = ongoing_chkpt.max_frame;
                     // Record two num pages fields to return as checkpoint result to caller.
                     // Ref: pnLog, pnCkpt on https://www.sqlite.org/c3ref/wal_checkpoint_v2.html
@@ -4790,6 +4824,7 @@ impl WalFile {
                         wal_max_frame,
                         wal_total_backfilled,
                         wal_checkpoint_backfilled,
+                        snapshot.checkpoint_seq,
                     );
                     tracing::debug!("checkpoint_result={:?}, mode={:?}", checkpoint_result, mode);
                     if mode.require_all_backfilled() && !checkpoint_result.everything_backfilled() {
@@ -6629,7 +6664,7 @@ pub mod test {
                 .extend([(1, vec![1, 4, 8]), (2, vec![2, 6])]);
         }
 
-        coordination.publish_backfill(8);
+        coordination.publish_backfill(8, snapshot.checkpoint_seq);
         assert_eq!(coordination.load_snapshot().nbackfills, 8);
         assert_eq!(coordination.bump_checkpoint_epoch(), 5);
         assert_eq!(coordination.checkpoint_epoch(), 6);
@@ -6653,6 +6688,29 @@ pub mod test {
         }
         assert!(guard.runtime.frame_cache.lock().is_empty());
         assert!(!guard.metadata.initialized.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn test_in_process_coordination_rejects_stale_backfill_publish() {
+        let (shared, _wal) = make_test_wal();
+        let coordination = make_test_coordination(&shared);
+        let snapshot = WalSnapshot {
+            max_frame: 9,
+            nbackfills: 3,
+            last_checksum: (55, 89),
+            checkpoint_seq: 7,
+            transaction_count: 11,
+        };
+        set_shared_snapshot(&shared, snapshot);
+
+        coordination.publish_backfill(8, snapshot.checkpoint_seq.wrapping_sub(1));
+        assert_eq!(coordination.load_snapshot().nbackfills, 3);
+
+        coordination.publish_backfill(8, snapshot.checkpoint_seq);
+        assert_eq!(coordination.load_snapshot().nbackfills, 8);
+
+        coordination.publish_backfill(5, snapshot.checkpoint_seq);
+        assert_eq!(coordination.load_snapshot().nbackfills, 8);
     }
 
     #[test]

--- a/testing/stress/tests/shuttle_wal.rs
+++ b/testing/stress/tests/shuttle_wal.rs
@@ -1,0 +1,182 @@
+#![cfg(shuttle)]
+
+use shuttle::scheduler::PctScheduler;
+use turso::{Builder, Value};
+
+fn shuttle_config() -> shuttle::Config {
+    turso_stress::shuttle_config()
+}
+
+fn check_corruption(e: &turso::Error, ctx: &str) {
+    let msg = format!("{e}");
+    if matches!(e, turso::Error::Corrupt(_)) || msg.contains("Invalid page type") {
+        panic!("CORRUPTION REPRODUCED ({ctx}): {e}");
+    }
+}
+
+fn is_transient(e: &turso::Error) -> bool {
+    let s = format!("{e}");
+    s.contains("locked")
+        || s.contains("busy")
+        || s.contains("Busy")
+        || s.contains("snapshot")
+        || s.contains("Snapshot")
+}
+
+async fn exec(conn: &turso::Connection, sql: &str, ctx: &str) {
+    if let Err(e) = conn.execute(sql, ()).await {
+        check_corruption(&e, ctx);
+        if !is_transient(&e) {
+            panic!("unexpected error ({ctx}) running `{sql}`: {e}");
+        }
+    }
+}
+
+async fn drain(conn: &turso::Connection, sql: &str, ctx: &str) -> Option<Value> {
+    let mut rows = match conn.query(sql, ()).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            check_corruption(&e, ctx);
+            if !is_transient(&e) {
+                panic!("unexpected error ({ctx}) preparing `{sql}`: {e}");
+            }
+            return None;
+        }
+    };
+    let mut first = None;
+    loop {
+        match rows.next().await {
+            Ok(Some(row)) => {
+                if first.is_none() {
+                    first = Some(row.get_value(0).unwrap());
+                }
+            }
+            Ok(None) => return first,
+            Err(e) => {
+                check_corruption(&e, ctx);
+                if !is_transient(&e) {
+                    panic!("unexpected error ({ctx}) stepping `{sql}`: {e}");
+                }
+                return first;
+            }
+        }
+    }
+}
+
+async fn checkpoint_publish_race_scenario() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let db = Builder::new_local(db_path.to_str().unwrap())
+        .build()
+        .await
+        .unwrap();
+
+    let setup = db.connect().unwrap();
+    exec(
+        &setup,
+        "CREATE TABLE t(a INTEGER PRIMARY KEY, b BLOB)",
+        "setup",
+    )
+    .await;
+    exec(
+        &setup,
+        "INSERT INTO t VALUES (1, zeroblob(120000))",
+        "setup",
+    )
+    .await;
+    drain(&setup, "PRAGMA wal_checkpoint(TRUNCATE)", "setup").await;
+    exec(&setup, "DELETE FROM t WHERE a = 1", "setup").await;
+    drain(&setup, "PRAGMA wal_checkpoint(TRUNCATE)", "setup").await;
+
+    exec(
+        &setup,
+        "INSERT INTO t VALUES (2, randomblob(25000))",
+        "setup",
+    )
+    .await;
+
+    let reader = db.connect().unwrap();
+    exec(&reader, "BEGIN", "reader").await;
+    drain(&reader, "SELECT count(*) FROM t", "reader").await;
+
+    exec(
+        &setup,
+        "INSERT INTO t VALUES (3, randomblob(25000))",
+        "setup",
+    )
+    .await;
+
+    let conn_c = db.connect().unwrap();
+    let c_task = turso_stress::future::spawn(async move {
+        drain(
+            &conn_c,
+            "PRAGMA wal_checkpoint(PASSIVE)",
+            "passive-checkpoint",
+        )
+        .await;
+    });
+
+    let conn_w = db.connect().unwrap();
+    let s_task = turso_stress::future::spawn(async move {
+        exec(&reader, "COMMIT", "reader-commit").await;
+        for _ in 0..20 {
+            let busy = drain(
+                &conn_w,
+                "PRAGMA wal_checkpoint(TRUNCATE)",
+                "truncate-checkpoint",
+            )
+            .await;
+            match busy {
+                Some(Value::Integer(0)) => break,
+                _ => shuttle::future::yield_now().await,
+            }
+        }
+        exec(
+            &conn_w,
+            "INSERT INTO t SELECT 10 + value, randomblob(1500) FROM generate_series(0, 29)",
+            "new-gen-insert",
+        )
+        .await;
+        exec(
+            &conn_w,
+            "INSERT INTO t VALUES (99, randomblob(15000))",
+            "new-gen-insert-overflow",
+        )
+        .await;
+    });
+
+    let _ = c_task.await;
+    let _ = s_task.await;
+
+    let verify = db.connect().unwrap();
+    drain(&verify, "SELECT count(*) FROM t", "verify-count").await;
+    drain(
+        &verify,
+        "SELECT sum(length(b)), count(*) FROM t",
+        "verify-scan",
+    )
+    .await;
+    match drain(&verify, "PRAGMA integrity_check", "verify-integrity").await {
+        Some(Value::Text(s)) => {
+            assert_eq!(
+                s.to_lowercase(),
+                "ok",
+                "integrity check failed after checkpoint race: {s}"
+            );
+        }
+        other => panic!("integrity_check returned no usable row: {other:?}"),
+    }
+    exec(
+        &verify,
+        "INSERT INTO t VALUES (100, randomblob(1000))",
+        "verify-write",
+    )
+    .await;
+}
+
+#[test]
+fn shuttle_wal_checkpoint_publish_race_pct() {
+    let scheduler = PctScheduler::new(3, 2000);
+    let runner = shuttle::Runner::new(scheduler, shuttle_config());
+    runner.run(|| shuttle::future::block_on(checkpoint_publish_race_scenario()));
+}


### PR DESCRIPTION
## Description

The PASSIVE-side instance of the #7722 race: `publish_backfill` was an unconditional store, so a partial checkpoint parked across pager IO yields could publish after a concurrent TRUNCATE checkpoint restarted the WAL, leaving `nbackfills > max_frame` and hiding committed new-generation frames (the Antithesis `Invalid page type: 0` failure).

`CheckpointResult` now captures the WAL generation (`checkpoint_seq`) while the checkpoint guard is still held; `publish_backfill(max_frame, checkpoint_seq)` rejects a stale-generation publish, asserts `nbackfills <= max_frame` on accept, and stores via `fetch_max` so a slower same-generation checkpoint cannot regress progress. Both WAL coordination backends validate identically. Includes the issue's shuttle reproducer; `turso_stress` shuttle tests are not wired into CI, though the test compiles in plain CI builds.

## Motivation and context

Fixes #7744. Related: #7722 / #7749 (checkpoint guard held through the publish).

## Description of AI Usage

Authored autonomously by Claude Code from the issue's analysis and reproducer.