### PR TITLE
core/translate: use abort journal analysis for upsert DO UPDATE arms

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1181,6 +1181,9 @@ pub fn translate_insert(
             .any(|m| m.column.notnull() && !m.column.is_rowid_alias());
         let has_unique = !constraints.constraints_to_check.is_empty();
         let has_triggers = has_before_triggers || has_after_triggers;
+        let has_upsert_do_update = upsert_actions
+            .iter()
+            .any(|(_, _, upsert)| matches!(upsert.do_clause, UpsertDo::Set { .. }));
         set_insert_stmt_journal_flags(
             program,
             resolver,
@@ -1192,6 +1195,7 @@ pub fn translate_insert(
             has_triggers,
             has_fks,
             has_upsert,
+            has_upsert_do_update,
             btree_table.has_autoincrement,
             notnull_col_exists,
             has_unique,

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -132,6 +132,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     has_triggers: bool,
     has_fks: bool,
     has_upsert: bool,
+    has_upsert_do_update: bool,
     has_autoincrement: bool,
     notnull_col_exists: bool,
     has_unique: bool,
@@ -157,9 +158,16 @@ pub(crate) fn set_insert_stmt_journal_flags(
     // inserts do not need this because there is no prior row in the
     // outer-tx write_set to roll back.
     let autoinc_may_abort_multi_row = has_autoincrement && inserting_multiple_rows;
+    // A DO UPDATE arm always runs with ABORT semantics, regardless of the
+    // statement-level conflict clause (SQLite hardcodes OE_Abort for the
+    // UPDATE inside an upsert). The arm re-checks the conflict target's
+    // UNIQUE constraint (and any other constraints touched by SET), so it
+    // can always fail mid-statement and must be undoable via a statement
+    // journal — even when e.g. INSERT OR REPLACE alone would never abort.
     let may_abort = has_triggers
         || has_fks
         || autoinc_may_abort_multi_row
+        || has_upsert_do_update
         || constraint_may_abort(
             has_statement_conflict,
             statement_conflict,

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -674,3 +674,79 @@ fn insert_or_replace_function_in_values_may_abort(tmp_db: TempDatabase) -> anyho
     ));
     Ok(())
 }
+
+// ──────────────────────────────────────────────────────────
+// Regression: issue #6859 — upsert DO UPDATE arm always has ABORT semantics
+// ──────────────────────────────────────────────────────────
+
+/// The DO UPDATE arm of an upsert always runs with ABORT semantics, regardless
+/// of the statement-level conflict clause (SQLite hardcodes OE_Abort for the
+/// UPDATE inside an upsert), so it must taint may_abort even when the
+/// statement's OR REPLACE clause alone would never abort. A DO NOTHING-only
+/// upsert has no UPDATE arm and cannot abort, so it stays journal-free.
+#[turso_macros::test]
+fn insert_or_replace_upsert_do_update_may_abort(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, u TEXT UNIQUE, a TEXT UNIQUE)")?;
+    assert!(needs_stmt_journal(
+        &conn,
+        "INSERT OR REPLACE INTO t(u,a) VALUES('u1','a2') \
+         ON CONFLICT(u) DO UPDATE SET a=excluded.a"
+    ));
+    assert!(!needs_stmt_journal(
+        &conn,
+        "INSERT OR REPLACE INTO t(u,a) VALUES('u1','a2') ON CONFLICT(u) DO NOTHING"
+    ));
+    Ok(())
+}
+
+/// End-to-end regression for issue #6859: `INSERT OR REPLACE ... ON CONFLICT(u)
+/// DO UPDATE` must use ABORT semantics for constraint violations raised by the
+/// DO UPDATE arm, like SQLite does. Turso derived may_abort from the
+/// statement's OR REPLACE clause, so no statement savepoint was opened and a
+/// failed DO UPDATE left the secondary index out of sync with the table
+/// (index corruption reported by `PRAGMA integrity_check`).
+#[turso_macros::test]
+fn upsert_or_replace_do_update_unique_failure_no_index_corruption(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, u TEXT UNIQUE, a TEXT UNIQUE)")?;
+    conn.execute("INSERT INTO t VALUES(1,'u1','a1'),(2,'u2','a2')")?;
+    conn.execute("BEGIN")?;
+
+    // The DO UPDATE arm sets t.a='a2' for row 1, conflicting with row 2's
+    // unique value. SQLite aborts this statement with a UNIQUE constraint
+    // failure and leaves the database intact.
+    let err = conn
+        .execute(
+            "INSERT OR REPLACE INTO t(u,a) VALUES('u1','a2') \
+             ON CONFLICT(u) DO UPDATE SET a=excluded.a",
+        )
+        .expect_err("DO UPDATE arm must fail with UNIQUE constraint violation");
+    assert!(
+        format!("{err}").contains("UNIQUE constraint failed: t.a"),
+        "unexpected error: {err}"
+    );
+
+    // The failed statement must have been rolled back cleanly: the secondary
+    // index on t.a must still be consistent with the table.
+    assert_eq!(
+        query_rows(&conn, "PRAGMA integrity_check"),
+        vec!["ok"],
+        "integrity_check must pass inside the transaction after the failed UPSERT"
+    );
+    conn.execute("COMMIT")?;
+    assert_eq!(
+        query_rows(&conn, "PRAGMA integrity_check"),
+        vec!["ok"],
+        "integrity_check must pass after COMMIT following the failed UPSERT"
+    );
+
+    // Table contents must be unchanged by the aborted statement.
+    assert_eq!(
+        query_rows(&conn, "SELECT id, u, a FROM t ORDER BY id"),
+        vec!["1|u1|a1", "2|u2|a2"]
+    );
+    Ok(())
+}


### PR DESCRIPTION
An ON CONFLICT ... DO UPDATE arm always runs with ABORT semantics,
regardless of the statement-level conflict clause: SQLite hardcodes
OE_Abort for the UPDATE inside an upsert, and Turso's upsert emitter
likewise hardcodes ResolveType::Abort for the arm's constraint checks.
Turso's statement-journal analysis instead derived may_abort from the
statement's OR clause, so INSERT OR REPLACE ... ON CONFLICT DO UPDATE
on a table without NOT NULL/CHECK constraints was classified as
never-aborting and no statement savepoint was opened. When the DO
UPDATE arm then failed a UNIQUE check partway through its index
rebuild, the partial writes had nothing to roll back against, leaving
the secondary index inconsistent with the table (integrity_check
reported a missing index row).

Compute a has_upsert_do_update flag in translate_insert and OR it into
may_abort in set_insert_stmt_journal_flags. The arm re-checks the
conflict target's UNIQUE constraint (and anything touched by SET), so
it can always fail mid-statement and must be undoable via the
statement savepoint; with the savepoint in place the existing abort
path rolls the partial writes back cleanly. DO NOTHING-only upserts
have no UPDATE arm and remain journal-free.

Tests: added to tests/integration/stmt_journal.rs — a needs_stmt_journal
flag assertion (DO UPDATE forces the journal, DO NOTHING does not) and
an end-to-end regression that fails the DO UPDATE arm inside a
transaction and checks integrity_check plus table contents. Both fail
without the fix. Full integration suite (973 tests) passes.

Fixes #6859