### PR TITLE
dotnet: support NativeAOT static native linking

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -70,25 +70,25 @@ jobs:
           artifact-name: native-android-x86
           target: i686-linux-android
 
-        - os: macos-latest
+        - os: macos-26-intel
           make-target: build-rust-macos64
           artifact-name: native-osx-x64
           target: x86_64-apple-darwin
           macos-deployment-target: "10.13"
 
-        - os: macos-latest
+        - os: macos-26
           make-target: build-rust-macosarm64
           target: aarch64-apple-darwin
           artifact-name: native-osx-arm64
           macos-deployment-target: "11.0"
 
-        - os: macos-latest
+        - os: macos-26
           make-target: build-rust-iosarm64
           target: aarch64-apple-ios
           artifact-name: native-ios-arm64
           ios-deployment-target: "12.2"
 
-        - os: macos-latest
+        - os: macos-26
           make-target: build-rust-iossimulatorarm64
           target: aarch64-apple-ios-sim
           artifact-name: native-iossimulator-arm64
@@ -133,7 +133,7 @@ jobs:
 
       - name: Set up Android SDK
         if: contains(matrix.target, 'linux-android')
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Install Android NDK
         if: contains(matrix.target, 'linux-android')
@@ -190,6 +190,48 @@ jobs:
         if: ${{ !contains(matrix.target, 'unknown-linux-gnu') && !contains(matrix.target, 'apple-darwin') && !contains(matrix.target, 'apple-ios') }}
         run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official'
 
+      - name: Collect Windows static native dependencies
+        if: contains(matrix.target, 'pc-windows-msvc')
+        shell: pwsh
+        run: |
+          $target = '${{ matrix.target }}'
+          $arch = if ($target -eq 'x86_64-pc-windows-msvc') { 'x86_64' } else { 'aarch64' }
+          $crate = "windows_${arch}_msvc"
+          $destination = "rs_compiled\$target\release-official\native-static-libs"
+          New-Item -ItemType Directory -Force $destination | Out-Null
+
+          $versions = @()
+          $currentPackage = $null
+          foreach ($line in Get-Content "..\..\Cargo.lock") {
+            if ($line -match '^name = "([^"]+)"') {
+              $currentPackage = $Matches[1]
+            } elseif ($currentPackage -eq $crate -and $line -match '^version = "([^"]+)"') {
+              $versions += $Matches[1]
+              $currentPackage = $null
+            }
+          }
+          if (-not $versions) {
+            throw "No $crate package entries were found in Cargo.lock"
+          }
+
+          $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $env:USERPROFILE ".cargo" }
+          $registrySrc = Join-Path $cargoHome "registry\src"
+          foreach ($version in ($versions | Sort-Object -Unique)) {
+            Get-ChildItem -Path $registrySrc -Recurse -Directory -Filter "$crate-$version" |
+              ForEach-Object {
+                Copy-Item -Path (Join-Path $_.FullName "lib\windows*.lib") -Destination $destination -Force
+              }
+          }
+
+          $collected = Get-ChildItem -Path $destination -Filter "windows*.lib"
+          if (-not $collected) {
+            throw "No windows*.lib static dependencies were collected for $target"
+          }
+          $now = [DateTime]::UtcNow
+          foreach ($library in $collected) {
+            $library.LastWriteTimeUtc = $now
+          }
+
       # Code-sign the Windows native DLL with Azure Artifact Signing (formerly
       # Trusted Signing). Runs only for the windows-msvc targets, only when
       # the AZURE_SIGNING_ENABLED repo variable is set to "true", and only on
@@ -224,14 +266,17 @@ jobs:
           name: ${{ matrix.artifact-name }}
           path: |
             ${{ env.working-directory }}/rs_compiled/**/turso_sdk_kit.dll
+            ${{ env.working-directory }}/rs_compiled/**/turso_sdk_kit.lib
+            ${{ env.working-directory }}/rs_compiled/**/windows*.lib
             ${{ env.working-directory }}/rs_compiled/**/libturso_sdk_kit.so
             ${{ env.working-directory }}/rs_compiled/**/libturso_sdk_kit.dylib
+            ${{ env.working-directory }}/rs_compiled/**/libturso_sdk_kit.a
 
           retention-days: 1
 
   package-ios-framework:
     needs: build-natives
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 15
     permissions:
       contents: read
@@ -295,7 +340,7 @@ jobs:
         run:
           make pack
 
-      - name: Verify mobile NuGet native assets
+      - name: Verify NuGet native assets
         shell: bash
         run: |
           set -euo pipefail
@@ -322,6 +367,59 @@ jobs:
             fi
           done
 
+          max_package_bytes=250000000
+          package_size=$(stat -c%s "$package")
+          if [ "$package_size" -gt "$max_package_bytes" ]; then
+            echo "$package is $package_size bytes, which exceeds nuget.org's $max_package_bytes byte package limit"
+            exit 1
+          fi
+
+          if grep -Eq '^buildTransitive/native/(win|linux|osx)-' package-files.txt; then
+            echo "Static NativeAOT assets must stay in RID-specific companion packages, not $package"
+            exit 1
+          fi
+
+          static_packages=(
+            "win-x64:turso_sdk_kit.lib"
+            "win-arm64:turso_sdk_kit.lib"
+            "linux-x64:libturso_sdk_kit.a"
+            "linux-arm64:libturso_sdk_kit.a"
+            "osx-x64:libturso_sdk_kit.a"
+            "osx-arm64:libturso_sdk_kit.a"
+          )
+          for static_package_spec in "${static_packages[@]}"; do
+            rid="${static_package_spec%%:*}"
+            library="${static_package_spec#*:}"
+            static_package=$(find src/Turso.Data.Sqlite.NativeAot/bin/Release -maxdepth 1 -name "Turso.Data.Sqlite.NativeAot.${rid}.*.nupkg" | head -n 1)
+            if [ -z "$static_package" ]; then
+              echo "No Turso.Data.Sqlite.NativeAot.${rid} NuGet package found"
+              exit 1
+            fi
+
+            static_package_size=$(stat -c%s "$static_package")
+            if [ "$static_package_size" -gt "$max_package_bytes" ]; then
+              echo "$static_package is $static_package_size bytes, which exceeds nuget.org's $max_package_bytes byte package limit"
+              exit 1
+            fi
+
+            unzip -Z1 "$static_package" > "package-files-${rid}.txt"
+            required_static_files=(
+              "buildTransitive/Turso.Data.Sqlite.NativeAot.${rid}.targets"
+              "buildTransitive/native/${rid}/${library}"
+            )
+            for required_static_file in "${required_static_files[@]}"; do
+              if ! grep -Fxq "$required_static_file" "package-files-${rid}.txt"; then
+                echo "Missing $required_static_file in $static_package"
+                exit 1
+              fi
+            done
+
+            if [[ "$rid" == win-* ]] && ! grep -Eq "^buildTransitive/native/${rid}/windows.*\\.lib$" "package-files-${rid}.txt"; then
+              echo "Missing Windows static dependency libraries in $static_package"
+              exit 1
+            fi
+          done
+
       - name: Collect NuGet packages
         run: |
           set -euo pipefail
@@ -330,6 +428,7 @@ jobs:
           mkdir -p artifacts/nuget-packages
           files=(
             src/Turso.Data.Sqlite/bin/Release/Turso.Data.Sqlite.*.nupkg
+            src/Turso.Data.Sqlite.NativeAot/bin/Release/Turso.Data.Sqlite.NativeAot.*.nupkg
           )
           if [ ${#files[@]} -eq 0 ]; then
             echo "No NuGet packages found to upload"
@@ -344,8 +443,150 @@ jobs:
           path: ${{ env.working-directory }}/artifacts/nuget-packages/*.nupkg
           retention-days: 7
 
+  validate-nativeaot-static-package:
+    needs: publish
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: windows-2025
+          rid: win-x64
+          executable: NativeAotSample.exe
+
+        - os: windows-11-arm
+          rid: win-arm64
+          executable: NativeAotSample.exe
+
+        - os: ubuntu-latest
+          rid: linux-x64
+          executable: NativeAotSample
+
+        - os: ubuntu-24.04-arm
+          rid: linux-arm64
+          executable: NativeAotSample
+
+        - os: macos-26-intel
+          rid: osx-x64
+          executable: NativeAotSample
+
+        - os: macos-26
+          rid: osx-arm64
+          executable: NativeAotSample
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install dotnet SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Verify NativeAOT prerequisites
+        if: startsWith(matrix.rid, 'linux-')
+        run: |
+          set -euo pipefail
+          clang --version
+          if [ ! -f /usr/include/zlib.h ]; then
+            echo "zlib1g-dev is required for Linux NativeAOT validation"
+            exit 1
+          fi
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@v7
+        with:
+          name: nuget-packages
+          path: ${{ env.working-directory }}/artifacts/nuget-packages
+
+      - name: Publish NativeAOT sample from package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $sampleProject = "${{ env.working-directory }}/samples/NativeAot/NativeAotSample.csproj"
+          $packageSource = Resolve-Path "${{ env.working-directory }}/artifacts/nuget-packages"
+          $publishDirectory = "${{ runner.temp }}/nativeaot-${{ matrix.rid }}"
+          $nugetConfig = "${{ env.working-directory }}/samples/NativeAot/NuGet.config"
+
+          @"
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local" value="$packageSource" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+            </packageSources>
+            <packageSourceMapping>
+              <packageSource key="local">
+                <package pattern="Turso.Data.Sqlite" />
+                <package pattern="Turso.Data.Sqlite.NativeAot.*" />
+              </packageSource>
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>
+          "@ | Set-Content -Path $nugetConfig -Encoding UTF8
+
+          dotnet restore $sampleProject -r "${{ matrix.rid }}" --configfile $nugetConfig
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+          dotnet publish $sampleProject -c Release -r "${{ matrix.rid }}" -o $publishDirectory --no-restore
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+          $sidecars = Get-ChildItem -Path $publishDirectory -Recurse -File |
+            Where-Object { $_.Name -in @("turso_sdk_kit.dll", "libturso_sdk_kit.so", "libturso_sdk_kit.dylib") }
+          if ($sidecars) {
+            throw "NativeAOT publish produced a Turso dynamic sidecar: $($sidecars.FullName -join ', ')"
+          }
+
+          $executable = Join-Path $publishDirectory "${{ matrix.executable }}"
+          if (-not (Test-Path $executable)) {
+            throw "NativeAOT executable was not produced at $executable"
+          }
+
+          if (-not $IsWindows) {
+            chmod +x $executable
+          }
+
+          $output = & $executable
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          if ($output -notcontains "Rows: 3") {
+            throw "Unexpected NativeAOT sample output: $output"
+          }
+
+  publish-to-nuget:
+    needs: validate-nativeaot-static-package
+    if: ${{ github.event_name == 'workflow_dispatch' && !inputs.skip-publish && !inputs.dry-run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Install dotnet SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@v7
+        with:
+          name: nuget-packages
+          path: nuget-packages
+
       # https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package
       - name: Publish to nuget
-        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.skip-publish && !inputs.dry-run }}
         run: |
-          dotnet nuget push ${{ env.working-directory }}/src/Turso.Data.Sqlite/bin/Release/Turso.Data.Sqlite.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          for package in nuget-packages/*.nupkg; do
+            dotnet nuget push "$package" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          done

--- a/bindings/dotnet/Makefile
+++ b/bindings/dotnet/Makefile
@@ -121,6 +121,15 @@ test: build
 benchmark: build-production
 	dotnet run -c Release --project ./src/Benchmarks/Benchmarks.csproj
 
+pack-nativeaot-static:
+	dotnet pack -c Release ./src/Turso.Data.Sqlite.NativeAot/Turso.Data.Sqlite.NativeAot.csproj -p:NativeAotRid=win-x64
+	dotnet pack -c Release ./src/Turso.Data.Sqlite.NativeAot/Turso.Data.Sqlite.NativeAot.csproj -p:NativeAotRid=win-arm64
+	dotnet pack -c Release ./src/Turso.Data.Sqlite.NativeAot/Turso.Data.Sqlite.NativeAot.csproj -p:NativeAotRid=linux-x64
+	dotnet pack -c Release ./src/Turso.Data.Sqlite.NativeAot/Turso.Data.Sqlite.NativeAot.csproj -p:NativeAotRid=linux-arm64
+	dotnet pack -c Release ./src/Turso.Data.Sqlite.NativeAot/Turso.Data.Sqlite.NativeAot.csproj -p:NativeAotRid=osx-x64
+	dotnet pack -c Release ./src/Turso.Data.Sqlite.NativeAot/Turso.Data.Sqlite.NativeAot.csproj -p:NativeAotRid=osx-arm64
+
 pack:
 	dotnet pack -c Release ./src/Turso.Data.Sqlite/Turso.Data.Sqlite.csproj
 	dotnet pack -c Release ./src/Turso.EntityFrameworkCore.Sqlite/Turso.EntityFrameworkCore.Sqlite.csproj
+	$(MAKE) pack-nativeaot-static

--- a/bindings/dotnet/Readme.md
+++ b/bindings/dotnet/Readme.md
@@ -14,6 +14,35 @@ Application code only needs to reference `Turso.Data.Sqlite`.
 
 The package targets `net8.0`, `net9.0`, and `net10.0`. It includes native runtime assets for Windows, Linux, macOS, Android (`android-arm64`, `android-arm`, `android-x64`, and `android-x86`), and iOS as an XCFramework with device and simulator slices.
 
+## NativeAOT static linking
+
+NativeAOT apps can opt into statically linking the Turso native library so publish output does not include a sidecar `turso_sdk_kit` DLL, `.so`, or `.dylib`. Reference the RID-specific static package alongside `Turso.Data.Sqlite`:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Turso.Data.Sqlite" Version="0.7.0-pre.18" />
+  <PackageReference Include="Turso.Data.Sqlite.NativeAot.win-x64" Version="0.7.0-pre.18" PrivateAssets="all" />
+</ItemGroup>
+```
+
+Then enable static linking:
+
+```xml
+<PropertyGroup>
+  <PublishAot>true</PublishAot>
+  <SelfContained>true</SelfContained>
+  <TursoUseStaticNativeLibrary>true</TursoUseStaticNativeLibrary>
+</PropertyGroup>
+```
+
+Publish with a supported runtime identifier, for example:
+
+```bash
+dotnet publish -c Release -r win-x64
+```
+
+Static native packages are published for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`. The dynamic native assets remain the default for non-AOT apps and for mobile targets. See `samples/NativeAot` for a complete executable sample.
+
 ## Getting started
 
 ```C#

--- a/bindings/dotnet/samples/NativeAot/NativeAotSample.csproj
+++ b/bindings/dotnet/samples/NativeAot/NativeAotSample.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+    <TursoUseStaticNativeLibrary>true</TursoUseStaticNativeLibrary>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Turso.Data.Sqlite" Version="$(Version)" />
+    <PackageReference Include="Turso.Data.Sqlite.NativeAot.$(RuntimeIdentifier)"
+                      Version="$(Version)"
+                      PrivateAssets="all"
+                      Condition="'$(PublishAot)' == 'true' and '$(TursoUseStaticNativeLibrary)' == 'true' and '$(RuntimeIdentifier)' != ''" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/samples/NativeAot/Program.cs
+++ b/bindings/dotnet/samples/NativeAot/Program.cs
@@ -1,0 +1,19 @@
+using Turso.Data.Sqlite;
+
+using var connection = new SqliteConnection("Data Source=:memory:");
+connection.Open();
+
+using (var command = connection.CreateCommand())
+{
+    command.CommandText = """
+        CREATE TABLE items (value TEXT NOT NULL);
+        INSERT INTO items VALUES ('native'), ('aot'), ('turso');
+        """;
+    command.ExecuteNonQuery();
+}
+
+using (var command = connection.CreateCommand())
+{
+    command.CommandText = "SELECT COUNT(*) FROM items";
+    Console.WriteLine($"Rows: {command.ExecuteScalar()}");
+}

--- a/bindings/dotnet/samples/NativeAot/README.md
+++ b/bindings/dotnet/samples/NativeAot/README.md
@@ -1,0 +1,15 @@
+# Turso NativeAOT sample
+
+This sample publishes a NativeAOT executable that statically links `turso_sdk_kit` from the RID-specific `Turso.Data.Sqlite.NativeAot.*` package:
+
+```bash
+dotnet publish -c Release -r win-x64
+```
+
+Set `<TursoUseStaticNativeLibrary>true</TursoUseStaticNativeLibrary>` with `<PublishAot>true</PublishAot>` and reference the matching `Turso.Data.Sqlite.NativeAot.<rid>` package to enable static native assets. Supported runtime identifiers are `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`.
+
+When using an unreleased local package, add the package output folder as a restore source, for example:
+
+```bash
+dotnet publish -c Release -r win-x64 -p:RestoreAdditionalProjectSources=..\..\artifacts\nuget-packages
+```

--- a/bindings/dotnet/src/Turso.Data.Sqlite.NativeAot/Turso.Data.Sqlite.NativeAot.csproj
+++ b/bindings/dotnet/src/Turso.Data.Sqlite.NativeAot/Turso.Data.Sqlite.NativeAot.csproj
@@ -1,0 +1,78 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <PackageId>Turso.Data.Sqlite.NativeAot.$(NativeAotRid)</PackageId>
+    <Title>Turso NativeAOT static library ($(NativeAotRid))</Title>
+    <Description>RID-specific static native library assets for NativeAOT publishing with Turso.Data.Sqlite.</Description>
+    <Authors>Turso authors</Authors>
+    <PackageTags>turso;sqlite;database;nativeaot;static;$(NativeAotRid)</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/tursodatabase/turso</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/tursodatabase/turso</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <RequireNativeAssetsForPack>true</RequireNativeAssetsForPack>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NativeAotTarget Condition="'$(NativeAotRid)' == 'win-x64'">x86_64-pc-windows-msvc</NativeAotTarget>
+    <NativeAotTarget Condition="'$(NativeAotRid)' == 'win-arm64'">aarch64-pc-windows-msvc</NativeAotTarget>
+    <NativeAotTarget Condition="'$(NativeAotRid)' == 'linux-x64'">x86_64-unknown-linux-gnu</NativeAotTarget>
+    <NativeAotTarget Condition="'$(NativeAotRid)' == 'linux-arm64'">aarch64-unknown-linux-gnu</NativeAotTarget>
+    <NativeAotTarget Condition="'$(NativeAotRid)' == 'osx-x64'">x86_64-apple-darwin</NativeAotTarget>
+    <NativeAotTarget Condition="'$(NativeAotRid)' == 'osx-arm64'">aarch64-apple-darwin</NativeAotTarget>
+
+    <NativeAotLibraryFile Condition="'$(NativeAotRid)' == 'win-x64' or '$(NativeAotRid)' == 'win-arm64'">turso_sdk_kit.lib</NativeAotLibraryFile>
+    <NativeAotLibraryFile Condition="'$(NativeAotRid)' == 'linux-x64' or '$(NativeAotRid)' == 'linux-arm64' or '$(NativeAotRid)' == 'osx-x64' or '$(NativeAotRid)' == 'osx-arm64'">libturso_sdk_kit.a</NativeAotLibraryFile>
+
+    <_NativeAotProfileDirectory Condition="'$(NativeAotTarget)' != '' and '$(NativeAotLibraryFile)' != '' and Exists('..\..\rs_compiled\$(NativeAotTarget)\release-official\$(NativeAotLibraryFile)')">release-official</_NativeAotProfileDirectory>
+    <_NativeAotProfileDirectory Condition="'$(_NativeAotProfileDirectory)' == '' and '$(NativeAotTarget)' != '' and '$(NativeAotLibraryFile)' != '' and Exists('..\..\rs_compiled\$(NativeAotTarget)\release\$(NativeAotLibraryFile)')">release</_NativeAotProfileDirectory>
+    <_NativeAotLibraryPath Condition="'$(NativeAotTarget)' != '' and '$(_NativeAotProfileDirectory)' != ''">..\..\rs_compiled\$(NativeAotTarget)\$(_NativeAotProfileDirectory)\$(NativeAotLibraryFile)</_NativeAotLibraryPath>
+    <_NativeAotWindowsDependencyDirectory Condition="'$(NativeAotRid)' == 'win-x64' or '$(NativeAotRid)' == 'win-arm64'">..\..\rs_compiled\$(NativeAotTarget)\$(_NativeAotProfileDirectory)\native-static-libs</_NativeAotWindowsDependencyDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\Readme.md" Pack="true" PackagePath="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="buildTransitive\Turso.Data.Sqlite.NativeAot.targets"
+          Pack="true"
+          PackagePath="buildTransitive\$(PackageId).targets" />
+    <None Include="$(_NativeAotLibraryPath)"
+          Visible="false"
+          Condition="'$(_NativeAotLibraryPath)' != '' and Exists('$(_NativeAotLibraryPath)')">
+      <Pack>true</Pack>
+      <PackagePath>buildTransitive\native\$(NativeAotRid)\$(NativeAotLibraryFile)</PackagePath>
+    </None>
+    <None Include="$(_NativeAotWindowsDependencyDirectory)\windows*.lib"
+          Visible="false"
+          Condition="'$(_NativeAotWindowsDependencyDirectory)' != '' and Exists('$(_NativeAotWindowsDependencyDirectory)')">
+      <Pack>true</Pack>
+      <PackagePath>buildTransitive\native\$(NativeAotRid)\</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <Target Name="ValidateNativeAotStaticPackage" BeforeTargets="Pack"
+          Condition="'$(RequireNativeAssetsForPack)' == 'true'">
+    <ItemGroup>
+      <_NativeAotWindowsDependencies Include="$(_NativeAotWindowsDependencyDirectory)\windows*.lib"
+                                     Condition="'$(_NativeAotWindowsDependencyDirectory)' != '' and Exists('$(_NativeAotWindowsDependencyDirectory)')" />
+    </ItemGroup>
+
+    <Error Condition="'$(NativeAotRid)' == ''"
+           Text="NativeAotRid is required when packing Turso.Data.Sqlite.NativeAot." />
+    <Error Condition="'$(NativeAotTarget)' == ''"
+           Text="Unsupported NativeAotRid '$(NativeAotRid)'." />
+    <Error Condition="'$(_NativeAotLibraryPath)' == '' or !Exists('$(_NativeAotLibraryPath)')"
+           Text="Missing $(NativeAotRid) static native asset. Build $(NativeAotLibraryFile) before packing $(PackageId)." />
+    <Error Condition="('$(NativeAotRid)' == 'win-x64' or '$(NativeAotRid)' == 'win-arm64') and '@(_NativeAotWindowsDependencies)' == ''"
+           Text="Missing $(NativeAotRid) static native dependency assets. Collect windows*.lib before packing $(PackageId)." />
+  </Target>
+</Project>

--- a/bindings/dotnet/src/Turso.Data.Sqlite.NativeAot/buildTransitive/Turso.Data.Sqlite.NativeAot.targets
+++ b/bindings/dotnet/src/Turso.Data.Sqlite.NativeAot/buildTransitive/Turso.Data.Sqlite.NativeAot.targets
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <_TursoDataSqliteStaticNativeLibrary Condition="'$(_TursoDataSqliteStaticNativeLibrary)' == '' and '$(RuntimeIdentifier)' == 'win-x64' and Exists('$(MSBuildThisFileDirectory)native\win-x64\turso_sdk_kit.lib')">$(MSBuildThisFileDirectory)native\win-x64\turso_sdk_kit.lib</_TursoDataSqliteStaticNativeLibrary>
+    <_TursoDataSqliteStaticNativeLibrary Condition="'$(_TursoDataSqliteStaticNativeLibrary)' == '' and '$(RuntimeIdentifier)' == 'win-arm64' and Exists('$(MSBuildThisFileDirectory)native\win-arm64\turso_sdk_kit.lib')">$(MSBuildThisFileDirectory)native\win-arm64\turso_sdk_kit.lib</_TursoDataSqliteStaticNativeLibrary>
+    <_TursoDataSqliteStaticNativeLibrary Condition="'$(_TursoDataSqliteStaticNativeLibrary)' == '' and '$(RuntimeIdentifier)' == 'linux-x64' and Exists('$(MSBuildThisFileDirectory)native\linux-x64\libturso_sdk_kit.a')">$(MSBuildThisFileDirectory)native\linux-x64\libturso_sdk_kit.a</_TursoDataSqliteStaticNativeLibrary>
+    <_TursoDataSqliteStaticNativeLibrary Condition="'$(_TursoDataSqliteStaticNativeLibrary)' == '' and '$(RuntimeIdentifier)' == 'linux-arm64' and Exists('$(MSBuildThisFileDirectory)native\linux-arm64\libturso_sdk_kit.a')">$(MSBuildThisFileDirectory)native\linux-arm64\libturso_sdk_kit.a</_TursoDataSqliteStaticNativeLibrary>
+    <_TursoDataSqliteStaticNativeLibrary Condition="'$(_TursoDataSqliteStaticNativeLibrary)' == '' and '$(RuntimeIdentifier)' == 'osx-x64' and Exists('$(MSBuildThisFileDirectory)native\osx-x64\libturso_sdk_kit.a')">$(MSBuildThisFileDirectory)native\osx-x64\libturso_sdk_kit.a</_TursoDataSqliteStaticNativeLibrary>
+    <_TursoDataSqliteStaticNativeLibrary Condition="'$(_TursoDataSqliteStaticNativeLibrary)' == '' and '$(RuntimeIdentifier)' == 'osx-arm64' and Exists('$(MSBuildThisFileDirectory)native\osx-arm64\libturso_sdk_kit.a')">$(MSBuildThisFileDirectory)native\osx-arm64\libturso_sdk_kit.a</_TursoDataSqliteStaticNativeLibrary>
+
+    <_TursoDataSqliteStaticNativeDependencyDirectory Condition="'$(RuntimeIdentifier)' == 'win-x64' and '$(_TursoDataSqliteStaticNativeLibrary)' != ''">$(MSBuildThisFileDirectory)native\win-x64\</_TursoDataSqliteStaticNativeDependencyDirectory>
+    <_TursoDataSqliteStaticNativeDependencyDirectory Condition="'$(RuntimeIdentifier)' == 'win-arm64' and '$(_TursoDataSqliteStaticNativeLibrary)' != ''">$(MSBuildThisFileDirectory)native\win-arm64\</_TursoDataSqliteStaticNativeDependencyDirectory>
+  </PropertyGroup>
+</Project>

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteDataReader.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteDataReader.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -221,6 +222,7 @@ public class SqliteDataReader : DbDataReader
 
     public override IEnumerator GetEnumerator() => new DbEnumerator(this, closeReader: false);
 
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
     public override Type GetFieldType(int ordinal)
     {
         EnsureOpen();
@@ -954,6 +956,7 @@ public class SqliteDataReader : DbDataReader
         };
     }
 
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
     private static Type GetClrTypeFromSqliteType(string typeName, TursoValueType fallback)
     {
         if (IsGuidType(typeName))
@@ -974,6 +977,7 @@ public class SqliteDataReader : DbDataReader
         return typeof(string);
     }
 
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
     private static Type GetClrTypeFromValueType(TursoValueType valueType)
         => valueType switch
         {

--- a/bindings/dotnet/src/Turso.Data.Sqlite/buildTransitive/Turso.Data.Sqlite.targets
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/buildTransitive/Turso.Data.Sqlite.targets
@@ -2,7 +2,60 @@
   <PropertyGroup>
     <_TursoDataSqlitePackageRoot>$(MSBuildThisFileDirectory)..\</_TursoDataSqlitePackageRoot>
     <_TursoDataSqliteTargetPlatform>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</_TursoDataSqliteTargetPlatform>
+    <_TursoDataSqliteStaticNativeEnabled Condition="'$(PublishAot)' == 'true' and '$(TursoUseStaticNativeLibrary)' == 'true'">true</_TursoDataSqliteStaticNativeEnabled>
+    <_TursoDataSqliteStaticNativeSupportedRid Condition="'$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64' or '$(RuntimeIdentifier)' == 'linux-x64' or '$(RuntimeIdentifier)' == 'linux-arm64' or '$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64'">true</_TursoDataSqliteStaticNativeSupportedRid>
+    <_TursoDataSqliteStaticNativePackageId>Turso.Data.Sqlite.NativeAot.$(RuntimeIdentifier)</_TursoDataSqliteStaticNativePackageId>
   </PropertyGroup>
+
+  <Target Name="ConfigureTursoStaticNativeLibrary"
+          BeforeTargets="SetupOSSpecificProps"
+          Condition="'$(_TursoDataSqliteStaticNativeEnabled)' == 'true'">
+    <Error Condition="'$(RuntimeIdentifier)' == ''"
+           Text="TursoUseStaticNativeLibrary requires a RuntimeIdentifier, for example win-x64, linux-x64, or osx-arm64." />
+    <Error Condition="'$(RuntimeIdentifier)' != '' and '$(_TursoDataSqliteStaticNativeSupportedRid)' != 'true'"
+           Text="TursoUseStaticNativeLibrary does not support RuntimeIdentifier '$(RuntimeIdentifier)'." />
+    <Error Condition="'$(_TursoDataSqliteStaticNativeSupportedRid)' == 'true' and '$(_TursoDataSqliteStaticNativeLibrary)' == ''"
+           Text="TursoUseStaticNativeLibrary for $(RuntimeIdentifier) requires a PackageReference to $(_TursoDataSqliteStaticNativePackageId) with the same version as Turso.Data.Sqlite." />
+    <Error Condition="'$(_TursoDataSqliteStaticNativeLibrary)' != '' and !Exists('$(_TursoDataSqliteStaticNativeLibrary)')"
+           Text="Missing Turso static native library '$(_TursoDataSqliteStaticNativeLibrary)'." />
+
+    <ItemGroup>
+      <DirectPInvoke Include="turso_sdk_kit" />
+      <NativeLibrary Include="$(_TursoDataSqliteStaticNativeLibrary)"
+                     Condition="'$(_TursoDataSqliteStaticNativeLibrary)' != ''" />
+      <_TursoDataSqliteWindowsStaticNativeDependencies Include="$(_TursoDataSqliteStaticNativeDependencyDirectory)windows*.lib"
+                                                      Condition="'$(_TursoDataSqliteStaticNativeDependencyDirectory)' != ''" />
+    </ItemGroup>
+
+    <Error Condition="('$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64') and '@(_TursoDataSqliteWindowsStaticNativeDependencies)' == ''"
+           Text="Missing Turso Windows static native dependency libraries from $(_TursoDataSqliteStaticNativePackageId)." />
+
+    <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64'">
+      <LinkerArg Include="/NODEFAULTLIB:MSVCRT" />
+      <NativeLibrary Include="@(_TursoDataSqliteWindowsStaticNativeDependencies)" />
+      <NativeLibrary Include="bcrypt.lib" />
+      <NativeLibrary Include="advapi32.lib" />
+      <NativeLibrary Include="kernel32.lib" />
+      <NativeLibrary Include="ntdll.lib" />
+      <NativeLibrary Include="userenv.lib" />
+      <NativeLibrary Include="ws2_32.lib" />
+      <NativeLibrary Include="dbghelp.lib" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64' or '$(RuntimeIdentifier)' == 'linux-arm64'">
+      <NativeSystemLibrary Include="util" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RemoveTursoDynamicNativeLibraryForStaticLink"
+          AfterTargets="ResolvePackageAssets"
+          BeforeTargets="CopyFilesToOutputDirectory;ComputeFilesToPublish"
+          Condition="'$(_TursoDataSqliteStaticNativeEnabled)' == 'true'">
+    <ItemGroup>
+      <NativeCopyLocalItems Remove="@(NativeCopyLocalItems)"
+                            Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == 'turso_sdk_kit.dll' or '%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == 'libturso_sdk_kit.so' or '%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == 'libturso_sdk_kit.dylib'" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup Condition="'$(_TursoDataSqliteTargetPlatform)' == 'android' and ($(AndroidSupportedAbis.Contains('armeabi-v7a')) or $(RuntimeIdentifiers.Contains('android-arm')) or '$(RuntimeIdentifier)' == 'android-arm')">
     <AndroidNativeLibrary Include="$(_TursoDataSqlitePackageRoot)runtimes\android-arm\native\libturso_sdk_kit.so"


### PR DESCRIPTION
## Summary

This adds an optional NativeAOT static-link path for the .NET `Turso.Data.Sqlite` package while keeping the normal NuGet consumer experience unchanged.

## What changes for NuGet consumers

Normal consumers keep referencing only the main package:

```xml
<PackageReference Include="Turso.Data.Sqlite" Version="0.7.0-pre.18" />
```

That package still contains the managed ADO.NET/SQLite-compatible API and the default shared native runtime assets for Windows, Linux, macOS, Android, and iOS. Normal CoreCLR/JIT apps and NativeAOT apps that do not opt into static linking continue to use the shared `turso_sdk_kit` sidecar library.

NativeAOT consumers that want a single executable with no Turso native sidecar add the matching RID-specific companion package and enable the opt-in MSBuild property:

```xml
<PropertyGroup>
  <PublishAot>true</PublishAot>
  <SelfContained>true</SelfContained>
  <TursoUseStaticNativeLibrary>true</TursoUseStaticNativeLibrary>
</PropertyGroup>

<ItemGroup>
  <PackageReference Include="Turso.Data.Sqlite" Version="0.7.0-pre.18" />
  <PackageReference Include="Turso.Data.Sqlite.NativeAot.win-x64" Version="0.7.0-pre.18" PrivateAssets="all" />
</ItemGroup>
```

The static companion packages are published per desktop RID:

- `Turso.Data.Sqlite.NativeAot.win-x64`
- `Turso.Data.Sqlite.NativeAot.win-arm64`
- `Turso.Data.Sqlite.NativeAot.linux-x64`
- `Turso.Data.Sqlite.NativeAot.linux-arm64`
- `Turso.Data.Sqlite.NativeAot.osx-x64`
- `Turso.Data.Sqlite.NativeAot.osx-arm64`

The companion packages only carry static link inputs (`turso_sdk_kit.lib` / `libturso_sdk_kit.a`, plus required Windows `windows*.lib` dependencies). The `Turso.Data.Sqlite` build targets use those assets only when `PublishAot=true` and `TursoUseStaticNativeLibrary=true`; otherwise the shared native runtime assets remain the default.

## Implementation notes

- Adds a `Turso.Data.Sqlite.NativeAot` packaging project that emits RID-specific static-asset packages.
- Adds `buildTransitive` targets that wire `DirectPInvoke` and `NativeLibrary` for supported desktop RIDs.
- Removes the dynamic Turso native sidecar from NativeAOT publish output when static linking is enabled.
- Adds a `bindings/dotnet/samples/NativeAot` sample used by CI to publish and run a package-based NativeAOT executable.
- Keeps static archives out of the main `Turso.Data.Sqlite` package so regular consumers do not download large unused `.lib` / `.a` files and the main package stays below nuget.org's package-size limit.

## Validation

- `dotnet build .\bindings\dotnet\src\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj`
- package-based `win-x64` NativeAOT publish/run with no `turso_sdk_kit.dll` sidecar
- Dotnet Publish workflow passed on the current head: https://github.com/awakecoding/turso/actions/runs/28952951667
- CI package artifact sizes are under nuget.org's 250 MB package limit: main package ~132 MB; static companion packages ~69-83 MB each


