### PR TITLE
core/json: fix UTF-8 corruption in JSON5 string serialization

### DIFF
--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -1378,10 +1378,18 @@ impl Jsonb {
                             }
                         }
 
-                        // Default case - just push the character
+                        // Default case - just push the character. `ch` may be the
+                        // lead byte of a multi-byte UTF-8 sequence (e.g. non-ASCII
+                        // letters), so decode the whole sequence rather than
+                        // casting a single byte to `char`, which mangles it.
                         _ => {
-                            string.push(ch as char);
-                            i += 1;
+                            let seq_len = utf8_sequence_len(ch);
+                            let end = (i + seq_len).min(word_slice.len());
+                            match std::str::from_utf8(&word_slice[i..end]) {
+                                Ok(s) => string.push_str(s),
+                                Err(_) => string.push(ch as char),
+                            }
+                            i = end;
                         }
                     }
                 }
@@ -3522,6 +3530,22 @@ fn is_json_ok(ch: u8) -> bool {
     (CHARACTER_TYPE_OK[ch as usize] & 4) != 0
 }
 
+/// Length in bytes of the UTF-8 sequence starting with lead byte `ch`.
+#[inline]
+fn utf8_sequence_len(ch: u8) -> usize {
+    if ch & 0x80 == 0 {
+        1
+    } else if ch & 0xE0 == 0xC0 {
+        2
+    } else if ch & 0xF0 == 0xE0 {
+        3
+    } else if ch & 0xF8 == 0xF0 {
+        4
+    } else {
+        1
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3764,6 +3788,15 @@ world""#,
         // Verify correct type
         let header = JsonbHeader::from_slice(0, &parsed.data).unwrap().0;
         assert!(matches!(header.0, ElementType::TEXT5));
+
+        // Multi-byte UTF-8 alongside a raw control byte (regression for #7786:
+        // TEXT5 serialization was casting each raw byte to `char`, corrupting
+        // multi-byte UTF-8 sequences).
+        let json_input = "\"ä\nworld\"";
+        let parsed = Jsonb::from_str(json_input).unwrap();
+        let header = JsonbHeader::from_slice(0, &parsed.data).unwrap().0;
+        assert!(matches!(header.0, ElementType::TEXT5));
+        assert_eq!(parsed.to_string().unwrap(), "\"ä\\nworld\"");
     }
 
     #[test]

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -1490,6 +1490,8 @@ mod tests {
             ("key", "Hello\rWorld", r#"{"key":"Hello\rWorld"}"#),
             ("key", "Hello\x01World", r#"{"key":"Hello\u0001World"}"#),
             ("key", "Hello\x08\x0cWorld", r#"{"key":"Hello\b\fWorld"}"#),
+            ("key", "ä\n", "{\"key\":\"ä\\n\"}"),
+            ("key", "日本語\t", "{\"key\":\"日本語\\t\"}"),
         ];
 
         for (key, value, expected) in cases {


### PR DESCRIPTION
TEXT5 serialization cast raw bytes to char one at a time, mangling multi-byte UTF-8 sequences whenever the string also contained a raw control byte (routes it through the TEXT5/JSON5 path). Decode full UTF-8 sequences instead.

Tests: core/json/jsonb.rs test_json5_string_serialization, core/json/mod.rs test_json_object_escapes_special_characters

Fixes #7786

## Description

Fixes multi-byte UTF-8 corruption in `json_object()`, `json_array()`, and `json_group_array()`. Any string containing both a multi-byte UTF-8 character and a control character requiring `\uXXXX`/`\n`/`\t`/`\r` escaping was returned corrupted (e.g. `ä` became `Ã¤`), because `Jsonb::serialize_string()`'s JSON5 (`TEXT5`) code path cast individual raw bytes to `char` instead of decoding full UTF-8 sequences. The fix decodes the complete UTF-8 sequence at each byte offset before pushing it to the output string.

## Motivation and context

Reported in #7786: a value round-tripped correctly through a plain `SELECT ?`, but the same value passed through `json_object()` came back mangled. Root-caused to the TEXT5 serialization path only being exercised when a string contains a raw (unescaped) control byte, which is exactly how `json_object`/`json_array`/`json_group_array` build their output today (they don't pre-escape control characters before parsing).

Fixes #7786


## Description of AI Usage

Used Claude Code to locate the corrupting code path (an Explore subagent traced the bug to Jsonb::serialize_string's TEXT5 branch in core/json/jsonb.rs), partially wrote the fix and the two regression tests, and drafted this PR description. I reviewed the root-cause analysis, the diff, and confirmed the fix locally (cargo build, cargo test -p turso_core json, cargo fmt, cargo clippy) before opening this PR.