### PR TITLE
core: pass TursoAllocator through Value::Blob

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -161,6 +161,7 @@ pprof = { version = "0.14.0", features = ["criterion", "flamegraph"] }
 
 [dev-dependencies]
 memory-stats = "1.2.0"
+serde_json = { workspace = true }
 criterion = { workspace = true, features = [
     "html_reports",
     "async",

--- a/core/benches/sql_functions/numeric.rs
+++ b/core/benches/sql_functions/numeric.rs
@@ -258,7 +258,7 @@ fn numeric_from_null(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn numeric_from_blob(bencher: Bencher) {
-    let value = Value::Blob(b"12345".to_vec());
+    let value = Value::from_slice(b"12345");
     bencher.bench_local(|| black_box(Numeric::from_value(black_box(&value))));
 }
 
@@ -370,6 +370,6 @@ fn numeric_strict_from_text_invalid_prefix(bencher: Bencher) {
 #[turso_macros::divan_bench]
 fn numeric_strict_from_blob(bencher: Bencher) {
     // Blob is always Null in strict mode
-    let value = Value::Blob(b"12345".to_vec());
+    let value = Value::from_slice(b"12345");
     bencher.bench_local(|| black_box(Numeric::from_value_strict(black_box(&value))));
 }

--- a/core/benches/sql_functions/value.rs
+++ b/core/benches/sql_functions/value.rs
@@ -79,7 +79,7 @@ fn length_float(bencher: Bencher) {
 #[cfg(feature = "nanosecond-bench")]
 #[turso_macros::divan_bench]
 fn length_blob(bencher: Bencher) {
-    let value = Value::Blob(vec![0u8; 100]);
+    let value = Value::from_slice(&[0u8; 100]);
     bencher.bench_local(|| black_box(black_box(&value).exec_length()));
 }
 
@@ -202,7 +202,7 @@ fn substring_negative_start(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn substring_blob(bencher: Bencher) {
-    let value = Value::Blob(b"hello world".to_vec());
+    let value = Value::from_slice(b"hello world");
     let start = Value::from_i64(1);
     let length = Value::from_i64(5);
     bencher.bench_local(|| {
@@ -242,8 +242,8 @@ fn instr_not_found(bencher: Bencher) {
 #[cfg(feature = "nanosecond-bench")]
 #[turso_macros::divan_bench]
 fn instr_blob(bencher: Bencher) {
-    let value = Value::Blob(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    let pattern = Value::Blob(vec![5, 6, 7]);
+    let value = Value::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    let pattern = Value::from_slice(&[5, 6, 7]);
     bencher.bench_local(|| black_box(black_box(&value).exec_instr(black_box(&pattern))));
 }
 
@@ -317,7 +317,7 @@ fn quote_integer(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn quote_blob(bencher: Bencher) {
-    let value = Value::Blob(vec![0x01, 0x02, 0xAB, 0xCD, 0xEF]);
+    let value = Value::from_slice(&[0x01, 0x02, 0xAB, 0xCD, 0xEF]);
     bencher.bench_local(|| black_box(black_box(&value).exec_quote()));
 }
 
@@ -379,7 +379,7 @@ fn typeof_text(bencher: Bencher) {
 #[cfg(feature = "nanosecond-bench")]
 #[turso_macros::divan_bench]
 fn typeof_blob(bencher: Bencher) {
-    let value = Value::Blob(vec![1, 2, 3]);
+    let value = Value::from_slice(&[1, 2, 3]);
     bencher.bench_local(|| black_box(black_box(&value).exec_typeof()));
 }
 
@@ -442,7 +442,7 @@ fn hex_text(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn hex_blob(bencher: Bencher) {
-    let value = Value::Blob(vec![0x01, 0x02, 0xAB, 0xCD, 0xEF]);
+    let value = Value::from_slice(&[0x01, 0x02, 0xAB, 0xCD, 0xEF]);
     bencher.bench_local(|| black_box(black_box(&value).exec_hex()));
 }
 
@@ -768,8 +768,8 @@ fn concat_string_integer(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn concat_blobs(bencher: Bencher) {
-    let a = Value::Blob(b"hello ".to_vec());
-    let b = Value::Blob(b"world".to_vec());
+    let a = Value::from_slice(b"hello ");
+    let b = Value::from_slice(b"world");
     bencher.bench_local(|| black_box(black_box(&a).exec_concat(black_box(&b))));
 }
 

--- a/core/btree_dump.rs
+++ b/core/btree_dump.rs
@@ -196,7 +196,7 @@ impl InternalVirtualTableCursor for BtreeDumpCursor {
     fn column(&self, column: usize) -> Result<Value> {
         match column {
             0 => match &self.current_record {
-                Some(data) => Ok(Value::from_blob(data.clone())),
+                Some(data) => Ok(Value::from_slice(data)),
                 None => Ok(Value::Null),
             },
             _ => Ok(Value::Null),

--- a/core/dbpage.rs
+++ b/core/dbpage.rs
@@ -182,7 +182,7 @@ impl InternalVirtualTableCursor for DbPageCursor {
                     if self.pgno == pending_page as i64 {
                         let page_size = self.pager.usable_space()
                             + self.pager.get_reserved_space().unwrap_or(0) as usize;
-                        return Ok(Value::from_blob(vec![0u8; page_size]));
+                        return Ok(Value::from_blob(crate::alloc::vec![0u8; page_size]));
                     }
                 }
 
@@ -194,7 +194,7 @@ impl InternalVirtualTableCursor for DbPageCursor {
 
                 let page_contents = page_ref.get_contents();
                 let data_slice = page_contents.as_ptr();
-                Ok(Value::from_blob(data_slice.to_vec()))
+                Ok(Value::from_slice(data_slice))
             }
             2 => Ok(Value::from_text("main")), // we don't support multiple databases - todo when we do
             _ => Ok(Value::Null),

--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -1519,17 +1519,17 @@ mod tests {
             Value::build_text("2024-07-21 23:60:00"), // Invalid minute
             Value::build_text("2024-07-21 22:58:60"), // Invalid second
             // Note: Invalid days now overflow like SQLite (2024-07-32 -> 2024-08-01)
-            Value::build_text("2024-13-01"),   // Invalid month
-            Value::build_text("invalid_date"), // Completely invalid string
-            Value::build_text(""),             // Empty string
-            Value::from_i64(i64::MAX),         // Large Julian day
-            Value::from_i64(-1),               // Negative Julian day
-            Value::from_f64(f64::MAX),         // Large float
-            Value::from_f64(-1.0),             // Negative Julian day as float
-            Value::from_f64(f64::NAN),         // NaN
-            Value::from_f64(f64::INFINITY),    // Infinity
-            Value::Null,                       // Null value
-            Value::Blob(vec![1, 2, 3]),        // Blob (unsupported type)
+            Value::build_text("2024-13-01"),          // Invalid month
+            Value::build_text("invalid_date"),        // Completely invalid string
+            Value::build_text(""),                    // Empty string
+            Value::from_i64(i64::MAX),                // Large Julian day
+            Value::from_i64(-1),                      // Negative Julian day
+            Value::from_f64(f64::MAX),                // Large float
+            Value::from_f64(-1.0),                    // Negative Julian day as float
+            Value::from_f64(f64::NAN),                // NaN
+            Value::from_f64(f64::INFINITY),           // Infinity
+            Value::Null,                              // Null value
+            Value::Blob(crate::alloc::vec![1, 2, 3]), // Blob (unsupported type)
             // Invalid timezone tests
             Value::build_text("2024-07-21T12:00:00+24:00"), // Invalid timezone offset (too large)
             Value::build_text("2024-07-21T12:00:00-24:00"), // Invalid timezone offset (too small)
@@ -1648,17 +1648,17 @@ mod tests {
             Value::build_text("2024-07-21 23:60:00"), // Invalid minute
             Value::build_text("2024-07-21 22:58:60"), // Invalid second
             // Note: Invalid days now overflow like SQLite (2024-07-32 -> 2024-08-01)
-            Value::build_text("2024-13-01"),   // Invalid month
-            Value::build_text("invalid_date"), // Completely invalid string
-            Value::build_text(""),             // Empty string
-            Value::from_i64(i64::MAX),         // Large Julian day
-            Value::from_i64(-1),               // Negative Julian day
-            Value::from_f64(f64::MAX),         // Large float
-            Value::from_f64(-1.0),             // Negative Julian day as float
-            Value::from_f64(f64::NAN),         // NaN
-            Value::from_f64(f64::INFINITY),    // Infinity
-            Value::Null,                       // Null value
-            Value::Blob(vec![1, 2, 3]),        // Blob (unsupported type)
+            Value::build_text("2024-13-01"),          // Invalid month
+            Value::build_text("invalid_date"),        // Completely invalid string
+            Value::build_text(""),                    // Empty string
+            Value::from_i64(i64::MAX),                // Large Julian day
+            Value::from_i64(-1),                      // Negative Julian day
+            Value::from_f64(f64::MAX),                // Large float
+            Value::from_f64(-1.0),                    // Negative Julian day as float
+            Value::from_f64(f64::NAN),                // NaN
+            Value::from_f64(f64::INFINITY),           // Infinity
+            Value::Null,                              // Null value
+            Value::Blob(crate::alloc::vec![1, 2, 3]), // Blob (unsupported type)
             // Invalid timezone tests
             Value::build_text("2024-07-21T12:00:00+24:00"), // Invalid timezone offset (too large)
             Value::build_text("2024-07-21T12:00:00-24:00"), // Invalid timezone offset (too small)

--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -1896,11 +1896,11 @@ mod tests {
     #[test]
     fn test_blob_nul_truncation() {
         // Bug 9: %s on blobs truncates at first NUL byte
-        let blob_val = Register::Value(Value::Blob(vec![0x48, 0x00, 0x4C])); // H\0L
+        let blob_val = Register::Value(Value::from_slice(&[0x48, 0x00, 0x4C])); // H\0L
         let result = exec_printf(&[text("%s"), blob_val]).unwrap();
         assert_eq!(result, *text("H").get_value());
 
-        let blob_hello = Register::Value(Value::Blob(b"Hello".to_vec()));
+        let blob_hello = Register::Value(Value::from_slice(b"Hello"));
         assert_eq!(
             exec_printf(&[text("%s"), blob_hello]).unwrap(),
             *text("Hello").get_value()

--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -1001,7 +1001,11 @@ impl AggregateState {
         Ok(state)
     }
 
-    fn to_blob(&self, aggregates: &[AggregateFunction], group_key: &[Value]) -> Result<Vec<u8>> {
+    fn to_blob(
+        &self,
+        aggregates: &[AggregateFunction],
+        group_key: &[Value],
+    ) -> Result<crate::ValueBlob> {
         let mut all_values = Vec::new();
         // Store the group key size first
         all_values.push(Value::from_i64(group_key.len() as i64));
@@ -1009,7 +1013,7 @@ impl AggregateState {
         all_values.extend(self.to_value_vector(aggregates));
 
         let record = ImmutableRecord::from_values(&all_values, all_values.len())?;
-        Ok(record.as_blob().clone())
+        Ok(record.into_payload())
     }
 
     pub fn from_blob(blob: &[u8]) -> Result<(Self, Vec<Value>)> {

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -1750,7 +1750,7 @@ mod tests {
                 // For integers, type code is 1 for 1-byte int, 2 for 2-byte, etc.
                 // Using type 6 (8-byte integer) for all values
                 // Header: 4 bytes (header size byte + 3 type bytes)
-                let mut payload = vec![
+                let mut payload = crate::alloc::vec![
                     4u8, // header size
                     6u8, // type for rowid (8-byte int)
                     6u8, // type for value (8-byte int)

--- a/core/incremental/dbsp.rs
+++ b/core/incremental/dbsp.rs
@@ -81,8 +81,8 @@ impl Hash128 {
     }
 
     /// Convert to a big-endian byte array for storage
-    pub fn to_blob(self) -> Vec<u8> {
-        self.uuid.as_bytes().to_vec()
+    pub fn to_blob(self) -> crate::ValueBlob {
+        crate::types::value_blob_from_slice(self.uuid.as_bytes())
     }
 
     /// Create from a big-endian byte array

--- a/core/incremental/filter_operator.rs
+++ b/core/incremental/filter_operator.rs
@@ -283,7 +283,7 @@ mod tests {
 
         let values_with_blob = vec![
             Value::from_i64(1),
-            Value::Blob(vec![1, 2, 3]),
+            Value::from_slice(&[1, 2, 3]),
             Value::Text(Text::from("test")),
         ];
         assert!(!filter.evaluate_predicate(&values_with_blob));
@@ -321,7 +321,7 @@ mod tests {
         // Test with non-NULL value (Blob)
         let values_with_blob = vec![
             Value::from_i64(1),
-            Value::Blob(vec![1, 2, 3]),
+            Value::from_slice(&[1, 2, 3]),
             Value::Text(Text::from("test")),
         ];
         assert!(filter.evaluate_predicate(&values_with_blob));

--- a/core/incremental/join_operator.rs
+++ b/core/incremental/join_operator.rs
@@ -572,7 +572,7 @@ fn deserialize_hashable_row(blob: &[u8]) -> Result<HashableRow> {
     Ok(HashableRow::new(rowid, values))
 }
 
-fn serialize_hashable_row(row: &HashableRow) -> Result<Vec<u8>> {
+fn serialize_hashable_row(row: &HashableRow) -> Result<crate::ValueBlob> {
     use crate::types::ImmutableRecord;
 
     let mut all_values = Vec::with_capacity(row.values.len() + 1);
@@ -580,7 +580,7 @@ fn serialize_hashable_row(row: &HashableRow) -> Result<Vec<u8>> {
     all_values.extend_from_slice(&row.values);
 
     let record = ImmutableRecord::from_values(&all_values, all_values.len())?;
-    Ok(record.as_blob().clone())
+    Ok(record.into_payload())
 }
 
 impl IncrementalOperator for JoinOperator {

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -704,7 +704,7 @@ impl HybridBTreeDirectory {
             &[
                 Value::Text(Text::new(path_str.clone())),
                 Value::from_i64(uncached_start as i64),
-                Value::Blob(vec![]),
+                Value::Blob(crate::alloc::vec![]),
             ],
             Self::CHUNK_LEN,
         )
@@ -884,7 +884,7 @@ impl HybridBTreeDirectory {
             &[
                 Value::Text(Text::new(path_str.clone())),
                 Value::from_i64(0),
-                Value::Blob(vec![]),
+                Value::Blob(crate::alloc::vec![]),
             ],
             Self::CHUNK_LEN,
         )
@@ -2123,7 +2123,7 @@ impl FtsCursor {
                         &[
                             Value::Text(Text::new(path_str.clone())),
                             Value::from_i64(0),
-                            Value::Blob(vec![]),
+                            Value::Blob(crate::alloc::vec![]),
                         ],
                         3,
                     )?;
@@ -2308,7 +2308,7 @@ impl FtsCursor {
                         &[
                             Value::Text(Text::new(path_str.clone())),
                             Value::from_i64(actual_chunk_idx as i64),
-                            Value::Blob(chunk_data.to_vec()),
+                            Value::from_slice(chunk_data),
                         ],
                         3,
                     )?;
@@ -2393,7 +2393,7 @@ impl FtsCursor {
                         &[
                             Value::Text(Text::new(path_str)),
                             Value::from_i64(0),
-                            Value::Blob(vec![]),
+                            Value::Blob(crate::alloc::vec![]),
                         ],
                         3,
                     )?;

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -548,7 +548,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "first value must be sparse vector".to_string(),
                         ));
                     };
-                    let vector = Vector::from_vec(vector.to_vec())?;
+                    let vector = Vector::from_vec(crate::types::value_blob_from_slice(vector))?;
                     if !matches!(vector.vector_type, VectorType::Float32Sparse) {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
@@ -800,7 +800,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "first value must be sparse vector".to_string(),
                         ));
                     };
-                    let vector = Vector::from_vec(vector.to_vec())?;
+                    let vector = Vector::from_vec(crate::types::value_blob_from_slice(vector))?;
                     if !matches!(vector.vector_type, VectorType::Float32Sparse) {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
@@ -900,7 +900,9 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                                 };
                         }
                         SeekResult::NotFound => {
-                            return Err(LimboError::Corrupt("inverted index corrupted".to_string()))
+                            return Err(LimboError::Corrupt(
+                                "inverted index corrupted".to_string(),
+                            ));
                         }
                     }
                 }
@@ -970,7 +972,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         SeekResult::NotFound | SeekResult::TryAdvance => {
                             return Err(LimboError::Corrupt(
                                 "stats index corrupted: can't find component row".to_string(),
-                            ))
+                            ));
                         }
                     }
                 }
@@ -1067,7 +1069,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "second value must be i64 limit parameter".to_string(),
                         ));
                     };
-                    let vector = Vector::from_vec(vector.to_vec())?;
+                    let vector = Vector::from_vec(crate::types::value_blob_from_slice(vector))?;
                     if !matches!(vector.vector_type, VectorType::Float32Sparse) {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
@@ -1532,7 +1534,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                                 "table column value must be sparse vector".to_string(),
                             ));
                         };
-                        let data = Vector::from_vec(data.to_vec())?;
+                        let data = Vector::from_vec(crate::types::value_blob_from_slice(data))?;
                         if !matches!(data.vector_type, VectorType::Float32Sparse) {
                             return Err(LimboError::InternalError(
                                 "table column value must be sparse vector".to_string(),
@@ -1543,7 +1545,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                                 "first value must be sparse vector".to_string(),
                             ));
                         };
-                        let arg = Vector::from_vec(arg.to_vec())?;
+                        let arg = Vector::from_vec(crate::types::value_blob_from_slice(arg))?;
                         if !matches!(arg.vector_type, VectorType::Float32Sparse) {
                             return Err(LimboError::InternalError(
                                 "first value must be sparse vector".to_string(),

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -1,5 +1,7 @@
+use crate::alloc::TursoVecExt;
 use crate::json::error::{Error as PError, Result as PResult};
 use crate::json::Conv;
+use crate::types::{value_blob_from_slice, ValueBlob};
 use crate::{bail_parse_error, LimboError, Result};
 use std::{
     borrow::Cow,
@@ -176,7 +178,7 @@ static CHARACTER_TYPE_OK: [u8; 256] = make_character_type_ok_table();
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Jsonb {
-    data: Vec<u8>,
+    data: ValueBlob,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -907,11 +909,11 @@ impl Jsonb {
     pub fn new(capacity: usize, data: Option<&[u8]>) -> Self {
         if let Some(data) = data {
             return Self {
-                data: data.to_vec(),
+                data: value_blob_from_slice(data),
             };
         }
         Self {
-            data: Vec::with_capacity(capacity),
+            data: <ValueBlob as TursoVecExt<u8>>::with_capacity(capacity),
         }
     }
 
@@ -921,7 +923,7 @@ impl Jsonb {
 
     pub fn make_empty_array(size: usize) -> Self {
         let mut jsonb = Self {
-            data: Vec::with_capacity(size),
+            data: <ValueBlob as TursoVecExt<u8>>::with_capacity(size),
         };
         jsonb
             .write_element_header(0, ElementType::ARRAY, 0, false)
@@ -931,7 +933,7 @@ impl Jsonb {
 
     pub fn make_empty_obj(size: usize) -> Self {
         let mut jsonb = Self {
-            data: Vec::with_capacity(size),
+            data: <ValueBlob as TursoVecExt<u8>>::with_capacity(size),
         };
         jsonb
             .write_element_header(0, ElementType::OBJECT, 0, false)
@@ -943,7 +945,7 @@ impl Jsonb {
         self.data.extend_from_slice(data);
     }
 
-    pub fn append_jsonb_to_end(&mut self, mut data: Vec<u8>) {
+    pub fn append_jsonb_to_end(&mut self, mut data: ValueBlob) {
         self.data.append(&mut data);
     }
 
@@ -2380,7 +2382,7 @@ impl Jsonb {
         Self::new(data.len(), Some(data))
     }
 
-    pub fn data(self) -> Vec<u8> {
+    pub fn data(self) -> ValueBlob {
         self.data
     }
 
@@ -4608,7 +4610,7 @@ mod path_operations_tests {
         // a value that would cause overflow when added to the position.
         // Header byte: 0xFB = element type ARRAY (11) + size marker 15 (8-byte size)
         // Followed by 8 bytes of near-max u64 value.
-        let malformed: Vec<u8> = vec![
+        let malformed: ValueBlob = crate::alloc::vec![
             0xFB, // ARRAY type (11) with 8-byte payload size marker (15 << 4)
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // huge payload size
         ];

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -78,7 +78,7 @@ pub fn jsonb(json_value: &Value, cache: &JsonCacheCell) -> crate::Result<Value> 
     }
 }
 
-pub fn convert_dbtype_to_raw_jsonb(data: &Value, strict: Conv) -> crate::Result<Vec<u8>> {
+pub fn convert_dbtype_to_raw_jsonb(data: &Value, strict: Conv) -> crate::Result<crate::ValueBlob> {
     let json = convert_dbtype_to_jsonb(data, strict)?;
     Ok(json.data())
 }
@@ -990,7 +990,7 @@ mod tests {
 
     #[test]
     fn test_get_json_blob_valid_jsonb() {
-        let binary_json = vec![124, 55, 104, 101, 121, 39, 121, 111];
+        let binary_json = crate::alloc::vec![124, 55, 104, 101, 121, 39, 121, 111];
         let input = Value::Blob(binary_json);
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
@@ -1003,7 +1003,7 @@ mod tests {
 
     #[test]
     fn test_get_json_blob_invalid_jsonb() {
-        let binary_json: Vec<u8> = vec![0xA2, 0x62, 0x6B, 0x31, 0x62, 0x76]; // Incomplete binary JSON
+        let binary_json: crate::ValueBlob = crate::alloc::vec![0xA2, 0x62, 0x6B, 0x31, 0x62, 0x76]; // Incomplete binary JSON
         let input = Value::Blob(binary_json);
         let result = get_json(&input, None);
         println!("{result:?}");
@@ -1123,7 +1123,7 @@ mod tests {
 
     #[test]
     fn test_json_array_blob_invalid() {
-        let blob = Value::Blob("1".as_bytes().to_vec());
+        let blob = Value::from_slice(b"1");
 
         let input = [blob];
 

--- a/core/json/ops.rs
+++ b/core/json/ops.rs
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "blob is not supported!")]
     fn test_blob_not_supported() {
-        let target = Value::Blob(vec![1, 2, 3]);
+        let target = Value::from_slice(&[1, 2, 3]);
         let patch = create_text("{}");
         let cache = JsonCacheCell::new();
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -177,7 +177,7 @@ pub use turso_macros::{
     turso_assert_unreachable, turso_debug_assert, turso_soft_unreachable,
 };
 use types::IOCompletions;
-pub use types::{IOResult, Value, ValueRef};
+pub use types::{IOResult, Value, ValueBlob, ValueRef};
 pub use util::IOExt;
 pub use vdbe::{
     builder::QueryMode, explain::EXPLAIN_COLUMNS, explain::EXPLAIN_QUERY_PLAN_COLUMNS,

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -3040,8 +3040,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> BuildLocalSchemaViewStateMachi
                         .data
                         .as_ref()
                         .expect("present schema version must carry row data at snapshot_ts");
-                    self.rows
-                        .insert(rowid, ImmutableRecord::from_bin_record(data.to_vec()));
+                    self.rows.insert(
+                        rowid,
+                        ImmutableRecord::from_bin_record(crate::types::value_blob_from_slice(data)),
+                    );
                 }
                 None => {
                     let existed_and_gone = versions.iter().any(|version| {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -183,7 +183,7 @@ pub struct SortableIndexKey {
 }
 
 impl SortableIndexKey {
-    pub fn new_from_bytes(key_bytes: Vec<u8>, metadata: Arc<IndexInfo>) -> Self {
+    pub fn new_from_bytes(key_bytes: crate::ValueBlob, metadata: Arc<IndexInfo>) -> Self {
         Self {
             key: ImmutableRecord::from_bin_record(key_bytes),
             metadata,
@@ -759,7 +759,7 @@ fn portable_delete_op_extension_for_row_version<Clock: LogicalClock, A: Concurre
     }
 
     let pk_record = if pk_values.is_empty() {
-        Vec::new()
+        crate::alloc::vec![]
     } else {
         ImmutableRecord::from_values(&pk_values, pk_values.len())?.into_payload()
     };
@@ -8656,7 +8656,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         crate::with_mv_store_allocation_site!(SchemaRowPayload, {
                             schema_rows_after.insert(
                                 rowid.row_id.to_int_or_panic(),
-                                ImmutableRecord::from_bin_record(record_bytes.clone()),
+                                ImmutableRecord::from_bin_record(
+                                    crate::types::value_blob_from_slice(record_bytes),
+                                ),
                             );
                         });
                     }
@@ -8883,7 +8885,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 crate::with_mv_store_allocation_site!(SchemaRowPayload, {
                                     schema_rows.insert(
                                         rowid_int,
-                                        ImmutableRecord::from_bin_record(row.payload().to_vec()),
+                                        ImmutableRecord::from_bin_record(
+                                            crate::types::value_blob_from_slice(row.payload()),
+                                        ),
                                     );
                                 });
                             } else if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -15462,9 +15462,10 @@ fn test_mvcc_portable_changes_delete_carries_pk_projection_not_old_record() {
         _ => None,
     });
     let delete_pk_record = delete_pk_record.expect("expected data DELETE op");
-    let pk_values = ImmutableRecord::from_bin_record(delete_pk_record)
-        .get_values_owned()
-        .unwrap();
+    let pk_values =
+        ImmutableRecord::from_bin_record(crate::types::value_blob_from_slice(&delete_pk_record))
+            .get_values_owned()
+            .unwrap();
     assert_eq!(
         pk_values,
         vec![Value::Text(Text::new("item-a".to_string()))]

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -3547,7 +3547,9 @@ impl StreamingLogicalLogReader {
                 commit_ts,
                 btree_resident,
             } => {
-                let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
+                let key_record = crate::types::ImmutableRecord::from_bin_record(
+                    crate::types::value_blob_from_slice(&payload),
+                );
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Upsert)?;
                 let key = Arc::new(SortableIndexKey::new_from_record(key_record, index_info));
@@ -3566,7 +3568,9 @@ impl StreamingLogicalLogReader {
                 commit_ts,
                 btree_resident,
             } => {
-                let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
+                let key_record = crate::types::ImmutableRecord::from_bin_record(
+                    crate::types::value_blob_from_slice(&payload),
+                );
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Delete)?;
                 let key = Arc::new(SortableIndexKey::new_from_record(key_record, index_info));
@@ -6365,7 +6369,10 @@ mod tests {
         commit_ts: u64,
         is_delete: bool,
     ) -> crate::mvcc::database::RowVersion {
-        let sortable_key = SortableIndexKey::new_from_bytes(payload_bytes, test_index_info());
+        let sortable_key = SortableIndexKey::new_from_bytes(
+            crate::types::value_blob_from_slice(&payload_bytes),
+            test_index_info(),
+        );
         let row_id = RowID::new(table_id, RowKey::Record(Arc::new(sortable_key)));
         let row = Row::new_index_row(row_id, 2);
         crate::mvcc::database::RowVersion {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -294,10 +294,18 @@ const OP_EXT_FIELD_DELETE_IDENTITY_RECORD: u64 = 1;
 const OP_EXT_FIELD_DELETE_PK_RECORD: u64 = 2;
 const OP_EXT_FIELD_DELETE_ROWID: u64 = 3;
 
-#[derive(Default)]
 struct DeletePortableExtension {
-    identity_record: Vec<u8>,
-    pk_record: Vec<u8>,
+    identity_record: crate::ValueBlob,
+    pk_record: crate::ValueBlob,
+}
+
+impl Default for DeletePortableExtension {
+    fn default() -> Self {
+        Self {
+            identity_record: crate::alloc::vec![],
+            pk_record: crate::alloc::vec![],
+        }
+    }
 }
 
 const TX_HEADER_SIZE_V2: usize = 24; // FRAME_MAGIC(4) + payload_size(8) + op_count(4) + commit_ts(8)
@@ -1252,7 +1260,8 @@ fn decode_delete_portable_extension(extension: &[u8]) -> Result<DeletePortableEx
                         "delete identity record exceeds op extension".into(),
                     ));
                 }
-                decoded.identity_record = extension[offset..end].to_vec();
+                decoded.identity_record =
+                    crate::types::value_blob_from_slice(&extension[offset..end]);
                 offset = end;
             }
             (OP_EXT_FIELD_DELETE_PK_RECORD, 2) => {
@@ -1268,7 +1277,7 @@ fn decode_delete_portable_extension(extension: &[u8]) -> Result<DeletePortableEx
                         "delete PK record exceeds op extension".into(),
                     ));
                 }
-                decoded.pk_record = extension[offset..end].to_vec();
+                decoded.pk_record = crate::types::value_blob_from_slice(&extension[offset..end]);
                 offset = end;
             }
             (OP_EXT_FIELD_DELETE_ROWID, 0) => {
@@ -1568,7 +1577,7 @@ fn try_parse_one_op_from_buf(buf: &[u8], commit_ts: u64) -> Result<Option<(Parse
             if rowid_len > payload.len() {
                 return Err(LimboError::Corrupt("rowid_len > payload".into()));
             }
-            let record_bytes = payload[rowid_len..].to_vec();
+            let record_bytes = crate::types::value_blob_from_slice(&payload[rowid_len..]);
             let rowid = RowID::new(table_id, RowKey::Int(rowid_u64 as i64));
             ParsedOp::UpsertTable {
                 table_id,
@@ -1587,8 +1596,8 @@ fn try_parse_one_op_from_buf(buf: &[u8], commit_ts: u64) -> Result<Option<(Parse
                     "DELETE_TABLE payload size mismatch".into(),
                 ));
             }
-            let mut record_bytes = payload[rowid_len..].to_vec();
-            let mut pk_record_bytes = Vec::new();
+            let mut record_bytes = crate::types::value_blob_from_slice(&payload[rowid_len..]);
+            let mut pk_record_bytes = crate::alloc::vec![];
             if !extension.is_empty() {
                 let decoded = decode_delete_portable_extension(extension)?;
                 if record_bytes.is_empty() {
@@ -1607,13 +1616,13 @@ fn try_parse_one_op_from_buf(buf: &[u8], commit_ts: u64) -> Result<Option<(Parse
         }
         OP_UPSERT_INDEX => ParsedOp::UpsertIndex {
             table_id: table_id.expect("index op must have table_id"),
-            payload: payload.to_vec(),
+            payload: crate::types::value_blob_from_slice(payload),
             commit_ts,
             btree_resident,
         },
         OP_DELETE_INDEX => ParsedOp::DeleteIndex {
             table_id: table_id.expect("index op must have table_id"),
-            payload: payload.to_vec(),
+            payload: crate::types::value_blob_from_slice(payload),
             commit_ts,
             btree_resident,
         },
@@ -2034,7 +2043,7 @@ impl StreamingLogicalLogReader {
                     let ops = match return_if_io!(self.parse_next_transaction()) {
                         ParseResult::Frame(frame) => frame.ops,
                         ParseResult::Eof | ParseResult::InvalidFrame => {
-                            return Ok(IOResult::Done(None))
+                            return Ok(IOResult::Done(None));
                         }
                     };
 
@@ -2406,7 +2415,7 @@ impl StreamingLogicalLogReader {
             )) {
                 EncryptedChunkReadResult::Ok { running_crc } => running_crc,
                 EncryptedChunkReadResult::Eof => {
-                    return Ok(IOResult::Done(PayloadParseResult::Eof))
+                    return Ok(IOResult::Done(PayloadParseResult::Eof));
                 }
             };
 
@@ -2658,7 +2667,7 @@ impl StreamingLogicalLogReader {
                 running_crc = crc32c::crc32c_append(running_crc, &extension);
                 (extension, extension_len_bytes_len + extension_len)
             } else {
-                (Vec::new(), 0)
+                (crate::alloc::vec![], 0)
             };
 
             let op_total_bytes = 6 + payload_len_bytes_len + payload_len + extension_total_bytes;
@@ -2708,7 +2717,7 @@ impl StreamingLogicalLogReader {
                     let rowid_i64 = rowid_u64 as i64;
                     let mut payload = payload;
                     let mut record_bytes = payload.split_off(rowid_len);
-                    let mut pk_record_bytes = Vec::new();
+                    let mut pk_record_bytes = crate::alloc::vec![];
                     if !portable_extension.is_empty() {
                         let decoded = decode_delete_portable_extension(&portable_extension)?;
                         if record_bytes.is_empty() {
@@ -3134,7 +3143,7 @@ impl StreamingLogicalLogReader {
             )? {
                 IOResult::Done(PayloadParseResult::Ok(ops, crc)) => (ops, crc),
                 IOResult::Done(PayloadParseResult::Eof) => {
-                    return Ok(IOResult::Done(PayloadOutcome::Eof))
+                    return Ok(IOResult::Done(PayloadOutcome::Eof));
                 }
                 IOResult::IO(io) => return Ok(IOResult::IO(io)),
             };
@@ -3547,9 +3556,7 @@ impl StreamingLogicalLogReader {
                 commit_ts,
                 btree_resident,
             } => {
-                let key_record = crate::types::ImmutableRecord::from_bin_record(
-                    crate::types::value_blob_from_slice(&payload),
-                );
+                let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Upsert)?;
                 let key = Arc::new(SortableIndexKey::new_from_record(key_record, index_info));
@@ -3568,9 +3575,7 @@ impl StreamingLogicalLogReader {
                 commit_ts,
                 btree_resident,
             } => {
-                let key_record = crate::types::ImmutableRecord::from_bin_record(
-                    crate::types::value_blob_from_slice(&payload),
-                );
+                let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Delete)?;
                 let key = Arc::new(SortableIndexKey::new_from_record(key_record, index_info));
@@ -3595,7 +3600,7 @@ impl StreamingLogicalLogReader {
         bytes_in_buffer + bytes_in_file
     }
 
-    fn try_consume_bytes(&mut self, amount: usize) -> Result<IOResult<Option<Vec<u8>>>> {
+    fn try_consume_bytes(&mut self, amount: usize) -> Result<IOResult<Option<crate::ValueBlob>>> {
         if self.remaining_bytes() < amount {
             return Ok(IOResult::Done(None));
         }
@@ -3603,7 +3608,7 @@ impl StreamingLogicalLogReader {
         let buffer = self.buffer.read();
         let start = self.buffer_offset;
         let end = start + amount;
-        let bytes = buffer[start..end].to_vec();
+        let bytes = crate::types::value_blob_from_slice(&buffer[start..end]);
         self.buffer_offset = end;
         Ok(IOResult::Done(Some(bytes)))
     }
@@ -3902,26 +3907,26 @@ pub(crate) enum ParsedOp {
     UpsertTable {
         table_id: MVTableId,
         rowid: RowID,
-        record_bytes: Vec<u8>,
+        record_bytes: crate::ValueBlob,
         commit_ts: u64,
         btree_resident: bool,
     },
     DeleteTable {
         rowid: RowID,
-        record_bytes: Vec<u8>,
-        pk_record_bytes: Vec<u8>,
+        record_bytes: crate::ValueBlob,
+        pk_record_bytes: crate::ValueBlob,
         commit_ts: u64,
         btree_resident: bool,
     },
     UpsertIndex {
         table_id: MVTableId,
-        payload: Vec<u8>,
+        payload: crate::ValueBlob,
         commit_ts: u64,
         btree_resident: bool,
     },
     DeleteIndex {
         table_id: MVTableId,
-        payload: Vec<u8>,
+        payload: crate::ValueBlob,
         commit_ts: u64,
         btree_resident: bool,
     },
@@ -4026,7 +4031,7 @@ mod tests {
     enum ExpectedTableOp {
         Upsert {
             rowid: i64,
-            payload: Vec<u8>,
+            payload: crate::ValueBlob,
             commit_ts: u64,
             btree_resident: bool,
         },
@@ -4938,9 +4943,9 @@ mod tests {
             read_back[0],
             ExpectedTableOp::Upsert {
                 rowid: 1,
-                payload: generate_simple_string_row((-2).into(), 1, "a")
-                    .payload()
-                    .to_vec(),
+                payload: crate::types::value_blob_from_slice(
+                    generate_simple_string_row((-2).into(), 1, "a").payload(),
+                ),
                 commit_ts: 1,
                 btree_resident: false,
             }
@@ -4949,9 +4954,9 @@ mod tests {
             read_back[1],
             ExpectedTableOp::Upsert {
                 rowid: 2,
-                payload: generate_simple_string_row((-2).into(), 2, "b")
-                    .payload()
-                    .to_vec(),
+                payload: crate::types::value_blob_from_slice(
+                    generate_simple_string_row((-2).into(), 2, "b").payload(),
+                ),
                 commit_ts: 2,
                 btree_resident: false,
             }
@@ -5226,9 +5231,9 @@ mod tests {
             read_back[0],
             ExpectedTableOp::Upsert {
                 rowid: 1,
-                payload: generate_simple_string_row((-2).into(), 1, "first")
-                    .payload()
-                    .to_vec(),
+                payload: crate::types::value_blob_from_slice(
+                    generate_simple_string_row((-2).into(), 1, "first").payload(),
+                ),
                 commit_ts: 1,
                 btree_resident: false,
             }
@@ -5366,9 +5371,9 @@ mod tests {
             ops,
             vec![ExpectedTableOp::Upsert {
                 rowid: 1,
-                payload: generate_simple_string_row((-2).into(), 1, "a")
-                    .payload()
-                    .to_vec(),
+                payload: crate::types::value_blob_from_slice(
+                    generate_simple_string_row((-2).into(), 1, "a").payload(),
+                ),
                 commit_ts: 10,
                 btree_resident: false,
             }]
@@ -5744,7 +5749,7 @@ mod tests {
                     });
                     expected.push(ExpectedTableOp::Upsert {
                         rowid,
-                        payload: row.payload().to_vec(),
+                        payload: crate::types::value_blob_from_slice(row.payload()),
                         commit_ts: tx.tx_timestamp,
                         btree_resident,
                     });
@@ -5764,7 +5769,7 @@ mod tests {
             let row = generate_simple_string_row((-3).into(), rowid, &large_text);
             expected.push(ExpectedTableOp::Upsert {
                 rowid,
-                payload: row.payload().to_vec(),
+                payload: crate::types::value_blob_from_slice(row.payload()),
                 commit_ts: large_commit_ts,
                 btree_resident: false,
             });
@@ -5828,7 +5833,7 @@ mod tests {
             } else {
                 ExpectedTableOp::Upsert {
                     rowid,
-                    payload: row.payload().to_vec(),
+                    payload: crate::types::value_blob_from_slice(row.payload()),
                     commit_ts,
                     btree_resident,
                 }
@@ -6740,7 +6745,7 @@ mod tests {
         ParsedOp::UpsertTable {
             table_id: (-2).into(),
             rowid: RowID::new((-2).into(), RowKey::Int(rowid)),
-            record_bytes: row_version.row.payload().to_vec(),
+            record_bytes: crate::types::value_blob_from_slice(row_version.row.payload()),
             commit_ts,
             btree_resident: false,
         }

--- a/core/numeric/decimal.rs
+++ b/core/numeric/decimal.rs
@@ -1,7 +1,8 @@
 use bigdecimal::BigDecimal;
 use num_bigint::{BigInt, Sign};
 
-use crate::LimboError;
+use crate::alloc::TursoVecExt;
+use crate::{LimboError, ValueBlob};
 
 const NUMERIC_BLOB_VERSION: u8 = 0x01;
 const FLAG_NEGATIVE: u8 = 0x01;
@@ -17,7 +18,7 @@ const MAX_SCALE_MAGNITUDE: i64 = 1_000_000;
 /// [num_limbs: 4 bytes, u32 LE]
 /// [limb0: 4 bytes u32 LE] [limb1: 4 bytes u32 LE] ... [limbN: 4 bytes u32 LE]
 /// ```
-pub fn bigdecimal_to_blob(val: &BigDecimal) -> Vec<u8> {
+pub fn bigdecimal_to_blob(val: &BigDecimal) -> ValueBlob {
     let (bigint, scale) = val.as_bigint_and_exponent();
     let (sign, magnitude) = bigint.into_parts();
 
@@ -30,7 +31,7 @@ pub fn bigdecimal_to_blob(val: &BigDecimal) -> Vec<u8> {
     );
     let num_limbs = limbs.len() as u32;
 
-    let mut buf = Vec::with_capacity(14 + limbs.len() * 4);
+    let mut buf = <ValueBlob as TursoVecExt<u8>>::with_capacity(14 + limbs.len() * 4);
 
     // version
     buf.push(NUMERIC_BLOB_VERSION);

--- a/core/stats.rs
+++ b/core/stats.rs
@@ -1,6 +1,7 @@
 use crate::sync::Arc;
 use rustc_hash::FxHashMap as HashMap;
 
+use crate::alloc::TursoVecExt;
 use crate::schema::Schema;
 use crate::translate::emitter::TransactionMode;
 use crate::types::IOResult;
@@ -346,8 +347,9 @@ impl StatAccum {
     }
 
     /// Serialize to bytes for storage in a blob register.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(8 + 8 + 8 * self.n_col);
+    pub fn to_bytes(&self) -> crate::ValueBlob {
+        let mut bytes =
+            <crate::ValueBlob as TursoVecExt<u8>>::with_capacity(8 + 8 + 8 * self.n_col);
         bytes.extend_from_slice(&(self.n_col as u64).to_le_bytes());
         bytes.extend_from_slice(&self.n_row.to_le_bytes());
         for &d in &self.distinct {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -9764,7 +9764,7 @@ mod tests {
         // Create a payload that is definitely larger than the maximum local size
         // This will force the creation of overflow pages
         let large_payload_size = max_local + usable_size * 2;
-        let large_payload = vec![b'X'; large_payload_size];
+        let large_payload = crate::alloc::vec![b'X'; large_payload_size];
 
         // Create a record with the large payload
         let regs = &[Register::Value(Value::Blob(large_payload))];
@@ -9819,7 +9819,7 @@ mod tests {
         );
 
         // Create a smaller record to overwrite with
-        let small_payload = vec![b'Y'; 100]; // Much smaller payload
+        let small_payload = crate::alloc::vec![b'Y'; 100]; // Much smaller payload
         let regs = &[Register::Value(Value::Blob(small_payload.clone()))];
         let small_record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
 
@@ -9939,7 +9939,7 @@ mod tests {
                     pager.deref(),
                 )
                 .unwrap();
-                let regs = &[Register::Value(Value::Blob(vec![0; *size]))];
+                let regs = &[Register::Value(Value::Blob(crate::alloc::vec![0; *size]))];
                 let value = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
                 tracing::info!("insert key:{}", key);
                 run_until_done(
@@ -10036,7 +10036,7 @@ mod tests {
                     pager.deref(),
                 )
                 .unwrap();
-                let regs = &[Register::Value(Value::Blob(vec![0; size]))];
+                let regs = &[Register::Value(Value::Blob(crate::alloc::vec![0; size]))];
                 let value = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
                 let btree_before = if do_validate {
                     format_btree(pager.clone(), root_page, 0)
@@ -10366,7 +10366,7 @@ mod tests {
                     }
                     expected_keys.push(key.clone());
 
-                    let regs = vec![Register::Value(Value::Blob(key))];
+                    let regs = vec![Register::Value(Value::from_slice(&key))];
                     let value = ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
 
                     let seek_result = run_until_done(
@@ -10397,7 +10397,7 @@ mod tests {
                             tracing::info!("delete {}/{}, seed: {seed}", i + 1, operations);
                         }
 
-                        let regs = vec![Register::Value(Value::Blob(key_to_delete.clone()))];
+                        let regs = vec![Register::Value(Value::from_slice(&key_to_delete))];
                         let record = ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
 
                         // Seek to the key to delete
@@ -10457,7 +10457,7 @@ mod tests {
             );
             let exists = run_until_done(
                 || {
-                    let regs = vec![Register::Value(Value::Blob(key.clone()))];
+                    let regs = vec![Register::Value(Value::from_slice(key))];
                     cursor.seek(
                         SeekKey::IndexKey(
                             &ImmutableRecord::from_registers(&regs, regs.len()).unwrap(),
@@ -11331,7 +11331,7 @@ mod tests {
             .block(|| pager.with_header(|header| header.database_size.get()))?;
 
         for rowid in 1..=record_count {
-            let large_blob = vec![b'A'; 8192];
+            let large_blob = crate::alloc::vec![b'A'; 8192];
             insert_record(&mut cursor, &pager, rowid, Value::Blob(large_blob))?;
         }
 
@@ -12000,7 +12000,7 @@ mod tests {
 
         let page = get_page(2);
         let usable_space = 4096;
-        let regs = &[Register::Value(Value::Blob(vec![0; 3600]))];
+        let regs = &[Register::Value(Value::Blob(crate::alloc::vec![0; 3600]))];
         let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let mut payload: Vec<u8> = Vec::new();
         let mut fill_cell_payload_state = FillCellPayloadState::Start;
@@ -12249,7 +12249,9 @@ mod tests {
 
     fn insert_cell(cell_idx: u64, size: u16, page: PageRef, pager: Arc<Pager>) {
         let mut payload = Vec::new();
-        let regs = &[Register::Value(Value::Blob(vec![0; size as usize]))];
+        let regs = &[Register::Value(Value::Blob(
+            crate::alloc::vec![0; size as usize],
+        ))];
         let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let mut fill_cell_payload_state = FillCellPayloadState::Start;
         let contents = page.get_contents();
@@ -12319,7 +12321,13 @@ mod tests {
 
             // Blob payloads so a handful of appends split the rightmost leaf.
             for rowid in 1..=8 {
-                insert_record(&mut writer, &pager, rowid, Value::Blob(vec![0u8; 1000])).unwrap();
+                insert_record(
+                    &mut writer,
+                    &pager,
+                    rowid,
+                    Value::Blob(crate::alloc::vec![0u8; 1000]),
+                )
+                .unwrap();
             }
 
             // Positions the reader on the last row and caches the rightmost page id.
@@ -12329,7 +12337,13 @@ mod tests {
 
             // Peer appends: balance_quick allocates a new rightmost leaf.
             for rowid in 9..=16 {
-                insert_record(&mut writer, &pager, rowid, Value::Blob(vec![0u8; 1000])).unwrap();
+                insert_record(
+                    &mut writer,
+                    &pager,
+                    rowid,
+                    Value::Blob(crate::alloc::vec![0u8; 1000]),
+                )
+                .unwrap();
             }
 
             run_until_done(|| reader.last(), pager.deref()).unwrap();

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -2226,8 +2226,8 @@ mod tests {
     #[case(&[0x40, 0x09, 0x21, 0xFB, 0x54, 0x44, 0x2D, 0x18], SerialType::f64(), Value::from_f64(std::f64::consts::PI))]
     #[case(&[1, 2], SerialType::const_int0(), Value::from_i64(0))]
     #[case(&[65, 66], SerialType::const_int1(), Value::from_i64(1))]
-    #[case(&[1, 2, 3], SerialType::blob(3), Value::Blob(vec![1, 2, 3]))]
-    #[case(&[], SerialType::blob(0), Value::Blob(vec![]))] // empty blob
+    #[case(&[1, 2, 3], SerialType::blob(3), Value::from_slice(&[1, 2, 3]))]
+    #[case(&[], SerialType::blob(0), Value::from_slice(&[]))] // empty blob
     #[case(&[65, 66, 67], SerialType::text(3), Value::build_text("ABC"))]
     #[case(&[0x80], SerialType::i8(), Value::from_i64(-128))]
     #[case(&[0x80, 0], SerialType::i16(), Value::from_i64(-32768))]

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1,3 +1,4 @@
+use crate::alloc::TursoIteratorExt;
 use crate::sync::Arc;
 use crate::{bail_parse_error, schema::BTreeTable, turso_assert_eq, turso_assert_ne};
 use turso_parser::{
@@ -420,7 +421,7 @@ pub(crate) fn literal_default_value(literal: &ast::Literal) -> Result<Value> {
                     let hex_byte = std::str::from_utf8(pair).expect("parser validated hex string");
                     u8::from_str_radix(hex_byte, 16).expect("parser validated hex digit")
                 })
-                .collect(),
+                .try_collect()?,
         )),
         ast::Literal::Null => Ok(Value::Null),
         ast::Literal::True => Ok(Value::from_i64(1)),

--- a/core/translate/expr/emission.rs
+++ b/core/translate/expr/emission.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::alloc::TursoIteratorExt;
 
 /// Emit literal values - shared between regular and RETURNING expression evaluation
 pub fn emit_literal(
@@ -42,7 +43,7 @@ pub fn emit_literal(
                     let hex_byte = std::str::from_utf8(pair).unwrap();
                     u8::from_str_radix(hex_byte, 16).unwrap()
                 })
-                .collect();
+                .try_collect()?;
             program.emit_insn(Insn::Blob {
                 value: bytes,
                 dest: target_register,

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1160,7 +1160,7 @@ pub fn resolve_index_method_parameters(
                             let hex_byte = std::str::from_utf8(pair).unwrap();
                             u8::from_str_radix(hex_byte, 16).unwrap()
                         })
-                        .collect(),
+                        .try_collect()?,
                 ),
                 _ => bail_parse_error!("parameters must be constant literals"),
             },

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -1931,7 +1931,7 @@ impl<'a> LogicalPlanBuilder<'a> {
                 };
                 Ok(Value::Text(unquoted.to_string().into()))
             }
-            ast::Literal::Blob(b) => Ok(Value::Blob(b.clone().into())),
+            ast::Literal::Blob(b) => Ok(Value::from_slice(b.as_bytes())),
             ast::Literal::CurrentDate
             | ast::Literal::CurrentTime
             | ast::Literal::CurrentTimestamp => Err(LimboError::ParseError(

--- a/core/types.rs
+++ b/core/types.rs
@@ -167,7 +167,7 @@ impl<T: AnyText> Extendable<T> for Text {
     }
 }
 
-impl<T: AnyBlob> Extendable<T> for std::vec::Vec<u8> {
+impl<T: AnyBlob> Extendable<T> for ValueBlob {
     #[inline(always)]
     fn do_extend(&mut self, other: &T) -> Result<()> {
         let other_slice = other.as_slice();
@@ -213,6 +213,13 @@ pub trait AnyBlob {
     fn as_slice(&self) -> &[u8];
 }
 
+impl AnyBlob for ValueBlob {
+    fn as_slice(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+#[cfg(nightly)]
 impl AnyBlob for std::vec::Vec<u8> {
     fn as_slice(&self) -> &[u8] {
         self.as_slice()
@@ -261,13 +268,74 @@ impl From<Text> for String {
 // No intermediate StructValue/UnionValue types are needed — blobs are
 // constructed from registers and extracted directly into registers.
 
+/// Owned bytes stored by [`Value::Blob`].
+///
+/// Stable builds use `std::vec::Vec`; allocator-enabled nightly builds retain
+/// [`TursoAllocator`] in the vector type.
+pub type ValueBlob = crate::alloc::Vec<u8>;
+
+#[inline]
+pub(crate) fn value_blob_from_slice(bytes: &[u8]) -> ValueBlob {
+    bytes.try_to_vec().expect(ALLOC_ERR_MSG)
+}
+
+#[cfg(feature = "serde")]
+mod value_blob_serde {
+    use super::ValueBlob;
+    use crate::alloc::{TursoAllocExt, TursoTryWithCapacityExt, TursoVecExt};
+    use serde::de::{Error as _, SeqAccess, Visitor};
+    use serde::{Deserializer, Serialize as _, Serializer};
+    use std::fmt;
+
+    pub fn serialize<S>(value: &ValueBlob, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value.as_slice().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<ValueBlob, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ValueBlobVisitor;
+
+        impl<'de> Visitor<'de> for ValueBlobVisitor {
+            type Value = ValueBlob;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a sequence of bytes")
+            }
+
+            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut value = match sequence.size_hint() {
+                    Some(capacity) => {
+                        <ValueBlob as TursoTryWithCapacityExt>::try_with_capacity_ext(capacity)
+                            .map_err(A::Error::custom)?
+                    }
+                    None => <ValueBlob as TursoAllocExt>::new(),
+                };
+                while let Some(byte) = sequence.next_element()? {
+                    value.try_push(byte).map_err(A::Error::custom)?;
+                }
+                Ok(value)
+            }
+        }
+
+        deserializer.deserialize_seq(ValueBlobVisitor)
+    }
+}
+
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Value {
     Null,
     Numeric(Numeric),
     Text(Text),
-    Blob(std::vec::Vec<u8>),
+    Blob(#[cfg_attr(feature = "serde", serde(with = "value_blob_serde"))] ValueBlob),
 }
 
 #[derive(Clone, Copy)]
@@ -391,8 +459,13 @@ impl Value {
         }
     }
 
-    pub fn from_blob(data: std::vec::Vec<u8>) -> Self {
+    pub const fn from_blob(data: ValueBlob) -> Self {
         Value::Blob(data)
+    }
+
+    #[inline]
+    pub fn from_slice(data: &[u8]) -> Self {
+        Value::Blob(value_blob_from_slice(data))
     }
 
     pub fn to_text(&self) -> Option<&str> {
@@ -402,14 +475,14 @@ impl Value {
         }
     }
 
-    pub const fn as_blob(&self) -> &std::vec::Vec<u8> {
+    pub const fn as_blob(&self) -> &ValueBlob {
         match self {
             Value::Blob(b) => b,
             _ => panic!("as_blob must be called only for Value::Blob"),
         }
     }
 
-    pub const fn as_blob_mut(&mut self) -> &mut std::vec::Vec<u8> {
+    pub const fn as_blob_mut(&mut self) -> &mut ValueBlob {
         match self {
             Value::Blob(b) => b,
             _ => panic!("as_blob must be called only for Value::Blob"),
@@ -564,7 +637,7 @@ impl Value {
                 let Some(blob) = v.to_blob() else {
                     return Ok(Value::Null);
                 };
-                Ok(Value::Blob(blob))
+                Ok(Value::from_slice(&blob))
             }
             ExtValueType::Error => {
                 let Some(err) = v.to_error_details() else {
@@ -631,7 +704,7 @@ impl FromValue for f64 {
 }
 impl Sealed for f64 {}
 
-impl FromValue for std::vec::Vec<u8> {
+impl FromValue for ValueBlob {
     fn from_sql(val: Value) -> Result<Self> {
         match val {
             Value::Null => Err(LimboError::NullValue),
@@ -640,13 +713,16 @@ impl FromValue for std::vec::Vec<u8> {
         }
     }
 }
-impl Sealed for std::vec::Vec<u8> {}
+impl Sealed for ValueBlob {}
 
 impl<const N: usize> FromValue for [u8; N] {
     fn from_sql(val: Value) -> Result<Self> {
         match val {
             Value::Null => Err(LimboError::NullValue),
-            Value::Blob(blob) => blob.try_into().map_err(|_| LimboError::InvalidBlobSize(N)),
+            Value::Blob(blob) => blob
+                .as_slice()
+                .try_into()
+                .map_err(|_| LimboError::InvalidBlobSize(N)),
             _ => Err(LimboError::InvalidColumnType),
         }
     }
@@ -1049,14 +1125,14 @@ mod immutable_record {
     }
 
     struct AppendWriter<'a> {
-        buf: &'a mut std::vec::Vec<u8>,
+        buf: &'a mut ValueBlob,
         pos: usize,
         buf_capacity_start: usize,
         buf_ptr_start: *const u8,
     }
 
     impl<'a> AppendWriter<'a> {
-        fn new(buf: &'a mut std::vec::Vec<u8>, pos: usize) -> Self {
+        fn new(buf: &'a mut ValueBlob, pos: usize) -> Self {
             let buf_ptr_start = buf.as_ptr();
             let buf_capacity_start = buf.capacity();
             Self {
@@ -1392,14 +1468,14 @@ mod immutable_record {
 
     impl ImmutableRecord {
         pub fn new(payload_capacity: usize) -> Result<Self> {
-            let mut payload = std::vec::Vec::new();
+            let mut payload = crate::alloc::vec![];
             payload.try_reserve_exact(payload_capacity)?;
             Ok(Self {
                 payload: Value::Blob(payload),
             })
         }
 
-        pub const fn from_bin_record(payload: std::vec::Vec<u8>) -> Self {
+        pub const fn from_bin_record(payload: ValueBlob) -> Self {
             Self {
                 payload: Value::Blob(payload),
             }
@@ -1444,7 +1520,7 @@ mod immutable_record {
             let header_size = Record::calc_header_size(size_header);
 
             // 1. write header size
-            let mut buf = std::vec::Vec::new();
+            let mut buf = crate::alloc::vec![];
             buf.try_reserve_exact(header_size + size_values)?;
             assert_eq!(buf.capacity(), header_size + size_values);
             let n = write_varint(&mut serial_type_buf, header_size as u64);
@@ -1504,7 +1580,7 @@ mod immutable_record {
         }
 
         #[inline]
-        pub fn into_payload(self) -> std::vec::Vec<u8> {
+        pub fn into_payload(self) -> ValueBlob {
             match self.payload {
                 Value::Blob(b) => b,
                 _ => panic!("payload must be a blob"),
@@ -1512,7 +1588,7 @@ mod immutable_record {
         }
 
         #[inline]
-        pub const fn as_blob(&self) -> &std::vec::Vec<u8> {
+        pub const fn as_blob(&self) -> &ValueBlob {
             match &self.payload {
                 Value::Blob(b) => b,
                 _ => panic!("payload must be a blob"),
@@ -1520,7 +1596,7 @@ mod immutable_record {
         }
 
         #[inline]
-        pub const fn as_blob_mut(&mut self) -> &mut std::vec::Vec<u8> {
+        pub const fn as_blob_mut(&mut self) -> &mut ValueBlob {
             match &mut self.payload {
                 Value::Blob(b) => b,
                 _ => panic!("payload must be a blob"),
@@ -1910,7 +1986,7 @@ impl<'a> ValueRef<'a> {
                 value: text.value.to_string().into(),
                 subtype: text.subtype,
             }),
-            ValueRef::Blob(b) => Value::Blob(b.to_vec()),
+            ValueRef::Blob(b) => Value::from_slice(b),
         }
     }
 
@@ -3302,6 +3378,41 @@ mod tests {
     use crate::alloc::vec;
     use crate::translate::collate::CollationSeq;
 
+    #[cfg(nightly)]
+    #[test]
+    fn moving_blobs_through_value_preserves_allocation() {
+        fn assert_move_preserves_allocation(blob: ValueBlob) {
+            let pointer = blob.as_ptr();
+            let capacity = blob.capacity();
+            let len = blob.len();
+
+            let value = Value::from_blob(blob);
+            let Value::Blob(blob) = value else {
+                unreachable!();
+            };
+
+            assert_eq!(blob.as_ptr(), pointer);
+            assert_eq!(blob.capacity(), capacity);
+            assert_eq!(blob.len(), len);
+        }
+
+        assert_move_preserves_allocation(vec![]);
+        assert_move_preserves_allocation(vec![1, 2, 3, 4]);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn value_blob_serde_preserves_sequence_format() {
+        let encoded = serde_json::to_string(&Value::from_slice(&[1, 2, 3, 4])).unwrap();
+        assert_eq!(encoded, r#"{"Blob":[1,2,3,4]}"#);
+
+        let decoded: Value = serde_json::from_str(&encoded).unwrap();
+        let Value::Blob(blob) = decoded else {
+            panic!("expected blob value");
+        };
+        assert_eq!(blob.as_slice(), &[1, 2, 3, 4]);
+    }
+
     #[test]
     fn test_value_iterator_simple() {
         let mut buf = std::vec::Vec::new();
@@ -3347,7 +3458,7 @@ mod tests {
             Value::from_i64(100),
             Value::from_f64(std::f64::consts::PI),
             Value::Text(Text::new("test")),
-            Value::Blob(std::vec![1, 2, 3]),
+            Value::from_slice(&[1, 2, 3]),
             Value::from_i64(0),
             Value::from_i64(1),
         ]);
@@ -3868,7 +3979,7 @@ mod tests {
                 "large_field_count",
             ),
             (
-                vec![Value::Blob(std::vec![1, 2, 3])],
+                vec![Value::from_slice(&[1, 2, 3])],
                 vec![ValueRef::Blob(&[1, 2, 3])],
                 "blob_first_field",
             ),
@@ -4158,7 +4269,7 @@ mod tests {
     #[test]
     fn test_serialize_blob() {
         let blob = std::vec![1, 2, 3, 4, 5];
-        let record = Record::new(vec![Value::Blob(blob.clone())]);
+        let record = Record::new(vec![Value::from_slice(&blob)]);
         let mut buf = std::vec::Vec::new();
         record.serialize(&mut buf);
 

--- a/core/vdbe/array.rs
+++ b/core/vdbe/array.rs
@@ -701,7 +701,7 @@ mod tests {
     #[test]
     fn test_compute_array_length_invalid_blob_returns_none() {
         // A random blob that is not a valid record should return None
-        let invalid = Value::Blob(vec![0xFF, 0xFE, 0xFD]);
+        let invalid = Value::from_slice(&[0xFF, 0xFE, 0xFD]);
         assert_eq!(compute_array_length(&invalid), None);
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2291,7 +2291,7 @@ pub fn op_array_element(
                         if t.value.as_bytes().iter().any(|&b| b > 0x7F)
                             && std::str::from_utf8(t.value.as_bytes()).is_err()
                         {
-                            return Value::Blob(t.value.as_bytes().to_vec());
+                            return Value::from_slice(t.value.as_bytes());
                         }
                     }
                     vref.to_owned()
@@ -2464,7 +2464,7 @@ pub fn op_union_pack(
     let record_bytes = record.into_payload();
 
     // Format: [tag_index: 1 byte][record bytes]
-    let mut blob = Vec::with_capacity(1 + record_bytes.len());
+    let mut blob = <crate::ValueBlob as TursoVecExt<u8>>::with_capacity(1 + record_bytes.len());
     blob.push(*tag_index);
     blob.extend_from_slice(&record_bytes);
     state.registers[*dest].set_value(Value::Blob(blob));
@@ -6025,11 +6025,11 @@ fn init_agg_payload(func: &AggFunc, payload: &mut crate::alloc::Vec<Value>) -> R
         }
         #[cfg(feature = "json")]
         AggFunc::JsonGroupObject | AggFunc::JsonbGroupObject => {
-            payload.push(Value::Blob(vec![]));
+            payload.push(Value::Blob(crate::alloc::vec![]));
         }
         #[cfg(feature = "json")]
         AggFunc::JsonGroupArray | AggFunc::JsonbGroupArray => {
-            payload.push(Value::Blob(vec![]));
+            payload.push(Value::Blob(crate::alloc::vec![]));
         }
     };
     Ok(())
@@ -12151,12 +12151,12 @@ const SEQ_COMMIT_STATUS_CONFLICT_RETRY: i64 = 1;
 /// "no prior mv_tx for this db" (must be restored to `None`).
 fn encode_saved_outer_mv_tx(
     outer: Option<(TxID, crate::translate::emitter::TransactionMode)>,
-) -> Vec<u8> {
+) -> crate::ValueBlob {
     use crate::translate::emitter::TransactionMode;
     let Some((tx_id, mode)) = outer else {
-        return Vec::new();
+        return crate::alloc::vec![];
     };
-    let mut buf = Vec::with_capacity(9);
+    let mut buf = <crate::ValueBlob as TursoVecExt<u8>>::with_capacity(9);
     buf.extend_from_slice(&tx_id.to_le_bytes());
     let mode_tag: u8 = match mode {
         TransactionMode::None => 0,
@@ -12230,7 +12230,7 @@ pub fn op_sequence_begin_inner_tx(
         // WAL mode: no inner tx needed. The WAL single-writer lock
         // already serializes writes across processes.
         state.registers[*path_kind_reg].set_value(Value::from_i64(SEQ_PATH_SKIPPED));
-        state.registers[*saved_outer_reg].set_value(Value::Blob(Vec::new()));
+        state.registers[*saved_outer_reg].set_value(Value::Blob(crate::alloc::vec![]));
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     };
@@ -12239,7 +12239,7 @@ pub fn op_sequence_begin_inner_tx(
     if let Some((outer_id, _)) = outer_tx {
         if mv_store.is_exclusive_tx(&outer_id) {
             state.registers[*path_kind_reg].set_value(Value::from_i64(SEQ_PATH_SKIPPED));
-            state.registers[*saved_outer_reg].set_value(Value::Blob(Vec::new()));
+            state.registers[*saved_outer_reg].set_value(Value::Blob(crate::alloc::vec![]));
             state.pc += 1;
             return Ok(InsnFunctionStepResult::Step);
         }

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -542,7 +542,8 @@ impl HashEntry {
                         "HashEntry: buffer too small for blob".to_string(),
                     ));
                 }
-                let b = buf[offset..offset + blob_len as usize].to_vec();
+                let b =
+                    crate::types::value_blob_from_slice(&buf[offset..offset + blob_len as usize]);
                 offset += blob_len as usize;
                 Value::Blob(b)
             }
@@ -3547,7 +3548,7 @@ mod hashtests {
                 Value::from_f64(std::f64::consts::PI),
             ],
             100,
-            vec![Value::Blob(std::vec![1, 2, 3, 4, 5]), Value::from_i64(-999)],
+            vec![Value::from_slice(&[1, 2, 3, 4, 5]), Value::from_i64(-999)],
         );
 
         // Serialize using the Vec-based method
@@ -4255,7 +4256,7 @@ mod hashtests {
         // Insert entry with blob payload
         let key = vec![Value::from_i64(1)];
         let blob_data = std::vec![0xDE, 0xAD, 0xBE, 0xEF];
-        let payload = vec![Value::Blob(blob_data.clone()), Value::from_i64(42)];
+        let payload = vec![Value::from_slice(&blob_data), Value::from_i64(42)];
         let _ = ht.insert(key.clone(), 100, payload, None).unwrap();
 
         let _ = ht.finalize_build(None);
@@ -4264,7 +4265,7 @@ mod hashtests {
         assert!(result.is_some());
         let entry = result.unwrap();
         assert_eq!(entry.payload_values.len(), 2);
-        assert_eq!(entry.payload_values[0], Value::Blob(blob_data));
+        assert_eq!(entry.payload_values[0], Value::from_slice(&blob_data));
         assert_eq!(entry.payload_values[1], Value::from_i64(42));
     }
 
@@ -4346,7 +4347,7 @@ mod hashtests {
                 Value::from_i64(999),
                 Value::from_f64(std::f64::consts::PI),
                 Value::Null,
-                Value::Blob(std::vec![1, 2, 3, 4]),
+                Value::from_slice(&[1, 2, 3, 4]),
             ],
         );
 
@@ -4377,7 +4378,7 @@ mod hashtests {
         assert_eq!(deserialized.payload_values[3], Value::Null);
         assert_eq!(
             deserialized.payload_values[4],
-            Value::Blob(std::vec![1, 2, 3, 4])
+            Value::from_slice(&[1, 2, 3, 4])
         );
     }
 

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -890,7 +890,7 @@ pub enum Insn {
 
     /// Write a blob value into a register.
     Blob {
-        value: Vec<u8>,
+        value: crate::ValueBlob,
         dest: usize,
     },
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -18,7 +18,7 @@
 //! https://www.sqlite.org/opcode.html
 
 use crate::translate::plan::BitSet;
-use crate::types::{Extendable, Text};
+use crate::types::{Extendable, Text, ValueBlob};
 use crate::{turso_assert, turso_assert_ne, turso_debug_assert, NonNan};
 pub mod affinity;
 pub mod array;
@@ -323,14 +323,10 @@ impl Register {
         Ok(())
     }
 
-    /// Set the value of the register to a blob,
-    /// reusing Register::Value(Value::Blob(_)) buffer if possible.
+    /// Move a blob into the register without copying its allocation.
     #[inline]
-    pub fn set_blob(&mut self, val: Vec<u8>) -> Result<()> {
+    pub fn set_blob(&mut self, val: ValueBlob) -> Result<()> {
         match self {
-            Register::Value(Value::Blob(existing)) => {
-                existing.do_extend(&val)?;
-            }
             Register::Value(other_value_kind) => {
                 *other_value_kind = Value::Blob(val);
             }
@@ -3084,7 +3080,9 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                         }
                     }
                     _ => {
-                        if let Err(err) = dest.set_blob(blob_data.to_vec()) {
+                        if let Err(err) =
+                            dest.set_blob(crate::types::value_blob_from_slice(blob_data))
+                        {
                             return Some(Err(err));
                         }
                     }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1115,8 +1115,9 @@ mod tests {
                     Value::from_f64(numerator / denominator)
                 }
                 ValueType::Blob => {
-                    let mut blob =
-                        std::vec::Vec::with_capacity((rng.next_u64() % 2047 + 1) as usize);
+                    let mut blob = <Vec<u8> as TursoVecExt<u8>>::with_capacity(
+                        (rng.next_u64() % 2047 + 1) as usize,
+                    );
                     rng.fill_bytes(&mut blob);
                     Value::Blob(blob)
                 }

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -650,12 +650,16 @@ impl Value {
         match self {
             Value::Null => Value::Null,
             _ => match ignored_chars {
-                None => match self
-                    .cast_text()
-                    .map(|s| hex::decode(&s[0..s.find('\0').unwrap_or(s.len())]))
-                {
-                    Some(Ok(bytes)) => Value::from_slice(&bytes),
-                    _ => Value::Null,
+                None => match self.cast_text() {
+                    Some(text) => {
+                        let input = &text[0..text.find('\0').unwrap_or(text.len())];
+                        let mut bytes = crate::alloc::vec![0; input.len() / 2];
+                        match hex::decode_to_slice(input, &mut bytes) {
+                            Ok(()) => Value::from_blob(bytes),
+                            Err(_) => Value::Null,
+                        }
+                    }
+                    None => Value::Null,
                 },
                 Some(ignore) => match ignore {
                     Value::Text(_) => {

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -344,7 +344,7 @@ impl Value {
             return Err(LimboError::TooBig);
         }
 
-        let mut blob: Vec<u8> = vec![0; length as usize];
+        let mut blob = crate::alloc::vec![0; length as usize];
         fill_bytes(&mut blob);
         Ok(Value::Blob(blob))
     }
@@ -549,7 +549,7 @@ impl Value {
         match (value, start_value) {
             (Value::Blob(b), Value::Numeric(Numeric::Integer(start))) => {
                 let (start, end) = calculate_postions(start, b.len(), length_value.as_ref());
-                Value::from_blob(b[start..end].to_vec())
+                Value::from_slice(&b[start..end])
             }
             (value, Value::Numeric(Numeric::Integer(start))) => {
                 if let Some(text) = value.cast_text() {
@@ -654,7 +654,7 @@ impl Value {
                     .cast_text()
                     .map(|s| hex::decode(&s[0..s.find('\0').unwrap_or(s.len())]))
                 {
-                    Some(Ok(bytes)) => Value::Blob(bytes),
+                    Some(Ok(bytes)) => Value::from_slice(&bytes),
                     _ => Value::Null,
                 },
                 Some(ignore) => match ignore {
@@ -662,7 +662,10 @@ impl Value {
                         let input = self.to_string();
                         let ignore = ignore.to_string();
                         let mut chars = input.chars().peekable();
-                        let mut out = Vec::with_capacity(input.len() / 2);
+                        let mut out =
+                            <crate::ValueBlob as crate::alloc::TursoVecExt<u8>>::with_capacity(
+                                input.len() / 2,
+                            );
 
                         let is_sep = |c: char| ignore.contains(c) && !c.is_ascii_hexdigit();
 
@@ -862,7 +865,7 @@ impl Value {
             return Err(LimboError::TooBig);
         }
 
-        Ok(Value::Blob(vec![0; length as usize]))
+        Ok(Value::Blob(crate::alloc::vec![0; length as usize]))
     }
 
     // exec_if returns whether you should jump
@@ -887,7 +890,7 @@ impl Value {
                 // Convert to TEXT first, then interpret as BLOB
                 // TODO: handle encoding
                 let text = self.to_string();
-                Value::Blob(text.into_bytes())
+                Value::from_slice(text.as_bytes())
             }
             // TEXT To cast a BLOB value to TEXT, the sequence of bytes that make up the BLOB is interpreted as text encoded using the database encoding.
             // Casting an INTEGER or REAL value into TEXT renders the value as if via sqlite3_snprintf() except that the resulting TEXT uses the encoding of the database connection.
@@ -1146,7 +1149,12 @@ impl Value {
 
     pub fn exec_concat(&self, rhs: &Value) -> Value {
         if let (Value::Blob(lhs), Value::Blob(rhs)) = (self, rhs) {
-            return Value::Blob([lhs.as_slice(), rhs.as_slice()].concat());
+            let mut blob = <crate::ValueBlob as crate::alloc::TursoVecExt<u8>>::with_capacity(
+                lhs.len() + rhs.len(),
+            );
+            blob.extend_from_slice(lhs);
+            blob.extend_from_slice(rhs);
+            return Value::Blob(blob);
         }
 
         let Some(lhs) = self.cast_text() else {
@@ -1996,7 +2004,7 @@ mod tests {
         let expected_len = Value::from_i64(7);
         assert_eq!(input_float.exec_length(), expected_len);
 
-        let expected_blob = Value::Blob("example".as_bytes().to_vec());
+        let expected_blob = Value::from_slice(b"example");
         let expected_len = Value::from_i64(7);
         assert_eq!(expected_blob.exec_length(), expected_len);
     }
@@ -2046,7 +2054,7 @@ mod tests {
         let expected: Value = Value::build_text("text");
         assert_eq!(input.exec_typeof(), expected);
 
-        let input = Value::Blob("limbo".as_bytes().to_vec());
+        let input = Value::from_slice(b"limbo");
         let expected: Value = Value::build_text("blob");
         assert_eq!(input.exec_typeof(), expected);
     }
@@ -2066,7 +2074,7 @@ mod tests {
         assert_eq!(Value::from_f64(23.45).exec_unicode(), Value::from_i64(50));
         assert_eq!(Value::Null.exec_unicode(), Value::Null);
         assert_eq!(
-            Value::Blob("example".as_bytes().to_vec()).exec_unicode(),
+            Value::from_slice(b"example").exec_unicode(),
             Value::from_i64(101)
         );
     }
@@ -2161,7 +2169,7 @@ mod tests {
             Value::build_text("1.5")
         );
         assert_eq!(
-            Value::Blob(vec![0xDE, 0xAD]).exec_unistr_quote(),
+            Value::from_slice(&[0xDE, 0xAD]).exec_unistr_quote(),
             Value::build_text("X'DEAD'")
         );
         assert_eq!(
@@ -2444,14 +2452,14 @@ mod tests {
         let expected_val = Value::build_text("31322E3334");
         assert_eq!(input_float.exec_hex(), expected_val);
 
-        let input_blob = Value::Blob(vec![0xff]);
+        let input_blob = Value::from_slice(&[0xff]);
         let expected_val = Value::build_text("FF");
         assert_eq!(input_blob.exec_hex(), expected_val);
     }
 
     #[test]
     fn test_cast_blob_preserves_blob_bytes() {
-        let input_blob = Value::Blob(vec![0xd2, 0x64, 0xc0, 0x07, 0xf6, 0x44, 0xe4, 0x59]);
+        let input_blob = Value::from_slice(&[0xd2, 0x64, 0xc0, 0x07, 0xf6, 0x44, 0xe4, 0x59]);
         let expected = input_blob.clone();
 
         assert_eq!(input_blob.exec_cast("BLOB"), expected);
@@ -2460,11 +2468,11 @@ mod tests {
     #[test]
     fn test_unhex() {
         let input = Value::build_text("6f");
-        let expected = Value::Blob(vec![0x6f]);
+        let expected = Value::from_slice(&[0x6f]);
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("6f");
-        let expected = Value::Blob(vec![0x6f]);
+        let expected = Value::from_slice(&[0x6f]);
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("611");
@@ -2472,7 +2480,7 @@ mod tests {
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("");
-        let expected = Value::Blob(vec![]);
+        let expected = Value::from_slice(&[]);
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("61x");
@@ -2484,19 +2492,19 @@ mod tests {
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("aa-bb");
-        let expected = Value::Blob(vec![0xaa, 0xbb]);
+        let expected = Value::from_slice(&[0xaa, 0xbb]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
 
         let input = Value::build_text("aa--bb");
-        let expected = Value::Blob(vec![0xaa, 0xbb]);
+        let expected = Value::from_slice(&[0xaa, 0xbb]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
 
         let input = Value::build_text("aa-bb-cc");
-        let expected = Value::Blob(vec![0xaa, 0xbb, 0xcc]);
+        let expected = Value::from_slice(&[0xaa, 0xbb, 0xcc]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
 
         let input = Value::build_text("aa bb");
-        let expected = Value::Blob(vec![0xaa, 0xbb]);
+        let expected = Value::from_slice(&[0xaa, 0xbb]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text(" "))), expected);
 
         let input = Value::build_text("A BCD");
@@ -2927,23 +2935,23 @@ mod tests {
         let expected = Value::from_i64(3);
         assert_eq!(input.exec_instr(&pattern), expected);
 
-        let input = Value::Blob(vec![1, 2, 3, 4, 5]);
-        let pattern = Value::Blob(vec![3, 4]);
+        let input = Value::from_slice(&[1, 2, 3, 4, 5]);
+        let pattern = Value::from_slice(&[3, 4]);
         let expected = Value::from_i64(3);
         assert_eq!(input.exec_instr(&pattern), expected);
 
-        let input = Value::Blob(vec![1, 2, 3, 4, 5]);
-        let pattern = Value::Blob(vec![3, 2]);
+        let input = Value::from_slice(&[1, 2, 3, 4, 5]);
+        let pattern = Value::from_slice(&[3, 2]);
         let expected = Value::from_i64(0);
         assert_eq!(input.exec_instr(&pattern), expected);
 
-        let input = Value::Blob(vec![0x61, 0x62, 0x63, 0x64, 0x65]);
+        let input = Value::from_slice(&[0x61, 0x62, 0x63, 0x64, 0x65]);
         let pattern = Value::build_text("cd");
         let expected = Value::from_i64(3);
         assert_eq!(input.exec_instr(&pattern), expected);
 
         let input = Value::build_text("abcde");
-        let pattern = Value::Blob(vec![0x63, 0x64]);
+        let pattern = Value::from_slice(&[0x63, 0x64]);
         let expected = Value::from_i64(3);
         assert_eq!(input.exec_instr(&pattern), expected);
 
@@ -2999,19 +3007,19 @@ mod tests {
         let expected = Some(Value::from_i64(0));
         assert_eq!(input.exec_sign(), expected);
 
-        let input = Value::Blob(b"abc".to_vec());
+        let input = Value::from_slice(b"abc");
         let expected = None;
         assert_eq!(input.exec_sign(), expected);
 
-        let input = Value::Blob(b"42".to_vec());
+        let input = Value::from_slice(b"42");
         let expected = None;
         assert_eq!(input.exec_sign(), expected);
 
-        let input = Value::Blob(b"-42".to_vec());
+        let input = Value::from_slice(b"-42");
         let expected = None;
         assert_eq!(input.exec_sign(), expected);
 
-        let input = Value::Blob(b"0".to_vec());
+        let input = Value::from_slice(b"0");
         let expected = None;
         assert_eq!(input.exec_sign(), expected);
 
@@ -3023,39 +3031,39 @@ mod tests {
     #[test]
     fn test_exec_zeroblob() {
         let input = Value::from_i64(0);
-        let expected = Value::Blob(vec![]);
+        let expected = Value::from_slice(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::Null;
-        let expected = Value::Blob(vec![]);
+        let expected = Value::from_slice(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::from_i64(4);
-        let expected = Value::Blob(vec![0; 4]);
+        let expected = Value::Blob(crate::alloc::vec![0; 4]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::from_i64(-1);
-        let expected = Value::Blob(vec![]);
+        let expected = Value::from_slice(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::build_text("5");
-        let expected = Value::Blob(vec![0; 5]);
+        let expected = Value::Blob(crate::alloc::vec![0; 5]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::build_text("-5");
-        let expected = Value::Blob(vec![]);
+        let expected = Value::from_slice(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::build_text("text");
-        let expected = Value::Blob(vec![]);
+        let expected = Value::from_slice(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::from_f64(2.6);
-        let expected = Value::Blob(vec![0; 2]);
+        let expected = Value::Blob(crate::alloc::vec![0; 2]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
-        let input = Value::Blob(vec![1]);
-        let expected = Value::Blob(vec![]);
+        let input = Value::from_slice(&[1]);
+        let expected = Value::from_slice(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         // Test TooBig error

--- a/core/vector/operations/concat.rs
+++ b/core/vector/operations/concat.rs
@@ -1,6 +1,7 @@
 use crate::{
+    alloc::TursoVecExt,
     vector::vector_types::{Vector, VectorType},
-    LimboError, Result,
+    LimboError, Result, ValueBlob,
 };
 
 pub fn vector_concat(v1: &Vector, v2: &Vector) -> Result<Vector<'static>> {
@@ -12,13 +13,15 @@ pub fn vector_concat(v1: &Vector, v2: &Vector) -> Result<Vector<'static>> {
 
     let data = match v1.vector_type {
         VectorType::Float32Dense | VectorType::Float64Dense => {
-            let mut data = Vec::with_capacity(v1.bin_len() + v2.bin_len());
+            let mut data =
+                <ValueBlob as TursoVecExt<u8>>::with_capacity(v1.bin_len() + v2.bin_len());
             data.extend_from_slice(v1.bin_data());
             data.extend_from_slice(v2.bin_data());
             data
         }
         VectorType::Float32Sparse => {
-            let mut data = Vec::with_capacity(v1.bin_len() + v2.bin_len());
+            let mut data =
+                <ValueBlob as TursoVecExt<u8>>::with_capacity(v1.bin_len() + v2.bin_len());
             data.extend_from_slice(&v1.bin_data()[..v1.bin_len() / 2]);
             data.extend_from_slice(&v2.bin_data()[..v2.bin_len() / 2]);
             data.extend_from_slice(&v1.bin_data()[v1.bin_len() / 2..]);
@@ -48,7 +51,7 @@ mod tests {
     };
 
     fn float32_vec_from(slice: &[f32]) -> Vector<'static> {
-        let mut data = Vec::new();
+        let mut data = crate::alloc::vec![];
         for &v in slice {
             data.extend_from_slice(&v.to_le_bytes());
         }

--- a/core/vector/operations/convert.rs
+++ b/core/vector/operations/convert.rs
@@ -1,6 +1,7 @@
 use crate::{
+    alloc::{TursoAllocExt, TursoIteratorExt, TursoVecExt, Vec},
     vector::vector_types::{Vector, VectorType},
-    Result,
+    Result, ValueBlob,
 };
 
 pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
@@ -9,13 +10,14 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
     }
     match (v.vector_type, target_type) {
         (VectorType::Float32Dense, VectorType::Float64Dense) => Ok(Vector::from_f64(
-            v.as_f32_slice().iter().map(|&x| x as f64).collect(),
+            v.as_f32_slice().iter().map(|&x| x as f64).try_collect()?,
         )),
         (VectorType::Float64Dense, VectorType::Float32Dense) => Ok(Vector::from_f32(
-            v.as_f64_slice().iter().map(|&x| x as f32).collect(),
+            v.as_f64_slice().iter().map(|&x| x as f32).try_collect()?,
         )),
         (VectorType::Float32Dense, VectorType::Float32Sparse) => {
-            let (mut idx, mut values) = (Vec::new(), Vec::new());
+            let mut idx: Vec<u32> = TursoAllocExt::new();
+            let mut values: Vec<f32> = TursoAllocExt::new();
             for (i, &value) in v.as_f32_slice().iter().enumerate() {
                 if value == 0.0 {
                     continue;
@@ -26,7 +28,8 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
             Ok(Vector::from_f32_sparse(v.dims, values, idx))
         }
         (VectorType::Float64Dense, VectorType::Float32Sparse) => {
-            let (mut idx, mut values) = (Vec::new(), Vec::new());
+            let mut idx: Vec<u32> = TursoAllocExt::new();
+            let mut values: Vec<f32> = TursoAllocExt::new();
             for (i, &value) in v.as_f64_slice().iter().enumerate() {
                 if value == 0.0 {
                     continue;
@@ -38,7 +41,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
         }
         (VectorType::Float32Sparse, VectorType::Float32Dense) => {
             let sparse = v.as_f32_sparse();
-            let mut data = vec![0f32; v.dims];
+            let mut data = crate::alloc::vec![0f32; v.dims];
             for (&i, &value) in sparse.idx.iter().zip(sparse.values.iter()) {
                 data[i as usize] = value;
             }
@@ -46,7 +49,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
         }
         (VectorType::Float32Sparse, VectorType::Float64Dense) => {
             let sparse = v.as_f32_sparse();
-            let mut data = vec![0f64; v.dims];
+            let mut data = crate::alloc::vec![0f64; v.dims];
             for (&i, &value) in sparse.idx.iter().zip(sparse.values.iter()) {
                 data[i as usize] = value as f64;
             }
@@ -56,7 +59,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
         (VectorType::Float32Dense, VectorType::Float1Bit) => {
             let dims = v.dims;
             let byte_count = dims.div_ceil(8);
-            let mut bits = vec![0u8; byte_count];
+            let mut bits = crate::alloc::vec![0u8; byte_count];
             for (i, &val) in v.as_f32_slice().iter().enumerate() {
                 if val > 0.0 {
                     bits[i / 8] |= 1 << (i & 7);
@@ -67,7 +70,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
         (VectorType::Float64Dense, VectorType::Float1Bit) => {
             let dims = v.dims;
             let byte_count = dims.div_ceil(8);
-            let mut bits = vec![0u8; byte_count];
+            let mut bits = crate::alloc::vec![0u8; byte_count];
             for (i, &val) in v.as_f64_slice().iter().enumerate() {
                 if val > 0.0 {
                     bits[i / 8] |= 1 << (i & 7);
@@ -85,7 +88,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
                         -1.0
                     }
                 })
-                .collect();
+                .try_collect()?;
             Ok(Vector::from_f32(floats))
         }
         (VectorType::Float1Bit, VectorType::Float64Dense) => {
@@ -98,7 +101,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
                         -1.0
                     }
                 })
-                .collect();
+                .try_collect()?;
             Ok(Vector::from_f64(floats))
         }
         // Float8 conversions
@@ -113,7 +116,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
             let floats: Vec<f32> = quantized
                 .iter()
                 .map(|&q| alpha * q as f32 + shift)
-                .collect();
+                .try_collect()?;
             Ok(Vector::from_f32(floats))
         }
         (VectorType::Float8, VectorType::Float64Dense) => {
@@ -121,7 +124,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
             let floats: Vec<f64> = quantized
                 .iter()
                 .map(|&q| alpha as f64 * q as f64 + shift as f64)
-                .collect();
+                .try_collect()?;
             Ok(Vector::from_f64(floats))
         }
         // Cross-conversions via intermediate
@@ -152,7 +155,7 @@ fn convert_floats_to_f8(
     dims: usize,
 ) -> Result<Vector<'static>> {
     if dims == 0 {
-        return Ok(Vector::from_f8(0, Vec::new(), 0.0, 0.0));
+        return Ok(Vector::from_f8(0, crate::alloc::vec![], 0.0, 0.0));
     }
     let mut min_val = f32::INFINITY;
     let mut max_val = f32::NEG_INFINITY;
@@ -166,7 +169,7 @@ fn convert_floats_to_f8(
     }
     let alpha = (max_val - min_val) / 255.0;
     let shift = min_val;
-    let mut quantized = Vec::with_capacity(dims);
+    let mut quantized = <ValueBlob as TursoVecExt<u8>>::with_capacity(dims);
     for val in values {
         let q = if alpha == 0.0 {
             0u8
@@ -181,14 +184,23 @@ fn convert_floats_to_f8(
 
 #[cfg(test)]
 mod tests {
-    use crate::vector::{
-        operations::convert::vector_convert,
-        vector_types::{tests::ArbitraryVector, Vector, VectorType},
+    use crate::{
+        alloc::{TursoIteratorExt, ALLOC_ERR_MSG},
+        types::value_blob_from_slice,
+        vector::{
+            operations::convert::vector_convert,
+            vector_types::{tests::ArbitraryVector, Vector, VectorType},
+        },
+        ValueBlob,
     };
     use quickcheck_macros::quickcheck;
 
-    fn concat<const N: usize>(data: &[[u8; N]]) -> Vec<u8> {
-        data.iter().flatten().cloned().collect::<Vec<u8>>()
+    fn concat<const N: usize>(data: &[[u8; N]]) -> ValueBlob {
+        data.iter()
+            .flatten()
+            .cloned()
+            .try_collect()
+            .expect(ALLOC_ERR_MSG)
     }
 
     fn assert_vectors(v1: &Vector, v2: &Vector) {
@@ -201,7 +213,7 @@ mod tests {
         Vector {
             vector_type: v.vector_type,
             dims: v.dims,
-            owned: Some(v.bin_data().to_vec()),
+            owned: Some(value_blob_from_slice(v.bin_data())),
             refer: None,
         }
     }
@@ -258,7 +270,7 @@ mod tests {
     /// Test that all 5x5 type conversions succeed and produce correct type/dims.
     #[test]
     pub fn test_vector_convert_all_types() {
-        let source = Vector::from_f32(vec![1.0, 0.5, 2.0]);
+        let source = Vector::from_f32(crate::alloc::vec![1.0, 0.5, 2.0]);
 
         let all_types = [
             VectorType::Float32Dense,
@@ -289,7 +301,7 @@ mod tests {
     /// Lossless conversions roundtrip exactly.
     #[test]
     pub fn test_vector_convert_lossless_roundtrip() {
-        let vf32 = Vector::from_f32(vec![1.0, 0.0, 2.0]);
+        let vf32 = Vector::from_f32(crate::alloc::vec![1.0, 0.0, 2.0]);
 
         // f32 -> f64 -> f32 is exact
         let via_f64 = vector_convert(
@@ -370,7 +382,7 @@ mod tests {
 
     #[test]
     fn test_vector_convert_empty_to_f8() {
-        let empty_f32 = Vector::from_f32(vec![]);
+        let empty_f32 = Vector::from_f32(crate::alloc::vec![]);
         let f8 = vector_convert(empty_f32, VectorType::Float8).unwrap();
         assert_eq!(f8.dims, 0);
         assert_eq!(f8.vector_type, VectorType::Float8);
@@ -382,7 +394,7 @@ mod tests {
 
     #[test]
     fn test_vector_convert_empty_f8_to_f32() {
-        let empty_f8 = Vector::from_f8(0, Vec::new(), 0.0, 0.0);
+        let empty_f8 = Vector::from_f8(0, crate::alloc::vec![], 0.0, 0.0);
         let f32_vec = vector_convert(empty_f8, VectorType::Float32Dense).unwrap();
         assert_eq!(f32_vec.dims, 0);
         assert!(f32_vec.as_f32_slice().is_empty());

--- a/core/vector/operations/distance_l2.rs
+++ b/core/vector/operations/distance_l2.rs
@@ -295,8 +295,8 @@ mod tests {
     /// Float1Bit L2 distance returns an error.
     #[test]
     fn test_vector_distance_l2_1bit_error() {
-        let v1 = Vector::from_1bit(4, vec![0b1010]);
-        let v2 = Vector::from_1bit(4, vec![0b0101]);
+        let v1 = Vector::from_1bit(4, crate::alloc::vec![0b1010]);
+        let v2 = Vector::from_1bit(4, crate::alloc::vec![0b0101]);
         assert!(vector_distance_l2(&v1, &v2).is_err());
     }
 }

--- a/core/vector/operations/serialize.rs
+++ b/core/vector/operations/serialize.rs
@@ -3,6 +3,12 @@ use crate::{
     Value,
 };
 
+#[cfg(nightly)]
+use crate::{alloc::TursoVecExt, ValueBlob};
+
+// Keep the stable move-based path unchanged while vector storage still uses
+// the standard allocator.
+#[cfg(not(nightly))]
 pub fn vector_serialize(x: Vector) -> Value {
     match x.vector_type {
         VectorType::Float32Dense => Value::from_blob(x.bin_eject()),
@@ -43,6 +49,61 @@ pub fn vector_serialize(x: Vector) -> Value {
             let trailing_bytes = dims.div_ceil(4) * 4 - dims;
             let mut blob = Vec::with_capacity(data.len() + 3);
             blob.extend_from_slice(&data);
+            blob.push(0); // padding
+            blob.push(trailing_bytes as u8);
+            blob.push(4); // type byte
+            Value::from_blob(blob)
+        }
+    }
+}
+
+// Build the allocator-backed destination directly and reserve its final size;
+// migrating vector storage itself is outside ValueBlob's type plumbing.
+#[cfg(nightly)]
+pub fn vector_serialize(x: Vector) -> Value {
+    match x.vector_type {
+        VectorType::Float32Dense => Value::from_slice(x.bin_data()),
+        VectorType::Float64Dense => {
+            let raw = x.bin_data();
+            let mut data = <ValueBlob as TursoVecExt<u8>>::with_capacity(raw.len() + 1);
+            data.extend_from_slice(raw);
+            data.push(2);
+            Value::from_blob(data)
+        }
+        VectorType::Float32Sparse => {
+            let dims = x.dims;
+            let raw = x.bin_data();
+            let mut data = <ValueBlob as TursoVecExt<u8>>::with_capacity(raw.len() + 5);
+            data.extend_from_slice(raw);
+            data.extend_from_slice(&(dims as u32).to_le_bytes());
+            data.push(9);
+            Value::from_blob(data)
+        }
+        VectorType::Float1Bit => {
+            // Format: [data bytes][optional padding][trailing_bits][0x03]
+            let dims = x.dims;
+            let data_size = dims.div_ceil(8);
+            let needs_padding = data_size % 2 == 0;
+            let meta_size = if needs_padding { 3 } else { 2 };
+            let blob_size = data_size + meta_size;
+            let mut blob = <ValueBlob as TursoVecExt<u8>>::with_capacity(blob_size);
+            let raw = x.bin_data();
+            blob.extend_from_slice(&raw[..data_size]);
+            if needs_padding {
+                blob.push(0); // padding
+            }
+            let trailing_bits = (blob_size - 1) * 8 - dims;
+            blob.push(trailing_bits as u8);
+            blob.push(3); // type byte
+            Value::from_blob(blob)
+        }
+        VectorType::Float8 => {
+            // Format: [quantized bytes][alignment padding][alpha f32][shift f32][padding 0x00][trailing_bytes][0x04]
+            let dims = x.dims;
+            let data = x.bin_data(); // ALIGN(dims, 4) + 8 bytes
+            let trailing_bytes = dims.div_ceil(4) * 4 - dims;
+            let mut blob = <ValueBlob as TursoVecExt<u8>>::with_capacity(data.len() + 3);
+            blob.extend_from_slice(data);
             blob.push(0); // padding
             blob.push(trailing_bytes as u8);
             blob.push(4); // type byte

--- a/core/vector/operations/serialize.rs
+++ b/core/vector/operations/serialize.rs
@@ -3,12 +3,6 @@ use crate::{
     Value,
 };
 
-#[cfg(nightly)]
-use crate::{alloc::TursoVecExt, ValueBlob};
-
-// Keep the stable move-based path unchanged while vector storage still uses
-// the standard allocator.
-#[cfg(not(nightly))]
 pub fn vector_serialize(x: Vector) -> Value {
     match x.vector_type {
         VectorType::Float32Dense => Value::from_blob(x.bin_eject()),
@@ -29,14 +23,12 @@ pub fn vector_serialize(x: Vector) -> Value {
             let dims = x.dims;
             let data_size = dims.div_ceil(8);
             let needs_padding = data_size % 2 == 0;
-            let meta_size = if needs_padding { 3 } else { 2 };
-            let blob_size = data_size + meta_size;
-            let mut blob = Vec::with_capacity(blob_size);
-            let raw = x.bin_eject();
-            blob.extend_from_slice(&raw[..data_size]);
+            let mut blob = x.bin_eject();
+            blob.truncate(data_size);
             if needs_padding {
                 blob.push(0); // padding
             }
+            let blob_size = blob.len() + 2;
             let trailing_bits = (blob_size - 1) * 8 - dims;
             blob.push(trailing_bits as u8);
             blob.push(3); // type byte
@@ -45,69 +37,40 @@ pub fn vector_serialize(x: Vector) -> Value {
         VectorType::Float8 => {
             // Format: [quantized bytes][alignment padding][alpha f32][shift f32][padding 0x00][trailing_bytes][0x04]
             let dims = x.dims;
-            let data = x.bin_eject(); // ALIGN(dims, 4) + 8 bytes
+            let mut data = x.bin_eject(); // ALIGN(dims, 4) + 8 bytes
             let trailing_bytes = dims.div_ceil(4) * 4 - dims;
-            let mut blob = Vec::with_capacity(data.len() + 3);
-            blob.extend_from_slice(&data);
-            blob.push(0); // padding
-            blob.push(trailing_bytes as u8);
-            blob.push(4); // type byte
-            Value::from_blob(blob)
+            data.push(0); // padding
+            data.push(trailing_bytes as u8);
+            data.push(4); // type byte
+            Value::from_blob(data)
         }
     }
 }
 
-// Build the allocator-backed destination directly and reserve its final size;
-// migrating vector storage itself is outside ValueBlob's type plumbing.
-#[cfg(nightly)]
-pub fn vector_serialize(x: Vector) -> Value {
-    match x.vector_type {
-        VectorType::Float32Dense => Value::from_slice(x.bin_data()),
-        VectorType::Float64Dense => {
-            let raw = x.bin_data();
-            let mut data = <ValueBlob as TursoVecExt<u8>>::with_capacity(raw.len() + 1);
-            data.extend_from_slice(raw);
-            data.push(2);
-            Value::from_blob(data)
-        }
-        VectorType::Float32Sparse => {
-            let dims = x.dims;
-            let raw = x.bin_data();
-            let mut data = <ValueBlob as TursoVecExt<u8>>::with_capacity(raw.len() + 5);
-            data.extend_from_slice(raw);
-            data.extend_from_slice(&(dims as u32).to_le_bytes());
-            data.push(9);
-            Value::from_blob(data)
-        }
-        VectorType::Float1Bit => {
-            // Format: [data bytes][optional padding][trailing_bits][0x03]
-            let dims = x.dims;
-            let data_size = dims.div_ceil(8);
-            let needs_padding = data_size % 2 == 0;
-            let meta_size = if needs_padding { 3 } else { 2 };
-            let blob_size = data_size + meta_size;
-            let mut blob = <ValueBlob as TursoVecExt<u8>>::with_capacity(blob_size);
-            let raw = x.bin_data();
-            blob.extend_from_slice(&raw[..data_size]);
-            if needs_padding {
-                blob.push(0); // padding
-            }
-            let trailing_bits = (blob_size - 1) * 8 - dims;
-            blob.push(trailing_bits as u8);
-            blob.push(3); // type byte
-            Value::from_blob(blob)
-        }
-        VectorType::Float8 => {
-            // Format: [quantized bytes][alignment padding][alpha f32][shift f32][padding 0x00][trailing_bytes][0x04]
-            let dims = x.dims;
-            let data = x.bin_data(); // ALIGN(dims, 4) + 8 bytes
-            let trailing_bytes = dims.div_ceil(4) * 4 - dims;
-            let mut blob = <ValueBlob as TursoVecExt<u8>>::with_capacity(data.len() + 3);
-            blob.extend_from_slice(data);
-            blob.push(0); // padding
-            blob.push(trailing_bytes as u8);
-            blob.push(4); // type byte
-            Value::from_blob(blob)
-        }
+#[cfg(all(test, nightly))]
+mod tests {
+    use super::vector_serialize;
+    use crate::{alloc::TursoVecExt, vector::vector_types::Vector, Value, ValueBlob};
+
+    fn assert_float32_move_preserves_allocation(bytes: &[u8]) {
+        let mut blob = <ValueBlob as TursoVecExt<u8>>::with_capacity(bytes.len() + 4);
+        blob.extend_from_slice(bytes);
+        let pointer = blob.as_ptr();
+        let capacity = blob.capacity();
+
+        let vector = Vector::from_vec(blob).unwrap();
+        let Value::Blob(blob) = vector_serialize(vector) else {
+            panic!("expected blob value");
+        };
+
+        assert_eq!(blob.as_ptr(), pointer);
+        assert_eq!(blob.capacity(), capacity);
+        assert_eq!(blob.as_slice(), bytes);
+    }
+
+    #[test]
+    fn float32_serialization_moves_value_blob_allocation() {
+        assert_float32_move_preserves_allocation(&[]);
+        assert_float32_move_preserves_allocation(&1.0f32.to_le_bytes());
     }
 }

--- a/core/vector/operations/slice.rs
+++ b/core/vector/operations/slice.rs
@@ -1,6 +1,8 @@
 use crate::{
+    alloc::TursoAllocExt,
+    types::value_blob_from_slice,
     vector::vector_types::{Vector, VectorType},
-    LimboError, Result,
+    LimboError, Result, ValueBlob,
 };
 
 pub fn vector_slice(vector: &Vector, start: usize, end: usize) -> Result<Vector<'static>> {
@@ -18,18 +20,22 @@ pub fn vector_slice(vector: &Vector, start: usize, end: usize) -> Result<Vector<
         VectorType::Float32Dense => Ok(Vector {
             vector_type: vector.vector_type,
             dims: end - start,
-            owned: Some(vector.bin_data()[start * 4..end * 4].to_vec()),
+            owned: Some(value_blob_from_slice(
+                &vector.bin_data()[start * 4..end * 4],
+            )),
             refer: None,
         }),
         VectorType::Float64Dense => Ok(Vector {
             vector_type: vector.vector_type,
             dims: end - start,
-            owned: Some(vector.bin_data()[start * 8..end * 8].to_vec()),
+            owned: Some(value_blob_from_slice(
+                &vector.bin_data()[start * 8..end * 8],
+            )),
             refer: None,
         }),
         VectorType::Float32Sparse => {
-            let mut values = Vec::new();
-            let mut idx = Vec::new();
+            let mut values: ValueBlob = TursoAllocExt::new();
+            let mut idx: ValueBlob = TursoAllocExt::new();
             let sparse = vector.as_f32_sparse();
             for (&i, &value) in sparse.idx.iter().zip(sparse.values.iter()) {
                 let i = i as usize;
@@ -61,7 +67,7 @@ mod tests {
     };
 
     fn float32_vec_from(slice: &[f32]) -> Vector {
-        let mut data = Vec::new();
+        let mut data = crate::alloc::vec![];
         for &v in slice {
             data.extend_from_slice(&v.to_le_bytes());
         }

--- a/core/vector/operations/text.rs
+++ b/core/vector/operations/text.rs
@@ -1,6 +1,7 @@
 use crate::{
+    alloc::{TursoAllocExt, TursoVecExt},
     vector::vector_types::{Vector, VectorType},
-    LimboError, Result,
+    LimboError, Result, ValueBlob,
 };
 
 pub fn vector_to_text(vector: &Vector) -> String {
@@ -81,12 +82,12 @@ pub fn vector_from_text(vector_type: VectorType, text: &str) -> Result<Vector> {
                 ));
             }
             VectorType::Float8 => {
-                return Ok(Vector::from_f8(0, Vec::new(), 0.0, 0.0));
+                return Ok(Vector::from_f8(0, crate::alloc::vec![], 0.0, 0.0));
             }
             _ => Vector {
                 vector_type,
                 dims: 0,
-                owned: Some(Vec::new()),
+                owned: Some(crate::alloc::vec![]),
                 refer: None,
             },
         });
@@ -102,7 +103,7 @@ pub fn vector_from_text(vector_type: VectorType, text: &str) -> Result<Vector> {
 }
 
 fn vector32_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vector<'static>> {
-    let mut data = Vec::new();
+    let mut data: ValueBlob = TursoAllocExt::new();
     for token in tokens {
         let value = token
             .parse::<f32>()
@@ -123,7 +124,7 @@ fn vector32_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vecto
 }
 
 fn vector64_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vector<'static>> {
-    let mut data = Vec::new();
+    let mut data: ValueBlob = TursoAllocExt::new();
     for token in tokens {
         let value = token
             .parse::<f64>()
@@ -144,8 +145,8 @@ fn vector64_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vecto
 }
 
 fn vector32_sparse_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vector<'static>> {
-    let mut idx = Vec::new();
-    let mut values = Vec::new();
+    let mut idx: ValueBlob = TursoAllocExt::new();
+    let mut values: ValueBlob = TursoAllocExt::new();
     let mut dims = 0u32;
     for token in tokens {
         let value = token
@@ -189,7 +190,7 @@ fn vector_1bit_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Ve
     }
     let dims = floats.len();
     let byte_count = dims.div_ceil(8);
-    let mut bits = vec![0u8; byte_count];
+    let mut bits = crate::alloc::vec![0u8; byte_count];
     for (i, &f) in floats.iter().enumerate() {
         if f > 0.0 {
             bits[i / 8] |= 1 << (i & 7);
@@ -216,7 +217,7 @@ fn vector_f8_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vect
     let max_val = floats.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     let alpha = (max_val - min_val) / 255.0;
     let shift = min_val;
-    let mut quantized = Vec::with_capacity(dims);
+    let mut quantized = <ValueBlob as TursoVecExt<u8>>::with_capacity(dims);
     for &f in &floats {
         let q = if alpha == 0.0 {
             0u8

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -1,5 +1,9 @@
-use crate::turso_debug_assert;
-use crate::{LimboError, Result};
+use crate::{
+    alloc::{TursoVecExt, Vec},
+    turso_debug_assert,
+    types::value_blob_from_slice,
+    LimboError, Result, ValueBlob,
+};
 
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum VectorType {
@@ -14,7 +18,7 @@ pub enum VectorType {
 pub struct Vector<'a> {
     pub vector_type: VectorType,
     pub dims: usize,
-    pub owned: Option<Vec<u8>>,
+    pub owned: Option<ValueBlob>,
     pub refer: Option<&'a [u8]>,
 }
 
@@ -89,11 +93,21 @@ impl<'a> Vector<'a> {
     }
     pub fn from_f32(mut values_f32: Vec<f32>) -> Self {
         let dims = values_f32.len();
+        #[cfg(not(nightly))]
         let values = unsafe {
-            Vec::from_raw_parts(
+            ValueBlob::from_raw_parts(
                 values_f32.as_mut_ptr() as *mut u8,
                 values_f32.len() * 4,
                 values_f32.capacity() * 4,
+            )
+        };
+        #[cfg(nightly)]
+        let values = unsafe {
+            ValueBlob::from_raw_parts_in(
+                values_f32.as_mut_ptr() as *mut u8,
+                values_f32.len() * 4,
+                values_f32.capacity() * 4,
+                crate::alloc::TursoAllocator,
             )
         };
         std::mem::forget(values_f32);
@@ -106,11 +120,21 @@ impl<'a> Vector<'a> {
     }
     pub fn from_f64(mut values_f64: Vec<f64>) -> Self {
         let dims = values_f64.len();
+        #[cfg(not(nightly))]
         let values = unsafe {
-            Vec::from_raw_parts(
+            ValueBlob::from_raw_parts(
                 values_f64.as_mut_ptr() as *mut u8,
                 values_f64.len() * 8,
                 values_f64.capacity() * 8,
+            )
+        };
+        #[cfg(nightly)]
+        let values = unsafe {
+            ValueBlob::from_raw_parts_in(
+                values_f64.as_mut_ptr() as *mut u8,
+                values_f64.len() * 8,
+                values_f64.capacity() * 8,
+                crate::alloc::TursoAllocator,
             )
         };
         std::mem::forget(values_f64);
@@ -122,20 +146,40 @@ impl<'a> Vector<'a> {
         }
     }
     pub fn from_f32_sparse(dims: usize, mut values_f32: Vec<f32>, mut idx_u32: Vec<u32>) -> Self {
+        #[cfg(not(nightly))]
         let mut values = unsafe {
-            Vec::from_raw_parts(
+            ValueBlob::from_raw_parts(
                 values_f32.as_mut_ptr() as *mut u8,
                 values_f32.len() * 4,
                 values_f32.capacity() * 4,
             )
         };
+        #[cfg(nightly)]
+        let mut values = unsafe {
+            ValueBlob::from_raw_parts_in(
+                values_f32.as_mut_ptr() as *mut u8,
+                values_f32.len() * 4,
+                values_f32.capacity() * 4,
+                crate::alloc::TursoAllocator,
+            )
+        };
         std::mem::forget(values_f32);
 
+        #[cfg(not(nightly))]
         let idx = unsafe {
-            Vec::from_raw_parts(
+            ValueBlob::from_raw_parts(
                 idx_u32.as_mut_ptr() as *mut u8,
                 idx_u32.len() * 4,
                 idx_u32.capacity() * 4,
+            )
+        };
+        #[cfg(nightly)]
+        let idx = unsafe {
+            ValueBlob::from_raw_parts_in(
+                idx_u32.as_mut_ptr() as *mut u8,
+                idx_u32.len() * 4,
+                idx_u32.capacity() * 4,
+                crate::alloc::TursoAllocator,
             )
         };
         std::mem::forget(idx_u32);
@@ -152,7 +196,7 @@ impl<'a> Vector<'a> {
         n.div_ceil(4) * 4
     }
 
-    pub fn from_1bit(dims: usize, bits: Vec<u8>) -> Self {
+    pub fn from_1bit(dims: usize, bits: ValueBlob) -> Self {
         debug_assert!(bits.len() == dims.div_ceil(8));
         Self {
             vector_type: VectorType::Float1Bit,
@@ -162,9 +206,9 @@ impl<'a> Vector<'a> {
         }
     }
 
-    pub fn from_f8(dims: usize, quantized: Vec<u8>, alpha: f32, shift: f32) -> Self {
+    pub fn from_f8(dims: usize, quantized: ValueBlob, alpha: f32, shift: f32) -> Self {
         let aligned = Self::align4(dims);
-        let mut data = Vec::with_capacity(aligned + 8);
+        let mut data = <ValueBlob as TursoVecExt<u8>>::with_capacity(aligned + 8);
         data.extend_from_slice(&quantized);
         data.resize(aligned, 0); // alignment padding
         data.extend_from_slice(&alpha.to_le_bytes());
@@ -178,7 +222,7 @@ impl<'a> Vector<'a> {
         }
     }
 
-    pub fn from_vec(mut blob: Vec<u8>) -> Result<Self> {
+    pub fn from_vec(mut blob: ValueBlob) -> Result<Self> {
         let (vector_type, len, explicit_dims) = Self::vector_type(&blob)?;
         blob.truncate(len);
         Self::from_data_with_dims(vector_type, Some(blob), None, explicit_dims)
@@ -189,7 +233,7 @@ impl<'a> Vector<'a> {
     }
     pub fn from_data(
         vector_type: VectorType,
-        owned: Option<Vec<u8>>,
+        owned: Option<ValueBlob>,
         refer: Option<&'a [u8]>,
     ) -> Result<Self> {
         Self::from_data_with_dims(vector_type, owned, refer, 0)
@@ -197,7 +241,7 @@ impl<'a> Vector<'a> {
 
     fn from_data_with_dims(
         vector_type: VectorType,
-        owned: Option<Vec<u8>>,
+        owned: Option<ValueBlob>,
         refer: Option<&'a [u8]>,
         explicit_dims: usize,
     ) -> Result<Self> {
@@ -321,11 +365,12 @@ impl<'a> Vector<'a> {
             .expect("Vector invariant: exactly one of owned or refer must be Some")
     }
 
-    pub fn bin_eject(self) -> Vec<u8> {
+    pub fn bin_eject(self) -> ValueBlob {
         self.owned.unwrap_or_else(|| {
-            self.refer
-                .expect("Vector invariant: exactly one of owned or refer must be Some")
-                .to_vec()
+            value_blob_from_slice(
+                self.refer
+                    .expect("Vector invariant: exactly one of owned or refer must be Some"),
+            )
         })
     }
 
@@ -435,6 +480,7 @@ impl<'a> Vector<'a> {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use crate::alloc::{TursoIteratorExt, ALLOC_ERR_MSG};
     use crate::vector::operations;
 
     use super::*;
@@ -467,7 +513,8 @@ pub(crate) mod tests {
                         }
                     }
                 })
-                .collect()
+                .try_collect()
+                .expect(ALLOC_ERR_MSG)
         }
 
         fn generate_f64_vector(g: &mut Gen) -> Vec<f64> {
@@ -487,7 +534,8 @@ pub(crate) mod tests {
                         }
                     }
                 })
-                .collect()
+                .try_collect()
+                .expect(ALLOC_ERR_MSG)
         }
     }
 
@@ -497,7 +545,7 @@ pub(crate) mod tests {
             Vector {
                 vector_type: v.vector_type,
                 dims: DIMS,
-                owned: Some(v.data),
+                owned: Some(value_blob_from_slice(&v.data)),
                 refer: None,
             }
         }
@@ -517,16 +565,24 @@ pub(crate) mod tests {
             let data = match vector_type {
                 VectorType::Float32Dense => {
                     let floats = Self::generate_f32_vector(g);
-                    floats.iter().flat_map(|f| f.to_le_bytes()).collect()
+                    floats
+                        .iter()
+                        .flat_map(|f| f.to_le_bytes())
+                        .try_collect()
+                        .expect(ALLOC_ERR_MSG)
                 }
                 VectorType::Float64Dense => {
                     let floats = Self::generate_f64_vector(g);
-                    floats.iter().flat_map(|f| f.to_le_bytes()).collect()
+                    floats
+                        .iter()
+                        .flat_map(|f| f.to_le_bytes())
+                        .try_collect()
+                        .expect(ALLOC_ERR_MSG)
                 }
                 VectorType::Float1Bit => {
                     // Generate random bits
                     let byte_count = DIMS.div_ceil(8);
-                    let mut bits = vec![0u8; byte_count];
+                    let mut bits = crate::alloc::vec![0u8; byte_count];
                     for b in bits.iter_mut() {
                         *b = u8::arbitrary(g);
                     }
@@ -547,7 +603,7 @@ pub(crate) mod tests {
                     let alpha = (max_val - min_val) / 255.0;
                     let shift = min_val;
                     let aligned = DIMS.div_ceil(4) * 4;
-                    let mut data = Vec::with_capacity(aligned + 8);
+                    let mut data: Vec<u8> = TursoVecExt::with_capacity(aligned + 8);
                     for &f in &floats {
                         let q = if alpha == 0.0 {
                             0u8
@@ -710,13 +766,13 @@ pub(crate) mod tests {
         let a = Vector {
             vector_type: VectorType::Float32Dense,
             dims: 2,
-            owned: Some(vec![0, 0, 0, 0, 52, 208, 106, 63]),
+            owned: Some(crate::alloc::vec![0, 0, 0, 0, 52, 208, 106, 63]),
             refer: None,
         };
         let b = Vector {
             vector_type: VectorType::Float32Dense,
             dims: 2,
-            owned: Some(vec![0, 0, 0, 0, 58, 100, 45, 192]),
+            owned: Some(crate::alloc::vec![0, 0, 0, 0, 58, 100, 45, 192]),
             refer: None,
         };
         assert!(

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -20,6 +20,7 @@ use crate::model::table::{
 use indexmap::IndexSet;
 use rand::seq::IndexedRandom;
 use rand::Rng;
+use turso_core::alloc::{TursoSliceExt, ALLOC_ERR_MSG};
 use turso_parser::ast::{ColumnConstraint, Expr, SortOrder};
 
 use super::{backtrack, pick};
@@ -778,7 +779,9 @@ impl Arbitrary for Update {
                 Some(size) => {
                     let p = "X".repeat(size);
                     if matches!(marker_col.column_type, ColumnType::Blob) {
-                        SimValue(turso_core::Value::Blob(p.into_bytes()))
+                        SimValue(turso_core::Value::Blob(
+                            p.as_bytes().try_to_vec().expect(ALLOC_ERR_MSG),
+                        ))
                     } else {
                         SimValue(turso_core::Value::Text(p.into()))
                     }

--- a/sql_generation/generation/value/cmp.rs
+++ b/sql_generation/generation/value/cmp.rs
@@ -227,8 +227,14 @@ mod tests {
             (SimValue(Value::from_i64(i64::MAX - 1)), ColumnType::Integer),
             (SimValue(Value::from_f64(1e10)), ColumnType::Float),
             (SimValue(Value::from_f64(2e10)), ColumnType::Float),
-            (SimValue(Value::Blob(Vec::new())), ColumnType::Blob),
-            (SimValue(Value::Blob(vec![0, 255])), ColumnType::Blob),
+            (
+                SimValue(Value::Blob(turso_core::alloc::vec![])),
+                ColumnType::Blob,
+            ),
+            (
+                SimValue(Value::Blob(turso_core::alloc::vec![0, 255])),
+                ColumnType::Blob,
+            ),
         ];
         for (val, col_type) in &cases {
             for _ in 0..200 {

--- a/sql_generation/generation/value/mod.rs
+++ b/sql_generation/generation/value/mod.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use turso_core::alloc::{TursoSliceExt, ALLOC_ERR_MSG};
 use turso_core::Value;
 
 use crate::{
@@ -53,7 +54,12 @@ impl ArbitraryFrom<&ColumnType> for SimValue {
             ColumnType::Integer => Value::from_i64(rng.random_range(-(1i64 << 53)..(1i64 << 53))),
             ColumnType::Float => Value::from_f64(rng.random_range(-1e10..1e10)),
             ColumnType::Text => Value::build_text(gen_random_text(rng)),
-            ColumnType::Blob => Value::Blob(gen_random_text(rng).into_bytes()),
+            ColumnType::Blob => Value::Blob(
+                gen_random_text(rng)
+                    .as_bytes()
+                    .try_to_vec()
+                    .expect(ALLOC_ERR_MSG),
+            ),
         };
         SimValue(value)
     }

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, hash::Hash, ops::Deref};
 
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use turso_core::alloc::{TursoIteratorExt, TursoSliceExt, ALLOC_ERR_MSG};
 use turso_core::{numeric::Numeric, types, LimboError};
 use turso_parser::ast::{self, ColumnConstraint, SortOrder};
 
@@ -121,11 +121,12 @@ impl Column {
 
 impl Display for Column {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let constraints = self
-            .constraints
-            .iter()
-            .map(|constraint| constraint.to_string())
-            .join(" ");
+        let constraints = itertools::join(
+            self.constraints
+                .iter()
+                .map(|constraint| constraint.to_string()),
+            " ",
+        );
         let mut col_string = format!("{} {}", self.name, self.column_type);
         if !constraints.is_empty() {
             col_string.push(' ');
@@ -243,7 +244,12 @@ impl SimValue {
             ColumnType::Integer => SimValue(types::Value::from_i64(offset)),
             ColumnType::Float => SimValue(types::Value::from_f64(offset as f64)),
             ColumnType::Text => SimValue(types::Value::Text(format!("u{offset}").into())),
-            ColumnType::Blob => SimValue(types::Value::Blob(format!("u{offset}").into_bytes())),
+            ColumnType::Blob => SimValue(types::Value::Blob(
+                format!("u{offset}")
+                    .as_bytes()
+                    .try_to_vec()
+                    .expect(ALLOC_ERR_MSG),
+            )),
         }
     }
 
@@ -457,7 +463,8 @@ impl From<&ast::Literal> for SimValue {
                         let hex_byte = std::str::from_utf8(pair).unwrap();
                         u8::from_str_radix(hex_byte, 16).unwrap()
                     })
-                    .collect(),
+                    .try_collect()
+                    .expect(ALLOC_ERR_MSG),
             ),
             ast::Literal::Keyword(keyword) => match keyword.to_uppercase().as_str() {
                 "TRUE" => types::Value::from_i64(1),


### PR DESCRIPTION
Main reason I need this is for fallible allocations. Right now, this just a mechanical change to change the type. Next will be propagating allocation errors. 

## Description

- add `ValueBlob` as the allocator-aware byte buffer used by `Value::Blob`
- route owned blob buffers through records, registers, payload holders, and core producers without allocator-erasing conversions
- update feature-gated DB page, B-tree dump, FTS, MVCC, and benchmark paths to construct the final `ValueBlob` directly
- preserve the existing serde sequence format while deserializing directly into allocator-backed storage
- add nightly coverage that verifies pointer and capacity survive moves into and out of `Value::Blob`

## Motivation & Context

Blob ownership needs to retain `TursoAllocator` on nightly builds without adding allocation, copying, or reallocation at handoff boundaries. Stable builds continue using `std::vec::Vec<u8>`, and pre-existing buffer growth behavior remains unchanged.


