### PR TITLE
simulator: fix dropping rows from improperly rolled back connection

### DIFF
--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -1013,8 +1013,17 @@ impl Property {
                                     return Ok(Ok(()));
                                 }
 
-                                // On error we rollback the transaction if there is any active here
-                                env.rollback_conn(connection_index);
+                                // A statement that fails due to an injected I/O fault is
+                                // rolled back at the statement level (its effects are not
+                                // shadowed, above). It does NOT necessarily abort the
+                                // enclosing transaction: the engine keeps the transaction
+                                // open and its prior statements intact. Only mirror a full
+                                // transaction rollback in the model when the engine actually
+                                // rolled back (returned to autocommit); otherwise the model
+                                // would drop rows that are still live in the open transaction.
+                                if !env.conn_db_in_transaction(connection_index) {
+                                    env.rollback_conn(connection_index);
+                                }
                                 Ok(Ok(()))
                             }
                         }

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1531,6 +1531,15 @@ impl SimulatorEnv {
             .is_some_and(|t| t.is_some())
     }
 
+    /// Whether the underlying database connection is currently inside an explicit transaction
+    pub fn conn_db_in_transaction(&self, conn_index: usize) -> bool {
+        match self.connections.get(conn_index) {
+            Some(SimConnection::LimboConnection(conn)) => !conn.get_auto_commit(),
+            Some(SimConnection::SQLiteConnection(conn)) => !conn.is_autocommit(),
+            _ => false,
+        }
+    }
+
     pub fn has_conn_executed_query_after_transaction(&self, conn_index: usize) -> bool {
         self.connection_last_query.get(conn_index)
     }


### PR DESCRIPTION
fixes the following failing simulator seed:

```console
./target/debug/limbo_sim --maximum-tests 1000 --min-tick 10 --max-tick 50 --profile write_heavy --io-backend=memory --seed 1740219952857961982
```

The shadowed/simulation connection should only roll back on I/O fault if the engine's connection already has (and it has returned to autocommit), otherwise it will drop rows that the engine still has retained inside that transaction.