### PR TITLE
core: classify virtual tables by parsing schema SQL

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -131,7 +131,7 @@ use storage::database::DatabaseFile;
 use storage::shared_wal_coordination::MappedSharedWalCoordination;
 use storage::{page_cache::PageCache, sqlite3_ondisk::PageSize};
 use tracing::{instrument, Level};
-use turso_macros::{match_ignore_ascii_case, AtomicEnum};
+use turso_macros::AtomicEnum;
 use turso_parser::{ast, ast::Cmd, parser::Parser};
 
 pub use connection::{resolve_ext_path, Connection, Row, StepResult, SymbolTable};

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -33,6 +33,7 @@ use crate::types::ImmutableRecord;
 use crate::types::ImmutableRecordRef;
 use crate::types::IndexInfo;
 use crate::types::SeekResult;
+use crate::Completion;
 use crate::File;
 use crate::IOExt;
 use crate::LimboError;
@@ -41,9 +42,6 @@ use crate::Result;
 #[cfg(feature = "conn_raw_api")]
 use crate::Value;
 use crate::ValueRef;
-use crate::{
-    contains_ignore_ascii_case, eq_ignore_ascii_case, match_ignore_ascii_case, Completion,
-};
 use crate::{io::FileSyncType, io_yield_one, return_if_io};
 use crate::{
     turso_assert, turso_assert_eq, turso_assert_less_than, turso_assert_reachable, Numeric,
@@ -7972,12 +7970,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     _ => None,
                                 };
                                 let is_virtual_table = row_type == "table"
-                                    && sql.is_some_and(|sql| {
-                                        contains_ignore_ascii_case!(
-                                            sql.as_bytes(),
-                                            b"create virtual"
-                                        )
-                                    });
+                                    && sql.is_some_and(crate::util::sql_is_create_virtual_table);
                                 let has_btree = match row_type {
                                     "index" => true,
                                     "table" => !is_virtual_table,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -152,10 +152,7 @@ use crate::util::{
     module_args_from_sql, module_name_from_sql, type_from_name, UnparsedFromSqlIndex,
 };
 use crate::Result;
-use crate::{
-    bail_parse_error, contains_ignore_ascii_case, eq_ignore_ascii_case, match_ignore_ascii_case,
-    LimboError, MvCursor, Pager, SymbolTable, ValueRef, VirtualTable,
-};
+use crate::{bail_parse_error, LimboError, MvCursor, Pager, SymbolTable, ValueRef, VirtualTable};
 use bitflags::bitflags;
 use core::fmt;
 use rustc_hash::{FxBuildHasher, FxHashMap as HashMap, FxHashSet as HashSet};
@@ -2084,99 +2081,115 @@ impl Schema {
         match ty {
             "table" => {
                 let sql = maybe_sql.expect("sql should be present for table");
-                let sql_bytes = sql.as_bytes();
-                if root_page == 0 && contains_ignore_ascii_case!(sql_bytes, b"create virtual") {
-                    // a virtual table is found in the sqlite_schema, but it's no
-                    // longer in the in-memory schema. We need to recreate it if
-                    // the module is loaded in the symbol table.
-                    let vtab = if let Some(vtab) = syms.vtabs.get(name) {
-                        vtab.clone()
-                    } else {
-                        let mod_name = module_name_from_sql(sql)?;
-                        crate::VirtualTable::table(
-                            Some(name),
-                            mod_name,
-                            module_args_from_sql(sql)?,
-                            syms,
-                        )?
-                    };
-                    self.add_virtual_table(vtab)?;
-                } else {
-                    let table = BTreeTable::from_sql(sql, root_page)?;
+                // Classify the row by parsing its schema SQL, mirroring
+                // SQLite, where sqlite3InitCallback feeds the sql column to
+                // the parser and a row becomes a virtual table purely as a
+                // byproduct of the create_vtab grammar rule.
+                match Parser::new(sql.as_bytes()).next_cmd()? {
+                    Some(Cmd::Stmt(Stmt::CreateVirtualTable(_))) => {
+                        if root_page != 0 {
+                            return Err(LimboError::Corrupt(format!(
+                                "sqlite_schema root_page must be 0 for virtual table {name}, got {root_page}"
+                            )));
+                        }
+                        // a virtual table is found in the sqlite_schema, but it's no
+                        // longer in the in-memory schema. We need to recreate it if
+                        // the module is loaded in the symbol table.
+                        let vtab = if let Some(vtab) = syms.vtabs.get(name) {
+                            vtab.clone()
+                        } else {
+                            let mod_name = module_name_from_sql(sql)?;
+                            crate::VirtualTable::table(
+                                Some(name),
+                                mod_name,
+                                module_args_from_sql(sql)?,
+                                syms,
+                            )?
+                        };
+                        self.add_virtual_table(vtab)?;
+                    }
+                    Some(Cmd::Stmt(Stmt::CreateTable { tbl_name, body, .. })) => {
+                        let table = create_table(tbl_name.name.as_str(), &body, root_page)?;
 
-                    if table.has_virtual_columns && !self.generated_columns_enabled {
-                        return Err(LimboError::ParseError(format!(
+                        if table.has_virtual_columns && !self.generated_columns_enabled {
+                            return Err(LimboError::ParseError(format!(
                             "table '{}' uses generated columns but the generated_columns feature is not enabled",
                             table.name
                         )));
-                    }
+                        }
 
-                    // Detect sequence-backing tables by name prefix.
-                    // Just add the table (for B-tree access); sequences are created by
-                    // AddSequence at CREATE time or initialize_sequences at open time.
-                    if table.name.starts_with(SEQ_BACKING_TABLE_PREFIX) {
-                        self.add_btree_table(Arc::new(table))?;
-                        return Ok(());
-                    }
+                        // Detect sequence-backing tables by name prefix.
+                        // Just add the table (for B-tree access); sequences are created by
+                        // AddSequence at CREATE time or initialize_sequences at open time.
+                        if table.name.starts_with(SEQ_BACKING_TABLE_PREFIX) {
+                            self.add_btree_table(Arc::new(table))?;
+                            return Ok(());
+                        }
 
-                    // Check if this is a DBSP state table
-                    if table.name.starts_with(DBSP_TABLE_PREFIX) {
-                        // Extract version and view name from __turso_internal_dbsp_state_v<version>_<viewname>
-                        let suffix = table.name.strip_prefix(DBSP_TABLE_PREFIX).unwrap();
+                        // Check if this is a DBSP state table
+                        if table.name.starts_with(DBSP_TABLE_PREFIX) {
+                            // Extract version and view name from __turso_internal_dbsp_state_v<version>_<viewname>
+                            let suffix = table.name.strip_prefix(DBSP_TABLE_PREFIX).unwrap();
 
-                        // Parse version and view name (format: "<version>_<viewname>")
-                        if let Some(underscore_pos) = suffix.find('_') {
-                            let version_str = &suffix[..underscore_pos];
-                            let view_name = &suffix[underscore_pos + 1..];
+                            // Parse version and view name (format: "<version>_<viewname>")
+                            if let Some(underscore_pos) = suffix.find('_') {
+                                let version_str = &suffix[..underscore_pos];
+                                let view_name = &suffix[underscore_pos + 1..];
 
-                            // Check version compatibility
-                            if let Ok(stored_version) = version_str.parse::<u32>() {
-                                if stored_version == DBSP_CIRCUIT_VERSION {
-                                    // Version matches, store the root page
-                                    dbsp_state_roots.insert(view_name.to_string(), root_page);
-                                } else {
-                                    // Version mismatch - DO NOT insert into dbsp_state_roots
-                                    // This will cause populate_materialized_views to skip this view
-                                    tracing::warn!(
+                                // Check version compatibility
+                                if let Ok(stored_version) = version_str.parse::<u32>() {
+                                    if stored_version == DBSP_CIRCUIT_VERSION {
+                                        // Version matches, store the root page
+                                        dbsp_state_roots.insert(view_name.to_string(), root_page);
+                                    } else {
+                                        // Version mismatch - DO NOT insert into dbsp_state_roots
+                                        // This will cause populate_materialized_views to skip this view
+                                        tracing::warn!(
                                         "Skipping materialized view '{}' - has version {} but current version is {}. DROP and recreate the view to use it.",
                                         view_name,
                                         stored_version,
                                         DBSP_CIRCUIT_VERSION
                                     );
-                                    // We can't track incompatible views here since we're in handle_schema_row
-                                    // which doesn't have mutable access to self
+                                        // We can't track incompatible views here since we're in handle_schema_row
+                                        // which doesn't have mutable access to self
+                                    }
                                 }
                             }
                         }
-                    }
 
-                    let mut table = table;
-                    table.resolve_custom_type_affinities(self);
-                    table.propagate_domain_constraints(self)?;
-                    let has_autoinc = table.has_autoincrement;
-                    let tbl_name = table.name.clone();
-                    self.add_btree_table(Arc::new(table))?;
+                        let mut table = table;
+                        table.resolve_custom_type_affinities(self);
+                        table.propagate_domain_constraints(self)?;
+                        let has_autoinc = table.has_autoincrement;
+                        let tbl_name = table.name.clone();
+                        self.add_btree_table(Arc::new(table))?;
 
-                    // Create the hidden sequence object owned by this
-                    // AUTOINCREMENT table. The `__turso_internal_autoincrement_`
-                    // prefix is a sequence namespace marker, not a table name;
-                    // the physical table is the corresponding
-                    // `__turso_internal_seq_<sequence-name>` backing table.
-                    if has_autoinc {
-                        let seq_name = autoincrement_sequence_name(&tbl_name);
-                        if let std::collections::hash_map::Entry::Vacant(e) =
-                            self.sequences.entry(normalize_ident(&seq_name))
-                        {
-                            let seq = Sequence::new(
-                                seq_name.clone(),
-                                Some(1),
-                                Some(1),
-                                None,
-                                None,
-                                false,
-                            )?;
-                            e.insert(Arc::new(seq));
+                        // Create the hidden sequence object owned by this
+                        // AUTOINCREMENT table. The `__turso_internal_autoincrement_`
+                        // prefix is a sequence namespace marker, not a table name;
+                        // the physical table is the corresponding
+                        // `__turso_internal_seq_<sequence-name>` backing table.
+                        if has_autoinc {
+                            let seq_name = autoincrement_sequence_name(&tbl_name);
+                            if let std::collections::hash_map::Entry::Vacant(e) =
+                                self.sequences.entry(normalize_ident(&seq_name))
+                            {
+                                let seq = Sequence::new(
+                                    seq_name.clone(),
+                                    Some(1),
+                                    Some(1),
+                                    None,
+                                    None,
+                                    false,
+                                )?;
+                                e.insert(Arc::new(seq));
+                            }
                         }
+                    }
+                    other => {
+                        return Err(LimboError::Corrupt(format!(
+                            "sqlite_schema table row {name} has unexpected SQL {sql:?}: parsed as {other:?}"
+                        )));
                     }
                 }
             }

--- a/core/util.rs
+++ b/core/util.rs
@@ -297,6 +297,20 @@ pub fn check_ident_equivalency(ident1: &str, ident2: &str) -> bool {
     strip_quotes(ident1).eq_ignore_ascii_case(strip_quotes(ident2))
 }
 
+/// Returns true if `sql` parses as a `CREATE VIRTUAL TABLE` statement.
+///
+/// Like SQLite (whose `sqlite3InitCallback` feeds schema SQL to the real
+/// parser, so a row is a virtual table purely as a byproduct of the
+/// `create_vtab` grammar rule), classification is done by parsing rather than
+/// by substring or token matching, which would misclassify regular tables
+/// whose SQL merely contains the text (e.g. in a DEFAULT literal).
+pub fn sql_is_create_virtual_table(sql: &str) -> bool {
+    matches!(
+        Parser::new(sql.as_bytes()).next_cmd(),
+        Ok(Some(ast::Cmd::Stmt(ast::Stmt::CreateVirtualTable(_))))
+    )
+}
+
 pub fn module_name_from_sql(sql: &str) -> Result<&str> {
     if let Some(start) = sql.find("USING") {
         let start = start + 6;
@@ -6227,6 +6241,40 @@ pub mod tests {
             parse_numeric_str("1.23e4extra"),
             Ok((ValueType::Float, "1.23e4"))
         );
+    }
+
+    #[test]
+    fn test_sql_is_create_virtual_table() {
+        assert!(sql_is_create_virtual_table(
+            "CREATE VIRTUAL TABLE x USING y;"
+        ));
+        assert!(sql_is_create_virtual_table(
+            "create virtual table x using y"
+        ));
+        assert!(sql_is_create_virtual_table(
+            "  \n\tCREATE  VIRTUAL TABLE x USING y"
+        ));
+        assert!(sql_is_create_virtual_table(
+            "-- comment\nCREATE /* c */ VIRTUAL TABLE x USING y"
+        ));
+        assert!(sql_is_create_virtual_table(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS x USING y(a, b)"
+        ));
+        // Quoted identifiers must not confuse the classifier either way.
+        assert!(sql_is_create_virtual_table(
+            "CREATE VIRTUAL TABLE \"create table\" USING y"
+        ));
+        // Regular table whose SQL merely contains the text must not match.
+        assert!(!sql_is_create_virtual_table(
+            "CREATE TABLE t(x TEXT DEFAULT 'create virtual')"
+        ));
+        assert!(!sql_is_create_virtual_table(
+            "CREATE TABLE \"create virtual\"(x)"
+        ));
+        assert!(!sql_is_create_virtual_table("CREATE TABLE t(x)"));
+        assert!(!sql_is_create_virtual_table("CREATE VIRTUALX TABLE t(x)"));
+        assert!(!sql_is_create_virtual_table("CREATE VIRTUAL"));
+        assert!(!sql_is_create_virtual_table(""));
     }
 
     #[test]

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1025,6 +1025,33 @@ fn test_create_insert_drop_checkpoint_recover(db: TempDatabase) -> anyhow::Resul
     Ok(())
 }
 
+/// Reproducer for #7475: MVCC recovery detects virtual tables by
+/// substring-matching the schema SQL for "create virtual", so a regular
+/// table whose SQL merely contains that substring (e.g. in a column
+/// DEFAULT literal) is misclassified as a virtual table and recovery
+/// fails with "sqlite_schema root_page must be 0 for table".
+#[turso_macros::test]
+fn test_recover_table_with_create_virtual_substring_in_sql(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.execute("pragma journal_mode = 'mvcc'")?;
+        conn.execute("create table t(x text default 'create virtual')")?;
+        conn.execute("insert into t default values")?;
+    }
+    drop(db);
+
+    // Reopen — triggers bootstrap / log replay; must not report corruption.
+    let db = Database::open_file(io, path.to_str().unwrap())?;
+    let conn = db.connect()?;
+    let rows: Vec<(String,)> = conn.exec_rows("select x from t");
+    assert_eq!(rows, vec![("create virtual".to_string(),)]);
+
+    Ok(())
+}
+
 /// Same-tx CREATE INDEX + DROP INDEX: the index schema row is inserted and
 /// deleted in the same transaction, producing an insert-delete cycle in
 /// sqlite_schema that must not panic during log replay.


### PR DESCRIPTION
MVCC log replay classified a sqlite_schema row as a virtual table by
substring-matching "create virtual" anywhere in the schema SQL. A
regular table whose SQL merely contains that text, such as
CREATE TABLE t(x TEXT DEFAULT 'create virtual'), was misclassified as
virtual, so recovery demanded root_page == 0 and rejected the table's
negative MVCC logical root page with a spurious corruption error,
making the database unopenable.

Follow SQLite, where sqlite3InitCallback feeds the sql column to the
real parser and a row becomes a virtual table purely as a byproduct of
the create_vtab grammar rule: util::sql_is_create_virtual_table() now
checks whether the SQL parses to Stmt::CreateVirtualTable, and MVCC
recovery uses it to decide whether a schema row owns a B-tree.
Schema::handle_schema_row, which relied on the same fragile substring
match, now parses the schema SQL once and branches on the AST variant
instead of scanning the SQL twice; a CREATE VIRTUAL TABLE row with a
nonzero root_page now reports corruption instead of hitting
unreachable!() in BTreeTable::from_sql.

Tests: mvcc::test_recover_table_with_create_virtual_substring_in_sql
passes (failed before); a unit test covers the classifier; core unit
tests, MVCC integration tests, and vtab.test still pass.

Fixes #7475