### PR TITLE
core/translate: rebuild secondary indexes when ALTER COLUMN changes column values

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -6,13 +6,17 @@ use turso_parser::{
 };
 
 use super::{
+    index::{emit_delete_index_entries, emit_rebuild_index},
     schema::{validate_check_expr, SQLITE_TABLEID},
     update::translate_update_for_schema_change,
 };
 use crate::{
     error::SQLITE_CONSTRAINT_CHECK,
     function::{AlterTableFunc, Func},
-    schema::{CheckConstraint, Column, ColumnLayout, ForeignKey, Table, RESERVED_TABLE_PREFIXES},
+    schema::{
+        CheckConstraint, Column, ColumnLayout, ForeignKey, GeneratedType, Index, Table,
+        RESERVED_TABLE_PREFIXES,
+    },
     translate::{
         emitter::{emit_check_constraints, gencol::compute_virtual_columns, Resolver},
         expr::{translate_expr, walk_expr, walk_expr_mut, WalkControl},
@@ -21,8 +25,8 @@ use crate::{
     },
     util::{
         check_expr_references_column, escape_sql_string_literal, normalize_ident,
-        parse_numeric_literal, rewrite_check_expr_table_refs, rewrite_trigger_cmd_table_refs,
-        rewrite_view_sql_for_column_rename,
+        parse_numeric_literal, rename_identifiers, rewrite_check_expr_table_refs,
+        rewrite_trigger_cmd_table_refs, rewrite_view_sql_for_column_rename,
     },
     vdbe::{
         affinity::Affinity,
@@ -1819,34 +1823,106 @@ pub fn translate_alter_table(
                 ));
             }
 
-            let (rewrites_physical_layout, replacement_column) = match rename {
-                true => (false, None),
-                false => {
-                    let replacement_column = Column::try_from(&definition)?;
-                    let old_column = &btree.columns()[column_index];
-                    let becomes_generated =
-                        !old_column.is_generated() && replacement_column.is_generated();
-                    // Toggling the virtual-generated bit changes whether the column
-                    // occupies a stored slot, so the on-disk row layout shifts even
-                    // if neither side is "becomes_generated" (e.g. virtual -> regular).
-                    // Without rewriting, post-ALTER reads use the new schema's column
-                    // indexes against rows that still hold the pre-ALTER layout, and
-                    // values land in the wrong logical columns. See issue #6624.
-                    let virtuality_changed = old_column.is_virtual_generated()
-                        != replacement_column.is_virtual_generated();
-                    // A change of declared type can change the column's affinity, in
-                    // which case existing on-disk values must be coerced to match the
-                    // new affinity. Without this, the row payload retains the old
-                    // serial type and SQLite's `PRAGMA integrity_check` reports the
-                    // file as corrupt (e.g. "NUMERIC value in <table>.<col>" when
-                    // changing NUMERIC -> TEXT). See issue #3706.
-                    let affinity_changed = old_column.affinity_with_strict(btree.is_strict)
-                        != replacement_column.affinity_with_strict(btree.is_strict);
-                    let rewrites_physical_layout =
-                        becomes_generated || virtuality_changed || affinity_changed;
-                    (rewrites_physical_layout, Some(replacement_column))
+            // ALTER COLUMN replaces the column's definition, and the new definition
+            // cannot carry UNIQUE or PRIMARY KEY constraints (rejected above). If the
+            // old column's constraint is enforced by an automatic index
+            // (sqlite_autoindex_*), the rewritten CREATE TABLE would no longer declare
+            // the constraint while the index row stays behind in sqlite_schema, which
+            // corrupts the database: SQLite reports "orphan index" and Turso fails to
+            // reload the schema. Reject the operation instead. See issue #7077.
+            // (RENAME COLUMN keeps the constraint in the table SQL, so it stays allowed,
+            // as does altering a rowid-alias INTEGER PRIMARY KEY, which has no
+            // automatic index.)
+            if !rename {
+                let old_column = &btree.columns()[column_index];
+                if old_column.unique() {
+                    return Err(LimboError::ParseError(format!(
+                        "cannot alter column \"{from}\": UNIQUE"
+                    )));
                 }
-            };
+                let is_pk_member = btree
+                    .primary_key_columns
+                    .iter()
+                    .any(|(name, _)| normalize_ident(name) == normalize_ident(from));
+                if !old_column.is_rowid_alias() && is_pk_member {
+                    if btree.primary_key_columns.len() == 1 {
+                        return Err(LimboError::ParseError(format!(
+                            "cannot alter column \"{from}\": PRIMARY KEY"
+                        )));
+                    }
+                    // A composite PRIMARY KEY is a table-level constraint, which
+                    // survives the rewrite with the column renamed, so altering a
+                    // member is fine in general. But a generated column cannot be
+                    // part of the PRIMARY KEY: allowing it would write a schema
+                    // that fails to reload ("malformed database schema").
+                    if definition
+                        .constraints
+                        .iter()
+                        .any(|c| matches!(c.constraint, ast::ColumnConstraint::Generated { .. }))
+                    {
+                        return Err(LimboError::ParseError(format!(
+                            "generated column \"{col_name}\" cannot be part of the PRIMARY KEY"
+                        )));
+                    }
+                }
+            }
+
+            let (rewrites_physical_layout, rewrites_column_values, replacement_column) =
+                match rename {
+                    true => (false, false, None),
+                    false => {
+                        let replacement_column = Column::try_from(&definition)?;
+                        let old_column = &btree.columns()[column_index];
+                        let becomes_generated =
+                            !old_column.is_generated() && replacement_column.is_generated();
+                        // Toggling the virtual-generated bit changes whether the column
+                        // occupies a stored slot, so the on-disk row layout shifts even
+                        // if neither side is "becomes_generated" (e.g. virtual -> regular).
+                        // Without rewriting, post-ALTER reads use the new schema's column
+                        // indexes against rows that still hold the pre-ALTER layout, and
+                        // values land in the wrong logical columns. See issue #6624.
+                        let virtuality_changed = old_column.is_virtual_generated()
+                            != replacement_column.is_virtual_generated();
+                        // A change of declared type can change the column's affinity, in
+                        // which case existing on-disk values must be coerced to match the
+                        // new affinity. Without this, the row payload retains the old
+                        // serial type and SQLite's `PRAGMA integrity_check` reports the
+                        // file as corrupt (e.g. "NUMERIC value in <table>.<col>" when
+                        // changing NUMERIC -> TEXT). See issue #3706.
+                        let affinity_changed = old_column.affinity_with_strict(btree.is_strict)
+                            != replacement_column.affinity_with_strict(btree.is_strict);
+                        let rewrites_physical_layout =
+                            becomes_generated || virtuality_changed || affinity_changed;
+                        // Changing a virtual generated column's expression keeps the
+                        // on-disk row layout intact (the column occupies no stored slot),
+                        // but its logical values still change, so any index containing
+                        // the column must be rebuilt just like in the layout-rewriting
+                        // cases. See issue #7077.
+                        let generated_expr_changed = match (
+                            old_column.generated_type(),
+                            replacement_column.generated_type(),
+                        ) {
+                            (
+                                GeneratedType::Virtual {
+                                    original_sql: old_sql,
+                                    ..
+                                },
+                                GeneratedType::Virtual {
+                                    original_sql: new_sql,
+                                    ..
+                                },
+                            ) => old_sql != new_sql,
+                            _ => false,
+                        };
+                        let rewrites_column_values =
+                            rewrites_physical_layout || generated_expr_changed;
+                        (
+                            rewrites_physical_layout,
+                            rewrites_column_values,
+                            Some(replacement_column),
+                        )
+                    }
+                };
             let clears_autoincrement_sequence = !rename
                 && btree.has_autoincrement
                 && btree.columns()[column_index].is_rowid_alias()
@@ -1895,12 +1971,12 @@ pub fn translate_alter_table(
                 }
             }
 
-            let rewritten_table = if rewrites_physical_layout {
+            let rewritten_table = if rewrites_column_values {
                 let mut table = btree.clone();
                 table.columns_mut()[column_index] =
                     replacement_column.expect("replacement_column must exist for ALTER COLUMN");
                 table.prepare_generated_columns()?;
-                Some(table)
+                Some(Arc::new(table))
             } else {
                 None
             };
@@ -2204,43 +2280,80 @@ pub fn translate_alter_table(
                     database_id,
                 )?;
 
-                let original_columns = original_btree.columns();
-                let source_column_by_schema_idx: Vec<Option<usize>> = rewritten_table
-                    .columns()
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, column)| {
-                        if column.is_virtual_generated() {
-                            // Virtual columns don't occupy a slot in the rewritten record.
-                            None
-                        } else if original_columns
-                            .get(idx)
-                            .is_some_and(|c| c.is_virtual_generated())
-                        {
-                            // Newly-stored slot (the original column was virtual): no
-                            // source value exists on the old row image — leave NULL.
-                            None
-                        } else {
-                            // The cursor is opened on the original btree, so the logical
-                            // index passed here is mapped to the original physical slot
-                            // by `emit_column_or_rowid` via the original's logical-to-
-                            // physical map. Schema order is preserved by ALTER COLUMN,
-                            // so the rewritten schema_idx also identifies the same
-                            // logical column in the original.
-                            Some(idx)
-                        }
-                    })
-                    .collect();
-                let layout = rewritten_table.column_layout()?;
-                emit_rewrite_table_rows(
-                    program,
-                    original_btree.clone(),
-                    &rewritten_table,
-                    &source_column_by_schema_idx,
-                    &layout,
-                    connection,
-                    database_id,
-                );
+                // Secondary indexes are keyed on column values, so changing the
+                // column's values (generated-ness, virtuality, affinity, or a
+                // virtual column's expression) leaves the existing index entries
+                // stale, which later corrupts DELETE/UPDATE (IdxDelete misses)
+                // and index-driven reads. Delete the old entries while the
+                // pre-ALTER values (which the index keys were built from) are
+                // still readable, then refill each index from the rewritten
+                // rows below. See issue #7077.
+                for index in &table_indexes {
+                    emit_delete_index_entries(
+                        program,
+                        resolver,
+                        database_id,
+                        &original_btree,
+                        index,
+                    )?;
+                }
+
+                if rewrites_physical_layout {
+                    let original_columns = original_btree.columns();
+                    let source_column_by_schema_idx: Vec<Option<usize>> = rewritten_table
+                        .columns()
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, column)| {
+                            if column.is_virtual_generated() {
+                                // Virtual columns don't occupy a slot in the rewritten record.
+                                None
+                            } else if original_columns
+                                .get(idx)
+                                .is_some_and(|c| c.is_virtual_generated())
+                            {
+                                // Newly-stored slot (the original column was virtual): no
+                                // source value exists on the old row image — leave NULL.
+                                None
+                            } else {
+                                // The cursor is opened on the original btree, so the logical
+                                // index passed here is mapped to the original physical slot
+                                // by `emit_column_or_rowid` via the original's logical-to-
+                                // physical map. Schema order is preserved by ALTER COLUMN,
+                                // so the rewritten schema_idx also identifies the same
+                                // logical column in the original.
+                                Some(idx)
+                            }
+                        })
+                        .collect();
+                    let layout = rewritten_table.column_layout()?;
+                    emit_rewrite_table_rows(
+                        program,
+                        original_btree.clone(),
+                        &rewritten_table,
+                        &source_column_by_schema_idx,
+                        &layout,
+                        connection,
+                        database_id,
+                    );
+                }
+
+                for index in &table_indexes {
+                    let remapped_index = Arc::new(remap_index_for_altered_column(
+                        index,
+                        &rewritten_table,
+                        column_index,
+                        from,
+                        col_name,
+                    ));
+                    emit_rebuild_index(
+                        program,
+                        resolver,
+                        database_id,
+                        &rewritten_table,
+                        &remapped_index,
+                    )?;
+                }
             }
 
             if clears_autoincrement_sequence {
@@ -2340,6 +2453,43 @@ fn emit_rewrite_table_rows(
             table_name: table_name.clone(),
         });
     });
+}
+
+/// Clone `index` and remap it to the post-ALTER definition of the altered column so a
+/// rebuild reads the new column values.
+///
+/// Plain references to the altered column pick up its new name and, when the column is
+/// (now) virtual generated, its generated expression, mirroring how `CREATE INDEX`
+/// resolves index columns on virtual columns. Expression-index columns and partial-index
+/// WHERE clauses that mention the old column name are renamed to the new name so they
+/// bind against `rewritten_table`.
+fn remap_index_for_altered_column(
+    index: &Index,
+    rewritten_table: &BTreeTable,
+    column_index: usize,
+    old_column_name: &str,
+    new_column_name: &str,
+) -> Index {
+    let old_name = normalize_ident(old_column_name);
+    let new_name = normalize_ident(new_column_name);
+    let mut index = index.clone();
+    let column = &rewritten_table.columns()[column_index];
+    for index_column in &mut index.columns {
+        if index_column.pos_in_table == column_index {
+            index_column.name.clone_from(&new_name);
+            index_column.default.clone_from(&column.default);
+            index_column.expr = match column.generated_type() {
+                GeneratedType::Virtual { expr, .. } => Some(expr.clone()),
+                GeneratedType::NotGenerated => None,
+            };
+        } else if let Some(expr) = &mut index_column.expr {
+            rename_identifiers(expr, &old_name, &new_name);
+        }
+    }
+    if let Some(where_clause) = &mut index.where_clause {
+        rename_identifiers(where_clause, &old_name, &new_name);
+    }
+    index
 }
 
 fn non_virtual_affinity_str(table: &BTreeTable) -> String {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -303,6 +303,148 @@ pub fn translate_create_index(
     Ok(())
 }
 
+/// Emits the bytecode that deletes every entry of `idx` by scanning `tbl` and computing
+/// each row's index key from the current row image.
+///
+/// `ALTER TABLE ... ALTER COLUMN` uses this before rewriting the table rows so stale
+/// index entries are removed while the pre-rewrite values (which the index keys were
+/// built from) are still readable. Unlike `ClearBtree`, this also works in MVCC mode.
+pub(crate) fn emit_delete_index_entries(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    database_id: usize,
+    tbl: &Arc<BTreeTable>,
+    idx: &Arc<Index>,
+) -> crate::Result<()> {
+    let table_ref = program.table_reference_counter.next();
+    let table_cursor_id = program.alloc_cursor_id_keyed(
+        CursorKey::table(table_ref),
+        CursorType::BTreeTable(tbl.clone()),
+    );
+    let index_cursor_id = program.alloc_cursor_index(None, idx)?;
+    let tbl_name = normalize_ident(tbl.name.as_str());
+
+    let mut table_references = TableReferences::new(
+        vec![JoinedTable {
+            op: Operation::Scan(Scan::BTreeTable {
+                iter_dir: IterationDirection::Forwards,
+                index: None,
+            }),
+            table: Table::BTree(tbl.clone()),
+            identifier: tbl_name,
+            internal_id: table_ref,
+            join_info: None,
+            col_used_mask: ColumnUsedMask::default(),
+            column_use_counts: Vec::new(),
+            expression_index_usages: Vec::new(),
+            database_id,
+            indexed: None,
+        }],
+        vec![],
+    );
+    let where_clause = idx.bind_where_expr(Some(&mut table_references), resolver);
+
+    program.emit_insn(Insn::OpenRead {
+        cursor_id: table_cursor_id,
+        root_page: tbl.root_page,
+        db: database_id,
+    });
+    program.emit_insn(Insn::OpenWrite {
+        cursor_id: index_cursor_id,
+        root_page: RegisterOrLiteral::Literal(idx.root_page),
+        db: database_id,
+    });
+
+    let loop_start_label = program.allocate_label();
+    let loop_end_label = program.allocate_label();
+    program.emit_insn(Insn::Rewind {
+        cursor_id: table_cursor_id,
+        pc_if_empty: loop_end_label,
+    });
+    program.preassign_label_to_next_insn(loop_start_label);
+
+    let mut skip_row_label = None;
+    if let Some(where_clause) = where_clause {
+        let label = program.allocate_label();
+        let condition_true_label = program.allocate_label();
+        translate_condition_expr(
+            program,
+            &table_references,
+            &where_clause,
+            ConditionMetadata {
+                jump_if_condition_is_true: false,
+                jump_target_when_false: label,
+                jump_target_when_true: condition_true_label,
+                jump_target_when_null: label,
+            },
+            resolver,
+        )?;
+        program.preassign_label_to_next_insn(condition_true_label);
+        skip_row_label = Some(label);
+    }
+
+    let num_regs = idx.columns.len() + 1;
+    let start_reg = program.alloc_registers(num_regs);
+    for (i, col) in idx.columns.iter().enumerate() {
+        emit_index_column_value_from_cursor(
+            program,
+            resolver,
+            &mut table_references,
+            table_cursor_id,
+            tbl,
+            col,
+            start_reg + i,
+        )?;
+    }
+    program.emit_insn(Insn::RowId {
+        cursor_id: table_cursor_id,
+        dest: start_reg + idx.columns.len(),
+    });
+    program.emit_insn(Insn::IdxDelete {
+        start_reg,
+        num_regs,
+        cursor_id: index_cursor_id,
+        raise_error_if_no_matching_entry: idx.where_clause.is_none(),
+    });
+
+    if let Some(skip_row_label) = skip_row_label {
+        program.preassign_label_to_next_insn(skip_row_label);
+    }
+    program.emit_insn(Insn::Next {
+        cursor_id: table_cursor_id,
+        pc_if_next: loop_start_label,
+    });
+    program.preassign_label_to_next_insn(loop_end_label);
+
+    program.close_cursors(&[table_cursor_id, index_cursor_id]);
+    Ok(())
+}
+
+/// Emits the bytecode that rebuilds `idx` into its existing, already emptied b-tree
+/// from a full scan of `tbl`.
+///
+/// `ALTER TABLE ... ALTER COLUMN` uses this after `emit_delete_index_entries` removed
+/// the stale entries, so the index reflects the post-ALTER column values.
+pub(crate) fn emit_rebuild_index(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    database_id: usize,
+    tbl: &Arc<BTreeTable>,
+    idx: &Arc<Index>,
+) -> crate::Result<()> {
+    let index_cursor_id = program.alloc_cursor_index(None, idx)?;
+    emit_refill_index(
+        program,
+        resolver,
+        database_id,
+        tbl,
+        idx,
+        index_cursor_id,
+        RegisterOrLiteral::Literal(idx.root_page),
+        None,
+    )
+}
+
 /// Emits the bytecode that rebuilds `idx` from a full scan of `tbl`.
 ///
 /// `CREATE INDEX` calls this with a newly allocated root page. `REINDEX` calls it with

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14555,6 +14555,31 @@ pub fn op_alter_column(
 
         btree.prepare_generated_columns()?;
 
+        // Refresh index columns that reference the altered column so future DML
+        // computes index keys from the new column definition: a column that is
+        // (now) virtual generated must carry its resolved generated expression,
+        // and one that is no longer virtual must drop the stale one. See issue #7077.
+        if !*rename {
+            let altered_column = &btree.columns()[*column_index];
+            let new_generated_expr = match altered_column.generated_type() {
+                crate::schema::GeneratedType::Virtual { expr, .. } => Some(expr.clone()),
+                crate::schema::GeneratedType::NotGenerated => None,
+            };
+            let new_default = altered_column.default.clone();
+            if let Some(idxs) = schema.indexes.get_mut(&normalized_table_name) {
+                for idx in idxs {
+                    let idx = Arc::make_mut(idx);
+                    for ic in &mut idx.columns {
+                        if ic.pos_in_table == *column_index {
+                            ic.name.clone_from(&new_name);
+                            ic.expr.clone_from(&new_generated_expr);
+                            ic.default.clone_from(&new_default);
+                        }
+                    }
+                }
+            }
+        }
+
         // Keep primary_key_columns consistent (names may change on rename)
         for (pk_name, _ord) in &mut btree.primary_key_columns {
             if pk_name.eq_ignore_ascii_case(&old_column_name) {

--- a/testing/sqltests/tests/alter-column-unique-index-rewrite-7077.sqltest
+++ b/testing/sqltests/tests/alter-column-unique-index-rewrite-7077.sqltest
@@ -1,0 +1,123 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/7077
+# ALTER COLUMN rewrote table rows but not secondary index entries, leaving
+# stale index keys that later caused DELETE/UPDATE corruption errors.
+#
+# A column-level UNIQUE (or single-column PRIMARY KEY) constraint is enforced
+# by an automatic index, and ALTER COLUMN replaces the column definition,
+# which cannot carry the constraint. Allowing the ALTER would orphan the
+# sqlite_autoindex_* schema row (SQLite reports "malformed database schema
+# ... orphan index" and Turso fails to reload the schema), so it is rejected.
+
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
+@cross-check-integrity
+test alter-column-column-level-unique-rejected {
+    CREATE TABLE p(a, b UNIQUE);
+    INSERT INTO p VALUES(1, 10);
+    ALTER TABLE p ALTER COLUMN b TO g AS (a + 1);
+}
+expect error {
+    cannot alter column "b": UNIQUE
+}
+
+# A composite PRIMARY KEY is a table-level constraint that survives the ALTER
+# with the column renamed, so altering a member is allowed in general — but a
+# generated column cannot be part of the PRIMARY KEY: allowing it would write
+# a schema that neither Turso nor SQLite can reload ("malformed database
+# schema ... generated columns cannot be part of the PRIMARY KEY").
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
+@cross-check-integrity
+test alter-column-composite-pk-member-to-generated-rejected {
+    CREATE TABLE p(a, b, c, PRIMARY KEY(b, c));
+    INSERT INTO p VALUES(1, 10, 20);
+    ALTER TABLE p ALTER COLUMN b TO g AS (a + 1);
+}
+expect error {
+    generated column "g" cannot be part of the PRIMARY KEY
+}
+
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
+@cross-check-integrity
+test alter-column-composite-pk-member-affinity-change-ok {
+    CREATE TABLE p(a, b, c, PRIMARY KEY(b, c));
+    INSERT INTO p VALUES(1, 10, 20);
+    ALTER TABLE p ALTER COLUMN b TO b2 TEXT;
+    SELECT sql FROM sqlite_schema WHERE name = 'p';
+    DELETE FROM p;
+    SELECT count(*) FROM p;
+    PRAGMA integrity_check;
+}
+expect {
+    CREATE TABLE p (a, b2 TEXT, c, PRIMARY KEY (b2, c))
+    0
+    ok
+}
+
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
+@cross-check-integrity
+test alter-column-single-column-pk-rejected {
+    CREATE TABLE p(a, b TEXT PRIMARY KEY);
+    INSERT INTO p VALUES(1, 'x');
+    ALTER TABLE p ALTER COLUMN b TO g AS (a + 1);
+}
+expect error {
+    cannot alter column "b": PRIMARY KEY
+}
+
+# Explicit indexes on the altered column must be rebuilt from the post-ALTER
+# column values; stale entries previously made DELETE fail with
+# "Corrupt database: IdxDelete: no matching index entry found".
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
+@cross-check-integrity
+test alter-column-unique-index-delete-no-corruption {
+    CREATE TABLE p(a, b);
+    CREATE UNIQUE INDEX p_b ON p(b);
+    INSERT INTO p VALUES(1, 10);
+    ALTER TABLE p ALTER COLUMN b TO g AS (a + 1);
+    SELECT rowid, a, g FROM p;
+    DELETE FROM p;
+    SELECT count(*) FROM p;
+}
+expect {
+    1|1|2
+    0
+}
+
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
+@cross-check-integrity
+test alter-column-unique-index-update-no-corruption {
+    CREATE TABLE p(a, b);
+    CREATE UNIQUE INDEX p_b ON p(b);
+    INSERT INTO p VALUES(1, 10);
+    ALTER TABLE p ALTER COLUMN b TO g AS (a + 1);
+    UPDATE p SET a = 5;
+    SELECT rowid, a, g FROM p;
+    PRAGMA integrity_check;
+}
+expect {
+    1|5|6
+    ok
+}
+
+# A table-level UNIQUE constraint survives the ALTER (renamed in the table
+# SQL), so its automatic index stays valid and must be rebuilt from the
+# post-ALTER column values.
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
+@cross-check-integrity
+test alter-column-table-level-unique-autoindex-rebuilt {
+    CREATE TABLE p(a, b, UNIQUE(b));
+    INSERT INTO p VALUES(1, 10);
+    ALTER TABLE p ALTER COLUMN b TO g AS (a + 1);
+    SELECT sql FROM sqlite_schema WHERE name = 'p';
+    SELECT rowid, a, g FROM p;
+    DELETE FROM p;
+    SELECT count(*) FROM p;
+    PRAGMA integrity_check;
+}
+expect {
+    CREATE TABLE p (a, g AS (a + 1), UNIQUE (g))
+    1|1|2
+    0
+    ok
+}


### PR DESCRIPTION
ALTER COLUMN rewrote table rows when a column's values changed (becoming
generated, virtuality toggle, affinity change) but left secondary index
entries keyed on the pre-ALTER values. Subsequent DELETE/UPDATE computed
index keys from the new column definition, missed the stale entries, and
failed with "Corrupt database: IdxDelete: no matching index entry found";
index-driven reads returned stale values.

The ALTER COLUMN program now deletes every affected index entry before the
row rewrite, while the old values the keys were built from are still
readable, and then refills each index from the rewritten rows. The delete
pass and the refill (via the existing CREATE INDEX/REINDEX machinery, which
also re-enforces UNIQUE) use only IdxDelete/IdxInsert, so they work in MVCC
mode where ClearBtree is unavailable. Each index is remapped to the
post-ALTER schema for the rebuild: plain references to the altered column
pick up its new name and resolved generated expression, and expression
indexes and partial-index WHERE clauses are renamed to the new column name.

Changing a virtual generated column's expression keeps the on-disk row
layout intact but still changes the column's logical values, so that case
now also triggers an index rebuild (without a row rewrite). op_alter_column
refreshes the generated expression cached on in-memory index columns
referencing the altered column, so DML after the ALTER computes index keys
from the new definition instead of the stale one.

Columns whose constraint is enforced by an automatic index are rejected
instead of rebuilt: ALTER COLUMN replaces the column definition, which
cannot carry UNIQUE or PRIMARY KEY, so altering a column-level UNIQUE or a
single-column (non-rowid-alias) PRIMARY KEY column would drop the
constraint from the rewritten CREATE TABLE while its sqlite_autoindex_* row
stays behind, and sqlite3 then reports "malformed database schema ...
orphan index". Converting a composite-PK member into a generated column is
rejected for the same reason: the resulting schema fails to reload.
Composite-PK members and table-level UNIQUE constraints survive the rewrite
with the column renamed, so those remain allowed and their indexes are
rebuilt.

Tests: testing/sqltests/tests/alter-column-unique-index-rewrite-7077.sqltest
passes on the rust and CLI backends, in MVCC mode, and under the sqlite3
integrity cross-check used by the CLI-backend CI job; full sqltest suite,
turso_core unit tests, and alter/index integration tests pass.

Fixes #7077