### PR TITLE
core/function: resolve jsonb_patch in function name lookup

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -1707,6 +1707,8 @@ impl Func {
             #[cfg(feature = "json")]
             "json_patch" => Ok(Some(Self::Json(JsonFunc::JsonPatch))),
             #[cfg(feature = "json")]
+            "jsonb_patch" => Ok(Some(Self::Json(JsonFunc::JsonbPatch))),
+            #[cfg(feature = "json")]
             "json_remove" => Ok(Some(Self::Json(JsonFunc::JsonRemove))),
             #[cfg(feature = "json")]
             "jsonb_remove" => Ok(Some(Self::Json(JsonFunc::JsonbRemove))),

--- a/testing/sqltests/tests/json/default.sqltest
+++ b/testing/sqltests/tests/json/default.sqltest
@@ -1553,6 +1553,41 @@ expect {
     {"a":{"b":{"x":{"new":"value"},"x":2,"c":{"updated":true},"d":{"e":{"replaced":100}}},"b":[{"c":5,"c":6},{"d":{"e":7,"e":null}}],"f":{"g":{"h":{"nested":"deep"}},"g":{"h":8,"h":[4,5,6]}},"i":{"j":{"k":{"l":{"modified":false}}},"j":{"k":false,"k":{"l":null,"l":"string"}}},"m":{"n":{"o":{"p":{"q":{"extra":"level"}},"p":{"q":10}},"o":{"r":11}}},"m":[{"s":{"t":12}},{"s":{"t":13,"t":{"u":14}}}],"aa":[{"bb":{"cc":{"dd":{"ee":"new"}}}},{"bb":{"cc":{"dd":{"ff":"value"}}}}],"v":{"w":{"x":{"y":{"z":{"final":"update"}}}}}},"a":{"v":{"w":{"x":{"y":{"z":15}}}},"v":{"w":{"x":16,"x":{"y":17}}},"aa":[{"bb":{"cc":18,"cc":{"dd":19}}},{"bb":{"cc":{"dd":20},"cc":21}}]},"newTop":{"level":{"key":[{"array":{"in":{"deep":{"structure":null}}}}]}}}
 }
 
+test jsonb-patch-basic-1 {
+    select json(jsonb_patch('{"a":1}', '{"b":2}'));
+}
+expect {
+    {"a":1,"b":2}
+}
+
+test jsonb-patch-nested {
+    select json(jsonb_patch('{"user":{"name":"john"}}', '{"user":{"age":30}}'));
+}
+expect {
+    {"user":{"name":"john","age":30}}
+}
+
+test jsonb-patch-null-removes-key {
+    select json(jsonb_patch('{"a":1,"b":2}', '{"b":null}'));
+}
+expect {
+    {"a":1}
+}
+
+test jsonb-patch-returns-blob {
+    select typeof(jsonb_patch('{"a":1}', '{"b":2}'));
+}
+expect {
+    blob
+}
+
+test jsonb-patch-blob-bytes {
+    select hex(jsonb_patch('{"a":1}', '{"b":2}'));
+}
+expect {
+    8C1761133117621332
+}
+
 test json-remove-1 {
     select json_remove('{"a": 5, "a": [5,4,3,2,1]}','$.a', '$.a[4]', '$.a[5]', '$.a');
 }


### PR DESCRIPTION
Fixes #7764

## Description

Calling `jsonb_patch()` fails with `Parse error: no such function: jsonb_patch`, even though the function shows up in `PRAGMA function_list` and COMPAT.md marks it as supported. `json_patch()` works.

The implementation is already there: the merge-patch op, the translator dispatch, the VDBE execution, the arity spec. What's missing is the name lookup. `Func::resolve_function` has no match arm for `"jsonb_patch"`, so the translator rejects the call before reaching any of that. `PRAGMA function_list` is generated from the enum, which is why it advertises a function that can't be called. The arm was never added: PR #1207 introduced jsonb_patch in March 2025 with resolver arms for its other new functions but not this one, and no test called jsonb_patch through SQL since, so it stayed unreachable.

This adds the match arm next to `json_patch`, behind the same `#[cfg(feature = "json")]` as the other jsonb functions, plus regression tests: three for merge semantics and `typeof`/`hex` tests that pin the JSONB blob return type.

```sql
SELECT json(jsonb_patch('{"a":1}', '{"b":2}'));
-- before: Parse error: no such function: jsonb_patch
-- after:  {"a":1,"b":2}  (same as SQLite)
```

SQLite reference: https://www.sqlite.org/json1.html#jpatch (sections 4.15 and 4.16).

## Testing

The five new sqltests fail on main with "no such function: jsonb_patch" and pass with the change. They also pass against a real SQLite 3.49.1 binary (`--backend cli --binary .sqlite3/sqlite3`), so the expected values come from SQLite itself rather than from me.

The `typeof` and `hex` tests are there because the `json()`-wrapped ones can't distinguish blob from text output. If the name ever gets wired to the text variant (`JsonFunc::JsonPatch`) they fail. The hex bytes match SQLite exactly.

I also checked by hand against 3.49.1: mixed case names, wrong arg counts, NULL args, malformed JSON, non-object patches (`'5'`, `'"str"'`, `'[1,2]'`), unicode, and use in CHECK constraints and expression indexes. All match. Full sqltest suite, `cargo test -p turso_core`, `cargo fmt --check`, and clippy with `--deny=warnings` pass.

## Pre-existing gaps noticed while testing (not part of this PR)

I kept the diff to #7764 only. Noting these for the record, happy to file them separately:

- `jsonb_replace` resolves to the text variant (`JsonFunc::JsonReplace`), so `typeof(jsonb_replace('{"a":1}','$.a',2))` returns `text` where SQLite returns `blob`. A `JsonbReplace` variant exists but no name maps to it.
- `jsonb_patch('{"a":1}', 'null')` returns SQL NULL, while SQLite returns a one byte JSONB null blob (hex `00`). Comes from an early return in `json_string_to_db_type` (core/json/mod.rs) that predates this change and probably affects other jsonb functions' top level null results too.
- `json_patch` and `jsonb_patch` both reject JSONB blob arguments ("blob is not supported!") where SQLite accepts them.

## Description of AI Usage

AI helped with the debugging and test drafts. I reviewed the diff and checked the results against real SQLite 3.49.1, including hex() of the jsonb output.
