### PR TITLE
bindings/js: serialize wasm native calls against sync-engine worker tasks

### DIFF
--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -158,7 +158,12 @@ class Database {
 
   private db: NativeDatabase;
   private ioStep: () => Promise<void>;
-  private execLock: AsyncLock;
+  // Serializes native calls on this connection. Subclasses that also drive
+  // the same underlying core database from async worker tasks (the sync
+  // engine on wasm) must hold this lock around those windows too: on
+  // browser wasm the main thread cannot block on a contended core lock, so
+  // main-thread native calls must never overlap an in-flight worker task.
+  protected execLock: AsyncLock;
   protected connected: boolean = false;
 
   constructor(db: NativeDatabase, ioStep?: () => Promise<void>) {

--- a/bindings/javascript/sync/packages/common/run.ts
+++ b/bindings/javascript/sync/packages/common/run.ts
@@ -219,9 +219,28 @@ export function runner(opts: RunOpts, io: ProtocolIo, engine: any): Runner {
     }
 }
 
-export async function run(runner: Runner, generator: any): Promise<any> {
+export async function run(runner: Runner, generator: any, lock?: AsyncLock): Promise<any> {
+    // When `lock` is provided, hold it while a native call is in flight:
+    // `resumeAsync` and the io loop inside `runner.wait()` execute sync-engine
+    // core work on the napi async worker, and on browser wasm the main thread
+    // panics if one of its own native calls contends on a core lock meanwhile.
+    // Callers pass the connection's exec lock so statement execution and
+    // sync-engine steps interleave without ever overlapping. The lock is
+    // released between steps, so waiting on a long-poll does not starve
+    // main-thread statement execution.
     while (true) {
-        const { type, ...rest }: GeneratorResponse = await generator.resumeAsync(null);
+        if (lock != null) {
+            await lock.acquire();
+        }
+        let response: GeneratorResponse;
+        try {
+            response = await generator.resumeAsync(null);
+        } finally {
+            if (lock != null) {
+                lock.release();
+            }
+        }
+        const { type, ...rest } = response;
         if (type == 'Done') {
             return null;
         }
@@ -232,7 +251,16 @@ export async function run(runner: Runner, generator: any): Promise<any> {
             //@ts-ignore
             return rest.changes;
         }
-        await runner.wait();
+        if (lock != null) {
+            await lock.acquire();
+        }
+        try {
+            await runner.wait();
+        } finally {
+            if (lock != null) {
+                lock.release();
+            }
+        }
     }
 }
 

--- a/bindings/javascript/sync/packages/wasm/promise-bundle.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-bundle.ts
@@ -179,7 +179,7 @@ class Database extends DatabasePromise {
                     registerFileAtWorker(this.#worker, `${this.name}-changes`),
                 ]);
             }
-            await run(this.#runner, this.#engine.connect());
+            await run(this.#runner, this.#engine.connect(), this.execLock);
         }
         this.connected = true;
     }
@@ -192,11 +192,11 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        const changes = await this.#guards.wait(async () => await run(this.#runner, this.#engine.wait()));
+        const changes = await this.#guards.wait(async () => await run(this.#runner, this.#engine.wait(), this.execLock));
         if (changes.empty()) {
             return false;
         }
-        await this.#guards.apply(async () => await run(this.#runner, this.#engine.apply(changes)));
+        await this.#guards.apply(async () => await run(this.#runner, this.#engine.apply(changes), this.execLock));
         return true;
     }
     /**
@@ -207,7 +207,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        await this.#guards.push(async () => await run(this.#runner, this.#engine.push()));
+        await this.#guards.push(async () => await run(this.#runner, this.#engine.push(), this.execLock));
     }
     /**
      * checkpoint WAL for local database
@@ -216,7 +216,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        await this.#guards.checkpoint(async () => await run(this.#runner, this.#engine.checkpoint()));
+        await this.#guards.checkpoint(async () => await run(this.#runner, this.#engine.checkpoint(), this.execLock));
     }
     /**
      * @returns statistic of current local database
@@ -225,7 +225,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        return (await run(this.#runner, this.#engine.stats()));
+        return (await run(this.#runner, this.#engine.stats(), this.execLock));
     }
 
     /**

--- a/bindings/javascript/sync/packages/wasm/promise-default.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-default.ts
@@ -179,7 +179,7 @@ class Database extends DatabasePromise {
                     registerFileAtWorker(this.#worker, `${this.name}-changes`),
                 ]);
             }
-            await run(this.#runner, this.#engine.connect());
+            await run(this.#runner, this.#engine.connect(), this.execLock);
         }
         this.connected = true;
     }
@@ -192,11 +192,11 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        const changes = await this.#guards.wait(async () => await run(this.#runner, this.#engine.wait()));
+        const changes = await this.#guards.wait(async () => await run(this.#runner, this.#engine.wait(), this.execLock));
         if (changes.empty()) {
             return false;
         }
-        await this.#guards.apply(async () => await run(this.#runner, this.#engine.apply(changes)));
+        await this.#guards.apply(async () => await run(this.#runner, this.#engine.apply(changes), this.execLock));
         return true;
     }
     /**
@@ -207,7 +207,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        await this.#guards.push(async () => await run(this.#runner, this.#engine.push()));
+        await this.#guards.push(async () => await run(this.#runner, this.#engine.push(), this.execLock));
     }
     /**
      * checkpoint WAL for local database
@@ -216,7 +216,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        await this.#guards.checkpoint(async () => await run(this.#runner, this.#engine.checkpoint()));
+        await this.#guards.checkpoint(async () => await run(this.#runner, this.#engine.checkpoint(), this.execLock));
     }
     /**
      * @returns statistic of current local database
@@ -225,7 +225,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        return (await run(this.#runner, this.#engine.stats()));
+        return (await run(this.#runner, this.#engine.stats(), this.execLock));
     }
 
     /**

--- a/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
@@ -179,7 +179,7 @@ class Database extends DatabasePromise {
                     registerFileAtWorker(this.#worker, `${this.name}-changes`),
                 ]);
             }
-            await run(this.#runner, this.#engine.connect());
+            await run(this.#runner, this.#engine.connect(), this.execLock);
         }
         this.connected = true;
     }
@@ -192,11 +192,11 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        const changes = await this.#guards.wait(async () => await run(this.#runner, this.#engine.wait()));
+        const changes = await this.#guards.wait(async () => await run(this.#runner, this.#engine.wait(), this.execLock));
         if (changes.empty()) {
             return false;
         }
-        await this.#guards.apply(async () => await run(this.#runner, this.#engine.apply(changes)));
+        await this.#guards.apply(async () => await run(this.#runner, this.#engine.apply(changes), this.execLock));
         return true;
     }
     /**
@@ -207,7 +207,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        await this.#guards.push(async () => await run(this.#runner, this.#engine.push()));
+        await this.#guards.push(async () => await run(this.#runner, this.#engine.push(), this.execLock));
     }
     /**
      * checkpoint WAL for local database
@@ -216,7 +216,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        await this.#guards.checkpoint(async () => await run(this.#runner, this.#engine.checkpoint()));
+        await this.#guards.checkpoint(async () => await run(this.#runner, this.#engine.checkpoint(), this.execLock));
     }
     /**
      * @returns statistic of current local database
@@ -225,7 +225,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        return (await run(this.#runner, this.#engine.stats()));
+        return (await run(this.#runner, this.#engine.stats(), this.execLock));
     }
 
     /**

--- a/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
@@ -179,7 +179,7 @@ class Database extends DatabasePromise {
                     registerFileAtWorker(this.#worker, `${this.name}-changes`),
                 ]);
             }
-            await run(this.#runner, this.#engine.connect());
+            await run(this.#runner, this.#engine.connect(), this.execLock);
         }
         this.connected = true;
     }
@@ -192,11 +192,11 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        const changes = await this.#guards.wait(async () => await run(this.#runner, this.#engine.wait()));
+        const changes = await this.#guards.wait(async () => await run(this.#runner, this.#engine.wait(), this.execLock));
         if (changes.empty()) {
             return false;
         }
-        await this.#guards.apply(async () => await run(this.#runner, this.#engine.apply(changes)));
+        await this.#guards.apply(async () => await run(this.#runner, this.#engine.apply(changes), this.execLock));
         return true;
     }
     /**
@@ -207,7 +207,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        await this.#guards.push(async () => await run(this.#runner, this.#engine.push()));
+        await this.#guards.push(async () => await run(this.#runner, this.#engine.push(), this.execLock));
     }
     /**
      * checkpoint WAL for local database
@@ -216,7 +216,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        await this.#guards.checkpoint(async () => await run(this.#runner, this.#engine.checkpoint()));
+        await this.#guards.checkpoint(async () => await run(this.#runner, this.#engine.checkpoint(), this.execLock));
     }
     /**
      * @returns statistic of current local database
@@ -225,7 +225,7 @@ class Database extends DatabasePromise {
         if (this.#engine == null) {
             throw new Error("sync is disabled as database was opened without sync support")
         }
-        return (await run(this.#runner, this.#engine.stats()));
+        return (await run(this.#runner, this.#engine.stats(), this.execLock));
     }
 
     /**

--- a/bindings/javascript/sync/packages/wasm/promise.test.ts
+++ b/bindings/javascript/sync/packages/wasm/promise.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, afterAll } from 'vitest'
 import { Database, connect, DatabaseRowMutation, DatabaseRowTransformResult } from './promise-default.js'
-import { MainWorker } from './index-default.js'
+import { MainWorker, SyncEngine, GeneratorHolder, Database as NativeDatabase } from './index-default.js'
 
 afterAll(() => {
     MainWorker?.terminate();
@@ -8,6 +8,82 @@ afterAll(() => {
 
 const localeCompare = (a: { x: string }, b: { x: string }) => a.x.localeCompare(b.x);
 const intCompare = (a: { x: number }, b: { x: number }) => a.x - b.x;
+
+test('no-native-call-overlap-with-worker-tasks', async () => {
+    // Regression test for the parking_lot "Parking not supported on this
+    // platform" panic on browser wasm. The sync engine executes core work on
+    // the napi async worker (resumeAsync / ioLoopAsync); if a main-thread
+    // native call runs while such a task is in flight, both threads can
+    // contend on a core lock. The browser main thread cannot park, so
+    // contention panics, and the aborted call leaks every lock it held,
+    // poisoning the whole instance.
+    //
+    // Instrument the native entry points to count main-thread executor steps
+    // that overlap an in-flight worker task. Each in-flight window is
+    // artificially extended by a few milliseconds, so an implementation that
+    // does not serialize the two overlaps on every run; the serialized
+    // implementation structurally cannot overlap.
+    {
+        const db = await connect({ path: ':memory:', url: process.env.VITE_TURSO_DB_URL, longPollTimeoutMs: 10 });
+        await db.exec("CREATE TABLE IF NOT EXISTS overlap_probe(x TEXT PRIMARY KEY, y)");
+        await db.exec("DELETE FROM overlap_probe");
+        await db.push();
+        await db.close();
+    }
+    const db = await connect({ path: ':memory:', url: process.env.VITE_TURSO_DB_URL, longPollTimeoutMs: 10 });
+
+    let inFlight = 0;
+    let overlaps = 0;
+    const extend = () => new Promise(resolve => setTimeout(resolve, 2));
+    const trackInFlight = (original: any) => async function (this: any, ...args: any[]) {
+        inFlight += 1;
+        try {
+            const result = await original.apply(this, args);
+            await extend();
+            return result;
+        } finally {
+            inFlight -= 1;
+        }
+    };
+    const origResume = (GeneratorHolder as any).prototype.resumeAsync;
+    const origIoLoop = (SyncEngine as any).prototype.ioLoopAsync;
+    const origExecutor = (NativeDatabase as any).prototype.executor;
+    (GeneratorHolder as any).prototype.resumeAsync = trackInFlight(origResume);
+    (SyncEngine as any).prototype.ioLoopAsync = trackInFlight(origIoLoop);
+    (NativeDatabase as any).prototype.executor = function (this: any, ...args: any[]) {
+        const executor = origExecutor.apply(this, args);
+        const origStep = executor.stepSync.bind(executor);
+        executor.stepSync = () => {
+            if (inFlight > 0) {
+                overlaps += 1;
+            }
+            return origStep();
+        };
+        return executor;
+    };
+    try {
+        const pulls = (async () => {
+            for (let i = 0; i < 10; i++) {
+                await db.pull();
+            }
+        })();
+        for (let i = 0; i < 50; i++) {
+            try {
+                await db.exec(`INSERT INTO overlap_probe VALUES ('${i % 4}', 0) ON CONFLICT DO UPDATE SET y = y + 1`);
+            } catch (e) {
+                // Busy conflicts with the concurrent pulls are irrelevant here;
+                // only the overlap counter matters.
+            }
+        }
+        await pulls;
+    } finally {
+        (GeneratorHolder as any).prototype.resumeAsync = origResume;
+        (SyncEngine as any).prototype.ioLoopAsync = origIoLoop;
+        (NativeDatabase as any).prototype.executor = origExecutor;
+        await db.close();
+    }
+    expect(overlaps).toBe(0);
+})
 
 test('open non-sync db', async () => {
     const db = await connect({ path: 'local.db' });


### PR DESCRIPTION
On browser wasm the binding executes core code on two threads:

- statement stepping runs on the main thread, while
- the sync engine's resumeAsync and ioLoopAsync AsyncTasks run core work on the napi async worker.

parking_lot cannot park on the browser main thread (its spin phase is a no-op and the wasm parker panics), so any cross-thread contention on a core lock aborts the call mid-flight, leaking every lock it held and poisoning the whole instance. Observed as "Parking not supported on this platform" panic storms in the browser sync test job, first contended lock being the db.schema mutex via Statement::reprepare racing a pull that bumped the schema cookie.

Hold the connection's exec lock around every window where a sync-engine native call is in flight, so main-thread statement execution and worker-side engine steps interleave without overlapping. The lock is released between steps, keeping long-polls from starving execution. The native binding is unchanged: parking works there and exec/sync parallelism is kept.

Attempts to fix this error in CI on various different PRs:

```
stderr | promise.test.ts > concurrent-updates
thread '<unnamed>' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/thread_parker/wasm.rs:26:9:
stderr | promise.test.ts > concurrent-updates
Parking not supported on this platform
stderr | promise.test.ts > concurrent-updates
```