### PR TITLE
core/json: make single arg json_valid validate strict RFC-8259

### DIFF
--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -176,16 +176,28 @@ const fn make_character_type_ok_table() -> [u8; 256] {
 
 static CHARACTER_TYPE_OK: [u8; 256] = make_character_type_ok_table();
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Jsonb {
     data: ValueBlob,
+    has_json5: bool,
 }
 
 impl TryClone for Jsonb {
     type Error = TryReserveError;
 
     fn try_clone(&self) -> std::result::Result<Self, Self::Error> {
-        Self::from_raw_data(&self.data)
+        let mut cloned = Self::from_raw_data(&self.data)?;
+        cloned.has_json5 = self.has_json5;
+        Ok(cloned)
+    }
+}
+
+/// Two JSONB values are equal when their encoded bytes match. The `has_json5`
+/// flag records how a value was parsed, not what it holds, so it is left out of
+/// equality on purpose.
+impl PartialEq for Jsonb {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
     }
 }
 
@@ -920,6 +932,7 @@ impl Jsonb {
     pub fn empty() -> Self {
         Self {
             data: <ValueBlob as TursoAllocExt>::new(),
+            has_json5: false,
         }
     }
 
@@ -927,7 +940,14 @@ impl Jsonb {
     pub fn new(capacity: usize) -> std::result::Result<Self, TryReserveError> {
         Ok(Self {
             data: <ValueBlob as TursoTryWithCapacityExt>::try_with_capacity_ext(capacity)?,
+            has_json5: false,
         })
+    }
+
+    /// Whether the JSON text this value was deserialized from used any JSON5
+    /// constructs. Always false for values built from raw JSONB bytes.
+    pub fn has_json5(&self) -> bool {
+        self.has_json5
     }
 
     pub fn len(&self) -> usize {
@@ -1551,6 +1571,12 @@ impl Jsonb {
         cursor
     }
 
+    fn skip_whitespace_and_flag_json5(&mut self, input: &[u8], pos: usize) -> usize {
+        let (pos, saw_comment) = skip_whitespace(input, pos);
+        self.has_json5 |= saw_comment;
+        pos
+    }
+
     fn deserialize_value(&mut self, input: &[u8], mut pos: usize, depth: usize) -> PResult<usize> {
         if depth > MAX_JSON_DEPTH {
             return Err(PError::Message {
@@ -1559,7 +1585,7 @@ impl Jsonb {
             });
         }
 
-        pos = skip_whitespace(input, pos);
+        pos = self.skip_whitespace_and_flag_json5(input, pos);
         if pos >= input.len() {
             return Err(PError::Message {
                 msg: "Unexpected end of input".to_string(),
@@ -1634,7 +1660,7 @@ impl Jsonb {
         let mut first = true;
 
         loop {
-            pos = skip_whitespace(input, pos);
+            pos = self.skip_whitespace_and_flag_json5(input, pos);
             if pos >= input.len() {
                 return Err(PError::Message {
                     msg: "Unexpected end of input".to_string(),
@@ -1659,7 +1685,7 @@ impl Jsonb {
                 }
                 b',' if !first => {
                     pos += 1; // consume ','
-                    pos = skip_whitespace(input, pos);
+                    pos = self.skip_whitespace_and_flag_json5(input, pos);
                     if pos >= input.len() {
                         return Err(PError::Message {
                             msg: "Unexpected end of input after comma in object".to_string(),
@@ -1672,12 +1698,16 @@ impl Jsonb {
                             location: Some(pos),
                         });
                     }
+                    if input[pos] == b'}' {
+                        // Trailing comma is JSON5
+                        self.has_json5 = true;
+                    }
                 }
                 _ => {
                     // Parse key (must be string)
                     pos = self.deserialize_string(input, pos)?;
 
-                    pos = skip_whitespace(input, pos);
+                    pos = self.skip_whitespace_and_flag_json5(input, pos);
                     if pos >= input.len() || input[pos] != b':' {
                         return Err(PError::Message {
                             msg: "Expected : after object key".to_string(),
@@ -1686,11 +1716,11 @@ impl Jsonb {
                     }
                     pos += 1; // consume ':'
 
-                    pos = skip_whitespace(input, pos);
+                    pos = self.skip_whitespace_and_flag_json5(input, pos);
 
                     // Parse value - can be any JSON value including another object
                     pos = self.deserialize_value(input, pos, depth + 1)?;
-                    pos = skip_whitespace(input, pos);
+                    pos = self.skip_whitespace_and_flag_json5(input, pos);
                     if pos < input.len() && !matches!(input[pos], b',' | b'}') {
                         return Err(PError::Message {
                             msg: "Should be , or }}".to_string(),
@@ -1721,7 +1751,7 @@ impl Jsonb {
         let mut first = true;
 
         loop {
-            pos = skip_whitespace(input, pos);
+            pos = self.skip_whitespace_and_flag_json5(input, pos);
             if pos >= input.len() {
                 return Err(PError::Message {
                     msg: "Unexpected end of input".to_string(),
@@ -1746,7 +1776,7 @@ impl Jsonb {
                 }
                 b',' if !first => {
                     pos += 1; // consume ','
-                    pos = skip_whitespace(input, pos);
+                    pos = self.skip_whitespace_and_flag_json5(input, pos);
                     if pos >= input.len() {
                         return Err(PError::Message {
                             msg: "Unexpected end of input after comma".to_string(),
@@ -1759,9 +1789,13 @@ impl Jsonb {
                             location: Some(pos),
                         });
                     }
+                    if input[pos] == b']' {
+                        // Trailing comma is JSON5
+                        self.has_json5 = true;
+                    }
                 }
                 _ => {
-                    pos = skip_whitespace(input, pos);
+                    pos = self.skip_whitespace_and_flag_json5(input, pos);
 
                     // Parse array element
                     pos = self.deserialize_value(input, pos, depth + 1)?;
@@ -1785,6 +1819,10 @@ impl Jsonb {
         pos += 1; // consume quote
 
         let quoted = quote == b'"' || quote == b'\'';
+        if quote != b'"' {
+            // Single-quoted strings and unquoted identifier keys are JSON5
+            self.has_json5 = true;
+        }
         let mut len = 0;
 
         if quoted {
@@ -2013,6 +2051,11 @@ impl Jsonb {
             }
         }
 
+        if element_type == ElementType::TEXT5 {
+            // JSON5-only escape or raw control character in the string
+            self.has_json5 = true;
+        }
+
         // Write final header with correct type and size
         self.write_element_header(string_start, element_type, len, false)
             .map_err(|_| PError::Message {
@@ -2083,6 +2126,7 @@ impl Jsonb {
                     });
                 }
 
+                self.has_json5 = true;
                 self.write_element_header(num_start, ElementType::INT5, len, false)
                     .map_err(|_| PError::Message {
                         msg: "Unexpected input after json".to_string(),
@@ -2124,6 +2168,7 @@ impl Jsonb {
             pos += infinity.len();
 
             // Write Infinity as 9.0e+999
+            self.has_json5 = true;
             self.data.extend_from_slice(b"9.0e+999");
             self.write_element_header(
                 num_start,
@@ -2190,6 +2235,10 @@ impl Jsonb {
                 msg: "Not a digit".to_string(),
                 location: Some(pos),
             });
+        }
+
+        if is_json5 {
+            self.has_json5 = true;
         }
 
         // Determine the appropriate element type
@@ -2276,6 +2325,7 @@ impl Jsonb {
             && (input[pos + 2] == b'n' || input[pos + 2] == b'N')
         {
             pos += 3;
+            self.has_json5 = true;
             self.data.push(ElementType::NULL as u8);
             return Ok(pos);
         }
@@ -2357,7 +2407,7 @@ impl Jsonb {
         pos = result.deserialize_value(input, pos, 0)?;
 
         // Skip any trailing whitespace
-        pos = skip_whitespace(input, pos);
+        pos = result.skip_whitespace_and_flag_json5(input, pos);
 
         // Check for any non-whitespace characters after the JSON value
         if pos < input.len() {
@@ -2387,6 +2437,7 @@ impl Jsonb {
     pub fn from_raw_data(data: &[u8]) -> std::result::Result<Self, TryReserveError> {
         Ok(Self {
             data: value_blob_from_slice(data)?,
+            has_json5: false,
         })
     }
 
@@ -3486,15 +3537,16 @@ pub fn unescape_string(input: &str) -> String {
 }
 
 #[inline]
-pub fn skip_whitespace(input: &[u8], mut pos: usize) -> usize {
+pub fn skip_whitespace(input: &[u8], mut pos: usize) -> (usize, bool) {
     let len = input.len();
+    let mut saw_comment = false;
     if pos >= len {
-        return pos;
+        return (pos, saw_comment);
     }
 
     // Fast path for non-whitespace, non-comment
     if (WS_TABLE[input[pos] as usize] & 1) == 0 && input[pos] != b'/' {
-        return pos;
+        return (pos, saw_comment);
     }
 
     // Process whitespace and comments
@@ -3508,6 +3560,7 @@ pub fn skip_whitespace(input: &[u8], mut pos: usize) -> usize {
             match input[pos + 1] {
                 b'/' => {
                     // Line comment - skip until newline
+                    saw_comment = true;
                     pos += 2;
                     while pos < len && input[pos] != b'\n' {
                         pos += 1;
@@ -3518,6 +3571,7 @@ pub fn skip_whitespace(input: &[u8], mut pos: usize) -> usize {
                 }
                 b'*' => {
                     // Block comment - skip until "*/"
+                    saw_comment = true;
                     pos += 2;
                     while pos + 1 < len {
                         if input[pos] == b'*' && input[pos + 1] == b'/' {
@@ -3538,7 +3592,7 @@ pub fn skip_whitespace(input: &[u8], mut pos: usize) -> usize {
         }
     }
 
-    pos
+    (pos, saw_comment)
 }
 
 #[inline]
@@ -4637,7 +4691,10 @@ mod path_operations_tests {
             0xFB, // ARRAY type (11) with 8-byte payload size marker (15 << 4)
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // huge payload size
         ];
-        let jsonb = Jsonb { data: malformed };
+        let jsonb = Jsonb {
+            data: malformed,
+            has_json5: false,
+        };
 
         // Should return an error instead of panicking with overflow
         let result = jsonb.array_len();

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -846,9 +846,16 @@ where
     json_string_to_db_type(json, ElementType::OBJECT, OutputVariant::Binary)
 }
 
-/// Tries to convert the value to jsonb. Returns Value::from_i64(1) if the conversion
-/// succeeded, and Value::from_i64(0) if it didn't.
+/// Implements single-argument json_valid(X): 1 only if the value converts to
+/// JSONB without using any JSON5 extension, matching SQLite's default flags=1
+/// (strict RFC-8259 text). JSON5 input is well-formed for every other JSON
+/// function but reports 0 here. Returns an error only when the conversion runs
+/// out of memory.
 pub fn is_json_valid(json_value: impl AsValueRef) -> Result<Value, TryReserveError> {
+    fn strict_validity(json: Jsonb) -> Value {
+        Value::from_i64(if json.has_json5() { 0 } else { 1 })
+    }
+
     let json_value = json_value.as_value_ref();
     Ok(match json_value {
         ValueRef::Null => Value::Null,
@@ -862,14 +869,14 @@ pub fn is_json_valid(json_value: impl AsValueRef) -> Result<Value, TryReserveErr
                 Value::from_i64(0)
             } else {
                 match parse_as_json_text(slice, Conv::Strict) {
-                    Ok(_) => Value::from_i64(1),
+                    Ok(json) => strict_validity(json),
                     Err(LimboError::OutOfMemory) => return Err(TryReserveError),
                     Err(_) => Value::from_i64(0),
                 }
             }
         }
         _ => match convert_dbtype_to_jsonb(json_value, Conv::Strict) {
-            Ok(_) => Value::from_i64(1),
+            Ok(json) => strict_validity(json),
             Err(LimboError::OutOfMemory) => return Err(TryReserveError),
             Err(_) => Value::from_i64(0),
         },
@@ -991,6 +998,53 @@ mod tests {
         match result {
             Ok(_) => panic!("Expected error for malformed JSON"),
             Err(e) => assert!(e.to_string().contains("malformed JSON")),
+        }
+    }
+
+    #[test]
+    fn test_json_valid_rejects_json5() {
+        for json5 in [
+            "[1,2,]",       // trailing comma, array
+            "{\"a\":1,}",   // trailing comma, object
+            "{a:1}",        // identifier without quotes
+            "[1,2]//c",     // comment
+            "/*c*/1",       // multi-line comment
+            "'abc'",        // single-quoted string
+            "0x1A",         // hex number
+            "+5",           // positive sign
+            ".5",           // leading decimal point
+            "5.",           // trailing decimal point
+            "Infinity",     // Infinity
+            "-Infinity",    // negative Infinity
+            "NaN",          // Not a Number
+            "[\"a\\x41\"]", // JSON5 hex escape (\xHH)
+            "[\"a\tb\"]",   // raw control character (unescaped tab)
+        ] {
+            assert_eq!(
+                is_json_valid(Value::build_text(json5)).unwrap(),
+                Value::from_i64(0),
+                "json_valid({json5:?}) should be 0"
+            );
+        }
+    }
+
+    #[test]
+    fn test_json_valid_accepts_rfc8259() {
+        for strict in [
+            "{\"a\":1}",
+            " [1,2] ",
+            "9e999",
+            "\"abc\"",
+            "null",
+            "true",
+            "-1.5e-3",
+            "{\"a\":[{\"b\":\"c\\u0041\"}]}",
+        ] {
+            assert_eq!(
+                is_json_valid(Value::build_text(strict)).unwrap(),
+                Value::from_i64(1),
+                "json_valid({strict:?}) should be 1"
+            );
         }
     }
 

--- a/testing/sqltests/tests/json/default.sqltest
+++ b/testing/sqltests/tests/json/default.sqltest
@@ -1365,6 +1365,128 @@ test json_valid_no_args {
 expect error {
 }
 
+# Single-arg json_valid validates strict RFC-8259: JSON5 input reports 0
+# even though every other JSON function accepts it (issue #7650).
+test json_valid_json5_array_trailing_comma {
+    SELECT json_valid('[1,2,]');
+}
+expect {
+    0
+}
+
+test json_valid_json5_object_trailing_comma {
+    SELECT json_valid('{"a":1,}');
+}
+expect {
+    0
+}
+
+test json_valid_json5_unquoted_key {
+    SELECT json_valid('{a:1}');
+}
+expect {
+    0
+}
+
+test json_valid_json5_line_comment {
+    SELECT json_valid('[1,2]//c');
+}
+expect {
+    0
+}
+
+test json_valid_json5_block_comment {
+    SELECT json_valid('/*c*/1');
+}
+expect {
+    0
+}
+
+test json_valid_json5_single_quoted_string {
+    SELECT json_valid('[''abc'']');
+}
+expect {
+    0
+}
+
+test json_valid_json5_hex_number {
+    SELECT json_valid('0x1A');
+}
+expect {
+    0
+}
+
+test json_valid_json5_leading_plus {
+    SELECT json_valid('+5');
+}
+expect {
+    0
+}
+
+test json_valid_json5_leading_dot {
+    SELECT json_valid('.5');
+}
+expect {
+    0
+}
+
+test json_valid_json5_trailing_dot {
+    SELECT json_valid('5.');
+}
+expect {
+    0
+}
+
+test json_valid_json5_infinity {
+    SELECT json_valid('Infinity'), json_valid('-Infinity'), json_valid('NaN');
+}
+expect {
+    0|0|0
+}
+
+test json_valid_json5_escape {
+    SELECT json_valid('["a\x41b"]');
+}
+expect {
+    0
+}
+
+test json_valid_json5_text_blob {
+    SELECT json_valid(CAST('{a:1}' AS BLOB));
+}
+expect {
+    0
+}
+
+test json_valid_strict_still_valid {
+    SELECT json_valid('{"a":1}'), json_valid(' [1,2] '), json_valid('9e999'), json_valid('"abc"');
+}
+expect {
+    1|1|1|1
+}
+
+test json_valid_strict_text_blob {
+    SELECT json_valid(CAST('{"a":1}' AS BLOB));
+}
+expect {
+    1
+}
+
+test json_valid_of_json_function_output {
+    SELECT json_valid(json('{a:1}'));
+}
+expect {
+    1
+}
+
+# JSON5 must remain accepted by the other JSON functions.
+test json_still_accepts_json5 {
+    SELECT json('{a:1, b: 0x1A, c: [1,2,]}');
+}
+expect {
+    {"a":1,"b":26,"c":[1,2]}
+}
+
 test json-patch-basic-1 {
     select json_patch('{"a":1}', '{"b":2}');
 }


### PR DESCRIPTION
## Description

SQLite defines single-argument `json_valid(X)` to return 1 only when X is well-formed RFC-8259 JSON text. Turso returned 1 for any text its JSON5-tolerant parser accepts, an incompatibility this PR fixes: `json_valid('[1,2,]')`, `json_valid('{a:1}')` etc. now return 0.

Parser acceptance is unchanged — every other JSON function still accepts JSON5, matching SQLite. Instead, `Jsonb` now has a `has_json5` flag that deserialization sets when any JSON5-only construct (comments, trailing commas, unquoted keys, single-quoted strings, JSON5 escapes, raw control chars, hex numbers, leading +, leading/trailing dot, Infinity, NaN) is consumed. `json_valid` reports 1 only when the parse succeeded and that
flag is unset.


```sql
-- trailing comma is JSON5-only | sqlite -> 0 | turso before -> 1 | turso now -> 0
select json_valid('[1,2,]');

-- unquoted key is JSON5-only | sqlite -> 0 | turso before -> 1 | turso now -> 0
select json_valid('{a:1}');

-- comments are JSON5-only | sqlite -> 0 | turso before -> 1 | turso now -> 0
select json_valid('[1,2]//c');

-- strict RFC-8259 control | sqlite -> 1 | turso before -> 1 | turso now -> 1
select json_valid('{"a":1}');
```
Fixes #7650

## Tests

- New `json_valid` cases in `testing/sqltests/tests/json/default.sqltest`: one per JSON5 construct (expect 0), strict-text/blob controls (expect 1), and a guard that `json()` still accepts JSON5.
- Unit tests in `core/json/mod.rs` exercising `is_json_valid` with JSON5 and RFC-8259 inputs, including a raw control character case the sqltest DSL  can't express.
- The rejection tests fail without this change: the same inputs return 1 on `main` — that is the bug being fixed.

## Follow-ups

- Two-argument `json_valid(X, flags)` remains unimplemented; this PR's flag corresponds to bit 0x01 of the [SQLite flags bitmask](https://sqlite.org/json1.html#jvalid).
-  Verification surfaced two pre-existing parser-acceptance gaps (unrelated to `json_valid`, present on main), filed with reproducers as #7753:
  - JSON5 ECMAScript whitespace such as `U+00A0`/`U+FEFF` is rejected by `json()` where SQLite accepts it.
  - `\` + CR/CRLF line continuations in strings are rejected (only `\` + LF is handled).