### PR TITLE
core/storage: fix savepoint rollback across WAL restart

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1227,6 +1227,7 @@ struct SavepointSnapshot {
     db_size: u32,
     wal_max_frame: u64,
     wal_checksum: (u32, u32),
+    wal_checkpoint_seq: u32,
     deferred_fk_violations: isize,
 }
 
@@ -1247,6 +1248,10 @@ struct Savepoint {
     wal_max_frame: AtomicU64,
     /// WAL checksum at the start of the savepoint.
     wal_checksum: RwLock<(u32, u32)>,
+    /// WAL checkpoint sequence (generation) at the start of the savepoint.
+    /// `wal_max_frame`/`wal_checksum` are only meaningful within this
+    /// generation; a WAL restart invalidates them.
+    wal_checkpoint_seq: AtomicU32,
     /// Deferred FK counter value at the start of this savepoint.
     deferred_fk_violations: AtomicIsize,
 }
@@ -1258,6 +1263,7 @@ impl Savepoint {
         db_size: u32,
         wal_max_frame: u64,
         wal_checksum: (u32, u32),
+        wal_checkpoint_seq: u32,
         deferred_fk_violations: isize,
     ) -> Self {
         Self {
@@ -1268,6 +1274,7 @@ impl Savepoint {
             db_size: AtomicU32::new(db_size),
             wal_max_frame: AtomicU64::new(wal_max_frame),
             wal_checksum: RwLock::new(wal_checksum),
+            wal_checkpoint_seq: AtomicU32::new(wal_checkpoint_seq),
             deferred_fk_violations: AtomicIsize::new(deferred_fk_violations),
         }
     }
@@ -1299,6 +1306,7 @@ impl Savepoint {
             db_size: self.db_size.load(Ordering::Acquire),
             wal_max_frame: self.wal_max_frame.load(Ordering::Acquire),
             wal_checksum: *self.wal_checksum.read(),
+            wal_checkpoint_seq: self.wal_checkpoint_seq.load(Ordering::Acquire),
             deferred_fk_violations: self.deferred_fk_violations.load(Ordering::Acquire),
         }
     }
@@ -1312,6 +1320,7 @@ impl Savepoint {
             db_size: AtomicU32::new(snapshot.db_size),
             wal_max_frame: AtomicU64::new(snapshot.wal_max_frame),
             wal_checksum: RwLock::new(snapshot.wal_checksum),
+            wal_checkpoint_seq: AtomicU32::new(snapshot.wal_checkpoint_seq),
             deferred_fk_violations: AtomicIsize::new(snapshot.deferred_fk_violations),
         }
     }
@@ -2152,10 +2161,14 @@ impl Pager {
             .last()
             .map(|savepoint| savepoint.write_offset())
             .unwrap_or(0);
-        let (wal_max_frame, wal_checksum) = if let Some(wal) = &self.wal {
-            (wal.get_max_frame(), wal.get_last_checksum())
+        let (wal_max_frame, wal_checksum, wal_checkpoint_seq) = if let Some(wal) = &self.wal {
+            (
+                wal.get_max_frame(),
+                wal.get_last_checksum(),
+                wal.get_checkpoint_seq(),
+            )
         } else {
-            (0, (0, 0))
+            (0, (0, 0), 0)
         };
         let savepoint = Savepoint::new(
             kind,
@@ -2163,6 +2176,7 @@ impl Pager {
             db_size,
             wal_max_frame,
             wal_checksum,
+            wal_checkpoint_seq,
             deferred_fk_violations,
         );
         self.savepoints.write().push(savepoint);
@@ -2265,10 +2279,15 @@ impl Pager {
             wal.rollback(Some(RollbackTo {
                 frame: savepoint.wal_max_frame,
                 checksum: savepoint.wal_checksum,
+                checkpoint_seq: savepoint.wal_checkpoint_seq,
             }));
+            // Use the WAL position the rollback actually installed rather
+            // than the savepoint's recorded frame: if the savepoint predates
+            // a WAL restart, the rollback clamps to the authority snapshot
+            // and the recorded frame belongs to the previous generation.
             self.page_cache
                 .write()
-                .delete_clean_pages_after_wal_frame(savepoint.wal_max_frame)
+                .delete_clean_pages_after_wal_frame(wal.get_max_frame())
                 .map_err(|e| {
                     LimboError::InternalError(format!(
                         "failed to invalidate rolled-back WAL pages: {e:?}"
@@ -2929,6 +2948,17 @@ impl Pager {
         return_if_io!(self.maybe_allocate_page1());
         let Some(wal) = self.wal.as_ref() else {
             return Ok(IOResult::Done(()));
+        };
+        // Open savepoints record the connection's WAL position (frame +
+        // checksum). Restarting the WAL header here would start a new
+        // generation and invalidate those positions, so a later ROLLBACK TO
+        // would rewind the WAL state into the previous generation and corrupt
+        // the append position. Keep the log as-is until the savepoints are
+        // resolved.
+        let allowed_auto_actions = if self.savepoints.read().is_empty() {
+            allowed_auto_actions
+        } else {
+            allowed_auto_actions.difference(WalAutoActions::Restart)
         };
         Ok(IOResult::Done(wal.begin_write_tx(allowed_auto_actions)?))
     }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -3,7 +3,7 @@
 use crate::io::FileSyncType;
 use crate::sync::Mutex;
 use crate::sync::OnceLock;
-use crate::{turso_assert, turso_assert_greater_than, turso_debug_assert};
+use crate::{turso_assert, turso_assert_greater_than, turso_debug_assert, turso_soft_unreachable};
 use branches::mark_unlikely;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::array;
@@ -51,6 +51,12 @@ use crate::{
 pub struct RollbackTo {
     pub frame: u64,
     pub checksum: (u32, u32),
+    /// WAL checkpoint sequence (generation) the frame/checksum pair was
+    /// captured in. A WAL restart starts a new generation, renumbering
+    /// frames from zero with a fresh checksum chain, so a rollback target
+    /// from an older generation must not be installed as the connection's
+    /// WAL position.
+    pub checkpoint_seq: u32,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -3884,6 +3890,30 @@ impl Wal for WalFile {
     fn rollback(&self, rollback_to: Option<RollbackTo>) {
         let is_savepoint = rollback_to.is_some();
         let snapshot = self.load_coordination_snapshot();
+        // A savepoint's recorded WAL position is only meaningful within the
+        // WAL generation it was captured in. If the log has been restarted
+        // since (new generation: frames renumbered from zero, new salts and
+        // checksum chain), installing the old-generation frame/checksum would
+        // make the next append continue from a bogus offset with a stale
+        // checksum seed, physically overwriting or misplacing WAL frames.
+        // Every frame this connection appended in the current generation came
+        // after such a savepoint, so the correct rollback target is the
+        // authoritative committed snapshot itself.
+        let rollback_to = rollback_to.filter(|r| {
+            let same_generation = r.checkpoint_seq == snapshot.checkpoint_seq;
+            if !same_generation {
+                turso_soft_unreachable!(
+                    "savepoint rollback across a WAL restart; clamping to the authority snapshot",
+                    {
+                        "savepoint_checkpoint_seq": r.checkpoint_seq,
+                        "authority_checkpoint_seq": snapshot.checkpoint_seq,
+                        "savepoint_frame": r.frame,
+                        "authority_max_frame": snapshot.max_frame
+                    }
+                );
+            }
+            same_generation
+        });
         let max_frame = rollback_to
             .as_ref()
             .map(|r| r.frame)
@@ -3903,6 +3933,14 @@ impl Wal for WalFile {
         self.coordination.rollback_cache(cache_rollback_frame);
         *self.last_checksum.write() = last_checksum;
         self.max_frame.store(max_frame, Ordering::Release);
+        if max_frame <= snapshot.max_frame {
+            // Every frame this connection appended past the committed
+            // high-water mark has been discarded, so no unpublished frames
+            // remain. Leaving the flag set would make a later
+            // `prepare_frames` trust the connection-local WAL position over
+            // the authority snapshot.
+            self.has_unpublished_frames.store(false, Ordering::Release);
+        }
         if !is_savepoint {
             self.reset_internal_states();
         }
@@ -4156,7 +4194,7 @@ impl Wal for WalFile {
                     && local_state.snapshot.checkpoint_seq == snapshot.checkpoint_seq
                     && local_state.snapshot.transaction_count == snapshot.transaction_count
                     && local_state.snapshot.last_checksum != snapshot.last_checksum;
-                if local_prepared_zero_frame_header {
+                let seed = if local_prepared_zero_frame_header {
                     // We already prepared the WAL header for the current
                     // zero-frame generation locally, but the authority snapshot
                     // still carries the pre-header checksum until the first
@@ -4198,7 +4236,13 @@ impl Wal for WalFile {
                         local_state.snapshot.last_checksum,
                         local_state.snapshot.max_frame + 1,
                     )
-                }
+                };
+                turso_assert!(
+                    seed.1 > snapshot.max_frame,
+                    "WAL append position must be past the committed high-water mark, otherwise committed frames get overwritten",
+                    { "next_frame_id": seed.1, "authority_max_frame": snapshot.max_frame }
+                );
+                seed
             }
         };
 
@@ -6746,6 +6790,7 @@ pub mod test {
         wal.rollback(Some(RollbackTo {
             frame: 10,
             checksum: (13, 21),
+            checkpoint_seq: 1,
         }));
 
         assert_eq!(coordination.find_frame(7, 0, 30, None), Some(10));

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -1607,6 +1607,108 @@ fn test_wal_savepoint_rollback_on_constraint_violation() {
     assert_eq!(row[0], Value::from_i64(1001));
 }
 
+/// Regression test for savepoint rollback across a WAL restart.
+///
+/// A named savepoint records the connection's WAL position (max frame +
+/// running checksum). If the savepoint is opened before the transaction's
+/// first write and the WAL is fully backfilled, the write upgrade restarts
+/// the WAL (new generation: max_frame = 0, new salts/checksums). The
+/// savepoint's recorded WAL position then belongs to the *previous* WAL
+/// generation. `ROLLBACK TO` must not install that stale position into the
+/// connection's WAL state: doing so makes the next spill/commit append
+/// frames at the old generation's offset with the old checksum chain,
+/// leaving rolled-back frames visible to readers and corrupting the log
+/// (surfaces as integrity_check errors like "Invalid page type: 0" and as
+/// committed data lost after recovery).
+#[test]
+fn test_savepoint_rollback_across_wal_restart() {
+    let tmp_db = TempDatabase::new("savepoint_wal_restart.db");
+    let conn = tmp_db.connect_limbo();
+
+    // Small page cache so the big transaction below spills to the WAL
+    // mid-transaction (uncommitted frames).
+    conn.execute("PRAGMA cache_size = 200").unwrap();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")
+        .unwrap();
+
+    let padding = "x".repeat(2000);
+    conn.execute("BEGIN").unwrap();
+    for i in 1..=300 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, '{padding}')"))
+            .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+
+    // Fully backfill the WAL so the next write transaction restarts the log.
+    conn.execute("PRAGMA wal_checkpoint(FULL)").unwrap();
+
+    // Open the savepoint before the transaction's first write: it records a
+    // WAL position from the fully-backfilled (pre-restart) generation.
+    conn.execute("BEGIN").unwrap();
+    conn.execute("SAVEPOINT sp").unwrap();
+    // The first INSERT upgrades to a write transaction, which restarts the
+    // WAL; the rest of the inserts overflow the page cache and spill
+    // uncommitted frames into the new WAL generation.
+    for i in 301..=900 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, '{padding}')"))
+            .unwrap();
+    }
+    conn.execute("ROLLBACK TO sp").unwrap();
+    for i in 901..=910 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, '{padding}')"))
+            .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+
+    // A fresh connection must see a consistent database: only the first
+    // batch and the post-rollback inserts.
+    let conn2 = tmp_db.connect_limbo();
+    let stmt = conn2.query("PRAGMA integrity_check").unwrap().unwrap();
+    let row = helper_read_single_row(stmt);
+    assert_eq!(
+        row[0],
+        Value::Text("ok".into()),
+        "integrity check must pass after savepoint rollback across a WAL restart"
+    );
+    let stmt = conn2.query("SELECT COUNT(*) FROM t").unwrap().unwrap();
+    let row = helper_read_single_row(stmt);
+    assert_eq!(row[0], Value::from_i64(310));
+
+    // The committed transaction must also survive WAL recovery from disk.
+    // With the append position corrupted, the commit's frames fail salt or
+    // checksum validation and recovery silently drops them. This check must
+    // run before any checkpoint: backfilling would launder the corrupted WAL
+    // into the database file and mask the recovery failure.
+    let rusqlite_conn = rusqlite::Connection::open(tmp_db.path.clone()).unwrap();
+    let result: String = rusqlite_conn
+        .pragma_query_value(None, "integrity_check", |row| row.get(0))
+        .unwrap();
+    assert_eq!(result, "ok");
+    let count: i64 = rusqlite_conn
+        .query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        count, 310,
+        "committed rows must survive WAL recovery after savepoint rollback across a WAL restart"
+    );
+    drop(rusqlite_conn);
+
+    // Checkpointing must not backfill rolled-back or stale-generation frames
+    // into the database file.
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    let stmt = conn2.query("PRAGMA integrity_check").unwrap().unwrap();
+    let row = helper_read_single_row(stmt);
+    assert_eq!(
+        row[0],
+        Value::Text("ok".into()),
+        "integrity check must pass after checkpointing"
+    );
+    let stmt = conn2.query("SELECT COUNT(*) FROM t").unwrap().unwrap();
+    let row = helper_read_single_row(stmt);
+    assert_eq!(row[0], Value::from_i64(310));
+}
+
 #[turso_macros::test]
 /// INSERT OR FAIL should keep changes made by the statement before the error.
 /// Unlike ABORT (the default), FAIL does not roll back successful inserts within the same statement.


### PR DESCRIPTION
## Description

Fix a critical bug where `ROLLBACK TO` a savepoint opened before a WAL restart would install a stale WAL position, causing subsequent writes to corrupt the log by appending frames at the wrong offset with an invalid checksum chain. This manifests as integrity check failures and data loss after recovery.

The fix tracks the WAL checkpoint sequence (generation) when a savepoint is created. During rollback, if the savepoint predates a WAL restart (new generation with frames renumbered from zero and fresh checksums), the rollback is clamped to the authority snapshot instead of installing the stale position. Additionally, WAL restart is now blocked while savepoints are open to prevent this scenario entirely.

## Motivation and context

When a savepoint is created, it records the connection's WAL position (max frame + checksum). If the WAL is fully backfilled and then restarted (e.g., during a write transaction upgrade), a new generation begins with frame numbering reset to zero and a fresh checksum chain. The savepoint's recorded position now belongs to the *previous* generation.

If `ROLLBACK TO` naively installs that old-generation position, the next frame append continues from a bogus offset with a stale checksum seed, physically overwriting or misplacing WAL frames. Rolled-back frames become visible to readers, and committed data is lost after recovery.

The fix:
1. **Track checkpoint sequence in savepoints** (`wal_checkpoint_seq`): Records which WAL generation the savepoint belongs to
2. **Validate generation on rollback**: If the savepoint predates a WAL restart, clamp to the authority snapshot instead
3. **Block WAL restart with open savepoints**: Prevents the restart from invalidating savepoint positions in the first place
4. **Clear unpublished frames flag on rollback**: Ensures the connection doesn't trust a stale WAL position over the authority snapshot

## Changes

- `core/storage/wal.rs`: Add `checkpoint_seq` to `RollbackTo`, validate generation during rollback, clear unpublished frames flag when rolling back to committed state, add assertion that append position stays past the high-water mark
- `core/storage/pager.rs`: Track `wal_checkpoint_seq` in savepoint snapshots, pass it to `RollbackTo`, use actual installed WAL position (not recorded position) for cache invalidation, block WAL restart when savepoints are open
- `tests/integration/query_processing/test_transactions.rs`: Add regression test `test_savepoint_rollback_across_wal_restart` that verifies integrity and data consistency after savepoint rollback across a WAL restart

## Tests

The new regression test `test_savepoint_rollback_across_wal_restart` covers:
- Creating a savepoint before a WAL restart
- Rolling back across the restart boundary
- Verifying database integrity and row count with a fresh connection
- Verifying data survives WAL recovery from disk
- Verifying checkpointing doesn't backfill corrupted frames

Existing transaction tests continue to pass.

https://claude.ai/code/session_019gsA1MZBnUeHtJz3a8xaRy