### PR TITLE
core/mvcc: retain checkpointed superseded versions in GC until overwrite is durable

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -7404,7 +7404,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Apply GC rules to a single version chain. Returns the number removed.
     ///
     /// Rule 1: aborted garbage (begin=None, end=None) — always remove.
-    /// Rule 2: superseded (end=Timestamp(e)) — remove once no reader can see it.
+    /// Rule 2: superseded (end=Timestamp(e)) — remove once no reader can see it,
+    ///         unless it's a tombstone (no committed current version) whose
+    ///         deletion hasn't been checkpointed, or a B-tree-resident version
+    ///         (flagged, or with a checkpointed insert: begin <= ckpt_max)
+    ///         whose physical delete/overwrite hasn't been checkpointed.
     /// Rule 3: checkpointed sole-survivor (end=None) — remove.
     ///
     /// Passive gates Rules 2/3 on `materialized_at` + `min_reader_mark`: reclaim only once the
@@ -7441,9 +7445,20 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     !materialized_for_readers(rv)
                 } else {
                     // Retain superseded versions until checkpoint makes the physical change
-                    // durable. btree_resident markers and tombstones without a committed
-                    // current successor must survive even when a newer current exists.
-                    *e > ckpt_max && (rv.btree_resident || !has_current)
+                    // durable. Tombstones without a committed current successor must survive
+                    // even when a newer current exists, and so must B-tree-resident versions.
+                    // A version is B-tree resident not only when flagged (seeded from
+                    // the B-tree by the dual cursor) but also when its insert was
+                    // made durable by a checkpoint (begin <= ckpt_max < end): the
+                    // checkpointer derives DB-file existence from begin/end
+                    // timestamps relative to the durable boundary, so dropping such
+                    // a version would erase the only evidence that a later delete
+                    // must be written to the B-tree (see #7638: an abandoned
+                    // post-commit checkpoint advances ckpt_max without clearing
+                    // these chains, and premature GC then resurrects the row).
+                    let in_btree = rv.btree_resident
+                        || matches!(&rv.begin(), Some(TxTimestampOrID::Timestamp(b)) if *b <= ckpt_max);
+                    *e > ckpt_max && (in_btree || !has_current)
                 }
             }
             _ => true,

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9751,6 +9751,44 @@ fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() 
     assert!(versions.is_empty());
 }
 
+/// A superseded version whose insert was checkpointed (begin <= ckpt_max) is
+/// physically in the B-tree even when its `btree_resident` flag is unset (the
+/// flag is only seeded by the dual cursor, not by checkpoint). Until its
+/// overwrite/delete is checkpointed (end > ckpt_max), it must be retained even
+/// with a committed current replacement: the checkpointer derives DB-file
+/// existence from begin/end timestamps against the durable boundary, so
+/// removing this version would make a later delete skip the B-tree write and
+/// resurrect the row (issue #7638).
+#[test]
+fn test_gc_rule2_checkpointed_insert_with_current_retained_until_checkpoint() {
+    // begin=2 <= ckpt_max=2 (insert checkpointed), end=5 > ckpt_max (overwrite not).
+    let checkpointed_btree_row = make_rv(ts(2), ts(5));
+    let current = make_rv(ts(5), None);
+    let mut versions = crate::alloc::vec![checkpointed_btree_row, current];
+
+    let dropped = MvStore::<MvccClock>::gc_version_chain(
+        &mut versions,
+        10,
+        2,
+        false,
+        crate::mvcc::database::WalPos::STAGED,
+    );
+    assert_eq!(dropped, 0);
+    assert_eq!(versions.len(), 2);
+
+    // Once the overwrite is checkpointed (end <= ckpt_max), both versions are
+    // reclaimable (rule 2 for the superseded, rule 3 for the current).
+    let dropped = MvStore::<MvccClock>::gc_version_chain(
+        &mut versions,
+        10,
+        5,
+        false,
+        crate::mvcc::database::WalPos::STAGED,
+    );
+    assert_eq!(dropped, 2);
+    assert!(versions.is_empty());
+}
+
 /// Garbage collection removes only versions that are provably unreachable and keeps versions still required for visibility and safety.
 #[test]
 /// B-tree tombstones (begin=None, end=e) represent rows that existed in the B-tree

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1468,3 +1468,134 @@ fn test_mvcc_index_scan_does_not_return_row_deleted_mid_scan(
     assert_eq!(rest, vec![(3, 4)]);
     Ok(())
 }
+
+// Regression coverage for issue #7638: an abandoned MVCC post-commit
+// auto-checkpoint combined with GC resurrects a deleted row and corrupts the
+// secondary index.
+
+fn open_file_conn(path: &str) -> Arc<turso_core::Connection> {
+    let io = Arc::new(turso_core::PlatformIO::new().unwrap());
+    let db =
+        Database::open_file_with_flags(io, path, OpenFlags::default(), DatabaseOpts::new(), None)
+            .unwrap();
+    db.connect().unwrap()
+}
+
+fn collect(conn: &Arc<turso_core::Connection>, sql: &str) -> Vec<Vec<turso_core::Value>> {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => rows.push(stmt.row().unwrap().get_values().cloned().collect()),
+            StepResult::Done => return rows,
+            StepResult::IO => stmt._io().step().unwrap(),
+            StepResult::Yield => {}
+            other => panic!("unexpected step result for {sql}: {other:?}"),
+        }
+    }
+}
+
+/// Step `sql`, counting IO/Yield pauses, and abandon the statement (drop it
+/// mid-flight) once `pause_target` pauses have been observed. Returns whether
+/// the statement was abandoned before completing.
+fn abandon_after_pause(conn: &Arc<turso_core::Connection>, sql: &str, pause_target: usize) -> bool {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let mut pauses = 0usize;
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::IO => {
+                pauses += 1;
+                stmt._io().step().unwrap();
+                if pauses == pause_target {
+                    drop(stmt);
+                    return true;
+                }
+            }
+            StepResult::Yield => {
+                pauses += 1;
+                if pauses == pause_target {
+                    drop(stmt);
+                    return true;
+                }
+            }
+            StepResult::Row => {}
+            StepResult::Done => return false,
+            other => panic!("unexpected step result for {sql}: {other:?}"),
+        }
+    }
+}
+
+/// Issue #7638: a post-commit auto-checkpoint abandoned after CommitPagerTxn
+/// advanced the durable boundary (but before the checkpoint's own chain GC)
+/// leaves superseded versions whose insert is durable but whose
+/// `btree_resident` flag is unset. GC must retain them until the physical
+/// delete/overwrite is checkpointed; dropping them makes a later DELETE skip
+/// the B-tree write, resurrecting the stale table row while the sibling index
+/// delete is still applied, corrupting the secondary index.
+#[test]
+fn test_issue_7638_gc_after_abandoned_checkpoint_does_not_resurrect_row() {
+    const ROWS: i64 = 1_500;
+    const TARGET: i64 = 1_500;
+    let pause_target = 9;
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("gc-witness-indexed.db");
+    let path = path.to_str().unwrap();
+
+    let conn = open_file_conn(path);
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    conn.execute("PRAGMA mvcc_gc_threshold = 1").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX t_v ON t(v)").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    for id in 1..=ROWS {
+        conn.execute(format!("INSERT INTO t VALUES({id}, 'old{id}')"))
+            .unwrap();
+    }
+
+    // COMMIT triggers a post-commit auto-checkpoint (threshold 0); abandon it
+    // after CommitPagerTxn has advanced the durable boundary but before the
+    // checkpoint's own chain GC runs.
+    assert!(abandon_after_pause(&conn, "COMMIT", pause_target));
+    assert_eq!(
+        collect(&conn, "SELECT count(*) FROM t")[0][0]
+            .as_int()
+            .unwrap(),
+        ROWS
+    );
+
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    // The UPDATE supersedes the checkpointed insert version and (with
+    // mvcc_gc_threshold=1) lets GC consider dropping it; the DELETE must then
+    // still be written through to the B-tree.
+    conn.execute(format!("UPDATE t SET v = 'mid' WHERE id = {TARGET}"))
+        .unwrap();
+    conn.execute(format!("DELETE FROM t WHERE id = {TARGET}"))
+        .unwrap();
+
+    assert_eq!(
+        collect(&conn, &format!("SELECT id, v FROM t WHERE id = {TARGET}")),
+        Vec::<Vec<turso_core::Value>>::new()
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let table_rows = collect(&conn, &format!("SELECT id, v FROM t WHERE id = {TARGET}"));
+    let index_rows = collect(
+        &conn,
+        &format!("SELECT id, v FROM t INDEXED BY t_v WHERE v = 'old{TARGET}'"),
+    );
+    let integrity = collect(&conn, "PRAGMA integrity_check");
+
+    assert_eq!(table_rows, Vec::<Vec<turso_core::Value>>::new());
+    assert_eq!(index_rows, Vec::<Vec<turso_core::Value>>::new());
+    assert_eq!(integrity, vec![vec![turso_core::Value::build_text("ok")]]);
+}


### PR DESCRIPTION
GC rule 2 dropped a superseded version with a committed current
replacement whenever its btree_resident flag was unset. But that flag is
only seeded by the dual cursor when it reads a row back from the B-tree;
versions whose insert was made durable by a checkpoint never carry it.
When a post-commit auto-checkpoint is abandoned after CommitPagerTxn
advanced durable_txid_max (but before the checkpoint's own chain GC),
such a version is the only evidence that the row physically exists in
the B-tree. The checkpointer derives DB-file existence from begin/end
timestamps against the durable boundary, so removing it made a later
DELETE look like a delete of a never-checkpointed row: the B-tree write
was skipped, resurrecting the stale table row while the sibling index
delete was still applied, leaving the secondary index inconsistent.

Treat a version whose insert was checkpointed (begin <= ckpt_max < end)
as B-tree resident in the rule 2 guard, retaining it until the physical
delete/overwrite becomes durable. Once end <= ckpt_max, it is reclaimed
exactly as before, so steady-state memory behavior is unchanged.

Tests: regression test
mvcc::test_issue_7638_gc_after_abandoned_checkpoint_does_not_resurrect_row
passes; new unit test
test_gc_rule2_checkpointed_insert_with_current_retained_until_checkpoint
fails on the old guard; full turso_core and core_tester suites pass.

Fixes #7638