### PR TITLE
bindings/javascript: pin better-sqlite3's node-gyp to v11

### DIFF
--- a/bindings/javascript/packages/native/package.json
+++ b/bindings/javascript/packages/native/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.1.5",
     "@types/node": "^24.3.1",
-    "better-sqlite3": "^12.2.0",
+    "better-sqlite3": "12.9.0",
     "drizzle-kit": "^0.31.4",
     "drizzle-orm": "^0.45.2",
     "typescript": "^5.9.2",

--- a/bindings/javascript/perf/package-lock.json
+++ b/bindings/javascript/perf/package-lock.json
@@ -7,14 +7,11 @@
       "name": "turso-perf",
       "dependencies": {
         "@tursodatabase/database": "../packages/native",
-        "better-sqlite3": "^12.9.0",
+        "better-sqlite3": "12.9.0",
         "mitata": "^0.1.11"
       }
     },
     "..": {
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "workspaces": [
         "packages/core",
         "packages/native",
@@ -23,15 +20,15 @@
     },
     "../packages/native": {
       "name": "@tursodatabase/database",
-      "version": "0.6.0-pre.23",
+      "version": "0.7.0-pre.18",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0-pre.23"
+        "@tursodatabase/database-common": "^0.7.0-pre.18"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
         "@types/node": "^24.3.1",
-        "better-sqlite3": "^12.2.0",
+        "better-sqlite3": "12.9.0",
         "drizzle-kit": "^0.31.4",
         "drizzle-orm": "^0.45.2",
         "typescript": "^5.9.2",

--- a/bindings/javascript/perf/package.json
+++ b/bindings/javascript/perf/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "better-sqlite3": "^12.9.0",
+    "better-sqlite3": "12.9.0",
     "@tursodatabase/database": "../packages/native",
     "mitata": "^0.1.11"
   }

--- a/bindings/javascript/yarn.lock
+++ b/bindings/javascript/yarn.lock
@@ -1831,7 +1831,7 @@ __metadata:
     "@napi-rs/cli": "npm:^3.1.5"
     "@tursodatabase/database-common": "npm:^0.7.0-pre.18"
     "@types/node": "npm:^24.3.1"
-    better-sqlite3: "npm:^12.2.0"
+    better-sqlite3: "npm:12.9.0"
     drizzle-kit: "npm:^0.31.4"
     drizzle-orm: "npm:^0.45.2"
     typescript: "npm:^5.9.2"
@@ -2112,14 +2112,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^12.2.0":
-  version: 12.11.1
-  resolution: "better-sqlite3@npm:12.11.1"
+"better-sqlite3@npm:12.9.0":
+  version: 12.9.0
+  resolution: "better-sqlite3@npm:12.9.0"
   dependencies:
     bindings: "npm:^1.5.0"
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
-  checksum: 10c0/162d3fa6c19a68191d09537bd113bd54a636c9fb38b0fc0796f4f270032770695ef35a1bca041a0a0fa9bfa47e20b9e17c94484a3899c31f38881af4d12b7fa5
+  checksum: 10c0/69ee0d908fa6a5c8643872aa664686ed02476e88cb654fe37f0fef5845081430d4280c82f5d370e169c2abe7a14a85d9bc718ea720058abf4f7cd9a8dbe227f0
   languageName: node
   linkType: hard
 

--- a/testing/conformance/javascript/package-lock.json
+++ b/testing/conformance/javascript/package-lock.json
@@ -9,7 +9,7 @@
         "@libsql/client": "^0.15.15",
         "@tursodatabase/database": "../../../bindings/javascript/packages/native",
         "@tursodatabase/serverless": "../../../serverless/javascript",
-        "better-sqlite3": "^12.9.0",
+        "better-sqlite3": "12.9.0",
         "libsql": "^0.6.0-pre.41"
       },
       "devDependencies": {
@@ -18,15 +18,15 @@
     },
     "../../../bindings/javascript/packages/native": {
       "name": "@tursodatabase/database",
-      "version": "0.7.0-pre.9",
+      "version": "0.7.0-pre.18",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.7.0-pre.9"
+        "@tursodatabase/database-common": "^0.7.0-pre.18"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
         "@types/node": "^24.3.1",
-        "better-sqlite3": "^12.2.0",
+        "better-sqlite3": "12.9.0",
         "drizzle-kit": "^0.31.4",
         "drizzle-orm": "^0.45.2",
         "typescript": "^5.9.2",
@@ -35,7 +35,7 @@
     },
     "../../../serverless/javascript": {
       "name": "@tursodatabase/serverless",
-      "version": "1.2.3",
+      "version": "1.3.0-pre.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.13",

--- a/testing/conformance/javascript/package.json
+++ b/testing/conformance/javascript/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@tursodatabase/serverless": "../../../serverless/javascript",
     "@tursodatabase/database": "../../../bindings/javascript/packages/native",
-    "better-sqlite3": "^12.9.0",
+    "better-sqlite3": "12.9.0",
     "libsql": "^0.6.0-pre.41",
     "@libsql/client": "^0.15.15"
   }


### PR DESCRIPTION
better-sqlite3 12.11.1 ships no darwin/arm64 prebuild, so `yarn install` compiles it from source with node-gyp. The transitively resolved node-gyp@13 loads an undici build that calls webidl.util.markAsUncloneable, an API only present in Node 22+, so it crashes at configure time on the Node 20 CI runners. Scope a resolution to better-sqlite3's node-gyp so only its source build uses node-gyp@11 (fsevents keeps node-gyp@13).