### PR TITLE
core/vdbe: open statement savepoints for all multi-write statements

### DIFF
--- a/core/tests/active_index_select_repro.rs
+++ b/core/tests/active_index_select_repro.rs
@@ -1,0 +1,129 @@
+#![cfg(feature = "io_memory_yield")]
+
+use std::sync::Arc;
+
+use turso_core::{Database, DatabaseOpts, OpenFlags, StepResult};
+
+#[test]
+fn abandoned_indexed_update_without_stmt_journal_does_not_corrupt_index() {
+    let old = "a".repeat(20_000);
+    let abandoned = "b".repeat(20_000);
+    let mut saw_abandoned_update = false;
+
+    for abandon_after_io in 1..=160 {
+        let io = Arc::new(turso_core::MemoryYieldIO::new());
+        let path = format!("abandoned-indexed-update-split-{abandon_after_io}.db");
+
+        {
+            let db = Database::open_file_with_flags(
+                io.clone(),
+                &path,
+                OpenFlags::default(),
+                DatabaseOpts::new(),
+                None,
+            )
+            .unwrap();
+            let conn = db.connect().unwrap();
+            conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+            conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT)")
+                .unwrap();
+            conn.execute("CREATE INDEX t_b ON t(b)").unwrap();
+            for id in 1..=12 {
+                conn.execute(format!("INSERT INTO t VALUES({id}, '{old}')"))
+                    .unwrap();
+            }
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        }
+
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            &path,
+            OpenFlags::default(),
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("BEGIN").unwrap();
+
+        let mut update = conn
+            .prepare(format!(
+                "UPDATE t SET b = '{abandoned}' WHERE id BETWEEN 1 AND 10"
+            ))
+            .unwrap();
+
+        let mut io_count = 0;
+        let mut abandoned_stmt = false;
+        loop {
+            match update.step().unwrap() {
+                StepResult::IO => {
+                    io_count += 1;
+                    update._io().step().unwrap();
+                    if io_count == abandon_after_io {
+                        drop(update);
+                        abandoned_stmt = true;
+                        saw_abandoned_update = true;
+                        break;
+                    }
+                }
+                StepResult::Done => break,
+                StepResult::Yield => {}
+                other => panic!("unexpected UPDATE step result: {other:?}"),
+            }
+        }
+
+        if !abandoned_stmt {
+            conn.execute("ROLLBACK").unwrap();
+            break;
+        }
+
+        conn.execute("COMMIT").unwrap_or_else(|err| {
+            panic!("abandon_after_io={abandon_after_io}: COMMIT failed after abandoned indexed UPDATE: {err}")
+        });
+
+        let integrity = conn
+            .prepare("PRAGMA integrity_check")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap()
+            .into_iter()
+            .map(|row| row[0].to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            integrity,
+            vec!["ok".to_string()],
+            "abandon_after_io={abandon_after_io}: abandoned indexed UPDATE corrupted the index"
+        );
+
+        drop(conn);
+        drop(db);
+
+        let reopened = Database::open_file_with_flags(
+            io,
+            &path,
+            OpenFlags::default(),
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap_or_else(|err| panic!("abandon_after_io={abandon_after_io}: reopen failed: {err}"));
+        let reopened_conn = reopened.connect().unwrap();
+        let integrity = reopened_conn
+            .prepare("PRAGMA integrity_check")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap()
+            .into_iter()
+            .map(|row| row[0].to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            integrity,
+            vec!["ok".to_string()],
+            "abandon_after_io={abandon_after_io}: abandoned indexed UPDATE corrupted reopened database"
+        );
+    }
+
+    assert!(
+        saw_abandoned_update,
+        "UPDATE completed without any IO boundary"
+    );
+}

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1169,11 +1169,6 @@ pub fn translate_insert(
 
     {
         let has_statement_conflict = ctx.statement_on_conflict.is_some();
-        let notnull_col_exists = insertion
-            .col_mappings
-            .iter()
-            .any(|m| m.column.notnull() && !m.column.is_rowid_alias());
-        let has_unique = !constraints.constraints_to_check.is_empty();
         let has_triggers = has_before_triggers || has_after_triggers;
         set_insert_stmt_journal_flags(
             program,
@@ -1184,11 +1179,8 @@ pub fn translate_insert(
             ctx.on_conflict,
             inserting_multiple_rows,
             has_triggers,
-            has_fks,
             has_upsert,
             btree_table.has_autoincrement,
-            notnull_col_exists,
-            has_unique,
         );
     }
 

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -1,25 +1,28 @@
-//! Statement journal flag analysis (`is_multi_write` / `may_abort`).
+//! Statement journal flag analysis (`is_multi_write`).
 //!
 //! Inside an explicit transaction (BEGIN...COMMIT), each statement runs within
-//! the larger transaction. If a statement partially completes and then aborts
-//! (e.g. a UNIQUE constraint violation on the third row of a multi-row INSERT),
+//! the larger transaction. If a statement partially completes and is then
+//! aborted (e.g. a UNIQUE constraint violation on the third row of a multi-row
+//! INSERT, or the application dropping the statement at an I/O yield point),
 //! the partial writes must be rolled back without discarding the entire
 //! transaction. SQLite solves this with a "statement journal" (subjournal): a
 //! savepoint taken at the start of each statement, rolled back on abort.
 //!
-//! Statement journals are expensive, so SQLite skips them when provably
-//! unnecessary. The condition is: `usesStmtJournal = isMultiWrite && mayAbort`.
+//! Statement journals are expensive, so they are skipped when provably
+//! unnecessary. SQLite's condition is `usesStmtJournal = isMultiWrite &&
+//! mayAbort`, but the `mayAbort` half relies on SQLite's VDBE never returning
+//! control to the application in the middle of built-in row mutation. Turso's
+//! VM yields `StepResult::IO` mid-mutation, and the caller may abandon (drop)
+//! the statement at any such yield point — so even a statement that cannot
+//! SQL-abort can need statement-level rollback (see #7594). Turso therefore
+//! only skips the statement journal for single-row writes:
 //!
 //! - **isMultiWrite**: the statement may modify more than one row (or more than
 //!   one table, e.g. FK counter + data table). A single-row write is atomic —
 //!   either all writes happen or none do — so no partial state to roll back.
 //!
-//! - **mayAbort**: the statement may fail mid-execution with an ABORT (e.g.
-//!   constraint violation, FK violation, RAISE(ABORT) in a trigger). If a
-//!   multi-write statement can never abort, partial rollback is moot.
-//!
-//! Both flags default to `true` (conservative). Each DML translate path calls
-//! into this module to set them to `false` when safe.
+//! The flag defaults to `true` (conservative). Each DML translate path calls
+//! into this module to set it to `false` when safe.
 
 use crate::translate::emitter::Resolver;
 use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
@@ -66,60 +69,11 @@ fn table_has_fks(
             || resolver.with_schema(database_id, |s| s.any_resolved_fks_referencing(table_name)))
 }
 
-/// Determine whether any constraint's effective resolution can trigger an
-/// ABORT. Each constraint has an effective resolution mode — either the
-/// statement-level override (when present) or its DDL-level mode (defaulting
-/// to ABORT). A constraint can cause an ABORT when:
+/// Set multi_write for INSERT statements.
 ///
-/// - Its effective mode is ABORT and it has any checkable constraint
-///   (NOT NULL, CHECK, UNIQUE).
-/// - Its effective mode is REPLACE and the table has NOT NULL or CHECK
-///   constraints, because REPLACE falls back to ABORT for those.
-///
-/// IGNORE and FAIL never trigger statement-level ABORT.
-/// Each index is represented as `(on_conflict, is_unique)`.
-pub(crate) fn constraint_may_abort(
-    has_statement_conflict: bool,
-    statement_conflict: ResolveType,
-    rowid_alias_conflict: Option<ResolveType>,
-    mut indexes: impl Iterator<Item = (Option<ResolveType>, bool)>,
-    has_notnull: bool,
-    has_check: bool,
-    has_unique: bool,
-) -> bool {
-    if has_statement_conflict {
-        // Statement-level override applies uniformly to all constraints.
-        return match statement_conflict {
-            ResolveType::Abort => has_notnull || has_check || has_unique,
-            ResolveType::Replace => has_notnull || has_check, // UNIQUE conflict gets replaced, not aborted.
-            _ => false, // IGNORE, FAIL, ROLLBACK don't need statement journal
-        };
-    }
-    // No statement-level override — each constraint uses its DDL-level mode.
-    let pk_mode = rowid_alias_conflict.unwrap_or(ResolveType::Abort);
-    let pk_aborts = match pk_mode {
-        ResolveType::Abort => has_unique, // PK is a unique constraint
-        ResolveType::Replace => false,    // PK REPLACE doesn't fall back for unique
-        _ => false,
-    };
-    let idx_aborts = indexes.any(|(on_conflict, unique)| {
-        let mode = on_conflict.unwrap_or(ResolveType::Abort);
-        match mode {
-            ResolveType::Abort => unique, // only unique indexes can conflict
-            ResolveType::Replace => has_notnull || has_check,
-            _ => false,
-        }
-    });
-    // Default ABORT applies to NOT NULL and CHECK (they aren't per-index).
-    let default_aborts = has_notnull || has_check;
-    pk_aborts || idx_aborts || default_aborts
-}
-
-/// Set multi_write / may_abort for INSERT statements.
-///
-/// Constraint analysis (any_replace, constraint_may_abort) is computed internally
-/// from the table schema and resolver. The caller provides INSERT-specific flags
-/// that come from the emitter's own analysis.
+/// Constraint analysis (any_replace) is computed internally from the table
+/// schema and resolver. The caller provides INSERT-specific flags that come
+/// from the emitter's own analysis.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn set_insert_stmt_journal_flags(
     program: &mut ProgramBuilder,
@@ -130,45 +84,20 @@ pub(crate) fn set_insert_stmt_journal_flags(
     statement_conflict: ResolveType,
     inserting_multiple_rows: bool,
     has_triggers: bool,
-    has_fks: bool,
     has_upsert: bool,
     has_autoincrement: bool,
-    notnull_col_exists: bool,
-    has_unique: bool,
 ) {
-    let index_modes: Vec<(Option<ResolveType>, bool)> = resolver.with_schema(database_id, |s| {
+    let index_modes: Vec<Option<ResolveType>> = resolver.with_schema(database_id, |s| {
         s.get_indices(&table.name)
-            .map(|idx| (idx.on_conflict, idx.unique))
+            .map(|idx| idx.on_conflict)
             .collect()
     });
     let any_replace = any_effective_replace(
         has_statement_conflict,
         statement_conflict,
         table.rowid_alias_conflict_clause,
-        index_modes.iter().map(|(oc, _)| *oc),
+        index_modes.into_iter(),
     );
-    let has_check = !table.check_constraints.is_empty();
-    // Multi-row AUTOINCREMENT inserts taint `may_abort` even when no
-    // constraint clause is declared on the table: `op_sequence_compute_next`
-    // returns `LimboError::DatabaseFull` on i64 exhaustion, and a second
-    // row that exhausts mid-statement must not leak the first row's
-    // table write past the next COMMIT — that breaks SQLite's
-    // per-statement atomicity contract. Single-row AUTOINCREMENT
-    // inserts do not need this because there is no prior row in the
-    // outer-tx write_set to roll back.
-    let autoinc_may_abort_multi_row = has_autoincrement && inserting_multiple_rows;
-    let may_abort = has_triggers
-        || has_fks
-        || autoinc_may_abort_multi_row
-        || constraint_may_abort(
-            has_statement_conflict,
-            statement_conflict,
-            table.rowid_alias_conflict_clause,
-            index_modes.into_iter(),
-            notnull_col_exists,
-            has_check,
-            has_unique,
-        );
 
     // UPSERT is multi-write because DO UPDATE modifies an existing row.
     // AUTOINCREMENT is multi-write because sqlite_sequence is updated before constraint checks.
@@ -180,10 +109,9 @@ pub(crate) fn set_insert_stmt_journal_flags(
     {
         program.set_multi_write(false);
     }
-    program.set_may_abort(may_abort);
 }
 
-/// Set multi_write / may_abort for UPDATE statements.
+/// Set multi_write for UPDATE statements.
 pub(crate) fn set_update_stmt_journal_flags(
     program: &mut ProgramBuilder,
     plan: &UpdatePlan,
@@ -228,38 +156,10 @@ pub(crate) fn set_update_stmt_journal_flags(
     if is_single_row && !has_triggers && !any_replace && !has_fks {
         program.set_multi_write(false);
     }
-
-    let has_notnull_cols = plan.set_clauses.iter().any(|set_clause| {
-        if set_clause.column_index == crate::schema::ROWID_SENTINEL {
-            return false;
-        }
-        btree_table
-            .columns()
-            .get(set_clause.column_index)
-            .is_some_and(|c| c.notnull() && !c.is_rowid_alias())
-    });
-    let has_check = !btree_table.check_constraints.is_empty();
-    let has_unique =
-        !btree_table.unique_sets.is_empty() || plan.indexes_to_update.iter().any(|idx| idx.unique);
-
-    let may_abort = has_triggers
-        || has_fks
-        || constraint_may_abort(
-            has_statement_conflict,
-            or_conflict,
-            btree_table.rowid_alias_conflict_clause,
-            plan.indexes_to_update
-                .iter()
-                .map(|idx| (idx.on_conflict, idx.unique)),
-            has_notnull_cols,
-            has_check,
-            has_unique,
-        );
-    program.set_may_abort(may_abort);
     Ok(())
 }
 
-/// Set multi_write / may_abort for DELETE statements.
+/// Set multi_write for DELETE statements.
 pub(crate) fn set_delete_stmt_journal_flags(
     program: &mut ProgramBuilder,
     plan: &DeletePlan,
@@ -282,12 +182,6 @@ pub(crate) fn set_delete_stmt_journal_flags(
         plan.limit.is_none() && plan.offset.is_none() && target_table.op.affects_max_1_row();
     if is_single_row && !has_triggers && !has_fks {
         program.set_multi_write(false);
-    }
-
-    // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
-    // only triggers (RAISE(ABORT)) or FK violations can abort.
-    if !has_triggers && !has_fks {
-        program.set_may_abort(false);
     }
     Ok(())
 }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -297,21 +297,17 @@ pub struct ProgramBuilderFlags(u8);
 impl ProgramBuilderFlags {
     const ROLLBACK: u8 = 1 << 0;
     const IS_MULTI_WRITE: u8 = 1 << 1;
-    const MAY_ABORT: u8 = 1 << 2;
-    const READONLY: u8 = 1 << 3;
-    const IS_SUBPROGRAM: u8 = 1 << 4;
-    const HAS_STATEMENT_CONFLICT: u8 = 1 << 5;
-    const SUPPRESS_CUSTOM_TYPE_DECODE: u8 = 1 << 6;
-    const SUPPRESS_COLUMN_DEFAULT: u8 = 1 << 7;
+    const READONLY: u8 = 1 << 2;
+    const IS_SUBPROGRAM: u8 = 1 << 3;
+    const HAS_STATEMENT_CONFLICT: u8 = 1 << 4;
+    const SUPPRESS_CUSTOM_TYPE_DECODE: u8 = 1 << 5;
+    const SUPPRESS_COLUMN_DEFAULT: u8 = 1 << 6;
 
     const fn new(is_subprogram: bool) -> Self {
         let mut new = Self(0);
         new.set_is_multi_write(true);
-        new.set_may_abort(true);
         new.set_readonly(true);
         new.set_is_subprogram(is_subprogram);
-        new.set_is_multi_write(true);
-        new.set_may_abort(true);
         new
     }
 
@@ -350,18 +346,6 @@ impl ProgramBuilderFlags {
     #[inline]
     pub const fn set_is_multi_write(&mut self, v: bool) {
         self.set(Self::IS_MULTI_WRITE, v)
-    }
-
-    #[inline]
-    /// Mirrors SQLite's mayAbort: true if the statement may throw an ABORT exception.
-    /// This flag is used in combination with is_multi_write to determine if statement subjournaling is required.
-    /// Defaults to true for safety; specific translate paths (e.g., INSERT with no constraints) set false.
-    pub const fn may_abort(self) -> bool {
-        self.get(Self::MAY_ABORT)
-    }
-    #[inline]
-    pub const fn set_may_abort(&mut self, v: bool) {
-        self.set(Self::MAY_ABORT, v)
     }
 
     #[inline]
@@ -826,11 +810,6 @@ impl ProgramBuilder {
     /// When false, statement journals are skipped since single-write statements are atomic.
     pub const fn set_multi_write(&mut self, is_multi_write: bool) {
         self.flags.set_is_multi_write(is_multi_write);
-    }
-
-    /// Mark that this statement may throw an ABORT exception (mirrors SQLite's sqlite3MayAbort).
-    pub const fn set_may_abort(&mut self, may_abort: bool) {
-        self.flags.set_may_abort(may_abort);
     }
 
     pub const fn capture_data_changes_info(&self) -> &Option<CaptureDataChangesInfo> {
@@ -1944,14 +1923,22 @@ impl ProgramBuilder {
 
         self.parameters.list.dedup();
 
-        // Mirrors SQLite's: usesStmtJournal = isMultiWrite && mayAbort
-        // Statement journals are only needed when a statement writes multiple rows AND could
-        // abort midway (e.g. constraint violation). Single-row writes are atomic and don't
-        // need statement-level rollback. Both flags default to true; specific translate paths
-        // (e.g., single-row INSERT) set is_multi_write=false to opt out.
-        let needs_stmt_subtransactions = matches!(self.txn_mode, TransactionMode::Write)
-            && self.flags.is_multi_write()
-            && self.flags.may_abort();
+        // SQLite uses: usesStmtJournal = isMultiWrite && mayAbort. It can skip the
+        // statement journal for multi-write statements that cannot SQL-abort because
+        // its VDBE never returns control to the application mid-mutation: a statement
+        // either runs to completion or fails, and "cannot abort" implies "no partial
+        // state to roll back".
+        //
+        // Turso cannot rely on the mayAbort half of that rule. The VM yields
+        // `StepResult::IO` in the middle of built-in row mutation, and the caller may
+        // drop (abandon) the statement at any such yield point. An abandoned
+        // multi-write statement inside an explicit transaction must roll back its
+        // prefix table/index writes on reset, or a later COMMIT persists a corrupt
+        // prefix (see #7594). So every multi-write statement needs the statement
+        // savepoint boundary, whether or not it can SQL-abort. Single-row writes are
+        // atomic and still opt out via is_multi_write=false in the translate paths.
+        let needs_stmt_subtransactions =
+            matches!(self.txn_mode, TransactionMode::Write) && self.flags.is_multi_write();
 
         let contains_trigger_subprograms = self
             .insns

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1363,7 +1363,7 @@ pub struct PreparedProgram {
     pub sql: String,
     /// Whether the statement needs to be wrapped in a statement subtransaction
     /// when run as part of an interactive (non-autocommit) transaction.
-    /// See [crate::vdbe::builder::ProgramBuilder::is_multi_write] and [crate::vdbe::builder::ProgramBuilder::may_abort] for more details.
+    /// See [crate::vdbe::builder::ProgramBuilderFlags::is_multi_write] for more details.
     pub needs_stmt_subtransactions: Arc<AtomicBool>,
     /// If this Program is a trigger subprogram, a ref to the trigger is stored here.
     pub trigger: Option<Arc<Trigger>>,

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -2355,7 +2355,7 @@ fn run_fk_constraint_case(
 
 /// Multi-row UPDATE that violates child-side FK: all rows must be rolled back.
 /// The FkCounter is incremented during the scan, then Halt checks the counter.
-/// Statement journal is required because multi_write=true (has_fks) and may_abort=true.
+/// Statement journal is required because multi_write=true (has_fks).
 #[turso_macros::test]
 fn test_update_fk_child_violation_multi_row_rollback(tmp_db: TempDatabase) -> anyhow::Result<()> {
     drop(tmp_db);

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -1,7 +1,11 @@
 /// Tests that the `needs_stmt_subtransactions` flag is correctly set based on
-/// the is_multi_write and may_abort analysis during statement compilation.
+/// the is_multi_write analysis during statement compilation.
 ///
-/// These tests mirror SQLite's usesStmtJournal = isMultiWrite && mayAbort (vdbeaux.c:2685).
+/// SQLite uses usesStmtJournal = isMultiWrite && mayAbort (vdbeaux.c:2685), but
+/// Turso cannot use the mayAbort half: the VM yields `StepResult::IO` in the
+/// middle of built-in row mutation and the caller may abandon (drop) the
+/// statement at any such yield point, so every multi-write statement needs a
+/// statement rollback boundary even if it cannot SQL-abort (see #7594).
 use crate::common::TempDatabase;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -34,7 +38,7 @@ fn query_rows(conn: &Arc<turso_core::Connection>, sql: &str) -> Vec<String> {
 // ──────────────────────────────────────────────────────────
 
 /// Single-row INSERT into a table with no constraints, no triggers, no FKs.
-/// Neither multi-write nor may-abort.
+/// Not multi-write.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b, c);")]
 fn insert_single_row_no_constraints(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
@@ -46,25 +50,25 @@ fn insert_single_row_no_constraints(tmp_db: TempDatabase) -> anyhow::Result<()> 
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b, c);")]
 fn insert_multi_row_no_constraints(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    // Multi-row but no may_abort → still no stmt journal.
-    assert!(!needs_stmt_journal(
+    // Multi-row → multi-write → stmt journal, even without constraints:
+    // the statement can be abandoned at an IO yield point mid-mutation (#7594).
+    assert!(needs_stmt_journal(
         &conn,
         "INSERT INTO t VALUES (1,2,3),(4,5,6)"
     ));
     Ok(())
 }
 
-/// INSERT with NOT NULL constraint and default (Abort) conflict resolution → may_abort.
+/// INSERT with NOT NULL constraint into a single row is still single-row.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a NOT NULL, b);")]
 fn insert_single_row_notnull(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    // Single-row (not multi-write) but may_abort.
-    // needs_stmt = multi_write && may_abort = false && true = false.
+    // Single-row → not multi-write → no stmt journal.
     assert!(!needs_stmt_journal(&conn, "INSERT INTO t VALUES (1, 2)"));
     Ok(())
 }
 
-/// Multi-row INSERT with NOT NULL → multi-write AND may-abort → needs stmt journal.
+/// Multi-row INSERT with NOT NULL → multi-write → needs stmt journal.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a NOT NULL, b);")]
 fn insert_multi_row_notnull(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
@@ -75,7 +79,7 @@ fn insert_multi_row_notnull(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// INSERT with UNIQUE constraint → may_abort.
+/// Multi-row INSERT with UNIQUE constraint → multi-write → stmt journal.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a UNIQUE, b);")]
 fn insert_multi_row_unique(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
@@ -86,40 +90,39 @@ fn insert_multi_row_unique(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// INSERT OR IGNORE with UNIQUE → may_abort is false (not OE_Abort).
+/// INSERT OR IGNORE with UNIQUE cannot SQL-abort, but is still multi-write
+/// (multiple rows) and can be abandoned mid-mutation → stmt journal.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a UNIQUE, b);")]
 fn insert_or_ignore_multi_row_unique(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "INSERT OR IGNORE INTO t VALUES (1, 2), (3, 4)"
     ));
     Ok(())
 }
 
-/// INSERT OR REPLACE is multi-write (REPLACE may delete conflicting rows).
-/// But may_abort=false (conflict resolution is not OE_Abort).
-/// needs_stmt = true && false = false.
+/// INSERT OR REPLACE is multi-write (REPLACE may delete conflicting rows)
+/// → stmt journal, even though the conflict resolution cannot SQL-abort.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a UNIQUE, b);")]
 fn insert_or_replace_single_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "INSERT OR REPLACE INTO t VALUES (1, 2)"
     ));
     Ok(())
 }
 
-/// AUTOINCREMENT is multi-write (writes to sqlite_sequence).
-/// No constraints → may_abort=false. needs_stmt = true && false = false.
+/// AUTOINCREMENT is multi-write (writes to sqlite_sequence) → stmt journal.
 #[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v);")]
 fn insert_autoincrement_single_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(&conn, "INSERT INTO t (v) VALUES (1)"));
+    assert!(needs_stmt_journal(&conn, "INSERT INTO t (v) VALUES (1)"));
     Ok(())
 }
 
-/// AUTOINCREMENT + NOT NULL → multi-write AND may-abort.
+/// AUTOINCREMENT + NOT NULL → multi-write.
 #[turso_macros::test(
     init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v NOT NULL);"
 )]
@@ -189,16 +192,17 @@ fn insert_fk_violation_in_tx_rolls_back_row(tmp_db: TempDatabase) -> anyhow::Res
 // UPDATE
 // ──────────────────────────────────────────────────────────
 
-/// UPDATE with no WHERE (table scan) is multi-write.
+/// UPDATE with no WHERE (table scan) is multi-write → stmt journal, even
+/// without constraints: the caller may abandon the statement at an IO yield
+/// point mid-mutation and the prefix writes must roll back (#7594).
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b);")]
 fn update_no_where(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    // Multi-write (table scan), but no constraints → may_abort=false.
-    assert!(!needs_stmt_journal(&conn, "UPDATE t SET a = 1"));
+    assert!(needs_stmt_journal(&conn, "UPDATE t SET a = 1"));
     Ok(())
 }
 
-/// UPDATE with no WHERE + NOT NULL → multi-write AND may-abort.
+/// UPDATE with no WHERE + NOT NULL → multi-write.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a NOT NULL, b);")]
 fn update_no_where_notnull(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
@@ -210,8 +214,7 @@ fn update_no_where_notnull(tmp_db: TempDatabase) -> anyhow::Result<()> {
 #[turso_macros::test(init_sql = "CREATE TABLE t (a NOT NULL, b);")]
 fn update_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    // Single-row → not multi-write. may_abort=true (NOT NULL).
-    // needs_stmt = false && true = false.
+    // Single-row → not multi-write → no stmt journal.
     assert!(!needs_stmt_journal(
         &conn,
         "UPDATE t SET a = 1 WHERE rowid = 5"
@@ -255,13 +258,12 @@ fn update_unindexed_where(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// UPDATE OR REPLACE → always multi-write (can delete conflicting rows).
-/// But may_abort = false (conflict resolution is not OE_Abort).
-/// needs_stmt = true && false = false.
+/// UPDATE OR REPLACE → always multi-write (can delete conflicting rows)
+/// → stmt journal, even though the conflict resolution cannot SQL-abort.
 #[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, a UNIQUE);")]
 fn update_or_replace_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "UPDATE OR REPLACE t SET a = 1 WHERE id = 5"
     ));
@@ -293,11 +295,12 @@ fn update_composite_unique_partial_cols(tmp_db: TempDatabase) -> anyhow::Result<
 // DELETE
 // ──────────────────────────────────────────────────────────
 
-/// DELETE with no WHERE (table scan) + no constraints → multi-write, no may-abort.
+/// DELETE with no WHERE (table scan) is multi-write → stmt journal, even
+/// without constraints (abandonment at an IO yield point, #7594).
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b);")]
 fn delete_no_where(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(&conn, "DELETE FROM t"));
+    assert!(needs_stmt_journal(&conn, "DELETE FROM t"));
     Ok(())
 }
 
@@ -317,13 +320,13 @@ fn delete_by_unique_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// DELETE with no WHERE on table with FK → may-abort.
+/// DELETE with no WHERE on table with FK → multi-write → stmt journal.
 #[turso_macros::test(init_sql = "CREATE TABLE parent (id INTEGER PRIMARY KEY);")]
 fn delete_with_fk(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
     conn.execute("PRAGMA foreign_keys = ON")?;
     conn.execute("CREATE TABLE child (pid REFERENCES parent(id))")?;
-    // multi-write (table scan) && may_abort (FK) → true.
+    // multi-write (table scan) → true.
     assert!(needs_stmt_journal(&conn, "DELETE FROM parent"));
     Ok(())
 }
@@ -337,7 +340,7 @@ fn delete_by_rowid_with_fk(tmp_db: TempDatabase) -> anyhow::Result<()> {
     conn.execute("PRAGMA foreign_keys = ON")?;
     conn.execute("CREATE TABLE child (pid REFERENCES parent(id))")?;
     // FK constraint checks modify deferred violation counter before the statement can abort,
-    // so multi_write stays true. needs_stmt = true && true = true.
+    // so multi_write stays true → needs stmt journal.
     assert!(needs_stmt_journal(&conn, "DELETE FROM parent WHERE id = 5"));
     Ok(())
 }


### PR DESCRIPTION
An abandoned (dropped) multi-write statement could commit table/index
corruption. Statement savepoint selection mirrored SQLite's
`usesStmtJournal = isMultiWrite && mayAbort`, but that rule assumes the
VDBE never returns control to the application in the middle of built-in
row mutation. Turso's VM yields `StepResult::IO` mid-mutation, and the
caller may drop the statement at any such yield point. A multi-write
statement that could not SQL-abort (e.g. an indexed UPDATE with no
constraints) opened no statement savepoint, so `Program::abort` on drop
had nothing to roll back inside an explicit transaction, and a later
COMMIT persisted the prefix table/index writes, leaving the index
inconsistent with the table.

Decide savepoint usage from `is_multi_write` alone so every multi-write
statement gets a statement rollback boundary, whether or not it can
SQL-abort. Remove the now-unused `may_abort` flag and its constraint
analysis in translate/stmt_journal.rs, and update the stmt_journal
integration tests that encoded the old rule's expectations. Single-row
writes still opt out via `is_multi_write = false`, and autocommit
statements still skip pager savepoints since errors roll back the whole
transaction.

Tests: cargo test -p turso_core --features io_memory_yield --test
active_index_select_repro; turso_core lib tests; core_tester
integration + fuzz; sqltests; TCL compat suite.

Fixes #7594