### PR TITLE
tests/fuzz: loosen float tolerance in math expression fuzz

### DIFF
--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -4261,9 +4261,13 @@ mod fuzz_tests {
                 (rusqlite::types::Value::Real(limbo), rusqlite::types::Value::Real(sqlite))
                     if limbo.is_finite() && sqlite.is_finite() =>
                 {
+                    // Rust and C libm may differ by 1 ulp, and inverse functions with
+                    // singular derivatives amplify that near domain boundaries: e.g.
+                    // atanh(tanh(-1.0)) is -1.0 in Rust but 1 ulp inside in glibc, and
+                    // asin turns that into a ~1.5e-8 difference. Hence the loose epsilon.
                     assert!(
-                        (limbo - sqlite).abs() < 1e-9
-                            || (limbo - sqlite) / (limbo.abs().max(sqlite.abs())) < 1e-9,
+                        (limbo - sqlite).abs() < 1e-6
+                            || (limbo - sqlite).abs() / (limbo.abs().max(sqlite.abs())) < 1e-6,
                         "query: {query}, limbo: {limbo:?}, sqlite: {sqlite:?} seed: {seed}"
                     )
                 }


### PR DESCRIPTION
Rust and C libm may legitimately differ by 1 ulp, and inverse functions
with singular derivatives amplify that near domain boundaries: for
atanh(tanh(-1.0)), Rust returns exactly -1.0 while glibc returns 1 ulp
inside, and asin turns that into a ~1.5e-8 difference that exceeded the
1e-9 epsilon. Widen the epsilon to 1e-6, which still catches real bugs
since those produce grossly different values.

Also fix the relative-error check, which was missing an abs() on the
numerator and therefore passed trivially whenever limbo < sqlite.

Tests: SEED=1783921200331 reproduces the failure before and passes
after; FUZZ_MULTIPLIER=20 stress run passes.
