### PR TITLE
core/vdbe: keep WAL mode until the final header flip in journal_mode=mvcc

### DIFF
--- a/core/database.rs
+++ b/core/database.rs
@@ -1785,8 +1785,10 @@ impl Database {
                     // `is_readonly` across the `_init` yields is stable.
                     let pager =
                         return_if_io!(self._init_nonblock(init, encryption_key, page_codec));
-                    let log_exists =
-                        journal_mode::logical_log_exists(std::path::Path::new(&self.path));
+                    let log_exists = journal_mode::logical_log_exists(
+                        self.io.as_ref(),
+                        std::path::Path::new(&self.path),
+                    );
                     let is_readonly = self.open_flags.contains(OpenFlags::ReadOnly);
                     turso_assert!(pager.wal.is_none(), "Pager should have no WAL yet");
                     *st = HeaderValidationState::Validate {
@@ -1956,14 +1958,29 @@ impl Database {
                         Version::Mvcc => false,
                     };
 
-                    // In WAL mode, a logical log is always unexpected.
-                    // In MVCC mode, WAL and logical-log coexistence can happen across interrupted checkpoint
-                    // recovery and is reconciled in MvStore::bootstrap().
+                    // In WAL mode, a logical log with committed frames is always
+                    // unexpected: those transactions would be silently invisible.
+                    // In MVCC mode, WAL and logical-log coexistence can happen across
+                    // interrupted checkpoint recovery and is reconciled in
+                    // MvStore::bootstrap(). A header-only logical log next to a
+                    // WAL-mode database is the benign leftover of a
+                    // `PRAGMA journal_mode=mvcc` switch abandoned before the final
+                    // page-1 header flip; ignore it (a later switch to MVCC rewrites
+                    // or validates it).
                     if !open_mv_store && log_exists {
-                        return Err(LimboError::Corrupt(format!(
-                            "MVCC logical log file exists for database {}, but database header indicates WAL mode. The database may be corrupted.",
+                        if journal_mode::logical_log_has_frames(
+                            self.io.as_ref(),
+                            std::path::Path::new(&self.path),
+                        ) {
+                            return Err(LimboError::Corrupt(format!(
+                                "MVCC logical log file with committed frames exists for database {}, but database header indicates WAL mode. The database may be corrupted.",
+                                self.path
+                            )));
+                        }
+                        tracing::warn!(
+                            "ignoring header-only MVCC logical log next to WAL-mode database {}; likely left by an abandoned PRAGMA journal_mode=mvcc switch",
                             self.path
-                        )));
+                        );
                     }
 
                     let page = header.page().clone();
@@ -2172,7 +2189,8 @@ impl Database {
         self.shared_wal
             .write()
             .replace_after_external_restore(new_shared_wal.into_inner());
-        if self.mvcc_enabled() || journal_mode::logical_log_exists(std::path::Path::new(&self.path))
+        if self.mvcc_enabled()
+            || journal_mode::logical_log_exists(self.io.as_ref(), std::path::Path::new(&self.path))
         {
             let mv_store = journal_mode::open_mv_store(
                 self.io.clone(),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -12320,13 +12320,16 @@ fn test_abandoned_commit_rolls_back_insert_with_injected_yield() {
 }
 
 /// `PRAGMA journal_mode=mvcc` installs the shared `MvStore` and demotes the
-/// connection in `Finalize`, then yields repeatedly while the store bootstraps
-/// (reparse, checkpoint, log recovery). If the statement is dropped while
-/// parked at one of those bootstrap yields, the abandonment guard must
-/// re-promote the connection and uninstall the un-bootstrapped store. Without
-/// the guard, `is_mvcc_bootstrap_connection` would stay set forever (silently
-/// bypassing MVCC) and other connections on the same `Database` could trip an
-/// assertion on the un-bootstrapped store (`global_header = None`) at commit.
+/// connection in `InstallMvStore`, then yields repeatedly while the store
+/// bootstraps (reparse, checkpoint, log recovery). The on-disk header still
+/// says WAL at that point (the durable page-1 flip is the last step of the
+/// switch), so if the statement is dropped while parked at one of those
+/// bootstrap yields, the abandonment guard must re-promote the connection and
+/// uninstall the un-bootstrapped store, leaving the database simply in WAL
+/// mode. Without the guard, `is_mvcc_bootstrap_connection` would stay set
+/// forever (silently bypassing MVCC) and other connections on the same
+/// `Database` could trip an assertion on the un-bootstrapped store
+/// (`global_header = None`) at commit (#7596).
 ///
 /// Gated on `io_memory_yield`: the test needs [`crate::MemoryYieldIO`] to defer
 /// completions so the bootstrap yields are observable. CI exercises it via the
@@ -12393,7 +12396,8 @@ fn test_abandoned_journal_mode_mvcc_bootstrap_restores_connection() {
     );
 
     // Abandon the statement mid-bootstrap; dropping it drops the
-    // `MvccBootstrapGuard` held in its `active_op_state`.
+    // `MvccBootstrapGuard` held in its `active_op_state`, which restores
+    // in-memory state (the on-disk header still says WAL).
     drop(stmt);
 
     assert!(
@@ -12404,6 +12408,26 @@ fn test_abandoned_journal_mode_mvcc_bootstrap_restores_connection() {
         db.get_mv_store().is_none(),
         "abandonment guard must uninstall the un-bootstrapped store",
     );
+
+    // The connection is simply back in WAL mode: ordinary writes work.
+    conn.execute("INSERT INTO t VALUES (1, 'after-abandon')")
+        .unwrap();
+    let rows = get_rows(&conn, "SELECT id, v FROM t");
+    assert_eq!(rows.len(), 1, "unexpected rows: {rows:?}");
+
+    // Re-running the pragma must complete the switch cleanly, after which
+    // MVCC-only features work and the earlier write is still visible.
+    conn.execute("PRAGMA journal_mode=mvcc").unwrap();
+    assert!(
+        db.get_mv_store().is_some(),
+        "re-running the pragma must install the bootstrapped store",
+    );
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    conn.execute("INSERT INTO t VALUES (2, 'after-switch')")
+        .unwrap();
+    conn.execute("COMMIT").unwrap();
+    let rows = get_rows(&conn, "SELECT id, v FROM t");
+    assert_eq!(rows.len(), 2, "unexpected rows: {rows:?}");
 }
 
 /// `step_build_log_record` chunks the commit's write_set into batches of

--- a/core/storage/journal_mode.rs
+++ b/core/storage/journal_mode.rs
@@ -56,10 +56,38 @@ impl From<Version> for JournalMode {
     }
 }
 
-pub fn logical_log_exists(db_path: impl AsRef<std::path::Path>) -> bool {
-    let db_path = db_path.as_ref();
-    let log_path = db_path.with_extension("db-log");
-    std::path::Path::exists(log_path.as_path()) && log_path.as_path().metadata().unwrap().len() > 0
+/// Size of the MVCC logical log next to `db_path`, probed through the IO
+/// backend (never the host filesystem directly), or `None` if the log file
+/// does not exist.
+fn logical_log_size(io: &dyn IO, db_path: impl AsRef<std::path::Path>) -> Option<u64> {
+    let log_path = db_path.as_ref().with_extension("db-log");
+    let log_path = log_path
+        .as_os_str()
+        .to_str()
+        .expect("path should be valid string");
+    // Read-only, no-lock, no-create probe: a missing (or unreadable) file is
+    // treated as "no logical log".
+    let file = io
+        .open_file(log_path, OpenFlags::ReadOnly | OpenFlags::NoLock, false)
+        .ok()?;
+    file.size().ok()
+}
+
+pub fn logical_log_exists(io: &dyn IO, db_path: impl AsRef<std::path::Path>) -> bool {
+    logical_log_size(io, db_path).is_some_and(|size| size > 0)
+}
+
+/// Whether the MVCC logical log next to `db_path` contains committed frames
+/// (i.e. is larger than the fixed-size log header).
+///
+/// A log at or below header size carries no transactions: it is the benign
+/// leftover of a `PRAGMA journal_mode=mvcc` switch that was abandoned before
+/// the database header was flipped to MVCC (the log header is written and
+/// synced before the page-1 flip, which is the last step of the switch).
+pub fn logical_log_has_frames(io: &dyn IO, db_path: impl AsRef<std::path::Path>) -> bool {
+    logical_log_size(io, db_path).is_some_and(|size| {
+        size > crate::mvcc::persistent_storage::logical_log::LOG_HDR_SIZE as u64
+    })
 }
 
 pub fn open_mv_store(

--- a/core/tests/active_index_select_repro.rs
+++ b/core/tests/active_index_select_repro.rs
@@ -1,0 +1,188 @@
+#[cfg(feature = "io_memory_yield")]
+use std::sync::Arc;
+
+#[cfg(feature = "io_memory_yield")]
+use turso_core::{Database, DatabaseOpts, OpenFlags, SqliteDialect, StepResult};
+
+#[cfg(feature = "io_memory_yield")]
+#[test]
+fn active_journal_mode_mvcc_interleaved_insert_does_not_corrupt_reopen() {
+    let io = Arc::new(turso_core::MemoryYieldIO::new());
+    let path = "active-mvcc-mode-switch-interleaved-insert.db";
+
+    {
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            path,
+            OpenFlags::default(),
+            DatabaseOpts::new(),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES(1,10)").unwrap();
+
+        let mut pragma = conn.prepare("PRAGMA journal_mode = 'mvcc'").unwrap();
+        let mut io_count = 0;
+        let mut interleaved = false;
+        loop {
+            match pragma.step().unwrap() {
+                StepResult::IO => {
+                    io_count += 1;
+                    turso_core::IO::step(io.as_ref()).unwrap();
+                    // The switch checkpoints first (holding the write lock),
+                    // then installs the MVCC store and writes+syncs the
+                    // logical-log header before bootstrapping. IO #8 is the
+                    // logical-log sync, so the insert below lands in the
+                    // yieldable window after the store install but before the
+                    // final page-1 header flip.
+                    if io_count == 8 {
+                        interleaved = true;
+                        conn.execute("INSERT INTO t VALUES(2,20)").unwrap();
+                    }
+                }
+                StepResult::Row | StepResult::Done => break,
+                StepResult::Yield => {}
+                other => panic!("unexpected journal_mode=mvcc step result: {other:?}"),
+            }
+        }
+        assert!(
+            interleaved,
+            "expected PRAGMA journal_mode=mvcc to yield mid-switch so a write could interleave"
+        );
+    }
+
+    let db = Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    let rows = conn
+        .prepare("SELECT id,x FROM t ORDER BY id")
+        .unwrap()
+        .run_collect_rows()
+        .unwrap()
+        .into_iter()
+        .map(|row| (row[0].as_int().unwrap(), row[1].as_int().unwrap()))
+        .collect::<Vec<_>>();
+    assert_eq!(rows, vec![(1, 10), (2, 20)]);
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    conn.execute("ROLLBACK").unwrap();
+}
+
+#[cfg(feature = "io_memory_yield")]
+#[test]
+fn writes_after_abandoned_journal_mode_mvcc_survive_fresh_reopen() {
+    let io = Arc::new(turso_core::MemoryYieldIO::new());
+
+    {
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            "abandoned-mvcc-followup-write.db",
+            OpenFlags::default(),
+            DatabaseOpts::new(),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x)")
+            .unwrap();
+
+        let mut stmt = conn.prepare("PRAGMA journal_mode = 'mvcc'").unwrap();
+        let mut io_count = 0;
+        loop {
+            match stmt.step().unwrap() {
+                StepResult::IO => {
+                    io_count += 1;
+                    // IO #8 is the logical-log header sync: the MVCC store is
+                    // already installed and the abandonment guard is armed,
+                    // but page 1 still says WAL. Drop the statement here,
+                    // mid-switch, without completing the pending IO.
+                    if io_count == 8 {
+                        drop(stmt);
+                        break;
+                    }
+                    turso_core::IO::step(io.as_ref()).unwrap();
+                }
+                other => panic!("expected eighth IO before completion, got {other:?}"),
+            }
+        }
+
+        // The switch never reached the final page-1 header flip, so the
+        // abandonment guard leaves the connection (and the on-disk header) in
+        // plain WAL mode.
+        assert!(!conn.is_mvcc_bootstrap_connection());
+        let mode = conn
+            .prepare("PRAGMA journal_mode")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap()[0][0]
+            .to_string();
+        assert_eq!(mode, "wal");
+
+        conn.execute("CREATE TABLE u(y)").unwrap();
+        conn.execute("INSERT INTO u VALUES(42)").unwrap();
+
+        let rows = conn
+            .prepare("SELECT y FROM u")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap()
+            .into_iter()
+            .map(|row| row[0].as_int().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(rows, vec![42]);
+    }
+
+    let db = Database::open_file_with_flags(
+        io,
+        "abandoned-mvcc-followup-write.db",
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    let rows = conn
+        .prepare("SELECT y FROM u")
+        .unwrap()
+        .run_collect_rows()
+        .unwrap()
+        .into_iter()
+        .map(|row| row[0].as_int().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(rows, vec![42]);
+
+    // The reopened database is still in WAL mode; re-running the switch to
+    // MVCC must complete cleanly and keep the earlier writes visible.
+    let mode = conn
+        .prepare("PRAGMA journal_mode")
+        .unwrap()
+        .run_collect_rows()
+        .unwrap()[0][0]
+        .to_string();
+    assert_eq!(mode, "wal");
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    let rows = conn
+        .prepare("SELECT y FROM u")
+        .unwrap()
+        .run_collect_rows()
+        .unwrap()
+        .into_iter()
+        .map(|row| row[0].as_int().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(rows, vec![42]);
+
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    conn.execute("ROLLBACK").unwrap();
+}

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -17320,7 +17320,13 @@ pub fn op_max_pgcnt(
     Ok(InsnFunctionStepResult::Step)
 }
 
-/// State machine for PRAGMA journal_mode changes
+/// State machine for PRAGMA journal_mode changes.
+///
+/// For a WAL→MVCC switch the durable page-1 header flip is the *last* step
+/// (`UpdateHeader`/`WritePage` run only after the MV store is installed and
+/// fully bootstrapped). Every earlier state is reversible in memory, so if the
+/// statement yields and is abandoned mid-switch the database simply stays in
+/// WAL mode (#7596).
 #[derive(Debug, Clone, Copy, Default)]
 pub enum OpJournalModeSubState {
     /// Initial state - read header to get current mode
@@ -17328,14 +17334,24 @@ pub enum OpJournalModeSubState {
     Start,
     /// Checkpointing WAL/MVCC before mode change
     Checkpoint,
+    /// (MVCC target only) Install the shared `MvStore` and demote the
+    /// connection while the on-disk header still says WAL.
+    InstallMvStore,
+    /// (MVCC target only) Write a fresh logical-log header before bootstrap,
+    /// so bootstrap (and any later recovery) always sees a valid logical log.
+    InitLogicalLog,
+    /// (MVCC target only) Sync the freshly written logical-log header.
+    SyncLogicalLog,
+    /// (MVCC target only) Bootstrap the MV store, still in WAL mode on disk.
+    BootstrapMvStore,
     /// Update the header with new version and get page reference
     UpdateHeader,
-    /// Write page 1 to disk
+    /// Write page 1 to disk. For an MVCC switch this is the point of no
+    /// return: everything else is already done, so once this write is
+    /// submitted the switch is complete.
     WritePage,
     /// Finalize - clear cache and setup new mode
     Finalize,
-    /// Bootstrap the MV store after switching to MVCC mode
-    BootstrapMvStore,
 }
 
 /// Holds the state for the journal mode change operation
@@ -17352,10 +17368,12 @@ pub struct OpJournalModeState {
     pub bootstrap_state: BootstrapState,
     /// Page reference for writing header
     pub page_ref: Option<PageRef>,
-    /// Abandonment guard for the WAL→MVCC switch. Armed in `Finalize` once the
-    /// store is installed and the connection demoted; disarmed only on
-    /// successful bootstrap. If the statement is reset/dropped while parked at a
-    /// bootstrap yield, dropping this guard restores in-memory state.
+    /// Abandonment guard for the WAL→MVCC switch. Armed in `InstallMvStore`,
+    /// before the shared store is installed and the connection demoted;
+    /// disarmed in `WritePage` once the durable page-1 header flip is
+    /// submitted. If the statement is reset/dropped (or errors) at any yield
+    /// in between, dropping this guard restores in-memory state and the
+    /// database simply stays in WAL mode.
     pub bootstrap_guard: Option<MvccBootstrapGuard>,
 }
 
@@ -17372,15 +17390,22 @@ impl OpJournalModeState {
     }
 }
 
-/// Restores in-memory MVCC state if a `PRAGMA journal_mode=mvcc` bootstrap is
-/// abandoned (statement reset/dropped) or errors after the connection has been
-/// demoted and the shared `MvStore` installed.
+/// Restores in-memory MVCC state if a `PRAGMA journal_mode=mvcc` switch is
+/// abandoned (statement reset/dropped) or errors before the durable page-1
+/// header flip is submitted.
 ///
-/// Without this, `ProgramState::reset()` would clear `active_op_state` while
-/// leaving `is_mvcc_bootstrap_connection` set forever (silently bypassing MVCC)
-/// and the DB-wide `mv_store` installed but un-bootstrapped (`global_header =
-/// None`), which other connections can trip an assertion on at commit. Mirrors
-/// `MvccVacuumGuard` in `vacuum.rs`.
+/// The switch installs the shared `MvStore`, demotes the connection, and
+/// bootstraps the store while the on-disk header still says WAL; the page-1
+/// version flip is the last step. Until that write is submitted every effect
+/// is reversible in memory, so abandoning the statement must re-promote the
+/// connection if it is still demoted (bootstrap promotes itself only at
+/// `Recover`) and uninstall the store: without this,
+/// `is_mvcc_bootstrap_connection` would stay set forever (silently bypassing
+/// MVCC) and other connections on the same `Database` could trip an assertion
+/// on an un-bootstrapped store (`global_header = None`) at commit. The
+/// database then just stays in WAL mode (#7596). Never performs I/O — once
+/// the header write is in flight the guard has already been disarmed.
+/// Mirrors `MvccVacuumGuard` in `vacuum.rs`.
 pub struct MvccBootstrapGuard {
     connection: Arc<Connection>,
     completed: bool,
@@ -17404,17 +17429,47 @@ impl Drop for MvccBootstrapGuard {
         if self.completed {
             return;
         }
-        // Bootstrap did not finish: re-promote the connection if it is still
-        // demoted (bootstrap promotes itself only at `Recover`) and uninstall
-        // the un-bootstrapped store so neither this connection nor others on
-        // the same `Database` observe a demoted-but-unbootstrapped MVCC store.
-        // The on-disk header already reads MVCC, so the database recovers on
-        // the next fresh open via the regular MVCC bootstrap path.
+        // The switch did not reach the page-1 header flip: undo the in-memory
+        // effects so the connection (and the shared `Database`) stay in plain
+        // WAL mode, matching the on-disk header.
         if self.connection.is_mvcc_bootstrap_connection() {
             self.connection.promote_to_regular_connection();
         }
         self.connection.db.mv_store.store(None);
     }
+}
+
+/// Next journal-mode sub-state after the pre-switch checkpoint: a WAL→MVCC
+/// switch installs and bootstraps the MV store first (keeping the on-disk
+/// header in WAL mode), every other transition goes straight to the header
+/// update.
+fn journal_mode_state_after_checkpoint(
+    new_mode: Option<journal_mode::JournalMode>,
+) -> OpJournalModeSubState {
+    if matches!(new_mode, Some(journal_mode::JournalMode::Mvcc)) {
+        OpJournalModeSubState::InstallMvStore
+    } else {
+        OpJournalModeSubState::UpdateHeader
+    }
+}
+
+/// Open (but do not install) the shared `MvStore` for a WAL→MVCC journal-mode
+/// switch on `connection`'s database.
+fn open_mv_store_for_journal_switch(
+    connection: &Arc<Connection>,
+    pager: &Pager,
+) -> Result<Arc<MvStore>> {
+    let db_path = connection.get_database_canonical_path();
+    let enc_ctx = pager.io_ctx.read().encryption_context().cloned();
+    journal_mode::open_mv_store(
+        pager.io.clone(),
+        &db_path,
+        connection.db.open_flags,
+        connection.db.durable_storage.clone(),
+        enc_ctx,
+        connection.db.mv_store_allocator.clone(),
+        connection.db.experimental_mvcc_passive_checkpoint_enabled(),
+    )
 }
 
 pub fn op_journal_mode(
@@ -17432,7 +17487,10 @@ pub fn op_journal_mode(
             Ok(result)
         }
         Err(err) => {
-            // Reset state on error
+            // Reset state on error. If a WAL→MVCC switch was in progress and
+            // had not yet submitted the page-1 header flip, this drops the
+            // armed `MvccBootstrapGuard`, which restores in-memory state so
+            // the database stays in WAL mode.
             state.active_op_state.clear();
             Err(err)
         }
@@ -17585,7 +17643,9 @@ fn op_journal_mode_inner(
                     return_if_io!(ckpt_sm.step(&()));
                     state.active_op_state.journal_mode().checkpoint_sm = None;
                     state.active_op_state.journal_mode().sub_state =
-                        OpJournalModeSubState::UpdateHeader;
+                        journal_mode_state_after_checkpoint(
+                            state.active_op_state.journal_mode().new_mode,
+                        );
                 } else {
                     // WAL checkpoint
                     let checkpoint_result = pager.checkpoint(
@@ -17597,8 +17657,29 @@ fn op_journal_mode_inner(
                     );
                     return_if_io!(checkpoint_result);
                     state.active_op_state.journal_mode().sub_state =
-                        OpJournalModeSubState::UpdateHeader;
+                        journal_mode_state_after_checkpoint(
+                            state.active_op_state.journal_mode().new_mode,
+                        );
                 }
+            }
+
+            OpJournalModeSubState::InstallMvStore => {
+                // WAL→MVCC: install the shared store and demote the connection
+                // while the on-disk header still says WAL. Everything from here
+                // until `WritePage` submits the page-1 flip is reversible in
+                // memory; the armed guard undoes it if the statement is
+                // abandoned, leaving the database in plain WAL mode (#7596).
+                let mv_store = open_mv_store_for_journal_switch(&program.connection, pager)?;
+                // Arm the abandonment guard *before* the store install +
+                // demote so a reset/drop at any subsequent yield restores
+                // in-memory state.
+                let guard = MvccBootstrapGuard::new(program.connection.clone());
+                program.connection.db.mv_store.store(Some(mv_store.clone()));
+                program.connection.demote_to_mvcc_connection();
+                state.active_op_state.journal_mode().bootstrap_guard = Some(guard);
+                state.active_op_state.journal_mode().bootstrap_state = BootstrapState::default();
+                state.active_op_state.journal_mode().sub_state =
+                    OpJournalModeSubState::InitLogicalLog;
             }
 
             OpJournalModeSubState::UpdateHeader => {
@@ -17632,6 +17713,37 @@ fn op_journal_mode_inner(
 
             OpJournalModeSubState::WritePage => {
                 // Write page 1 to disk to flush the header
+                let new_mode = state
+                    .active_op_state
+                    .journal_mode()
+                    .new_mode
+                    .expect("new_mode should be set");
+                if matches!(new_mode, journal_mode::JournalMode::Mvcc) {
+                    // The MV store is installed and fully bootstrapped, so the
+                    // page-1 write below is the final step of the switch.
+                    // Propagate the version flip to the store's cached header
+                    // (bootstrap captured it from the pager before the flip)
+                    // so MVCC header reads — e.g. a later `PRAGMA
+                    // journal_mode` query — report MVCC.
+                    let raw_version = RawVersion::from(
+                        new_mode
+                            .as_version()
+                            .expect("Should be a supported Journal Mode"),
+                    );
+                    let mv_store_guard = program.connection.db.get_mv_store();
+                    let mv_store = mv_store_guard.as_ref().ok_or_else(|| {
+                        LimboError::InternalError(
+                            "MVCC journal mode switch missing MV store".to_string(),
+                        )
+                    })?;
+                    mv_store.with_header_mut(
+                        |header| {
+                            header.read_version = raw_version;
+                            header.write_version = raw_version;
+                        },
+                        None,
+                    )?;
+                }
                 let page = state
                     .active_op_state
                     .journal_mode()
@@ -17639,6 +17751,19 @@ fn op_journal_mode_inner(
                     .as_ref()
                     .expect("page_ref should be set");
                 let completion = begin_write_btree_page(pager, page)?;
+                if matches!(new_mode, journal_mode::JournalMode::Mvcc) {
+                    // The page-1 flip is submitted: the switch is complete
+                    // (the IO layer finishes the write regardless of whether
+                    // the statement keeps being driven), so disarm the
+                    // abandonment guard.
+                    let guard = state
+                        .active_op_state
+                        .journal_mode()
+                        .bootstrap_guard
+                        .as_mut()
+                        .expect("WAL→MVCC abandonment guard must be armed by InstallMvStore");
+                    guard.complete();
+                }
                 state.active_op_state.journal_mode().sub_state = OpJournalModeSubState::Finalize;
                 return Ok(InsnFunctionStepResult::IO(IOCompletions(completion)));
             }
@@ -17650,39 +17775,13 @@ fn op_journal_mode_inner(
                     .new_mode
                     .expect("new_mode should be set");
 
-                // Clear page cache
+                // Clear page cache. For the WAL→MVCC switch this also drops
+                // the dirty page-1 copy left behind by the direct header
+                // write, so it cannot be re-flushed later.
                 pager.clear_page_cache(true);
 
-                // Setup new mode
-                if matches!(new_mode, journal_mode::JournalMode::Mvcc) {
-                    let db_path = program.connection.get_database_canonical_path();
-                    let enc_ctx = pager.io_ctx.read().encryption_context().cloned();
-                    let mv_store = journal_mode::open_mv_store(
-                        pager.io.clone(),
-                        &db_path,
-                        program.connection.db.open_flags,
-                        program.connection.db.durable_storage.clone(),
-                        enc_ctx,
-                        program.connection.db.mv_store_allocator.clone(),
-                        program
-                            .connection
-                            .db
-                            .experimental_mvcc_passive_checkpoint_enabled(),
-                    )?;
-                    // Arm the abandonment guard *before* the irreversible
-                    // store install + demote so a reset/drop at any subsequent
-                    // bootstrap yield restores in-memory state.
-                    let guard = MvccBootstrapGuard::new(program.connection.clone());
-                    program.connection.db.mv_store.store(Some(mv_store.clone()));
-                    program.connection.demote_to_mvcc_connection();
-                    state.active_op_state.journal_mode().bootstrap_guard = Some(guard);
-                    state.active_op_state.journal_mode().bootstrap_state =
-                        BootstrapState::default();
-                    state.active_op_state.journal_mode().sub_state =
-                        OpJournalModeSubState::BootstrapMvStore;
-                    continue;
-                }
-
+                // Setup new mode. For MVCC the store was already installed and
+                // bootstrapped before the header flip; nothing left to do.
                 if matches!(new_mode, journal_mode::JournalMode::Wal) {
                     program.connection.db.mv_store.store(None);
                 }
@@ -17693,6 +17792,57 @@ fn op_journal_mode_inner(
                 state.pc += 1;
 
                 return Ok(InsnFunctionStepResult::Step);
+            }
+
+            OpJournalModeSubState::InitLogicalLog => {
+                // Make the logical-log header durable *before* bootstrap runs,
+                // so bootstrap never observes WAL frames without a valid
+                // logical log. Any WAL frames committed by interleaved
+                // same-connection writes around the switch are then reconciled
+                // by bootstrap's interrupted-checkpoint recovery instead of
+                // tripping its fail-closed "WAL frames without logical log
+                // header" corruption check (#7596).
+                let completion = {
+                    let mv_store_guard = program.connection.db.get_mv_store();
+                    let Some(mv_store) = mv_store_guard.as_ref() else {
+                        return Err(LimboError::InternalError(
+                            "MVCC journal mode switch missing MV store".to_string(),
+                        ));
+                    };
+                    if mv_store.get_logical_log_file().size()?
+                        < crate::mvcc::persistent_storage::logical_log::LOG_HDR_SIZE as u64
+                    {
+                        Some(mv_store.reset_logical_log_after_external_restore()?)
+                    } else {
+                        // A complete header (or more) already exists on disk;
+                        // never clobber it, bootstrap validates it instead.
+                        None
+                    }
+                };
+                if let Some(completion) = completion {
+                    state.active_op_state.journal_mode().sub_state =
+                        OpJournalModeSubState::SyncLogicalLog;
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions(completion)));
+                }
+                state.active_op_state.journal_mode().sub_state =
+                    OpJournalModeSubState::BootstrapMvStore;
+            }
+
+            OpJournalModeSubState::SyncLogicalLog => {
+                let completion = {
+                    let mv_store_guard = program.connection.db.get_mv_store();
+                    let Some(mv_store) = mv_store_guard.as_ref() else {
+                        return Err(LimboError::InternalError(
+                            "MVCC journal mode switch missing MV store".to_string(),
+                        ));
+                    };
+                    mv_store.sync_logical_log_after_external_restore(&program.connection)?
+                };
+                state.active_op_state.journal_mode().sub_state =
+                    OpJournalModeSubState::BootstrapMvStore;
+                if let Some(completion) = completion {
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions(completion)));
+                }
             }
 
             OpJournalModeSubState::BootstrapMvStore => {
@@ -17707,22 +17857,12 @@ fn op_journal_mode_inner(
                     &mut state.active_op_state.journal_mode().bootstrap_state
                 ));
 
-                // Bootstrap finished: disarm the abandonment guard so it does
-                // not roll back the now-published MVCC store on drop.
-                if let Some(guard) = state
-                    .active_op_state
-                    .journal_mode()
-                    .bootstrap_guard
-                    .as_mut()
-                {
-                    guard.complete();
-                }
-
-                let ret: &'static str = journal_mode::JournalMode::Mvcc.into();
-                state.registers[*dest].set_text(Text::new(ret))?;
-                state.pc += 1;
-
-                return Ok(InsnFunctionStepResult::Step);
+                // Bootstrap finished, but the on-disk header still says WAL.
+                // Keep the abandonment guard armed and flip the header as the
+                // final step; a drop before `WritePage` submits the flip still
+                // unwinds cleanly back to WAL mode.
+                state.active_op_state.journal_mode().sub_state =
+                    OpJournalModeSubState::UpdateHeader;
             }
         }
     }


### PR DESCRIPTION
PRAGMA journal_mode=mvcc durably flipped page 1 to MVCC read/write
versions before the MVCC store was installed and bootstrapped. In the
yieldable window after the page-1 write, a same-connection write could
commit ordinary WAL frames (tripping bootstrap's fail-closed "WAL has
committed frames but logical log header is missing" check), and dropping
the statement left the durable header saying MVCC with no MVCC store
installed, so follow-up writes corrupted the database for reopen.

Reorder the switch so the database stays in WAL mode on disk until the
very last step:

- After the pre-switch checkpoint, install the shared MvStore, demote
  the connection, write and sync a fresh logical-log header, and drive
  the full bootstrap — all while page 1 still says WAL. WAL frames
  committed by interleaved writes around the switch are reconciled by
  bootstrap's interrupted-checkpoint recovery.

- Only then flip page 1 to the MVCC read/write versions. Submitting that
  write is the point of no return: the switch is already complete in
  memory, the flip is propagated to the MvStore's cached global header,
  and the IO layer finishes the write regardless of whether the
  statement keeps being driven.

- MvccBootstrapGuard is armed before the store install and disarmed at
  the header-write submission. Dropping (or erroring) the statement at
  any yield in between only restores in-memory state — no I/O from
  drop — and the database simply stays in WAL mode.

- Database::open now tolerates a header-only logical log next to a
  WAL-mode database (the benign leftover of an abandoned switch) while
  still failing closed if the log contains committed frames.

Tests: cargo test -p turso_core --features io_memory_yield --test
active_index_select_repro; full turso_core lib suite with
io_memory_yield; core_tester integration suite; sqltests.

Fixes #7596