### PR TITLE
core/function: resolve jsonb_replace to its jsonb variant

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -1719,7 +1719,7 @@ impl Func {
             #[cfg(feature = "json")]
             "jsonb_insert" => Ok(Some(Self::Json(JsonFunc::JsonbInsert))),
             #[cfg(feature = "json")]
-            "jsonb_replace" => Ok(Some(Self::Json(JsonFunc::JsonReplace))),
+            "jsonb_replace" => Ok(Some(Self::Json(JsonFunc::JsonbReplace))),
             #[cfg(feature = "json")]
             "json_pretty" => Ok(Some(Self::Json(JsonFunc::JsonPretty))),
             #[cfg(feature = "json")]

--- a/testing/sqltests/tests/json/default.sqltest
+++ b/testing/sqltests/tests/json/default.sqltest
@@ -2201,6 +2201,48 @@ expect {
     text
 }
 
+test jsonb_replace_basic {
+    SELECT json(jsonb_replace('{"a":1}', '$.a', 2))
+}
+expect {
+    {"a":2}
+}
+
+test jsonb_replace_multiple_paths {
+    SELECT json(jsonb_replace('{"a":1,"b":2}', '$.a', 9, '$.b', 8))
+}
+expect {
+    {"a":9,"b":8}
+}
+
+test jsonb_replace_missing_path_noop {
+    SELECT json(jsonb_replace('{"a":1}', '$.missing', 5))
+}
+expect {
+    {"a":1}
+}
+
+test jsonb_replace_root {
+    SELECT hex(jsonb_replace('{"a":1}', '$', 5))
+}
+expect {
+    1335
+}
+
+test jsonb_replace_returns_blob {
+    SELECT typeof(jsonb_replace('{"a":1}', '$.a', 2))
+}
+expect {
+    blob
+}
+
+test jsonb_replace_blob_bytes {
+    SELECT hex(jsonb_replace('{"a":1}', '$.a', 2))
+}
+expect {
+    4C17611332
+}
+
 # Tests for json_remove() function
 # Basic removal tests
 test json_remove_basic_1 {


### PR DESCRIPTION

## Description

`jsonb_replace()` returns text JSON instead of a JSONB blob. `typeof(jsonb_replace('{"a":1}','$.a',2))` gives `text` where SQLite gives `blob`. The content is correct, only the storage class is wrong, which is why it went unnoticed for so long.

The cause is in `Func::resolve_function`: the name `"jsonb_replace"` mapped to `JsonFunc::JsonReplace`, the text variant. A `JsonbReplace` variant, with its own VDBE execution path calling the blob implementation, existed all along but no name mapped to it. I found this while fixing jsonb_patch resolution in #7770 and noted it there as a pre-existing gap.

This changes the mapping to `JsonFunc::JsonbReplace` and adds regression tests: three for replace semantics, a root replacement case, and `typeof`/`hex` tests that pin the blob return type. The docs already describe jsonb_replace as returning a BLOB (docs/sql-reference/functions/json.mdx), so this makes the behavior match both SQLite and the repo's own documentation.

```sql
SELECT typeof(jsonb_replace('{"a":1}', '$.a', 2));
-- before: text
-- after:  blob  (same as SQLite)
```

This is a behavior change for anything relying on the old text return, but the old behavior contradicted SQLite and COMPAT.md, which marks jsonb_replace as supported.

SQLite reference: https://www.sqlite.org/json1.html sections 4.11 and 4.12 (json_replace and jsonb_replace share the insert/replace/set sections).

## Testing

The `typeof` and `hex` tests fail on main (text, and the hex of the text bytes) and pass with the change. The semantic tests pass on both, since the content was already correct. All six pass against a real SQLite 3.49.1 binary via the runner's cli backend (`--backend cli --binary .sqlite3/sqlite3`). The missing-path no-op and existing-key cases also distinguish jsonb_replace from jsonb_set and jsonb_insert, so a mis-mapping to any adjacent variant fails the suite.

I also compared output by hand against SQLite 3.49.1 on about 20 cases: multi-pair replaces, nested paths, array indexes including `$[#-1]` and out-of-bounds no-ops, root replacement, floats, NULL values, NULL input, unicode. Structural and numeric output is byte-identical to SQLite.

Three divergences remain that predate this change and show on already-callable functions too, so I left them out of scope:

- string values encode as JSONB type TEXT where SQLite uses TEXTRAW (one nibble; both are valid JSONB and render identically through `json()`; the shipped `jsonb_set`/`jsonb_insert` encode the same way today)
- a top-level JSON null result collapses to SQL NULL where SQLite returns a 1-byte JSONB null blob (noted in #7770, shared helper)
- even-argument calls like `jsonb_replace(x, '$.a')` no-op instead of erroring; #7758 covers this class, including the jsonb variants

Full sqltest suite, `cargo test -p turso_core`, `cargo fmt --check`, and clippy with `--deny=warnings` pass.

## Description of AI Usage

AI helped with the debugging and test drafts. I reviewed the diff and checked the results against real SQLite 3.49.1, including hex() of the jsonb output.
