### PR TITLE
core/mvcc: finish live-version rewrite when a committed commit statement is dropped

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2604,16 +2604,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             let (_id, row_versions) = &write_set.entries[ctx.cursor];
             let mut row_versions = row_versions.write();
             for row_version in row_versions.iter_mut() {
-                if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.begin() {
-                    if rv_id == tx_id {
-                        row_version.set_begin(Some(TxTimestampOrID::Timestamp(end_ts)));
-                    }
-                }
-                if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.end() {
-                    if rv_id == tx_id {
-                        row_version.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
-                    }
-                }
+                row_version.rewrite_txid_to_timestamp(tx_id, end_ts);
             }
             ctx.cursor += 1;
             iterations += 1;
@@ -5997,7 +5988,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             Some(TransactionState::Active | TransactionState::Preparing(_)) => {
                 self.rollback_tx_inner(tx_id, Some(connection), db_id);
             }
-            Some(TransactionState::Committed(_)) => {
+            Some(TransactionState::Committed(end_ts)) => {
+                // The dropped statement may have been interrupted mid
+                // `RewriteLiveVersions`, leaving live row versions (e.g. b-tree
+                // tombstones) that still reference this TxID. Finish the rewrite
+                // synchronously before removing the tx from `txs`, otherwise later
+                // visibility/conflict checks would find versions pointing at a
+                // removed TxID (https://github.com/tursodatabase/turso/issues/7477).
+                self.rewrite_live_versions_for_committed_tx(tx_id, end_ts);
                 if let Some(tx) = self.txs.get(&tx_id) {
                     self.unlock_commit_lock_if_held(tx.value());
                 }
@@ -6015,6 +6013,30 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 if self.is_exclusive_tx(&tx_id) {
                     self.release_exclusive_tx(&tx_id);
                 }
+            }
+        }
+    }
+
+    /// Rewrite every live row version in `tx_id`'s write set that still
+    /// references the TxID to the committed timestamp `end_ts`.
+    ///
+    /// Synchronous (unchunked) counterpart of `step_rewrite_live_versions`:
+    /// a commit statement dropped mid-`RewriteLiveVersions` must finish
+    /// publishing its timestamps before the tx is removed from `txs`, so no
+    /// row version is left referencing a TxID that no longer resolves.
+    fn rewrite_live_versions_for_committed_tx(&self, tx_id: TxID, end_ts: u64) {
+        let Some(tx_entry) = self.txs.get(&tx_id) else {
+            return;
+        };
+        turso_assert!(
+            matches!(tx_entry.value().state.load(), TransactionState::Committed(ts) if ts == end_ts),
+            "rewrite_live_versions_for_committed_tx requires a committed transaction state"
+        );
+        let write_set = tx_entry.value().write_set.lock();
+        for (_id, row_versions) in write_set.iter() {
+            let mut row_versions = row_versions.write();
+            for row_version in row_versions.iter_mut() {
+                row_version.rewrite_txid_to_timestamp(tx_id, end_ts);
             }
         }
     }
@@ -8614,6 +8636,24 @@ impl RowVersion {
     #[inline]
     pub fn set_end(&mut self, value: Option<TxTimestampOrID>) {
         self.end = crate::mvcc::database::PackedTs::pack(value);
+    }
+
+    /// Replace `begin`/`end` references to `tx_id` with the committed
+    /// timestamp `end_ts`. Shared by the chunked commit step
+    /// (`step_rewrite_live_versions`) and the dropped-statement cleanup path
+    /// (`rewrite_live_versions_for_committed_tx`) so the two cannot drift.
+    #[inline]
+    fn rewrite_txid_to_timestamp(&mut self, tx_id: TxID, end_ts: u64) {
+        if let Some(TxTimestampOrID::TxID(rv_id)) = self.begin() {
+            if rv_id == tx_id {
+                self.set_begin(Some(TxTimestampOrID::Timestamp(end_ts)));
+            }
+        }
+        if let Some(TxTimestampOrID::TxID(rv_id)) = self.end() {
+            if rv_id == tx_id {
+                self.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
+            }
+        }
     }
 
     /// A row is visible to a transaction if:

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -16988,3 +16988,82 @@ fn test_checkpoint_seek_skip_divider_reinsert_loses_row() {
         );
     }
 }
+
+/// Regression test for https://github.com/tursodatabase/turso/issues/7477.
+///
+/// A large committed DELETE whose commit statement is dropped mid-flight
+/// (after `LogRecordPrepared`, before finishing tombstone TxID rewriting)
+/// must not leave tombstones pointing at the removed TxID; otherwise a
+/// later writer panics with
+/// "check_version_conflicts: tombstone end TxID not found in txn map".
+#[test]
+fn mvcc_bug_repro_dropped_committed_delete_rewrites_all_tombstone_txids() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    let n_rows = MVCC_COMMIT_BATCH_SIZE + 476;
+    let values = (1..=n_rows)
+        .map(|i| format!("({i}, 'v{i}')"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    setup
+        .execute(format!("INSERT INTO t(id, v) VALUES {values}"))
+        .unwrap();
+
+    setup.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    setup.close().unwrap();
+
+    let conn_a = db.connect();
+    conn_a.execute("BEGIN CONCURRENT").unwrap();
+    conn_a.execute("DELETE FROM t").unwrap();
+
+    let log_record_prepared =
+        FixedYieldInjector::new([CommitYieldPoint::LogRecordPrepared.point()]);
+    conn_a.set_yield_injector(Some(log_record_prepared.clone()));
+
+    let mut commit_a = conn_a.prepare("COMMIT").unwrap();
+
+    for _ in 0..10_000 {
+        match commit_a.step().unwrap() {
+            StepResult::IO | StepResult::Yield if log_record_prepared.is_empty() => break,
+            StepResult::IO | StepResult::Yield => {}
+            StepResult::Done => panic!("COMMIT completed before LogRecordPrepared yielded"),
+            other => panic!("unexpected COMMIT result before LogRecordPrepared: {other:?}"),
+        }
+    }
+
+    conn_a.set_yield_injector(None);
+
+    match commit_a.step().unwrap() {
+        StepResult::IO | StepResult::Yield => {}
+        StepResult::Done => panic!("COMMIT completed before RewriteLiveVersions yielded"),
+        other => panic!("unexpected COMMIT result after LogRecordPrepared: {other:?}"),
+    }
+
+    drop(commit_a);
+
+    let conn_b = db.connect();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        conn_b.execute("BEGIN CONCURRENT").unwrap();
+        conn_b
+            .execute(format!(
+                "INSERT INTO t(id, v) VALUES ({n_rows}, 'replacement')"
+            ))
+            .unwrap();
+        conn_b.execute("COMMIT")
+    }));
+
+    assert!(
+        result.is_ok(),
+        "later public writer must not panic on a stale removed tombstone TxID"
+    );
+
+    result
+        .unwrap()
+        .expect("later public writer must not conflict on a stale removed tombstone TxID");
+}


### PR DESCRIPTION
A committed concurrent DELETE whose COMMIT statement is dropped
mid-flight (after the transaction reaches Committed but before the
chunked RewriteLiveVersions step finishes) was retired through
cleanup_dropped_commit -> finish_committed_tx with un-rewritten
row versions still referencing its TxID. A later writer whose commit
validation touched one of those b-tree tombstones (begin: None,
end: TxID) then panicked with "check_version_conflicts: tombstone end
TxID not found in txn map", because the TxID had been removed from the
txn map.

Fix the drop path to clean up after itself: cleanup_dropped_commit's
Committed branch now calls rewrite_live_versions_for_committed_tx, a
synchronous (unchunked) counterpart of step_rewrite_live_versions that
rewrites every write-set row version still referencing the TxID to the
committed Timestamp(end_ts) before the transaction is removed from
`txs`. This is safe because the transaction's fate is already decided
(state is Committed and the log record is durable); it is exactly the
work the interrupted RewriteLiveVersions step would have completed.

With the drop path publishing its timestamps, no row version can
outlive its TxID's presence in the txn map, so check_version_conflicts
keeps its strict raw-lookup invariant instead of falling back to
finalized_tx_states.

The regression test drives a large DELETE's COMMIT to yield inside
RewriteLiveVersions, drops the statement, and asserts a later writer
neither panics nor spuriously conflicts.

Fixes #7477