### PR TITLE
testing/simulator: skip injected integrity check inside explicit transactions

### DIFF
--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -272,7 +272,14 @@ pub fn execute_interaction_turso(
 
             stack.push(results);
             // TODO: skip integrity check with mvcc
-            if !env.profile.mvcc && env.rng.random_ratio(1, 10) {
+            // Skip inside explicit transactions: this hidden read is invisible to
+            // the shadow model, and right after BEGIN DEFERRED it would pin the
+            // engine's read snapshot earlier than the model's lazily-taken one,
+            // causing false "expected content" mismatches under concurrency.
+            if !env.profile.mvcc
+                && env.rng.random_ratio(1, 10)
+                && !env.conn_db_in_transaction(connection_index)
+            {
                 let SimConnection::LimboConnection(conn) = &mut env.connections[connection_index]
                 else {
                     unreachable!()
@@ -334,7 +341,11 @@ pub fn execute_interaction_turso(
             // Reset fault injection
             env.io.inject_fault(false);
             // TODO: skip integrity check with mvcc
-            if !env.profile.mvcc && env.rng.random_ratio(1, 10) {
+            // Skip inside explicit transactions — see the Query arm above.
+            if !env.profile.mvcc
+                && env.rng.random_ratio(1, 10)
+                && !env.conn_db_in_transaction(connection_index)
+            {
                 limbo_integrity_check(&conn)?;
             }
         }


### PR DESCRIPTION
The runner injects a random PRAGMA integrity_check on the active connection after successful queries. When the draw lands right after BEGIN DEFERRED, the hidden read pins the engine's WAL snapshot at that point, while the shadow model takes its snapshot lazily at the transaction's first plan-level statement. A commit from another connection landing between the two produces a false "table should have the expected content" mismatch (and spurious BusySnapshot errors) even though the engine behaves correctly.

Keep the RNG draw so seed streams are unchanged, but only run the check when the connection is in autocommit; the hidden read is harmless there because its read transaction ends with the statement.

Tests: seed 14376183891491691549 (faultless profile, memory IO) failed with "expected 9 rows but got 4" before this change and passes after.