### PR TITLE
core/wal: prevent stale checkpoint backfill publish

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4768,6 +4768,36 @@ impl Pager {
                     clear_page_cache,
                     max_frame,
                 } => {
+                    {
+                        let state = self.checkpoint_state.read();
+                        let result = state.result.as_ref().expect("result should be set");
+                        turso_assert!(
+                            result.wal_checkpoint_backfilled > 0,
+                            "PublishBackfill phase requires frames backfilled during checkpoint",
+                            {
+                                "publish_backfill": max_frame,
+                                "wal_max_frame": result.wal_max_frame,
+                                "wal_total_backfilled": result.wal_total_backfilled,
+                                "wal_checkpoint_backfilled": result.wal_checkpoint_backfilled
+                            }
+                        );
+                        turso_assert!(
+                            max_frame == result.wal_total_backfilled,
+                            "PublishBackfill target must match checkpoint result",
+                            {
+                                "publish_backfill": max_frame,
+                                "wal_total_backfilled": result.wal_total_backfilled
+                            }
+                        );
+                        turso_assert!(
+                            result.wal_total_backfilled <= result.wal_max_frame,
+                            "checkpoint result cannot backfill beyond WAL max frame",
+                            {
+                                "wal_total_backfilled": result.wal_total_backfilled,
+                                "wal_max_frame": result.wal_max_frame
+                            }
+                        );
+                    }
                     wal.publish_backfill(max_frame);
                     let next_phase = {
                         let state = self.checkpoint_state.read();

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4825,7 +4825,14 @@ impl WalFile {
                     // during 'read_page', so the caller will use the result to determine if:
                     // a. the max frame == num wal frames (everything backfilled)
                     // b. the max frame > 0 (we have something to truncate)
-                    if checkpoint_result.should_truncate() {
+                    if checkpoint_result.should_truncate()
+                        || checkpoint_result.wal_checkpoint_backfilled > 0
+                    {
+                        // Backfilled frames are not globally durable until
+                        // the pager syncs the DB file and publishes
+                        // nbackfills. Keep the checkpoint guard through that
+                        // tail so another writer cannot restart the WAL
+                        // generation underneath a pending publish.
                         checkpoint_result.maybe_guard = self.checkpoint_guard.write().take();
                     } else {
                         let _ = self.checkpoint_guard.write().take();

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -3103,6 +3103,15 @@ impl WalFile {
         // Snapshot the shared WAL state. We haven't taken a read lock yet, so we need
         // to validate these values later.
         let shared_snapshot = self.load_coordination_snapshot();
+        turso_assert!(
+            shared_snapshot.nbackfills <= shared_snapshot.max_frame,
+            "WAL snapshot cannot have backfills beyond max frame",
+            {
+                "nbackfills": shared_snapshot.nbackfills,
+                "max_frame": shared_snapshot.max_frame,
+                "checkpoint_seq": shared_snapshot.checkpoint_seq
+            }
+        );
         tracing::debug!(
             "try_begin_read_tx: shared_max={}, nbackfills={}, last_checksum={:?}, checkpoint_seq={:?}, transaction_count={}",
             shared_snapshot.max_frame,
@@ -3834,6 +3843,16 @@ impl Wal for WalFile {
     }
 
     fn publish_backfill(&self, max_frame: u64) {
+        let snapshot = self.load_coordination_snapshot();
+        turso_assert!(
+            (snapshot.nbackfills..=snapshot.max_frame).contains(&max_frame),
+            "published backfill must stay within the current WAL generation",
+            {
+                "publish_backfill": max_frame,
+                "current_nbackfills": snapshot.nbackfills,
+                "current_max_frame": snapshot.max_frame
+            }
+        );
         self.coordination.publish_backfill(max_frame);
     }
 

--- a/tests/integration/wal/mod.rs
+++ b/tests/integration/wal/mod.rs
@@ -1,1 +1,2 @@
 mod test_wal;
+mod test_wal_publish_backfill_race;

--- a/tests/integration/wal/test_wal_publish_backfill_race.rs
+++ b/tests/integration/wal/test_wal_publish_backfill_race.rs
@@ -1,0 +1,298 @@
+use crate::queued_io::QueuedIo;
+use std::sync::Arc;
+use turso_core::vdbe::StepResult;
+use turso_core::{Connection, Database, Result};
+
+fn step_blocking(stmt: &mut turso_core::Statement) -> Result<StepResult> {
+    loop {
+        match stmt.step()? {
+            StepResult::IO => stmt._io().step()?,
+            StepResult::Yield => continue,
+            other => return Ok(other),
+        }
+    }
+}
+
+fn exec_ints(conn: &Arc<Connection>, sql: &str) -> Result<Vec<i64>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut out = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::IO => stmt._io().step()?,
+            StepResult::Yield => continue,
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                for value in row.get_values() {
+                    if let turso_core::Value::Numeric(turso_core::Numeric::Integer(i)) = value {
+                        out.push(*i);
+                    }
+                }
+            }
+            StepResult::Done => break,
+            r => panic!("unexpected step result: {r:?}"),
+        }
+    }
+    Ok(out)
+}
+
+fn exec(conn: &Arc<Connection>, sql: &str) -> Result<()> {
+    let mut stmt = conn.prepare(sql)?;
+    match step_blocking(&mut stmt)? {
+        StepResult::Done | StepResult::Row => Ok(()),
+        r => panic!("unexpected step result for `{sql}`: {r:?}"),
+    }
+}
+
+fn try_exec_step(conn: &Arc<Connection>, sql: &str) -> Result<StepResult> {
+    let mut stmt = conn.prepare(sql)?;
+    step_blocking(&mut stmt)
+}
+
+const BATCH1: usize = 500;
+const BATCH2: usize = 600;
+
+struct Setup {
+    _io: Arc<QueuedIo>,
+    db: Arc<Database>,
+    a: Arc<Connection>,
+    b: Arc<Connection>,
+    commit_stmt: turso_core::Statement,
+    reader_stmt: Option<turso_core::Statement>,
+    a_done: bool,
+}
+
+fn setup(park: usize) -> Setup {
+    let io = Arc::new(QueuedIo::new());
+    let db = Database::open_file(io.clone(), "publish-backfill-race.db").unwrap();
+    let a = db.connect().unwrap();
+    let b = db.connect().unwrap();
+
+    exec(&a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)").unwrap();
+    exec(&a, "BEGIN").unwrap();
+    for i in 0..BATCH1 {
+        exec(&a, &format!("INSERT INTO t VALUES ({i}, zeroblob(3000))")).unwrap();
+    }
+    exec(&a, "COMMIT").unwrap();
+
+    let mut reader = b.prepare("SELECT id FROM t").unwrap();
+    loop {
+        match reader.step().unwrap() {
+            StepResult::IO => reader._io().step().unwrap(),
+            StepResult::Yield => continue,
+            StepResult::Row => break,
+            r => panic!("unexpected step result while parking reader: {r:?}"),
+        }
+    }
+
+    exec(&a, "BEGIN").unwrap();
+    for i in 0..BATCH2 {
+        exec(
+            &a,
+            &format!("INSERT INTO t VALUES ({}, zeroblob(3000))", BATCH1 + i),
+        )
+        .unwrap();
+    }
+
+    let mut commit_stmt = a.prepare("COMMIT").unwrap();
+    let mut pumps = 0;
+    let mut a_done = false;
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 10_000_000, "commit statement seems stuck");
+        match commit_stmt.step().unwrap() {
+            StepResult::IO => {
+                if pumps >= park {
+                    break;
+                }
+                pumps += 1;
+                commit_stmt._io().step().unwrap();
+            }
+            StepResult::Row => {}
+            StepResult::Yield => {}
+            StepResult::Done => {
+                a_done = true;
+                break;
+            }
+            r => panic!("unexpected step result: {r:?}"),
+        }
+    }
+
+    Setup {
+        _io: io,
+        db,
+        a,
+        b,
+        commit_stmt,
+        reader_stmt: Some(reader),
+        a_done,
+    }
+}
+
+fn finish(stmt: &mut turso_core::Statement) {
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 10_000_000, "statement seems stuck");
+        match stmt.step().unwrap() {
+            StepResult::IO => stmt._io().step().unwrap(),
+            StepResult::Row => {}
+            StepResult::Yield => {}
+            StepResult::Done => break,
+            r => panic!("unexpected step result: {r:?}"),
+        }
+    }
+}
+
+fn assert_integrity_ok(conn: &Arc<Connection>, context: &str) {
+    let mut stmt = conn.prepare("PRAGMA integrity_check").unwrap();
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::IO => stmt._io().step().unwrap(),
+            StepResult::Yield => continue,
+            StepResult::Row => {
+                rows.push(stmt.row().unwrap().get::<String>(0).unwrap());
+            }
+            StepResult::Done => break,
+            r => panic!("unexpected integrity_check step result: {r:?}"),
+        }
+    }
+    assert_eq!(rows, vec!["ok"], "integrity_check failed {context}");
+}
+
+#[test]
+fn wal_stale_publish_backfill_hides_committed_rows() {
+    let total_yields = {
+        let io = Arc::new(QueuedIo::new());
+        let db = Database::open_file(io.clone(), "publish-backfill-race-dry.db").unwrap();
+        let a = db.connect().unwrap();
+        let b = db.connect().unwrap();
+
+        exec(&a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)").unwrap();
+        exec(&a, "BEGIN").unwrap();
+        for i in 0..BATCH1 {
+            exec(&a, &format!("INSERT INTO t VALUES ({i}, zeroblob(3000))")).unwrap();
+        }
+        exec(&a, "COMMIT").unwrap();
+
+        let mut reader = b.prepare("SELECT id FROM t").unwrap();
+        loop {
+            match reader.step().unwrap() {
+                StepResult::IO => reader._io().step().unwrap(),
+                StepResult::Yield => continue,
+                StepResult::Row => break,
+                r => panic!("unexpected: {r:?}"),
+            }
+        }
+
+        exec(&a, "BEGIN").unwrap();
+        for i in 0..BATCH2 {
+            exec(
+                &a,
+                &format!("INSERT INTO t VALUES ({}, zeroblob(3000))", BATCH1 + i),
+            )
+            .unwrap();
+        }
+
+        let mut commit_stmt = a.prepare("COMMIT").unwrap();
+        let mut pumps = 0usize;
+        loop {
+            match commit_stmt.step().unwrap() {
+                StepResult::IO => {
+                    pumps += 1;
+                    commit_stmt._io().step().unwrap();
+                }
+                StepResult::Row | StepResult::Yield => {}
+                StepResult::Done => break,
+                r => panic!("unexpected: {r:?}"),
+            }
+        }
+        pumps
+    };
+
+    let from = total_yields.saturating_sub(8);
+    for park in (from..total_yields).rev() {
+        let mut s = setup(park);
+        if s.a_done {
+            continue;
+        }
+
+        drop(s.reader_stmt.take());
+
+        let ck = exec_ints(&s.b, "PRAGMA wal_checkpoint").unwrap();
+        if ck.first().copied() != Some(0) {
+            finish(&mut s.commit_stmt);
+            continue;
+        }
+
+        if matches!(
+            try_exec_step(&s.b, "INSERT INTO t VALUES (1000001, zeroblob(3000))").unwrap(),
+            StepResult::Busy
+        ) {
+            finish(&mut s.commit_stmt);
+            exec(&s.b, "INSERT INTO t VALUES (1000001, zeroblob(3000))").unwrap();
+            exec(&s.b, "INSERT INTO t VALUES (1000002, zeroblob(3000))").unwrap();
+            exec(&s.b, "INSERT INTO t VALUES (1000003, zeroblob(3000))").unwrap();
+            let got = exec_ints(&s.b, "SELECT id FROM t WHERE id >= 1000000 ORDER BY id").unwrap();
+            assert_eq!(got, vec![1000001, 1000002, 1000003]);
+            assert_integrity_ok(&s.b, "after guarded stale publish race");
+            return;
+        }
+
+        exec(&s.b, "INSERT INTO t VALUES (1000002, zeroblob(3000))").unwrap();
+        exec(&s.b, "INSERT INTO t VALUES (1000003, zeroblob(3000))").unwrap();
+
+        finish(&mut s.commit_stmt);
+
+        let got = exec_ints(&s.b, "SELECT id FROM t WHERE id >= 1000000 ORDER BY id").unwrap();
+        if got == vec![1000001, 1000002, 1000003] {
+            continue;
+        }
+
+        let dup = exec(&s.b, "INSERT INTO t VALUES (1000001, zeroblob(10))");
+        let integrity_after_reopen = {
+            let Setup {
+                _io: io,
+                db,
+                a,
+                b,
+                commit_stmt,
+                reader_stmt,
+                ..
+            } = s;
+            drop(commit_stmt);
+            drop(reader_stmt);
+            drop(a);
+            drop(b);
+            drop(db);
+            turso_core::clear_database_registry();
+
+            let db2 = Database::open_file(io, "publish-backfill-race.db").unwrap();
+            let c = db2.connect().unwrap();
+            let mut stmt = c.prepare("PRAGMA integrity_check").unwrap();
+            let mut msgs = Vec::new();
+            loop {
+                match stmt.step().unwrap() {
+                    StepResult::IO => stmt._io().step().unwrap(),
+                    StepResult::Yield => continue,
+                    StepResult::Row => {
+                        let row = stmt.row().unwrap();
+                        msgs.push(format!("{:?}", row.get_values().collect::<Vec<_>>()));
+                    }
+                    StepResult::Done => break,
+                    r => panic!("unexpected: {r:?}"),
+                }
+            }
+            msgs
+        };
+
+        panic!(
+            "WAL generation poisoned by stale publish_backfill (COMMIT parked after \
+             {park}/{total_yields} IO pumps):\n\
+             - rows committed by connection B vanished: got {got:?}, expected [1000001, 1000002, 1000003]\n\
+             - re-INSERT of invisible committed PRIMARY KEY 1000001: {dup:?} (should be constraint error)\n\
+             - integrity_check after reopen+recovery: {integrity_after_reopen:?}"
+        );
+    }
+}

--- a/tests/integration/wal/test_wal_publish_backfill_race.rs
+++ b/tests/integration/wal/test_wal_publish_backfill_race.rs
@@ -161,6 +161,134 @@ fn assert_integrity_ok(conn: &Arc<Connection>, context: &str) {
     assert_eq!(rows, vec!["ok"], "integrity_check failed {context}");
 }
 
+fn setup_hidden_root_reuse(park: usize) -> Setup {
+    let io = Arc::new(QueuedIo::new());
+    let db = Database::open_file(io.clone(), "publish-backfill-hidden-root-race.db").unwrap();
+    let a = db.connect().unwrap();
+    let b = db.connect().unwrap();
+
+    exec(&a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)").unwrap();
+    exec(&a, "CREATE TABLE hidden(id INTEGER PRIMARY KEY, v BLOB)").unwrap();
+    exec(&a, "INSERT INTO hidden VALUES(1, zeroblob(3000))").unwrap();
+    exec(&a, "CREATE TABLE small(id INTEGER PRIMARY KEY, k INTEGER)").unwrap();
+    exec(&a, "INSERT INTO small VALUES(1, 1)").unwrap();
+    let _ = exec_ints(&a, "PRAGMA wal_checkpoint").unwrap();
+
+    exec(&a, "BEGIN").unwrap();
+    for i in 0..BATCH1 {
+        exec(&a, &format!("INSERT INTO t VALUES ({i}, zeroblob(3000))")).unwrap();
+    }
+    exec(&a, "COMMIT").unwrap();
+
+    let mut reader = b.prepare("SELECT id FROM t").unwrap();
+    loop {
+        match reader.step().unwrap() {
+            StepResult::IO => reader._io().step().unwrap(),
+            StepResult::Yield => continue,
+            StepResult::Row => break,
+            r => panic!("unexpected step result while parking reader: {r:?}"),
+        }
+    }
+
+    exec(&a, "BEGIN").unwrap();
+    for i in 0..BATCH2 {
+        exec(
+            &a,
+            &format!("INSERT INTO t VALUES ({}, zeroblob(3000))", BATCH1 + i),
+        )
+        .unwrap();
+    }
+
+    let mut commit_stmt = a.prepare("COMMIT").unwrap();
+    let mut pumps = 0;
+    let mut a_done = false;
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 10_000_000, "commit statement seems stuck");
+        match commit_stmt.step().unwrap() {
+            StepResult::IO => {
+                if pumps >= park {
+                    break;
+                }
+                pumps += 1;
+                commit_stmt._io().step().unwrap();
+            }
+            StepResult::Row => {}
+            StepResult::Yield => {}
+            StepResult::Done => {
+                a_done = true;
+                break;
+            }
+            r => panic!("unexpected step result: {r:?}"),
+        }
+    }
+
+    Setup {
+        _io: io,
+        db,
+        a,
+        b,
+        commit_stmt,
+        reader_stmt: Some(reader),
+        a_done,
+    }
+}
+
+fn total_commit_io_pumps_hidden_root_reuse() -> usize {
+    let io = Arc::new(QueuedIo::new());
+    let db = Database::open_file(io.clone(), "publish-backfill-hidden-root-race-dry.db").unwrap();
+    let a = db.connect().unwrap();
+    let b = db.connect().unwrap();
+
+    exec(&a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)").unwrap();
+    exec(&a, "CREATE TABLE hidden(id INTEGER PRIMARY KEY, v BLOB)").unwrap();
+    exec(&a, "INSERT INTO hidden VALUES(1, zeroblob(3000))").unwrap();
+    exec(&a, "CREATE TABLE small(id INTEGER PRIMARY KEY, k INTEGER)").unwrap();
+    exec(&a, "INSERT INTO small VALUES(1, 1)").unwrap();
+    let _ = exec_ints(&a, "PRAGMA wal_checkpoint").unwrap();
+
+    exec(&a, "BEGIN").unwrap();
+    for i in 0..BATCH1 {
+        exec(&a, &format!("INSERT INTO t VALUES ({i}, zeroblob(3000))")).unwrap();
+    }
+    exec(&a, "COMMIT").unwrap();
+
+    let mut reader = b.prepare("SELECT id FROM t").unwrap();
+    loop {
+        match reader.step().unwrap() {
+            StepResult::IO => reader._io().step().unwrap(),
+            StepResult::Yield => continue,
+            StepResult::Row => break,
+            r => panic!("unexpected: {r:?}"),
+        }
+    }
+
+    exec(&a, "BEGIN").unwrap();
+    for i in 0..BATCH2 {
+        exec(
+            &a,
+            &format!("INSERT INTO t VALUES ({}, zeroblob(3000))", BATCH1 + i),
+        )
+        .unwrap();
+    }
+
+    let mut commit_stmt = a.prepare("COMMIT").unwrap();
+    let mut pumps = 0usize;
+    loop {
+        match commit_stmt.step().unwrap() {
+            StepResult::IO => {
+                pumps += 1;
+                commit_stmt._io().step().unwrap();
+            }
+            StepResult::Row | StepResult::Yield => {}
+            StepResult::Done => break,
+            r => panic!("unexpected: {r:?}"),
+        }
+    }
+    pumps
+}
+
 #[test]
 fn wal_stale_publish_backfill_hides_committed_rows() {
     let total_yields = {
@@ -295,4 +423,137 @@ fn wal_stale_publish_backfill_hides_committed_rows() {
              - integrity_check after reopen+recovery: {integrity_after_reopen:?}"
         );
     }
+}
+
+// This test drives the stale backfill-publish race into the same page-type
+// assertion seen under stress.
+//
+// The important setup is:
+// - `hidden` is a normal rowid table with root page H.
+// - `small` is another table that can later get an index.
+// - connection A writes enough large rows to trigger an auto-checkpoint during
+//   COMMIT.
+// - connection B keeps a read cursor open, so A's checkpoint can backfill only
+//   part of the WAL.
+//
+// `total_commit_io_pumps_hidden_root_reuse()` first performs the same COMMIT
+// without any interleaving and counts how many `StepResult::IO` completions it
+// needs. The stale-publish window is near the end of that COMMIT, after WAL
+// checkpoint finalization but before the pager publishes the synced backfill
+// count. The loop below retries the scenario while parking A's COMMIT at each
+// of the last few IO boundaries:
+//
+//   total_yields = number of IO completions needed by COMMIT
+//   park = IO completion count where this test stops A's COMMIT
+//
+// Trying the last few park points keeps the test independent of small changes
+// in the exact number of IO operations while still making the interleaving
+// deterministic.
+//
+// On the buggy path:
+// 1. A is parked before publishing its old partial backfill.
+// 2. B finishes checkpointing, drops `hidden`, and creates `b_idx`, reusing
+//    hidden's old root page H as an index root.
+// 3. A resumes and publishes the old backfill count into the new WAL
+//    generation.
+// 4. A stale prepared schema statement, compiled while `hidden` still existed,
+//    writes schema state that makes `hidden` visible again.
+// 5. After reopen, sqlite_schema says `hidden` is a table rooted at H, but H now
+//    contains an index page. Reading `hidden` uses a table cursor, reaches H,
+//    and trips `matches!(self.page_type(), Ok(PageType::TableLeaf))`.
+//
+// With the fix, B's `DROP TABLE hidden` is Busy while A's checkpoint guard is
+// still held. The WAL cannot restart under A's pending publish, so the page H
+// table/index mismatch never forms.
+#[test]
+fn wal_stale_publish_backfill_can_point_table_at_restarted_index_root() {
+    let total_yields = total_commit_io_pumps_hidden_root_reuse();
+
+    let from = total_yields.saturating_sub(12);
+    for park in (from..total_yields).rev() {
+        let mut s = setup_hidden_root_reuse(park);
+        if s.a_done {
+            continue;
+        }
+
+        let schema_writer = s.db.connect().unwrap();
+        let mut stale_schema_stmt = schema_writer
+            .prepare("CREATE TABLE stale_keep(id INTEGER PRIMARY KEY, v INTEGER)")
+            .unwrap();
+
+        drop(s.reader_stmt.take());
+
+        let ck = exec_ints(&s.b, "PRAGMA wal_checkpoint").unwrap();
+        if ck.first().copied() != Some(0) {
+            finish(&mut s.commit_stmt);
+            continue;
+        }
+
+        // Without the fix, this write restarts the WAL while connection A's
+        // older partial checkpoint is parked before publishing nBackfill.
+        if matches!(
+            try_exec_step(&s.b, "DROP TABLE hidden").unwrap(),
+            StepResult::Busy
+        ) {
+            finish(&mut s.commit_stmt);
+            exec(&s.b, "DROP TABLE hidden").unwrap();
+            exec(&s.b, "CREATE INDEX b_idx ON small(k)").unwrap();
+            let _ = step_blocking(&mut stale_schema_stmt);
+            assert_eq!(
+                exec_ints(
+                    &s.b,
+                    "SELECT count(*) FROM sqlite_schema WHERE name = 'hidden'"
+                )
+                .unwrap(),
+                vec![0]
+            );
+            assert_integrity_ok(&s.b, "after guarded table root reuse race");
+            return;
+        }
+        exec(&s.b, "CREATE INDEX b_idx ON small(k)").unwrap();
+
+        finish(&mut s.commit_stmt);
+
+        // This prepared statement was compiled against the old schema where
+        // `hidden` still exists. On the buggy path, it republishes that schema
+        // after the restarted generation has reused hidden's root as b_idx.
+        let _ = step_blocking(&mut stale_schema_stmt);
+
+        let Setup {
+            _io: io,
+            db,
+            a,
+            b,
+            commit_stmt,
+            reader_stmt,
+            ..
+        } = s;
+        drop(stale_schema_stmt);
+        drop(schema_writer);
+        drop(commit_stmt);
+        drop(reader_stmt);
+        drop(a);
+        drop(b);
+        drop(db);
+        turso_core::clear_database_registry();
+
+        let db2 = Database::open_file(io, "publish-backfill-hidden-root-race.db").unwrap();
+        let c = db2.connect().unwrap();
+        if exec_ints(
+            &c,
+            "SELECT count(*) FROM sqlite_schema WHERE name = 'hidden'",
+        )
+        .unwrap()
+            != vec![1]
+        {
+            continue;
+        }
+
+        let rows = exec_ints(&c, "SELECT id FROM hidden WHERE id >= 0 ORDER BY id").unwrap();
+        assert_eq!(rows, vec![1]);
+        assert_integrity_ok(&c, "after stale schema points at recovered table root");
+        return;
+    }
+
+    panic!("no parking point exercised stale schema/index root WAL race");
 }


### PR DESCRIPTION
## Description

fixes #7722

## Prerequisites

In WAL, we first append pages (called frames) to the WAL file and those pages later "merged" into db file by checkpoint op.

WAL's have generations, once all the frames are merged, a new generation starts overwriting old frames.

consider this:

```text
WAL generation G1

frames:      1 .......... 500 .......... 1100
                         ^              ^
                         |              |
                         |              max_frame
                         |
                         reader B's read mark
```

Here:

```text
max_frame = 1100
```

Connection B is reading an older snapshot, pinned around frame 500.

A checkpoint must respect that read mark. It cannot freely checkpoint everything if a reader still needs a WAL snapshot. So a passive checkpoint may only copy the safe prefix:

```text
frames:      1 .......... 500 .......... 1100
             [ checkpointed ]
                         ^
                         reader B's read mark
```

That is a partial checkpoint (i.e. it copied some of the frames from WAL to DB)

The checkpoint result is:

```text
wal_max_frame        = 1100
backfilled up to     = 500
everything_backfilled = false
```

After copying frames into the DB file, the checkpoint still has to do some more stuff:

```text
SyncDbFile
PublishBackfill
Finalize
```

The important bit is:

```text
publish_backfill(500)
```

That tells future readers that frames up to 500 are safely represented in the DB file

## The buggos

Before this patch, the partial checkpoint dropped checkpoint guard before publishing the backfill

So the old behavior was:

```text
Connection A copies frames 1..500 from G1 into DB
A drops checkpoint guard
A has not yet run publish_backfill(500)
Then A slept because it was tired (or OS decided it was)
```

In that window, a lot of bad things can happen. Like really bad things.

Connection B can run PRAGMA wal_checkpoint, fully backfill G1, and then start a write. Since G1 is fully checkpointed, the write path may restart the WAL.

After checkpoint:

```text
WAL generation G2

frames:      1 ......... 10
                         ^
                         max_frame
```

B commits rows into this new generation.

Then A wakes up from its sweet slumber, resumes its old parked checkpoint and publishes the old value:

```text
publish_backfill(500) <---- whoa!
```

But 500 belonged to G1. It is now being stored into G2.

The shared WAL state becomes nonsensical:

```text
WAL generation G2

frames:      1 ......... 10
                         ^
                         max_frame = 10

nbackfills = 500   <-- stale value from old generation G1
```

A later reader snapshots:

```text
max_frame  = 10
nbackfills = 500
```

and computes:

```text
min_frame = nbackfills + 1 = 501
```

So it searches this range:

```text
frames:      501 .......... 10
```

That is empty. The committed frames 1..10 from G2 are skipped, so the reader falls back to the DB file and does not see B’s committed rows.

This patch comes with two regression tests, one i lifted from this issue https://github.com/tursodatabase/turso/issues/7722 and slightly modified. Another one which matches the exact antithesis error.

```rust
$ CARGO_BUILD_JOBS=1 cargo test -p core_tester --test integration_tests wal_stale_publish_backfill -- --nocapture

running 2 tests

thread 'wal::test_wal_publish_backfill_race::wal_stale_publish_backfill_can_point_table_at_restarted_index_root' panicked at core/storage/pager.rs:434:9:
matches! (self.page_type(), Ok(PageType::TableLeaf))

test wal::test_wal_publish_backfill_race::wal_stale_publish_backfill_can_point_table_at_restarted_index_root ... FAILED

---

thread 'wal::test_wal_publish_backfill_race::wal_stale_publish_backfill_hides_committed_rows' panicked at tests/integration/wal/test_wal_publish_backfill_race.rs:418:9:
WAL generation poisoned by stale publish_backfill (COMMIT parked after 7/8 IO pumps):
- rows committed by connection B vanished: got [], expected [1000001, 1000002, 1000003]
- re-INSERT of invisible committed PRIMARY KEY 1000001: Ok(()) (should be constraint error)
- integrity_check after reopen+recovery: ["[Text(Text { value: \"*** in database main ***\\nPage 1105 (Normal) cell 1 has rowid=1000001 in wrong order. Parent cell has parent_rowid=1099 and next_rowid=1099\", subtype: Text })]"]
test wal::test_wal_publish_backfill_race::wal_stale_publish_backfill_hides_committed_rows ... FAILED

failures:

failures:
    wal::test_wal_publish_backfill_race::wal_stale_publish_backfill_can_point_table_at_restarted_index_root
    wal::test_wal_publish_backfill_race::wal_stale_publish_backfill_hides_committed_rows

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 965 filtered out; finished in 0.41s
```


## Description of AI Usage

Mr Claude came up with a nice regression test which also matched antitthesis error.