### PR TITLE
sync: fix race between concurrent opens of the same synced replica

### DIFF
--- a/bindings/python/tests/test_database_sync.py
+++ b/bindings/python/tests/test_database_sync.py
@@ -2,6 +2,7 @@ import logging
 import multiprocessing
 import os
 import tempfile
+import threading
 import time
 
 import turso
@@ -217,6 +218,42 @@ def test_bootstrap_concurrency():
 
             assert t1.exitcode == 0, f"t1 exitcode: {t1.exitcode}"
             assert t2.exitcode == 0, f"t2 exitcode: {t2.exitcode}"
+
+
+def test_concurrent_open_existing_replica():
+    # Opening an already-hydrated replica from many threads at once must
+    # always succeed: opens read (and, when the configuration changed, write)
+    # the shared metadata file, and a non-atomic write lets a concurrent
+    # reader observe an empty or truncated file ("meta must be initialized
+    # before open" / "deserialization error").
+    with TursoServer() as server:
+        server.db_sql("CREATE TABLE t(x)")
+        server.db_sql("INSERT INTO t VALUES (42)")
+
+        with tempfile.TemporaryDirectory(prefix="pyturso-") as dir:
+            path = os.path.join(dir, "local.db")
+            conn = turso.sync.connect(path, remote_url=server.db_url())
+            conn.pull()
+            conn.close()
+
+            k = 8
+            errors = []
+
+            def open_and_read():
+                try:
+                    c = turso.sync.connect(path, remote_url=server.db_url())
+                    assert c.execute("SELECT * FROM t").fetchall() == [(42,)]
+                    c.close()
+                except Exception as e:
+                    errors.append(e)
+
+            for _ in range(3):
+                threads = [threading.Thread(target=open_and_read) for _ in range(k)]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join(timeout=120)
+                assert not errors, f"concurrent opens failed: {errors[0]}"
 
 
 def test_configuration_persistence():

--- a/bindings/python/turso/lib_sync.py
+++ b/bindings/python/turso/lib_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import threading
 import urllib.error
 
 # for HTTP IO
@@ -260,8 +261,12 @@ def _process_full_write_item(io_item: PyTursoSyncIoItem, req_kind: Any) -> None:
         # ignore directory creation errors, attempt to write anyway
         pass
 
+    # Write to a temp file and rename it over the target so concurrent readers
+    # (e.g. other connections opening the same replica) never observe a
+    # truncated or partially written file.
+    tmp_path = f"{path}.tmp.{os.getpid()}.{threading.get_ident()}"
     try:
-        with open(path, "wb") as f:
+        with open(tmp_path, "wb") as f:
             # Write in chunks if content is large
             view = memoryview(content)
             offset = 0
@@ -270,8 +275,13 @@ def _process_full_write_item(io_item: PyTursoSyncIoItem, req_kind: Any) -> None:
                 end = min(offset + _HTTP_CHUNK_SIZE, length)
                 f.write(view[offset:end])
                 offset = end
+        os.replace(tmp_path, path)
         io_item.done()
     except Exception as e:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
         io_item.poison(f"fs write error: {e}")
 
 

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -213,18 +213,27 @@ impl DatabaseMetadata {
             self.saved_configuration = Some(configuration);
             return true;
         };
+        // Only report a change when a value actually differs: every open calls
+        // this, and a spurious `true` makes every open rewrite the metadata
+        // file, racing with concurrent opens reading it.
         let mut changed = false;
         if let Some(remote_url) = configuration.remote_url {
-            saved_configuration.remote_url = Some(remote_url);
-            changed |= true;
+            if saved_configuration.remote_url.as_ref() != Some(&remote_url) {
+                saved_configuration.remote_url = Some(remote_url);
+                changed = true;
+            }
         }
         if let Some(partial_sync_prefetch) = configuration.partial_sync_prefetch {
-            saved_configuration.partial_sync_prefetch = Some(partial_sync_prefetch);
-            changed |= true;
+            if saved_configuration.partial_sync_prefetch != Some(partial_sync_prefetch) {
+                saved_configuration.partial_sync_prefetch = Some(partial_sync_prefetch);
+                changed = true;
+            }
         }
         if let Some(partial_sync_segment_size) = configuration.partial_sync_segment_size {
-            saved_configuration.partial_sync_segment_size = Some(partial_sync_segment_size);
-            changed |= true;
+            if saved_configuration.partial_sync_segment_size != Some(partial_sync_segment_size) {
+                saved_configuration.partial_sync_segment_size = Some(partial_sync_segment_size);
+                changed = true;
+            }
         }
         changed
     }
@@ -661,7 +670,47 @@ pub fn parse_bin_record(
 
 #[cfg(test)]
 mod tests {
-    use super::DatabaseMetadata;
+    use super::{DatabaseMetadata, DatabaseSavedConfiguration};
+
+    #[test]
+    fn update_configuration_reports_change_only_when_values_differ() {
+        let mut meta = DatabaseMetadata::load(
+            br#"{
+                "version": "v1",
+                "client_unique_id": "client-a",
+                "synced_revision": null,
+                "revert_since_wal_salt": null,
+                "revert_since_wal_watermark": 0,
+                "last_pull_unix_time": null,
+                "last_push_unix_time": null,
+                "last_pushed_pull_gen_hint": 0,
+                "last_pushed_change_id_hint": 0,
+                "partial_bootstrap_server_revision": null,
+                "saved_configuration": null
+            }"#,
+        )
+        .unwrap();
+        let configuration = DatabaseSavedConfiguration {
+            remote_url: Some("http://remote".to_string()),
+            partial_sync_prefetch: Some(true),
+            partial_sync_segment_size: Some(4096),
+        };
+
+        assert!(meta.update_configuration(configuration.clone()));
+        assert_eq!(meta.saved_configuration, Some(configuration.clone()));
+
+        // Re-applying the identical configuration (what every open of an
+        // existing replica does) must not report a change, otherwise every
+        // open rewrites the metadata file.
+        assert!(!meta.update_configuration(configuration.clone()));
+
+        let updated = DatabaseSavedConfiguration {
+            remote_url: Some("http://other-remote".to_string()),
+            ..configuration
+        };
+        assert!(meta.update_configuration(updated.clone()));
+        assert_eq!(meta.saved_configuration, Some(updated));
+    }
 
     #[test]
     fn metadata_load_defaults_missing_logical_table_map() {


### PR DESCRIPTION
## Problem

A user sent us a reproducer where opening K \`turso.sync.connect()\` handles to the same (already-hydrated) replica concurrently from threads fails intermittently — with K=8 it fails nearly every run — with either:

- \`sync engine operation failed: database sync engine error: meta must be initialized before open\`
- \`sync engine operation failed: deserialization error: trailing characters at line 1 column 635\`

The only workaround was pre-opening connections serially, which no threaded server wants to do.

## Root cause

Two defects compound:

1. **Every open rewrites the metadata file.** \`DatabaseMetadata::update_configuration\` reported \`changed = true\` whenever the incoming configuration had a \`remote_url\` (or partial-sync option) *present*, not when it *differed* from the saved value. Since every open passes a remote_url, every open of an existing replica rewrote the \`-info\` file.

2. **The Python binding's \`full_write\` is not atomic.** It wrote the metadata file in place with \`open(path, "wb")\` (truncate, then write), despite its docstring claiming atomicity. A concurrent opener reading the file mid-write sees an empty file ("meta must be initialized before open") or a torn JSON ("trailing characters"). The JavaScript binding already writes via temp file + rename; Python was the outlier.

## Fix (one commit per layer)

- \`sync/engine\`: \`update_configuration\` only reports a change when a value actually differs, so steady-state opens stop writing the metadata file entirely.
- \`bindings/python\`: \`full_write\` writes to a temp file and \`os.replace()\`s it over the target, matching the JS binding. This also protects the remaining legitimate write paths (first configuration, pull/push metadata updates) from torn reads.

Other sdk-kit consumers that implement their own \`full_write\` (Go, .NET) should get the same temp+rename treatment as a follow-up; JS already has it.

## Validation

- New unit test \`update_configuration_reports_change_only_when_values_differ\` — fails on the previous function body, passes now.
- New e2e test \`test_concurrent_open_existing_replica\` (8 threads × 3 rounds opening a hydrated replica via the local sync server harness) — fails on the previous build, passes now.
- \`cargo test -p turso_sync_engine\`: 76 passed; clippy clean; full \`test_database_sync.py\`: 11 passed.
- The user's reproducer scenario against a real Turso Cloud database: failed 13/13 runs before, passes 8/8 runs (all scenarios, including opens after serial open/read/close cycles) after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)