### PR TITLE
github: Fix Windows release build and signing failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,13 +228,15 @@ jobs:
             mkdir -p "$extract_dir"
             unzip -o "$zip_path" tursodb.exe -d "$extract_dir"
 
-            exe_path="$(pwd)/$extract_dir/tursodb.exe"
+            exe_path="$extract_dir/tursodb.exe"
             if [[ ! -f "$exe_path" ]]; then
               echo "Expected tursodb.exe in $zip_path" >&2
               exit 1
             fi
 
-            printf '%s\n' "$exe_path" >> sign-tmp/files-to-sign.txt
+            # signtool.exe parses MSYS-style /d/... paths as options, so hand
+            # the signing action a native Windows path.
+            cygpath -w "$(pwd)/$exe_path" >> sign-tmp/files-to-sign.txt
             printf '%s\t%s\n' "$zip_path" "$extract_dir" >> sign-tmp/archives.txt
           done
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,8 +15,10 @@ targets = ["aarch64-apple-darwin", "aarch64-pc-windows-msvc", "aarch64-unknown-l
 pr-run-mode = "plan"
 # Path that installers should place binaries in
 install-path = "~/.turso"
-# Whether to install an updater program
-install-updater = true
+# Whether to install an updater program. Must stay off: dist provides no
+# prebuilt updater binary for aarch64-pc-windows-msvc, and the setting cannot
+# be toggled per target, so enabling it fails the Windows ARM64 release build.
+install-updater = false
 # Whether to consider the binaries in a package for distribution (defaults true)
 dist = false
 # Whether to enable GitHub Attestations


### PR DESCRIPTION
The v0.7.0-pre.19 release run failed on both Windows jobs, each for a
different reason:

- aarch64-pc-windows-msvc: dist errored after a successful build because
  it provides no standalone updater binary for that target and
  install-updater cannot be toggled per target. Disable the updater
  globally, as the dist error message prescribes. This drops the bundled
  self-update binary from all platforms' archives and installers.

- x86_64-pc-windows-msvc: the signing extraction step runs under Git
  Bash, so it emitted an MSYS-style /d/a/... exe path that signtool.exe
  parsed as an invalid option. Convert the path with cygpath -w so the
  trusted-signing action receives a native Windows path.
