### PR TITLE
core/translate: Fix cost model for InSeek for IN LIST query

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -676,6 +676,35 @@ fn consider_in_seek_access_method(
     }))
 }
 
+fn residual_literal_in_list_eval_cost(
+    constraints: &[Constraint],
+    where_clause: &[WhereTerm],
+    consumed_where_terms: &[usize],
+    input_cardinality: f64,
+    rows_per_outer_row: f64,
+    params: &CostModelParams,
+) -> Cost {
+    let eval_count = input_cardinality * rows_per_outer_row;
+    let comparison_count: f64 = constraints
+        .iter()
+        .filter(|constraint| !consumed_where_terms.contains(&constraint.where_clause_pos.0))
+        .filter(|constraint| {
+            where_clause
+                .get(constraint.where_clause_pos.0)
+                .is_some_and(|term| matches!(term.expr, ast::Expr::InList { .. }))
+        })
+        .filter_map(|constraint| match constraint.operator {
+            ConstraintOperator::In {
+                not: false,
+                estimated_values,
+            } => Some(estimated_values),
+            _ => None,
+        })
+        .sum();
+
+    Cost(eval_count * comparison_count * params.cpu_cost_per_row)
+}
+
 /// Return the best [AccessMethod] for a given join order.
 #[allow(clippy::too_many_arguments)]
 pub fn find_best_access_method_for_join_order(
@@ -830,6 +859,15 @@ fn find_best_access_method_for_btree(
     // Skip alternative access methods (in-seek, multi-index) when INDEXED BY or NOT INDEXED
     // is specified — the user explicitly requested a specific index or no index.
     if rhs_table.indexed.is_none() && rhs_table.btree().is_some_and(|b| b.has_rowid) {
+        let in_seek_threshold = best_access_method.cost
+            + residual_literal_in_list_eval_cost(
+                &rhs_constraints.constraints,
+                where_clause,
+                &best_access_method.consumed_where_terms,
+                input_cardinality,
+                best_access_method.estimated_rows_per_outer_row,
+                params,
+            );
         if let Some(in_seek_method) = consider_in_seek_access_method(
             rhs_table,
             rhs_constraints,
@@ -837,7 +875,7 @@ fn find_best_access_method_for_btree(
             input_cardinality,
             base_row_count,
             params,
-            best_access_method.cost,
+            in_seek_threshold,
         )? {
             let mut in_seek_method = in_seek_method;
             if let AccessMethodParams::InSeek { index, .. } = &in_seek_method.params {

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -3,6 +3,7 @@ mod test_btree;
 mod test_ddl;
 mod test_ephemeral_cleanup;
 mod test_hash_join_materialization;
+mod test_in_seek;
 mod test_materialized_subquery;
 mod test_read_path;
 mod test_vacuum;

--- a/tests/integration/query_processing/test_in_seek.rs
+++ b/tests/integration/query_processing/test_in_seek.rs
@@ -1,0 +1,49 @@
+use crate::common::{limbo_exec_rows, TempDatabase};
+use rusqlite::types::Value;
+
+fn value_as_text(value: &Value) -> Option<&str> {
+    match value {
+        Value::Text(v) => Some(v.as_str()),
+        _ => None,
+    }
+}
+
+#[test]
+fn large_indexed_in_list_uses_seek_loop() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(
+        &conn,
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, x INTEGER, v TEXT)",
+    );
+    limbo_exec_rows(&conn, "CREATE INDEX t_x ON t(x)");
+    limbo_exec_rows(
+        &conn,
+        "INSERT INTO t
+        SELECT value, value, 'v' || value
+        FROM generate_series(1, 10000)",
+    );
+    limbo_exec_rows(&conn, "ANALYZE");
+
+    let values = (1..=5000)
+        .map(|i| i.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let query = format!("SELECT count(*) FROM t WHERE x IN ({values})");
+
+    let eqp_rows = limbo_exec_rows(&conn, &format!("EXPLAIN QUERY PLAN {query}"));
+    let plan = eqp_rows
+        .iter()
+        .filter_map(|row| row.get(3).and_then(value_as_text))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        plan.contains("SEARCH t USING INDEX t_x (x=?)"),
+        "expected IN-list to drive indexed seeks, got:\n{plan}"
+    );
+    assert!(
+        !plan.contains("SCAN t USING COVERING INDEX t_x"),
+        "large IN-list regressed to residual scan:\n{plan}"
+    );
+}


### PR DESCRIPTION
User provided good reproducer where after a certain number of items, an `IN LIST` query would degrade to a SCAN instead of InSeek