### PR TITLE
testing/stress: reset shuttle step counter on iteration progress

### DIFF
--- a/testing/stress/lib.rs
+++ b/testing/stress/lib.rs
@@ -146,6 +146,21 @@ pub fn shuttle_config() -> shuttle::Config {
     config
 }
 
+/// Under shuttle, reset the scheduler's step counter to mark that the test is
+/// making progress. The `max_steps` bound exists to catch livelocks (schedules
+/// where no task ever completes work), not to cap total workload size: a full
+/// stress run consumes steps proportional to `nr_threads * nr_iterations`, so
+/// without resets a large-but-healthy run trips the bound on unlucky seeds.
+/// Call this after each completed unit of work so the bound instead measures
+/// "steps since the last completed iteration".
+#[cfg(shuttle)]
+pub fn note_progress() {
+    shuttle::current::reset_step_count();
+}
+
+#[cfg(not(shuttle))]
+pub fn note_progress() {}
+
 #[derive(Debug, Clone)]
 pub struct ThreadId(String);
 

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -810,6 +810,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
 
                     progress_bar.tick();
                     iteration_count_this_batch += 1;
+                    turso_stress::note_progress();
                 }
 
                 // In case this thread is running an exclusive transaction, commit it so that it doesn't block other threads.


### PR DESCRIPTION
The shuttle stress run enforces MaxSteps::FailAfter(10_000_000) over one whole execution, but the work per execution scales with nr_threads * nr_iterations, so an unlucky seed can exceed the bound while making healthy forward progress, and CI fails with "exceeded max_steps bound ... unfair schedule (e.g. a spin loop)?". Seed 16526203544944194225 reproduces this deterministically at --nr-threads 2 --nr-iterations 1000: it trips the bound roughly 85% through the workload, and the same seed runs to completion and passes both integrity checks when the bound is raised, so there is no actual livelock or spin loop.

Reset the scheduler step counter each time a worker completes an iteration, so the bound measures steps since the last completed unit of work - a real liveness detector - instead of capping total workload size. A genuine livelock still fails: a stuck worker produces no resets once the remaining workers drain their iterations.

Tests: seed 16526203544944194225 panics at the 10M bound before this change and completes (including the final SQLite integrity check) after it.