### PR TITLE
core/storage: assert checkpoint backfill crash-atomicity (reveals a NORMAL-mode torn-recovery bug)

### DIFF
--- a/.aristo/canon-matches.toml
+++ b/.aristo/canon-matches.toml
@@ -1,11 +1,31 @@
 [__meta__]
 schema_version = 1
 canon_version = "v0.1.0"
-last_fetched = "2026-05-30T06:00:12.353Z"
+last_fetched = "2026-07-07T07:53:35.240089285Z"
 
 [aret_4mbjdhds]
 last_match_text_hash = "sha256:9d400437abc7d933b5a5f93bdc8bef54c9f0dbc03d029683fd41dbfe40b5bc16"
 canon_fetched_at = "2026-05-26T06:22:36.7271Z"
+
+["aristos:wal_checkpoint_backfill_crash_atomic"]
+last_match_text_hash = "sha256:964113cb0dc5eb70d66767acf6391b0a93398867ba7eabf81a7364058b6b8747"
+canon_fetched_at = "2026-07-07T07:54:27Z"
+
+[["aristos:wal_checkpoint_backfill_crash_atomic".accepted_matches]]
+canon_id = "wal_checkpoint_backfill_crash_atomic"
+version = "v0.1.0"
+canonical_text = "Checkpoint backfill copies a log frame into the main database file only after that frame is durable in the log, so a crash can never recover a database torn between persisted backfill pages and dropped log frames"
+canon_version = "v0.1.0"
+confidence = 0.9763275354539468
+prefix_tier = "aristos:"
+backed_by = "model-derived crash-consistency differential test"
+linked = "arta_e93bbba0b482550ba1a513e42a0c7c42"
+accepted_at = "2026-07-07T07:54:27Z"
+bound_at = "2026-07-07T07:54:27Z"
+
+["aristos:wal_checkpoint_backfill_crash_atomic".accepted_matches.verification]
+coverage_level = "partial"
+test_binaries = []
 
 ["aristos:wal_checkpoint_error_no_db_leak"]
 last_match_text_hash = "sha256:99cf0a4664b81492fcaf3eaace7c7ab17a51261a6c340c7cad8faae4be7d45cc"
@@ -113,6 +133,14 @@ backed_by = "golden model + proofs + differential testing"
 linked = "arta_013316bc46e9af51cf52612fe2533e90"
 accepted_at = "2026-05-30T05:43:56Z"
 bound_at = "2026-05-30T05:43:56Z"
+
+[savepoint_rollback_shape_and_bytes_consistent]
+last_match_text_hash = "sha256:9eb52c41e3fcf89d2515efa52befc82509297ce3c657585352714afe61147e87"
+canon_fetched_at = "2026-07-07T07:53:35.241472796Z"
+
+[wal_checkpoint_backfill_crash_atomic]
+last_match_text_hash = "sha256:964113cb0dc5eb70d66767acf6391b0a93398867ba7eabf81a7364058b6b8747"
+canon_fetched_at = "2026-07-07T07:53:35.241472796Z"
 
 [wal_checkpoint_error_no_db_leak]
 last_match_text_hash = "sha256:99cf0a4664b81492fcaf3eaace7c7ab17a51261a6c340c7cad8faae4be7d45cc"

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4562,6 +4562,7 @@ impl WalFile {
         Ok(())
     }
 
+    #[aristo::intent("Checkpoint backfill copies a log frame into the main database file only after that frame is durable in the log, so a crash can never recover a database torn between persisted backfill pages and dropped log frames", id = "aristos:wal_checkpoint_backfill_crash_atomic", verify = "full", parent = "wal_protocol_correctness")]
     fn checkpoint_inner(
         &self,
         pager: &Pager,


### PR DESCRIPTION
## What this adds

An `#[aristo::intent]` on `WalFile::checkpoint_inner` asserting the WAL ordering a checkpoint owes:

> Checkpoint backfill copies a log frame into the main database file only after that frame is durable in the log, so a crash can never recover a database torn between persisted backfill pages and dropped log frames.

This is the correctly-scoped successor to the no-DB-leak intent removed in #7725: crash-**consistency** (recovery to a committed prefix), not durability of the last transaction.

## The bug it reveals

`checkpoint_inner`'s `Start` state carries this comment (`core/storage/wal.rs`):

```rust
// Acquire the relevant exclusive locks and checkpoint_lock
// so no other checkpointer can run. fsync WAL if there are unapplied frames.
```

…but the runtime path performs **no such WAL fsync**. Under `PRAGMA synchronous=NORMAL` the commit also skips the WAL fsync, so the committed frames being backfilled are **not durable in the log**. A power-loss crash mid-backfill persists some `.db` pages while WAL recovery drops the unsynced tail — leaving the database **torn between persisted backfill pages and lost log frames**, matching no committed prefix (neither the pre-checkpoint state nor the fully-applied transaction). `PRAGMA integrity_check` does not detect the cross-page inconsistency, so the corruption is **silent**.

This is not a "don't use NORMAL" footgun. In WAL mode, `synchronous=NORMAL` is a supported, crash-**safe** setting — it trades away last-transaction *durability*, never *consistency*. SQLite's `walCheckpoint` fsyncs the WAL up to the backfill target before copying frames into the DB file, so SQLite under NORMAL does not tear; turso lacks that checkpoint-time fsync. FULL masks it (the commit-time fsync already made the frames durable); NORMAL exposes it.

## Discriminant

The identical workload + crash under `synchronous=FULL` heals the same `.db` split — the sole difference is the missing checkpoint-time WAL fsync. So the root cause is checkpoint-time (sync-mode-independent), and the fix is to issue the fsync the comment already promises, before the first backfill write.

## Evidence

A crash-consistency differential test on the `dm-log-writes` substrate: commit one cross-page-invariant transaction under NORMAL, run a PASSIVE checkpoint that backfills its committed frames, simulate power-loss at swept split points, then rebuild + recover + read with a fresh process. Oracle: the recovered read must equal some committed prefix; a per-row mix is a torn recovery. Controls: a drop positive-control (substrate faithfulness) and the FULL/NORMAL differential above. Demonstrated on `d9609538e`; the `checkpoint_inner` Start-state path on current `main` is materially identical (comment present, no sync call), so the finding carries forward.

## Suggested fix

Issue the WAL fsync up to the checkpoint's `max_frame` (the safe backfill target) before the first backfill write in the `Start` state, matching SQLite's `walCheckpoint` ordering. Recovery to a committed prefix then holds under all sync modes.

## AI Usage

Authored by Sushant and Aristo + Claude Code


Found by Aristo.
