### PR TITLE
docs: document CDC commit records and change_txn_id

### DIFF
--- a/cli/manuals/cdc.md
+++ b/cli/manuals/cdc.md
@@ -77,12 +77,30 @@ The CDC table (default name: `turso_cdc`) contains the following columns:
 |--------|------|-------------|
 | `change_id` | INTEGER | Auto-incrementing unique identifier for each change |
 | `change_time` | INTEGER | Timestamp of the change (Unix epoch) |
-| `change_type` | INTEGER | Type of change: 1 (INSERT), 0 (UPDATE), -1 (DELETE) |
-| `table_name` | TEXT | Name of the table that was changed |
-| `id` | varies | Primary key/rowid of the changed row |
+| `change_type` | INTEGER | Type of change: 1 (INSERT), 0 (UPDATE), -1 (DELETE), 2 (COMMIT) |
+| `table_name` | TEXT | Name of the table that was changed (NULL for COMMIT records) |
+| `id` | varies | Primary key/rowid of the changed row (NULL for COMMIT records) |
 | `before` | BLOB | Row data before the change (for modes: before, full) |
 | `after` | BLOB | Row data after the change (for modes: after, full) |
 | `updates` | BLOB | Details of updated columns (for mode: full) |
+| `change_txn_id` | INTEGER | Identifier grouping records that belong to the same transaction |
+
+### Commit Records
+
+In addition to row changes, the CDC table records transaction boundaries. A row
+with `change_type = 2` (COMMIT) marks the end of a transaction. Commit records
+carry no row data: their `table_name`, `id`, `before`, `after`, and `updates`
+columns are all NULL, so they appear as mostly empty rows when you select from
+the CDC table.
+
+Every statement executed outside an explicit transaction commits on its own, so
+each such statement is followed by its own COMMIT record. Inside an explicit
+transaction (`BEGIN ... COMMIT`), a single COMMIT record is written when the
+transaction commits.
+
+All records belonging to the same transaction, including its COMMIT record,
+share the same `change_txn_id` value (the `change_id` of the first record in
+the transaction).
 
 ## Querying Changes
 
@@ -100,6 +118,12 @@ SELECT * FROM turso_cdc WHERE change_type = 0;
 
 -- View only deletes
 SELECT * FROM turso_cdc WHERE change_type = -1;
+
+-- View row changes without transaction boundary (COMMIT) records
+SELECT * FROM turso_cdc WHERE change_type != 2;
+
+-- View all changes made by a single transaction
+SELECT * FROM turso_cdc WHERE change_txn_id = 5;
 
 -- View changes for a specific table
 SELECT * FROM turso_cdc WHERE table_name = 'users';
@@ -129,14 +153,18 @@ UPDATE users SET email = 'alice@newdomain.com' WHERE id = 1;
 DELETE FROM users WHERE id = 2;
 
 -- View the captured changes
-SELECT change_type, table_name, id
+SELECT change_type, table_name, id, change_txn_id
 FROM turso_cdc;
 
 -- Results will show:
--- 1 (INSERT) for Alice
--- 1 (INSERT) for Bob
--- 0 (UPDATE) for Alice's email change
--- -1 (DELETE) for Bob
+-- 1 (INSERT) for Alice, followed by a 2 (COMMIT) record
+-- 1 (INSERT) for Bob, followed by a 2 (COMMIT) record
+-- 0 (UPDATE) for Alice's email change, followed by a 2 (COMMIT) record
+-- -1 (DELETE) for Bob, followed by a 2 (COMMIT) record
+--
+-- Each statement above runs in autocommit mode, so each one is its own
+-- transaction and produces its own COMMIT record. The table_name and id
+-- columns of COMMIT records are NULL.
 ```
 
 ## Multiple Connections
@@ -156,19 +184,22 @@ PRAGMA capture_data_changes_conn('id,sync_queue');
 
 ## Transactions
 
-CDC respects transaction boundaries. Changes are only recorded when a transaction commits:
+CDC records are written in the same transaction as the changes themselves, so
+rolling back a transaction also discards its CDC entries. When a transaction
+commits, a single COMMIT record (`change_type = 2`) marks the boundary, and
+every record in the transaction shares the same `change_txn_id`:
 
 ```sql
 BEGIN;
 INSERT INTO users VALUES (3, 'Charlie', 'charlie@example.com');
 UPDATE users SET name = 'Charles' WHERE id = 3;
--- CDC table is not yet updated
-
 COMMIT;
--- Now both the INSERT and UPDATE appear in the CDC table
+
+-- The CDC table now contains the INSERT, the UPDATE, and one COMMIT record,
+-- all with the same change_txn_id
 ```
 
-If a transaction rolls back, no CDC entries are created for those changes.
+If a transaction rolls back, no CDC entries remain for those changes.
 
 ## Schema Changes
 

--- a/cli/manuals/cdc.md
+++ b/cli/manuals/cdc.md
@@ -102,6 +102,12 @@ All records belonging to the same transaction, including its COMMIT record,
 share the same `change_txn_id` value (the `change_id` of the first record in
 the transaction).
 
+An explicit transaction that captures no changes, for example one whose only
+statement is an `UPDATE` matching zero rows, commits without writing a COMMIT
+record. Outside an explicit transaction, a statement that changes no rows
+still writes a COMMIT record; since there are no row records to take a
+`change_txn_id` from, its `change_txn_id` is -1.
+
 ## Querying Changes
 
 Once CDC is enabled, you can query the changes table like any other table:
@@ -200,6 +206,10 @@ COMMIT;
 ```
 
 If a transaction rolls back, no CDC entries remain for those changes.
+
+An explicit transaction that commits without capturing any changes leaves no
+trace either: its COMMIT record is only written when the transaction recorded
+at least one change.
 
 ## Schema Changes
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1089,14 +1089,17 @@ When **Change Data Capture (CDC)** is enabled for a connection, Turso automatica
   - `1` → INSERT  
   - `0` → UPDATE (also used for ALTER TABLE)  
   - `-1` → DELETE (also covers DROP TABLE, DROP INDEX)  
+  - `2` → COMMIT (marks a transaction boundary; all other data columns are NULL)  
 
 - **`table_name` (TEXT)**  
   Name of the affected table.  
   - For schema changes (DDL), this is always `"sqlite_schema"`.  
+  - NULL for COMMIT records.  
 
 - **`id` (INTEGER)**  
   Rowid of the affected row in the source table.  
   - For DDL operations: rowid of the `sqlite_schema` entry.  
+  - NULL for COMMIT records.  
   - **Note:** `WITHOUT ROWID` tables are not supported in the tursodb and CDC
 
 - **`before` (BLOB)**  
@@ -1112,12 +1115,18 @@ When **Change Data Capture (CDC)** is enabled for a connection, Turso automatica
 - **`updates` (BLOB)**  
   Granular details about the change.  
   - For UPDATE: shows specific column modifications.  
+  - NULL for COMMIT records.  
 
+- **`change_txn_id` (INTEGER)**  
+  Identifier grouping records that belong to the same transaction.  
+  - All records of a transaction, including its COMMIT record, share the same value (the `change_id` of the first record in the transaction).  
+
+Every transaction ends with a COMMIT record (`change_type = 2`). Statements executed outside an explicit transaction commit individually, so each one produces its own COMMIT record. Inside a `BEGIN ... COMMIT` block, a single COMMIT record is written when the transaction commits. Because a COMMIT record has NULL in all data columns, it appears as a mostly empty row when you select from the CDC table.
 
 > CDC records are visible even before a transaction commits. 
 > Operations that fail (e.g., constraint violations) are not recorded in CDC.
 
-> Changes to the CDC table itself are also logged to CDC table. if CDC is enabled for that connection.
+> Changes to the CDC table itself are never captured, even if CDC is enabled for that connection.
 
 ```zsh
 Example:
@@ -1134,23 +1143,33 @@ UPDATE users SET name='John Doe' WHERE id=1;
 
 DELETE FROM users WHERE id=2;
 
-SELECT * FROM turso_cdc;
-┌───────────┬─────────────┬─────────────┬───────────────┬────┬──────────┬──────────────────────────────────────────────────────────────────────────────┬───────────────┐
-│ change_id │ change_time │ change_type │ table_name    │ id │ before   │ after                                                                        │ updates       │
-├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
-│         1 │  1756713161 │           1 │ sqlite_schema │  2 │          │ ytableusersusersCREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT) │               │
-├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
-│         2 │  1756713176 │           1 │ users         │  1 │          │       John                                                                      │               │
-├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
-│         3 │  1756713176 │           1 │ users         │  2 │          │ Jane                                                                     │               │
-├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
-│         4 │  1756713176 │           0 │ users         │  1 │  John  │         John Doe                                                                  │     John Doe │
-├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
-│         5 │  1756713176 │          -1 │ users         │  2 │ Jane │                                                                              │               │
-└───────────┴─────────────┴─────────────┴───────────────┴────┴──────────┴──────────────────────────────────────────────────────────────────────────────┴───────────────┘
+SELECT change_id, change_time, change_type, table_name, id, change_txn_id FROM turso_cdc;
+┌───────────┬─────────────┬─────────────┬───────────────┬────┬───────────────┐
+│ change_id │ change_time │ change_type │ table_name    │ id │ change_txn_id │
+├───────────┼─────────────┼─────────────┼───────────────┼────┼───────────────┤
+│         1 │  1783939853 │           1 │ sqlite_schema │  5 │             1 │
+├───────────┼─────────────┼─────────────┼───────────────┼────┼───────────────┤
+│         2 │  1783939853 │           2 │               │    │             1 │
+├───────────┼─────────────┼─────────────┼───────────────┼────┼───────────────┤
+│         3 │  1783939853 │           1 │ users         │  1 │             3 │
+├───────────┼─────────────┼─────────────┼───────────────┼────┼───────────────┤
+│         4 │  1783939853 │           1 │ users         │  2 │             3 │
+├───────────┼─────────────┼─────────────┼───────────────┼────┼───────────────┤
+│         5 │  1783939853 │           2 │               │    │             3 │
+├───────────┼─────────────┼─────────────┼───────────────┼────┼───────────────┤
+│         6 │  1783939853 │           0 │ users         │  1 │             6 │
+├───────────┼─────────────┼─────────────┼───────────────┼────┼───────────────┤
+│         7 │  1783939853 │           2 │               │    │             6 │
+├───────────┼─────────────┼─────────────┼───────────────┼────┼───────────────┤
+│         8 │  1783939853 │          -1 │ users         │  2 │             8 │
+├───────────┼─────────────┼─────────────┼───────────────┼────┼───────────────┤
+│         9 │  1783939853 │           2 │               │    │             8 │
+└───────────┴─────────────┴─────────────┴───────────────┴────┴───────────────┘
 turso>
 
 ```
+
+Each statement above runs in autocommit mode, so each one forms its own transaction and is followed by a COMMIT record (`change_type = 2`) with NULL data columns. The two-row `INSERT` is a single statement, so both row records and the COMMIT record share `change_txn_id = 3`.
 
 If you modify your table schema (adding/dropping columns), the `table_columns_json_array()` function returns the current schema, not the historical one. This can lead to incorrect results when decoding older CDC records. Manually track schema versions by storing the output of `table_columns_json_array()` before making schema changes.
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1120,8 +1120,11 @@ When **Change Data Capture (CDC)** is enabled for a connection, Turso automatica
 - **`change_txn_id` (INTEGER)**  
   Identifier grouping records that belong to the same transaction.  
   - All records of a transaction, including its COMMIT record, share the same value (the `change_id` of the first record in the transaction).  
+  - `-1` for the COMMIT record of a statement outside an explicit transaction that changed no rows.  
 
 Every transaction ends with a COMMIT record (`change_type = 2`). Statements executed outside an explicit transaction commit individually, so each one produces its own COMMIT record. Inside a `BEGIN ... COMMIT` block, a single COMMIT record is written when the transaction commits. Because a COMMIT record has NULL in all data columns, it appears as a mostly empty row when you select from the CDC table.
+
+An explicit transaction that captures no changes, for example one whose only statement is an `UPDATE` matching zero rows, commits without writing a COMMIT record. Outside an explicit transaction, a statement that changes no rows still writes a COMMIT record with `change_txn_id = -1`.
 
 > CDC records are visible even before a transaction commits. 
 > Operations that fail (e.g., constraint violations) are not recorded in CDC.


### PR DESCRIPTION
CDC v2 emits a COMMIT record (change_type=2, all data columns NULL) at every transaction boundary and stamps each record with a change_txn_id, but neither the CLI manual nor the database manual mentioned them. Users reading the manual mistook the commit records for corrupt empty rows.

Also correct two inaccurate claims: CDC rows are written in the same transaction as the DML (visible before commit, discarded on rollback), and changes to the CDC table itself are never captured.

Fixes #7815