### PR TITLE
core/alloc: clone Vec elements through TryClone

### DIFF
--- a/core/alloc/collections/mod.rs
+++ b/core/alloc/collections/mod.rs
@@ -12,6 +12,7 @@ mod traits;
 mod vec;
 mod vec_deque;
 
+pub(crate) use traits::impl_try_clone_via_clone;
 #[cfg(nightly)]
 pub use traits::TursoFromIteratorIn;
 pub use traits::{

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -108,6 +108,72 @@ pub trait TryClone: Sized {
     fn try_clone(&self) -> Result<Self, Self::Error>;
 }
 
+/// Forward `TryClone` to `Clone` for element types whose clone either cannot
+/// allocate at all (`Copy` primitives) or only allocates through the std
+/// global allocator for now (std-pinned types like `String`). The
+/// `Infallible` error encodes that these clones never return `Err`. The
+/// std-pinned group is a migration marker: once such a type becomes
+/// allocator-aware, give it a real `TryClone<Error = TryReserveError>` impl
+/// and remove it from this list.
+macro_rules! impl_try_clone_via_clone {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl TryClone for $ty {
+                type Error = std::convert::Infallible;
+
+                #[inline(always)]
+                fn try_clone(&self) -> Result<Self, Self::Error> {
+                    Ok(self.clone())
+                }
+            }
+        )+
+    };
+}
+
+pub(crate) use impl_try_clone_via_clone;
+
+impl_try_clone_via_clone!(
+    bool,
+    char,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    f32,
+    f64,
+    std::string::String,
+);
+
+impl<A, B> TryClone for (A, B)
+where
+    A: TryClone,
+    B: TryClone<Error = A::Error>,
+{
+    type Error = A::Error;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok((self.0.try_clone()?, self.1.try_clone()?))
+    }
+}
+
+/// `Arc` clones are refcount bumps — no allocation, never fails.
+impl<T> TryClone for crate::sync::Arc<T> {
+    type Error = std::convert::Infallible;
+
+    #[inline(always)]
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(self.clone())
+    }
+}
+
 impl<T> TryClone for Option<T>
 where
     T: TryClone,

--- a/core/alloc/collections/vec/mod.rs
+++ b/core/alloc/collections/vec/mod.rs
@@ -100,13 +100,22 @@ impl<T: Clone> TursoSliceExt<T> for [T] {
 }
 
 #[cfg(not(nightly))]
-impl<T: Clone> TryClone for Vec<T> {
+impl<T: TryClone> TryClone for Vec<T>
+where
+    TryReserveError: From<T::Error>,
+{
     type Error = TryReserveError;
 
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
+        // Same `TryClone` bound as the nightly impl so code compiles
+        // identically on both cfgs. Elements clone through `TryClone`; on
+        // stable this is Clone-forwarded for std-pinned types anyway.
         let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
-        cloned.extend(self.iter().cloned());
+        for item in self {
+            // Capacity reserved above; push cannot allocate.
+            cloned.push(item.try_clone()?);
+        }
         Ok(cloned)
     }
 }

--- a/core/alloc/collections/vec/mod.rs
+++ b/core/alloc/collections/vec/mod.rs
@@ -111,11 +111,39 @@ where
         // Same `TryClone` bound as the nightly impl so code compiles
         // identically on both cfgs. Elements clone through `TryClone`; on
         // stable this is Clone-forwarded for std-pinned types anyway.
-        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
-        for item in self {
-            // Capacity reserved above; push cannot allocate.
-            cloned.push(item.try_clone()?);
+        //
+        // Write into spare capacity directly instead of `push`: the
+        // per-element capacity check defeats vectorization (6x slower for
+        // Copy elements, 1.7x for non-Copy in alloc_collections benches).
+        // The guard keeps `len` covering exactly the elements written, so an
+        // `Err` from an element clone (or a panic) drops a consistent vec.
+        struct SetLenOnDrop<'a, T> {
+            vec: &'a mut Vec<T>,
+            len: usize,
         }
+        impl<T> Drop for SetLenOnDrop<'_, T> {
+            #[inline]
+            fn drop(&mut self) {
+                unsafe {
+                    self.vec.set_len(self.len);
+                }
+            }
+        }
+
+        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
+        let ptr = cloned.as_mut_ptr();
+        let mut guard = SetLenOnDrop {
+            vec: &mut cloned,
+            len: 0,
+        };
+        for item in self {
+            let item = item.try_clone()?;
+            unsafe {
+                std::ptr::write(ptr.add(guard.len), item);
+            }
+            guard.len += 1;
+        }
+        drop(guard);
         Ok(cloned)
     }
 }

--- a/core/alloc/collections/vec/nightly.rs
+++ b/core/alloc/collections/vec/nightly.rs
@@ -114,7 +114,8 @@ impl<T: Clone> TursoSliceExt<T> for [T] {
 
 impl<T, A> TryClone for Vec<T, A>
 where
-    T: Clone,
+    T: TryClone,
+    TryReserveError: From<T::Error>,
     A: Allocator + Clone,
 {
     type Error = TryReserveError;
@@ -122,9 +123,17 @@ where
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         let allocator = self.allocator().clone();
+        // `|_| TryReserveError`: `TryReserveError::from` is ambiguous here
+        // because the `TryReserveError: From<T::Error>` bound adds a second
+        // candidate `From` impl.
         let mut cloned =
-            Self::try_with_capacity_in(self.len(), allocator).map_err(TryReserveError::from)?;
-        cloned.try_spec_extend_ref(self.iter())?;
+            Self::try_with_capacity_in(self.len(), allocator).map_err(|_| TryReserveError)?;
+        for item in self {
+            // Capacity reserved above; push cannot allocate. Elements clone
+            // through `TryClone` so nested allocator-backed allocations fail
+            // with `TryReserveError` instead of aborting.
+            cloned.push(item.try_clone()?);
+        }
         Ok(cloned)
     }
 }
@@ -448,5 +457,40 @@ where
         unsafe {
             self.vec.set_len(self.len);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Element type whose fallible clone always fails: proves `Vec::try_clone`
+    /// clones elements through `TryClone` instead of the infallible `Clone`.
+    #[derive(Clone)]
+    struct FallibleElem;
+
+    impl TryClone for FallibleElem {
+        type Error = TryReserveError;
+
+        fn try_clone(&self) -> Result<Self, Self::Error> {
+            Err(TryReserveError)
+        }
+    }
+
+    #[test]
+    fn vec_try_clone_clones_elements_fallibly() {
+        let mut source: Vec<FallibleElem> = vec();
+        source.try_push(FallibleElem).unwrap();
+        assert!(
+            source.try_clone().is_err(),
+            "Vec::try_clone must clone elements through TryClone"
+        );
+    }
+
+    #[test]
+    fn vec_try_clone_bulk_copies_copy_elements() {
+        let mut source: Vec<u32> = vec();
+        source.try_push(7).unwrap();
+        assert_eq!(source.try_clone().unwrap().as_slice(), &[7]);
     }
 }

--- a/core/alloc/collections/vec/nightly.rs
+++ b/core/alloc/collections/vec/nightly.rs
@@ -128,12 +128,24 @@ where
         // candidate `From` impl.
         let mut cloned =
             Self::try_with_capacity_in(self.len(), allocator).map_err(|_| TryReserveError)?;
+        // Write into spare capacity directly instead of `push`: the
+        // per-element capacity check defeats vectorization (`push` costs
+        // ~1.7x on non-Copy elements in alloc_collections benches).
+        // `SetLenOnDrop` keeps `len` covering exactly the elements written,
+        // so an `Err` from an element clone (or a panic) drops a consistent
+        // vec without leaking or double-dropping. Elements clone through
+        // `TryClone` so nested allocator-backed allocations fail with
+        // `TryReserveError` instead of aborting.
+        let ptr = cloned.as_mut_ptr();
+        let mut guard = SetLenOnDrop::new(&mut cloned);
         for item in self {
-            // Capacity reserved above; push cannot allocate. Elements clone
-            // through `TryClone` so nested allocator-backed allocations fail
-            // with `TryReserveError` instead of aborting.
-            cloned.push(item.try_clone()?);
+            let item = item.try_clone()?;
+            unsafe {
+                ptr::write(ptr.add(guard.current_len()), item);
+            }
+            guard.increment_len();
         }
+        drop(guard);
         Ok(cloned)
     }
 }
@@ -457,40 +469,5 @@ where
         unsafe {
             self.vec.set_len(self.len);
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Element type whose fallible clone always fails: proves `Vec::try_clone`
-    /// clones elements through `TryClone` instead of the infallible `Clone`.
-    #[derive(Clone)]
-    struct FallibleElem;
-
-    impl TryClone for FallibleElem {
-        type Error = TryReserveError;
-
-        fn try_clone(&self) -> Result<Self, Self::Error> {
-            Err(TryReserveError)
-        }
-    }
-
-    #[test]
-    fn vec_try_clone_clones_elements_fallibly() {
-        let mut source: Vec<FallibleElem> = vec();
-        source.try_push(FallibleElem).unwrap();
-        assert!(
-            source.try_clone().is_err(),
-            "Vec::try_clone must clone elements through TryClone"
-        );
-    }
-
-    #[test]
-    fn vec_try_clone_bulk_copies_copy_elements() {
-        let mut source: Vec<u32> = vec();
-        source.try_push(7).unwrap();
-        assert_eq!(source.try_clone().unwrap().as_slice(), &[7]);
     }
 }

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -22,6 +22,7 @@ pub use api::ApiAllocator;
 pub use api::{AllocError, Global, Layout};
 pub use arc::{try_arc_slice_from_slice, try_arc_slice_from_slice_in, ArcSlice};
 pub use backend::{set_allocator, SetAllocatorError, TursoAllocBackend};
+pub(crate) use collections::impl_try_clone_via_clone;
 #[cfg(nightly)]
 pub use collections::TursoFromIteratorIn;
 pub use collections::{
@@ -53,6 +54,14 @@ impl From<api::TryReserveError> for TryReserveError {
 impl From<std::collections::TryReserveError> for TryReserveError {
     fn from(_: std::collections::TryReserveError) -> Self {
         Self
+    }
+}
+
+/// Lets containers whose elements clone infallibly (`TryClone<Error =
+/// Infallible>`) satisfy `TryReserveError: From<T::Error>` bounds.
+impl From<std::convert::Infallible> for TryReserveError {
+    fn from(never: std::convert::Infallible) -> Self {
+        match never {}
     }
 }
 

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -373,3 +373,83 @@ fn try_with_capacity_builds_turso_collections() {
     assert!(queue.capacity() >= 3);
     assert!(heap.capacity() >= 3);
 }
+
+/// Element type whose fallible clone always fails: proves `Vec::try_clone`
+/// clones elements through `TryClone` instead of the infallible `Clone`.
+#[derive(Clone)]
+struct FallibleElem;
+
+impl TryClone for FallibleElem {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Err(TryReserveError)
+    }
+}
+
+#[test]
+fn vec_try_clone_clones_elements_fallibly() {
+    let mut source: Vec<FallibleElem> = self::vec![];
+    source.try_push(FallibleElem).unwrap();
+    assert!(
+        source.try_clone().is_err(),
+        "Vec::try_clone must clone elements through TryClone"
+    );
+}
+
+#[test]
+fn vec_try_clone_bulk_copies_copy_elements() {
+    let mut source: Vec<u32> = self::vec![];
+    source.try_push(7).unwrap();
+    assert_eq!(source.try_clone().unwrap().as_slice(), &[7]);
+}
+
+/// Fails cloning a marked element: exercises the early-`Err` path of the
+/// spare-capacity write loop (partially written clone must drop cleanly,
+/// source must stay intact).
+#[derive(Clone, Debug, PartialEq)]
+struct FailOnMarked {
+    payload: std::string::String,
+    fail: bool,
+}
+
+impl TryClone for FailOnMarked {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        if self.fail {
+            Err(TryReserveError)
+        } else {
+            Ok(self.clone())
+        }
+    }
+}
+
+#[test]
+fn vec_try_clone_partial_element_failure_is_clean() {
+    let elem = |payload: &str, fail| FailOnMarked {
+        payload: payload.into(),
+        fail,
+    };
+    let mut source: Vec<FailOnMarked> = self::vec![];
+    source.try_push(elem("a", false)).unwrap();
+    source.try_push(elem("b", false)).unwrap();
+    source.try_push(elem("c", true)).unwrap();
+    source.try_push(elem("d", false)).unwrap();
+
+    assert!(source.try_clone().is_err());
+    // Source unchanged; the two successfully written clones were dropped.
+    assert_eq!(source.len(), 4);
+    assert_eq!(source[0], elem("a", false));
+    assert_eq!(source[3], elem("d", false));
+}
+
+#[test]
+fn vec_try_clone_deep_values_roundtrip() {
+    let mut source: Vec<(std::string::String, u32)> = self::vec![];
+    for i in 0..100u32 {
+        source.try_push((format!("value-{i}"), i)).unwrap();
+    }
+    let cloned = source.try_clone().unwrap();
+    assert_eq!(cloned.as_slice(), source.as_slice());
+}

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -69,6 +69,40 @@ fn non_copy_values_std(len: usize) -> std::vec::Vec<NonCopyValue> {
     (0..len).map(NonCopyValue::new).collect()
 }
 
+/// Element type whose `TryClone` does real fallible work: owns an
+/// allocator-backed vec, like `schema::UniqueSet`. Exercises the
+/// element-wise `TryClone` path of `Vec::try_clone`.
+#[derive(Clone)]
+struct FallibleValue {
+    inner: alloc::Vec<usize>,
+}
+
+impl turso_core::alloc::TryClone for FallibleValue {
+    type Error = turso_core::alloc::TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            inner: self.inner.try_clone()?,
+        })
+    }
+}
+
+fn fallible_values_turso(len: usize) -> alloc::Vec<FallibleValue> {
+    (0..len)
+        .map(|id| FallibleValue {
+            inner: (id..id + 4).try_collect().unwrap(),
+        })
+        .try_collect()
+        .unwrap()
+}
+
+fn string_values_turso(len: usize) -> alloc::Vec<alloc::String> {
+    (0..len)
+        .map(|id| format!("value-{id:08}"))
+        .try_collect()
+        .unwrap()
+}
+
 struct LowerBoundOnly<I> {
     iter: I,
 }
@@ -790,6 +824,36 @@ fn vec_non_copy_clone_turso(bencher: Bencher, len: usize) {
 fn vec_non_copy_try_clone_turso(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| non_copy_values_turso(len))
+        .bench_local_values(|values| black_box(values).try_clone().unwrap());
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_string_clone_turso(bencher: Bencher, len: usize) {
+    #[expect(clippy::redundant_clone)]
+    bencher
+        .with_inputs(|| string_values_turso(len))
+        .bench_local_values(|values| black_box(values).clone());
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_string_try_clone_turso(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| string_values_turso(len))
+        .bench_local_values(|values| black_box(values).try_clone().unwrap());
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_fallible_clone_turso(bencher: Bencher, len: usize) {
+    #[expect(clippy::redundant_clone)]
+    bencher
+        .with_inputs(|| fallible_values_turso(len))
+        .bench_local_values(|values| black_box(values).clone());
+}
+
+#[turso_macros::divan_bench(args = [64, 1_024, 16_384])]
+fn vec_fallible_try_clone_turso(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| fallible_values_turso(len))
         .bench_local_values(|values| black_box(values).try_clone().unwrap());
 }
 

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -30,6 +30,15 @@ struct NonCopyValue {
     payload: [usize; 4],
 }
 
+impl turso_core::alloc::TryClone for NonCopyValue {
+    type Error = std::convert::Infallible;
+
+    #[inline(always)]
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(self.clone())
+    }
+}
+
 impl NonCopyValue {
     fn new(id: usize) -> Self {
         Self {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2589,6 +2589,31 @@ impl Schema {
     }
 }
 
+impl TryClone for UniqueSet {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            columns: self.columns.try_clone()?,
+            collations: self.collations.try_clone()?,
+            is_primary_key: self.is_primary_key,
+            conflict_clause: self.conflict_clause,
+        })
+    }
+}
+
+// Copy enums stored as `Vec` elements: their clone cannot allocate.
+crate::alloc::impl_try_clone_via_clone!(
+    turso_parser::ast::SortOrder,
+    crate::translate::collate::CollationSeq,
+);
+
+// Std-pinned schema element types: every owned field allocates through the
+// std global allocator (Strings, `std::vec::Vec`, boxed parser AST), so
+// forwarding to `Clone` is correct today. TODO(alloc): give these real
+// fallible impls when their fields become allocator-aware.
+crate::alloc::impl_try_clone_via_clone!(Column, IndexColumn, CheckConstraint);
+
 impl Clone for Schema {
     /// Cloning a `Schema` requires deep cloning of all internal tables and indexes, even though they are wrapped in `Arc`.
     /// Simply copying the `Arc` pointers would result in multiple `Schema` instances sharing the same underlying tables and indexes,


### PR DESCRIPTION
## Summary
- require `TryClone` (with `TryReserveError: From<T::Error>`) for `Vec::try_clone` elements on both cfgs, so nested allocator-backed clones propagate allocation failure instead of aborting
- forward `TryClone` to `Clone` with `Error = Infallible` for types whose clone cannot allocate through the Turso allocator (primitives, `Arc`, std-pinned `String`/`Column`/`IndexColumn`/`CheckConstraint`) via `impl_try_clone_via_clone!` — the macro list doubles as the migration marker for making them allocator-aware later
- give `schema::UniqueSet` a real fallible `TryClone` (it owns allocator-backed vecs)
- write cloned elements into spare capacity behind a `SetLenOnDrop` guard instead of `push`

## Why
`Vec::try_clone` cloned elements through infallible `Clone`, so element types that own allocator-backed collections (e.g. `UniqueSet`'s `columns`/`collations` vecs) aborted the process on allocation failure instead of returning `TryReserveError`. Found by whopper allocation-fault injection against the schema copy-on-write path in #7746, which stacks on top of this PR.

The naive reserve-then-push loop was 1.7x slower than `Clone` for non-Copy elements and 6x slower for Copy elements on stable (per-element capacity checks defeat vectorization). With the spare-capacity write no `Copy` specialization is needed — LLVM folds the infallible element `try_clone` and vectorizes to memcpy parity. After: `try_clone` matches `clone` in the `alloc_collections` benches on both cfgs (medians at len 16384): Copy 2.9µs vs 3.0µs, non-Copy 17.7µs vs 17.6µs, `String` and nested-fallible elements at parity.

## Validation
- `cargo test -p turso_core --lib` on stable and nightly (`--cfg nightly`), including new `vec_try_clone_*` unit tests in `alloc/tests.rs` covering element fallibility, the early-`Err` path of the spare-capacity loop, Copy elements, and a deep-values roundtrip
- new `vec_string_*`/`vec_fallible_*` clone vs try_clone bench pairs in `alloc_collections`
- `cargo clippy --all-features --all-targets` and `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)