### PR TITLE
core/translate: resolve inner join ON clauses against the whole FROM

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1467,6 +1467,12 @@ pub fn parse_from(
             connection,
         )?;
 
+        // ON predicates of inner joins are resolved after every table in the FROM
+        // clause has been added, so they can reference any table regardless of its
+        // position (SQLite treats the whole FROM clause as one namespace). Outer
+        // joins keep binding against the tables to their left to preserve their
+        // null-extension semantics.
+        let mut deferred_inner_on: Vec<usize> = vec![];
         for join in joins_owned.into_iter() {
             parse_join(
                 join,
@@ -1477,6 +1483,16 @@ pub fn parse_from(
                 vtab_predicates,
                 table_references,
                 connection,
+                &mut deferred_inner_on,
+            )?;
+        }
+        for idx in deferred_inner_on {
+            bind_and_rewrite_expr(
+                &mut out_where_clause[idx].expr,
+                Some(table_references),
+                None,
+                resolver,
+                BindingBehavior::TryResultColumnsFirst,
             )?;
         }
     }
@@ -1811,6 +1827,7 @@ fn parse_join(
     vtab_predicates: &mut Vec<Expr>,
     table_references: &mut TableReferences,
     connection: &Arc<crate::Connection>,
+    deferred_inner_on: &mut Vec<usize>,
 ) -> Result<()> {
     let ast::JoinedSelectTable {
         operator: join_operator,
@@ -1918,19 +1935,23 @@ fn parse_join(
             ast::JoinConstraint::On(ref expr) => {
                 let start_idx = out_where_clause.len();
                 break_predicate_at_and_boundaries(expr, out_where_clause);
-                for predicate in out_where_clause[start_idx..].iter_mut() {
+                for (offset, predicate) in out_where_clause[start_idx..].iter_mut().enumerate() {
                     predicate.from_outer_join = if outer {
                         Some(table_references.joined_tables().last().unwrap().internal_id)
                     } else {
                         None
                     };
-                    bind_and_rewrite_expr(
-                        &mut predicate.expr,
-                        Some(table_references),
-                        None,
-                        resolver,
-                        BindingBehavior::TryResultColumnsFirst,
-                    )?;
+                    if outer {
+                        bind_and_rewrite_expr(
+                            &mut predicate.expr,
+                            Some(table_references),
+                            None,
+                            resolver,
+                            BindingBehavior::TryResultColumnsFirst,
+                        )?;
+                    } else {
+                        deferred_inner_on.push(start_idx + offset);
+                    }
                 }
             }
             ast::JoinConstraint::Using(distinct_names) => {

--- a/testing/sqltests/tests/joins/on_clause_forward_reference.sqltest
+++ b/testing/sqltests/tests/joins/on_clause_forward_reference.sqltest
@@ -1,0 +1,95 @@
+@database :memory:
+
+# Regression tests for #7765: an inner JOIN's ON clause could not reference a
+# table alias that appears later in the FROM list, even though SQLite resolves
+# ON clauses against the whole FROM clause. Reordering the joins was the only
+# workaround. Binding the inner-join ON predicates after every table has been
+# added lets them see the later tables.
+
+setup abc {
+    CREATE TABLE a(x);
+    CREATE TABLE b(y);
+    CREATE TABLE c(z);
+    INSERT INTO a VALUES (1);
+    INSERT INTO b VALUES (1);
+    INSERT INTO c VALUES (1);
+}
+
+@setup abc
+test on-references-later-table {
+    SELECT * FROM a
+    JOIN b ON a.x = c.z
+    JOIN c ON b.y = c.z;
+}
+expect {
+1|1|1
+}
+
+# The already-working ordering must keep working.
+@setup abc
+test on-references-earlier-table {
+    SELECT * FROM a
+    JOIN c ON a.x = c.z
+    JOIN b ON b.y = c.z;
+}
+expect {
+1|1|1
+}
+
+# An unqualified column that only exists in a later table now resolves to it.
+@setup abc
+test on-bare-column-from-later-table {
+    SELECT * FROM a
+    JOIN b ON z = 1
+    JOIN c ON b.y = c.z;
+}
+expect {
+1|1|1
+}
+
+setup chain {
+    CREATE TABLE a(x);
+    CREATE TABLE b(y);
+    CREATE TABLE c(z);
+    CREATE TABLE d(w);
+    INSERT INTO a VALUES (1), (2);
+    INSERT INTO b VALUES (1), (2);
+    INSERT INTO c VALUES (1), (2);
+    INSERT INTO d VALUES (1), (2);
+}
+
+# Forward references across a multi-way join, including one inside an AND.
+@setup chain
+test on-forward-reference-chain {
+    SELECT * FROM a
+    JOIN b ON a.x = d.w AND a.x = b.y
+    JOIN c ON b.y = c.z
+    JOIN d ON c.z = d.w
+    ORDER BY 1, 2, 3, 4;
+}
+expect {
+1|1|1|1
+2|2|2|2
+}
+
+# An inner join whose ON references a table that is LEFT JOINed later still
+# matches SQLite, including when that table is null-extended.
+setup abc_multi {
+    CREATE TABLE a(x);
+    CREATE TABLE b(y);
+    CREATE TABLE c(z);
+    INSERT INTO a VALUES (1), (2), (3);
+    INSERT INTO b VALUES (1), (2);
+    INSERT INTO c VALUES (2);
+}
+
+@setup abc_multi
+test on-references-later-outer-joined-table {
+    SELECT a.x, b.y, c.z FROM a
+    JOIN b ON a.x = c.z
+    LEFT JOIN c ON b.y = c.z
+    ORDER BY 1, 2, 3;
+}
+expect {
+2|2|2
+}


### PR DESCRIPTION
## Description

`JOIN` queries broke when an `ON` clause pointed at a table alias defined later in the `FROM` list:

```sql
SELECT * FROM a JOIN b ON a.x = c.z JOIN c ON b.y = c.z;
-- Turso:  Parse error: no such table: c
-- SQLite: 1|1|1
```

Each `ON` clause was bound as soon as its join was parsed, so it only saw the tables to its left. SQLite resolves `ON` against the whole `FROM`, so the only workaround was reordering the joins.

Fix binds inner-join `ON` clauses after all the FROM tables are in, instead of one join at a time. Outer joins are left alone so their null handling doesn't change.

I kept this to inner joins on purpose. Outer-join forward refs have their own SQLite rules (some allowed, some a hard error) and matching that felt like a separate change, so they stay rejected like today. Can add it here or later, your call.

## Motivation and context

Fixes #7765. These run fine on SQLite and COMPAT.md says `JOIN` is supported, so it's a compat gap.

Added a `.sqltest` under `testing/sqltests/tests/joins/` with the repro and a few variants. All fail without the fix, pass with it, and the rest of the join suite still passes.
