### PR TITLE
bindings/python: enable SQLAlchemy reflection now supported by turso, bump min version to 2.0.45

### DIFF
--- a/bindings/python/SQLALCHEMY_DIALECT.md
+++ b/bindings/python/SQLALCHEMY_DIALECT.md
@@ -251,38 +251,36 @@ All dialects share these overrides via `_TursoDialectMixin` and direct method im
 
 ### Reflection Overrides (via `_TursoDialectMixin`)
 
+Index, unique-constraint, and check-constraint reflection (`get_indexes`,
+`get_unique_constraints`, `get_check_constraints`, and their `get_multi_*`
+counterparts) are inherited from SQLAlchemy's parent SQLite dialect — Turso
+supports `PRAGMA index_list` / `index_info` / `index_xinfo` and returns the
+original DDL via `sqlite_master.sql`.
+
+Only the following remain overridden as empty stubs:
+
 Single-table methods (return empty list):
 - `get_foreign_keys()` - `PRAGMA foreign_key_list` not supported
-- `get_indexes()` - `PRAGMA index_list` not supported
-- `get_unique_constraints()` - Relies on `PRAGMA index_list`
-- `get_check_constraints()` - `sqlite_master` parsing not fully supported
+- `get_temp_table_names()` / `get_temp_view_names()` - no temp database
 
 Multi-table methods (return empty dict):
-- `get_multi_indexes()`
-- `get_multi_unique_constraints()`
 - `get_multi_foreign_keys()`
-- `get_multi_check_constraints()`
 
 ## Limitations
 
 ### Table Reflection
 
-Turso doesn't support some SQLite PRAGMAs used for table reflection:
-- `PRAGMA foreign_key_list` - Foreign key introspection
-- `PRAGMA index_list` - Index introspection
+Foreign-key reflection is not yet supported because Turso has not implemented
+`PRAGMA foreign_key_list`. As a result:
+- `inspector.get_foreign_keys()` returns an empty list
+- Foreign key constraints still **work** at runtime, they just can't be
+  introspected
+- All other reflection (`get_indexes()`, `get_unique_constraints()`,
+  `get_check_constraints()`, `get_table_names()`, `get_columns()`) works
+  normally
 
-This means:
-- `inspector.get_foreign_keys()` returns empty list
-- `inspector.get_indexes()` returns empty list
-- `inspector.get_unique_constraints()` returns empty list
-- `inspector.get_check_constraints()` returns empty list
-- Foreign keys, indexes, and constraints still **work** at runtime, just can't be introspected
-- `inspector.get_table_names()` and `inspector.get_columns()` work normally
-
-This doesn't affect normal usage including:
-- Pandas `df.to_sql()` with `if_exists='replace'`
-- SQLAlchemy ORM operations
-- Alembic migrations (when using `--autogenerate`, manually verify FK/index changes)
+This means Alembic `--autogenerate` will not detect added or dropped foreign
+keys; verify FK changes manually.
 
 ### Native Datetime
 

--- a/bindings/python/SQLALCHEMY_DIALECT.md
+++ b/bindings/python/SQLALCHEMY_DIALECT.md
@@ -4,7 +4,7 @@ This document describes the SQLAlchemy dialect implementation for pyturso.
 
 ## Status: Implemented
 
-The SQLAlchemy dialect is fully implemented with three dialects:
+The SQLAlchemy dialect is implemented with three dialects:
 - `sqlite+turso://` - Basic local database connections
 - `sqlite+aioturso://` - Basic local database connections for SQLAlchemy async engines
 - `sqlite+turso_sync://` - Sync-enabled connections with remote database support
@@ -61,8 +61,7 @@ engine = create_engine(
 )
 
 with engine.connect() as conn:
-    # Access sync operations
-    sync = get_sync_connection(conn)
+    sync = get_sync_connection(conn) # get_sync_connection() exposes the underlying sync engine
     sync.pull()  # Pull changes from remote
 
     result = conn.execute(text("SELECT * FROM users"))
@@ -160,7 +159,7 @@ URL validation:
 - Host/port in URL raises `ValueError` (use `remote_url` query param instead)
 - Unrecognized query parameters emit a `UserWarning`
 
-## Sync Operations
+## Sync Operations 
 
 The `get_sync_connection()` helper provides access to sync-specific methods:
 
@@ -251,36 +250,19 @@ All dialects share these overrides via `_TursoDialectMixin` and direct method im
 
 ### Reflection Overrides (via `_TursoDialectMixin`)
 
-Index, unique-constraint, and check-constraint reflection (`get_indexes`,
-`get_unique_constraints`, `get_check_constraints`, and their `get_multi_*`
-counterparts) are inherited from SQLAlchemy's parent SQLite dialect — Turso
-supports `PRAGMA index_list` / `index_info` / `index_xinfo` and returns the
-original DDL via `sqlite_master.sql`.
+Index, unique-constraint, check-constraint, and foreign-key reflection
+(`get_indexes`, `get_unique_constraints`, `get_check_constraints`,
+`get_foreign_keys`, and their `get_multi_*` counterparts) are inherited from
+SQLAlchemy's parent SQLite dialect — Turso supports `PRAGMA index_list` /
+`index_info` / `index_xinfo` / `foreign_key_list` and returns the original DDL
+via `sqlite_master.sql`.
 
-Only the following remain overridden as empty stubs:
+The following are overridden and return empty stubs:
 
-Single-table methods (return empty list):
-- `get_foreign_keys()` - `PRAGMA foreign_key_list` not supported
 - `get_temp_table_names()` / `get_temp_view_names()` - no temp database
-
-Multi-table methods (return empty dict):
-- `get_multi_foreign_keys()`
+  (`sqlite_temp_master` not supported)
 
 ## Limitations
-
-### Table Reflection
-
-Foreign-key reflection is not yet supported because Turso has not implemented
-`PRAGMA foreign_key_list`. As a result:
-- `inspector.get_foreign_keys()` returns an empty list
-- Foreign key constraints still **work** at runtime, they just can't be
-  introspected
-- All other reflection (`get_indexes()`, `get_unique_constraints()`,
-  `get_check_constraints()`, `get_table_names()`, `get_columns()`) works
-  normally
-
-This means Alembic `--autogenerate` will not detect added or dropped foreign
-keys; verify FK changes manually.
 
 ### Native Datetime
 

--- a/bindings/python/SQLALCHEMY_DIALECT.md
+++ b/bindings/python/SQLALCHEMY_DIALECT.md
@@ -124,7 +124,7 @@ sqlite+turso:///db.db?isolation_level=IMMEDIATE
 ```
 
 Query parameters:
-- `isolation_level` - Transaction isolation level (DEFERRED, IMMEDIATE, EXCLUSIVE, AUTOCOMMIT)
+- `isolation_level` - Transaction isolation level: DEFERRED (default), IMMEDIATE, EXCLUSIVE, or AUTOCOMMIT (disables implicit transactions)
 - `experimental_features` - Comma-separated feature flags
 
 ### Async Local Dialect (`sqlite+aioturso://`)
@@ -136,7 +136,7 @@ sqlite+aioturso:///db.db?isolation_level=IMMEDIATE
 ```
 
 Query parameters:
-- `isolation_level` - Transaction isolation level (DEFERRED, IMMEDIATE, EXCLUSIVE, AUTOCOMMIT)
+- `isolation_level` - Transaction isolation level: DEFERRED (default), IMMEDIATE, EXCLUSIVE, or AUTOCOMMIT (disables implicit transactions)
 - `experimental_features` - Comma-separated feature flags
 
 ### Sync Dialect (`sqlite+turso_sync://`)
@@ -151,7 +151,7 @@ Query parameters:
 - `client_name` - Client identifier (default: turso-sqlalchemy)
 - `long_poll_timeout_ms` - Long poll timeout in milliseconds
 - `bootstrap_if_empty` - Bootstrap from remote if local empty (default: true)
-- `isolation_level` - Transaction isolation level
+- `isolation_level` - Transaction isolation level: DEFERRED (default), IMMEDIATE, EXCLUSIVE, or AUTOCOMMIT (disables implicit transactions)
 - `experimental_features` - Comma-separated feature flags
 
 URL validation:
@@ -161,28 +161,12 @@ URL validation:
 
 ## Sync Operations 
 
-The `get_sync_connection()` helper provides access to sync-specific methods:
+The `get_sync_connection()` helper (shown in Quick Start above) exposes the underlying `turso.sync.ConnectionSync` with these sync-specific methods:
 
-```python
-from turso.sqlalchemy import get_sync_connection
-
-with engine.connect() as conn:
-    sync = get_sync_connection(conn)
-
-    # Pull changes from remote (returns True if updates were pulled)
-    if sync.pull():
-        print("Pulled new changes!")
-
-    # Push local changes to remote
-    sync.push()
-
-    # Checkpoint the WAL
-    sync.checkpoint()
-
-    # Get sync statistics
-    stats = sync.stats()
-    print(f"Network received: {stats.network_received_bytes} bytes")
-```
+- `pull()` - Pull changes from remote; returns `True` if updates were pulled
+- `push()` - Push local changes to remote
+- `checkpoint()` - Checkpoint the WAL
+- `stats()` - Sync statistics (e.g. `stats().network_received_bytes`)
 
 `get_sync_connection()` raises `TypeError` if called on a non-sync connection (e.g. a plain `sqlite+turso://` or standard `sqlite://` engine).
 

--- a/bindings/python/SQLALCHEMY_DIALECT.md
+++ b/bindings/python/SQLALCHEMY_DIALECT.md
@@ -10,9 +10,9 @@ The SQLAlchemy dialect is implemented with three dialects:
 - `sqlite+turso_sync://` - Sync-enabled connections with remote database support
 
 ## Installation
-
+Requires SQLAlchemy ≥ 2.0.45
 ```bash
-pip install pyturso[sqlalchemy]
+pip install pyturso[sqlalchemy] # ensures compatible version of SQLAlchemy is installed
 ```
 
 ## Quick Start

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "maturin==1.12.6",
 ]
 sqlalchemy = [
-    "sqlalchemy>=2.0",
+    "sqlalchemy>=2.0.45",
 ]
 
 [project.urls]

--- a/bindings/python/tests/test_sqlalchemy.py
+++ b/bindings/python/tests/test_sqlalchemy.py
@@ -411,9 +411,6 @@ class TestBasicDialectIntegration:
             from sqlalchemy import inspect
             inspector = inspect(engine)
 
-            # get_foreign_keys is the only one that always returns empty
-            # (Turso lacks PRAGMA foreign_key_list). The others happen to be
-            # empty here only because this table has no indexes/unique/check.
             assert inspector.get_foreign_keys("test") == []
             assert inspector.get_indexes("test") == []
             assert inspector.get_unique_constraints("test") == []

--- a/bindings/python/tests/test_sqlalchemy.py
+++ b/bindings/python/tests/test_sqlalchemy.py
@@ -1,5 +1,9 @@
 """Tests for the SQLAlchemy dialect."""
 
+import importlib
+import sys
+import types
+
 import pytest
 
 # Skip all tests if SQLAlchemy is not installed
@@ -9,6 +13,41 @@ from sqlalchemy import Column, Integer, String, create_engine, text  # noqa: E40
 from sqlalchemy.engine import URL  # noqa: E402
 from sqlalchemy.orm import Session, declarative_base  # noqa: E402
 from turso.sqlalchemy import TursoDialect, TursoSyncDialect, get_sync_connection  # noqa: E402
+
+
+class TestSQLAlchemyVersionGuard:
+    """The dialects require SQLAlchemy >= 2.0.45 and must fail with a clear error on older versions."""
+
+    @pytest.mark.parametrize(
+        ("version", "asyncio_module_layout"),
+        [
+            # 1.4: sqlalchemy.connectors.asyncio does not exist at all
+            ("1.4.54", "absent"),
+            # 2.0.41: the module exists but does not export AsyncAdapt_dbapi_module
+            ("2.0.41", "missing-name"),
+            # 2.0.44: imports work, but SQLite reflection of multiple CHECK
+            # constraints is broken upstream (fixed in 2.0.45)
+            ("2.0.44", "intact"),
+        ],
+    )
+    def test_old_sqlalchemy_raises_clear_import_error(self, monkeypatch, version, asyncio_module_layout):
+        """Importing turso.sqlalchemy under SQLAlchemy < 2.0.45 must raise the
+        version-guard ImportError, not an error about SQLAlchemy internals.
+        Floors verified empirically: AsyncAdapt_dbapi_module first shipped in
+        2.0.42, multi-CHECK reflection was fixed in 2.0.45. Each parametrized
+        case mirrors its release's actual module layout."""
+        monkeypatch.setattr(sqlalchemy, "__version__", version)
+        if asyncio_module_layout == "absent":
+            # None in sys.modules makes importing the module raise ImportError
+            monkeypatch.setitem(sys.modules, "sqlalchemy.connectors.asyncio", None)
+        elif asyncio_module_layout == "missing-name":
+            empty_module = types.ModuleType("sqlalchemy.connectors.asyncio")
+            monkeypatch.setitem(sys.modules, "sqlalchemy.connectors.asyncio", empty_module)
+        monkeypatch.delitem(sys.modules, "turso.sqlalchemy", raising=False)
+        monkeypatch.delitem(sys.modules, "turso.sqlalchemy.dialect", raising=False)
+
+        with pytest.raises(ImportError, match=r"SQLAlchemy >= 2\.0\.45"):
+            importlib.import_module("turso.sqlalchemy")
 
 
 class TestTursoDialectImport:

--- a/bindings/python/tests/test_sqlalchemy.py
+++ b/bindings/python/tests/test_sqlalchemy.py
@@ -503,13 +503,13 @@ class TestSyncDialectIntegration:
 class TestTursoDialectMixin:
     """Test the reflection surface after _TursoDialectMixin overrides.
 
-    Index, unique-constraint, and check-constraint reflection is delegated to
-    SQLAlchemy's parent SQLite dialect (Turso supports `PRAGMA index_list`,
-    `index_info`, `index_xinfo`, and returns full DDL via `sqlite_master.sql`).
+    Index, unique-constraint, check-constraint, and foreign-key reflection is
+    delegated to SQLAlchemy's parent SQLite dialect (Turso supports `PRAGMA
+    index_list`, `index_info`, `index_xinfo`, `foreign_key_list`, and returns
+    full DDL via `sqlite_master.sql`).
 
-    Foreign-key and temp-table reflection still return empty stubs because
-    `PRAGMA foreign_key_list` and `sqlite_temp_master` are not implemented in
-    Turso.
+    Temp-table reflection still returns empty stubs because
+    `sqlite_temp_master` is not implemented in Turso.
     """
 
     @pytest.fixture
@@ -522,7 +522,12 @@ class TestTursoDialectMixin:
 
         with engine.connect() as conn:
             conn.execute(text("CREATE TABLE alpha (id INTEGER PRIMARY KEY, name TEXT)"))
-            conn.execute(text("CREATE TABLE beta (id INTEGER PRIMARY KEY, val REAL)"))
+            conn.execute(
+                text(
+                    "CREATE TABLE beta (id INTEGER PRIMARY KEY, val REAL, "
+                    "alpha_id INTEGER REFERENCES alpha(id))"
+                )
+            )
             conn.commit()
 
         return inspect(engine)
@@ -540,18 +545,29 @@ class TestTursoDialectMixin:
         assert "id" in col_names
         assert "name" in col_names
 
-    # ── Foreign keys: still genuinely unsupported ────────────────────
+    # ── Foreign keys: reflected via PRAGMA foreign_key_list ──────────
 
-    def test_get_foreign_keys_returns_empty(self, inspector):
-        """`PRAGMA foreign_key_list` not implemented → stub returns []."""
+    def test_get_foreign_keys_reflects_constraint(self, inspector):
+        """A REFERENCES clause is reflected with constrained/referred columns."""
+        fks = inspector.get_foreign_keys("beta")
+        assert len(fks) == 1
+        fk = fks[0]
+        assert fk["constrained_columns"] == ["alpha_id"]
+        assert fk["referred_table"] == "alpha"
+        assert fk["referred_columns"] == ["id"]
+
+    def test_get_foreign_keys_empty_without_fks(self, inspector):
+        """A table with no foreign keys reflects an empty list."""
         assert inspector.get_foreign_keys("alpha") == []
 
-    def test_multi_foreign_keys_returns_empty(self, inspector):
-        """get_multi_foreign_keys returns empty dict."""
-        dialect = TursoDialect()
-        with inspector.bind.connect() as conn:
-            result = dialect.get_multi_foreign_keys(conn, filter_names=["alpha", "beta"])
-        assert result == {}
+    def test_get_multi_foreign_keys_reflects_constraints(self, inspector):
+        """get_multi_foreign_keys returns per-table FK lists, not empty stubs."""
+        result = inspector.get_multi_foreign_keys(filter_names=["alpha", "beta"])
+        assert result[(None, "alpha")] == []
+        beta_fks = result[(None, "beta")]
+        assert len(beta_fks) == 1
+        assert beta_fks[0]["constrained_columns"] == ["alpha_id"]
+        assert beta_fks[0]["referred_table"] == "alpha"
 
     # ── Indexes ──────────────────────────────────────────────────────
 

--- a/bindings/python/tests/test_sqlalchemy.py
+++ b/bindings/python/tests/test_sqlalchemy.py
@@ -360,27 +360,25 @@ class TestBasicDialectIntegration:
             result = pd.read_sql("SELECT * FROM test_table", conn)
             assert len(result) == 3
 
-    def test_table_reflection_returns_empty(self):
-        """Test that table reflection methods return empty (not error)."""
+    def test_reflection_on_simple_table(self):
+        """Reflection on a table with no FKs, indexes, or UNIQUE clauses
+        returns empty for each — and never raises."""
         engine = create_engine("sqlite+turso:///:memory:")
 
         with engine.connect() as conn:
             conn.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)"))
             conn.commit()
 
-            # Get inspector
             from sqlalchemy import inspect
             inspector = inspect(engine)
 
-            # These should return empty lists, not raise errors
-            fks = inspector.get_foreign_keys("test")
-            assert fks == []
-
-            indexes = inspector.get_indexes("test")
-            assert indexes == []
-
-            ucs = inspector.get_unique_constraints("test")
-            assert ucs == []
+            # get_foreign_keys is the only one that always returns empty
+            # (Turso lacks PRAGMA foreign_key_list). The others happen to be
+            # empty here only because this table has no indexes/unique/check.
+            assert inspector.get_foreign_keys("test") == []
+            assert inspector.get_indexes("test") == []
+            assert inspector.get_unique_constraints("test") == []
+            assert inspector.get_check_constraints("test") == []
 
 
 class TestSyncDialectIntegration:
@@ -503,7 +501,16 @@ class TestSyncDialectIntegration:
 
 
 class TestTursoDialectMixin:
-    """Test the _TursoDialectMixin methods via inspector and directly."""
+    """Test the reflection surface after _TursoDialectMixin overrides.
+
+    Index, unique-constraint, and check-constraint reflection is delegated to
+    SQLAlchemy's parent SQLite dialect (Turso supports `PRAGMA index_list`,
+    `index_info`, `index_xinfo`, and returns full DDL via `sqlite_master.sql`).
+
+    Foreign-key and temp-table reflection still return empty stubs because
+    `PRAGMA foreign_key_list` and `sqlite_temp_master` are not implemented in
+    Turso.
+    """
 
     @pytest.fixture
     def engine(self):
@@ -520,10 +527,6 @@ class TestTursoDialectMixin:
 
         return inspect(engine)
 
-    def test_get_check_constraints_returns_empty(self, inspector):
-        """get_check_constraints returns empty list for any table."""
-        assert inspector.get_check_constraints("alpha") == []
-
     def test_get_table_names_works(self, inspector):
         """inspector.get_table_names() returns the created tables."""
         tables = inspector.get_table_names()
@@ -537,19 +540,11 @@ class TestTursoDialectMixin:
         assert "id" in col_names
         assert "name" in col_names
 
-    def test_multi_indexes_returns_empty(self, inspector):
-        """get_multi_indexes returns empty dict for multiple tables."""
-        dialect = TursoDialect()
-        with inspector.bind.connect() as conn:
-            result = dialect.get_multi_indexes(conn, filter_names=["alpha", "beta"])
-        assert result == {}
+    # ── Foreign keys: still genuinely unsupported ────────────────────
 
-    def test_multi_unique_constraints_returns_empty(self, inspector):
-        """get_multi_unique_constraints returns empty dict."""
-        dialect = TursoDialect()
-        with inspector.bind.connect() as conn:
-            result = dialect.get_multi_unique_constraints(conn, filter_names=["alpha", "beta"])
-        assert result == {}
+    def test_get_foreign_keys_returns_empty(self, inspector):
+        """`PRAGMA foreign_key_list` not implemented → stub returns []."""
+        assert inspector.get_foreign_keys("alpha") == []
 
     def test_multi_foreign_keys_returns_empty(self, inspector):
         """get_multi_foreign_keys returns empty dict."""
@@ -558,22 +553,165 @@ class TestTursoDialectMixin:
             result = dialect.get_multi_foreign_keys(conn, filter_names=["alpha", "beta"])
         assert result == {}
 
-    def test_multi_check_constraints_returns_empty(self, inspector):
-        """get_multi_check_constraints returns empty dict."""
-        dialect = TursoDialect()
-        with inspector.bind.connect() as conn:
-            result = dialect.get_multi_check_constraints(conn, filter_names=["alpha", "beta"])
-        assert result == {}
+    # ── Indexes ──────────────────────────────────────────────────────
 
-    def test_multi_table_reflection(self, inspector):
-        """Reflection with multiple tables: all tables visible, constraints empty."""
-        tables = inspector.get_table_names()
-        assert len(tables) >= 2
-        for table in ["alpha", "beta"]:
-            assert inspector.get_foreign_keys(table) == []
-            assert inspector.get_indexes(table) == []
-            assert inspector.get_unique_constraints(table) == []
-            assert inspector.get_check_constraints(table) == []
+    def test_get_indexes_user_index(self):
+        """A user-created index is reflected with name, columns, unique flag."""
+        engine = create_engine("sqlite+turso:///:memory:")
+        with engine.connect() as conn:
+            conn.execute(text("CREATE TABLE t (a INTEGER, b TEXT)"))
+            conn.execute(text("CREATE INDEX i_a ON t(a)"))
+            conn.commit()
+
+        from sqlalchemy import inspect
+
+        indexes = inspect(engine).get_indexes("t")
+
+        assert len(indexes) == 1
+        assert indexes[0]["name"] == "i_a"
+        assert indexes[0]["column_names"] == ["a"]
+        assert not indexes[0]["unique"]
+
+    def test_get_indexes_filters_unique_autoindex(self):
+        """`get_indexes` hides `sqlite_autoindex_*`; that constraint surfaces
+        in `get_unique_constraints` instead."""
+        engine = create_engine("sqlite+turso:///:memory:")
+        with engine.connect() as conn:
+            conn.execute(text("CREATE TABLE t (a INTEGER UNIQUE, b TEXT)"))
+            conn.commit()
+
+        from sqlalchemy import inspect
+
+        insp = inspect(engine)
+
+        assert insp.get_indexes("t") == []
+
+        ucs = insp.get_unique_constraints("t")
+        assert len(ucs) == 1
+        assert ucs[0]["column_names"] == ["a"]
+
+    def test_get_indexes_unique_index(self):
+        """`CREATE UNIQUE INDEX` reflects with `unique=True`."""
+        engine = create_engine("sqlite+turso:///:memory:")
+        with engine.connect() as conn:
+            conn.execute(text("CREATE TABLE t (a INTEGER, b TEXT)"))
+            conn.execute(text("CREATE UNIQUE INDEX i_u ON t(a)"))
+            conn.commit()
+
+        from sqlalchemy import inspect
+
+        indexes = inspect(engine).get_indexes("t")
+
+        assert len(indexes) == 1
+        assert indexes[0]["name"] == "i_u"
+        assert indexes[0]["unique"]
+
+    # ── Unique constraints ───────────────────────────────────────────
+
+    def test_get_unique_constraints_named_table_level(self):
+        """Named table-level UNIQUE: `sqlite_master.sql` regex extracts name."""
+        engine = create_engine("sqlite+turso:///:memory:")
+        with engine.connect() as conn:
+            conn.execute(text(
+                "CREATE TABLE t (a INTEGER, b INTEGER, "
+                "CONSTRAINT uq_ab UNIQUE (a, b))"
+            ))
+            conn.commit()
+
+        from sqlalchemy import inspect
+
+        ucs = inspect(engine).get_unique_constraints("t")
+
+        assert len(ucs) == 1
+        assert ucs[0]["name"] == "uq_ab"
+        assert ucs[0]["column_names"] == ["a", "b"]
+
+    # ── Check constraints ────────────────────────────────────────────
+
+    def test_get_check_constraints_inline(self):
+        """Inline column CHECK is reflected with its sqltext."""
+        engine = create_engine("sqlite+turso:///:memory:")
+        with engine.connect() as conn:
+            conn.execute(text("CREATE TABLE t (c INTEGER CHECK (c > 0))"))
+            conn.commit()
+
+        from sqlalchemy import inspect
+
+        cks = inspect(engine).get_check_constraints("t")
+
+        assert len(cks) == 1
+        assert "c > 0" in cks[0]["sqltext"]
+
+    def test_get_check_constraints_named_and_table_level(self):
+        """Named CHECK and unnamed table-level CHECK both reflect."""
+        engine = create_engine("sqlite+turso:///:memory:")
+        with engine.connect() as conn:
+            conn.execute(text(
+                "CREATE TABLE t ("
+                "a INTEGER, b INTEGER, "
+                "CONSTRAINT ck_t CHECK (a > 0), "
+                "CHECK (a > b)"
+                ")"
+            ))
+            conn.commit()
+
+        from sqlalchemy import inspect
+
+        cks = inspect(engine).get_check_constraints("t")
+
+        assert len(cks) == 2
+        named = [c for c in cks if c.get("name") == "ck_t"]
+        assert len(named) == 1
+        assert "a > 0" in named[0]["sqltext"]
+        assert any("a > b" in c["sqltext"] for c in cks)
+
+    # ── Multi-table reflection ──────────────────────────────────────
+
+    def test_get_multi_indexes_shape(self):
+        """Multi-reflection returns a dict keyed by (schema, table_name)."""
+        from sqlalchemy import inspect
+
+        engine = create_engine("sqlite+turso:///:memory:")
+        with engine.connect() as conn:
+            conn.execute(text("CREATE TABLE t1 (a INTEGER, b TEXT)"))
+            conn.execute(text("CREATE TABLE t2 (a INTEGER, b TEXT)"))
+            conn.execute(text("CREATE INDEX i_t1_a ON t1(a)"))
+            conn.execute(text("CREATE INDEX i_t2_b ON t2(b)"))
+            conn.commit()
+
+        result = inspect(engine).get_multi_indexes(filter_names=["t1", "t2"])
+
+        assert (None, "t1") in result
+        assert (None, "t2") in result
+        assert [i["name"] for i in result[(None, "t1")]] == ["i_t1_a"]
+        assert [i["name"] for i in result[(None, "t2")]] == ["i_t2_b"]
+
+    def test_get_multi_unique_and_check_shape(self):
+        """Multi-reflection of unique + check constraints across two tables."""
+        from sqlalchemy import inspect
+
+        engine = create_engine("sqlite+turso:///:memory:")
+        with engine.connect() as conn:
+            conn.execute(text(
+                "CREATE TABLE t1 (a INTEGER, b INTEGER, "
+                "CONSTRAINT uq_t1 UNIQUE (a, b))"
+            ))
+            conn.execute(text("CREATE TABLE t2 (c INTEGER CHECK (c > 0))"))
+            conn.commit()
+
+        insp = inspect(engine)
+        ucs = insp.get_multi_unique_constraints(filter_names=["t1", "t2"])
+        cks = insp.get_multi_check_constraints(filter_names=["t1", "t2"])
+
+        assert (None, "t1") in ucs
+        t1_ucs = ucs[(None, "t1")]
+        assert len(t1_ucs) == 1
+        assert t1_ucs[0]["name"] == "uq_t1"
+
+        assert (None, "t2") in cks
+        t2_cks = cks[(None, "t2")]
+        assert len(t2_cks) == 1
+        assert "c > 0" in t2_cks[0]["sqltext"]
 
 
 class TestTursoDialectMethods:

--- a/bindings/python/turso/sqlalchemy/__init__.py
+++ b/bindings/python/turso/sqlalchemy/__init__.py
@@ -30,7 +30,29 @@ Usage:
         sync.push()  # Push local changes
 """
 
-from .dialect import AioTursoDialect, TursoDialect, TursoSyncDialect, get_sync_connection
+import re
+
+import sqlalchemy
+
+# SQLAlchemy 2.0.42 first shipped AsyncAdapt_dbapi_module (imported by .dialect),
+# and 2.0.45 fixed SQLite reflection of multiple CHECK constraints, so 2.0.45 is
+# the oldest release the dialects fully work on. This guard must run before
+# importing .dialect, which fails on releases before 2.0.42 with an ImportError
+# about SQLAlchemy internals instead of a clear message.
+_MIN_SQLALCHEMY_VERSION = (2, 0, 45)
+
+if tuple(int(n) for n in re.findall(r"\d+", sqlalchemy.__version__)[:3]) < _MIN_SQLALCHEMY_VERSION:
+    raise ImportError(
+        f"pyturso's SQLAlchemy dialects require SQLAlchemy >= 2.0.45 "
+        f"(found {sqlalchemy.__version__}). Upgrade with: pip install 'sqlalchemy>=2.0.45'"
+    )
+
+from .dialect import (  # noqa: E402
+    AioTursoDialect,
+    TursoDialect,
+    TursoSyncDialect,
+    get_sync_connection,
+)
 
 __all__ = [
     "AioTursoDialect",

--- a/bindings/python/turso/sqlalchemy/dialect.py
+++ b/bindings/python/turso/sqlalchemy/dialect.py
@@ -9,6 +9,7 @@ This module provides SQLAlchemy dialects:
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List
 
 from sqlalchemy import pool
@@ -437,6 +438,14 @@ class TursoSyncDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):
 
     def connect(self, *cargs, **cparams):
         """Remap sync_url to remote_url for libsql-sqlalchemy compatibility."""
+        if "sync_url" in cparams:
+            warnings.warn(
+                "'sync_url' is deprecated (libsql-sqlalchemy compatibility shim) "
+                "and will be removed in a future release; use 'remote_url' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if "sync_url" in cparams and "remote_url" not in cparams:
             cparams["remote_url"] = cparams.pop("sync_url")
         return super().connect(*cargs, **cparams)
@@ -531,6 +540,13 @@ class TursoSyncDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):
 
         query_params = dict(url.query)
         # Accept both remote_url and sync_url (libsql-sqlalchemy compat)
+        if "sync_url" in query_params:
+            warnings.warn(
+                "'sync_url' is deprecated (libsql-sqlalchemy compatibility shim) "
+                "and will be removed in a future release; use 'remote_url' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         remote_url = query_params.pop("remote_url", None) or query_params.pop("sync_url", None)
         kwargs = self._extract_sync_params(query_params)
 
@@ -549,8 +565,6 @@ class TursoSyncDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):
 
         # Warn about unused query parameters
         if query_params:
-            import warnings
-
             warnings.warn(
                 f"Unrecognized query parameters ignored: {list(query_params.keys())}",
                 UserWarning,

--- a/bindings/python/turso/sqlalchemy/dialect.py
+++ b/bindings/python/turso/sqlalchemy/dialect.py
@@ -369,13 +369,6 @@ class TursoSyncDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):
 
     def connect(self, *cargs, **cparams):
         """Remap sync_url to remote_url for libsql-sqlalchemy compatibility."""
-        if "sync_url" in cparams:
-            warnings.warn(
-                "'sync_url' is deprecated (libsql-sqlalchemy compatibility shim) "
-                "and will be removed in a future release; use 'remote_url' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
         if "sync_url" in cparams and "remote_url" not in cparams:
             cparams["remote_url"] = cparams.pop("sync_url")
@@ -444,13 +437,7 @@ class TursoSyncDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):
 
         query_params = dict(url.query)
         # Accept both remote_url and sync_url (libsql-sqlalchemy compat)
-        if "sync_url" in query_params:
-            warnings.warn(
-                "'sync_url' is deprecated (libsql-sqlalchemy compatibility shim) "
-                "and will be removed in a future release; use 'remote_url' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+
         remote_url = query_params.pop("remote_url", None) or query_params.pop("sync_url", None)
         kwargs = self._extract_sync_params(query_params)
 

--- a/bindings/python/turso/sqlalchemy/dialect.py
+++ b/bindings/python/turso/sqlalchemy/dialect.py
@@ -32,9 +32,11 @@ logger = logging.getLogger(__name__)
 class _TursoDialectMixin:
     """
     Mixin providing Turso-specific overrides for SQLAlchemy dialect.
-    The methods below override the parent where the underlying 
-    capability is not supported by turso:
-    - sqlite_temp_master (temp tables/views)
+    The methods below override the parent where the underlying
+    capability differs in turso:
+    - sqlite_temp_master (temp tables/views) is not supported
+    - create_function (used by pysqlite's REGEXP setup) is not supported
+    - isolation level is set at connect time, not via PRAGMA
     """
 
     def get_temp_table_names(self, connection, **kw) -> List[str]:
@@ -52,6 +54,18 @@ class _TursoDialectMixin:
         """
         logger.debug("sqlite_temp_master not supported; temp view reflection unavailable")
         return []
+
+    def on_connect(self):
+        """Skip pysqlite's REGEXP function setup (turso doesn't support create_function)."""
+        return None
+
+    def get_isolation_level(self, dbapi_connection):
+        """Turso doesn't support PRAGMA read_uncommitted; always report SERIALIZABLE."""
+        return "SERIALIZABLE"
+
+    def set_isolation_level(self, dbapi_connection, level):
+        """No-op: turso sets isolation at connect time via the isolation_level parameter."""
+        logger.debug("set_isolation_level(%r) ignored; isolation is set at connect time", level)
 
 
 class TursoDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):
@@ -90,37 +104,6 @@ class TursoDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):
         import turso
 
         return turso
-
-    def on_connect(self):
-        """
-        Return a callable to run on each new connection.
-
-        We override this to skip the REGEXP function setup that pysqlite does,
-        since turso doesn't support create_function.
-        """
-        # Skip the parent's on_connect which tries to register REGEXP
-        # Return None to indicate no special connection setup needed
-        return None
-
-    def get_isolation_level(self, dbapi_connection):
-        """
-        Return the current isolation level.
-
-        Turso doesn't support PRAGMA read_uncommitted, so we return
-        SERIALIZABLE as the default (which is what SQLite uses).
-        """
-        return "SERIALIZABLE"
-
-    def set_isolation_level(self, dbapi_connection, level):
-        """
-        Set the isolation level.
-
-        Turso handles isolation through the isolation_level connection parameter,
-        not through PRAGMA statements. This is a no-op since the isolation level
-        is set at connection time.
-        """
-        # No-op: turso handles isolation via connection parameter
-        pass
 
     def create_connect_args(self, url: URL) -> ConnectArgsType:
         """
@@ -280,18 +263,6 @@ class AioTursoDialect(_TursoDialectMixin, SQLiteDialect_aiosqlite):
 
         return AsyncAdapt_turso_dbapi(turso.aio, turso)
 
-    def on_connect(self):
-        """Skip pysqlite REGEXP function setup (unsupported by turso)."""
-        return None
-
-    def get_isolation_level(self, dbapi_connection):
-        """Turso does not use PRAGMA read_uncommitted; always SERIALIZABLE."""
-        return "SERIALIZABLE"
-
-    def set_isolation_level(self, dbapi_connection, level):
-        """No-op: isolation level is set at connect time."""
-        pass
-
     def create_connect_args(self, url: URL) -> ConnectArgsType:
         """
         Create connection arguments from SQLAlchemy URL.
@@ -409,33 +380,6 @@ class TursoSyncDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):
         if "sync_url" in cparams and "remote_url" not in cparams:
             cparams["remote_url"] = cparams.pop("sync_url")
         return super().connect(*cargs, **cparams)
-
-    def on_connect(self):
-        """
-        Return a callable to run on each new connection.
-
-        We override this to skip the REGEXP function setup that pysqlite does,
-        since turso doesn't support create_function.
-        """
-        return None
-
-    def get_isolation_level(self, dbapi_connection):
-        """
-        Return the current isolation level.
-
-        Turso doesn't support PRAGMA read_uncommitted, so we return
-        SERIALIZABLE as the default.
-        """
-        return "SERIALIZABLE"
-
-    def set_isolation_level(self, dbapi_connection, level):
-        """
-        Set the isolation level.
-
-        Turso handles isolation through the isolation_level connection parameter.
-        This is a no-op since the isolation level is set at connection time.
-        """
-        pass
 
     @staticmethod
     def _validate_sync_url(opts: Dict[str, Any]) -> None:

--- a/bindings/python/turso/sqlalchemy/dialect.py
+++ b/bindings/python/turso/sqlalchemy/dialect.py
@@ -23,7 +23,7 @@ from sqlalchemy.engine.reflection import ObjectKind
 from sqlalchemy.util.concurrency import await_only
 
 if TYPE_CHECKING:
-    from sqlalchemy.engine.interfaces import ConnectArgsType, ReflectedForeignKeyConstraint, ReflectedIndex
+    from sqlalchemy.engine.interfaces import ConnectArgsType, ReflectedForeignKeyConstraint
     from sqlalchemy.pool import Pool
 
 logger = logging.getLogger(__name__)
@@ -33,10 +33,15 @@ class _TursoDialectMixin:
     """
     Mixin providing Turso-specific overrides for SQLAlchemy dialect.
 
-    Turso doesn't support all SQLite PRAGMAs. This mixin overrides methods
-    that would otherwise fail due to unsupported PRAGMAs:
-    - PRAGMA foreign_key_list (not supported)
-    - PRAGMA index_list (not supported)
+    Index, unique-constraint, and check-constraint reflection (single- and
+    multi-table) are inherited from SQLAlchemy's parent SQLite dialect, which
+    issues `PRAGMA index_list` / `PRAGMA index_info` and parses
+    `sqlite_master.sql` — all supported by Turso.
+
+    The methods below override the parent only where Turso still lacks the
+    underlying capability:
+    - PRAGMA foreign_key_list (foreign key reflection)
+    - sqlite_temp_master (temp tables/views)
     """
 
     def get_foreign_keys(
@@ -58,87 +63,6 @@ class _TursoDialectMixin:
         )
         return []
 
-    def get_indexes(
-        self,
-        connection,
-        table_name,
-        schema=None,
-        **kw,
-    ) -> List[ReflectedIndex]:
-        """
-        Return indexes for a table.
-
-        Turso doesn't support PRAGMA index_list, so we return an empty list.
-        Indexes still exist and are used for query optimization.
-        """
-        logger.debug(
-            "PRAGMA index_list not supported; index reflection unavailable for table '%s'",
-            table_name,
-        )
-        return []
-
-    def get_unique_constraints(
-        self,
-        connection,
-        table_name,
-        schema=None,
-        **kw,
-    ) -> List[Dict[str, Any]]:
-        """
-        Return unique constraints for a table.
-
-        This also relies on PRAGMA index_list which Turso doesn't support.
-        """
-        logger.debug(
-            "PRAGMA index_list not supported; unique constraint reflection unavailable for table '%s'",
-            table_name,
-        )
-        return []
-
-    def get_check_constraints(
-        self,
-        connection,
-        table_name,
-        schema=None,
-        **kw,
-    ) -> List[Dict[str, Any]]:
-        """
-        Return check constraints for a table.
-
-        SQLite stores these in sqlite_master which Turso may not fully support.
-        """
-        logger.debug(
-            "check constraint reflection not supported for table '%s'",
-            table_name,
-        )
-        return []
-
-    def get_multi_indexes(
-        self,
-        connection,
-        schema=None,
-        filter_names=None,
-        kind=ObjectKind.TABLE,
-        scope=None,
-        **kw,
-    ) -> Dict[Any, List[ReflectedIndex]]:
-        """Return indexes for multiple tables."""
-        logger.debug("PRAGMA index_list not supported; multi-index reflection unavailable")
-        return {}
-
-    def get_multi_unique_constraints(
-        self,
-        connection,
-        schema=None,
-        filter_names=None,
-        kind=ObjectKind.TABLE,
-        scope=None,
-        **kw,
-    ) -> Dict[Any, List[Dict[str, Any]]]:
-        """Return unique constraints for multiple tables."""
-        logger.debug("PRAGMA index_list not supported; multi-unique-constraint reflection unavailable")
-        return {}
-
     def get_multi_foreign_keys(
         self,
         connection,
@@ -150,19 +74,6 @@ class _TursoDialectMixin:
     ) -> Dict[Any, List[ReflectedForeignKeyConstraint]]:
         """Return foreign keys for multiple tables."""
         logger.debug("PRAGMA foreign_key_list not supported; multi-foreign-key reflection unavailable")
-        return {}
-
-    def get_multi_check_constraints(
-        self,
-        connection,
-        schema=None,
-        filter_names=None,
-        kind=ObjectKind.TABLE,
-        scope=None,
-        **kw,
-    ) -> Dict[Any, List[Dict[str, Any]]]:
-        """Return check constraints for multiple tables."""
-        logger.debug("multi-check-constraint reflection not supported")
         return {}
 
     def get_temp_table_names(self, connection, **kw) -> List[str]:

--- a/bindings/python/turso/sqlalchemy/dialect.py
+++ b/bindings/python/turso/sqlalchemy/dialect.py
@@ -20,11 +20,10 @@ from sqlalchemy.connectors.asyncio import (
 from sqlalchemy.dialects.sqlite.aiosqlite import SQLiteDialect_aiosqlite
 from sqlalchemy.dialects.sqlite.pysqlite import SQLiteDialect_pysqlite
 from sqlalchemy.engine import URL
-from sqlalchemy.engine.reflection import ObjectKind
 from sqlalchemy.util.concurrency import await_only
 
 if TYPE_CHECKING:
-    from sqlalchemy.engine.interfaces import ConnectArgsType, ReflectedForeignKeyConstraint
+    from sqlalchemy.engine.interfaces import ConnectArgsType
     from sqlalchemy.pool import Pool
 
 logger = logging.getLogger(__name__)
@@ -33,54 +32,15 @@ logger = logging.getLogger(__name__)
 class _TursoDialectMixin:
     """
     Mixin providing Turso-specific overrides for SQLAlchemy dialect.
-
-    Index, unique-constraint, and check-constraint reflection (single- and
-    multi-table) are inherited from SQLAlchemy's parent SQLite dialect, which
-    issues `PRAGMA index_list` / `PRAGMA index_info` and parses
-    `sqlite_master.sql` — all supported by Turso.
-
-    The methods below override the parent only where Turso still lacks the
-    underlying capability:
-    - PRAGMA foreign_key_list (foreign key reflection)
+    The methods below override the parent where the underlying 
+    capability is not supported by turso:
     - sqlite_temp_master (temp tables/views)
     """
-
-    def get_foreign_keys(
-        self,
-        connection,
-        table_name,
-        schema=None,
-        **kw,
-    ) -> List[ReflectedForeignKeyConstraint]:
-        """
-        Return foreign keys for a table.
-
-        Turso doesn't support PRAGMA foreign_key_list, so we return an empty list.
-        Foreign key constraints are still enforced at write time if defined.
-        """
-        logger.debug(
-            "PRAGMA foreign_key_list not supported; foreign key reflection unavailable for table '%s'",
-            table_name,
-        )
-        return []
-
-    def get_multi_foreign_keys(
-        self,
-        connection,
-        schema=None,
-        filter_names=None,
-        kind=ObjectKind.TABLE,
-        scope=None,
-        **kw,
-    ) -> Dict[Any, List[ReflectedForeignKeyConstraint]]:
-        """Return foreign keys for multiple tables."""
-        logger.debug("PRAGMA foreign_key_list not supported; multi-foreign-key reflection unavailable")
-        return {}
 
     def get_temp_table_names(self, connection, **kw) -> List[str]:
         """Return temporary table names.
 
-        Turso doesn't support sqlite_temp_master, so we return an empty list.
+        Turso doesn't currently support sqlite_temp_master, so we return an empty list.
         """
         logger.debug("sqlite_temp_master not supported; temp table reflection unavailable")
         return []
@@ -88,7 +48,7 @@ class _TursoDialectMixin:
     def get_temp_view_names(self, connection, **kw) -> List[str]:
         """Return temporary view names.
 
-        Turso doesn't support sqlite_temp_master, so we return an empty list.
+        Turso doesn't currently support sqlite_temp_master, so we return an empty list.
         """
         logger.debug("sqlite_temp_master not supported; temp view reflection unavailable")
         return []

--- a/uv.lock
+++ b/uv.lock
@@ -394,7 +394,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.5.4" },
-    { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0" },
+    { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0.45" },
     { name = "typing-extensions", specifier = ">=4.6.0,!=4.7.0" },
 ]
 provides-extras = ["dev", "sqlalchemy"]


### PR DESCRIPTION
## Description

This PR updates the Turso Python binding's SQLAlchemy dialect to enable reflection features that Turso now supports, and does some related housekeeping:

- Remove overrides for table reflection methods that depended on previously unsupported SQLite PRAGMAs (`foreign_key_list`, `index_list`)
- Move methods duplicated across the three dialect classes into the central `_TursoDialectMixin` (~50 fewer lines)
- Bump the minimum SQLAlchemy version to >= 2.0.45 and add a guard that fails with an explicit message on older versions
- Add a deprecation warning when `sync_url` is passed via connection parameters
- Add test coverage for the newly enabled reflection methods (foreign keys, indexes, unique and check constraints, and their `get_multi_*` variants) plus a version-guard regression test
- Update docs: remove redundant sync examples, make the SQLAlchemy version requirement explicit

## Motivation and context

When we first introduced SQLAlchemy support, several SQLAlchemy reflection functions depended on SQLite PRAGMAs that Turso did not support at the time (`foreign_key_list`, `index_list`). To prevent errors, we overrode them to return empty results. Subsequent Turso updates enabled those PRAGMAs, so the overrides are no longer needed and actively hide real schema information.

We originally pinned SQLAlchemy to 2.0+. Two things now require a higher floor: async dialect support depends on `AsyncAdapt_dbapi_module` (first shipped in 2.0.42), and the newly enabled CHECK constraint reflection depends on a fix for tables with multiple CHECK constraints (shipped in 2.0.45). Testing also showed that older versions fail with confusing errors about SQLAlchemy internals, so the new guard raises an explicit message telling users to upgrade.

The first version of the dialect added a shim accepting libsql-style `sync_url` in place of `remote_url`. Since we may not keep this indefinitely, the shim now emits a `DeprecationWarning` directing users to `remote_url`.

Clean-up: each of the three dialect classes had its own identical `on_connect()`, `get_isolation_level()`, and `set_isolation_level()` methods; these now live once in `_TursoDialectMixin`. The docs' duplicated sync examples in Quick Start and Sync Operations are consolidated into one.

## Description of AI Usage

Claude Opus 4.8 and Fable 5 were used to verify which reflection functions are now supported, assist in generating and reviewing code, and write tests. All generated code was carefully reviewed.
