### PR TITLE
core: propagate ValueBlob allocation failures

### DIFF
--- a/core/alloc/allocation_site.rs
+++ b/core/alloc/allocation_site.rs
@@ -5,7 +5,18 @@ pub enum AllocationSite {
     MvStore(MvStoreAllocationSite),
     MvccCheckpoint(MvccCheckpointAllocationSite),
     Schema(SchemaAllocationSite),
+    ValueBlob(ValueBlobAllocationSite),
+    Vector(VectorAllocationSite),
     NoFaultInjection,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ValueBlobAllocationSite {
+    Concat,
+    FromSlice,
+    JsonbCopy,
+    Hash128,
+    RecordDecode,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -34,6 +45,18 @@ pub enum MvccCheckpointAllocationSite {
     CheckpointSequenceCompactions,
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum VectorAllocationSite {
+    Parse,
+    Convert,
+    Concat,
+    Slice,
+    Serialize,
+    SparseConstruction,
+    Float8Construction,
+    IndexPayloadCopy,
+}
+
 impl From<MvStoreAllocationSite> for AllocationSite {
     fn from(site: MvStoreAllocationSite) -> Self {
         Self::MvStore(site)
@@ -49,6 +72,18 @@ impl From<MvccCheckpointAllocationSite> for AllocationSite {
 impl From<SchemaAllocationSite> for AllocationSite {
     fn from(site: SchemaAllocationSite) -> Self {
         Self::Schema(site)
+    }
+}
+
+impl From<VectorAllocationSite> for AllocationSite {
+    fn from(site: VectorAllocationSite) -> Self {
+        Self::Vector(site)
+    }
+}
+
+impl From<ValueBlobAllocationSite> for AllocationSite {
+    fn from(site: ValueBlobAllocationSite) -> Self {
+        Self::ValueBlob(site)
     }
 }
 
@@ -101,6 +136,16 @@ macro_rules! with_mv_store_allocation_site {
         #[cfg(feature = "allocation_metric")]
         let _turso_allocation_site_guard =
             $crate::alloc::enter_allocation_site($crate::alloc::MvStoreAllocationSite::$site);
+        $expr
+    }};
+}
+
+#[macro_export]
+macro_rules! with_value_blob_allocation_site {
+    ($site:ident, $expr:expr) => {{
+        #[cfg(feature = "allocation_metric")]
+        let _turso_allocation_site_guard =
+            $crate::alloc::enter_allocation_site($crate::alloc::ValueBlobAllocationSite::$site);
         $expr
     }};
 }

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -15,6 +15,7 @@ mod collections;
 pub use allocation_site::{
     current_allocation_site, enter_allocation_site, AllocationSite, AllocationSiteGuard,
     MvStoreAllocationSite, MvccCheckpointAllocationSite, SchemaAllocationSite,
+    ValueBlobAllocationSite, VectorAllocationSite,
 };
 /// The underlying allocator trait: `allocator_api2::alloc::Allocator` on
 /// stable, `std::alloc::Allocator` on `--cfg nightly` builds.

--- a/core/benches/sql_functions/numeric.rs
+++ b/core/benches/sql_functions/numeric.rs
@@ -258,7 +258,7 @@ fn numeric_from_null(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn numeric_from_blob(bencher: Bencher) {
-    let value = Value::from_slice(b"12345");
+    let value = Value::from_slice(b"12345").expect(turso_core::alloc::ALLOC_ERR_MSG);
     bencher.bench_local(|| black_box(Numeric::from_value(black_box(&value))));
 }
 
@@ -370,6 +370,6 @@ fn numeric_strict_from_text_invalid_prefix(bencher: Bencher) {
 #[turso_macros::divan_bench]
 fn numeric_strict_from_blob(bencher: Bencher) {
     // Blob is always Null in strict mode
-    let value = Value::from_slice(b"12345");
+    let value = Value::from_slice(b"12345").expect(turso_core::alloc::ALLOC_ERR_MSG);
     bencher.bench_local(|| black_box(Numeric::from_value_strict(black_box(&value))));
 }

--- a/core/benches/sql_functions/value.rs
+++ b/core/benches/sql_functions/value.rs
@@ -79,7 +79,7 @@ fn length_float(bencher: Bencher) {
 #[cfg(feature = "nanosecond-bench")]
 #[turso_macros::divan_bench]
 fn length_blob(bencher: Bencher) {
-    let value = Value::from_slice(&[0u8; 100]);
+    let value = Value::from_slice(&[0u8; 100]).expect(turso_core::alloc::ALLOC_ERR_MSG);
     bencher.bench_local(|| black_box(black_box(&value).exec_length()));
 }
 
@@ -202,7 +202,7 @@ fn substring_negative_start(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn substring_blob(bencher: Bencher) {
-    let value = Value::from_slice(b"hello world");
+    let value = Value::from_slice(b"hello world").expect(turso_core::alloc::ALLOC_ERR_MSG);
     let start = Value::from_i64(1);
     let length = Value::from_i64(5);
     bencher.bench_local(|| {
@@ -242,8 +242,9 @@ fn instr_not_found(bencher: Bencher) {
 #[cfg(feature = "nanosecond-bench")]
 #[turso_macros::divan_bench]
 fn instr_blob(bencher: Bencher) {
-    let value = Value::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    let pattern = Value::from_slice(&[5, 6, 7]);
+    let value = Value::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        .expect(turso_core::alloc::ALLOC_ERR_MSG);
+    let pattern = Value::from_slice(&[5, 6, 7]).expect(turso_core::alloc::ALLOC_ERR_MSG);
     bencher.bench_local(|| black_box(black_box(&value).exec_instr(black_box(&pattern))));
 }
 
@@ -317,7 +318,8 @@ fn quote_integer(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn quote_blob(bencher: Bencher) {
-    let value = Value::from_slice(&[0x01, 0x02, 0xAB, 0xCD, 0xEF]);
+    let value =
+        Value::from_slice(&[0x01, 0x02, 0xAB, 0xCD, 0xEF]).expect(turso_core::alloc::ALLOC_ERR_MSG);
     bencher.bench_local(|| black_box(black_box(&value).exec_quote()));
 }
 
@@ -379,7 +381,7 @@ fn typeof_text(bencher: Bencher) {
 #[cfg(feature = "nanosecond-bench")]
 #[turso_macros::divan_bench]
 fn typeof_blob(bencher: Bencher) {
-    let value = Value::from_slice(&[1, 2, 3]);
+    let value = Value::from_slice(&[1, 2, 3]).expect(turso_core::alloc::ALLOC_ERR_MSG);
     bencher.bench_local(|| black_box(black_box(&value).exec_typeof()));
 }
 
@@ -442,7 +444,8 @@ fn hex_text(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn hex_blob(bencher: Bencher) {
-    let value = Value::from_slice(&[0x01, 0x02, 0xAB, 0xCD, 0xEF]);
+    let value =
+        Value::from_slice(&[0x01, 0x02, 0xAB, 0xCD, 0xEF]).expect(turso_core::alloc::ALLOC_ERR_MSG);
     bencher.bench_local(|| black_box(black_box(&value).exec_hex()));
 }
 
@@ -768,8 +771,8 @@ fn concat_string_integer(bencher: Bencher) {
 
 #[turso_macros::divan_bench]
 fn concat_blobs(bencher: Bencher) {
-    let a = Value::from_slice(b"hello ");
-    let b = Value::from_slice(b"world");
+    let a = Value::from_slice(b"hello ").expect(turso_core::alloc::ALLOC_ERR_MSG);
+    let b = Value::from_slice(b"world").expect(turso_core::alloc::ALLOC_ERR_MSG);
     bencher.bench_local(|| black_box(black_box(&a).exec_concat(black_box(&b))));
 }
 

--- a/core/btree_dump.rs
+++ b/core/btree_dump.rs
@@ -196,7 +196,7 @@ impl InternalVirtualTableCursor for BtreeDumpCursor {
     fn column(&self, column: usize) -> Result<Value> {
         match column {
             0 => match &self.current_record {
-                Some(data) => Ok(Value::from_slice(data)),
+                Some(data) => Ok(Value::from_slice(data)?),
                 None => Ok(Value::Null),
             },
             _ => Ok(Value::Null),

--- a/core/dbpage.rs
+++ b/core/dbpage.rs
@@ -194,7 +194,7 @@ impl InternalVirtualTableCursor for DbPageCursor {
 
                 let page_contents = page_ref.get_contents();
                 let data_slice = page_contents.as_ptr();
-                Ok(Value::from_slice(data_slice))
+                Ok(Value::from_slice(data_slice)?)
             }
             2 => Ok(Value::from_text("main")), // we don't support multiple databases - todo when we do
             _ => Ok(Value::Null),

--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -1896,11 +1896,14 @@ mod tests {
     #[test]
     fn test_blob_nul_truncation() {
         // Bug 9: %s on blobs truncates at first NUL byte
-        let blob_val = Register::Value(Value::from_slice(&[0x48, 0x00, 0x4C])); // H\0L
+        let blob_val = Register::Value(
+            Value::from_slice(&[0x48, 0x00, 0x4C]).expect(crate::alloc::ALLOC_ERR_MSG),
+        ); // H\0L
         let result = exec_printf(&[text("%s"), blob_val]).unwrap();
         assert_eq!(result, *text("H").get_value());
 
-        let blob_hello = Register::Value(Value::from_slice(b"Hello"));
+        let blob_hello =
+            Register::Value(Value::from_slice(b"Hello").expect(crate::alloc::ALLOC_ERR_MSG));
         assert_eq!(
             exec_printf(&[text("%s"), blob_hello]).unwrap(),
             *text("Hello").get_value()

--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -551,8 +551,8 @@ impl AggregateEvalState {
                         // Create index key values
                         let index_key_values = vec![
                             Value::from_i64(operator_storage_id),
-                            zset_hash.to_value(),
-                            element_id.to_value(),
+                            zset_hash.to_value()?,
+                            element_id.to_value()?,
                         ];
 
                         // Create an immutable record for the index key
@@ -1910,8 +1910,8 @@ impl IncrementalOperator for AggregateOperator {
 
                         // Build the aggregate storage format: [operator_id, zset_hash, element_id, value, weight]
                         let operator_id_val = Value::from_i64(operator_storage_id);
-                        let zset_hash_val = zset_hash.to_value();
-                        let element_id_val = element_id.to_value();
+                        let zset_hash_val = zset_hash.to_value()?;
+                        let element_id_val = element_id.to_value()?;
                         let blob_val = blob_value.clone();
 
                         // Create index key - the first 3 columns of our primary key
@@ -2351,7 +2351,7 @@ impl ScanState {
         };
 
         // Get the value (3rd element)
-        Ok(IOResult::Done(Some(third?.to_owned())))
+        Ok(IOResult::Done(Some(third?.to_owned()?)))
     }
 
     pub fn new_for_max(
@@ -2473,7 +2473,7 @@ impl ScanState {
                     // Seek to the next value in the index
                     let index_key = vec![
                         Value::from_i64(*storage_id),
-                        zset_hash.to_value(),
+                        zset_hash.to_value()?,
                         current_candidate.clone(),
                     ];
                     let index_record = ImmutableRecord::from_values(&index_key, index_key.len())?;
@@ -2727,8 +2727,8 @@ impl FetchDistinctState {
                     // First, seek in the index cursor
                     let index_key = vec![
                         Value::from_i64(storage_id),
-                        zset_hash.to_value(),
-                        element_id.to_value(),
+                        zset_hash.to_value()?,
+                        element_id.to_value()?,
                     ];
                     let index_record = ImmutableRecord::from_values(&index_key, index_key.len())?;
 
@@ -2795,7 +2795,7 @@ impl FetchDistinctState {
                         // The weight is at index 4
                         if let Some(weight) = r.get_value_opt(4) {
                             // Get the weight directly from column 5(index 4)
-                            let weight = match weight.to_owned() {
+                            let weight = match weight.to_owned()? {
                                 Value::Numeric(Numeric::Integer(w)) => w,
                                 _ => 0,
                             };
@@ -2983,8 +2983,8 @@ impl DistinctPersistState {
                     // Create index key
                     let index_key = vec![
                         Value::from_i64(storage_id),
-                        zset_hash.to_value(),
-                        element_id.to_value(),
+                        zset_hash.to_value()?,
+                        element_id.to_value()?,
                     ];
 
                     // Record values (operator_id, zset_hash, element_id, weight_blob)
@@ -2997,8 +2997,8 @@ impl DistinctPersistState {
 
                     let record_values = vec![
                         Value::from_i64(storage_id),
-                        zset_hash.to_value(),
-                        element_id.to_value(),
+                        zset_hash.to_value()?,
+                        element_id.to_value()?,
                         Value::Blob(weight_blob),
                     ];
 
@@ -3133,7 +3133,7 @@ impl MinMaxPersistState {
                     // Create index key
                     let index_key = vec![
                         Value::from_i64(storage_id),
-                        zset_hash.to_value(),
+                        zset_hash.to_value()?,
                         element_id_val.clone(),
                     ];
 
@@ -3141,7 +3141,7 @@ impl MinMaxPersistState {
                     // For MIN/MAX, the element_id IS the value, so we use NULL for the 4th column
                     let record_values = vec![
                         Value::from_i64(storage_id),
-                        zset_hash.to_value(),
+                        zset_hash.to_value()?,
                         element_id_val.clone(),
                         Value::Null, // Placeholder - not used for MIN/MAX
                     ];

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -81,7 +81,7 @@ impl WriteRowView {
 
                         // Weight is always the last value
                         let existing_weight = match last {
-                            Some(val) => match val?.to_owned() {
+                            Some(val) => match val?.to_owned()? {
                                 Value::Numeric(Numeric::Integer(w)) => w as isize,
                                 _ => {
                                     return Err(LimboError::InternalError(format!(
@@ -2778,7 +2778,7 @@ mod tests {
 
             for _ in 0..num_data_columns {
                 let value = values_iter.next().expect("we already checked bounds")?;
-                values.push(value.to_owned());
+                values.push(value.to_owned()?);
             }
 
             delta.insert(rowid, values);

--- a/core/incremental/dbsp.rs
+++ b/core/incremental/dbsp.rs
@@ -81,7 +81,8 @@ impl Hash128 {
     }
 
     /// Convert to a big-endian byte array for storage
-    pub fn to_blob(self) -> crate::ValueBlob {
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::Hash128)]
+    pub fn to_blob(self) -> std::result::Result<crate::ValueBlob, crate::alloc::TryReserveError> {
         crate::types::value_blob_from_slice(self.uuid.as_bytes())
     }
 
@@ -99,8 +100,8 @@ impl Hash128 {
     }
 
     /// Convert to a Value::Blob for storage
-    pub fn to_value(self) -> Value {
-        Value::Blob(self.to_blob())
+    pub fn to_value(self) -> std::result::Result<Value, crate::alloc::TryReserveError> {
+        Ok(Value::Blob(self.to_blob()?))
     }
 
     /// Try to extract a Hash128 from a Value
@@ -171,7 +172,7 @@ impl HashableRow {
 impl Hash for HashableRow {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Hash the 128-bit value by hashing both parts
-        self.cached_hash.to_blob().hash(state);
+        self.cached_hash.uuid.as_bytes().hash(state);
     }
 }
 

--- a/core/incremental/filter_operator.rs
+++ b/core/incremental/filter_operator.rs
@@ -283,7 +283,7 @@ mod tests {
 
         let values_with_blob = vec![
             Value::from_i64(1),
-            Value::from_slice(&[1, 2, 3]),
+            Value::from_slice(&[1, 2, 3]).expect(crate::alloc::ALLOC_ERR_MSG),
             Value::Text(Text::from("test")),
         ];
         assert!(!filter.evaluate_predicate(&values_with_blob));
@@ -321,7 +321,7 @@ mod tests {
         // Test with non-NULL value (Blob)
         let values_with_blob = vec![
             Value::from_i64(1),
-            Value::from_slice(&[1, 2, 3]),
+            Value::from_slice(&[1, 2, 3]).expect(crate::alloc::ALLOC_ERR_MSG),
             Value::Text(Text::from("test")),
         ];
         assert!(filter.evaluate_predicate(&values_with_blob));

--- a/core/incremental/join_operator.rs
+++ b/core/incremental/join_operator.rs
@@ -37,12 +37,12 @@ fn read_next_join_row(
     let index_key_values = match last_element_hash {
         Some(last_hash) => vec![
             Value::from_i64(storage_id),
-            zset_hash.to_value(),
-            last_hash.to_value(),
+            zset_hash.to_value()?,
+            last_hash.to_value()?,
         ],
         None => vec![
             Value::from_i64(storage_id),
-            zset_hash.to_value(),
+            zset_hash.to_value()?,
             Value::Null, // Start iteration from beginning
         ],
     };
@@ -73,17 +73,17 @@ fn read_next_join_row(
 
         // Index has 4 values: storage_id, zset_id, element_id, rowid (appended by WriteRow)
         if let Ok((v0, v1, v2)) = values {
-            let found_storage_id = match &v0.to_owned() {
+            let found_storage_id = match &v0.to_owned()? {
                 Value::Numeric(Numeric::Integer(id)) => *id,
                 _ => return Ok(IOResult::Done(None)),
             };
-            let found_zset_hash = match &v1.to_owned() {
+            let found_zset_hash = match &v1.to_owned()? {
                 Value::Blob(blob) => Hash128::from_blob(blob).ok_or_else(|| {
                     crate::LimboError::InternalError("Invalid zset_hash blob".to_string())
                 })?,
                 _ => return Ok(IOResult::Done(None)),
             };
-            let element_hash = match &v2.to_owned() {
+            let element_hash = match &v2.to_owned()? {
                 Value::Blob(blob) => Hash128::from_blob(blob).ok_or_else(|| {
                     crate::LimboError::InternalError("Invalid element_hash blob".to_string())
                 })?,
@@ -118,7 +118,7 @@ fn read_next_join_row(
             // Table format: [storage_id, zset_id, element_id, value_blob, weight]
             if let Ok((value_at_3, value_at_4)) = table_values {
                 // Deserialize the row from the blob
-                let value_at_3 = value_at_3.to_owned();
+                let value_at_3 = value_at_3.to_owned()?;
                 let blob = match value_at_3 {
                     Value::Blob(ref b) => b,
                     _ => return Ok(IOResult::Done(None)),
@@ -128,7 +128,7 @@ fn read_next_join_row(
                 // For now, let's deserialize it simply
                 let row = deserialize_hashable_row(blob)?;
 
-                let weight = match &value_at_4.to_owned() {
+                let weight = match &value_at_4.to_owned()? {
                     Value::Numeric(Numeric::Integer(w)) => *w as isize,
                     _ => return Ok(IOResult::Done(None)),
                 };
@@ -646,16 +646,16 @@ impl IncrementalOperator for JoinOperator {
                     let element_hash = row.cached_hash();
                     let index_key = vec![
                         Value::from_i64(storage_id),
-                        zset_hash.to_value(),
-                        element_hash.to_value(),
+                        zset_hash.to_value()?,
+                        element_hash.to_value()?,
                     ];
 
                     // The record values: we'll store the serialized row as a blob
                     let row_blob = serialize_hashable_row(row)?;
                     let record_values = vec![
                         Value::from_i64(self.left_storage_id()),
-                        zset_hash.to_value(),
-                        element_hash.to_value(),
+                        zset_hash.to_value()?,
+                        element_hash.to_value()?,
                         Value::Blob(row_blob),
                     ];
 
@@ -694,16 +694,16 @@ impl IncrementalOperator for JoinOperator {
                     let element_hash = row.cached_hash();
                     let index_key = vec![
                         Value::from_i64(self.right_storage_id()),
-                        zset_hash.to_value(),
-                        element_hash.to_value(),
+                        zset_hash.to_value()?,
+                        element_hash.to_value()?,
                     ];
 
                     // The record values: we'll store the serialized row as a blob
                     let row_blob = serialize_hashable_row(row)?;
                     let record_values = vec![
                         Value::from_i64(self.right_storage_id()),
-                        zset_hash.to_value(),
-                        element_hash.to_value(),
+                        zset_hash.to_value()?,
+                        element_hash.to_value()?,
                         Value::Blob(row_blob),
                     ];
 

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -39,7 +39,7 @@ impl ReadRecord {
                             ))
                         })?;
                         // The blob is in column 3: operator_id, zset_id, element_id, value, weight
-                        let blob = r.get_value(3)?.to_owned();
+                        let blob = r.get_value(3)?.to_owned()?;
 
                         let (state, _group_key) = match blob {
                             Value::Blob(blob) => AggregateState::from_blob(&blob),
@@ -155,7 +155,7 @@ impl WriteRow {
 
                         // Weight is always the last value (column 4 in our 5-column structure)
                         let existing_weight = match weight_opt {
-                            Some(val) => match val.to_owned() {
+                            Some(val) => match val.to_owned()? {
                                 Value::Numeric(Numeric::Integer(w)) => w as isize,
                                 _ => {
                                     return Err(LimboError::InternalError(

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -2308,7 +2308,7 @@ impl FtsCursor {
                         &[
                             Value::Text(Text::new(path_str.clone())),
                             Value::from_i64(actual_chunk_idx as i64),
-                            Value::from_slice(chunk_data),
+                            Value::from_slice(chunk_data)?,
                         ],
                         3,
                     )?;

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -548,7 +548,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "first value must be sparse vector".to_string(),
                         ));
                     };
-                    let vector = Vector::from_vec(crate::types::value_blob_from_slice(vector))?;
+                    let vector = Vector::from_slice_owned(vector)?;
                     if !matches!(vector.vector_type, VectorType::Float32Sparse) {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
@@ -800,7 +800,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "first value must be sparse vector".to_string(),
                         ));
                     };
-                    let vector = Vector::from_vec(crate::types::value_blob_from_slice(vector))?;
+                    let vector = Vector::from_slice_owned(vector)?;
                     if !matches!(vector.vector_type, VectorType::Float32Sparse) {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
@@ -1069,7 +1069,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "second value must be i64 limit parameter".to_string(),
                         ));
                     };
-                    let vector = Vector::from_vec(crate::types::value_blob_from_slice(vector))?;
+                    let vector = Vector::from_slice_owned(vector)?;
                     if !matches!(vector.vector_type, VectorType::Float32Sparse) {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
@@ -1534,7 +1534,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                                 "table column value must be sparse vector".to_string(),
                             ));
                         };
-                        let data = Vector::from_vec(crate::types::value_blob_from_slice(data))?;
+                        let data = Vector::from_slice_owned(data)?;
                         if !matches!(data.vector_type, VectorType::Float32Sparse) {
                             return Err(LimboError::InternalError(
                                 "table column value must be sparse vector".to_string(),
@@ -1545,7 +1545,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                                 "first value must be sparse vector".to_string(),
                             ));
                         };
-                        let arg = Vector::from_vec(crate::types::value_blob_from_slice(arg))?;
+                        let arg = Vector::from_slice_owned(arg)?;
                         if !matches!(arg.vector_type, VectorType::Float32Sparse) {
                             return Err(LimboError::InternalError(
                                 "first value must be sparse vector".to_string(),

--- a/core/json/cache.rs
+++ b/core/json/cache.rs
@@ -1,5 +1,6 @@
 use std::cell::{Cell, UnsafeCell};
 
+use crate::alloc::TryReserveError;
 use crate::types::AsValueRef;
 use crate::{Value, ValueRef};
 
@@ -39,20 +40,25 @@ impl JsonCache {
         oldest_idx
     }
 
-    pub fn insert(&mut self, key: impl AsValueRef, value: &Jsonb) {
+    pub fn insert(
+        &mut self,
+        key: impl AsValueRef,
+        value: &Jsonb,
+    ) -> std::result::Result<(), TryReserveError> {
         let key = key.as_value_ref();
         if self.used < JSON_CACHE_SIZE {
-            self.entries[self.used] = Some((key.to_owned(), value.clone()));
+            self.entries[self.used] = Some((key.to_owned()?, value.clone()));
             self.age[self.used] = self.counter;
             self.counter += 1;
             self.used += 1
         } else {
             let id = self.find_oldest_entry();
 
-            self.entries[id] = Some((key.to_owned(), value.clone()));
+            self.entries[id] = Some((key.to_owned()?, value.clone()));
             self.age[id] = self.counter;
             self.counter += 1;
         }
+        Ok(())
     }
 
     pub fn lookup(&mut self, key: impl AsValueRef) -> Option<Jsonb> {
@@ -142,7 +148,7 @@ impl JsonCacheCell {
                     let result = value(key);
                     match result {
                         Ok(json) => {
-                            cache.insert(key, &json);
+                            cache.insert(key, &json)?;
                             Ok(json)
                         }
                         Err(e) => Err(e),
@@ -207,7 +213,9 @@ mod tests {
         let (key, value) = create_test_pair(json_str);
 
         // Insert a value
-        cache.insert(&key, &value);
+        cache
+            .insert(&key, &value)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
 
         // Verify it was inserted
         assert_eq!(cache.used, 1);
@@ -244,9 +252,15 @@ mod tests {
         let (key2, value2) = create_test_pair("{\"id\": 2}");
         let (key3, value3) = create_test_pair("{\"id\": 3}");
 
-        cache.insert(&key1, &value1);
-        cache.insert(&key2, &value2);
-        cache.insert(&key3, &value3);
+        cache
+            .insert(&key1, &value1)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
+        cache
+            .insert(&key2, &value2)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
+        cache
+            .insert(&key3, &value3)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
 
         // Verify they were all inserted
         assert_eq!(cache.used, 3);
@@ -276,10 +290,18 @@ mod tests {
         let (key4, value4) = create_test_pair("{\"id\": 4}");
         let (key5, value5) = create_test_pair("{\"id\": 5}");
 
-        cache.insert(&key1, &value1);
-        cache.insert(&key2, &value2);
-        cache.insert(&key3, &value3);
-        cache.insert(&key4, &value4);
+        cache
+            .insert(&key1, &value1)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
+        cache
+            .insert(&key2, &value2)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
+        cache
+            .insert(&key3, &value3)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
+        cache
+            .insert(&key4, &value4)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
 
         // Cache is now full
         assert_eq!(cache.used, 4);
@@ -288,7 +310,9 @@ mod tests {
         let _ = cache.lookup(&key1);
 
         // Insert one more entry - should evict the oldest (key2)
-        cache.insert(&key5, &value5);
+        cache
+            .insert(&key5, &value5)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
 
         // Cache size should still be JSON_CACHE_SIZE
         assert_eq!(cache.used, 4);
@@ -313,9 +337,15 @@ mod tests {
         let (key2, value2) = create_test_pair("{\"id\": 2}");
         let (key3, value3) = create_test_pair("{\"id\": 3}");
 
-        cache.insert(&key1, &value1);
-        cache.insert(&key2, &value2);
-        cache.insert(&key3, &value3);
+        cache
+            .insert(&key1, &value1)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
+        cache
+            .insert(&key2, &value2)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
+        cache
+            .insert(&key3, &value3)
+            .expect(crate::alloc::ALLOC_ERR_MSG);
 
         // key1 should be the oldest
         assert_eq!(cache.find_oldest_entry(), 0);

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -1,4 +1,4 @@
-use crate::alloc::TursoVecExt;
+use crate::alloc::{TryReserveError, TursoVecExt};
 use crate::json::error::{Error as PError, Result as PResult};
 use crate::json::Conv;
 use crate::types::{value_blob_from_slice, ValueBlob};
@@ -638,7 +638,7 @@ impl SearchOperation {
     pub fn new(capacity: usize) -> Self {
         Self {
             mode: PathOperationMode::ReplaceExisting,
-            value: Jsonb::new(capacity, None),
+            value: Jsonb::new(capacity),
         }
     }
 
@@ -905,13 +905,11 @@ pub struct ObjectIteratorState {
     index: usize,
 }
 
+pub type ArrayIteratorItem = ((usize, Jsonb), ArrayIteratorState);
+pub type ObjectIteratorItem = ((usize, Jsonb, Jsonb), ObjectIteratorState);
+
 impl Jsonb {
-    pub fn new(capacity: usize, data: Option<&[u8]>) -> Self {
-        if let Some(data) = data {
-            return Self {
-                data: value_blob_from_slice(data),
-            };
-        }
+    pub fn new(capacity: usize) -> Self {
         Self {
             data: <ValueBlob as TursoVecExt<u8>>::with_capacity(capacity),
         }
@@ -2337,7 +2335,7 @@ impl Jsonb {
     }
 
     fn from_str(input: &str) -> PResult<Self> {
-        let mut result = Self::new(input.len(), None);
+        let mut result = Self::new(input.len());
         let input = input.as_bytes();
 
         if input.is_empty() {
@@ -2378,8 +2376,11 @@ impl Jsonb {
         }
     }
 
-    pub fn from_raw_data(data: &[u8]) -> Self {
-        Self::new(data.len(), Some(data))
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::JsonbCopy)]
+    pub fn from_raw_data(data: &[u8]) -> std::result::Result<Self, TryReserveError> {
+        Ok(Self {
+            data: value_blob_from_slice(data)?,
+        })
     }
 
     pub fn data(self) -> ValueBlob {
@@ -3129,7 +3130,7 @@ impl Jsonb {
                             if target_header.0 == ElementType::OBJECT {
                                 work_stack.push_back((key_path, value_cursor));
                             } else {
-                                let patch_obj = Jsonb::new(value_data.len(), Some(value_data));
+                                let patch_obj = Jsonb::from_raw_data(value_data)?;
                                 let mut op = ReplaceOperation::new(patch_obj);
                                 result.operate_on_path(&key_path, &mut op)?;
                                 let _ = result.operate_on_path(&key_path, &mut op);
@@ -3137,10 +3138,9 @@ impl Jsonb {
                                 work_stack.push_back((key_path, value_cursor));
                             }
                         } else {
-                            let empty_obj = Jsonb::new(
-                                1,
-                                Some(JsonbHeader::make_obj().into_bytes().as_bytes()),
-                            );
+                            let empty_obj = Jsonb::from_raw_data(
+                                JsonbHeader::make_obj().into_bytes().as_bytes(),
+                            )?;
                             let mut op = SetOperation::new(empty_obj);
                             let _ = result.operate_on_path(&key_path, &mut op);
 
@@ -3150,7 +3150,7 @@ impl Jsonb {
                     _ => {
                         let value_data = &patch.data
                             [value_cursor..value_cursor + value_header_size + value_size];
-                        let patch_value = Jsonb::new(value_data.len(), Some(value_data));
+                        let patch_value = Jsonb::from_raw_data(value_data)?;
 
                         let mut op = SetOperation::new(patch_value);
 
@@ -3178,27 +3178,31 @@ impl Jsonb {
     pub fn array_iterator_next(
         &self,
         st: &ArrayIteratorState,
-    ) -> Option<((usize, Jsonb), ArrayIteratorState)> {
+    ) -> std::result::Result<Option<ArrayIteratorItem>, TryReserveError> {
         if st.cursor >= st.end {
-            return None;
+            return Ok(None);
         }
 
-        let (JsonbHeader(_, payload_len), header_len) = self.read_header(st.cursor).ok()?;
+        let Ok((JsonbHeader(_, payload_len), header_len)) = self.read_header(st.cursor) else {
+            return Ok(None);
+        };
         let start = st.cursor;
-        let stop = start.checked_add(header_len + payload_len)?;
+        let Some(stop) = start.checked_add(header_len + payload_len) else {
+            return Ok(None);
+        };
 
         if stop > st.end || stop > self.data.len() {
-            return None;
+            return Ok(None);
         }
 
-        let elem = Jsonb::new(stop - start, Some(&self.data[start..stop]));
+        let elem = Jsonb::from_raw_data(&self.data[start..stop])?;
         let next = ArrayIteratorState {
             cursor: stop,
             end: st.end,
             index: st.index + 1,
         };
 
-        Some(((st.index, elem), next))
+        Ok(Some(((st.index, elem), next)))
     }
 
     pub fn object_iterator(&self) -> Result<ObjectIteratorState> {
@@ -3216,39 +3220,47 @@ impl Jsonb {
     pub fn object_iterator_next(
         &self,
         st: &ObjectIteratorState,
-    ) -> Option<((usize, Jsonb, Jsonb), ObjectIteratorState)> {
+    ) -> std::result::Result<Option<ObjectIteratorItem>, TryReserveError> {
         if st.cursor >= st.end {
-            return None;
+            return Ok(None);
         }
 
         // key
-        let (JsonbHeader(key_ty, key_len), key_hdr_len) = self.read_header(st.cursor).ok()?;
+        let Ok((JsonbHeader(key_ty, key_len), key_hdr_len)) = self.read_header(st.cursor) else {
+            return Ok(None);
+        };
         if !key_ty.is_valid_key() {
-            return None;
+            return Ok(None);
         }
         let key_start = st.cursor;
-        let key_stop = key_start.checked_add(key_hdr_len + key_len)?;
+        let Some(key_stop) = key_start.checked_add(key_hdr_len + key_len) else {
+            return Ok(None);
+        };
         if key_stop > st.end || key_stop > self.data.len() {
-            return None;
+            return Ok(None);
         }
 
         // value
-        let (JsonbHeader(_, val_len), val_hdr_len) = self.read_header(key_stop).ok()?;
+        let Ok((JsonbHeader(_, val_len), val_hdr_len)) = self.read_header(key_stop) else {
+            return Ok(None);
+        };
         let val_start = key_stop;
-        let val_stop = val_start.checked_add(val_hdr_len + val_len)?;
+        let Some(val_stop) = val_start.checked_add(val_hdr_len + val_len) else {
+            return Ok(None);
+        };
         if val_stop > st.end || val_stop > self.data.len() {
-            return None;
+            return Ok(None);
         }
 
-        let key = Jsonb::new(key_stop - key_start, Some(&self.data[key_start..key_stop]));
-        let value = Jsonb::new(val_stop - val_start, Some(&self.data[val_start..val_stop]));
+        let key = Jsonb::from_raw_data(&self.data[key_start..key_stop])?;
+        let value = Jsonb::from_raw_data(&self.data[val_start..val_stop])?;
         let next = ObjectIteratorState {
             cursor: val_stop,
             end: st.end,
             index: st.index + 1,
         };
 
-        Some(((st.index, key, value), next))
+        Ok(Some(((st.index, key, value), next)))
     }
 
     /// If the iterator points at a container value, return an iterator for that container.
@@ -3555,7 +3567,7 @@ mod tests {
     #[test]
     fn test_null_serialization() {
         // Create JSONB with null value
-        let mut jsonb = Jsonb::new(10, None);
+        let mut jsonb = Jsonb::new(10);
         jsonb.data.push(ElementType::NULL as u8);
 
         // Test serialization
@@ -3570,12 +3582,12 @@ mod tests {
     #[test]
     fn test_boolean_serialization() {
         // True
-        let mut jsonb_true = Jsonb::new(10, None);
+        let mut jsonb_true = Jsonb::new(10);
         jsonb_true.data.push(ElementType::TRUE as u8);
         assert_eq!(jsonb_true.to_string().unwrap(), "true");
 
         // False
-        let mut jsonb_false = Jsonb::new(10, None);
+        let mut jsonb_false = Jsonb::new(10);
         jsonb_false.data.push(ElementType::FALSE as u8);
         assert_eq!(jsonb_false.to_string().unwrap(), "false");
 
@@ -3642,7 +3654,7 @@ mod tests {
             93,  // ']'
         ];
 
-        let jsonb = Jsonb::from_raw_data(&data);
+        let jsonb = Jsonb::from_raw_data(&data).expect(crate::alloc::ALLOC_ERR_MSG);
         // This should not panic - the fix uses byte-level checks that handle
         // non-ASCII safely. The malformed data is rejected as invalid INT5,
         // matching SQLite's "malformed JSON" behavior.
@@ -3657,7 +3669,7 @@ mod tests {
         assert!(valid.to_string().is_ok());
 
         // Malformed JSONB with invalid element type should error
-        let malformed = Jsonb::from_raw_data(&[0xFF]);
+        let malformed = Jsonb::from_raw_data(&[0xFF]).expect(crate::alloc::ALLOC_ERR_MSG);
         let err = malformed.to_string().unwrap_err();
         assert!(err.to_string().contains("Invalid element type"));
 
@@ -3665,14 +3677,16 @@ mod tests {
         let bad_int5 = Jsonb::from_raw_data(&[
             0x34, // INT5 header, 3 bytes payload
             b'a', b'b', b'c', // not a valid number
-        ]);
+        ])
+        .expect(crate::alloc::ALLOC_ERR_MSG);
         let err = bad_int5.to_string().unwrap_err();
         assert!(err.to_string().contains("malformed JSON"));
 
         // Empty INT5 payload should error
         let empty_int5 = Jsonb::from_raw_data(&[
             0x04, // INT5 header, 0 bytes payload
-        ]);
+        ])
+        .expect(crate::alloc::ALLOC_ERR_MSG);
         let err = empty_int5.to_string().unwrap_err();
         assert!(err.to_string().contains("malformed JSON"));
 
@@ -3680,14 +3694,16 @@ mod tests {
         let sign_only_int5 = Jsonb::from_raw_data(&[
             0x14, // INT5 header, 1 byte payload
             b'+',
-        ]);
+        ])
+        .expect(crate::alloc::ALLOC_ERR_MSG);
         let err = sign_only_int5.to_string().unwrap_err();
         assert!(err.to_string().contains("malformed JSON"));
 
         let minus_only_int5 = Jsonb::from_raw_data(&[
             0x14, // INT5 header, 1 byte payload
             b'-',
-        ]);
+        ])
+        .expect(crate::alloc::ALLOC_ERR_MSG);
         let err = minus_only_int5.to_string().unwrap_err();
         assert!(err.to_string().contains("malformed JSON"));
     }
@@ -4103,7 +4119,7 @@ world""#,
         let binary_data = parsed.data;
 
         // Create a new Jsonb from the binary data
-        let from_binary = Jsonb::new(0, Some(&binary_data));
+        let from_binary = Jsonb::from_raw_data(&binary_data).expect(crate::alloc::ALLOC_ERR_MSG);
         assert_eq!(from_binary.to_string().unwrap(), original);
     }
 
@@ -4134,7 +4150,7 @@ world""#,
         let mut invalid = jsonb.data;
         if !invalid.is_empty() {
             invalid[0] = 0xFF; // Invalid element type
-            let jsonb = Jsonb::new(0, Some(&invalid));
+            let jsonb = Jsonb::from_raw_data(&invalid).expect(crate::alloc::ALLOC_ERR_MSG);
             assert!(jsonb.element_type().is_err());
         }
     }
@@ -4177,7 +4193,7 @@ world""#,
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // u64::MAX as payload size
             b'a', b'b', b'c', // some actual data (doesn't matter, cursor+len will overflow)
         ];
-        let jsonb = Jsonb::new(0, Some(&malformed_text));
+        let jsonb = Jsonb::from_raw_data(&malformed_text).expect(crate::alloc::ALLOC_ERR_MSG);
         let result = jsonb.to_string();
         assert!(result.is_err());
         assert!(
@@ -4192,7 +4208,7 @@ world""#,
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // u64::MAX as payload size
             0x01, // NULL element inside (doesn't matter, cursor+len will overflow)
         ];
-        let jsonb = Jsonb::new(0, Some(&malformed_array));
+        let jsonb = Jsonb::from_raw_data(&malformed_array).expect(crate::alloc::ALLOC_ERR_MSG);
         let result = jsonb.to_string();
         assert!(result.is_err());
         assert!(
@@ -4207,7 +4223,7 @@ world""#,
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // u64::MAX as payload size
             0x17, b'k', // TEXT key "k" (doesn't matter, cursor+len will overflow)
         ];
-        let jsonb = Jsonb::new(0, Some(&malformed_object));
+        let jsonb = Jsonb::from_raw_data(&malformed_object).expect(crate::alloc::ALLOC_ERR_MSG);
         let result = jsonb.to_string();
         assert!(result.is_err());
         assert!(

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -5,6 +5,7 @@ mod ops;
 pub(crate) mod path;
 pub(crate) mod vtab;
 
+use crate::alloc::TryReserveError;
 use crate::json::error::Error as JsonError;
 pub use crate::json::ops::{
     json_insert, json_patch, json_remove, json_replace, jsonb_insert, jsonb_patch, jsonb_remove,
@@ -84,7 +85,7 @@ pub fn convert_dbtype_to_raw_jsonb(data: &Value, strict: Conv) -> crate::Result<
 }
 
 pub fn json_from_raw_bytes_agg(data: &[u8], raw: bool) -> crate::Result<Value> {
-    let mut json = Jsonb::from_raw_data(data);
+    let mut json = Jsonb::from_raw_data(data)?;
     let el_type = json.element_type()?;
     json.finalize_unsafe(el_type)?;
     if raw {
@@ -107,24 +108,26 @@ fn parse_as_json_text(slice: &[u8], mode: Conv) -> crate::Result<Jsonb> {
     Jsonb::from_str_with_mode(str, mode).map_err(Into::into)
 }
 
-fn is_jsonb_blob(slice: &[u8]) -> bool {
+fn is_jsonb_blob(slice: &[u8]) -> Result<bool, TryReserveError> {
     let Ok((header, header_offset)) = JsonbHeader::from_slice(0, slice) else {
-        return false;
+        return Ok(false);
     };
     let payload_size = header.payload_size();
     let Some(total_expected) = header_offset.checked_add(payload_size) else {
-        return false;
+        return Ok(false);
     };
     if total_expected != slice.len() {
-        return false;
+        return Ok(false);
     }
 
-    let jsonb = Jsonb::from_raw_data(slice);
-    if header.is_scalar() || payload_size <= JSONB_AMBIGUOUS_PAYLOAD_MAX {
-        jsonb.is_valid()
-    } else {
-        jsonb.element_type().is_ok()
-    }
+    let jsonb = Jsonb::from_raw_data(slice)?;
+    Ok(
+        if header.is_scalar() || payload_size <= JSONB_AMBIGUOUS_PAYLOAD_MAX {
+            jsonb.is_valid()
+        } else {
+            jsonb.element_type().is_ok()
+        },
+    )
 }
 
 pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Result<Jsonb> {
@@ -167,7 +170,7 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
                         if total_expected != slice.len() {
                             parse_as_json_text(slice, strict)?
                         } else {
-                            let jsonb = Jsonb::from_raw_data(slice);
+                            let jsonb = Jsonb::from_raw_data(slice)?;
                             let is_valid_json = if payload_size <= 7 {
                                 jsonb.is_valid()
                             } else {
@@ -188,7 +191,7 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
         }
         ValueRef::Null => Ok(Jsonb::from_raw_data(
             JsonbHeader::make_null().into_bytes().as_bytes(),
-        )),
+        )?),
         ValueRef::Numeric(numeric) if matches!(strict, Conv::ToString) => {
             let text = Value::from(numeric).to_string();
             Jsonb::from_str_with_mode(&text, strict)
@@ -532,7 +535,7 @@ where
     V: AsValueRef,
     E: ExactSizeIterator<Item = V>,
 {
-    let null = Jsonb::from_raw_data(JsonbHeader::make_null().into_bytes().as_bytes());
+    let null = Jsonb::from_raw_data(JsonbHeader::make_null().into_bytes().as_bytes())?;
     if paths.len() == 1 {
         let first_path = paths.next().ok_or_else(|| {
             crate::LimboError::InternalError("paths should have one element".to_string())
@@ -838,9 +841,9 @@ where
 
 /// Tries to convert the value to jsonb. Returns Value::from_i64(1) if the conversion
 /// succeeded, and Value::from_i64(0) if it didn't.
-pub fn is_json_valid(json_value: impl AsValueRef) -> Value {
+pub fn is_json_valid(json_value: impl AsValueRef) -> Result<Value, TryReserveError> {
     let json_value = json_value.as_value_ref();
-    match json_value {
+    Ok(match json_value {
         ValueRef::Null => Value::Null,
         ValueRef::Blob(blob) => {
             let index = blob
@@ -848,18 +851,22 @@ pub fn is_json_valid(json_value: impl AsValueRef) -> Value {
                 .position(|&b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'))
                 .unwrap_or(blob.len());
             let slice = &blob[index..];
-            if is_jsonb_blob(slice) {
+            if is_jsonb_blob(slice)? {
                 Value::from_i64(0)
             } else {
-                parse_as_json_text(slice, Conv::Strict)
-                    .map(|_| Value::from_i64(1))
-                    .unwrap_or_else(|_| Value::from_i64(0))
+                match parse_as_json_text(slice, Conv::Strict) {
+                    Ok(_) => Value::from_i64(1),
+                    Err(LimboError::OutOfMemory) => return Err(TryReserveError),
+                    Err(_) => Value::from_i64(0),
+                }
             }
         }
-        _ => convert_dbtype_to_jsonb(json_value, Conv::Strict)
-            .map(|_| Value::from_i64(1))
-            .unwrap_or_else(|_| Value::from_i64(0)),
-    }
+        _ => match convert_dbtype_to_jsonb(json_value, Conv::Strict) {
+            Ok(_) => Value::from_i64(1),
+            Err(LimboError::OutOfMemory) => return Err(TryReserveError),
+            Err(_) => Value::from_i64(0),
+        },
+    })
 }
 
 pub fn json_quote(value: impl AsValueRef) -> crate::Result<Value> {
@@ -870,7 +877,7 @@ pub fn json_quote(value: impl AsValueRef) -> crate::Result<Value> {
             // then this function is a no-op
             if t.subtype == TextSubtype::Json {
                 // Should just return the json value with no quotes
-                return Ok(value.to_owned());
+                return Ok(value.to_owned()?);
             }
 
             let mut escaped_value = String::with_capacity(t.value.len() + 4);
@@ -1123,7 +1130,7 @@ mod tests {
 
     #[test]
     fn test_json_array_blob_invalid() {
-        let blob = Value::from_slice(b"1");
+        let blob = Value::from_slice(b"1").expect(crate::alloc::ALLOC_ERR_MSG);
 
         let input = [blob];
 
@@ -1877,6 +1884,6 @@ mod tests {
     fn test_is_jsonb_blob_rejects_scalar_like_overlap_header() {
         let overlapping_scalar = b"|1234567";
         assert_eq!(overlapping_scalar.len(), JSONB_AMBIGUOUS_PAYLOAD_MAX + 1);
-        assert!(!is_jsonb_blob(overlapping_scalar));
+        assert!(!is_jsonb_blob(overlapping_scalar).expect(crate::alloc::ALLOC_ERR_MSG));
     }
 }

--- a/core/json/ops.rs
+++ b/core/json/ops.rs
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "blob is not supported!")]
     fn test_blob_not_supported() {
-        let target = Value::from_slice(&[1, 2, 3]);
+        let target = Value::from_slice(&[1, 2, 3]).expect(crate::alloc::ALLOC_ERR_MSG);
         let patch = create_text("{}");
         let cache = JsonCacheCell::new();
 

--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -206,7 +206,7 @@ impl JsonEachCursor {
     fn empty(traversal_mode: JsonTraversalMode) -> Self {
         Self {
             rowid: 0,
-            json: Jsonb::new(0, None),
+            json: Jsonb::new(0),
             traversal_states: Vec::new(),
             path_to_current_value: InPlaceJsonPath::new_root(),
             columns: Columns::default(),
@@ -348,7 +348,7 @@ impl InternalVirtualTableCursor for JsonEachCursor {
         };
         match traversal_state.iterator_state {
             IteratorState::Array(state) => {
-                let Some(((idx, value), new_state)) = self.json.array_iterator_next(&state) else {
+                let Some(((idx, value), new_state)) = self.json.array_iterator_next(&state)? else {
                     self.path_to_current_value.pop();
                     return self.next();
                 };
@@ -385,7 +385,8 @@ impl InternalVirtualTableCursor for JsonEachCursor {
                 }
             }
             IteratorState::Object(state) => {
-                let Some(((_idx, key, value), new_state)) = self.json.object_iterator_next(&state)
+                let Some(((_idx, key, value), new_state)) =
+                    self.json.object_iterator_next(&state)?
                 else {
                     self.path_to_current_value.pop();
                     return self.next();
@@ -547,7 +548,7 @@ mod columns {
         fn default() -> Columns {
             Self {
                 key: Key::empty(),
-                value: Jsonb::new(0, None),
+                value: Jsonb::new(0),
                 fullkey: "".to_owned(),
                 parent_id: None,
                 innermost_container_path: "".to_owned(),

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2987,7 +2987,7 @@ pub struct BuildLocalSchemaViewStateMachine<
     connection: Arc<Connection>,
     snapshot_ts: u64,
     state: BuildLocalSchemaViewState,
-    rows: HashMap<i64, ImmutableRecord>,
+    rows: HashMap<i64, ImmutableRecordRef<'static>>,
     finalized: bool,
 }
 
@@ -3042,10 +3042,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> BuildLocalSchemaViewStateMachi
                         .data
                         .as_ref()
                         .expect("present schema version must carry row data at snapshot_ts");
-                    self.rows.insert(
-                        rowid,
-                        ImmutableRecord::from_bin_record(crate::types::value_blob_from_slice(data)),
-                    );
+                    self.rows
+                        .insert(rowid, ImmutableRecordRef::from_shared_record(data.clone()));
                 }
                 None => {
                     let existed_and_gone = versions.iter().any(|version| {
@@ -3105,7 +3103,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition
                     IOResult::Done(None) => None,
                 };
                 if let Some(record) = record {
-                    self.rows.insert(rowid, record);
+                    self.rows
+                        .insert(rowid, ImmutableRecordRef::from_owned_record(record));
                 }
                 self.state = BuildLocalSchemaViewState::Advance;
                 Ok(TransitionResult::Continue)
@@ -3185,6 +3184,18 @@ mod tests {
             btree_resident: false,
             materialized_at: crate::mvcc::database::WalPos::ORIGIN,
         }
+    }
+
+    #[test]
+    fn local_schema_record_shares_mvcc_payload() {
+        let version = sqlite_schema_row_version(2, "table", "t", "t", -2, Some(1), None);
+        let payload = version.row.data.as_ref().unwrap();
+        let payload_ptr = payload.as_ptr();
+
+        let record = ImmutableRecordRef::from_shared_record(payload.clone());
+
+        assert_eq!(record.get_payload().as_ptr(), payload_ptr);
+        assert_eq!(record.column_count(), SQLITE_SCHEMA_COLUMN_COUNT);
     }
 
     #[test]

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -8218,7 +8218,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     pub(crate) fn build_schema_from_rows(
         &self,
         connection: &Arc<Connection>,
-        schema_rows: &HashMap<i64, ImmutableRecord>,
+        schema_rows: &HashMap<i64, ImmutableRecordRef<'static>>,
         preserved_table_valued_functions: &[Arc<crate::vtab::VirtualTable>],
     ) -> Result<Arc<Schema>> {
         let pager = connection.pager.load().clone();
@@ -8657,7 +8657,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             schema_rows_after.insert(
                                 rowid.row_id.to_int_or_panic(),
                                 ImmutableRecord::from_bin_record(
-                                    crate::types::value_blob_from_slice(record_bytes),
+                                    crate::types::value_blob_from_slice(record_bytes)?,
                                 ),
                             );
                         });
@@ -8886,7 +8886,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     schema_rows.insert(
                                         rowid_int,
                                         ImmutableRecord::from_bin_record(
-                                            crate::types::value_blob_from_slice(row.payload()),
+                                            crate::types::value_blob_from_slice(row.payload())?,
                                         ),
                                     );
                                 });

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -15502,10 +15502,11 @@ fn test_mvcc_portable_changes_delete_carries_pk_projection_not_old_record() {
         _ => None,
     });
     let delete_pk_record = delete_pk_record.expect("expected data DELETE op");
-    let pk_values =
-        ImmutableRecord::from_bin_record(crate::types::value_blob_from_slice(&delete_pk_record))
-            .get_values_owned()
-            .unwrap();
+    let pk_values = ImmutableRecord::from_bin_record(
+        crate::types::value_blob_from_slice(&delete_pk_record).expect(crate::alloc::ALLOC_ERR_MSG),
+    )
+    .get_values_owned()
+    .unwrap();
     assert_eq!(
         pk_values,
         vec![Value::Text(Text::new("item-a".to_string()))]

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1261,7 +1261,7 @@ fn decode_delete_portable_extension(extension: &[u8]) -> Result<DeletePortableEx
                     ));
                 }
                 decoded.identity_record =
-                    crate::types::value_blob_from_slice(&extension[offset..end]);
+                    crate::types::value_blob_from_slice(&extension[offset..end])?;
                 offset = end;
             }
             (OP_EXT_FIELD_DELETE_PK_RECORD, 2) => {
@@ -1277,7 +1277,7 @@ fn decode_delete_portable_extension(extension: &[u8]) -> Result<DeletePortableEx
                         "delete PK record exceeds op extension".into(),
                     ));
                 }
-                decoded.pk_record = crate::types::value_blob_from_slice(&extension[offset..end]);
+                decoded.pk_record = crate::types::value_blob_from_slice(&extension[offset..end])?;
                 offset = end;
             }
             (OP_EXT_FIELD_DELETE_ROWID, 0) => {
@@ -1577,7 +1577,7 @@ fn try_parse_one_op_from_buf(buf: &[u8], commit_ts: u64) -> Result<Option<(Parse
             if rowid_len > payload.len() {
                 return Err(LimboError::Corrupt("rowid_len > payload".into()));
             }
-            let record_bytes = crate::types::value_blob_from_slice(&payload[rowid_len..]);
+            let record_bytes = crate::types::value_blob_from_slice(&payload[rowid_len..])?;
             let rowid = RowID::new(table_id, RowKey::Int(rowid_u64 as i64));
             ParsedOp::UpsertTable {
                 table_id,
@@ -1596,7 +1596,7 @@ fn try_parse_one_op_from_buf(buf: &[u8], commit_ts: u64) -> Result<Option<(Parse
                     "DELETE_TABLE payload size mismatch".into(),
                 ));
             }
-            let mut record_bytes = crate::types::value_blob_from_slice(&payload[rowid_len..]);
+            let mut record_bytes = crate::types::value_blob_from_slice(&payload[rowid_len..])?;
             let mut pk_record_bytes = crate::alloc::vec![];
             if !extension.is_empty() {
                 let decoded = decode_delete_portable_extension(extension)?;
@@ -1616,13 +1616,13 @@ fn try_parse_one_op_from_buf(buf: &[u8], commit_ts: u64) -> Result<Option<(Parse
         }
         OP_UPSERT_INDEX => ParsedOp::UpsertIndex {
             table_id: table_id.expect("index op must have table_id"),
-            payload: crate::types::value_blob_from_slice(payload),
+            payload: crate::types::value_blob_from_slice(payload)?,
             commit_ts,
             btree_resident,
         },
         OP_DELETE_INDEX => ParsedOp::DeleteIndex {
             table_id: table_id.expect("index op must have table_id"),
-            payload: crate::types::value_blob_from_slice(payload),
+            payload: crate::types::value_blob_from_slice(payload)?,
             commit_ts,
             btree_resident,
         },
@@ -3608,7 +3608,7 @@ impl StreamingLogicalLogReader {
         let buffer = self.buffer.read();
         let start = self.buffer_offset;
         let end = start + amount;
-        let bytes = crate::types::value_blob_from_slice(&buffer[start..end]);
+        let bytes = crate::types::value_blob_from_slice(&buffer[start..end])?;
         self.buffer_offset = end;
         Ok(IOResult::Done(Some(bytes)))
     }
@@ -4945,7 +4945,8 @@ mod tests {
                 rowid: 1,
                 payload: crate::types::value_blob_from_slice(
                     generate_simple_string_row((-2).into(), 1, "a").payload(),
-                ),
+                )
+                .expect(crate::alloc::ALLOC_ERR_MSG),
                 commit_ts: 1,
                 btree_resident: false,
             }
@@ -4956,7 +4957,8 @@ mod tests {
                 rowid: 2,
                 payload: crate::types::value_blob_from_slice(
                     generate_simple_string_row((-2).into(), 2, "b").payload(),
-                ),
+                )
+                .expect(crate::alloc::ALLOC_ERR_MSG),
                 commit_ts: 2,
                 btree_resident: false,
             }
@@ -5233,7 +5235,8 @@ mod tests {
                 rowid: 1,
                 payload: crate::types::value_blob_from_slice(
                     generate_simple_string_row((-2).into(), 1, "first").payload(),
-                ),
+                )
+                .expect(crate::alloc::ALLOC_ERR_MSG),
                 commit_ts: 1,
                 btree_resident: false,
             }
@@ -5373,7 +5376,8 @@ mod tests {
                 rowid: 1,
                 payload: crate::types::value_blob_from_slice(
                     generate_simple_string_row((-2).into(), 1, "a").payload(),
-                ),
+                )
+                .expect(crate::alloc::ALLOC_ERR_MSG),
                 commit_ts: 10,
                 btree_resident: false,
             }]
@@ -5749,7 +5753,8 @@ mod tests {
                     });
                     expected.push(ExpectedTableOp::Upsert {
                         rowid,
-                        payload: crate::types::value_blob_from_slice(row.payload()),
+                        payload: crate::types::value_blob_from_slice(row.payload())
+                            .expect(crate::alloc::ALLOC_ERR_MSG),
                         commit_ts: tx.tx_timestamp,
                         btree_resident,
                     });
@@ -5769,7 +5774,8 @@ mod tests {
             let row = generate_simple_string_row((-3).into(), rowid, &large_text);
             expected.push(ExpectedTableOp::Upsert {
                 rowid,
-                payload: crate::types::value_blob_from_slice(row.payload()),
+                payload: crate::types::value_blob_from_slice(row.payload())
+                    .expect(crate::alloc::ALLOC_ERR_MSG),
                 commit_ts: large_commit_ts,
                 btree_resident: false,
             });
@@ -5833,7 +5839,8 @@ mod tests {
             } else {
                 ExpectedTableOp::Upsert {
                     rowid,
-                    payload: crate::types::value_blob_from_slice(row.payload()),
+                    payload: crate::types::value_blob_from_slice(row.payload())
+                        .expect(crate::alloc::ALLOC_ERR_MSG),
                     commit_ts,
                     btree_resident,
                 }
@@ -6375,7 +6382,7 @@ mod tests {
         is_delete: bool,
     ) -> crate::mvcc::database::RowVersion {
         let sortable_key = SortableIndexKey::new_from_bytes(
-            crate::types::value_blob_from_slice(&payload_bytes),
+            crate::types::value_blob_from_slice(&payload_bytes).expect(crate::alloc::ALLOC_ERR_MSG),
             test_index_info(),
         );
         let row_id = RowID::new(table_id, RowKey::Record(Arc::new(sortable_key)));
@@ -6745,7 +6752,8 @@ mod tests {
         ParsedOp::UpsertTable {
             table_id: (-2).into(),
             rowid: RowID::new((-2).into(), RowKey::Int(rowid)),
-            record_bytes: crate::types::value_blob_from_slice(row_version.row.payload()),
+            record_bytes: crate::types::value_blob_from_slice(row_version.row.payload())
+                .expect(crate::alloc::ALLOC_ERR_MSG),
             commit_ts,
             btree_resident: false,
         }

--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -25,7 +25,7 @@ impl PseudoCursor {
     #[inline]
     pub fn get_value(&self, column: usize) -> Result<Value> {
         if let Some(record) = self.current.as_ref() {
-            Ok(record.get_value(column)?.to_owned())
+            Ok(record.get_value(column)?.to_owned()?)
         } else {
             Ok(Value::Null)
         }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10261,7 +10261,7 @@ mod tests {
                     .get_values()
                     .unwrap()
                     .iter()
-                    .map(ValueRef::to_owned)
+                    .map(|value| value.to_owned().expect(crate::alloc::ALLOC_ERR_MSG))
                     .collect::<Vec<_>>();
                 if let Some(prev) = prev {
                     if prev >= cur {
@@ -10366,7 +10366,9 @@ mod tests {
                     }
                     expected_keys.push(key.clone());
 
-                    let regs = vec![Register::Value(Value::from_slice(&key))];
+                    let regs = vec![Register::Value(
+                        Value::from_slice(&key).expect(crate::alloc::ALLOC_ERR_MSG),
+                    )];
                     let value = ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
 
                     let seek_result = run_until_done(
@@ -10397,7 +10399,9 @@ mod tests {
                             tracing::info!("delete {}/{}, seed: {seed}", i + 1, operations);
                         }
 
-                        let regs = vec![Register::Value(Value::from_slice(&key_to_delete))];
+                        let regs = vec![Register::Value(
+                            Value::from_slice(&key_to_delete).expect(crate::alloc::ALLOC_ERR_MSG),
+                        )];
                         let record = ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
 
                         // Seek to the key to delete
@@ -10457,7 +10461,9 @@ mod tests {
             );
             let exists = run_until_done(
                 || {
-                    let regs = vec![Register::Value(Value::from_slice(key))];
+                    let regs = vec![Register::Value(
+                        Value::from_slice(key).expect(crate::alloc::ALLOC_ERR_MSG),
+                    )];
                     cursor.seek(
                         SeekKey::IndexKey(
                             &ImmutableRecord::from_registers(&regs, regs.len()).unwrap(),

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -2226,8 +2226,16 @@ mod tests {
     #[case(&[0x40, 0x09, 0x21, 0xFB, 0x54, 0x44, 0x2D, 0x18], SerialType::f64(), Value::from_f64(std::f64::consts::PI))]
     #[case(&[1, 2], SerialType::const_int0(), Value::from_i64(0))]
     #[case(&[65, 66], SerialType::const_int1(), Value::from_i64(1))]
-    #[case(&[1, 2, 3], SerialType::blob(3), Value::from_slice(&[1, 2, 3]))]
-    #[case(&[], SerialType::blob(0), Value::from_slice(&[]))] // empty blob
+    #[case(
+        &[1, 2, 3],
+        SerialType::blob(3),
+        Value::from_slice(&[1, 2, 3]).expect(crate::alloc::ALLOC_ERR_MSG)
+    )]
+    #[case(
+        &[],
+        SerialType::blob(0),
+        Value::from_slice(&[]).expect(crate::alloc::ALLOC_ERR_MSG)
+    )] // empty blob
     #[case(&[65, 66, 67], SerialType::text(3), Value::build_text("ABC"))]
     #[case(&[0x80], SerialType::i8(), Value::from_i64(-128))]
     #[case(&[0x80, 0], SerialType::i16(), Value::from_i64(-32768))]
@@ -2247,7 +2255,10 @@ mod tests {
         #[case] expected: Value,
     ) {
         let result = read_value(buf, serial_type).unwrap();
-        assert_eq!(result.0.to_owned(), expected);
+        assert_eq!(
+            result.0.to_owned().expect(crate::alloc::ALLOC_ERR_MSG),
+            expected
+        );
     }
 
     #[test]

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -31,7 +31,7 @@ use crate::{
         insn::{to_u16, CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
     },
     vtab::VirtualTable,
-    LimboError, Numeric, Result, Value,
+    LimboError, Numeric, Result, Value, ValueRef,
 };
 use either::Either;
 use rustc_hash::FxHashSet as HashSet;
@@ -471,7 +471,10 @@ pub(crate) fn eval_constant_default_value(expr: &ast::Expr) -> Result<Value> {
 fn apply_affinity_to_value(value: &mut Value, affinity: Affinity) {
     if let Some(converted) = affinity.convert(value) {
         *value = match converted {
-            Either::Left(val_ref) => val_ref.to_owned(),
+            Either::Left(ValueRef::Numeric(numeric)) => Value::from(numeric),
+            Either::Left(_) => {
+                unreachable!("affinity conversion returned an unexpected borrowed value")
+            }
             Either::Right(val) => val,
         };
     }

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -1931,7 +1931,7 @@ impl<'a> LogicalPlanBuilder<'a> {
                 };
                 Ok(Value::Text(unquoted.to_string().into()))
             }
-            ast::Literal::Blob(b) => Ok(Value::from_slice(b.as_bytes())),
+            ast::Literal::Blob(b) => Ok(Value::from_slice(b.as_bytes())?),
             ast::Literal::CurrentDate
             | ast::Literal::CurrentTime
             | ast::Literal::CurrentTimestamp => Err(LimboError::ParseError(

--- a/core/types.rs
+++ b/core/types.rs
@@ -184,9 +184,9 @@ impl<T: AnyBlob> Extendable<T> for ValueBlob {
                 self.set_len(needed);
             }
         } else {
+            // Reserve before mutation so an allocation failure leaves the old value intact.
+            self.try_reserve(needed - self.len())?;
             self.clear();
-            // Reserve mores space to extend the slice
-            self.try_reserve(self.len().abs_diff(needed))?;
             self.extend_from_slice(other_slice);
         }
         Ok(())
@@ -275,8 +275,10 @@ impl From<Text> for String {
 pub type ValueBlob = crate::alloc::Vec<u8>;
 
 #[inline]
-pub(crate) fn value_blob_from_slice(bytes: &[u8]) -> ValueBlob {
-    bytes.try_to_vec().expect(ALLOC_ERR_MSG)
+pub(crate) fn value_blob_from_slice(
+    bytes: &[u8],
+) -> std::result::Result<ValueBlob, crate::alloc::TryReserveError> {
+    bytes.try_to_vec()
 }
 
 #[cfg(feature = "serde")]
@@ -464,8 +466,9 @@ impl Value {
     }
 
     #[inline]
-    pub fn from_slice(data: &[u8]) -> Self {
-        Value::Blob(value_blob_from_slice(data))
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::FromSlice)]
+    pub fn from_slice(data: &[u8]) -> std::result::Result<Self, TryReserveError> {
+        Ok(Value::Blob(value_blob_from_slice(data)?))
     }
 
     pub fn to_text(&self) -> Option<&str> {
@@ -637,7 +640,7 @@ impl Value {
                 let Some(blob) = v.to_blob() else {
                     return Ok(Value::Null);
                 };
-                Ok(Value::from_slice(&blob))
+                Ok(Value::from_slice(&blob)?)
             }
             ExtValueType::Error => {
                 let Some(err) = v.to_error_details() else {
@@ -995,8 +998,10 @@ impl std::ops::DivAssign<Value> for Value {
     }
 }
 
-impl From<ValueRef<'_>> for Value {
-    fn from(value: ValueRef<'_>) -> Self {
+impl TryFrom<ValueRef<'_>> for Value {
+    type Error = TryReserveError;
+
+    fn try_from(value: ValueRef<'_>) -> std::result::Result<Self, Self::Error> {
         value.to_owned()
     }
 }
@@ -1107,14 +1112,21 @@ mod immutable_record {
         }
     }
 
-    #[derive(Clone, Copy)]
+    #[derive(Clone)]
     pub struct ImmutableRecordRef<'a> {
-        payload: &'a [u8],
+        payload: ImmutableRecordRefPayload<'a>,
+    }
+
+    #[derive(Clone)]
+    enum ImmutableRecordRefPayload<'a> {
+        Borrowed(&'a [u8]),
+        Owned(ValueBlob),
+        Shared(crate::alloc::ArcSlice<u8>),
     }
 
     impl std::fmt::Debug for ImmutableRecordRef<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            let bytes = self.payload;
+            let bytes = self.get_payload();
             let preview = if bytes.len() > 20 {
                 format!("{:?} ... ({} bytes total)", &bytes[..20], bytes.len())
             } else {
@@ -1236,7 +1248,7 @@ mod immutable_record {
     fn values_owned(payload: &[u8]) -> Result<Vec<Value>> {
         let iter = iter(payload).expect("Failed to create payload iterator");
         let values = iter
-            .map(|v| Ok::<_, LimboError>(v?.to_owned()))
+            .map(|v| Ok::<_, LimboError>(v?.to_owned()?))
             .try_collect::<Result<_>>()??;
         Ok(values)
     }
@@ -1245,13 +1257,13 @@ mod immutable_record {
         let mut iter = iter(payload).expect("Failed to create payload iterator");
         let mut values = Vec::try_with_capacity_ext(range.end - range.start)?;
         if let Some(value) = iter.nth(range.start) {
-            values.push(value?.to_owned());
+            values.push(value?.to_owned()?);
         } else {
             return Ok(values);
         }
         for _ in range.start + 1..range.end {
             if let Some(value) = iter.next() {
-                values.push(value?.to_owned());
+                values.push(value?.to_owned()?);
             } else {
                 break;
             }
@@ -1427,20 +1439,20 @@ mod immutable_record {
 
     impl<'a> ImmutableRecordRef<'a> {
         #[inline(always)]
-        pub fn iter(&self) -> Result<ValueIterator<'a>, LimboError> {
-            iter(self.payload)
+        pub fn iter(&self) -> Result<ValueIterator<'_>, LimboError> {
+            iter(self.get_payload())
         }
 
-        pub fn get_values(&self) -> Result<Vec<ValueRef<'a>>> {
-            values(self.payload)
+        pub fn get_values(&self) -> Result<Vec<ValueRef<'_>>> {
+            values(self.get_payload())
         }
 
         pub fn get_two_values(
             &self,
             idx1: usize,
             idx2: usize,
-        ) -> Result<(ValueRef<'a>, ValueRef<'a>)> {
-            two_values(self.payload, idx1, idx2)
+        ) -> Result<(ValueRef<'_>, ValueRef<'_>)> {
+            two_values(self.get_payload(), idx1, idx2)
         }
 
         pub fn get_three_values(
@@ -1453,16 +1465,16 @@ mod immutable_record {
         }
 
         pub fn get_values_owned(&self) -> Result<Vec<Value>> {
-            values_owned(self.payload)
+            values_owned(self.get_payload())
         }
 
         #[inline]
-        pub fn get_value_opt(&self, idx: usize) -> Option<ValueRef<'a>> {
-            value_opt(self.payload, idx)
+        pub fn get_value_opt(&self, idx: usize) -> Option<ValueRef<'_>> {
+            value_opt(self.get_payload(), idx)
         }
 
         pub fn column_count(&self) -> usize {
-            column_count(self.payload)
+            column_count(self.get_payload())
         }
     }
 
@@ -1634,17 +1646,37 @@ mod immutable_record {
 
     impl<'a> ImmutableRecordRef<'a> {
         pub const fn from_bin_record(payload: &'a [u8]) -> Self {
-            Self { payload }
+            Self {
+                payload: ImmutableRecordRefPayload::Borrowed(payload),
+            }
+        }
+
+        pub(crate) fn from_owned_record(record: ImmutableRecord) -> ImmutableRecordRef<'static> {
+            ImmutableRecordRef {
+                payload: ImmutableRecordRefPayload::Owned(record.into_payload()),
+            }
+        }
+
+        pub(crate) fn from_shared_record(
+            payload: crate::alloc::ArcSlice<u8>,
+        ) -> ImmutableRecordRef<'static> {
+            ImmutableRecordRef {
+                payload: ImmutableRecordRefPayload::Shared(payload),
+            }
         }
 
         #[inline]
-        pub const fn get_payload(&self) -> &'a [u8] {
-            self.payload
+        pub fn get_payload(&self) -> &[u8] {
+            match &self.payload {
+                ImmutableRecordRefPayload::Borrowed(payload) => payload,
+                ImmutableRecordRefPayload::Owned(payload) => payload,
+                ImmutableRecordRefPayload::Shared(payload) => payload,
+            }
         }
 
         #[inline]
-        pub const fn is_invalidated(&self) -> bool {
-            self.payload.is_empty()
+        pub fn is_invalidated(&self) -> bool {
+            self.get_payload().is_empty()
         }
     }
 }
@@ -1978,16 +2010,16 @@ impl<'a> ValueRef<'a> {
     }
 
     #[inline]
-    pub fn to_owned(&self) -> Value {
-        match self {
+    pub fn to_owned(&self) -> std::result::Result<Value, TryReserveError> {
+        Ok(match self {
             ValueRef::Null => Value::Null,
             ValueRef::Numeric(n) => Value::from(*n),
             ValueRef::Text(text) => Value::Text(Text {
                 value: text.value.to_string().into(),
                 subtype: text.subtype,
             }),
-            ValueRef::Blob(b) => Value::from_slice(b),
-        }
+            ValueRef::Blob(b) => return Value::from_slice(b),
+        })
     }
 
     pub fn value_type(&self) -> ValueType {
@@ -3403,7 +3435,8 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn value_blob_serde_preserves_sequence_format() {
-        let encoded = serde_json::to_string(&Value::from_slice(&[1, 2, 3, 4])).unwrap();
+        let value = Value::from_slice(&[1, 2, 3, 4]).expect(crate::alloc::ALLOC_ERR_MSG);
+        let encoded = serde_json::to_string(&value).unwrap();
         assert_eq!(encoded, r#"{"Blob":[1,2,3,4]}"#);
 
         let decoded: Value = serde_json::from_str(&encoded).unwrap();
@@ -3458,7 +3491,7 @@ mod tests {
             Value::from_i64(100),
             Value::from_f64(std::f64::consts::PI),
             Value::Text(Text::new("test")),
-            Value::from_slice(&[1, 2, 3]),
+            Value::from_slice(&[1, 2, 3]).expect(crate::alloc::ALLOC_ERR_MSG),
             Value::from_i64(0),
             Value::from_i64(1),
         ]);
@@ -3979,7 +4012,7 @@ mod tests {
                 "large_field_count",
             ),
             (
-                vec![Value::from_slice(&[1, 2, 3])],
+                vec![Value::from_slice(&[1, 2, 3]).expect(crate::alloc::ALLOC_ERR_MSG)],
                 vec![ValueRef::Blob(&[1, 2, 3])],
                 "blob_first_field",
             ),
@@ -4269,7 +4302,9 @@ mod tests {
     #[test]
     fn test_serialize_blob() {
         let blob = std::vec![1, 2, 3, 4, 5];
-        let record = Record::new(vec![Value::from_slice(&blob)]);
+        let record = Record::new(vec![
+            Value::from_slice(&blob).expect(crate::alloc::ALLOC_ERR_MSG)
+        ]);
         let mut buf = std::vec::Vec::new();
         record.serialize(&mut buf);
 

--- a/core/vdbe/array.rs
+++ b/core/vdbe/array.rs
@@ -12,7 +12,7 @@ pub(crate) fn array_values_from_blob(blob: &[u8]) -> Result<Vec<Value>> {
     let iter = ValueIterator::new(blob)?;
     let mut values = Vec::with_capacity(iter.size_hint().0);
     for value in iter {
-        values.push(value?.to_owned());
+        values.push(value?.to_owned()?);
     }
     Ok(values)
 }
@@ -701,7 +701,7 @@ mod tests {
     #[test]
     fn test_compute_array_length_invalid_blob_returns_none() {
         // A random blob that is not a valid record should return None
-        let invalid = Value::from_slice(&[0xFF, 0xFE, 0xFD]);
+        let invalid = Value::from_slice(&[0xFF, 0xFE, 0xFD]).expect(crate::alloc::ALLOC_ERR_MSG);
         assert_eq!(compute_array_length(&invalid), None);
     }
 

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,4 +1,4 @@
-use crate::{alloc, turso_assert, turso_assert_eq, turso_debug_assert, Result};
+use crate::{alloc, turso_assert, turso_assert_eq, turso_debug_assert, Result, Value, ValueRef};
 
 use rustc_hash::FxHashMap as HashMap;
 use tracing::{instrument, Level};
@@ -1940,7 +1940,10 @@ impl ProgramBuilder {
             };
             if let Some(converted) = affinity.convert(&value) {
                 value = match converted {
-                    either::Either::Left(val_ref) => val_ref.to_owned(),
+                    either::Either::Left(ValueRef::Numeric(numeric)) => Value::from(numeric),
+                    either::Either::Left(_) => {
+                        unreachable!("affinity conversion returned an unexpected borrowed value")
+                    }
                     either::Either::Right(val) => val,
                 };
             }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -235,8 +235,8 @@ fn make_sort_comparator(
                     (_, ValueRef::Null) => Ordering::Greater,
                     _ => {
                         // Decode from ValueRef to Value for value_to_bigdecimal
-                        let a_val = a.to_owned();
-                        let b_val = b.to_owned();
+                        let a_val = a.to_owned()?;
+                        let b_val = b.to_owned()?;
                         match (value_to_bigdecimal(&a_val), value_to_bigdecimal(&b_val)) {
                             (Ok(a_dec), Ok(b_dec)) => a_dec.cmp(&b_dec),
                             _ => a.partial_cmp(b).unwrap_or(Ordering::Equal),
@@ -1063,15 +1063,15 @@ pub fn op_comparison(
 
     match (new_lhs, new_rhs) {
         (Some(new_lhs), None) => {
-            state.registers[lhs].set_value(new_lhs.as_value_ref().to_owned());
+            state.registers[lhs].set_value(new_lhs.as_value_ref().to_owned()?);
         }
         (None, Some(new_rhs)) => {
-            state.registers[rhs].set_value(new_rhs.as_value_ref().to_owned());
+            state.registers[rhs].set_value(new_rhs.as_value_ref().to_owned()?);
         }
         (Some(new_lhs), Some(new_rhs)) => {
             let (new_lhs, new_rhs) = (
-                new_lhs.as_value_ref().to_owned(),
-                new_rhs.as_value_ref().to_owned(),
+                new_lhs.as_value_ref().to_owned()?,
+                new_rhs.as_value_ref().to_owned()?,
             );
             state.registers[lhs].set_value(new_lhs);
             state.registers[rhs].set_value(new_rhs);
@@ -1932,7 +1932,7 @@ pub fn op_column(
                         };
                         if let Some(record) = record {
                             state.registers[*dest].set_value(match record.get_value_opt(*column) {
-                                Some(val) => val.to_owned(),
+                                Some(val) => val.to_owned()?,
                                 None => default.clone().unwrap_or(Value::Null),
                             });
                         } else {
@@ -2296,6 +2296,7 @@ pub fn op_array_element(
                     }
                     vref.to_owned()
                 })
+                .transpose()?
                 .unwrap_or(Value::Null),
             Err(_) => Value::Null,
         },
@@ -5406,7 +5407,7 @@ pub fn seek_internal(
                         let new_val = apply_numeric_affinity(temp_value.as_value_ref(), false);
                         let converted = new_val.is_some();
                         if let Some(new_val) = new_val {
-                            temp_value = new_val.to_owned();
+                            temp_value = new_val.to_owned()?;
                         }
                         converted
                     } else {
@@ -7462,7 +7463,7 @@ pub fn op_function(
             }
             JsonFunc::JsonValid => {
                 let json_value = &state.registers[*start_reg];
-                state.registers[*dest].set_value(is_json_valid(json_value.get_value()));
+                state.registers[*dest].set_value(is_json_valid(json_value.get_value())?);
             }
             JsonFunc::JsonPatch => {
                 assert_eq!(arg_count, 2);
@@ -7625,7 +7626,7 @@ pub fn op_function(
                 };
                 let result = reg_value_argument
                     .get_value()
-                    .exec_cast(reg_value_type.as_str());
+                    .exec_cast(reg_value_type.as_str())?;
                 state.registers[*dest].set_value(result);
             }
             ScalarFunc::Changes => {
@@ -7669,7 +7670,7 @@ pub fn op_function(
                 } else {
                     let pattern_cow = match pattern_value {
                         Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
-                        v => match v.exec_cast("TEXT") {
+                        v => match v.exec_cast("TEXT")? {
                             Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                             _ => unreachable!("Cast to TEXT should yield Text"),
                         },
@@ -7677,7 +7678,7 @@ pub fn op_function(
 
                     let match_cow = match match_value {
                         Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
-                        v => match v.exec_cast("TEXT") {
+                        v => match v.exec_cast("TEXT")? {
                             Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                             _ => unreachable!("Cast to TEXT should yield Text"),
                         },
@@ -7724,7 +7725,7 @@ pub fn op_function(
                             _ => {
                                 let escape_cow = match escape_value {
                                     Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
-                                    v => match v.exec_cast("TEXT") {
+                                    v => match v.exec_cast("TEXT")? {
                                         Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                                         _ => unreachable!("Cast to TEXT should yield Text"),
                                     },
@@ -7748,7 +7749,7 @@ pub fn op_function(
                         // 3. Prepare Pattern and Text
                         let pattern_cow = match pattern_value {
                             Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
-                            v => match v.exec_cast("TEXT") {
+                            v => match v.exec_cast("TEXT")? {
                                 Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                                 _ => unreachable!("Cast to TEXT should yield Text"),
                             },
@@ -7756,7 +7757,7 @@ pub fn op_function(
 
                         let match_cow = match match_value {
                             Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
-                            v => match v.exec_cast("TEXT") {
+                            v => match v.exec_cast("TEXT")? {
                                 Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                                 _ => unreachable!("Cast to TEXT should yield Text"),
                             },
@@ -8001,7 +8002,7 @@ pub fn op_function(
                     str_value.get_value(),
                     start_value.get_value(),
                     length_value.map(|x| x.get_value()),
-                );
+                )?;
                 state.registers[*dest].set_value(result);
             }
             ScalarFunc::Date => {
@@ -8083,7 +8084,7 @@ pub fn op_function(
                     source.get_value(),
                     pattern.get_value(),
                     replacement.get_value(),
-                ));
+                )?);
             }
             #[cfg(feature = "fs")]
             #[cfg(not(target_family = "wasm"))]
@@ -13377,11 +13378,10 @@ pub fn op_concat(
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Concat { lhs, rhs, dest }, insn);
-    state.registers[*dest].set_value(
-        state.registers[*lhs]
-            .get_value()
-            .exec_concat(state.registers[*rhs].get_value()),
-    );
+    let value = state.registers[*lhs]
+        .get_value()
+        .exec_concat(state.registers[*rhs].get_value())?;
+    state.registers[*dest].set_value(value);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -14116,7 +14116,7 @@ pub fn op_cast(
         Affinity::Numeric => value.exec_cast("NUMERIC"),
         Affinity::Integer => value.exec_cast("INTEGER"),
         Affinity::Real => value.exec_cast("REAL"),
-    };
+    }?;
 
     state.registers[*reg].set_value(result);
     state.pc += 1;

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -543,7 +543,7 @@ impl HashEntry {
                     ));
                 }
                 let b =
-                    crate::types::value_blob_from_slice(&buf[offset..offset + blob_len as usize]);
+                    crate::types::value_blob_from_slice(&buf[offset..offset + blob_len as usize])?;
                 offset += blob_len as usize;
                 Value::Blob(b)
             }
@@ -3548,7 +3548,10 @@ mod hashtests {
                 Value::from_f64(std::f64::consts::PI),
             ],
             100,
-            vec![Value::from_slice(&[1, 2, 3, 4, 5]), Value::from_i64(-999)],
+            vec![
+                Value::from_slice(&[1, 2, 3, 4, 5]).expect(crate::alloc::ALLOC_ERR_MSG),
+                Value::from_i64(-999),
+            ],
         );
 
         // Serialize using the Vec-based method
@@ -4256,7 +4259,10 @@ mod hashtests {
         // Insert entry with blob payload
         let key = vec![Value::from_i64(1)];
         let blob_data = std::vec![0xDE, 0xAD, 0xBE, 0xEF];
-        let payload = vec![Value::from_slice(&blob_data), Value::from_i64(42)];
+        let payload = vec![
+            Value::from_slice(&blob_data).expect(crate::alloc::ALLOC_ERR_MSG),
+            Value::from_i64(42),
+        ];
         let _ = ht.insert(key.clone(), 100, payload, None).unwrap();
 
         let _ = ht.finalize_build(None);
@@ -4265,7 +4271,10 @@ mod hashtests {
         assert!(result.is_some());
         let entry = result.unwrap();
         assert_eq!(entry.payload_values.len(), 2);
-        assert_eq!(entry.payload_values[0], Value::from_slice(&blob_data));
+        assert_eq!(
+            entry.payload_values[0],
+            Value::from_slice(&blob_data).expect(crate::alloc::ALLOC_ERR_MSG)
+        );
         assert_eq!(entry.payload_values[1], Value::from_i64(42));
     }
 
@@ -4347,7 +4356,7 @@ mod hashtests {
                 Value::from_i64(999),
                 Value::from_f64(std::f64::consts::PI),
                 Value::Null,
-                Value::from_slice(&[1, 2, 3, 4]),
+                Value::from_slice(&[1, 2, 3, 4]).expect(crate::alloc::ALLOC_ERR_MSG),
             ],
         );
 
@@ -4378,7 +4387,7 @@ mod hashtests {
         assert_eq!(deserialized.payload_values[3], Value::Null);
         assert_eq!(
             deserialized.payload_values[4],
-            Value::from_slice(&[1, 2, 3, 4])
+            Value::from_slice(&[1, 2, 3, 4]).expect(crate::alloc::ALLOC_ERR_MSG)
         );
     }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3083,7 +3083,7 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 ))));
             }
             // BLOB (n >= 12 && n & 1 == 0)
-            n if n >= 12 && n & 1 == 0 => {
+            n if n >= 12 && n & 1 == 0 => crate::with_value_blob_allocation_site!(RecordDecode, {
                 let content_size = ((n - 12) / 2) as usize;
                 if unlikely(data.len() < content_size) {
                     return Some(Err(LimboError::Corrupt("Invalid Blob value".into())));
@@ -3097,14 +3097,16 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                         }
                     }
                     _ => {
-                        if let Err(err) =
-                            dest.set_blob(crate::types::value_blob_from_slice(blob_data))
-                        {
+                        let blob = match crate::types::value_blob_from_slice(blob_data) {
+                            Ok(blob) => blob,
+                            Err(err) => return Some(Err(err.into())),
+                        };
+                        if let Err(err) = dest.set_blob(blob) {
                             return Some(Err(err));
                         }
                     }
                 }
-            }
+            }),
             // TEXT (n >= 13 && n & 1 == 1)
             n if n >= 13 && n & 1 == 1 => {
                 let content_size = ((n - 13) / 2) as usize;

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -457,7 +457,7 @@ impl Value {
         value: &Value,
         start_value: &Value,
         length_value: Option<&Value>,
-    ) -> Value {
+    ) -> std::result::Result<Value, crate::alloc::TryReserveError> {
         /// Function is stabilized but not released for version 1.88 \
         /// https://doc.rust-lang.org/src/core/str/mod.rs.html#453
         const fn ceil_char_boundary(s: &str, index: usize) -> usize {
@@ -538,18 +538,20 @@ impl Value {
             (start, end)
         }
 
-        let start_value = start_value.exec_cast("INT");
-        let length_value = length_value.map(|value| value.exec_cast("INT"));
+        let start_value = start_value.exec_cast("INT")?;
+        let length_value = length_value
+            .map(|value| value.exec_cast("INT"))
+            .transpose()?;
 
         // If length is explicitly NULL, return NULL (SQLite behavior)
         if matches!(length_value, Some(Value::Null)) {
-            return Value::Null;
+            return Ok(Value::Null);
         }
 
-        match (value, start_value) {
+        Ok(match (value, start_value) {
             (Value::Blob(b), Value::Numeric(Numeric::Integer(start))) => {
                 let (start, end) = calculate_postions(start, b.len(), length_value.as_ref());
-                Value::from_slice(&b[start..end])
+                return Value::from_slice(&b[start..end]);
             }
             (value, Value::Numeric(Numeric::Integer(start))) => {
                 if let Some(text) = value.cast_text() {
@@ -577,7 +579,7 @@ impl Value {
                 }
             }
             _ => Value::Null,
-        }
+        })
     }
 
     pub fn exec_instr(&self, pattern: &Value) -> Value {
@@ -880,21 +882,24 @@ impl Value {
             .unwrap_or(jump_if_null)
     }
 
-    pub fn exec_cast(&self, datatype: &str) -> Value {
+    pub fn exec_cast(
+        &self,
+        datatype: &str,
+    ) -> std::result::Result<Value, crate::alloc::TryReserveError> {
         if matches!(self, Value::Null) {
-            return Value::Null;
+            return Ok(Value::Null);
         }
-        match Affinity::affinity(datatype) {
+        Ok(match Affinity::affinity(datatype) {
             // NONE	Casting a value to a type-name with no affinity causes the value to be converted into a BLOB. Casting to a BLOB consists of first casting the value to TEXT in the encoding of the database connection, then interpreting the resulting byte sequence as a BLOB instead of as TEXT.
             // Historically called NONE, but it's the same as BLOB
             Affinity::Blob => {
                 if let Value::Blob(blob) = self {
-                    return Value::Blob(blob.clone());
+                    return Ok(Value::Blob(blob.clone()));
                 }
                 // Convert to TEXT first, then interpret as BLOB
                 // TODO: handle encoding
                 let text = self.to_string();
-                Value::from_slice(text.as_bytes())
+                return Value::from_slice(text.as_bytes());
             }
             // TEXT To cast a BLOB value to TEXT, the sequence of bytes that make up the BLOB is interpreted as text encoded using the database encoding.
             // Casting an INTEGER or REAL value into TEXT renders the value as if via sqlite3_snprintf() except that the resulting TEXT uses the encoding of the database connection.
@@ -947,10 +952,14 @@ impl Value {
                         .unwrap_or_else(|| Value::from_i64(0))
                 }
             },
-        }
+        })
     }
 
-    pub fn exec_replace(source: &Value, pattern: &Value, replacement: &Value) -> Value {
+    pub fn exec_replace(
+        source: &Value,
+        pattern: &Value,
+        replacement: &Value,
+    ) -> std::result::Result<Value, crate::alloc::TryReserveError> {
         // The replace(X,Y,Z) function returns a string formed by substituting string Z for every occurrence of
         // string Y in string X. The BINARY collating sequence is used for comparisons. If Y is an empty string
         // then return X unchanged. If Z is not initially a string, it is cast to a UTF-8 string prior to processing.
@@ -960,24 +969,24 @@ impl Value {
             || matches!(pattern, Value::Null)
             || matches!(replacement, Value::Null)
         {
-            return Value::Null;
+            return Ok(Value::Null);
         }
 
-        let source = source.exec_cast("TEXT");
-        let pattern = pattern.exec_cast("TEXT");
-        let replacement = replacement.exec_cast("TEXT");
+        let source = source.exec_cast("TEXT")?;
+        let pattern = pattern.exec_cast("TEXT")?;
+        let replacement = replacement.exec_cast("TEXT")?;
 
         // If any of the casts failed, panic as text casting is not expected to fail.
         match (&source, &pattern, &replacement) {
             (Value::Text(source), Value::Text(pattern), Value::Text(replacement)) => {
                 if pattern.as_str().is_empty() || pattern.as_str().starts_with('\0') {
-                    return Value::Text(source.clone());
+                    return Ok(Value::Text(source.clone()));
                 }
 
                 let result = source
                     .as_str()
                     .replace(pattern.as_str(), replacement.as_str());
-                Value::build_text(result)
+                Ok(Value::build_text(result))
             }
             _ => unreachable!("text cast should never fail"),
         }
@@ -1151,25 +1160,30 @@ impl Value {
         }
     }
 
-    pub fn exec_concat(&self, rhs: &Value) -> Value {
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::Concat)]
+    pub fn exec_concat(
+        &self,
+        rhs: &Value,
+    ) -> std::result::Result<Value, crate::alloc::TryReserveError> {
         if let (Value::Blob(lhs), Value::Blob(rhs)) = (self, rhs) {
-            let mut blob = <crate::ValueBlob as crate::alloc::TursoVecExt<u8>>::with_capacity(
-                lhs.len() + rhs.len(),
-            );
+            let mut blob =
+                <crate::ValueBlob as crate::alloc::TursoTryWithCapacityExt>::try_with_capacity_ext(
+                    lhs.len() + rhs.len(),
+                )?;
             blob.extend_from_slice(lhs);
             blob.extend_from_slice(rhs);
-            return Value::Blob(blob);
+            return Ok(Value::Blob(blob));
         }
 
         let Some(lhs) = self.cast_text() else {
-            return Value::Null;
+            return Ok(Value::Null);
         };
 
         let Some(rhs) = rhs.cast_text() else {
-            return Value::Null;
+            return Ok(Value::Null);
         };
 
-        Value::build_text(lhs + &rhs)
+        Ok(Value::build_text(lhs + &rhs))
     }
 
     pub fn exec_and(&self, rhs: &Value) -> Value {
@@ -1640,6 +1654,22 @@ mod tests {
 
     use rand::{Rng, RngCore};
 
+    fn blob(bytes: &[u8]) -> Value {
+        Value::from_slice(bytes).expect(crate::alloc::ALLOC_ERR_MSG)
+    }
+
+    fn allocated(result: std::result::Result<Value, crate::alloc::TryReserveError>) -> Value {
+        result.expect(crate::alloc::ALLOC_ERR_MSG)
+    }
+
+    #[test]
+    fn exec_concat_builds_blob_fallibly() {
+        let lhs = blob(&[1, 2]);
+        let rhs = blob(&[3, 4]);
+
+        assert_eq!(lhs.exec_concat(&rhs).unwrap(), blob(&[1, 2, 3, 4]));
+    }
+
     #[test]
     fn test_exec_add() {
         let inputs = vec![
@@ -2008,7 +2038,7 @@ mod tests {
         let expected_len = Value::from_i64(7);
         assert_eq!(input_float.exec_length(), expected_len);
 
-        let expected_blob = Value::from_slice(b"example");
+        let expected_blob = blob(b"example");
         let expected_len = Value::from_i64(7);
         assert_eq!(expected_blob.exec_length(), expected_len);
     }
@@ -2058,7 +2088,7 @@ mod tests {
         let expected: Value = Value::build_text("text");
         assert_eq!(input.exec_typeof(), expected);
 
-        let input = Value::from_slice(b"limbo");
+        let input = blob(b"limbo");
         let expected: Value = Value::build_text("blob");
         assert_eq!(input.exec_typeof(), expected);
     }
@@ -2077,10 +2107,7 @@ mod tests {
         assert_eq!(Value::from_f64(0.0).exec_unicode(), Value::from_i64(48));
         assert_eq!(Value::from_f64(23.45).exec_unicode(), Value::from_i64(50));
         assert_eq!(Value::Null.exec_unicode(), Value::Null);
-        assert_eq!(
-            Value::from_slice(b"example").exec_unicode(),
-            Value::from_i64(101)
-        );
+        assert_eq!(blob(b"example").exec_unicode(), Value::from_i64(101));
     }
 
     #[test]
@@ -2173,7 +2200,7 @@ mod tests {
             Value::build_text("1.5")
         );
         assert_eq!(
-            Value::from_slice(&[0xDE, 0xAD]).exec_unistr_quote(),
+            blob(&[0xDE, 0xAD]).exec_unistr_quote(),
             Value::build_text("X'DEAD'")
         );
         assert_eq!(
@@ -2456,27 +2483,27 @@ mod tests {
         let expected_val = Value::build_text("31322E3334");
         assert_eq!(input_float.exec_hex(), expected_val);
 
-        let input_blob = Value::from_slice(&[0xff]);
+        let input_blob = blob(&[0xff]);
         let expected_val = Value::build_text("FF");
         assert_eq!(input_blob.exec_hex(), expected_val);
     }
 
     #[test]
     fn test_cast_blob_preserves_blob_bytes() {
-        let input_blob = Value::from_slice(&[0xd2, 0x64, 0xc0, 0x07, 0xf6, 0x44, 0xe4, 0x59]);
+        let input_blob = blob(&[0xd2, 0x64, 0xc0, 0x07, 0xf6, 0x44, 0xe4, 0x59]);
         let expected = input_blob.clone();
 
-        assert_eq!(input_blob.exec_cast("BLOB"), expected);
+        assert_eq!(allocated(input_blob.exec_cast("BLOB")), expected);
     }
 
     #[test]
     fn test_unhex() {
         let input = Value::build_text("6f");
-        let expected = Value::from_slice(&[0x6f]);
+        let expected = blob(&[0x6f]);
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("6f");
-        let expected = Value::from_slice(&[0x6f]);
+        let expected = blob(&[0x6f]);
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("611");
@@ -2484,7 +2511,7 @@ mod tests {
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("");
-        let expected = Value::from_slice(&[]);
+        let expected = blob(&[]);
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("61x");
@@ -2496,19 +2523,19 @@ mod tests {
         assert_eq!(input.exec_unhex(None), expected);
 
         let input = Value::build_text("aa-bb");
-        let expected = Value::from_slice(&[0xaa, 0xbb]);
+        let expected = blob(&[0xaa, 0xbb]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
 
         let input = Value::build_text("aa--bb");
-        let expected = Value::from_slice(&[0xaa, 0xbb]);
+        let expected = blob(&[0xaa, 0xbb]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
 
         let input = Value::build_text("aa-bb-cc");
-        let expected = Value::from_slice(&[0xaa, 0xbb, 0xcc]);
+        let expected = blob(&[0xaa, 0xbb, 0xcc]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
 
         let input = Value::build_text("aa bb");
-        let expected = Value::from_slice(&[0xaa, 0xbb]);
+        let expected = blob(&[0xaa, 0xbb]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text(" "))), expected);
 
         let input = Value::build_text("A BCD");
@@ -2807,7 +2834,11 @@ mod tests {
         let length_value = Value::from_i64(3);
         let expected_val = Value::build_text("lim");
         assert_eq!(
-            Value::exec_substring(&str_value, &start_value, Some(&length_value)),
+            allocated(Value::exec_substring(
+                &str_value,
+                &start_value,
+                Some(&length_value),
+            )),
             expected_val
         );
 
@@ -2816,7 +2847,11 @@ mod tests {
         let length_value = Value::from_i64(10);
         let expected_val = Value::build_text("limbo");
         assert_eq!(
-            Value::exec_substring(&str_value, &start_value, Some(&length_value)),
+            allocated(Value::exec_substring(
+                &str_value,
+                &start_value,
+                Some(&length_value),
+            )),
             expected_val
         );
 
@@ -2825,7 +2860,11 @@ mod tests {
         let length_value = Value::from_i64(3);
         let expected_val = Value::build_text("");
         assert_eq!(
-            Value::exec_substring(&str_value, &start_value, Some(&length_value)),
+            allocated(Value::exec_substring(
+                &str_value,
+                &start_value,
+                Some(&length_value),
+            )),
             expected_val
         );
 
@@ -2834,7 +2873,11 @@ mod tests {
         let length_value = Value::Null;
         let expected_val = Value::Null;
         assert_eq!(
-            Value::exec_substring(&str_value, &start_value, Some(&length_value)),
+            allocated(Value::exec_substring(
+                &str_value,
+                &start_value,
+                Some(&length_value),
+            )),
             expected_val
         );
 
@@ -2843,7 +2886,11 @@ mod tests {
         let length_value = Value::Null;
         let expected_val = Value::Null;
         assert_eq!(
-            Value::exec_substring(&str_value, &start_value, Some(&length_value)),
+            allocated(Value::exec_substring(
+                &str_value,
+                &start_value,
+                Some(&length_value),
+            )),
             expected_val
         );
 
@@ -2852,7 +2899,11 @@ mod tests {
         let length_value = Value::from_i64(-4_829_175_794_346_763_833);
         let expected_val = Value::build_text("");
         assert_eq!(
-            Value::exec_substring(&str_value, &start_value, Some(&length_value)),
+            allocated(Value::exec_substring(
+                &str_value,
+                &start_value,
+                Some(&length_value),
+            )),
             expected_val
         );
     }
@@ -2939,23 +2990,23 @@ mod tests {
         let expected = Value::from_i64(3);
         assert_eq!(input.exec_instr(&pattern), expected);
 
-        let input = Value::from_slice(&[1, 2, 3, 4, 5]);
-        let pattern = Value::from_slice(&[3, 4]);
+        let input = blob(&[1, 2, 3, 4, 5]);
+        let pattern = blob(&[3, 4]);
         let expected = Value::from_i64(3);
         assert_eq!(input.exec_instr(&pattern), expected);
 
-        let input = Value::from_slice(&[1, 2, 3, 4, 5]);
-        let pattern = Value::from_slice(&[3, 2]);
+        let input = blob(&[1, 2, 3, 4, 5]);
+        let pattern = blob(&[3, 2]);
         let expected = Value::from_i64(0);
         assert_eq!(input.exec_instr(&pattern), expected);
 
-        let input = Value::from_slice(&[0x61, 0x62, 0x63, 0x64, 0x65]);
+        let input = blob(&[0x61, 0x62, 0x63, 0x64, 0x65]);
         let pattern = Value::build_text("cd");
         let expected = Value::from_i64(3);
         assert_eq!(input.exec_instr(&pattern), expected);
 
         let input = Value::build_text("abcde");
-        let pattern = Value::from_slice(&[0x63, 0x64]);
+        let pattern = blob(&[0x63, 0x64]);
         let expected = Value::from_i64(3);
         assert_eq!(input.exec_instr(&pattern), expected);
 
@@ -3011,19 +3062,19 @@ mod tests {
         let expected = Some(Value::from_i64(0));
         assert_eq!(input.exec_sign(), expected);
 
-        let input = Value::from_slice(b"abc");
+        let input = blob(b"abc");
         let expected = None;
         assert_eq!(input.exec_sign(), expected);
 
-        let input = Value::from_slice(b"42");
+        let input = blob(b"42");
         let expected = None;
         assert_eq!(input.exec_sign(), expected);
 
-        let input = Value::from_slice(b"-42");
+        let input = blob(b"-42");
         let expected = None;
         assert_eq!(input.exec_sign(), expected);
 
-        let input = Value::from_slice(b"0");
+        let input = blob(b"0");
         let expected = None;
         assert_eq!(input.exec_sign(), expected);
 
@@ -3035,11 +3086,11 @@ mod tests {
     #[test]
     fn test_exec_zeroblob() {
         let input = Value::from_i64(0);
-        let expected = Value::from_slice(&[]);
+        let expected = blob(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::Null;
-        let expected = Value::from_slice(&[]);
+        let expected = blob(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::from_i64(4);
@@ -3047,7 +3098,7 @@ mod tests {
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::from_i64(-1);
-        let expected = Value::from_slice(&[]);
+        let expected = blob(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::build_text("5");
@@ -3055,19 +3106,19 @@ mod tests {
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::build_text("-5");
-        let expected = Value::from_slice(&[]);
+        let expected = blob(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::build_text("text");
-        let expected = Value::from_slice(&[]);
+        let expected = blob(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         let input = Value::from_f64(2.6);
         let expected = Value::Blob(crate::alloc::vec![0; 2]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
-        let input = Value::from_slice(&[1]);
-        let expected = Value::from_slice(&[]);
+        let input = blob(&[1]);
+        let expected = blob(&[]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         // Test TooBig error
@@ -3082,7 +3133,7 @@ mod tests {
         let replace_str = Value::build_text("a");
         let expected_str = Value::build_text("aoa");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3091,7 +3142,7 @@ mod tests {
         let replace_str = Value::build_text("");
         let expected_str = Value::build_text("o");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3100,7 +3151,7 @@ mod tests {
         let replace_str = Value::build_text("abc");
         let expected_str = Value::build_text("abcoabc");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3109,7 +3160,7 @@ mod tests {
         let replace_str = Value::build_text("b");
         let expected_str = Value::build_text("bob");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3118,7 +3169,7 @@ mod tests {
         let replace_str = Value::build_text("a");
         let expected_str = Value::build_text("bob");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3127,7 +3178,7 @@ mod tests {
         let replace_str = Value::build_text("a");
         let expected_str = Value::Null;
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3136,7 +3187,7 @@ mod tests {
         let replace_str = Value::build_text("a");
         let expected_str = Value::build_text("boa");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3145,7 +3196,7 @@ mod tests {
         let replace_str = Value::build_text("a");
         let expected_str = Value::build_text("boa");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3154,7 +3205,7 @@ mod tests {
         let replace_str = Value::build_text("a");
         let expected_str = Value::build_text("bo5");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3163,7 +3214,7 @@ mod tests {
         let replace_str = Value::from_f64(6.0);
         let expected_str = Value::build_text("bo6.0");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
 
@@ -3173,7 +3224,7 @@ mod tests {
         let replace_str = Value::from_f64(0.3);
         let expected_str = Value::build_text("tes0.3");
         assert_eq!(
-            Value::exec_replace(&input_str, &pattern_str, &replace_str),
+            allocated(Value::exec_replace(&input_str, &pattern_str, &replace_str,)),
             expected_str
         );
     }

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -894,7 +894,7 @@ impl Value {
             // Historically called NONE, but it's the same as BLOB
             Affinity::Blob => {
                 if let Value::Blob(blob) = self {
-                    return Ok(Value::Blob(blob.clone()));
+                    return Value::from_slice(blob);
                 }
                 // Convert to TEXT first, then interpret as BLOB
                 // TODO: handle encoding

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -43,7 +43,7 @@ pub fn vector32(args: &[Register]) -> Result<Value> {
     let value = args[0].get_value();
     let vector = parse_vector(value, Some(VectorType::Float32Dense))?;
     let vector = operations::convert::vector_convert(vector, VectorType::Float32Dense)?;
-    Ok(operations::serialize::vector_serialize(vector))
+    Ok(operations::serialize::vector_serialize(vector)?)
 }
 
 pub fn vector32_sparse(args: &[Register]) -> Result<Value> {
@@ -55,7 +55,7 @@ pub fn vector32_sparse(args: &[Register]) -> Result<Value> {
     let value = args[0].get_value();
     let vector = parse_vector(value, Some(VectorType::Float32Sparse))?;
     let vector = operations::convert::vector_convert(vector, VectorType::Float32Sparse)?;
-    Ok(operations::serialize::vector_serialize(vector))
+    Ok(operations::serialize::vector_serialize(vector)?)
 }
 
 pub fn vector64(args: &[Register]) -> Result<Value> {
@@ -67,7 +67,7 @@ pub fn vector64(args: &[Register]) -> Result<Value> {
     let value = args[0].get_value();
     let vector = parse_vector(value, Some(VectorType::Float64Dense))?;
     let vector = operations::convert::vector_convert(vector, VectorType::Float64Dense)?;
-    Ok(operations::serialize::vector_serialize(vector))
+    Ok(operations::serialize::vector_serialize(vector)?)
 }
 
 pub fn vector8(args: &[Register]) -> Result<Value> {
@@ -79,7 +79,7 @@ pub fn vector8(args: &[Register]) -> Result<Value> {
     let value = args[0].get_value();
     let vector = parse_vector(value, Some(VectorType::Float8))?;
     let vector = operations::convert::vector_convert(vector, VectorType::Float8)?;
-    Ok(operations::serialize::vector_serialize(vector))
+    Ok(operations::serialize::vector_serialize(vector)?)
 }
 
 pub fn vector1bit(args: &[Register]) -> Result<Value> {
@@ -91,7 +91,7 @@ pub fn vector1bit(args: &[Register]) -> Result<Value> {
     let value = args[0].get_value();
     let vector = parse_vector(value, Some(VectorType::Float1Bit))?;
     let vector = operations::convert::vector_convert(vector, VectorType::Float1Bit)?;
-    Ok(operations::serialize::vector_serialize(vector))
+    Ok(operations::serialize::vector_serialize(vector)?)
 }
 
 pub fn vector_extract(args: &[Register]) -> Result<Value> {
@@ -191,7 +191,7 @@ pub fn vector_concat(args: &[Register]) -> Result<Value> {
     let x = parse_vector(value_0, None)?;
     let y = parse_vector(value_1, None)?;
     let vector = operations::concat::vector_concat(&x, &y)?;
-    Ok(operations::serialize::vector_serialize(vector))
+    Ok(operations::serialize::vector_serialize(vector)?)
 }
 
 pub fn vector_slice(args: &[Register]) -> Result<Value> {
@@ -223,5 +223,5 @@ pub fn vector_slice(args: &[Register]) -> Result<Value> {
     let result =
         operations::slice::vector_slice(&vector, start_index as usize, end_index as usize)?;
 
-    Ok(operations::serialize::vector_serialize(result))
+    Ok(operations::serialize::vector_serialize(result)?)
 }

--- a/core/vector/operations/concat.rs
+++ b/core/vector/operations/concat.rs
@@ -1,9 +1,10 @@
 use crate::{
-    alloc::TursoVecExt,
+    alloc::TursoTryWithCapacityExt,
     vector::vector_types::{Vector, VectorType},
     LimboError, Result, ValueBlob,
 };
 
+#[turso_macros::allocation_site(crate::alloc::VectorAllocationSite::Concat)]
 pub fn vector_concat(v1: &Vector, v2: &Vector) -> Result<Vector<'static>> {
     if v1.vector_type != v2.vector_type {
         return Err(LimboError::ConversionError(
@@ -13,15 +14,17 @@ pub fn vector_concat(v1: &Vector, v2: &Vector) -> Result<Vector<'static>> {
 
     let data = match v1.vector_type {
         VectorType::Float32Dense | VectorType::Float64Dense => {
-            let mut data =
-                <ValueBlob as TursoVecExt<u8>>::with_capacity(v1.bin_len() + v2.bin_len());
+            let mut data = <ValueBlob as TursoTryWithCapacityExt>::try_with_capacity_ext(
+                v1.bin_len() + v2.bin_len(),
+            )?;
             data.extend_from_slice(v1.bin_data());
             data.extend_from_slice(v2.bin_data());
             data
         }
         VectorType::Float32Sparse => {
-            let mut data =
-                <ValueBlob as TursoVecExt<u8>>::with_capacity(v1.bin_len() + v2.bin_len());
+            let mut data = <ValueBlob as TursoTryWithCapacityExt>::try_with_capacity_ext(
+                v1.bin_len() + v2.bin_len(),
+            )?;
             data.extend_from_slice(&v1.bin_data()[..v1.bin_len() / 2]);
             data.extend_from_slice(&v2.bin_data()[..v2.bin_len() / 2]);
             data.extend_from_slice(&v1.bin_data()[v1.bin_len() / 2..]);

--- a/core/vector/operations/convert.rs
+++ b/core/vector/operations/convert.rs
@@ -1,9 +1,10 @@
 use crate::{
-    alloc::{TursoAllocExt, TursoIteratorExt, TursoVecExt, Vec},
+    alloc::{TursoAllocExt, TursoIteratorExt, TursoTryWithCapacityExt, TursoVecExt, Vec},
     vector::vector_types::{Vector, VectorType},
     Result, ValueBlob,
 };
 
+#[turso_macros::allocation_site(crate::alloc::VectorAllocationSite::Convert)]
 pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
     if v.vector_type == target_type {
         return Ok(v);
@@ -22,10 +23,10 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
                 if value == 0.0 {
                     continue;
                 }
-                idx.push(i as u32);
-                values.push(value);
+                idx.try_push(i as u32)?;
+                values.try_push(value)?;
             }
-            Ok(Vector::from_f32_sparse(v.dims, values, idx))
+            Ok(Vector::from_f32_sparse(v.dims, values, idx)?)
         }
         (VectorType::Float64Dense, VectorType::Float32Sparse) => {
             let mut idx: Vec<u32> = TursoAllocExt::new();
@@ -34,14 +35,14 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
                 if value == 0.0 {
                     continue;
                 }
-                idx.push(i as u32);
-                values.push(value as f32);
+                idx.try_push(i as u32)?;
+                values.try_push(value as f32)?;
             }
-            Ok(Vector::from_f32_sparse(v.dims, values, idx))
+            Ok(Vector::from_f32_sparse(v.dims, values, idx)?)
         }
         (VectorType::Float32Sparse, VectorType::Float32Dense) => {
             let sparse = v.as_f32_sparse();
-            let mut data = crate::alloc::vec![0f32; v.dims];
+            let mut data = crate::alloc::try_vec![0f32; v.dims]?;
             for (&i, &value) in sparse.idx.iter().zip(sparse.values.iter()) {
                 data[i as usize] = value;
             }
@@ -49,7 +50,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
         }
         (VectorType::Float32Sparse, VectorType::Float64Dense) => {
             let sparse = v.as_f32_sparse();
-            let mut data = crate::alloc::vec![0f64; v.dims];
+            let mut data = crate::alloc::try_vec![0f64; v.dims]?;
             for (&i, &value) in sparse.idx.iter().zip(sparse.values.iter()) {
                 data[i as usize] = value as f64;
             }
@@ -59,7 +60,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
         (VectorType::Float32Dense, VectorType::Float1Bit) => {
             let dims = v.dims;
             let byte_count = dims.div_ceil(8);
-            let mut bits = crate::alloc::vec![0u8; byte_count];
+            let mut bits = crate::alloc::try_vec![0u8; byte_count]?;
             for (i, &val) in v.as_f32_slice().iter().enumerate() {
                 if val > 0.0 {
                     bits[i / 8] |= 1 << (i & 7);
@@ -70,7 +71,7 @@ pub fn vector_convert(v: Vector, target_type: VectorType) -> Result<Vector> {
         (VectorType::Float64Dense, VectorType::Float1Bit) => {
             let dims = v.dims;
             let byte_count = dims.div_ceil(8);
-            let mut bits = crate::alloc::vec![0u8; byte_count];
+            let mut bits = crate::alloc::try_vec![0u8; byte_count]?;
             for (i, &val) in v.as_f64_slice().iter().enumerate() {
                 if val > 0.0 {
                     bits[i / 8] |= 1 << (i & 7);
@@ -155,7 +156,7 @@ fn convert_floats_to_f8(
     dims: usize,
 ) -> Result<Vector<'static>> {
     if dims == 0 {
-        return Ok(Vector::from_f8(0, crate::alloc::vec![], 0.0, 0.0));
+        return Ok(Vector::from_f8(0, crate::alloc::vec![], 0.0, 0.0)?);
     }
     let mut min_val = f32::INFINITY;
     let mut max_val = f32::NEG_INFINITY;
@@ -169,7 +170,7 @@ fn convert_floats_to_f8(
     }
     let alpha = (max_val - min_val) / 255.0;
     let shift = min_val;
-    let mut quantized = <ValueBlob as TursoVecExt<u8>>::with_capacity(dims);
+    let mut quantized = <ValueBlob as TursoTryWithCapacityExt>::try_with_capacity_ext(dims)?;
     for val in values {
         let q = if alpha == 0.0 {
             0u8
@@ -179,7 +180,7 @@ fn convert_floats_to_f8(
         };
         quantized.push(q);
     }
-    Ok(Vector::from_f8(dims, quantized, alpha, shift))
+    Ok(Vector::from_f8(dims, quantized, alpha, shift)?)
 }
 
 #[cfg(test)]
@@ -213,7 +214,7 @@ mod tests {
         Vector {
             vector_type: v.vector_type,
             dims: v.dims,
-            owned: Some(value_blob_from_slice(v.bin_data())),
+            owned: Some(value_blob_from_slice(v.bin_data()).expect(ALLOC_ERR_MSG)),
             refer: None,
         }
     }
@@ -323,7 +324,11 @@ mod tests {
     /// Float1Bit roundtrip preserves sign information: positive → 1, non-positive → -1.
     #[quickcheck]
     fn prop_vector_convert_1bit_roundtrip(v: ArbitraryVector<100>) -> bool {
-        let v_f32 = vector_convert(v.into(), VectorType::Float32Dense).unwrap();
+        let v_f32 = vector_convert(
+            v.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let orig_slice = v_f32.as_f32_slice().to_vec();
         let v_1bit = vector_convert(v_f32, VectorType::Float1Bit).unwrap();
         let v_back = vector_convert(v_1bit, VectorType::Float32Dense).unwrap();
@@ -341,7 +346,11 @@ mod tests {
     /// Float8 roundtrip approximately preserves values within one quantization step.
     #[quickcheck]
     fn prop_vector_convert_f8_roundtrip(v: ArbitraryVector<100>) -> bool {
-        let v_f32 = vector_convert(v.into(), VectorType::Float32Dense).unwrap();
+        let v_f32 = vector_convert(
+            v.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let orig_slice = v_f32.as_f32_slice().to_vec();
         let v_f8 = vector_convert(v_f32, VectorType::Float8).unwrap();
         let v_back = vector_convert(v_f8, VectorType::Float32Dense).unwrap();
@@ -363,7 +372,7 @@ mod tests {
     /// All type-pair conversions succeed for arbitrary vectors.
     #[quickcheck]
     fn prop_vector_convert_all_pairs(v: ArbitraryVector<16>) -> bool {
-        let v: Vector = v.into();
+        let v: Vector = v.try_into().expect("generated vector must be valid");
         let all_types = [
             VectorType::Float32Dense,
             VectorType::Float64Dense,
@@ -394,7 +403,7 @@ mod tests {
 
     #[test]
     fn test_vector_convert_empty_f8_to_f32() {
-        let empty_f8 = Vector::from_f8(0, crate::alloc::vec![], 0.0, 0.0);
+        let empty_f8 = Vector::from_f8(0, crate::alloc::vec![], 0.0, 0.0).unwrap();
         let f32_vec = vector_convert(empty_f8, VectorType::Float32Dense).unwrap();
         assert_eq!(f32_vec.dims, 0);
         assert!(f32_vec.as_f32_slice().is_empty());

--- a/core/vector/operations/distance_cos.rs
+++ b/core/vector/operations/distance_cos.rs
@@ -238,8 +238,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let d1 = vector_distance_cos(&v1, &v2).unwrap();
 
         let sparse1 = vector_convert(v1, VectorType::Float32Sparse).unwrap();
@@ -254,8 +262,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let d1 = vector_f32_distance_cos_rust(v1.as_f32_slice(), v2.as_f32_slice());
         let d2 = vector_f32_distance_cos_simsimd(v1.as_f32_slice(), v2.as_f32_slice());
         println!("d1 vs d2: {d1} vs {d2}");
@@ -267,8 +283,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float64Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float64Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float64Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float64Dense,
+        )
+        .unwrap();
         let d1 = vector_f64_distance_cos_rust(v1.as_f64_slice(), v2.as_f64_slice());
         let d2 = vector_f64_distance_cos_simsimd(v1.as_f64_slice(), v2.as_f64_slice());
         println!("d1 vs d2: {d1} vs {d2}");
@@ -281,8 +305,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let v1_f8 = vector_convert(v1, VectorType::Float8).unwrap();
         let v2_f8 = vector_convert(v2, VectorType::Float8).unwrap();
         let d_f8 = vector_distance_cos(&v1_f8, &v2_f8).unwrap();
@@ -300,8 +332,16 @@ mod tests {
         v2: ArbitraryVector<100>,
     ) -> bool {
         use crate::vector::operations::distance_dot::vector_distance_dot;
-        let v1 = vector_convert(v1.into(), VectorType::Float1Bit).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float1Bit).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float1Bit,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float1Bit,
+        )
+        .unwrap();
         let cos = vector_distance_cos(&v1, &v2).unwrap();
         let dot = vector_distance_dot(&v1, &v2).unwrap();
         // hamming = cos, dot = -(dims - 2*hamming), so cos = (dims + dot) / 2

--- a/core/vector/operations/distance_dot.rs
+++ b/core/vector/operations/distance_dot.rs
@@ -208,8 +208,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1_dense = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2_dense = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1_dense = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2_dense = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let d_dense =
             vector_f32_distance_dot_rust(v1_dense.as_f32_slice(), v2_dense.as_f32_slice());
         let v1_sparse = vector_convert(v1_dense, VectorType::Float32Sparse).unwrap();
@@ -224,8 +232,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let d_rust = vector_f32_distance_dot_rust(v1.as_f32_slice(), v2.as_f32_slice());
         let d_simd = vector_f32_distance_dot_simsimd(v1.as_f32_slice(), v2.as_f32_slice());
         (d_rust.is_nan() && d_simd.is_nan()) || (d_rust - d_simd).abs() < 1e-4
@@ -236,8 +252,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float64Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float64Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float64Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float64Dense,
+        )
+        .unwrap();
         let d_rust = vector_f64_distance_dot_rust(v1.as_f64_slice(), v2.as_f64_slice());
         let d_simd = vector_f64_distance_dot_simsimd(v1.as_f64_slice(), v2.as_f64_slice());
         (d_rust.is_nan() && d_simd.is_nan()) || (d_rust - d_simd).abs() < 1e-6
@@ -249,8 +273,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let v1_f8 = vector_convert(v1, VectorType::Float8).unwrap();
         let v2_f8 = vector_convert(v2, VectorType::Float8).unwrap();
         let d_f8 = vector_distance_dot(&v1_f8, &v2_f8).unwrap();
@@ -266,8 +298,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float1Bit).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float1Bit).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float1Bit,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float1Bit,
+        )
+        .unwrap();
         let d_1bit = vector_distance_dot(&v1, &v2).unwrap();
         let v1_f32 = vector_convert(v1, VectorType::Float32Dense).unwrap();
         let v2_f32 = vector_convert(v2, VectorType::Float32Dense).unwrap();

--- a/core/vector/operations/distance_l2.rs
+++ b/core/vector/operations/distance_l2.rs
@@ -240,8 +240,16 @@ mod tests {
         // Dense uses simsimd, sparse uses rust impl. These can differ by up to 1e-4
         // (as demonstrated by prop_vector_distance_l2_rust_vs_simsimd_f32).
         let tolerance = 1e-4;
-        let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let d1 = vector_distance_l2(&v1, &v2).unwrap();
 
         let sparse1 = vector_convert(v1, VectorType::Float32Sparse).unwrap();
@@ -256,8 +264,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let d1 = vector_f32_distance_l2_rust(v1.as_f32_slice(), v2.as_f32_slice());
         let d2 = vector_f32_distance_l2_simsimd(v1.as_f32_slice(), v2.as_f32_slice());
         (d1.is_nan() && d2.is_nan()) || (d1 - d2).abs() < 1e-4
@@ -268,8 +284,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float64Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float64Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float64Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float64Dense,
+        )
+        .unwrap();
         let d1 = vector_f64_distance_l2_rust(v1.as_f64_slice(), v2.as_f64_slice());
         let d2 = vector_f64_distance_l2_simsimd(v1.as_f64_slice(), v2.as_f64_slice());
         (d1.is_nan() && d2.is_nan()) || (d1 - d2).abs() < 1e-6
@@ -281,8 +305,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let v1_f8 = vector_convert(v1, VectorType::Float8).unwrap();
         let v2_f8 = vector_convert(v2, VectorType::Float8).unwrap();
         let d_f8 = vector_distance_l2(&v1_f8, &v2_f8).unwrap();

--- a/core/vector/operations/jaccard.rs
+++ b/core/vector/operations/jaccard.rs
@@ -180,8 +180,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float32Dense,
+        )
+        .unwrap();
         let d1 = vector_distance_jaccard(&v1, &v2).unwrap();
         println!("v1: {:?}, v2: {:?}", v1.as_f32_slice(), v2.as_f32_slice());
 
@@ -204,8 +212,8 @@ mod tests {
     //     v1: ArbitraryVector<100>,
     //     v2: ArbitraryVector<100>,
     // ) -> bool {
-    //     let v1 = vector_convert(v1.into(), VectorType::Float32Dense).unwrap();
-    //     let v2 = vector_convert(v2.into(), VectorType::Float32Dense).unwrap();
+    //     let v1 = vector_convert(v1.try_into().expect("generated vector must be valid"), VectorType::Float32Dense).unwrap();
+    //     let v2 = vector_convert(v2.try_into().expect("generated vector must be valid"), VectorType::Float32Dense).unwrap();
     //     let v1_f8 = vector_convert(v1, VectorType::Float8).unwrap();
     //     let v2_f8 = vector_convert(v2, VectorType::Float8).unwrap();
     //     let d_f8 = vector_distance_jaccard(&v1_f8, &v2_f8).unwrap();
@@ -221,8 +229,16 @@ mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        let v1 = vector_convert(v1.into(), VectorType::Float1Bit).unwrap();
-        let v2 = vector_convert(v2.into(), VectorType::Float1Bit).unwrap();
+        let v1 = vector_convert(
+            v1.try_into().expect("generated vector must be valid"),
+            VectorType::Float1Bit,
+        )
+        .unwrap();
+        let v2 = vector_convert(
+            v2.try_into().expect("generated vector must be valid"),
+            VectorType::Float1Bit,
+        )
+        .unwrap();
         let d = vector_distance_jaccard(&v1, &v2).unwrap();
         // Manual: binary Jaccard = 1 - |intersection| / |union| over set bits
         let d1 = v1.as_1bit_data();

--- a/core/vector/operations/serialize.rs
+++ b/core/vector/operations/serialize.rs
@@ -1,30 +1,35 @@
 use crate::{
+    alloc::TryReserveError,
     vector::vector_types::{Vector, VectorType},
     Value,
 };
 
-pub fn vector_serialize(x: Vector) -> Value {
+#[turso_macros::allocation_site(crate::alloc::VectorAllocationSite::Serialize)]
+pub fn vector_serialize(x: Vector) -> Result<Value, TryReserveError> {
     match x.vector_type {
-        VectorType::Float32Dense => Value::from_blob(x.bin_eject()),
+        VectorType::Float32Dense => Ok(Value::from_blob(x.bin_eject()?)),
         VectorType::Float64Dense => {
-            let mut data = x.bin_eject();
+            let mut data = x.bin_eject()?;
+            data.try_reserve(1)?;
             data.push(2);
-            Value::from_blob(data)
+            Ok(Value::from_blob(data))
         }
         VectorType::Float32Sparse => {
             let dims = x.dims;
-            let mut data = x.bin_eject();
+            let mut data = x.bin_eject()?;
+            data.try_reserve(5)?;
             data.extend_from_slice(&(dims as u32).to_le_bytes());
             data.push(9);
-            Value::from_blob(data)
+            Ok(Value::from_blob(data))
         }
         VectorType::Float1Bit => {
             // Format: [data bytes][optional padding][trailing_bits][0x03]
             let dims = x.dims;
             let data_size = dims.div_ceil(8);
             let needs_padding = data_size % 2 == 0;
-            let mut blob = x.bin_eject();
+            let mut blob = x.bin_eject()?;
             blob.truncate(data_size);
+            blob.try_reserve(usize::from(needs_padding) + 2)?;
             if needs_padding {
                 blob.push(0); // padding
             }
@@ -32,17 +37,18 @@ pub fn vector_serialize(x: Vector) -> Value {
             let trailing_bits = (blob_size - 1) * 8 - dims;
             blob.push(trailing_bits as u8);
             blob.push(3); // type byte
-            Value::from_blob(blob)
+            Ok(Value::from_blob(blob))
         }
         VectorType::Float8 => {
             // Format: [quantized bytes][alignment padding][alpha f32][shift f32][padding 0x00][trailing_bytes][0x04]
             let dims = x.dims;
-            let mut data = x.bin_eject(); // ALIGN(dims, 4) + 8 bytes
+            let mut data = x.bin_eject()?; // ALIGN(dims, 4) + 8 bytes
             let trailing_bytes = dims.div_ceil(4) * 4 - dims;
+            data.try_reserve(3)?;
             data.push(0); // padding
             data.push(trailing_bytes as u8);
             data.push(4); // type byte
-            Value::from_blob(data)
+            Ok(Value::from_blob(data))
         }
     }
 }
@@ -59,7 +65,7 @@ mod tests {
         let capacity = blob.capacity();
 
         let vector = Vector::from_vec(blob).unwrap();
-        let Value::Blob(blob) = vector_serialize(vector) else {
+        let Value::Blob(blob) = vector_serialize(vector).unwrap() else {
             panic!("expected blob value");
         };
 

--- a/core/vector/operations/slice.rs
+++ b/core/vector/operations/slice.rs
@@ -5,6 +5,7 @@ use crate::{
     LimboError, Result, ValueBlob,
 };
 
+#[turso_macros::allocation_site(crate::alloc::VectorAllocationSite::Slice)]
 pub fn vector_slice(vector: &Vector, start: usize, end: usize) -> Result<Vector<'static>> {
     if start > end {
         return Err(LimboError::InvalidArgument(
@@ -22,7 +23,7 @@ pub fn vector_slice(vector: &Vector, start: usize, end: usize) -> Result<Vector<
             dims: end - start,
             owned: Some(value_blob_from_slice(
                 &vector.bin_data()[start * 4..end * 4],
-            )),
+            )?),
             refer: None,
         }),
         VectorType::Float64Dense => Ok(Vector {
@@ -30,7 +31,7 @@ pub fn vector_slice(vector: &Vector, start: usize, end: usize) -> Result<Vector<
             dims: end - start,
             owned: Some(value_blob_from_slice(
                 &vector.bin_data()[start * 8..end * 8],
-            )),
+            )?),
             refer: None,
         }),
         VectorType::Float32Sparse => {
@@ -42,9 +43,12 @@ pub fn vector_slice(vector: &Vector, start: usize, end: usize) -> Result<Vector<
                 if i < start || i >= end {
                     continue;
                 }
+                values.try_reserve(4)?;
                 values.extend_from_slice(&value.to_le_bytes());
+                idx.try_reserve(4)?;
                 idx.extend_from_slice(&((i - start) as u32).to_le_bytes());
             }
+            values.try_reserve(idx.len())?;
             values.extend_from_slice(&idx);
             Ok(Vector {
                 vector_type: vector.vector_type,

--- a/core/vector/operations/text.rs
+++ b/core/vector/operations/text.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alloc::{TursoAllocExt, TursoVecExt},
+    alloc::{TursoAllocExt, TursoTryWithCapacityExt, TursoVecExt},
     vector::vector_types::{Vector, VectorType},
     LimboError, Result, ValueBlob,
 };
@@ -65,6 +65,7 @@ fn format_text<T: std::string::ToString>(values: impl Iterator<Item = T>) -> Str
 /// ```console
 /// [1.0, 2.0, 3.0]
 /// ```
+#[turso_macros::allocation_site(crate::alloc::VectorAllocationSite::Parse)]
 pub fn vector_from_text(vector_type: VectorType, text: &str) -> Result<Vector> {
     let text = text.trim();
     let mut chars = text.chars();
@@ -75,22 +76,20 @@ pub fn vector_from_text(vector_type: VectorType, text: &str) -> Result<Vector> {
     }
     let text = &text[1..text.len() - 1];
     if text.trim().is_empty() {
-        return Ok(match vector_type {
+        return match vector_type {
             VectorType::Float1Bit => {
                 return Err(LimboError::ConversionError(
                     "empty vector not supported for this type".to_string(),
                 ));
             }
-            VectorType::Float8 => {
-                return Ok(Vector::from_f8(0, crate::alloc::vec![], 0.0, 0.0));
-            }
-            _ => Vector {
+            VectorType::Float8 => Ok(Vector::from_f8(0, crate::alloc::vec![], 0.0, 0.0)?),
+            _ => Ok(Vector {
                 vector_type,
                 dims: 0,
                 owned: Some(crate::alloc::vec![]),
                 refer: None,
-            },
-        });
+            }),
+        };
     }
     let tokens = text.split(',').map(|x| x.trim());
     match vector_type {
@@ -113,6 +112,7 @@ fn vector32_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vecto
                 "Invalid vector value".to_string(),
             ));
         }
+        data.try_reserve(4)?;
         data.extend_from_slice(&value.to_le_bytes());
     }
     Ok(Vector {
@@ -134,6 +134,7 @@ fn vector64_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vecto
                 "Invalid vector value".to_string(),
             ));
         }
+        data.try_reserve(8)?;
         data.extend_from_slice(&value.to_le_bytes());
     }
     Ok(Vector {
@@ -162,10 +163,13 @@ fn vector32_sparse_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Resul
         if value == 0.0 {
             continue;
         }
+        idx.try_reserve(4)?;
         idx.extend_from_slice(&(dims - 1).to_le_bytes());
+        values.try_reserve(4)?;
         values.extend_from_slice(&value.to_le_bytes());
     }
 
+    values.try_reserve(idx.len())?;
     values.extend_from_slice(&idx);
     Ok(Vector {
         vector_type: VectorType::Float32Sparse,
@@ -176,7 +180,7 @@ fn vector32_sparse_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Resul
 }
 
 fn vector_1bit_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vector<'static>> {
-    let mut floats = Vec::new();
+    let mut floats: crate::alloc::Vec<f32> = TursoAllocExt::new();
     for token in tokens {
         let value = token
             .parse::<f32>()
@@ -186,11 +190,11 @@ fn vector_1bit_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Ve
                 "Invalid vector value".to_string(),
             ));
         }
-        floats.push(value);
+        floats.try_push(value)?;
     }
     let dims = floats.len();
     let byte_count = dims.div_ceil(8);
-    let mut bits = crate::alloc::vec![0u8; byte_count];
+    let mut bits = crate::alloc::try_vec![0u8; byte_count]?;
     for (i, &f) in floats.iter().enumerate() {
         if f > 0.0 {
             bits[i / 8] |= 1 << (i & 7);
@@ -200,7 +204,7 @@ fn vector_1bit_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Ve
 }
 
 fn vector_f8_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vector<'static>> {
-    let mut floats = Vec::new();
+    let mut floats: crate::alloc::Vec<f32> = TursoAllocExt::new();
     for token in tokens {
         let value = token
             .parse::<f32>()
@@ -210,14 +214,14 @@ fn vector_f8_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vect
                 "Invalid vector value".to_string(),
             ));
         }
-        floats.push(value);
+        floats.try_push(value)?;
     }
     let dims = floats.len();
     let min_val = floats.iter().cloned().fold(f32::INFINITY, f32::min);
     let max_val = floats.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     let alpha = (max_val - min_val) / 255.0;
     let shift = min_val;
-    let mut quantized = <ValueBlob as TursoVecExt<u8>>::with_capacity(dims);
+    let mut quantized = <ValueBlob as TursoTryWithCapacityExt>::try_with_capacity_ext(dims)?;
     for &f in &floats {
         let q = if alpha == 0.0 {
             0u8
@@ -227,5 +231,5 @@ fn vector_f8_from_text<'a>(tokens: impl Iterator<Item = &'a str>) -> Result<Vect
         };
         quantized.push(q);
     }
-    Ok(Vector::from_f8(dims, quantized, alpha, shift))
+    Ok(Vector::from_f8(dims, quantized, alpha, shift)?)
 }

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alloc::{TursoVecExt, Vec},
+    alloc::{TryReserveError, TursoTryWithCapacityExt, Vec},
     turso_debug_assert,
     types::value_blob_from_slice,
     LimboError, Result, ValueBlob,
@@ -145,7 +145,12 @@ impl<'a> Vector<'a> {
             refer: None,
         }
     }
-    pub fn from_f32_sparse(dims: usize, mut values_f32: Vec<f32>, mut idx_u32: Vec<u32>) -> Self {
+    #[turso_macros::allocation_site(crate::alloc::VectorAllocationSite::SparseConstruction)]
+    pub fn from_f32_sparse(
+        dims: usize,
+        mut values_f32: Vec<f32>,
+        mut idx_u32: Vec<u32>,
+    ) -> std::result::Result<Self, TryReserveError> {
         #[cfg(not(nightly))]
         let mut values = unsafe {
             ValueBlob::from_raw_parts(
@@ -184,13 +189,14 @@ impl<'a> Vector<'a> {
         };
         std::mem::forget(idx_u32);
 
+        values.try_reserve(idx.len())?;
         values.extend_from_slice(&idx);
-        Self {
+        Ok(Self {
             vector_type: VectorType::Float32Sparse,
             dims,
             owned: Some(values),
             refer: None,
-        }
+        })
     }
     fn align4(n: usize) -> usize {
         n.div_ceil(4) * 4
@@ -206,20 +212,26 @@ impl<'a> Vector<'a> {
         }
     }
 
-    pub fn from_f8(dims: usize, quantized: ValueBlob, alpha: f32, shift: f32) -> Self {
+    #[turso_macros::allocation_site(crate::alloc::VectorAllocationSite::Float8Construction)]
+    pub fn from_f8(
+        dims: usize,
+        quantized: ValueBlob,
+        alpha: f32,
+        shift: f32,
+    ) -> std::result::Result<Self, TryReserveError> {
         let aligned = Self::align4(dims);
-        let mut data = <ValueBlob as TursoVecExt<u8>>::with_capacity(aligned + 8);
+        let mut data = <ValueBlob as TursoTryWithCapacityExt>::try_with_capacity_ext(aligned + 8)?;
         data.extend_from_slice(&quantized);
         data.resize(aligned, 0); // alignment padding
         data.extend_from_slice(&alpha.to_le_bytes());
         data.extend_from_slice(&shift.to_le_bytes());
         debug_assert!(data.len() == aligned + 8);
-        Self {
+        Ok(Self {
             vector_type: VectorType::Float8,
             dims,
             owned: Some(data),
             refer: None,
-        }
+        })
     }
 
     pub fn from_vec(mut blob: ValueBlob) -> Result<Self> {
@@ -227,6 +239,12 @@ impl<'a> Vector<'a> {
         blob.truncate(len);
         Self::from_data_with_dims(vector_type, Some(blob), None, explicit_dims)
     }
+
+    #[turso_macros::allocation_site(crate::alloc::VectorAllocationSite::IndexPayloadCopy)]
+    pub fn from_slice_owned(blob: &[u8]) -> Result<Vector<'static>> {
+        Vector::from_vec(value_blob_from_slice(blob)?)
+    }
+
     pub fn from_slice(blob: &'a [u8]) -> Result<Self> {
         let (vector_type, len, explicit_dims) = Self::vector_type(blob)?;
         Self::from_data_with_dims(vector_type, None, Some(&blob[..len]), explicit_dims)
@@ -365,13 +383,14 @@ impl<'a> Vector<'a> {
             .expect("Vector invariant: exactly one of owned or refer must be Some")
     }
 
-    pub fn bin_eject(self) -> ValueBlob {
-        self.owned.unwrap_or_else(|| {
-            value_blob_from_slice(
+    pub fn bin_eject(self) -> std::result::Result<ValueBlob, TryReserveError> {
+        match self.owned {
+            Some(owned) => Ok(owned),
+            None => value_blob_from_slice(
                 self.refer
                     .expect("Vector invariant: exactly one of owned or refer must be Some"),
-            )
-        })
+            ),
+        }
     }
 
     /// # Safety
@@ -480,7 +499,7 @@ impl<'a> Vector<'a> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::alloc::{TursoIteratorExt, ALLOC_ERR_MSG};
+    use crate::alloc::{TursoIteratorExt, TursoVecExt, ALLOC_ERR_MSG};
     use crate::vector::operations;
 
     use super::*;
@@ -540,14 +559,11 @@ pub(crate) mod tests {
     }
 
     /// Convert an ArbitraryVector to a Vector.
-    impl<const DIMS: usize> From<ArbitraryVector<DIMS>> for Vector<'static> {
-        fn from(v: ArbitraryVector<DIMS>) -> Self {
-            Vector {
-                vector_type: v.vector_type,
-                dims: DIMS,
-                owned: Some(value_blob_from_slice(&v.data)),
-                refer: None,
-            }
+    impl<const DIMS: usize> TryFrom<ArbitraryVector<DIMS>> for Vector<'static> {
+        type Error = LimboError;
+
+        fn try_from(v: ArbitraryVector<DIMS>) -> Result<Self> {
+            Vector::from_data_with_dims(v.vector_type, Some(v.data), None, DIMS)
         }
     }
 
@@ -626,33 +642,33 @@ pub(crate) mod tests {
 
     #[quickcheck]
     fn prop_vector_type_identification_2d(v: ArbitraryVector<2>) -> bool {
-        test_vector_type::<2>(v.into())
+        test_vector_type::<2>(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_vector_type_identification_3d(v: ArbitraryVector<3>) -> bool {
-        test_vector_type::<3>(v.into())
+        test_vector_type::<3>(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_vector_type_identification_4d(v: ArbitraryVector<4>) -> bool {
-        test_vector_type::<4>(v.into())
+        test_vector_type::<4>(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_vector_type_identification_100d(v: ArbitraryVector<100>) -> bool {
-        test_vector_type::<100>(v.into())
+        test_vector_type::<100>(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_vector_type_identification_1536d(v: ArbitraryVector<1536>) -> bool {
-        test_vector_type::<1536>(v.into())
+        test_vector_type::<1536>(v.try_into().expect("generated vector must be valid"))
     }
 
     /// Test if the vector type identification is correct for a given vector.
     fn test_vector_type<const DIMS: usize>(v: Vector) -> bool {
         let vtype = v.vector_type;
-        let value = operations::serialize::vector_serialize(v);
+        let value = operations::serialize::vector_serialize(v).unwrap();
         let blob = value.to_blob().unwrap().to_vec();
         match Vector::vector_type(&blob) {
             Ok((detected_type, _, _)) => detected_type == vtype,
@@ -662,27 +678,27 @@ pub(crate) mod tests {
 
     #[quickcheck]
     fn prop_slice_conversion_safety_2d(v: ArbitraryVector<2>) -> bool {
-        test_slice_conversion::<2>(v.into())
+        test_slice_conversion::<2>(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_slice_conversion_safety_3d(v: ArbitraryVector<3>) -> bool {
-        test_slice_conversion::<3>(v.into())
+        test_slice_conversion::<3>(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_slice_conversion_safety_4d(v: ArbitraryVector<4>) -> bool {
-        test_slice_conversion::<4>(v.into())
+        test_slice_conversion::<4>(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_slice_conversion_safety_100d(v: ArbitraryVector<100>) -> bool {
-        test_slice_conversion::<100>(v.into())
+        test_slice_conversion::<100>(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_slice_conversion_safety_1536d(v: ArbitraryVector<1536>) -> bool {
-        test_slice_conversion::<1536>(v.into())
+        test_slice_conversion::<1536>(v.try_into().expect("generated vector must be valid"))
     }
 
     /// Test if the slice conversion is safe for a given vector:
@@ -712,17 +728,26 @@ pub(crate) mod tests {
 
     #[quickcheck]
     fn prop_vector_distance_safety_2d(v1: ArbitraryVector<2>, v2: ArbitraryVector<2>) -> bool {
-        test_vector_distance::<2>(&v1.into(), &v2.into())
+        test_vector_distance::<2>(
+            &v1.try_into().expect("generated vector must be valid"),
+            &v2.try_into().expect("generated vector must be valid"),
+        )
     }
 
     #[quickcheck]
     fn prop_vector_distance_safety_3d(v1: ArbitraryVector<3>, v2: ArbitraryVector<3>) -> bool {
-        test_vector_distance::<3>(&v1.into(), &v2.into())
+        test_vector_distance::<3>(
+            &v1.try_into().expect("generated vector must be valid"),
+            &v2.try_into().expect("generated vector must be valid"),
+        )
     }
 
     #[quickcheck]
     fn prop_vector_distance_safety_4d(v1: ArbitraryVector<4>, v2: ArbitraryVector<4>) -> bool {
-        test_vector_distance::<4>(&v1.into(), &v2.into())
+        test_vector_distance::<4>(
+            &v1.try_into().expect("generated vector must be valid"),
+            &v2.try_into().expect("generated vector must be valid"),
+        )
     }
 
     #[quickcheck]
@@ -730,7 +755,10 @@ pub(crate) mod tests {
         v1: ArbitraryVector<100>,
         v2: ArbitraryVector<100>,
     ) -> bool {
-        test_vector_distance::<100>(&v1.into(), &v2.into())
+        test_vector_distance::<100>(
+            &v1.try_into().expect("generated vector must be valid"),
+            &v2.try_into().expect("generated vector must be valid"),
+        )
     }
 
     #[quickcheck]
@@ -738,7 +766,10 @@ pub(crate) mod tests {
         v1: ArbitraryVector<1536>,
         v2: ArbitraryVector<1536>,
     ) -> bool {
-        test_vector_distance::<1536>(&v1.into(), &v2.into())
+        test_vector_distance::<1536>(
+            &v1.try_into().expect("generated vector must be valid"),
+            &v2.try_into().expect("generated vector must be valid"),
+        )
     }
 
     /// Test if the vector distance calculation is correct for a given pair of vectors:
@@ -820,27 +851,27 @@ pub(crate) mod tests {
 
     #[quickcheck]
     fn prop_vector_text_roundtrip_2d(v: ArbitraryVector<2>) -> bool {
-        test_vector_text_roundtrip(v.into())
+        test_vector_text_roundtrip(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_vector_text_roundtrip_3d(v: ArbitraryVector<3>) -> bool {
-        test_vector_text_roundtrip(v.into())
+        test_vector_text_roundtrip(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_vector_text_roundtrip_4d(v: ArbitraryVector<4>) -> bool {
-        test_vector_text_roundtrip(v.into())
+        test_vector_text_roundtrip(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_vector_text_roundtrip_100d(v: ArbitraryVector<100>) -> bool {
-        test_vector_text_roundtrip(v.into())
+        test_vector_text_roundtrip(v.try_into().expect("generated vector must be valid"))
     }
 
     #[quickcheck]
     fn prop_vector_text_roundtrip_1536d(v: ArbitraryVector<1536>) -> bool {
-        test_vector_text_roundtrip(v.into())
+        test_vector_text_roundtrip(v.try_into().expect("generated vector must be valid"))
     }
 
     /// Test that a vector can be converted to text and back without loss of precision

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1467,7 +1467,11 @@ impl TursoStatement {
                 "attempt to access row value out of bounds".to_string(),
             ));
         }
-        Ok(row.get_value(index).as_value_ref().to_owned())
+        Ok(row
+            .get_value(index)
+            .as_value_ref()
+            .to_owned()
+            .map_err(LimboError::from)?)
     }
     /// returns column count
     pub fn column_count(&self) -> usize {

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -277,7 +277,7 @@ impl SimValue {
             ast::Operator::BitwiseAnd => self.0.exec_bit_and(&other.0).into(),
             ast::Operator::BitwiseOr => self.0.exec_bit_or(&other.0).into(),
             ast::Operator::BitwiseNot => todo!(), // TODO: Do not see any function usage of this operator in Core
-            ast::Operator::Concat => self.0.exec_concat(&other.0).into(),
+            ast::Operator::Concat => self.0.exec_concat(&other.0).expect(ALLOC_ERR_MSG).into(),
             ast::Operator::Equals => self
                 .sqlite_cmp(other)
                 .map(|o| o == std::cmp::Ordering::Equal)

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use turso_core::alloc::{
     AllocError, AllocationSite, ApiAllocator, Global, Layout, MvStoreAllocationSite,
     MvccCheckpointAllocationSite, SchemaAllocationSite, SetAllocatorError, TursoAllocBackend,
+    ValueBlobAllocationSite, VectorAllocationSite,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -220,6 +221,23 @@ fn allocation_site_id(site: AllocationSite) -> u64 {
         AllocationSite::Schema(site) => match site {
             SchemaAllocationSite::MakeMut => 14,
         },
+        AllocationSite::ValueBlob(site) => match site {
+            ValueBlobAllocationSite::Concat => 23,
+            ValueBlobAllocationSite::RecordDecode => 24,
+            ValueBlobAllocationSite::FromSlice => 25,
+            ValueBlobAllocationSite::JsonbCopy => 26,
+            ValueBlobAllocationSite::Hash128 => 27,
+        },
+        AllocationSite::Vector(site) => match site {
+            VectorAllocationSite::Parse => 15,
+            VectorAllocationSite::Convert => 16,
+            VectorAllocationSite::Concat => 17,
+            VectorAllocationSite::Slice => 18,
+            VectorAllocationSite::Serialize => 19,
+            VectorAllocationSite::SparseConstruction => 20,
+            VectorAllocationSite::Float8Construction => 21,
+            VectorAllocationSite::IndexPayloadCopy => 22,
+        },
     }
 }
 
@@ -254,5 +272,80 @@ mod tests {
             allocation_hash(4, context, site, 0, layout),
             allocation_hash(4, context, site, 1, layout)
         );
+    }
+
+    #[test]
+    fn vector_allocation_sites_have_distinct_ids() {
+        let sites = [
+            VectorAllocationSite::Parse,
+            VectorAllocationSite::Convert,
+            VectorAllocationSite::Concat,
+            VectorAllocationSite::Slice,
+            VectorAllocationSite::Serialize,
+            VectorAllocationSite::SparseConstruction,
+            VectorAllocationSite::Float8Construction,
+            VectorAllocationSite::IndexPayloadCopy,
+        ];
+        let ids = sites.map(|site| allocation_site_id(AllocationSite::Vector(site)));
+        for (index, id) in ids.iter().enumerate() {
+            assert!(!ids[index + 1..].contains(id), "duplicate site id {id}");
+        }
+    }
+
+    #[test]
+    fn value_blob_allocation_sites_have_distinct_ids() {
+        let sites = [
+            ValueBlobAllocationSite::Concat,
+            ValueBlobAllocationSite::RecordDecode,
+            ValueBlobAllocationSite::FromSlice,
+            ValueBlobAllocationSite::JsonbCopy,
+            ValueBlobAllocationSite::Hash128,
+        ];
+        let ids = sites.map(|site| allocation_site_id(AllocationSite::ValueBlob(site)));
+        for (index, id) in ids.iter().enumerate() {
+            assert!(!ids[index + 1..].contains(id), "duplicate site id {id}");
+        }
+    }
+
+    #[test]
+    fn vector_allocation_site_is_fault_injectable() {
+        static INJECTOR: SimulatorAllocationFaultInjector = SimulatorAllocationFaultInjector {
+            enabled: AtomicBool::new(true),
+            seed: AtomicU64::new(7),
+            threshold: AtomicU64::new(u64::MAX),
+            injected_faults: AtomicU64::new(0),
+        };
+
+        let _context = INJECTOR.enter_context(AllocationFaultContext {
+            step: 1,
+            fiber_idx: 2,
+            execution_id: 3,
+        });
+        let _site = turso_core::alloc::enter_allocation_site(VectorAllocationSite::Serialize);
+        let layout = Layout::from_size_align(16, 8).unwrap();
+
+        assert!(INJECTOR.allocate(layout).is_err());
+        assert_eq!(INJECTOR.injected_faults(), 1);
+    }
+
+    #[test]
+    fn value_blob_concat_site_is_fault_injectable() {
+        static INJECTOR: SimulatorAllocationFaultInjector = SimulatorAllocationFaultInjector {
+            enabled: AtomicBool::new(true),
+            seed: AtomicU64::new(11),
+            threshold: AtomicU64::new(u64::MAX),
+            injected_faults: AtomicU64::new(0),
+        };
+
+        let _context = INJECTOR.enter_context(AllocationFaultContext {
+            step: 4,
+            fiber_idx: 5,
+            execution_id: 6,
+        });
+        let _site = turso_core::alloc::enter_allocation_site(ValueBlobAllocationSite::Concat);
+        let layout = Layout::from_size_align(16, 8).unwrap();
+
+        assert!(INJECTOR.allocate(layout).is_err());
+        assert_eq!(INJECTOR.injected_faults(), 1);
     }
 }

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -34,7 +34,7 @@ fn run<T>(db: &TempDatabase, mut f: impl FnMut() -> Result<IOResult<T>>) -> Resu
 
 fn sparse_vector(v: &str) -> Value {
     let vector = vector::operations::text::vector_from_text(VectorType::Float32Sparse, v).unwrap();
-    vector::operations::serialize::vector_serialize(vector)
+    vector::operations::serialize::vector_serialize(vector).expect(turso_core::alloc::ALLOC_ERR_MSG)
 }
 
 // TODO: cannot use MVCC as we use indexes here


### PR DESCRIPTION
## Description

Stacked on #7835.

- register blob and vector allocation sites with Whopper fault injection
- make `Value::Blob` construction and copying return allocation errors instead of aborting
- propagate those fallible copies through the existing VDBE, JSONB, vector, record, incremental, and storage call sites
- make blob affinity copies return out-of-memory errors instead of panicking

## Context

The allocator plumbing in #7835 makes `Value::Blob` allocations visible to `TursoAllocator`. Core must surface failures from those allocation points so injected out-of-memory behavior does not terminate the process.

This PR establishes the fallible blob API and updates its existing consumers. #7846 carries the remaining JSON cache/construction guarantees, targeted production fault-injection coverage, and the Whopper JSON workload.
