### PR TITLE
core/alloc: add stable push_within_capacity helper

### DIFF
--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -22,6 +22,19 @@ pub trait TursoBoxExt<T>: Sized {
 
 pub trait TursoVecExt<T>: Sized {
     fn with_capacity(capacity: usize) -> Self;
+
+    /// Appends an element and returns a reference to it if there is sufficient spare capacity,
+    /// otherwise an error is returned with the element.
+    ///
+    /// Unlike `push`, this method does not reallocate when capacity is exhausted. Callers should
+    /// reserve capacity before using this when insertion must succeed.
+    ///
+    /// Mirrors the unstable standard library implementation:
+    /// <https://doc.rust-lang.org/src/alloc/vec/mod.rs.html#2786>
+    ///
+    /// Takes O(1) time.
+    fn push_within_capacity(&mut self, value: T) -> Result<&mut T, T>;
+
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError>;
 }
 

--- a/core/alloc/collections/vec/mod.rs
+++ b/core/alloc/collections/vec/mod.rs
@@ -35,6 +35,22 @@ impl<T> TursoVecExt<T> for Vec<T> {
     }
 
     #[inline(always)]
+    fn push_within_capacity(&mut self, value: T) -> Result<&mut T, T> {
+        if self.len() == self.capacity() {
+            return Err(value);
+        }
+
+        unsafe {
+            let end = self.as_mut_ptr().add(self.len());
+            std::ptr::write(end, value);
+            self.set_len(self.len() + 1);
+
+            // SAFETY: We just wrote a value to the pointer that will live the lifetime of the reference.
+            Ok(&mut *end)
+        }
+    }
+
+    #[inline(always)]
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
         self.push(value);
         Ok(())

--- a/core/alloc/collections/vec/nightly.rs
+++ b/core/alloc/collections/vec/nightly.rs
@@ -28,12 +28,28 @@ impl<T> TursoVecExt<T> for Vec<T> {
     }
 
     #[inline(always)]
+    fn push_within_capacity(&mut self, value: T) -> Result<&mut T, T> {
+        if self.len() == self.capacity() {
+            return Err(value);
+        }
+
+        unsafe {
+            let end = self.as_mut_ptr().add(self.len());
+            ptr::write(end, value);
+            self.set_len(self.len() + 1);
+
+            // SAFETY: We just wrote a value to the pointer that will live the lifetime of the reference.
+            Ok(&mut *end)
+        }
+    }
+
+    #[inline(always)]
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
-        match self.push_within_capacity(value) {
+        match <Self as TursoVecExt<T>>::push_within_capacity(self, value) {
             Ok(_) => Ok(()),
             Err(value) => {
                 self.try_reserve(1).map_err(TryReserveError::from)?;
-                match self.push_within_capacity(value) {
+                match <Self as TursoVecExt<T>>::push_within_capacity(self, value) {
                     Ok(_) => Ok(()),
                     Err(_) => unreachable!("Vec::try_reserve(1) did not make room"),
                 }

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -149,6 +149,25 @@ fn try_extend_accepts_underreported_lower_bound_iterators() {
 }
 
 #[test]
+fn vec_push_within_capacity_uses_reserved_slot() {
+    let mut values = <Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(1).unwrap();
+    let initial_capacity = values.capacity();
+
+    *values.push_within_capacity(1).unwrap() = 2;
+
+    assert_eq!(values.as_slice(), &[2]);
+    assert_eq!(values.capacity(), initial_capacity);
+}
+
+#[test]
+fn vec_push_within_capacity_returns_value_when_full() {
+    let mut values = <Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(0).unwrap();
+
+    assert_eq!(values.push_within_capacity(1), Err(1));
+    assert!(values.is_empty());
+}
+
+#[test]
 fn iterator_try_collect_accepts_iterators_without_upper_bounds() {
     let values: Vec<_> = LowerBoundOnly { next: 0, end: 3 }.try_collect().unwrap();
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1855,8 +1855,9 @@ impl Schema {
                                 col_name, table.name
                             )));
                         };
-                        // preallocated enough to no use try_push
-                        column_indices_and_sort_orders.push((pos_in_table, *sort_order));
+                        column_indices_and_sort_orders
+                            .push_within_capacity((pos_in_table, *sort_order))
+                            .expect("unique columns vector was preallocated to its input length");
                     }
                     if let Some(index_entry) = automatic_indexes.pop() {
                         self.add_index(Arc::new(Index::automatic_from_unique(
@@ -2421,8 +2422,13 @@ impl Schema {
             let parent_tbl = self
                 .get_btree_table(&parent_name)
                 .ok_or_else(|| fk_mismatch_err(&child.name, &parent_name))?;
-            // Preallocated enough to not use try_push
-            out.push(self.resolve_fk(fk, &child, &parent_tbl, /*require_unique=*/ true)?);
+            out.push_within_capacity(self.resolve_fk(
+                fk,
+                &child,
+                &parent_tbl,
+                /*require_unique=*/ true,
+            )?)
+            .expect("resolved FK vector was preallocated to child.foreign_keys.len()");
         }
         Ok(out)
     }
@@ -2448,8 +2454,9 @@ impl Schema {
             let (i, _) = child
                 .get_column(cname)
                 .ok_or_else(|| fk_mismatch_err(&child.name, &parent_tbl.name))?;
-            // Preallocated enough to not use try_push
-            child_pos.push(i);
+            child_pos
+                .push_within_capacity(i)
+                .expect("child FK position vector was preallocated to fk.child_columns.len()");
         }
 
         // Resolve parent columns: explicit list, or default to parent's PK columns.
@@ -2481,8 +2488,9 @@ impl Schema {
             let Some(p) = pos else {
                 return Err(fk_mismatch_err(&child.name, &parent_tbl.name));
             };
-            // Preallocated enough to not use try_push
-            parent_pos.push(p);
+            parent_pos
+                .push_within_capacity(p)
+                .expect("parent FK position vector was preallocated to parent_cols.len()");
         }
 
         // A single-column parent key is the rowid when it names rowid/_rowid_/oid
@@ -5690,19 +5698,20 @@ impl Index {
                 )));
             };
             let (_, column) = table.get_column(col_name).unwrap();
-            // preallocated enough to not need try_push
-            primary_keys.push(IndexColumn {
-                name: normalize_ident(col_name),
-                order: *order,
-                pos_in_table,
-                collation: collation_overrides
-                    .get(i)
-                    .copied()
-                    .flatten()
-                    .or_else(|| column.collation_opt()),
-                default: column.default.clone(),
-                expr: None,
-            });
+            primary_keys
+                .push_within_capacity(IndexColumn {
+                    name: normalize_ident(col_name),
+                    order: *order,
+                    pos_in_table,
+                    collation: collation_overrides
+                        .get(i)
+                        .copied()
+                        .flatten()
+                        .or_else(|| column.collation_opt()),
+                    default: column.default.clone(),
+                    expr: None,
+                })
+                .expect("primary key index columns vector was preallocated");
         }
 
         assert!(primary_keys.len() == column_count);
@@ -5743,19 +5752,20 @@ impl Index {
                     table.name
                 )));
             };
-            // preallocated enough to not need try_push
-            unique_cols.push(IndexColumn {
-                name: normalize_ident(col.name.as_ref().unwrap()),
-                order: *sort_order,
-                pos_in_table,
-                collation: collation_overrides
-                    .get(i)
-                    .copied()
-                    .flatten()
-                    .or_else(|| col.collation_opt()),
-                default: col.default.clone(),
-                expr: None,
-            });
+            unique_cols
+                .push_within_capacity(IndexColumn {
+                    name: normalize_ident(col.name.as_ref().unwrap()),
+                    order: *sort_order,
+                    pos_in_table,
+                    collation: collation_overrides
+                        .get(i)
+                        .copied()
+                        .flatten()
+                        .or_else(|| col.collation_opt()),
+                    default: col.default.clone(),
+                    expr: None,
+                })
+                .expect("unique index columns vector was preallocated");
         }
 
         Ok(Index {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{TryClone, TursoIteratorExt};
+use crate::alloc::{TryClone, TursoIteratorExt, TursoVecExt};
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::Func;
 use crate::index_method::IndexMethodConfiguration;
@@ -902,29 +902,31 @@ fn resolve_sorted_columns_with_resolver(
                 GeneratedType::Virtual { expr, .. } => Some(expr.clone()),
                 GeneratedType::NotGenerated => None,
             };
-            // Capacity is preallocated to cols.len(); this loop pushes at most one column per input.
-            resolved.push(IndexColumn {
-                name: column_name,
-                order,
-                pos_in_table: pos,
-                collation,
-                default: column.default.clone(),
-                expr,
-            });
+            resolved
+                .push_within_capacity(IndexColumn {
+                    name: column_name,
+                    order,
+                    pos_in_table: pos,
+                    collation,
+                    default: column.default.clone(),
+                    expr,
+                })
+                .expect("resolved index columns vector was preallocated to cols.len()");
             continue;
         }
         if !validate_index_expression(unwrapped_expr, table) {
             crate::bail_parse_error!("Error: invalid expression in CREATE INDEX: {}", sc.expr);
         }
-        // Capacity is preallocated to cols.len(); this loop pushes at most one column per input.
-        resolved.push(IndexColumn {
-            name: sc.expr.to_string(),
-            order,
-            pos_in_table: EXPR_INDEX_SENTINEL,
-            collation: explicit_collation,
-            default: None,
-            expr: Some(sc.expr.clone()),
-        });
+        resolved
+            .push_within_capacity(IndexColumn {
+                name: sc.expr.to_string(),
+                order,
+                pos_in_table: EXPR_INDEX_SENTINEL,
+                collation: explicit_collation,
+                default: None,
+                expr: Some(sc.expr.clone()),
+            })
+            .expect("resolved index columns vector was preallocated to cols.len()");
     }
     Ok(resolved)
 }

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -5,7 +5,7 @@ use smallvec::SmallVec;
 use turso_ext::{ConstraintInfo, ConstraintUsage, ResultCode};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
 
-use crate::alloc::{TursoIteratorExt, TursoTryWithCapacityExt};
+use crate::alloc::{TursoIteratorExt, TursoTryWithCapacityExt, TursoVecExt};
 use crate::schema::Schema;
 use crate::stats::AnalyzeStats;
 use crate::translate::collate::CollationSeq;
@@ -1668,30 +1668,32 @@ fn materialized_subquery_ephemeral_index(
         if !seen_col_positions.insert(col_pos) {
             continue;
         }
-        // Capacity is preallocated to subquery.columns.len(); key columns are deduplicated.
-        index_columns.push(IndexColumn {
-            name: column.name.clone().unwrap_or_default(),
-            order: SortOrder::Asc,
-            pos_in_table: col_pos,
-            collation: column.collation_opt(),
-            default: column.default.clone(),
-            expr: None,
-        });
+        index_columns
+            .push_within_capacity(IndexColumn {
+                name: column.name.clone().unwrap_or_default(),
+                order: SortOrder::Asc,
+                pos_in_table: col_pos,
+                collation: column.collation_opt(),
+                default: column.default.clone(),
+                expr: None,
+            })
+            .expect("subquery index columns vector was preallocated to subquery.columns.len()");
     }
 
     for (col_pos, column) in subquery.columns.iter().enumerate() {
         if seen_col_positions.contains(&col_pos) {
             continue;
         }
-        // Capacity is preallocated to subquery.columns.len(); non-key columns fill the remainder.
-        index_columns.push(IndexColumn {
-            name: column.name.clone().unwrap_or_default(),
-            order: SortOrder::Asc,
-            pos_in_table: col_pos,
-            collation: column.collation_opt(),
-            default: column.default.clone(),
-            expr: None,
-        });
+        index_columns
+            .push_within_capacity(IndexColumn {
+                name: column.name.clone().unwrap_or_default(),
+                order: SortOrder::Asc,
+                pos_in_table: col_pos,
+                collation: column.collation_opt(),
+                default: column.default.clone(),
+                expr: None,
+            })
+            .expect("subquery index columns vector was preallocated to subquery.columns.len()");
     }
 
     Ok(Arc::new(Index {

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -752,20 +752,23 @@ pub fn order_by_deduplicate_result_columns(
             .iter()
             .enumerate()
             .find(|(_, (expr, _, _))| exprs_are_equivalent(expr, &rc.expr));
-        // No need to use `try_push` as we preallocated enough capacity already
         if let Some((j, _)) = found {
-            result_column_remapping.push(OrderByRemapping {
-                orderby_sorter_idx: j,
-                deduplicated: true,
-            });
+            result_column_remapping
+                .push_within_capacity(OrderByRemapping {
+                    orderby_sorter_idx: j,
+                    deduplicated: true,
+                })
+                .expect("ORDER BY remapping vector was preallocated to result_columns.len()");
         } else {
             // This result column is not a duplicate of any ORDER BY key, so its sorter
             // index comes after all ORDER BY entries (hence the +order_by_len). The
             // counter `i` tracks how many such non-duplicate result columns we've seen.
-            result_column_remapping.push(OrderByRemapping {
-                orderby_sorter_idx: order_by_len + sequence_offset + i,
-                deduplicated: false,
-            });
+            result_column_remapping
+                .push_within_capacity(OrderByRemapping {
+                    orderby_sorter_idx: order_by_len + sequence_offset + i,
+                    deduplicated: false,
+                })
+                .expect("ORDER BY remapping vector was preallocated to result_columns.len()");
             i += 1;
         }
     }

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -453,8 +453,9 @@ impl HashEntry {
         let mut key_values = Vec::try_with_capacity_ext(num_keys as usize)?;
         for _ in 0..num_keys {
             let (value, consumed) = Self::deserialize_value(&buf[offset..])?;
-            // Preallocated enough already
-            key_values.push(value);
+            key_values
+                .push_within_capacity(value)
+                .expect("key values vector was preallocated");
             offset += consumed;
         }
 
@@ -465,8 +466,9 @@ impl HashEntry {
         let mut payload_values = Vec::try_with_capacity_ext(num_payload as usize)?;
         for _ in 0..num_payload {
             let (value, consumed) = Self::deserialize_value(&buf[offset..])?;
-            // Preallocated enough already
-            payload_values.push(value);
+            payload_values
+                .push_within_capacity(value)
+                .expect("payload values vector was preallocated");
             offset += consumed;
         }
 
@@ -1466,8 +1468,9 @@ impl HashTable {
         let mut total_size = 0usize;
         for entry in &partition.entries {
             let entry_size = entry.serialized_size();
-            // Preallocated enough already
-            entry_sizes.push(entry_size);
+            entry_sizes
+                .push_within_capacity(entry_size)
+                .expect("entry sizes vector was preallocated");
             total_size += varint_len(entry_size as u64) + entry_size;
         }
 
@@ -1589,8 +1592,9 @@ impl HashTable {
             let mut partition_size = 0usize;
             for entry in &partition.entries {
                 let entry_size = entry.serialized_size();
-                // Preallocated enough
-                entry_sizes.push(entry_size);
+                entry_sizes
+                    .push_within_capacity(entry_size)
+                    .expect("entry sizes vector was preallocated");
                 partition_size += varint_len(entry_size as u64) + entry_size;
             }
 
@@ -1618,8 +1622,9 @@ impl HashTable {
         let mut partition_offsets = Vec::try_with_capacity_ext(metas.len())?;
 
         for meta in &metas {
-            // Preallocated enough already
-            partition_offsets.push(offset);
+            partition_offsets
+                .push_within_capacity(offset)
+                .expect("partition offsets vector was preallocated");
             let partition = &spill_state.partition_buffers[meta.idx];
 
             for (entry, &entry_size) in partition.entries.iter().zip(meta.entry_sizes.iter()) {
@@ -2443,7 +2448,6 @@ impl HashTable {
             } else {
                 let mut combined =
                     Vec::try_with_capacity_ext(partition.partial_entry.len() + data.len())?;
-                // Preallocated enough already
                 combined.extend_from_slice(&partition.partial_entry);
                 combined.extend_from_slice(data);
                 combined

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -905,8 +905,9 @@ impl BoxedSortableRecord {
                 Some(Ok(value)) => {
                     // SAFETY: value points into record which lives as long as this struct
                     let value: ValueRef<'static> = unsafe { std::mem::transmute(value) };
-                    // Preallocated enough space
-                    key_values.push(value);
+                    key_values
+                        .push_within_capacity(value)
+                        .expect("sort key vector was preallocated");
                 }
                 Some(Err(err)) => {
                     mark_unlikely();


### PR DESCRIPTION
## Description

- add `TursoVecExt::push_within_capacity` as a stable mirror of the unstable std `Vec` API
- use the helper at exact-capacity vector push sites so the no-reallocation invariant is explicit
- add focused allocator tests for successful insertion and full-capacity failure

## Motivation
encode the idea of infallible allocation better when pushing into preallocated vec