### PR TITLE
core: require statement subtransactions for all write statements

### DIFF
--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -20,6 +20,16 @@
 //!
 //! Both flags default to `true` (conservative). Each DML translate path calls
 //! into this module to set them to `false` when safe.
+//!
+//! NOTE: SQLite's optimization is currently disabled — every write statement
+//! gets a statement subtransaction regardless of these flags (see
+//! `ProgramBuilder::build_prepared_program`). Its soundness relies on write
+//! statements never being observable mid-execution, which does not hold in
+//! Turso: statements yield at I/O boundaries and can be abandoned (dropped)
+//! there, leaving partial multi-btree writes that only a statement savepoint
+//! can undo (#7682). The analysis is kept because it still describes
+//! per-statement abort semantics and can gate the optimization again if
+//! abandonment is ever handled without eager savepoints.
 
 use crate::translate::emitter::Resolver;
 use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1956,14 +1956,19 @@ impl ProgramBuilder {
 
         self.parameters.list.dedup();
 
-        // Mirrors SQLite's: usesStmtJournal = isMultiWrite && mayAbort
-        // Statement journals are only needed when a statement writes multiple rows AND could
-        // abort midway (e.g. constraint violation). Single-row writes are atomic and don't
-        // need statement-level rollback. Both flags default to true; specific translate paths
-        // (e.g., single-row INSERT) set is_multi_write=false to opt out.
-        let needs_stmt_subtransactions = matches!(self.txn_mode, TransactionMode::Write)
-            && self.flags.is_multi_write()
-            && self.flags.may_abort();
+        // SQLite only opens statement journals when a statement writes multiple rows
+        // AND could abort midway (usesStmtJournal = isMultiWrite && mayAbort; see
+        // translate/stmt_journal.rs). That optimization relies on statements never
+        // being observable mid-write: sqlite3_step runs each write statement to
+        // completion synchronously. Turso instead yields to the caller at every I/O
+        // boundary, so ANY write statement can be abandoned (dropped/reset) midway,
+        // leaving partially-applied changes — e.g. an index entry written but not the
+        // matching table row. Inside an explicit transaction those partial effects can
+        // only be undone with a statement savepoint, so every write statement needs
+        // one regardless of the is_multi_write/may_abort analysis. begin_statement
+        // still skips pager savepoints in autocommit mode, where statement abort
+        // escalates to full-transaction rollback.
+        let needs_stmt_subtransactions = matches!(self.txn_mode, TransactionMode::Write);
 
         let contains_trigger_subprograms = self
             .insns

--- a/tests/integration/abandoned_statement_pager.rs
+++ b/tests/integration/abandoned_statement_pager.rs
@@ -1,0 +1,279 @@
+#![cfg(feature = "io_memory_yield")]
+
+use std::sync::Arc;
+
+use turso_core::{Connection, Database, DatabaseOpts, MemoryYieldIO, OpenFlags, StepResult, IO};
+
+fn open_conn(io: Arc<MemoryYieldIO>, path: &str) -> Arc<Connection> {
+    Database::open_file_with_flags(io, path, OpenFlags::default(), DatabaseOpts::new(), None)
+        .unwrap()
+        .connect()
+        .unwrap()
+}
+
+fn integrity_check(conn: &Arc<Connection>) -> Vec<String> {
+    conn.prepare("PRAGMA integrity_check")
+        .unwrap()
+        .run_collect_rows()
+        .unwrap()
+        .into_iter()
+        .map(|row| row[0].to_string())
+        .collect()
+}
+
+fn ids(conn: &Arc<Connection>, sql: &str) -> Vec<i64> {
+    conn.prepare(sql)
+        .unwrap()
+        .run_collect_rows()
+        .unwrap()
+        .into_iter()
+        .map(|row| row[0].as_int().unwrap())
+        .collect()
+}
+
+/// Steps `sql` until the `target_io`-th `StepResult::IO`, completes that I/O,
+/// then drops the statement without stepping it again. Returns false if the
+/// statement finished before reaching `target_io` I/Os.
+fn abandon_statement_after_io_completion(
+    conn: &Arc<Connection>,
+    io: &Arc<MemoryYieldIO>,
+    sql: &str,
+    target_io: usize,
+) -> bool {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let mut io_count = 0;
+
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::IO => {
+                io_count += 1;
+                io.step().unwrap();
+                if io_count == target_io {
+                    drop(stmt);
+                    return true;
+                }
+            }
+            StepResult::Done => return false,
+            StepResult::Yield => {}
+            other => panic!("unexpected step result while abandoning statement: {other:?}"),
+        }
+    }
+}
+
+/// Steps `sql` until the `target_io`-th `StepResult::IO` and drops the
+/// statement while that I/O is still pending. Returns false if the statement
+/// finished before reaching `target_io` I/Os.
+fn abandon_statement_before_io_completion(
+    conn: &Arc<Connection>,
+    io: &Arc<MemoryYieldIO>,
+    sql: &str,
+    target_io: usize,
+) -> bool {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let mut io_count = 0;
+
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::IO => {
+                io_count += 1;
+                if io_count == target_io {
+                    drop(stmt);
+                    return true;
+                }
+                io.step().unwrap();
+            }
+            StepResult::Done => return false,
+            StepResult::Yield => {}
+            other => panic!("unexpected step result while abandoning statement: {other:?}"),
+        }
+    }
+}
+
+fn seed_indexed_overflow_rows(conn: &Arc<Connection>, payload: &str) {
+    conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x, b TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX t_x ON t(x)").unwrap();
+    for id in 1..=8 {
+        conn.execute(format!("INSERT INTO t VALUES({id}, {id}, '{payload}')"))
+            .unwrap();
+    }
+    conn.execute("DELETE FROM t WHERE id = 1").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+}
+
+#[test]
+fn test_abandoned_insert_savepoint_rollback_preserves_freelist() {
+    for target_io in 1..=512 {
+        let io = Arc::new(MemoryYieldIO::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join(format!("abandoned-overflow-insert-{target_io}.db"));
+        let path = path.to_str().unwrap();
+
+        {
+            let conn = open_conn(io.clone(), path);
+            conn.execute("PRAGMA page_size=512").unwrap();
+            conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+            conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB)")
+                .unwrap();
+            conn.execute(
+                "INSERT INTO t VALUES
+                 (1, zeroblob(50000)),
+                 (2, zeroblob(50000)),
+                 (3, zeroblob(50000)),
+                 (4, zeroblob(50000)),
+                 (5, zeroblob(50000))",
+            )
+            .unwrap();
+            conn.execute("DELETE FROM t WHERE id IN (2,3,4)").unwrap();
+        }
+
+        let conn = open_conn(io.clone(), path);
+        conn.execute("BEGIN").unwrap();
+        conn.execute("SAVEPOINT s").unwrap();
+
+        if !abandon_statement_before_io_completion(
+            &conn,
+            &io,
+            "INSERT INTO t VALUES (100, zeroblob(50000))",
+            target_io,
+        ) {
+            conn.execute("ROLLBACK").unwrap();
+            break;
+        }
+
+        conn.execute("ROLLBACK TO s").unwrap();
+        conn.execute("RELEASE s").unwrap();
+
+        let rows = conn
+            .prepare("SELECT id, length(b) FROM t ORDER BY id")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap()
+            .into_iter()
+            .map(|row| (row[0].as_int().unwrap(), row[1].as_int().unwrap()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            rows,
+            vec![(1, 50000), (5, 50000)],
+            "target_io={target_io}: abandoned INSERT changed visible table rows"
+        );
+
+        conn.execute("INSERT INTO t VALUES (200, zeroblob(50000))")
+            .unwrap();
+        conn.execute("COMMIT").unwrap();
+
+        assert_eq!(
+            integrity_check(&conn),
+            vec!["ok"],
+            "target_io={target_io}: abandoned INSERT poisoned freelist state"
+        );
+    }
+}
+
+#[test]
+fn test_abandoned_delete_does_not_poison_next_delete() {
+    let payload = "x".repeat(20_000);
+
+    for target_io in 1..=128 {
+        let io = Arc::new(MemoryYieldIO::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join(format!("abandoned-delete-{target_io}.db"));
+        let path = path.to_str().unwrap();
+
+        {
+            let conn = open_conn(io.clone(), path);
+            seed_indexed_overflow_rows(&conn, &payload);
+        }
+
+        let conn = open_conn(io.clone(), path);
+        conn.execute("BEGIN").unwrap();
+
+        if !abandon_statement_after_io_completion(
+            &conn,
+            &io,
+            "DELETE FROM t WHERE id IN (2,3)",
+            target_io,
+        ) {
+            conn.execute("ROLLBACK").unwrap();
+            break;
+        }
+
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t ORDER BY id"),
+            vec![2, 3, 4, 5, 6, 7, 8],
+            "target_io={target_io}: abandoned DELETE was not rolled back"
+        );
+
+        conn.execute("DELETE FROM t WHERE id = 4").unwrap();
+        conn.execute("COMMIT").unwrap();
+
+        assert_eq!(
+            integrity_check(&conn),
+            vec!["ok"],
+            "target_io={target_io}: abandoned DELETE poisoned the next DELETE"
+        );
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t INDEXED BY t_x ORDER BY x"),
+            vec![2, 3, 5, 6, 7, 8],
+            "target_io={target_io}: indexed scan disagrees after next DELETE"
+        );
+    }
+}
+
+#[test]
+fn test_abandoned_insert_does_not_poison_next_insert() {
+    let payload = "x".repeat(20_000);
+
+    for target_io in 1..=128 {
+        let io = Arc::new(MemoryYieldIO::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join(format!("abandoned-insert-{target_io}.db"));
+        let path = path.to_str().unwrap();
+
+        {
+            let conn = open_conn(io.clone(), path);
+            seed_indexed_overflow_rows(&conn, &payload);
+        }
+
+        let conn = open_conn(io.clone(), path);
+        conn.execute("BEGIN").unwrap();
+
+        if !abandon_statement_after_io_completion(
+            &conn,
+            &io,
+            &format!("INSERT INTO t VALUES(9, 9, '{payload}')"),
+            target_io,
+        ) {
+            conn.execute("ROLLBACK").unwrap();
+            break;
+        }
+
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t ORDER BY id"),
+            vec![2, 3, 4, 5, 6, 7, 8],
+            "target_io={target_io}: abandoned INSERT was not rolled back"
+        );
+
+        conn.execute(format!("INSERT INTO t VALUES(10, 10, '{payload}')"))
+            .unwrap();
+        conn.execute("COMMIT").unwrap();
+
+        assert_eq!(
+            integrity_check(&conn),
+            vec!["ok"],
+            "target_io={target_io}: abandoned INSERT poisoned the next INSERT"
+        );
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t INDEXED BY t_x ORDER BY x"),
+            vec![2, 3, 4, 5, 6, 7, 8, 10],
+            "target_io={target_io}: indexed scan disagrees after next INSERT"
+        );
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 mod abandoned_create_index;
+mod abandoned_statement_pager;
 mod assert_details;
 mod attach;
 mod common;

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -1,7 +1,14 @@
-/// Tests that the `needs_stmt_subtransactions` flag is correctly set based on
-/// the is_multi_write and may_abort analysis during statement compilation.
+/// Tests that the `needs_stmt_subtransactions` flag is correctly set during
+/// statement compilation.
 ///
-/// These tests mirror SQLite's usesStmtJournal = isMultiWrite && mayAbort (vdbeaux.c:2685).
+/// SQLite only uses a statement journal when a statement is both multi-write
+/// and may abort (usesStmtJournal = isMultiWrite && mayAbort, vdbeaux.c:2685).
+/// That optimization relies on write statements never being observable
+/// mid-execution. Turso yields to the caller at every I/O boundary, so any
+/// write statement can be abandoned (dropped/reset) midway, leaving partial
+/// multi-btree writes that only a statement savepoint can undo (#7682).
+/// Therefore EVERY write statement needs a statement subtransaction, and
+/// read-only statements never do.
 use crate::common::TempDatabase;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -34,11 +41,11 @@ fn query_rows(conn: &Arc<turso_core::Connection>, sql: &str) -> Vec<String> {
 // ──────────────────────────────────────────────────────────
 
 /// Single-row INSERT into a table with no constraints, no triggers, no FKs.
-/// Neither multi-write nor may-abort.
+/// Still needs a stmt journal: it can be abandoned at an I/O boundary.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b, c);")]
 fn insert_single_row_no_constraints(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(&conn, "INSERT INTO t VALUES (1, 2, 3)"));
+    assert!(needs_stmt_journal(&conn, "INSERT INTO t VALUES (1, 2, 3)"));
     Ok(())
 }
 
@@ -46,8 +53,7 @@ fn insert_single_row_no_constraints(tmp_db: TempDatabase) -> anyhow::Result<()> 
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b, c);")]
 fn insert_multi_row_no_constraints(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    // Multi-row but no may_abort → still no stmt journal.
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "INSERT INTO t VALUES (1,2,3),(4,5,6)"
     ));
@@ -58,9 +64,7 @@ fn insert_multi_row_no_constraints(tmp_db: TempDatabase) -> anyhow::Result<()> {
 #[turso_macros::test(init_sql = "CREATE TABLE t (a NOT NULL, b);")]
 fn insert_single_row_notnull(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    // Single-row (not multi-write) but may_abort.
-    // needs_stmt = multi_write && may_abort = false && true = false.
-    assert!(!needs_stmt_journal(&conn, "INSERT INTO t VALUES (1, 2)"));
+    assert!(needs_stmt_journal(&conn, "INSERT INTO t VALUES (1, 2)"));
     Ok(())
 }
 
@@ -86,11 +90,11 @@ fn insert_multi_row_unique(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// INSERT OR IGNORE with UNIQUE → may_abort is false (not OE_Abort).
+/// INSERT OR IGNORE with UNIQUE — cannot abort, but can still be abandoned.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a UNIQUE, b);")]
 fn insert_or_ignore_multi_row_unique(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "INSERT OR IGNORE INTO t VALUES (1, 2), (3, 4)"
     ));
@@ -98,12 +102,10 @@ fn insert_or_ignore_multi_row_unique(tmp_db: TempDatabase) -> anyhow::Result<()>
 }
 
 /// INSERT OR REPLACE is multi-write (REPLACE may delete conflicting rows).
-/// But may_abort=false (conflict resolution is not OE_Abort).
-/// needs_stmt = true && false = false.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a UNIQUE, b);")]
 fn insert_or_replace_single_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "INSERT OR REPLACE INTO t VALUES (1, 2)"
     ));
@@ -111,11 +113,10 @@ fn insert_or_replace_single_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
 }
 
 /// AUTOINCREMENT is multi-write (writes to sqlite_sequence).
-/// No constraints → may_abort=false. needs_stmt = true && false = false.
 #[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v);")]
 fn insert_autoincrement_single_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(&conn, "INSERT INTO t (v) VALUES (1)"));
+    assert!(needs_stmt_journal(&conn, "INSERT INTO t (v) VALUES (1)"));
     Ok(())
 }
 
@@ -138,9 +139,7 @@ fn insert_select_source(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Single-row INSERT with immediate FK constraints does NOT need a statement journal.
-/// Immediate FK violations emit a direct Halt before any writes (matching SQLite's
-/// usesStmtJournal=0 for this case), so there's nothing to roll back.
+/// Single-row INSERT with immediate FK constraints.
 #[turso_macros::test(init_sql = "CREATE TABLE parent (id INTEGER PRIMARY KEY);")]
 fn insert_single_row_with_immediate_fk(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
@@ -148,7 +147,7 @@ fn insert_single_row_with_immediate_fk(tmp_db: TempDatabase) -> anyhow::Result<(
     conn.execute(
         "CREATE TABLE child (id UNIQUE, pid INT, FOREIGN KEY(pid) REFERENCES parent(id))",
     )?;
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "INSERT INTO child VALUES (1, 1)"
     ));
@@ -193,8 +192,7 @@ fn insert_fk_violation_in_tx_rolls_back_row(tmp_db: TempDatabase) -> anyhow::Res
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b);")]
 fn update_no_where(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    // Multi-write (table scan), but no constraints → may_abort=false.
-    assert!(!needs_stmt_journal(&conn, "UPDATE t SET a = 1"));
+    assert!(needs_stmt_journal(&conn, "UPDATE t SET a = 1"));
     Ok(())
 }
 
@@ -210,9 +208,7 @@ fn update_no_where_notnull(tmp_db: TempDatabase) -> anyhow::Result<()> {
 #[turso_macros::test(init_sql = "CREATE TABLE t (a NOT NULL, b);")]
 fn update_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    // Single-row → not multi-write. may_abort=true (NOT NULL).
-    // needs_stmt = false && true = false.
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "UPDATE t SET a = 1 WHERE rowid = 5"
     ));
@@ -223,7 +219,7 @@ fn update_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
 #[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, a NOT NULL, b);")]
 fn update_by_rowid_alias(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "UPDATE t SET a = 1 WHERE id = 5"
     ));
@@ -234,7 +230,7 @@ fn update_by_rowid_alias(tmp_db: TempDatabase) -> anyhow::Result<()> {
 #[turso_macros::test(init_sql = "CREATE TABLE t (a NOT NULL, b UNIQUE);")]
 fn update_by_unique_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(&conn, "UPDATE t SET a = 1 WHERE b = 5"));
+    assert!(needs_stmt_journal(&conn, "UPDATE t SET a = 1 WHERE b = 5"));
     Ok(())
 }
 
@@ -256,12 +252,10 @@ fn update_unindexed_where(tmp_db: TempDatabase) -> anyhow::Result<()> {
 }
 
 /// UPDATE OR REPLACE → always multi-write (can delete conflicting rows).
-/// But may_abort = false (conflict resolution is not OE_Abort).
-/// needs_stmt = true && false = false.
 #[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, a UNIQUE);")]
 fn update_or_replace_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "UPDATE OR REPLACE t SET a = 1 WHERE id = 5"
     ));
@@ -273,7 +267,7 @@ fn update_or_replace_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
 fn update_composite_unique_all_cols(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
     conn.execute("CREATE UNIQUE INDEX idx_bc ON t(b, c)")?;
-    assert!(!needs_stmt_journal(
+    assert!(needs_stmt_journal(
         &conn,
         "UPDATE t SET a = 1 WHERE b = 1 AND c = 2"
     ));
@@ -293,11 +287,11 @@ fn update_composite_unique_partial_cols(tmp_db: TempDatabase) -> anyhow::Result<
 // DELETE
 // ──────────────────────────────────────────────────────────
 
-/// DELETE with no WHERE (table scan) + no constraints → multi-write, no may-abort.
+/// DELETE with no WHERE (table scan) + no constraints.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b);")]
 fn delete_no_where(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(&conn, "DELETE FROM t"));
+    assert!(needs_stmt_journal(&conn, "DELETE FROM t"));
     Ok(())
 }
 
@@ -305,7 +299,7 @@ fn delete_no_where(tmp_db: TempDatabase) -> anyhow::Result<()> {
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b);")]
 fn delete_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(&conn, "DELETE FROM t WHERE rowid = 5"));
+    assert!(needs_stmt_journal(&conn, "DELETE FROM t WHERE rowid = 5"));
     Ok(())
 }
 
@@ -313,7 +307,7 @@ fn delete_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b UNIQUE);")]
 fn delete_by_unique_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
-    assert!(!needs_stmt_journal(&conn, "DELETE FROM t WHERE b = 5"));
+    assert!(needs_stmt_journal(&conn, "DELETE FROM t WHERE b = 5"));
     Ok(())
 }
 
@@ -483,14 +477,7 @@ fn update_abort_partial_index_not_preflighted(tmp_db: TempDatabase) -> anyhow::R
     conn.execute("CREATE UNIQUE INDEX idx_b ON t(b)")?;
     conn.execute("INSERT INTO t VALUES(1, 10, 100)")?;
     conn.execute("INSERT INTO t VALUES(2, 20, 200)")?;
-    // With three-phase index updates, constraint checks (Phase 1) are fully
-    // separated from mutations (Phase 2+3), so partial unique indexes do not
-    // require the statement journal for single-row updates — Phase 1 handles
-    // the partial index constraint check before any IdxDelete/IdxInsert.
-    assert!(
-        !needs_stmt_journal(&conn, "UPDATE t SET b=40, c=200 WHERE a=1"),
-        "stmt journal not needed: three-phase update handles partial indexes"
-    );
+    assert!(needs_stmt_journal(&conn, "UPDATE t SET b=40, c=200 WHERE a=1"));
 
     conn.execute("BEGIN")?;
     // b=40 passes preflight (non-partial idx_b). c=200 conflicts on partial idx_c.


### PR DESCRIPTION
## Description

This PR changes the statement journal logic to require a statement subtransaction for **every** write statement, rather than only for multi-write statements that may abort. This is necessary because Turso yields to the caller at every I/O boundary, allowing statements to be abandoned (dropped/reset) mid-execution, leaving partial multi-btree writes that only a statement savepoint can undo.

### Changes

1. **core/vdbe/builder.rs**: Simplified `needs_stmt_subtransactions` logic to return `true` for all write statements (previously gated by `is_multi_write() && may_abort()`)

2. **core/translate/stmt_journal.rs**: Added documentation explaining why SQLite's optimization is disabled and the abandonment hazard

3. **tests/integration/stmt_journal.rs**: Updated all test assertions to expect statement journals for write statements. Updated comments to reflect the new rationale (abandonment safety rather than multi-write + may-abort analysis)

4. **tests/integration/abandoned_statement_pager.rs** (new): Added comprehensive integration tests covering:
   - `test_abandoned_insert_savepoint_rollback_preserves_freelist`: Verifies that abandoned INSERTs with overflow don't poison the freelist when rolled back
   - `test_abandoned_delete_does_not_poison_next_delete`: Ensures abandoned DELETEs don't corrupt state for subsequent operations
   - `test_abandoned_insert_does_not_poison_next_insert`: Verifies abandoned INSERTs don't affect subsequent writes
   
   Each test iterates through 128+ I/O boundaries to stress-test statement abandonment at various points in execution.

## Motivation and context

SQLite's `usesStmtJournal = isMultiWrite && mayAbort` optimization assumes write statements run to completion synchronously. Turso's async I/O model yields at every I/O boundary, making any write statement observable mid-execution. If a statement is abandoned (dropped) while holding partial writes across multiple B-trees (e.g., table + index), those partial effects persist until the next operation, corrupting database state.

The fix ensures every write statement gets a statement savepoint, which is rolled back on abandonment. This is safe because:
- In autocommit mode, statement abort escalates to full-transaction rollback anyway
- In explicit transactions, the savepoint provides the necessary isolation

Fixes #7682

## Test Plan

- All existing `stmt_journal.rs` tests pass with updated expectations
- New `abandoned_statement_pager.rs` tests verify correctness across 128+ I/O abandonment points for INSERT, DELETE, and overflow scenarios
- Integrity checks and indexed scans confirm no corruption after abandonment + rollback

https://claude.ai/code/session_016B6eoNAYvnRm5GrRtkb83e