### PR TITLE
core/mvcc: reject exclusive upgrade past committed-but-unpublished writers

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -6316,7 +6316,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         // txn gets exclusive txn status. check below after the CAS
         if let Some(tx) = self.txs.get(tx_id) {
             let tx = tx.value();
-            if tx.begin_ts < self.last_committed_tx_ts.load(Ordering::Acquire) {
+            if self.has_committed_write_tx_newer_than(*tx_id, tx.begin_ts)
+                || tx.begin_ts < self.last_committed_tx_ts.load(Ordering::Acquire)
+            {
                 // Another transaction committed after this transaction's begin timestamp, do not allow exclusive lock.
                 // This mimics regular (non-CONCURRENT) sqlite transaction behavior.
                 return Err(LimboError::Busy);
@@ -6367,7 +6369,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 // `CommitState::Initial`.
                 if let Some(tx) = self.txs.get(tx_id) {
                     let tx = tx.value();
-                    if tx.begin_ts < self.last_committed_tx_ts.load(Ordering::Acquire) {
+                    if self.has_committed_write_tx_newer_than(*tx_id, tx.begin_ts)
+                        || tx.begin_ts < self.last_committed_tx_ts.load(Ordering::Acquire)
+                    {
                         self.release_exclusive_tx(tx_id);
                         return Err(LimboError::Busy);
                     }
@@ -6379,6 +6383,25 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 Err(LimboError::Busy)
             }
         }
+    }
+
+    /// Returns true if another write transaction has committed with an end
+    /// timestamp newer than `begin_ts` but has not yet published
+    /// `last_committed_tx_ts`, making it invisible to both the Preparing check
+    /// and the watermark check (#7481). Callers must run this scan before
+    /// loading the watermark: FinalizeCommit publishes the watermark before
+    /// removing the transaction from `txs`, so a committed writer missing from
+    /// the scan is caught by the subsequent watermark load. Read-only
+    /// transactions are excluded because they never publish the watermark.
+    fn has_committed_write_tx_newer_than(&self, tx_id: TxID, begin_ts: u64) -> bool {
+        self.txs.iter().any(|entry| {
+            if *entry.key() == tx_id {
+                return false;
+            }
+            let tx = entry.value();
+            matches!(tx.state.load(), TransactionState::Committed(end_ts) if end_ts > begin_ts)
+                && (tx.header_dirty.load(Ordering::Acquire) || !tx.write_set.lock().is_empty())
+        })
     }
 
     /// Release the exclusive transaction lock if held by the this transaction.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -16842,6 +16842,91 @@ fn test_global_header_regression_would_lose_committed_user_version() {
     );
 }
 
+/// Regression: `CREATE INDEX` in a transaction that began before a writer
+/// committed must not succeed while the writer's commit is paused between
+/// being marked Committed and publishing the committed watermark /
+/// global_header. If it does, the index is built without the committed row
+/// and index scans silently miss it.
+#[test]
+fn test_create_index_exclusive_acquire_rechecks_committed_tx_before_watermark_publish() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER)")
+        .unwrap();
+    setup.execute("INSERT INTO t VALUES (1, 100)").unwrap();
+    setup.close().unwrap();
+
+    let writer = db.connect();
+    writer.execute("BEGIN CONCURRENT").unwrap();
+    writer.execute("INSERT INTO t VALUES (2, 200)").unwrap();
+
+    let ddl = db.connect();
+    ddl.execute("BEGIN DEFERRED").unwrap();
+    let mut read = ddl.prepare("SELECT COUNT(*) FROM t").unwrap();
+    read.run_ignore_rows().unwrap();
+    drop(read);
+
+    // Pause the writer's commit after it has been marked Committed but
+    // before it publishes the committed watermark / global_header.
+    writer.set_yield_injector(Some(FixedYieldInjector::new([
+        CommitYieldPoint::BeforeGlobalHeaderUpdate.point(),
+    ])));
+
+    let mut writer_commit = writer.prepare("COMMIT").unwrap();
+    let mut yielded = false;
+    for _ in 0..200 {
+        match writer_commit.step().unwrap() {
+            StepResult::Yield => {
+                yielded = true;
+                break;
+            }
+            StepResult::Done => break,
+            _ => {}
+        }
+    }
+    assert!(
+        yielded,
+        "writer COMMIT should yield before publishing global_header"
+    );
+
+    // The DDL transaction is older than the already-committed writer, so it
+    // must not be allowed to build the index from its stale snapshot.
+    let result = ddl.execute("CREATE INDEX idx_v ON t(v)");
+    assert!(
+        matches!(result, Err(crate::LimboError::Busy)),
+        "DDL transaction older than an already-committed writer should return Busy, got {result:?}"
+    );
+
+    // Let the writer finish publishing and clean up.
+    writer.set_yield_injector(None);
+    writer_commit.run_ignore_rows().unwrap();
+    drop(writer_commit);
+    if ddl.get_mv_tx_id().is_some() {
+        ddl.execute("ROLLBACK").unwrap();
+    }
+
+    // A fresh connection can build the index, and it must see the committed
+    // row through the index.
+    let observer = db.connect();
+    observer.execute("CREATE INDEX idx_v ON t(v)").unwrap();
+
+    let integrity = get_rows(&observer, "PRAGMA integrity_check");
+    assert_eq!(integrity.len(), 1);
+    assert_eq!(integrity[0][0].to_string(), "ok");
+
+    let rows = get_rows(
+        &observer,
+        "SELECT id, v FROM t INDEXED BY idx_v WHERE v = 200",
+    );
+    assert_eq!(
+        rows.len(),
+        1,
+        "index scan must find the committed row (2, 200)"
+    );
+}
+
 #[test]
 fn test_create_index_exclusive_acquire_rechecks_timestamp_after_cas() {
     let db = MvccTestDbNoConn::new_with_random_db();


### PR DESCRIPTION
CommitEnd marks a writer Committed(end_ts) but last_committed_tx_ts is
only published later in FinalizeCommit. In that window the writer is
invisible to both guards in acquire_exclusive_tx: it is no longer
Preparing, and the watermark still predates its commit. An older
transaction (BEGIN DEFERRED + CREATE INDEX) could therefore take the
exclusive slot and build the index from its stale snapshot, silently
missing the already-committed row on subsequent index scans.

Add has_committed_write_tx_newer_than, which scans txs for other
transactions in Committed(end_ts) state with end_ts newer than the
candidate's begin_ts, and apply it at both check sites in
acquire_exclusive_tx (the optimistic pre-CAS check and the definitive
post-CAS recheck). The scan must run BEFORE the watermark load:
FinalizeCommit bumps last_committed_tx_ts before finish_committed_tx
removes the tx from txs, so a committed writer absent from the scan has
necessarily already published the watermark and is caught by the
subsequent load. The reverse order leaves a gap where the writer bumps
the watermark and leaves txs between the two checks. Writers cannot
newly enter Preparing after the post-CAS point because the exclusive
slot is held and CommitState::Initial aborts them, so the post-CAS
guard has no remaining window. Read-only transactions (empty write set,
clean header) are excluded to match the read-only commit fast path that
deliberately skips the watermark update to avoid spurious Busy errors.

Tests: cargo test -p turso_core --lib test_create_index_exclusive_acquire_rechecks_committed_tx_before_watermark_publish; full turso_core MVCC lib suite passes

Fixes #7481