### PR TITLE
core/json: coerce numeric JSONB aggregate object labels to strings

### DIFF
--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -78,8 +78,8 @@ pub fn jsonb(json_value: &Value, cache: &JsonCacheCell) -> crate::Result<Value> 
     }
 }
 
-pub fn convert_dbtype_to_raw_jsonb(data: &Value) -> crate::Result<Vec<u8>> {
-    let json = convert_dbtype_to_jsonb(data, Conv::NotStrict)?;
+pub fn convert_dbtype_to_raw_jsonb(data: &Value, strict: Conv) -> crate::Result<Vec<u8>> {
+    let json = convert_dbtype_to_jsonb(data, strict)?;
     Ok(json.data())
 }
 
@@ -189,6 +189,11 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
         ValueRef::Null => Ok(Jsonb::from_raw_data(
             JsonbHeader::make_null().into_bytes().as_bytes(),
         )),
+        ValueRef::Numeric(numeric) if matches!(strict, Conv::ToString) => {
+            let text = Value::from(numeric).to_string();
+            Jsonb::from_str_with_mode(&text, strict)
+                .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))
+        }
         ValueRef::Numeric(Numeric::Float(float)) => {
             let float: f64 = float.into();
             // Handle infinity for JSON compatibility with SQLite (#4196)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -150,7 +150,7 @@ use crate::{
     json::json_from_raw_bytes_agg, json::json_insert, json::json_object, json::json_patch,
     json::json_quote, json::json_remove, json::json_replace, json::json_set, json::json_type,
     json::jsonb, json::jsonb_array, json::jsonb_extract, json::jsonb_insert, json::jsonb_object,
-    json::jsonb_patch, json::jsonb_remove, json::jsonb_replace, json::jsonb_set,
+    json::jsonb_patch, json::jsonb_remove, json::jsonb_replace, json::jsonb_set, json::Conv,
 };
 
 use super::{make_record, Program, ProgramState, Register};
@@ -6148,8 +6148,8 @@ fn update_agg_payload(
                     "JsonGroupObject/JsonbGroupObject: no value provided".to_string(),
                 ));
             };
-            let mut key_vec = convert_dbtype_to_raw_jsonb(arg)?;
-            let mut val_vec = convert_dbtype_to_raw_jsonb(&value)?;
+            let mut key_vec = convert_dbtype_to_raw_jsonb(arg, Conv::ToString)?;
+            let mut val_vec = convert_dbtype_to_raw_jsonb(&value, Conv::NotStrict)?;
             let Value::Blob(vec) = &mut payload[0] else {
                 mark_unlikely();
                 return Err(LimboError::InternalError(
@@ -6197,7 +6197,7 @@ fn update_agg_payload(
         #[cfg(feature = "json")]
         AggFunc::JsonGroupArray | AggFunc::JsonbGroupArray => {
             // arg = value
-            let mut data = convert_dbtype_to_raw_jsonb(arg)?;
+            let mut data = convert_dbtype_to_raw_jsonb(arg, Conv::NotStrict)?;
             let Value::Blob(vec) = &mut payload[0] else {
                 mark_unlikely();
                 return Err(LimboError::InternalError(

--- a/testing/sqltests/tests/agg-functions/jsonb-group-object-numeric-labels.sqltest
+++ b/testing/sqltests/tests/agg-functions/jsonb-group-object-numeric-labels.sqltest
@@ -1,0 +1,41 @@
+@database :memory:
+
+test jsonb_group_object_integer_label {
+	SELECT hex(jsonb_group_object(1, 2)),
+		   json(jsonb_group_object(1, 2));
+}
+expect {
+	4C17311332|{"1":2}
+}
+
+test jsonb_group_object_real_label {
+	SELECT hex(jsonb_group_object(1.5, 2)),
+		   json(jsonb_group_object(1.5, 2));
+}
+expect {
+	6C37312E351332|{"1.5":2}
+}
+
+test jsonb_group_object_text_numeric_label_unchanged {
+	SELECT hex(jsonb_group_object('1', 2)),
+		   json(jsonb_group_object('1', 2));
+}
+expect {
+	4C17311332|{"1":2}
+}
+
+test jsonb_group_object_numeric_column_labels {
+	CREATE TABLE t(label, value);
+	INSERT INTO t VALUES (1, 2), (1.5, 3);
+	SELECT json(jsonb_group_object(label, value)) FROM t;
+}
+expect {
+	{"1":2,"1.5":3}
+}
+
+test jsonb_group_object_does_not_stringify_value {
+	SELECT json(jsonb_group_object(1, jsonb_array(2)));
+}
+expect {
+	{"1":[2]}
+}


### PR DESCRIPTION
Fixes #7759

## Description

add `strict` param to `convert_dbtype_to_raw_jsonb()` to coerce JSONB objects' key to a string (object values and array elements retain their original JSON types).

## Description of AI Usage

mostly sanity checks like verifying my code once I'm done. And writing tests.