### PR TITLE
core/mvcc: reset index shadow finger when index keys are created mid-scan

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -517,6 +517,16 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator 
     dual_peek: DualCursorPeek<A>,
     /// Forward-scan finger over `index_rows`; see [`IndexShadowFinger`].
     index_finger: IndexShadowFinger<A>,
+    /// [`MvStore::index_rows_epoch`] snapshot taken the last time
+    /// `index_finger` was consulted. New index keys can be created at or
+    /// behind an already-positioned finger while the scan's cursor is open
+    /// (e.g. a DELETE on the same connection inserts a tombstone key
+    /// mid-scan, #7578); versions appended to *existing* keys are fine
+    /// (chains are read live through their `Arc`), but a new key would be
+    /// silently skipped. On an epoch mismatch the finger is reset so it
+    /// reseeds at the current B-tree key instead of trusting its stale
+    /// position.
+    index_finger_epoch: u64,
 }
 
 pub enum NextRowidResult {
@@ -568,6 +578,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             btree_advance_state: None,
             dual_peek: DualCursorPeek::default(),
             index_finger: IndexShadowFinger::default(),
+            index_finger_epoch: 0,
         })
     }
 
@@ -577,6 +588,14 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         let RowKey::Record(rec) = key else {
             return self.query_btree_version_is_valid(key);
         };
+        // Read the epoch before the finger (re)seeds: if a key insert races
+        // past this load, the next shadow check observes the mismatch and
+        // resets. See `index_finger_epoch`.
+        let epoch = self.db.index_rows_epoch();
+        if self.index_finger_epoch != epoch {
+            self.index_finger.reset();
+            self.index_finger_epoch = epoch;
+        }
         let valid = self
             .index_finger
             .btree_row_is_valid(&self.db, self.table_id, self.tx_id, rec);

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3792,6 +3792,13 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// because operations like last() on an index are much easier when we don't have to take the
     /// table identifier into account.
     pub index_rows: SkipMap<MVTableId, IndexRowsMap<A>, BasicComparator, A>,
+    /// Bumped whenever the key set of `index_rows` may change (every
+    /// [`Self::insert_index_version`], which is the single funnel through which
+    /// new index keys are created). Forward-scan cursors snapshot this next to
+    /// their [`crate::mvcc::cursor::IndexShadowFinger`] and reset the finger on
+    /// a mismatch, since a key inserted at or behind an already-positioned
+    /// finger would otherwise be skipped (#7578).
+    index_rows_epoch: AtomicU64,
     txs: SkipMap<TxID, Transaction<A>, BasicComparator, A>,
     /// Final state for removed transactions. Readers may still race with stale TxID
     /// references in row versions after a transaction is removed from `txs`.
@@ -3984,6 +3991,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             rows: SkipMap::new_in(alloc.clone()),
             table_id_to_rootpage,
             index_rows: SkipMap::new_in(alloc.clone()),
+            index_rows_epoch: AtomicU64::new(0),
             txs: SkipMap::new_in(alloc.clone()),
             finalized_tx_states: SkipMap::new_in(alloc.clone()),
             alloc,
@@ -6959,6 +6967,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         key: Arc<SortableIndexKey>,
         mut row_version: RowVersion,
     ) -> Result<(Arc<SortableIndexKey>, RowVersions<A>)> {
+        // Publish the key-set mutation *before* the key becomes visible in the
+        // map: a concurrent shadow finger that races with this insert may then
+        // reset spuriously, but can never miss the new key (#7578).
+        self.index_rows_epoch.fetch_add(1, Ordering::SeqCst);
         let index = self.get_or_create_index_rows(index_id)?;
         let index = index.value();
         let entry = self.get_or_create_index_key_entry(index, key)?;
@@ -6970,6 +6982,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         let row_versions = entry.value().clone();
         self.insert_version_raw(&mut row_versions.write(), row_version)?;
         Ok((canonical_key, row_versions))
+    }
+
+    /// Current epoch of `index_rows` key-set mutations; see the field docs.
+    pub(crate) fn index_rows_epoch(&self) -> u64 {
+        self.index_rows_epoch.load(Ordering::SeqCst)
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::IndexRowsEntry)]

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1385,3 +1385,59 @@ fn test_mvcc_update_btree_only_row_after_truncate_checkpoint(
 
     Ok(())
 }
+
+/// Regression test for https://github.com/tursodatabase/turso/issues/7578
+///
+/// An active MVCC index scan must not return a row deleted after the scan
+/// cursor was opened. Pre-fix, the scan panicked with
+/// `index finger diverged from query_btree_version_is_valid` in
+/// core/mvcc/cursor.rs (or, without the assertion, returned the deleted row).
+#[turso_macros::test]
+fn test_mvcc_index_scan_does_not_return_row_deleted_mid_scan(
+    db: TempDatabase,
+) -> anyhow::Result<()> {
+    fn next_pair(stmt: &mut turso_core::Statement) -> anyhow::Result<Option<(i64, i64)>> {
+        loop {
+            match stmt.step()? {
+                StepResult::Row => {
+                    let row = stmt.row().unwrap();
+                    return Ok(Some((row.get::<i64>(0)?, row.get::<i64>(1)?)));
+                }
+                StepResult::Done => return Ok(None),
+                StepResult::IO => {
+                    stmt._io().step()?;
+                }
+                StepResult::Yield => {}
+                other => anyhow::bail!("unexpected step result: {other:?}"),
+            }
+        }
+    }
+
+    let conn = db.connect_limbo();
+    conn.pragma_update("journal_mode", "'mvcc'")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x)")?;
+    conn.execute("CREATE INDEX t_x ON t(x)")?;
+
+    conn.execute("INSERT INTO t VALUES (1,1),(2,3),(3,4),(4,5)")?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+    // Creates an MVCC-only index entry (x=2,id=2) shadowing the durable
+    // old index entry (x=3,id=2).
+    conn.execute("UPDATE t SET x=2 WHERE id=2")?;
+
+    let mut scan = conn.prepare("SELECT id,x FROM t INDEXED BY t_x WHERE x>=1 ORDER BY x")?;
+
+    assert_eq!(next_pair(&mut scan)?, Some((1, 1)));
+    assert_eq!(next_pair(&mut scan)?, Some((2, 2)));
+
+    // Delete a later durable index key while the original index cursor is still open.
+    conn.execute("DELETE FROM t WHERE id=4")?;
+
+    let mut rest = Vec::new();
+    while let Some(row) = next_pair(&mut scan)? {
+        rest.push(row);
+    }
+
+    assert_eq!(rest, vec![(3, 4)]);
+    Ok(())
+}


### PR DESCRIPTION
The forward-scan IndexShadowFinger assumes the key set of `index_rows`
is stable while it is positioned: it advances monotonically past keys
and, once exhausted, treats every remaining B-tree row as visible.
That assumption breaks when a write creates a new index key at or
behind the finger while the scan's cursor is still open — e.g. a
DELETE on the same connection materializes a tombstone key mid-scan.
The finger then skipped the tombstone and reported the deleted B-tree
row as visible, diverging from query_btree_version_is_valid (panicking
on the debug assert; returning the deleted row in release builds).
Versions appended to existing chains were never affected, since the
finger reads chains live through their Arc — only new keys were.

Fix by versioning the key set: MvStore keeps an index_rows_epoch
counter bumped in insert_index_version, the single funnel through
which new index keys are created (deletes never create keys — they
only set `end` on versions in existing chains, and B-tree-only rows
are first materialized through the insert funnel). The bump happens
before the key becomes visible in the map, so a racing scan can at
worst reset spuriously but can never miss a key. MvccLazyCursor
snapshots the epoch next to its finger and, on any mismatch, resets
the finger so it reseeds at the current B-tree key — restoring the
exact semantics of the authoritative per-row lookup while keeping the
amortized-O(1) fast path for scans that do not interleave with index
writes. The finger itself is unchanged.

Tests: cargo test -p core_tester --test integration_tests
test_mvcc_index_scan_does_not_return_row_deleted_mid_scan (real-query
repro; fails with the epoch reset neutralized), full turso_core MVCC
and core_tester MVCC integration suites

Fixes #7578