### PR TITLE
core/storage: capture savepoint WAL position during write_tx upgrade after acquiring write lock

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1226,13 +1226,22 @@ pub enum SavepointResult {
     NotFound,
 }
 
+/// A connection's WAL position (max frame, running frame checksum, and the
+/// WAL generation they belong to), captured as one unit for savepoint
+/// rollback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SavepointWalPos {
+    max_frame: u64,
+    checksum: (u32, u32),
+    checkpoint_seq: u32,
+}
+
 #[derive(Debug, Clone)]
 struct SavepointSnapshot {
     kind: SavepointKind,
     start_offset: u64,
     db_size: u32,
-    wal_max_frame: u64,
-    wal_checksum: (u32, u32),
+    wal_pos: Option<SavepointWalPos>,
     deferred_fk_violations: isize,
 }
 
@@ -1248,11 +1257,12 @@ struct Savepoint {
     /// If the database grows during the savepoint and a rollback to the savepoint is performed,
     /// the pages exceeding the database size at the start of the savepoint will be ignored.
     db_size: AtomicU32,
-    /// We might want to rollback.
-    /// WAL max frame at the start of the savepoint.
-    wal_max_frame: AtomicU64,
-    /// WAL checksum at the start of the savepoint.
-    wal_checksum: RwLock<(u32, u32)>,
+    /// WAL position to rewind to on `ROLLBACK TO`. Captured only under the
+    /// write lock: eagerly if the savepoint is opened inside a write
+    /// transaction, otherwise at write upgrade. `None` while the
+    /// transaction has never held the write lock (no frames to rewind), or
+    /// when the pager has no WAL.
+    wal_pos: RwLock<Option<SavepointWalPos>>,
     /// Deferred FK counter value at the start of this savepoint.
     deferred_fk_violations: AtomicIsize,
 }
@@ -1262,8 +1272,7 @@ impl Savepoint {
         kind: SavepointKind,
         subjournal_offset: u64,
         db_size: u32,
-        wal_max_frame: u64,
-        wal_checksum: (u32, u32),
+        wal_pos: Option<SavepointWalPos>,
         deferred_fk_violations: isize,
     ) -> Self {
         Self {
@@ -1272,8 +1281,7 @@ impl Savepoint {
             write_offset: AtomicU64::new(subjournal_offset),
             page_bitmap: RwLock::new(RoaringBitmap::new()),
             db_size: AtomicU32::new(db_size),
-            wal_max_frame: AtomicU64::new(wal_max_frame),
-            wal_checksum: RwLock::new(wal_checksum),
+            wal_pos: RwLock::new(wal_pos),
             deferred_fk_violations: AtomicIsize::new(deferred_fk_violations),
         }
     }
@@ -1303,8 +1311,7 @@ impl Savepoint {
             kind: self.kind.clone(),
             start_offset: self.start_offset(),
             db_size: self.db_size.load(Ordering::Acquire),
-            wal_max_frame: self.wal_max_frame.load(Ordering::Acquire),
-            wal_checksum: *self.wal_checksum.read(),
+            wal_pos: *self.wal_pos.read(),
             deferred_fk_violations: self.deferred_fk_violations.load(Ordering::Acquire),
         }
     }
@@ -1316,8 +1323,7 @@ impl Savepoint {
             write_offset: AtomicU64::new(snapshot.start_offset),
             page_bitmap: RwLock::new(RoaringBitmap::new()),
             db_size: AtomicU32::new(snapshot.db_size),
-            wal_max_frame: AtomicU64::new(snapshot.wal_max_frame),
-            wal_checksum: RwLock::new(snapshot.wal_checksum),
+            wal_pos: RwLock::new(snapshot.wal_pos),
             deferred_fk_violations: AtomicIsize::new(snapshot.deferred_fk_violations),
         }
     }
@@ -2158,17 +2164,20 @@ impl Pager {
             .last()
             .map(|savepoint| savepoint.write_offset())
             .unwrap_or(0);
-        let (wal_max_frame, wal_checksum) = if let Some(wal) = &self.wal {
-            (wal.get_max_frame(), wal.get_last_checksum())
-        } else {
-            (0, (0, 0))
-        };
+        let wal_pos = self
+            .wal
+            .as_ref()
+            .filter(|wal| wal.holds_write_lock())
+            .map(|wal| SavepointWalPos {
+                max_frame: wal.get_max_frame(),
+                checksum: wal.get_last_checksum(),
+                checkpoint_seq: wal.get_checkpoint_seq(),
+            });
         let savepoint = Savepoint::new(
             kind,
             subjournal_offset,
             db_size,
-            wal_max_frame,
-            wal_checksum,
+            wal_pos,
             deferred_fk_violations,
         );
         self.savepoints.write().push(savepoint);
@@ -2267,14 +2276,17 @@ impl Pager {
             cache.truncate(db_size as usize)?;
         }
 
-        if let Some(wal) = &self.wal {
+        // No WAL position: the transaction never upgraded to a write
+        // transaction, so there are no frames to rewind.
+        if let (Some(wal), Some(wal_pos)) = (&self.wal, savepoint.wal_pos) {
             wal.rollback(Some(RollbackTo {
-                frame: savepoint.wal_max_frame,
-                checksum: savepoint.wal_checksum,
+                frame: wal_pos.max_frame,
+                checksum: wal_pos.checksum,
+                checkpoint_seq: wal_pos.checkpoint_seq,
             }));
             self.page_cache
                 .write()
-                .delete_clean_pages_after_wal_frame(savepoint.wal_max_frame)
+                .delete_clean_pages_after_wal_frame(wal_pos.max_frame)
                 .map_err(|e| {
                     LimboError::InternalError(format!(
                         "failed to invalidate rolled-back WAL pages: {e:?}"
@@ -2936,7 +2948,32 @@ impl Pager {
         let Some(wal) = self.wal.as_ref() else {
             return Ok(IOResult::Done(()));
         };
-        Ok(IOResult::Done(wal.begin_write_tx(allowed_auto_actions)?))
+        wal.begin_write_tx(allowed_auto_actions)?;
+        // Must run after the upgrade (and any log restart it performed) so
+        // the positions belong to the current WAL generation.
+        self.materialize_savepoint_wal_positions();
+        Ok(IOResult::Done(()))
+    }
+
+    /// Fill in the WAL position of savepoints opened before this write
+    /// transaction, mirroring SQLite's `sqlite3PagerOpenSavepoint` at
+    /// write-transaction begin. Idempotent: only fills unmaterialized
+    /// positions, so upgrade retry loops (Busy/BusySnapshot) are safe.
+    fn materialize_savepoint_wal_positions(&self) {
+        let Some(wal) = self.wal.as_ref() else {
+            return;
+        };
+        let pos = SavepointWalPos {
+            max_frame: wal.get_max_frame(),
+            checksum: wal.get_last_checksum(),
+            checkpoint_seq: wal.get_checkpoint_seq(),
+        };
+        for savepoint in self.savepoints.read().iter() {
+            let mut wal_pos = savepoint.wal_pos.write();
+            if wal_pos.is_none() {
+                *wal_pos = Some(pos);
+            }
+        }
     }
 
     /// Acquire exclusive WAL access + block new transactions (used by VACUUM).

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -51,6 +51,9 @@ use crate::{
 pub struct RollbackTo {
     pub frame: u64,
     pub checksum: (u32, u32),
+    /// WAL checkpoint sequence (generation) the position was captured in;
+    /// asserted against the current generation on rollback.
+    pub checkpoint_seq: u32,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -3890,6 +3893,37 @@ impl Wal for WalFile {
     fn rollback(&self, rollback_to: Option<RollbackTo>) {
         let is_savepoint = rollback_to.is_some();
         let snapshot = self.load_coordination_snapshot();
+        if let Some(r) = &rollback_to {
+            // Savepoint WAL positions are captured under the write lock
+            // (still held here), and no restart can happen while it is
+            // held: the writer-upgrade restart runs before positions
+            // materialize, and checkpoint RESTART/TRUNCATE takes the writer
+            // lock. A cross-generation position is therefore impossible.
+            // (SQLite must clamp instead — sqlite3WalSavepointUndo resets
+            // aWalData on an nCkpt mismatch — because it captures at
+            // write-tx begin but restarts later, at the first frame write.)
+            turso_assert!(
+                r.checkpoint_seq == snapshot.checkpoint_seq,
+                "savepoint WAL position must be from the current WAL generation",
+                {
+                    "savepoint_checkpoint_seq": r.checkpoint_seq,
+                    "authority_checkpoint_seq": snapshot.checkpoint_seq,
+                    "savepoint_frame": r.frame,
+                    "authority_max_frame": snapshot.max_frame
+                }
+            );
+            // The committed mark cannot advance while the write lock is
+            // held, so the position can never be behind it.
+            turso_assert!(
+                r.frame >= snapshot.max_frame,
+                "savepoint WAL position must not be behind the committed high-water mark",
+                { "savepoint_frame": r.frame, "authority_max_frame": snapshot.max_frame }
+            );
+        }
+        // Restored verbatim, like SQLite's aWalData. A checksum captured at
+        // frame 0 of a freshly restarted generation predates the new WAL
+        // header; that is harmless because prepare_frames seeds frame 1
+        // from the header itself.
         let max_frame = rollback_to
             .as_ref()
             .map(|r| r.frame)
@@ -3898,17 +3932,14 @@ impl Wal for WalFile {
             .as_ref()
             .map(|r| r.checksum)
             .unwrap_or(snapshot.last_checksum);
-        // Savepoints can be opened on a stale connection-local WAL snapshot.
-        // Do not let that rollback remove frame-cache mappings for frames that
-        // are already globally committed by another connection.
-        let cache_rollback_frame = if is_savepoint {
-            max_frame.max(snapshot.max_frame)
-        } else {
-            max_frame
-        };
-        self.coordination.rollback_cache(cache_rollback_frame);
+        self.coordination.rollback_cache(max_frame);
         *self.last_checksum.write() = last_checksum;
         self.max_frame.store(max_frame, Ordering::Release);
+        if max_frame == snapshot.max_frame {
+            // Everything past the committed mark was discarded, so no
+            // unpublished frames remain.
+            self.has_unpublished_frames.store(false, Ordering::Release);
+        }
         if !is_savepoint {
             self.reset_internal_states();
         }
@@ -6711,7 +6742,7 @@ pub mod test {
     }
 
     #[test]
-    fn test_savepoint_rollback_preserves_committed_frame_cache() {
+    fn test_savepoint_rollback_discards_frame_cache_past_rollback_point() {
         let (shared, wal) = make_test_wal();
         let coordination = make_test_coordination(&shared);
         set_shared_snapshot(
@@ -6725,20 +6756,40 @@ pub mod test {
             },
         );
 
+        // The connection spilled uncommitted frames past the committed
+        // high-water mark (25); a savepoint opened mid-transaction recorded
+        // frame 27.
         coordination.cache_frame(7, 10);
-        coordination.cache_frame(9, 20);
-        coordination.cache_frame(11, 30);
+        coordination.cache_frame(9, 26);
+        coordination.cache_frame(11, 28);
         wal.max_frame.store(30, Ordering::Release);
+        wal.has_unpublished_frames.store(true, Ordering::Release);
 
         wal.rollback(Some(RollbackTo {
-            frame: 10,
+            frame: 27,
             checksum: (13, 21),
+            checkpoint_seq: 1,
         }));
 
+        // Mappings at or below the rollback point survive, later ones are
+        // discarded; frames 26..=27 remain as unpublished spills.
         assert_eq!(coordination.find_frame(7, 0, 30, None), Some(10));
-        assert_eq!(coordination.find_frame(9, 0, 30, None), Some(20));
+        assert_eq!(coordination.find_frame(9, 0, 30, None), Some(26));
         assert_eq!(coordination.find_frame(11, 0, 30, None), None);
-        assert_eq!(wal.get_max_frame(), 10);
+        assert_eq!(wal.get_max_frame(), 27);
+        assert_eq!(*wal.last_checksum.read(), (13, 21));
+        assert!(wal.has_unpublished_frames.load(Ordering::Acquire));
+
+        // Rolling back to the committed high-water mark discards every
+        // spill, so no unpublished frames remain.
+        wal.rollback(Some(RollbackTo {
+            frame: 25,
+            checksum: (55, 89),
+            checkpoint_seq: 1,
+        }));
+        assert_eq!(coordination.find_frame(9, 0, 30, None), None);
+        assert_eq!(wal.get_max_frame(), 25);
+        assert!(!wal.has_unpublished_frames.load(Ordering::Acquire));
     }
 
     #[test]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4156,23 +4156,7 @@ impl Wal for WalFile {
             None => {
                 let snapshot = self.load_coordination_snapshot();
                 let local_state = self.connection_state();
-                let local_prepared_zero_frame_header = snapshot.max_frame == 0
-                    && self.coordination.wal_is_initialized()
-                    && local_state.snapshot.max_frame == 0
-                    && local_state.snapshot.checkpoint_seq == snapshot.checkpoint_seq
-                    && local_state.snapshot.transaction_count == snapshot.transaction_count
-                    && local_state.snapshot.last_checksum != snapshot.last_checksum;
-                if local_prepared_zero_frame_header {
-                    // We already prepared the WAL header for the current
-                    // zero-frame generation locally, but the authority snapshot
-                    // still carries the pre-header checksum until the first
-                    // commit publishes it. Seed the checksum chain from the
-                    // prepared local header, not the stale authority checksum.
-                    (
-                        local_state.snapshot.last_checksum,
-                        local_state.snapshot.max_frame + 1,
-                    )
-                } else if snapshot != local_state.snapshot {
+                let seed = if snapshot != local_state.snapshot {
                     let has_unpublished_frames =
                         self.has_unpublished_frames.load(Ordering::Acquire);
                     if has_unpublished_frames {
@@ -4198,9 +4182,26 @@ impl Wal for WalFile {
                         local_state.snapshot.last_checksum,
                         local_state.snapshot.max_frame + 1,
                     )
-                }
+                };
+                turso_assert!(
+                    seed.1 > snapshot.max_frame,
+                    "WAL append position must be past the committed high-water mark, otherwise committed frames get overwritten",
+                    { "next_frame_id": seed.1, "authority_max_frame": snapshot.max_frame }
+                );
+                seed
             }
         };
+
+        // The first frame of a generation always chains from the WAL header
+        // checksum, like SQLite's walFrames at mxFrame == 0. Connection and
+        // authority state may still carry the pre-header checksum here: a
+        // restart resets the position before the next append writes the new
+        // header, and a savepoint rollback can reinstall a position captured
+        // in that window. The wal_is_initialized assert above guarantees
+        // `header` is the current generation's synced header.
+        if next_frame_id == 1 {
+            rolling_checksum = (header.checksum_1, header.checksum_2);
+        }
 
         let first_frame_id = next_frame_id;
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2621,11 +2621,6 @@ pub struct WalFile {
 
     io_ctx: RwLock<IOContext>,
 
-    /// Set when WAL frames are appended without a commit marker (`db_size == 0`),
-    /// meaning the coordination backend's max_frame is behind our connection-local
-    /// max_frame. Cleared once `finish_append_frames_commit` publishes the state.
-    has_unpublished_frames: AtomicBool,
-
     /// The WAL file is dirty: frames were appended that no successful fsync
     /// has covered yet. Set whenever a frame is recorded via
     /// `complete_append_frame`, cleared when a WAL fsync completes
@@ -3777,8 +3772,6 @@ impl Wal for WalFile {
         self.complete_append_frame(page_id, frame_id, checksums);
         if db_size > 0 {
             self.finish_append_frames_commit()?;
-        } else {
-            self.has_unpublished_frames.store(true, Ordering::Release);
         }
         Ok(())
     }
@@ -3935,11 +3928,6 @@ impl Wal for WalFile {
         self.coordination.rollback_cache(max_frame);
         *self.last_checksum.write() = last_checksum;
         self.max_frame.store(max_frame, Ordering::Release);
-        if max_frame == snapshot.max_frame {
-            // Everything past the committed mark was discarded, so no
-            // unpublished frames remain.
-            self.has_unpublished_frames.store(false, Ordering::Release);
-        }
         if !is_savepoint {
             self.reset_internal_states();
         }
@@ -4042,7 +4030,6 @@ impl Wal for WalFile {
             last_checksum,
             transaction_count,
         });
-        self.has_unpublished_frames.store(false, Ordering::Release);
         Ok(())
     }
 
@@ -4187,39 +4174,37 @@ impl Wal for WalFile {
             None => {
                 let snapshot = self.load_coordination_snapshot();
                 let local_state = self.connection_state();
-                let seed = if snapshot != local_state.snapshot {
-                    let has_unpublished_frames =
-                        self.has_unpublished_frames.load(Ordering::Acquire);
-                    if has_unpublished_frames {
-                        // Spill/raw frames have no commit marker yet
-                        // (db_size == 0), so the coordination backend's
-                        // max_frame is behind our local max_frame. Chain from
-                        // local state so we don't overwrite those frames.
-                        (
-                            local_state.snapshot.last_checksum,
-                            local_state.snapshot.max_frame + 1,
-                        )
-                    } else {
-                        // The current generation was restarted/truncated back to
-                        // frame 0 or another process changed the durable WAL
-                        // state. Re-seed this connection from the authoritative
-                        // snapshot so replacement generations after
-                        // RESTART/TRUNCATE do not append using stale local state.
-                        self.install_connection_state(local_state.with_snapshot(snapshot));
-                        (snapshot.last_checksum, snapshot.max_frame + 1)
-                    }
-                } else {
+                if local_state.snapshot.max_frame > snapshot.max_frame {
+                    // The local position is past the committed high-water
+                    // mark exactly when this connection has spilled or
+                    // raw-inserted frames that carry no commit marker yet.
+                    // Chain from local state so we don't overwrite them.
                     (
                         local_state.snapshot.last_checksum,
                         local_state.snapshot.max_frame + 1,
                     )
-                };
-                turso_assert!(
-                    seed.1 > snapshot.max_frame,
-                    "WAL append position must be past the committed high-water mark, otherwise committed frames get overwritten",
-                    { "next_frame_id": seed.1, "authority_max_frame": snapshot.max_frame }
-                );
-                seed
+                } else {
+                    // Inside a write transaction the local position can
+                    // never be behind the committed mark: the upgrade
+                    // requires a fresh snapshot, and the mark cannot advance
+                    // while the write lock is held.
+                    turso_assert!(
+                        local_state.snapshot.max_frame == snapshot.max_frame,
+                        "connection WAL position must not be behind the committed high-water mark",
+                        {
+                            "local_max_frame": local_state.snapshot.max_frame,
+                            "authority_max_frame": snapshot.max_frame
+                        }
+                    );
+                    // At the mark the authority owns the seed; re-sync local
+                    // state if it drifted (e.g. a savepoint rollback
+                    // reinstalled a pre-header checksum at frame 0, or a
+                    // concurrent checkpoint advanced nbackfills).
+                    if snapshot != local_state.snapshot {
+                        self.install_connection_state(local_state.with_snapshot(snapshot));
+                    }
+                    (snapshot.last_checksum, snapshot.max_frame + 1)
+                }
             }
         };
 
@@ -4422,12 +4407,6 @@ impl Wal for WalFile {
 
         self.io.drain_completions(std::slice::from_ref(&c))?;
 
-        if !page_frame_and_checksum.is_empty() {
-            // Spill frames are durable but unpublished until the commit marker
-            // advances the shared WAL snapshot.
-            self.has_unpublished_frames.store(true, Ordering::Release);
-        }
-
         for (page, fid, csum) in &page_frame_and_checksum {
             self.complete_append_frame(page.get().id as u64, *fid, *csum);
         }
@@ -4525,7 +4504,6 @@ impl WalFile {
             last_checksum: RwLock::new(last_checksum),
             checkpoint_guard: RwLock::new(None),
             io_ctx: RwLock::new(IOContext::default()),
-            has_unpublished_frames: AtomicBool::new(false),
             dirty: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -6763,7 +6741,6 @@ pub mod test {
         coordination.cache_frame(9, 26);
         coordination.cache_frame(11, 28);
         wal.max_frame.store(30, Ordering::Release);
-        wal.has_unpublished_frames.store(true, Ordering::Release);
 
         wal.rollback(Some(RollbackTo {
             frame: 27,
@@ -6778,10 +6755,9 @@ pub mod test {
         assert_eq!(coordination.find_frame(11, 0, 30, None), None);
         assert_eq!(wal.get_max_frame(), 27);
         assert_eq!(*wal.last_checksum.read(), (13, 21));
-        assert!(wal.has_unpublished_frames.load(Ordering::Acquire));
 
         // Rolling back to the committed high-water mark discards every
-        // spill, so no unpublished frames remain.
+        // spill.
         wal.rollback(Some(RollbackTo {
             frame: 25,
             checksum: (55, 89),
@@ -6789,7 +6765,6 @@ pub mod test {
         }));
         assert_eq!(coordination.find_frame(9, 0, 30, None), None);
         assert_eq!(wal.get_max_frame(), 25);
-        assert!(!wal.has_unpublished_frames.load(Ordering::Acquire));
     }
 
     #[test]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4190,6 +4190,14 @@ pub fn op_savepoint(
                             deferred_fk_violations,
                         );
                     } else {
+                        // TODO: SQLite's SAVEPOINT takes no locks and no
+                        // snapshot; its pager savepoint materializes at
+                        // write-tx begin (sqlite3PagerOpenSavepoint). The
+                        // eager read tx here pins the snapshot too early and
+                        // holds a read lock while idle — not needed for
+                        // correctness, since the WAL position already
+                        // materializes at write upgrade and db_size could
+                        // move there the same way.
                         if !pager.holds_read_lock() {
                             pager.begin_read_tx()?;
                         }

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -1607,6 +1607,106 @@ fn test_wal_savepoint_rollback_on_constraint_violation() {
     assert_eq!(row[0], Value::from_i64(1001));
 }
 
+/// Regression test for savepoint rollback across a WAL restart.
+///
+/// A savepoint opened before the transaction's first write predates the
+/// WAL restart that the write upgrade performs when the log is fully
+/// backfilled (new generation: frames renumbered from zero, fresh salts
+/// and checksum chain). `ROLLBACK TO` must rewind to a position in the
+/// new generation: installing a pre-restart position would make the next
+/// spill/commit append at the old generation's offset with the old
+/// checksum chain — rolled-back frames stay visible to readers and the
+/// commit's frames fail recovery validation (integrity_check errors,
+/// committed data lost after recovery).
+#[test]
+fn test_savepoint_rollback_across_wal_restart() {
+    let tmp_db = TempDatabase::new("savepoint_wal_restart.db");
+    let conn = tmp_db.connect_limbo();
+
+    // Small page cache so the big transaction below spills to the WAL
+    // mid-transaction (uncommitted frames).
+    conn.execute("PRAGMA cache_size = 200").unwrap();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")
+        .unwrap();
+
+    let padding = "x".repeat(2000);
+    conn.execute("BEGIN").unwrap();
+    for i in 1..=300 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, '{padding}')"))
+            .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+
+    // Fully backfill the WAL so the next write transaction restarts the log.
+    conn.execute("PRAGMA wal_checkpoint(FULL)").unwrap();
+
+    // Open the savepoint before the transaction's first write, so it
+    // predates the WAL restart.
+    conn.execute("BEGIN").unwrap();
+    conn.execute("SAVEPOINT sp").unwrap();
+    // The first INSERT upgrades to a write transaction, which restarts the
+    // WAL; the rest of the inserts overflow the page cache and spill
+    // uncommitted frames into the new WAL generation.
+    for i in 301..=900 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, '{padding}')"))
+            .unwrap();
+    }
+    conn.execute("ROLLBACK TO sp").unwrap();
+    for i in 901..=910 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, '{padding}')"))
+            .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+
+    // A fresh connection must see a consistent database: only the first
+    // batch and the post-rollback inserts.
+    let conn2 = tmp_db.connect_limbo();
+    let stmt = conn2.query("PRAGMA integrity_check").unwrap().unwrap();
+    let row = helper_read_single_row(stmt);
+    assert_eq!(
+        row[0],
+        Value::Text("ok".into()),
+        "integrity check must pass after savepoint rollback across a WAL restart"
+    );
+    let stmt = conn2.query("SELECT COUNT(*) FROM t").unwrap().unwrap();
+    let row = helper_read_single_row(stmt);
+    assert_eq!(row[0], Value::from_i64(310));
+
+    // The committed transaction must also survive WAL recovery from disk.
+    // With the append position corrupted, the commit's frames fail salt or
+    // checksum validation and recovery silently drops them. This check must
+    // run before any checkpoint: backfilling would launder the corrupted WAL
+    // into the database file and mask the recovery failure.
+    let rusqlite_conn = rusqlite::Connection::open(tmp_db.path.clone()).unwrap();
+    let result: String = rusqlite_conn
+        .pragma_query_value(None, "integrity_check", |row| row.get(0))
+        .unwrap();
+    assert_eq!(result, "ok");
+    let count: i64 = rusqlite_conn
+        .query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        count, 310,
+        "committed rows must survive WAL recovery after savepoint rollback across a WAL restart"
+    );
+    drop(rusqlite_conn);
+
+    // Checkpointing must not backfill rolled-back or stale-generation frames
+    // into the database file.
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    let stmt = conn2.query("PRAGMA integrity_check").unwrap().unwrap();
+    let row = helper_read_single_row(stmt);
+    assert_eq!(
+        row[0],
+        Value::Text("ok".into()),
+        "integrity check must pass after checkpointing"
+    );
+    let stmt = conn2.query("SELECT COUNT(*) FROM t").unwrap().unwrap();
+    let row = helper_read_single_row(stmt);
+    assert_eq!(row[0], Value::from_i64(310));
+}
+
 #[turso_macros::test]
 /// INSERT OR FAIL should keep changes made by the statement before the error.
 /// Unlike ABORT (the default), FAIL does not roll back successful inserts within the same statement.


### PR DESCRIPTION
Supersedes #7774, which handled stale savepoint positions at rollback time; this makes them unrepresentable instead.

---

# Problem

`ROLLBACK TO` a savepoint that was opened before the transaction's first write corrupted the WAL when the write upgrade restarted the log:

- Savepoint WAL positions (max frame + running checksum) were captured at **savepoint open, possibly before the write lock was taken**.
- A restart at write upgrade renumbers frames from zero with fresh salts/checksums, so the captured position belonged to the dead generation.
- `ROLLBACK TO` reinstalled it verbatim: later appends continued the old chain at its offset — rolled-back frames stayed visible, committed frames failed recovery validation, checkpointing laundered the damage into the DB file.

# Fix (one commit per bullet)

1. Seed a generation's first frame from the WAL header checksum (SQLite's walFrames at mxFrame == 0). Makes pre-header checksums in connection state harmless; deletes the local_prepared_zero_frame_header special case.
2. The most important part: capture savepoint WAL positions only under the write lock: eagerly inside a write tx, otherwise at write upgrade after any restart (SQLite's sqlite3PagerOpenSavepoint timing). No restart can run under the write lock, so rollback asserts same-generation and ≥ committed mark instead of clamping like SQLite does (and #7774 emulated). A savepoint with no position skips the WAL rewind. Restarts are no longer affected by open savepoints.
3. Delete `has_unpublished_frames` - under the invariant from 2 above, this bookkeeping is no longer necessary