### PR TITLE
core/mvcc: keep exact-seek short-circuit for b-tree-only rows

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1479,17 +1479,28 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         //    INCORRECTLY finds the index cursor exhausted and breaks out of the delete loop, even
         //    though there are still b-tree-resident rows to delete.
         if self.state.is_none() && op.eq_only() {
-            if let CursorPosition::Loaded { row_id, .. } = &self.current_pos {
+            if let CursorPosition::Loaded {
+                row_id, in_btree, ..
+            } = &self.current_pos
+            {
                 if current_pos_matches_seek_key(&row_id.row_id, &seek_key, &self.mv_cursor_type)? {
                     let maybe_index_id = match &self.mv_cursor_type {
                         MvccCursorType::Index(_) => Some(self.table_id),
                         MvccCursorType::Table => None,
                     };
-                    if self
+                    // The current row is visible either because MvStore has a visible version
+                    // for it, or because it is a b-tree-resident row that is not shadowed by
+                    // any MVCC version. Both cases must short-circuit: otherwise a b-tree-only
+                    // row would fall through to the full eq-only seek below, which resets the
+                    // iterators and marks the MVCC peek exhausted, skipping MvStore-resident
+                    // rows that the enclosing range scan (see the comment above) still needs
+                    // to visit.
+                    let visible = self
                         .db
                         .read_from_table_or_index(self.tx_id, row_id, maybe_index_id)?
                         .is_some()
-                    {
+                        || (*in_btree && self.query_btree_version_is_valid(&row_id.row_id));
+                    if visible {
                         // We need to clear the null flag for the table cursor before seeking,
                         // because it might have been set to false by an unmatched left-join row
                         // during the previous iteration on the outer loop.

--- a/testing/sqltests/tests/mvcc-idxdelete-exact-seek.sqltest
+++ b/testing/sqltests/tests/mvcc-idxdelete-exact-seek.sqltest
@@ -1,0 +1,25 @@
+@database :temp:
+@skip-file-if sqlite "MVCC is not supported in SQLite"
+
+# Regression coverage for https://github.com/tursodatabase/turso/issues/7579:
+# an exact-seek IdxDelete on the same MVCC index cursor skipped MVCC-only
+# rows, leaving rows behind after DELETE.
+
+test mvcc-idxdelete-exact-seek {
+    PRAGMA journal_mode='MVCC';
+    CREATE TABLE t(id INTEGER PRIMARY KEY, x);
+    CREATE INDEX t_x ON t(x);
+    INSERT INTO t VALUES (1,1),(2,2);
+    PRAGMA wal_checkpoint(TRUNCATE);
+    INSERT OR REPLACE INTO t(id,x) VALUES(2,2);
+    DELETE FROM t WHERE x>=1;
+    SELECT count(*) FROM t;
+    -- Scan through the index too: the bug also left stale t_x entries behind.
+    SELECT count(*) FROM t WHERE x>=1;
+}
+expect {
+   mvcc
+   0|0|0
+   0
+   0
+}


### PR DESCRIPTION
An eq-only seek on an MVCC cursor short-circuits when the cursor is
already positioned on the target key, so that ops like IdxDelete issued
mid-scan do not reset the dual-cursor iteration state that the
enclosing range scan depends on. The short-circuit only recognized rows
with a visible MvStore version, so a checkpointed b-tree-only row fell
through to the full eq-only seek, which reset the iterators and marked
the MVCC peek exhausted. The following Next then skipped MvStore-only
rows, leaving rows behind after DELETE (and stale index entries).

Extend the short-circuit visibility check to also accept a
b-tree-resident current row that is not shadowed by any MVCC version
(query_btree_version_is_valid), matching the visibility rules the
dual-cursor scan itself applies when picking rows.

Tests: testing/sqltests/tests/mvcc-idxdelete-exact-seek.sqltest now
passes; MVCC unit and integration tests and the sqltests suite pass.

Fixes #7579