### PR TITLE
core: reject co-enablement of MVCC and multiprocess WAL

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1854,6 +1854,18 @@ impl Database {
                     // MVCC is controlled only by the database header (set via PRAGMA journal_mode)
                     let open_mv_store = matches!(read_version, Version::Mvcc);
 
+                    // MVCC has no cross-process coordination: commit
+                    // serialization, the logical-log append offset, and
+                    // checkpoint exclusion are all process-local, so
+                    // concurrent multiprocess access silently loses committed
+                    // transactions and corrupts live views.
+                    if open_mv_store && self.opts.enable_multiprocess_wal {
+                        return Err(LimboError::InvalidArgument(format!(
+                            "cannot open MVCC database '{}' with experimental multiprocess WAL: MVCC does not support multiprocess access",
+                            self.path
+                        )));
+                    }
+
                     // Now check the Header Version to see which mode the DB file really is on
                     // Track if header was modified so we can write it to disk
                     let header_modified = match read_version {

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -311,6 +311,49 @@ fn database_open_with_experimental_multiprocess_wal_rejects_unsupported_io_backe
 }
 
 #[test]
+fn multiprocess_wal_rejects_journal_mode_mvcc_pragma() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("multiprocess-rejects-mvcc-pragma.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = multiprocess_test_io();
+
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    let err = conn
+        .execute("PRAGMA journal_mode = mvcc")
+        .expect_err("switching a multiprocess-coordinated database to MVCC must be rejected");
+    assert!(
+        matches!(err, LimboError::InvalidArgument(ref message) if message.contains("multiprocess")),
+        "expected InvalidArgument about multiprocess WAL, got {err:?}"
+    );
+}
+
+#[test]
+fn multiprocess_wal_rejects_opening_mvcc_database() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("multiprocess-rejects-mvcc-open.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = multiprocess_test_io();
+
+    {
+        let db = Database::open_file(io.clone(), db_path_str).unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("create table test(id integer primary key, value text)")
+            .unwrap();
+        conn.execute("PRAGMA journal_mode = mvcc").unwrap();
+        conn.execute("insert into test(value) values ('mvcc-row')")
+            .unwrap();
+    }
+
+    let err = open_multiprocess_db(io, db_path_str)
+        .expect_err("opening an MVCC-marked database with multiprocess WAL must be rejected");
+    assert!(
+        matches!(err, LimboError::InvalidArgument(ref message) if message.contains("MVCC")),
+        "expected InvalidArgument about MVCC, got {err:?}"
+    );
+}
+
+#[test]
 fn readonly_open_with_experimental_multiprocess_wal_allows_missing_coordination_file() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("readonly-multiprocess-no-tshm.db");

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -16182,6 +16182,23 @@ fn op_journal_mode_inner(
                     return Err(LimboError::ReadOnly);
                 }
 
+                // MVCC has no cross-process coordination: commit
+                // serialization, the logical-log append offset, and
+                // checkpoint exclusion are all process-local, so switching a
+                // multiprocess-coordinated database to MVCC would silently
+                // lose committed transactions and corrupt live views.
+                if matches!(new_mode, journal_mode::JournalMode::Mvcc)
+                    && program
+                        .connection
+                        .db
+                        .experimental_multiprocess_wal_enabled()
+                {
+                    return Err(LimboError::InvalidArgument(
+                        "journal_mode=mvcc is not supported with experimental multiprocess WAL: MVCC does not support multiprocess access"
+                            .to_string(),
+                    ));
+                }
+
                 state.active_op_state.journal_mode().new_mode = Some(new_mode);
                 state.active_op_state.journal_mode().sub_state = OpJournalModeSubState::Checkpoint;
             }


### PR DESCRIPTION
MVCC has no cross-process coordination: commit serialization (MvStore::pager_commit_lock), the logical-log append offset (LogicalLog::offset, used directly as the pwrite position), and the blocking checkpoint's stop-the-world gate (blocking_checkpoint_lock) are all process-local, in-memory state. Two processes sharing an MVCC database therefore silently lose durably-acknowledged commits (racing log appends overwrite each other's records and replay follows a single CRC lineage) and corrupt live views when a blocking or automatic checkpoint backfills one process's view while peers keep writing.

Guard both entry points into the combination: switching a database that was opened with experimental multiprocess WAL to journal_mode=mvcc, and opening an MVCC-marked database file with multiprocess WAL enabled. Both now fail with InvalidArgument instead of corrupting.

Tests: multiprocess_wal_rejects_journal_mode_mvcc_pragma and multiprocess_wal_rejects_opening_mvcc_database in
core/multiprocess_tests.rs; both scenarios succeeded (and lost data) before the guard.