### PR TITLE
bump fossier dependency to allow for vouch command

### DIFF
--- a/.github/workflows/fossier.yml
+++ b/.github/workflows/fossier.yml
@@ -26,7 +26,7 @@ jobs:
             echo "has_command=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: PThorpe92/fossier@55e7dd21039e405fbad7c43ac6f3bef42e308836
+      - uses: PThorpe92/fossier@d2ef6eacab5f50cb799703da21e50c860f2fc739
         if: github.event_name != 'issue_comment' || steps.check-cmd.outputs.has_command == 'true'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Our repo/org does not allow github actions to create or approve pull requests, so the `/fossier vouch` command fails silently.

this change at least leaves a comment with a link pointing at the branch to 'compare and pull request' if we chose not to enable this permission