### PR TITLE
core/translate: don't leak collation from IN to following comparisons

### DIFF
--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -182,7 +182,7 @@ pub(super) fn translate_in_list(
             }
         }
     }
-
+    program.reset_collation();
     if check_null_reg != 0 {
         program.emit_insn(Insn::IsNull {
             reg: check_null_reg,

--- a/sqlite/conformance/sqlite-sqltests/collate.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/collate.sqltest
@@ -274,6 +274,14 @@ expect {
     Apple|0
 }
 
+@cross-check-integrity
+test collate_in_list_does_not_leak_to_following_result {
+    SELECT 'A' COLLATE NOCASE IN ('a'), 'A' IN ('a'), 'B' IN ('b');
+}
+expect {
+    1|0|0
+}
+
 # =====================================================================
 # --- Hash join with NOCASE on build-side column, comparison in SELECT ---
 # The NOCASE column ends up in the hash payload; the cached register must


### PR DESCRIPTION
## Description
I cleared the collation after the IN comparison, so it doesn't leak to following comparisons
## Motivation and context
Fixes #7649
## Description of AI Usage
Used claude code to help find the cause. I wrote and tested the fix, verified that the regression tests fails without the fix, and ran tests locally. 
