### PR TITLE
core/mvcc: annotate and instrument logical-log durability invariants

### DIFF
--- a/.aristo/canon-matches.toml
+++ b/.aristo/canon-matches.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 canon_version = "v0.1.0"
-last_fetched = "2026-07-07T07:53:35.240089285Z"
+last_fetched = "2026-07-10T07:09:09.697220051Z"
 
 [aret_4mbjdhds]
 last_match_text_hash = "sha256:9d400437abc7d933b5a5f93bdc8bef54c9f0dbc03d029683fd41dbfe40b5bc16"
@@ -25,6 +25,259 @@ bound_at = "2026-07-07T07:54:27Z"
 
 ["aristos:wal_checkpoint_backfill_crash_atomic".accepted_matches.verification]
 coverage_level = "partial"
+test_binaries = []
+
+["aristos:logical_log_header_publish_after_fsync"]
+last_match_text_hash = "sha256:3f6afab40638b16a555ecf9684e49947a002d985a3885cd83421977479ccea61"
+canon_fetched_at = "2026-07-10T07:09:58Z"
+
+[["aristos:logical_log_header_publish_after_fsync".accepted_matches]]
+canon_id = "logical_log_header_publish_after_fsync"
+version = "v0.1.1"
+canonical_text = "the in-memory log header is published only after the on-disk header pwrite has completed durably"
+canon_version = "v0.1.0"
+confidence = 0.9999995524555196
+prefix_tier = "aristos:"
+backed_by = "differentially tested against another implementation"
+linked = "arta_cd4620222780dc449d3fa11b12ac9eea"
+accepted_at = "2026-07-10T07:09:58Z"
+bound_at = "2026-07-10T07:09:58Z"
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification]
+coverage_level = "informal"
+test_binaries = ["c1_header_upgrade_failure"]
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation]
+bundle_id = "turso:c193ae1:dc5694ef4986"
+companions = []
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.provenance]
+base_ref = "ad351877c5cf38c1fafc7f08703bfe521b8f4437"
+payload_ref = "c193ae1768a0e7f3bb3d938dba60280d6b5bcd09"
+macro_grammar_rev = "aristo-macros 0.3.0 (two-mode Inspect grammar)"
+authored_at = "c193ae1768a0e7f3bb3d938dba60280d6b5bcd09"
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.provenance.sut_binding]
+turso_core = "core"
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.compile_check]
+package = "turso_core"
+features = "aristo-instr,turso_core/aristo-instr"
+
+[["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.records]]
+accessor_id = "inspect_header_version"
+kind = "inspect_projection"
+class = "A"
+semantic_tier = "none"
+intent = "Expose the in-memory logical-log header version so a verifier can observe header.version advancing (None -> Some(2)) across a failed header write."
+catch = "Logical-log durability-or-intact under LogicalLogWriteHeader"
+upstream_status = "local-only"
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.records.landing]
+annotation = '#[cfg_attr(feature = "aristo-instr", inspect(ret = Option<u8>, with = |h| h.as_ref().map(|x| x.version), name = "header_version"))]'
+ensure_derive = '#[cfg_attr(feature = "aristo-instr", derive(Inspect))]'
+required_use = []
+companions_ref = []
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.records.landing.target]
+container = "LogicalLog"
+crate = "turso_core"
+field = "header"
+field_type = "Option<LogHeader>"
+file = "core/mvcc/persistent_storage/logical_log.rs"
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.records.presence]
+expected_symbol = "LogicalLog::inspect_header_version"
+expected_signature = "fn inspect_header_version(&self) -> Option<u8>"
+harness_probe = "let impl_header = log.inspect_header_version().map(|version| HeaderView {"
+
+[["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.records]]
+accessor_id = "read_logicallog_offset_crc"
+kind = "field_read"
+class = "A"
+semantic_tier = "none"
+intent = "Read the logical-log write cursor and running CRC directly off the pub fields so a verifier can bound a torn write. These are ALWAYS-pub fields (present in clean upstream); they place nothing and are not the instrumentation gate — this row documents a coupling the routed tests read."
+catch = "Logical-log durability-or-intact under LogicalLogWriteHeader"
+upstream_status = "upstream"
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.records.landing]
+required_use = []
+companions_ref = []
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.records.landing.target]
+container = "LogicalLog"
+crate = "turso_core"
+field = [
+    "offset",
+    "running_crc",
+]
+field_type = "u64 / u32"
+file = "core/mvcc/persistent_storage/logical_log.rs"
+
+["aristos:logical_log_header_publish_after_fsync".accepted_matches.verification.instrumentation.records.presence]
+expected_symbol = "LogicalLog::read_logicallog_offset_crc"
+expected_signature = "fn read_logicallog_offset_crc(&self) -> u64 / u32"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write"]
+last_match_text_hash = "sha256:69987375b5915574c5fada86beca138d461c413bba84b8c1e326418c6407a955"
+canon_fetched_at = "2026-07-10T07:09:58Z"
+
+[["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches]]
+canon_id = "logical_log_inmemory_offset_advances_after_durable_write"
+version = "v0.1.1"
+canonical_text = "the in-memory log offset advances only after the corresponding frame pwrite has completed durably"
+canon_version = "v0.1.0"
+confidence = 1.0000000029926728
+prefix_tier = "aristos:"
+backed_by = "differentially tested against another implementation"
+linked = "arta_51abd96d0aa4aed2b32b8292c2c453df"
+accepted_at = "2026-07-10T07:09:58Z"
+bound_at = "2026-07-10T07:09:58Z"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification]
+coverage_level = "informal"
+test_binaries = ["lwf_write_frame_failure"]
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation]
+bundle_id = "turso:c193ae1:8568341f097a"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.provenance]
+base_ref = "ad351877c5cf38c1fafc7f08703bfe521b8f4437"
+payload_ref = "c193ae1768a0e7f3bb3d938dba60280d6b5bcd09"
+macro_grammar_rev = "aristo-macros 0.3.0 (two-mode Inspect grammar)"
+authored_at = "c193ae1768a0e7f3bb3d938dba60280d6b5bcd09"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.provenance.sut_binding]
+turso_core = "core"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.compile_check]
+package = "turso_core"
+features = "aristo-instr,turso_core/aristo-instr"
+
+[["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.companions]]
+symbol = "LogRecord::new"
+role = "delegate_method"
+file = "core/mvcc/database/mod.rs"
+visibility = "pub(crate)"
+payload_ref = "c193ae17"
+
+[["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records]]
+accessor_id = "inspect_pending_running_crc"
+kind = "inspect_clone"
+class = "A"
+semantic_tier = "none"
+intent = "Clone the pending-running-CRC (deferred-offset write state) so a verifier can distinguish a torn write from a discarded one after a failed frame write."
+catch = "Logical-log durability-or-intact under LogicalLogWriteFrame"
+upstream_status = "local-only"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records.landing]
+annotation = '#[cfg_attr(feature = "aristo-instr", inspect(name = "pending_running_crc"))]'
+ensure_derive = '#[cfg_attr(feature = "aristo-instr", derive(Inspect))]'
+required_use = []
+companions_ref = []
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records.landing.target]
+container = "LogicalLog"
+crate = "turso_core"
+field = "pending_running_crc"
+field_type = "Option<u32>"
+file = "core/mvcc/persistent_storage/logical_log.rs"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records.presence]
+expected_symbol = "LogicalLog::inspect_pending_running_crc"
+expected_signature = "fn inspect_pending_running_crc(&self) -> Option<u32>"
+harness_probe = "let observed_pending_running_crc = log.inspect_pending_running_crc();"
+
+[["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records]]
+accessor_id = "new_for_test"
+kind = "hand_written_fn"
+class = "A"
+semantic_tier = "none"
+intent = "Deterministic LogRecord constructor for MVCC recovery tests (pre-reserves LOG_HDR_SIZE + TX_HEADER_SIZE, op_count=0, has_header=false), delegating to LogRecord::new."
+catch = "Logical-log durability-or-intact under LogicalLogWriteFrame"
+upstream_status = "local-only"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records.landing]
+required_use = []
+companions_ref = ["LogRecord::new"]
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records.landing.target]
+container = "LogRecord"
+crate = "turso_core"
+file = "core/mvcc/database/mod.rs"
+method = "new_for_test"
+signature = "fn new_for_test(tx_timestamp: TxID) -> Self"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records.presence]
+expected_symbol = "LogRecord::new_for_test"
+expected_signature = "fn new_for_test(tx_timestamp: TxID) -> Self"
+harness_probe = "let tx = LogRecord::new_for_test(0);"
+
+[["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records]]
+accessor_id = "read_logicallog_offset_crc"
+kind = "field_read"
+class = "A"
+semantic_tier = "none"
+intent = "Read the logical-log write cursor and running CRC directly off the pub fields so a verifier can bound a torn write. These are ALWAYS-pub fields (present in clean upstream); they place nothing and are not the instrumentation gate — this row documents a coupling the routed tests read."
+catch = "Logical-log durability-or-intact under LogicalLogWriteFrame"
+upstream_status = "upstream"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records.landing]
+required_use = []
+companions_ref = []
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records.landing.target]
+container = "LogicalLog"
+crate = "turso_core"
+field = [
+    "offset",
+    "running_crc",
+]
+field_type = "u64 / u32"
+file = "core/mvcc/persistent_storage/logical_log.rs"
+
+["aristos:logical_log_inmemory_offset_advances_after_durable_write".accepted_matches.verification.instrumentation.records.presence]
+expected_symbol = "LogicalLog::read_logicallog_offset_crc"
+expected_signature = "fn read_logicallog_offset_crc(&self) -> u64 / u32"
+
+["aristos:logical_log_shadow_offset_matches_durable"]
+last_match_text_hash = "sha256:5a74c1a5142874836d6dfcf8557b1af99381f07c946d0caa45a4a05a6756a824"
+canon_fetched_at = "2026-07-10T07:09:59Z"
+
+[["aristos:logical_log_shadow_offset_matches_durable".accepted_matches]]
+canon_id = "logical_log_shadow_offset_matches_durable"
+version = "v0.1.0"
+canonical_text = "the shadow offset tracking the log's durable boundary equals the durable offset at every quiescent boundary after a truncate"
+canon_version = "v0.1.0"
+confidence = 1.0000000030914833
+prefix_tier = "aristos:"
+backed_by = "differentially tested against another implementation"
+linked = "arta_b45fe637d1b7c73d115ac9a0833dff83"
+accepted_at = "2026-07-10T07:09:59Z"
+bound_at = "2026-07-10T07:09:59Z"
+
+["aristos:logical_log_shadow_offset_matches_durable".accepted_matches.verification]
+coverage_level = "none"
+test_binaries = []
+
+["aristos:logical_log_truncate_crc_reseed_after_completion"]
+last_match_text_hash = "sha256:207d5abc31d86f4e78320981e396e0a50fd6df12b9a9fb51a71c8d3b79e0bfd3"
+canon_fetched_at = "2026-07-10T07:09:59Z"
+
+[["aristos:logical_log_truncate_crc_reseed_after_completion".accepted_matches]]
+canon_id = "logical_log_truncate_crc_reseed_after_completion"
+version = "v0.1.0"
+canonical_text = "the running CRC of the log is reseeded only after the truncate operation has completed durably"
+canon_version = "v0.1.0"
+confidence = 0.9999995376893536
+prefix_tier = "aristos:"
+backed_by = "differentially tested against another implementation"
+linked = "arta_ca1e4e378b30acb57cc56d73fd0bcf86"
+accepted_at = "2026-07-10T07:09:59Z"
+bound_at = "2026-07-10T07:09:59Z"
+
+["aristos:logical_log_truncate_crc_reseed_after_completion".accepted_matches.verification]
+coverage_level = "none"
 test_binaries = []
 
 ["aristos:wal_checkpoint_error_no_db_leak"]
@@ -136,7 +389,7 @@ bound_at = "2026-05-30T05:43:56Z"
 
 [savepoint_rollback_shape_and_bytes_consistent]
 last_match_text_hash = "sha256:9eb52c41e3fcf89d2515efa52befc82509297ce3c657585352714afe61147e87"
-canon_fetched_at = "2026-07-07T07:53:35.241472796Z"
+canon_fetched_at = "2026-07-10T07:09:09.698962846Z"
 
 [wal_checkpoint_backfill_crash_atomic]
 last_match_text_hash = "sha256:964113cb0dc5eb70d66767acf6391b0a93398867ba7eabf81a7364058b6b8747"
@@ -157,6 +410,25 @@ canon_fetched_at = "2026-05-30T05:43:33.980749Z"
 [wal_nbackfills_orders_with_recovery]
 last_match_text_hash = "sha256:7e7d1fd2ae298d6be58888acc49a0b7464f686bb0aa5725cf62e7459d3c59f42"
 canon_fetched_at = "2026-05-30T06:00:12.360964Z"
+
+[wal_protocol_correctness]
+last_match_text_hash = "sha256:9e70f3e012c13ec400044e473cb06d4935d943af34d40aa0e04d7acb7e3ada86"
+canon_fetched_at = "2026-07-10T07:09:09.698962846Z"
+
+[[wal_protocol_correctness.pending_matches]]
+canon_id = "wal_protocol_correctness"
+version = "v0.1.0"
+canonical_text = "the WAL subsystem maintains LSN monotonicity, frame commitment ordering, recovery idempotency, checkpoint safety, and group-commit atomicity"
+canon_version = "v0.1.0"
+confidence = 0.9521647919254752
+prefix_tier = "kanon:"
+disposition = "open"
+found_at = "2026-07-10T07:09:09.698962846Z"
+found_by = "aristo canon refresh"
+
+[wal_protocol_correctness.pending_matches.verification]
+coverage_level = "none"
+test_binaries = []
 
 [wal_truncate_atomic_under_concurrent_writers]
 last_match_text_hash = "sha256:3d260cf86a59e54d02ee3224cc3951b4c17aa0488e8be1109cf70e0912eef1ae"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,11 @@ path = "lib.rs"
 default = ["fs", "uuid", "time", "json", "series", "encryption", "percentile"]
 tracing_release = ["tracing/release_max_level_info"]
 conn_raw_api = []
+# Harness-side observability: turns on aristo's instrument surface so the
+# logical-log conformance DTs can read private LogicalLog state (header
+# version, pending running CRC) and construct LogRecords. Off by default;
+# production builds carry zero instrumentation.
+aristo-instr = ["aristo/aristo_instrument"]
 fs = ["turso_ext/vfs"]
 json = []
 uuid = ["dep:uuid"]

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -400,6 +400,11 @@ pub struct SqliteSchemaBtreeIdentity {
 /// Identity of a sqlite_schema row version that refers to a B-tree-backed object.
 /// Schema rewrites that preserve this identity are metadata-only and should not be
 /// treated as create/drop lifecycle changes.
+#[aristo::intent(
+    "Recovery never replays a sqlite_schema delete as an empty payload; it keeps the row's pre-delete record, so every recovered schema row still has a decodable (type, rootpage)",
+    id = "mvcc_recovered_schema_record_wellformed",
+    verify = "full"
+)]
 pub fn sqlite_schema_btree_identity(version: &RowVersion) -> Option<SqliteSchemaBtreeIdentity> {
     if version.row.id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
         return None;

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -516,6 +516,10 @@ pub struct LogRecord {
 }
 
 impl LogRecord {
+    #[cfg_attr(
+        feature = "aristo-instr",
+        aristo::instrument::expose_pub(as = "new_for_test")
+    )]
     pub(crate) fn new(tx_timestamp: TxID) -> Self {
         Self {
             tx_timestamp,
@@ -8569,6 +8573,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Replay a single committed logical-log transaction frame into the MVCC
     /// store. Fully synchronous (the only recovery IO is reading the next frame,
     /// driven by the caller); operates on accumulators borrowed from `ctx`.
+    ///
+    /// A same-transaction create-then-drop leaves a delete of a sqlite_schema rowid absent from
+    /// the merged state; replay treats that as a legal no-op, not corruption.
+    #[aristo::intent(
+        "Replaying a committed logical-log transaction never aborts with a corruption error",
+        id = "mvcc_recovery_total_on_committed_log",
+        verify = "full"
+    )]
     fn recover_process_frame(
         &self,
         connection: &Arc<Connection>,

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -572,10 +572,12 @@ fn derive_initial_crc(salt: u64) -> u32 {
     crc32c::crc32c(&salt.to_le_bytes())
 }
 
+#[cfg_attr(feature = "aristo-instr", derive(aristo::instrument::Inspect))]
 pub struct LogicalLog {
     pub file: Arc<dyn File>,
     io: Arc<dyn crate::IO>,
     pub offset: u64,
+    #[cfg_attr(feature = "aristo-instr", inspect(ret = Option<u8>, with = |h| h.as_ref().map(|x| x.version), name = "header_version"))]
     header: Option<LogHeader>,
     /// Running CRC state for chained checksums. Seeded from the header salt;
     /// updated after each committed frame. The next frame's CRC is computed as
@@ -584,12 +586,24 @@ pub struct LogicalLog {
     /// Pending CRC from a deferred-offset write. Applied by
     /// `advance_offset_after_success` so that an abandoned write
     /// doesn't corrupt the chain.
+    #[cfg_attr(feature = "aristo-instr", inspect(name = "pending_running_crc"))]
     pending_running_crc: Option<u32>,
     encryption_ctx: Option<EncryptionContext>,
     /// Plaintext bytes per encrypted payload chunk. Production uses the fixed format constant;
     /// tests may override via `new_with_encrypted_payload_chunk_size_for_test`.
     encrypted_payload_chunk_size: usize,
     max_appended_commit_ts: u64,
+}
+
+#[cfg(feature = "aristo-instr")]
+impl LogicalLog {
+    /// Harness accessor: the logical-log write cursor and running CRC as one
+    /// owned snapshot, read by the durability-ordering (DOI) differential tests.
+    /// Both underlying fields are already `pub`; this pairs them under the exact
+    /// symbol the routed conformance tests expect.
+    pub fn read_logicallog_offset_crc(&self) -> (u64, u32) {
+        (self.offset, self.running_crc)
+    }
 }
 
 impl LogicalLog {
@@ -918,6 +932,7 @@ impl LogicalLog {
         self.frame_and_pwrite_tx(tx, false, on_serialization_complete)
     }
 
+    #[aristo::intent("the in-memory log offset advances only after the corresponding frame pwrite has completed durably", id = "aristos:logical_log_inmemory_offset_advances_after_durable_write", verify = "full")]
     pub fn advance_offset_after_success(&mut self, bytes: u64) {
         self.offset = self
             .offset
@@ -950,6 +965,7 @@ impl LogicalLog {
         ))
     }
 
+    #[aristo::intent("the in-memory log header is published only after the on-disk header pwrite has completed durably", id = "aristos:logical_log_header_publish_after_fsync", verify = "full")]
     fn write_header(&mut self, mut header: LogHeader) -> Result<Completion> {
         let header_bytes = header.encode();
         header.hdr_crc32c = u32::from_le_bytes([
@@ -981,6 +997,7 @@ impl LogicalLog {
         self.write_header(header)
     }
 
+    #[aristo::intent("the running CRC of the log is reseeded only after the truncate operation has completed durably", id = "aristos:logical_log_truncate_crc_reseed_after_completion", verify = "full")]
     fn truncate_to_zero(&mut self) -> Result<Completion> {
         // Regenerate salt so stale frames (from before truncation) cannot validate
         // against the new CRC chain.

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -97,6 +97,11 @@ pub trait DurableStorage: Send + Sync + Debug {
     fn set_checkpoint_threshold(&self, threshold: i64);
     fn checkpoint_threshold(&self) -> i64;
     fn advance_logical_log_offset_after_success(&self, bytes: u64) -> Result<()>;
+    #[aristo::intent(
+        "the pending running-CRC slot is cleared by the storage abort path after an abandoned deferred-offset write",
+        id = "logical_log_pending_crc_cleared_on_abort",
+        verify = "full"
+    )]
     fn discard_pending_log_write(&self) -> Result<()> {
         Ok(())
     }
@@ -210,6 +215,7 @@ impl DurableStorage for Storage {
         self.logical_log.write().update_header()
     }
 
+    #[aristo::intent("after a truncate, once no write is in flight, the in-memory shadow_offset equals the on-disk durable_offset (the tracked end-of-log matches what's been fsync'd)", id = "aristos:logical_log_shadow_offset_matches_durable", verify = "full")]
     fn truncate(
         &self,
         checkpointed_through_ts: u64,


### PR DESCRIPTION
## What

Adds `#[aristo::intent]` annotations capturing the durability and crash-recovery invariants of the MVCC logical log, plus an opt-in `aristo-instr` feature that exposes the private state a differential / conformance harness needs to observe them.

This extends the aristo intent coverage already in the tree (e.g. `wal_protocol_correctness`, `wal_commit_requires_fsync`) to the logical-log subsystem (`core/mvcc/persistent_storage/`, `core/mvcc/database/`).

## Annotations

**NOTE:** Please review the intents, these are our best guesses on the invariants that need to hold for the top-level durability proof to go through :)

Natural-language behavioral specs, each attached to the site that enforces the invariant:

| Invariant | Site |
|---|---|
| in-memory header is published only after the header pwrite is durable | `LogicalLog::write_header` |
| in-memory offset advances only after the frame pwrite is durable | `LogicalLog::advance_offset_after_success` |
| the pending running-CRC is cleared by the storage abort path | `DurableStorage::discard_pending_log_write` |
| the shadow offset equals the durable offset at quiescent boundaries after a truncate | `Storage::truncate` |
| the running CRC is reseeded only after the truncate completes durably | `LogicalLog::truncate_to_zero` |
| recovery never produces a schema row version with an undecodable record | `sqlite_schema_btree_identity` |
| replaying a committed log never aborts as corruption | `MvStore::recover_process_frame` |

## Instrumentation

Behind a new **opt-in** `aristo-instr` feature (`aristo-instr = ["aristo/aristo_instrument"]`), **off by default** — the default build carries zero instrumentation:

- `#[derive(Inspect)]` projections for `LogicalLog::header`
  (`inspect_header_version`) and `pending_running_crc`
  (`inspect_pending_running_crc`)
- `read_logicallog_offset_crc` — pairs the already-`pub` `offset` /
  `running_crc` under one accessor
- `expose_pub(as = "new_for_test")` on `LogRecord::new`

These let a fault-injection harness observe private `LogicalLog` state and construct `LogRecord`s without widening the public API.

## Current intent violations (observed under fault injection)

These invariants share one failure-handling anti-pattern: **in-memory state is advanced ahead of a fallible IO whose completion swallows or only logs the error, with no rollback** — so if the IO fails, the in-memory view claims a durability the disk does not have. A fault harness that injects EIO at each site and compares the post-fault state against a reference model observes the following (witness = reference vs turso):

| Site | Invariant | Fault-path observation (reference → turso) |
|---|---|---|
| `write_header` | header published only after durable | `header.version`: `None` → `Some(2)` — the in-memory header advances before the pwrite completes; the write completion discards the IO error |
| `truncate_to_zero` | CRC reseeded only after truncate durable | `running_crc`: `0` → non-zero — reseed + `offset = 0` run before `file.truncate`; the completion only `tracing::error!`s the failure |
| `Storage::truncate` | shadow == durable after truncate | `shadow_offset`: durable value → `0` — the shadow is stored before the truncate IO completes |
| `advance_offset` (immediate path) | offset advances only after durable | `offset`: `0` → frame width — a failed frame write leaves the in-memory offset past the durable end-of-log |
| `discard_pending_log_write` | pending CRC cleared on abort | default trait impl is a no-op, so an aborted deferred write leaves a stale `pending_running_crc` (latent: harmless until a caller consumes it) |

None reproduce on the success path — these are strictly failure-path gaps. The header and truncate cases are the most consequential: a failed header upgrade can leave recovery rejecting committed frames, and a failed truncate leaves orphan on-disk bytes under a fresh in-memory CRC chain.

## AI Usage

Interpretation of intents/results/and bugs generated by Claude Code. Annotations by Aristo.