### PR TITLE
core/wal: add regression test for non writer clearing wal index

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1101,6 +1101,8 @@ struct CommitInfo {
     page_sources: Vec<PageSource>,
     page_source_cursor: usize,
     prepared_frames: Vec<PreparedFrames>,
+    #[cfg(test)]
+    wal_frames_cached_before_commit_publish: bool,
 }
 
 /// Represents a dirty page that will be committed to the log.
@@ -1120,6 +1122,10 @@ impl CommitInfo {
         self.page_sources.clear();
         self.prepared_frames.clear();
         self.page_source_cursor = 0;
+        #[cfg(test)]
+        {
+            self.wal_frames_cached_before_commit_publish = false;
+        }
     }
 
     /// Clear and reserve space for n pages in each vector.
@@ -1357,6 +1363,8 @@ pub struct Pager {
     subjournal: RwLock<Option<Subjournal>>,
     savepoints: Arc<RwLock<Vec<Savepoint>>>,
     commit_info: RwLock<CommitInfo>,
+    #[cfg(test)]
+    commit_yield_after_wal_frames_cached_before_publish: AtomicBool,
     checkpoint_state: RwLock<CheckpointState>,
     syncing: Arc<AtomicBool>,
     auto_vacuum_mode: AtomicU8,
@@ -1651,7 +1659,11 @@ impl Pager {
                 prepared_frames: Vec::new(),
                 page_sources: Vec::new(),
                 page_source_cursor: 0,
+                #[cfg(test)]
+                wal_frames_cached_before_commit_publish: false,
             }),
+            #[cfg(test)]
+            commit_yield_after_wal_frames_cached_before_publish: AtomicBool::new(false),
             syncing: Arc::new(AtomicBool::new(false)),
             checkpoint_state: RwLock::new(CheckpointState::default()),
             buffer_pool,
@@ -4333,11 +4345,33 @@ impl Pager {
                 CommitState::WalCommitDone => {
                     // all I/O complete, NOW it's safe to advance WAL state
                     let mut commit_info = self.commit_info.write();
-                    wal.commit_prepared_frames(&commit_info.prepared_frames);
+                    #[cfg(test)]
+                    {
+                        if !commit_info.wal_frames_cached_before_commit_publish {
+                            wal.commit_prepared_frames(&commit_info.prepared_frames);
+                            commit_info.wal_frames_cached_before_commit_publish = true;
+                        }
+                        if self
+                            .commit_yield_after_wal_frames_cached_before_publish
+                            .swap(false, Ordering::AcqRel)
+                        {
+                            return Ok(IOResult::IO(
+                                IOCompletions::Single(Completion::new_yield()),
+                            ));
+                        }
+                    }
+                    #[cfg(not(test))]
+                    {
+                        wal.commit_prepared_frames(&commit_info.prepared_frames);
+                    }
                     wal.finalize_committed_pages(&commit_info.prepared_frames);
                     wal.finish_append_frames_commit()?;
                     self.dirty_pages.write().clear();
                     commit_info.prepared_frames.clear();
+                    #[cfg(test)]
+                    {
+                        commit_info.wal_frames_cached_before_commit_publish = false;
+                    }
 
                     let need_checkpoint = allowed_auto_actions.contains(WalAutoActions::Checkpoint)
                         && wal.should_checkpoint();
@@ -5924,13 +5958,106 @@ pub(crate) mod ptrmap {
 
 #[cfg(test)]
 mod tests {
-    use crate::sync::Arc;
-
-    use crate::sync::RwLock;
-
     use crate::storage::page_cache::{PageCache, PageCacheKey};
+    use crate::sync::atomic::Ordering;
+    use crate::sync::Arc;
+    use crate::sync::RwLock;
+    use crate::{Connection, Database, PlatformIO, StepResult, IO};
 
     use super::Page;
+
+    const CREATE_TABLE: &str = "CREATE TABLE t(k BLOB PRIMARY KEY, v INTEGER)";
+    const CONN0_INSERT: &str = "INSERT INTO t(k, v) VALUES (zeroblob(5735), 577)";
+
+    fn exec_ok(conn: &Arc<Connection>, sql: &str) {
+        conn.execute(sql)
+            .unwrap_or_else(|err| panic!("failed `{sql}`: {err}"));
+    }
+
+    fn is_locked_error(err: &str) -> bool {
+        let err = err.to_ascii_lowercase();
+        err.contains("database is locked") || err.contains("database is busy")
+    }
+
+    fn exec_locked(conn: &Arc<Connection>, sql: &str) {
+        let err = conn
+            .execute(sql)
+            .expect_err("statement should be blocked by conn0's write tx")
+            .to_string();
+        assert!(
+            is_locked_error(&err),
+            "expected lock error for `{sql}`, got {err}"
+        );
+    }
+
+    fn query_single_i64(conn: &Arc<Connection>, sql: &str) -> i64 {
+        let mut stmt = conn
+            .prepare(sql)
+            .unwrap_or_else(|err| panic!("failed to prepare `{sql}`: {err}"));
+        match stmt.step().unwrap() {
+            StepResult::Row => stmt.row().unwrap().get::<i64>(0).unwrap(),
+            other => panic!("expected row from `{sql}`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn committed_row_visible_after_wal_frames_cached_before_commit_publish_yield() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("wal-frame-cache-visible-before-publish.db");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io.clone(), db_path.to_str().unwrap()).unwrap();
+
+        let setup = db.connect().unwrap();
+        exec_ok(&setup, "PRAGMA data_sync_retry = 1");
+        exec_ok(&setup, CREATE_TABLE);
+
+        let conn0 = db.connect().unwrap();
+        let conn1 = db.connect().unwrap();
+        exec_ok(&conn0, "PRAGMA data_sync_retry = 1");
+        exec_ok(&conn1, "PRAGMA data_sync_retry = 1");
+
+        conn0
+            .pager
+            .load()
+            .commit_yield_after_wal_frames_cached_before_publish
+            .store(true, Ordering::Release);
+
+        let mut conn0_stmt = conn0.prepare(CONN0_INSERT).unwrap();
+        loop {
+            match conn0_stmt.step().unwrap() {
+                StepResult::Yield => break,
+                StepResult::IO => io.step().unwrap(),
+                StepResult::Done => panic!("conn0 completed before commit-publish yield fired"),
+                StepResult::Row => {}
+                StepResult::Interrupt | StepResult::Busy => {
+                    panic!("conn0 stopped before commit-publish yield fired")
+                }
+            }
+        }
+
+        exec_ok(&conn1, "BEGIN");
+        exec_ok(&conn1, "SAVEPOINT s");
+        exec_locked(
+            &conn1,
+            "INSERT INTO t(k, v) VALUES (x'6c6f75645f73756e5f383333', 233)",
+        );
+        exec_ok(&conn1, "ROLLBACK TO s");
+
+        conn0_stmt.run_ignore_rows().unwrap();
+
+        let conn2 = db.connect().unwrap();
+        exec_ok(&conn2, "PRAGMA data_sync_retry = 1");
+        assert_eq!(
+            query_single_i64(
+                &conn2,
+                "SELECT COUNT(*) FROM t WHERE k = zeroblob(5735) AND v = 577",
+            ),
+            1
+        );
+
+        exec_ok(&conn1, "RELEASE s");
+        exec_ok(&conn1, "COMMIT");
+    }
 
     #[test]
     fn test_shared_cache() {


### PR DESCRIPTION
# Note

The work of this PR is superceded by commit 46cd926d3. So I have just kept the regression test.

## Background

Turso supports both concurrent MVCC and single-writer WAL mode, similar to
SQLite. In WAL mode, database changes are written as WAL frames.

A WAL frame maps a frame number to a database page:

```text
frame 11 -> page 1
frame 12 -> page 5
frame 13 -> page 9
```

To read a page, Turso keeps a shared WAL index:

```text
page id -> latest WAL frame(s)

page 1 -> [3, 11]
page 5 -> [12]
page 9 -> [13]
```

Readers do not blindly read the newest cached frame. Each reader has a WAL
snapshot range:

```text
reader snapshot: min_frame..=max_frame
```

For example, an old reader with `max_frame = 10` ignores `page 1 -> frame 11`
because frame 11 is outside its snapshot.

A writer can insert WAL index entries before publishing the final commit
watermark. The final commit publication is the point where new readers are
allowed to see the new `max_frame`.

The intended ordering is:

1. Writer writes WAL frames.
2. Writer installs `page -> frame` mappings in the shared WAL index.
3. Writer publishes the commit `max_frame`.
4. New readers can read committed frames up to that `max_frame`.

This ordering matters. If the commit watermark were published before the shared
WAL index was populated, a new reader could see the commit but fail to find the
frames needed for that commit.

## The Bug

In WAL mode there can be only one writer at a time. The bug was that one
connection could delete another connection's in-flight shared WAL index entries
during savepoint rollback.

The old savepoint rollback path always did WAL rollback work:

```rust
wal.rollback(Some(RollbackTo {
    frame: savepoint.wal_max_frame,
    checksum: savepoint.wal_checksum,
}));

self.page_cache
    .write()
    .delete_clean_pages_after_wal_frame(savepoint.wal_max_frame)?;
```

That is valid only for a writer rolling back its own savepoint. It is not valid
for a reader or blocked writer that does not own the WAL write lock.

## Failing Interleaving

Initial committed WAL state:

```text
global committed max_frame = 10
shared WAL index has mappings through frame 10
```

Then `conn0` starts a write:

```sql
INSERT INTO t(k, v) VALUES (zeroblob(5735), 577);
```

During commit, `conn0` writes frames like:

```text
frame 11 -> page 1
frame 12 -> page 69
```

Page 1 is especially important because it contains database shape metadata,
such as database size and freelist/header state.

At the dangerous moment:

```text
shared WAL index:
  frame 11 -> page 1
  frame 12 -> page 69

conn0 local WAL state:
  max_frame = 12

global committed WAL state:
  max_frame = 10
```

Frames 11..12 are in the WAL index, but the commit is not globally visible yet.
This is normally safe because old readers still have `max_frame = 10`, so they
ignore frame 11 and frame 12.

Now `conn1` has a transaction and savepoint while `conn0` is paused during
commit:

```sql
BEGIN;
-- Some work here.
SAVEPOINT s;
ROLLBACK TO s;
```

`conn1` does not hold the WAL write lock. It may have attempted writes, but
those writes failed with busy/locked because `conn0` is the writer.

The ownership state is:

```text
conn0.holds_write_lock() = true
conn1.holds_write_lock() = false
```

`conn1`'s savepoint was taken before `conn0` published the commit, so its
savepoint frame is still:

```text
savepoint.wal_max_frame = 10
```

The rollback then trims shared WAL index mappings newer than frame 10. That
deletes:

```text
page 1 -> frame 11
```

even though frame 11 belongs to `conn0`'s in-flight commit.

## Timeline

```text
conn0                                  shared WAL index                  conn1
-----                                  ----------------                  -----

write WAL frame 11 for page 1
cache page 1 -> frame 11    ------->   page 1 -> frame 11

                                       committed max_frame still 10

                                                                          BEGIN
                                                                          SAVEPOINT s
                                                                          ROLLBACK TO s

                                   <--- rollback WAL index to frame 10
                                        deletes page 1 -> frame 11

resume commit
publish commit max_frame = 12  --->    committed max_frame now 12
                                       but page 1 -> frame 11 is gone
```

## Result

The shared state is now inconsistent:

```text
global commit state:
  frames up to 12 are visible

shared WAL index:
  missing page 1 -> frame 11
```

A new reader starts after the commit and gets:

```text
reader snapshot max_frame = 12
```

When it reads page 1, it asks the shared WAL index:

```text
find latest frame for page 1 in range 1..=12
```

But the correct mapping was deleted. The reader may get an older page 1 frame,
or no WAL frame for page 1 and fall back to the database file.

That creates a mixed database view.

The regression test passes on current main but fails before the fix commit: 

```rust

$ cargo test -p turso_core storage::pager::tests::committed_row_visible_after_wal_frames_cached_before_commit_publish_yield -- --nocapture --test-threads=1

  assertion `left == right` failed
    left: 0
   right: 1

  test result: FAILED. 0 passed; 1 failed
```