### PR TITLE
fix: prevent cache insertion panics by upserting pages during concurr…

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3294,6 +3294,15 @@ impl Pager {
         {
             let mut page_cache = self.page_cache.write();
             let page_key = PageCacheKey::new(page_idx);
+            // A concurrent fiber may have inserted a page for this key after
+            // the caller checked the cache but before we acquired the write
+            // lock (e.g. after a spill-yield re-entry via `pending_reads`).
+            // Upsert our caller-owned PageRef so the cache and the caller
+            // share the same canonical Arc rather than duplicating keys.
+            if page_cache.peek(&page_key, false).is_some() {
+                page_cache.upsert_page(page_key, page)?;
+                return Ok(IOResult::Done(()));
+            }
             match page_cache.insert(page_key, page.clone()) {
                 Ok(_) => return Ok(IOResult::Done(())),
                 Err(CacheError::KeyExists) => {
@@ -3310,10 +3319,16 @@ impl Pager {
             IOResult::Done(true) => {
                 let mut page_cache = self.page_cache.write();
                 let page_key = PageCacheKey::new(page_idx);
-                match page_cache.insert(page_key, page) {
-                    Ok(_) => Ok(IOResult::Done(())),
-                    Err(CacheError::KeyExists) => Ok(IOResult::Done(())),
-                    Err(e) => Err(e.into()),
+                // After spilling, check whether a concurrent fiber inserted a
+                // page for this key while we were yielding.  Upsert our
+                // caller-owned PageRef so the cache stays canonical and the
+                // caller's modifications are not silently lost.
+                if page_cache.peek(&page_key, false).is_some() {
+                    page_cache.upsert_page(page_key, page)?;
+                    Ok(IOResult::Done(()))
+                } else {
+                    page_cache.insert(page_key, page)?;
+                    Ok(IOResult::Done(()))
                 }
             }
             IOResult::Done(false) => Err(LimboError::Busy),
@@ -6289,6 +6304,73 @@ mod ptrmap_tests {
             }
             IOResult::IO(_) => panic!("loaded cache hit must not yield"),
         }
+    }
+
+    /// A concurrent fiber may insert a page for key X into the cache after
+    /// the first fiber's `read_page` has created its own PageRef (stored in
+    /// `pending_reads`) but before `cache_insert` acquires the page-cache
+    /// write lock.  `cache_insert` must upsert rather than panic on the
+    /// different-Arc assertion in `_insert`, so that the cache stays
+    /// canonical and the caller's modifications are not silently lost.
+    #[test]
+    fn cache_insert_handles_concurrently_inserted_key() {
+        let target: i64 = 9999;
+        let pager = test_pager_setup(4096, 10);
+
+        // Simulate the state after `read_page_no_cache` + `pending_reads`
+        // insertion but before `cache_insert` acquired the cache lock.
+        let our_page = Arc::new(Page::new(target));
+        our_page.set_loaded();
+
+        // Concurrent fiber inserted a *different* PageRef for the same key.
+        let concurrent_page = Arc::new(Page::new(target));
+        concurrent_page.set_loaded();
+        pager
+            .page_cache
+            .write()
+            .insert(PageCacheKey::new(target as usize), concurrent_page)
+            .unwrap();
+
+        // Pre-populate pending_reads so read_page uses the re-entry path
+        // which calls `cache_insert` directly (with no cache check).
+        let stub_completion = Completion::new_yield();
+        pager.pending_reads.write().insert(
+            target,
+            PendingRead {
+                page: our_page.clone(),
+                disk_read: Some(stub_completion),
+            },
+        );
+
+        // This would previously panic at the `Arc::ptr_eq` assertion in
+        // `_insert` because the cache already has a different PageRef for
+        // the same key.  Now `cache_insert` must upsert gracefully.
+        let res = pager.read_page(target).unwrap();
+        let (page, c) = match res {
+            IOResult::Done(v) => v,
+            IOResult::IO(_) => panic!("should not yield"),
+        };
+
+        // The cache should now hold *our* PageRef (the upsert replaced it).
+        assert!(
+            Arc::ptr_eq(&page, &our_page),
+            "cache_insert must return the caller's PageRef"
+        );
+        assert!(
+            c.is_some(),
+            "should return the disk-read completion from pending_reads"
+        );
+        assert!(
+            pager.pending_reads.read().get(&target).is_none(),
+            "pending_reads entry must be cleared once read_page returns Done"
+        );
+
+        // Verify the cache indeed has our page.
+        let cached = pager.cache_get(target as usize).unwrap().unwrap();
+        assert!(
+            Arc::ptr_eq(&cached, &our_page),
+            "cache must hold the caller's PageRef after upsert"
+        );
     }
 }
 


### PR DESCRIPTION
Description ￼

Fix a page cache assertion panic in ‎`page_cache.rs:261` that can occur when two concurrent fibers both read the same database page and their distinct ‎`Arc<Page>` instances collide in the cache. This addresses #7776.

The root cause is in ‎`cache_insert` in ‎`pager.rs`, which calls ‎`page_cache.insert()` and asserts ‎`Arc::ptr_eq` between the existing and new page. This assertion becomes reachable after a spill yield:

- Fiber A creates ‎`page_a` for key ‎`X`, stores it in ‎`pending_reads`, and yields during spill.

- Fiber B reads the same page, creates ‎`page_b` (a different ‎`Arc`), and inserts it into the cache.

- When fiber A resumes, ‎`cache_insert` finds key ‎`X` already occupied by ‎`page_b` and hits the assertion.

The existing ‎`Err(CacheError::KeyExists) => Ok(())` handler on the retry path was effectively unreachable because ‎`_insert` panics via the ‎`Arc::ptr_eq` assertion before returning ‎`KeyExists`.

This change makes ‎`cache_insert` resilient to that race by:

- Checking ‎`peek()` for key existence before both the initial insert and the spill-retry insert.

- If a page is already present, using ‎`upsert_page` to replace the cache entry with the caller-owned ‎`PageRef`, so the cache and the caller share the same canonical ‎`Arc` for that key.

- Adding a regression test (‎`cache_insert_handles_concurrently_inserted_key`) that simulates the ‎`pending_reads` + concurrent insert scenario and asserts that ‎`read_page` returns the caller’s ‎`PageRef`, clears ‎`pending_reads`, and does not panic.

Motivation and context ￼

This fixes the assertion:

Attempted to insert different page with same key

at ‎`page_cache.rs:261`, which has been observed as a rare but repeatable panic (roughly 1 in 20k runs) under concurrent read workloads, as reported in #7776.

By upserting instead of asserting on ‎`Arc::ptr_eq`, we ensure that:

- The cache remains canonical for each page key (only one ‎`Arc<Page>` is used).

- The caller’s modifications are not silently discarded when a concurrent fiber has already populated the cache.

- ‎`read_page` no longer panics in this race, and the behavior is covered by a dedicated test.