### PR TITLE
Raise expression depth limit to SQLite parity via iterative chain translation

### DIFF
--- a/core/translate/expr/binary.rs
+++ b/core/translate/expr/binary.rs
@@ -72,100 +72,193 @@ pub(super) fn emit_binary_expr_scalar(
     resolver: &Resolver,
     emit_mode: BinaryEmitMode,
 ) -> Result<usize> {
+    // A left spine of binary operators (`a OR b OR c ...`) can be up to
+    // MAX_EXPR_DEPTH links long, while recursion in the translator must stay
+    // within MAX_EXPR_NESTING frames. Translate the spine iteratively:
+    // descend it running each node's prologue (constant-span bookkeeping,
+    // operand-equivalence check, register allocation) in exactly the order
+    // the recursive translate_expr -> binary path ran them, then emit from
+    // the innermost node outwards. Only the operands hanging off the spine
+    // are translated via (nesting-bounded) recursion.
+
+    /// Registers of one spine node: either one register shared by both
+    /// operands (when they are equivalent expressions), or a contiguous
+    /// (lhs, rhs) pair starting at the given register.
+    enum SpineRegs {
+        Shared(usize),
+        Pair(usize),
+    }
+
+    struct SpineNode<'a> {
+        lhs: &'a ast::Expr,
+        op: &'a ast::Operator,
+        rhs: &'a ast::Expr,
+        /// Register this node's value is emitted into.
+        target: usize,
+        regs: SpineRegs,
+        /// Constant span opened by this node's prologue. Always `None` for
+        /// the outermost node: its prologue ran in its own translate_expr
+        /// frame, which also closes the span.
+        constant_span: Option<usize>,
+        emit_mode: BinaryEmitMode,
+    }
+
     // Check if both sides of the expression are equivalent and reuse the same register if so
-    if exprs_are_equivalent(e1, e2) {
-        let shared_reg = program.alloc_register();
-        translate_expr(program, referenced_tables, e1, shared_reg, resolver)?;
-
-        match emit_mode {
-            BinaryEmitMode::Value => emit_binary_insn(
-                program,
-                op,
-                shared_reg,
-                shared_reg,
-                target_register,
-                e1,
-                e2,
-                referenced_tables,
-                Some(resolver),
-            )?,
-            BinaryEmitMode::Condition(metadata) => emit_binary_condition_insn(
-                program,
-                op,
-                shared_reg,
-                shared_reg,
-                target_register,
-                e1,
-                e2,
-                referenced_tables,
-                metadata,
-                Some(resolver),
-            )?,
+    fn alloc_operand_regs(
+        program: &mut ProgramBuilder,
+        e1: &ast::Expr,
+        e2: &ast::Expr,
+    ) -> (SpineRegs, usize) {
+        if exprs_are_equivalent(e1, e2) {
+            let shared_reg = program.alloc_register();
+            (SpineRegs::Shared(shared_reg), shared_reg)
+        } else {
+            let e1_reg = program.alloc_registers(2);
+            (SpineRegs::Pair(e1_reg), e1_reg)
         }
-        if op.is_comparison() {
-            program.reset_collation();
+    }
+
+    let (regs, mut cur_target) = alloc_operand_regs(program, e1, e2);
+    let mut nodes = vec![SpineNode {
+        lhs: e1,
+        op,
+        rhs: e2,
+        target: target_register,
+        regs,
+        constant_span: None,
+        emit_mode,
+    }];
+    let mut cur = e1;
+    loop {
+        let ast::Expr::Binary(cur_lhs, cur_op, cur_rhs) = cur else {
+            break;
+        };
+        // Nodes that translate_expr's Binary arm routes to dedicated paths
+        // terminate the spine and are translated as opaque operands below:
+        // IS TRUE/FALSE forms (bounded because the parser counts them as
+        // nesting), custom-type operator nodes (bounded because they require
+        // a Column lhs, so they can never be consecutive on a spine), and
+        // cached subexpressions (terminal: they emit a register copy).
+        if matches!(
+            (cur_op, cur_rhs.as_ref()),
+            (
+                ast::Operator::Is | ast::Operator::IsNot,
+                ast::Expr::Literal(ast::Literal::True | ast::Literal::False)
+            )
+        ) {
+            break;
         }
-        Ok(target_register)
-    } else {
-        let e1_reg = program.alloc_registers(2);
-        let e2_reg = e1_reg + 1;
+        if resolver.resolve_cached_expr_reg(cur).is_some() {
+            break;
+        }
+        if find_custom_type_operator(cur_lhs, cur_rhs, cur_op, referenced_tables, resolver)
+            .is_some()
+        {
+            break;
+        }
+        // Row-valued comparisons (e.g. `(a,b,c) < (1,2,3)`) produce a scalar,
+        // so they can sit on a spine, but their own emission needs the
+        // row-valued path; only nodes with scalar operands are foldable.
+        // These arities were already validated by the caller's
+        // expr_vector_size checks, so this cannot fail here.
+        if expr_vector_size(cur_lhs)? != 1 || expr_vector_size(cur_rhs)? != 1 {
+            break;
+        }
+        // Replica of translate_expr's entry prologue for this node.
+        let constant_span = if cur.is_constant(resolver) {
+            if !program.constant_span_is_open() {
+                Some(program.constant_span_start())
+            } else {
+                None
+            }
+        } else {
+            program.constant_span_end_all();
+            None
+        };
+        let (regs, next_target) = alloc_operand_regs(program, cur_lhs, cur_rhs);
+        nodes.push(SpineNode {
+            lhs: cur_lhs,
+            op: cur_op,
+            rhs: cur_rhs,
+            target: cur_target,
+            regs,
+            constant_span,
+            emit_mode: BinaryEmitMode::Value,
+        });
+        cur_target = next_target;
+        cur = cur_lhs;
+    }
 
-        translate_expr(program, referenced_tables, e1, e1_reg, resolver)?;
-        let left_collation_ctx = program.curr_collation_ctx();
-        program.reset_collation();
+    // The leftmost operand of the spine.
+    translate_expr(program, referenced_tables, cur, cur_target, resolver)?;
 
-        translate_expr(program, referenced_tables, e2, e2_reg, resolver)?;
-        let right_collation_ctx = program.curr_collation_ctx();
-        program.reset_collation();
+    for node in nodes.into_iter().rev() {
+        let (lhs_reg, rhs_reg) = match node.regs {
+            SpineRegs::Shared(shared_reg) => (shared_reg, shared_reg),
+            SpineRegs::Pair(e1_reg) => {
+                let e2_reg = e1_reg + 1;
+                let left_collation_ctx = program.curr_collation_ctx();
+                program.reset_collation();
 
-        /*
-         * The rules for determining which collating function to use for a binary comparison
-         * operator (=, <, >, <=, >=, !=, IS, and IS NOT) are as follows:
-         *
-         * 1. If either operand has an explicit collating function assignment using the postfix COLLATE operator,
-         * then the explicit collating function is used for comparison,
-         * with precedence to the collating function of the left operand.
-         *
-         * 2. If either operand is a column, then the collating function of that column is used
-         * with precedence to the left operand. For the purposes of the previous sentence,
-         * a column name preceded by one or more unary "+" operators and/or CAST operators is still considered a column name.
-         *
-         * 3. Otherwise, the BINARY collating function is used for comparison.
-         */
-        let collation_ctx = {
-            match (left_collation_ctx, right_collation_ctx) {
-                (Some((c_left, true)), _) => Some((c_left, true)),
-                (_, Some((c_right, true))) => Some((c_right, true)),
-                (Some((c_left, from_collate_left)), None) => Some((c_left, from_collate_left)),
-                (None, Some((c_right, from_collate_right))) => Some((c_right, from_collate_right)),
-                (Some((c_left, from_collate_left)), Some((_, false))) => {
-                    Some((c_left, from_collate_left))
-                }
-                _ => None,
+                translate_expr(program, referenced_tables, node.rhs, e2_reg, resolver)?;
+                let right_collation_ctx = program.curr_collation_ctx();
+                program.reset_collation();
+
+                /*
+                 * The rules for determining which collating function to use for a binary comparison
+                 * operator (=, <, >, <=, >=, !=, IS, and IS NOT) are as follows:
+                 *
+                 * 1. If either operand has an explicit collating function assignment using the postfix COLLATE operator,
+                 * then the explicit collating function is used for comparison,
+                 * with precedence to the collating function of the left operand.
+                 *
+                 * 2. If either operand is a column, then the collating function of that column is used
+                 * with precedence to the left operand. For the purposes of the previous sentence,
+                 * a column name preceded by one or more unary "+" operators and/or CAST operators is still considered a column name.
+                 *
+                 * 3. Otherwise, the BINARY collating function is used for comparison.
+                 */
+                let collation_ctx = {
+                    match (left_collation_ctx, right_collation_ctx) {
+                        (Some((c_left, true)), _) => Some((c_left, true)),
+                        (_, Some((c_right, true))) => Some((c_right, true)),
+                        (Some((c_left, from_collate_left)), None) => {
+                            Some((c_left, from_collate_left))
+                        }
+                        (None, Some((c_right, from_collate_right))) => {
+                            Some((c_right, from_collate_right))
+                        }
+                        (Some((c_left, from_collate_left)), Some((_, false))) => {
+                            Some((c_left, from_collate_left))
+                        }
+                        _ => None,
+                    }
+                };
+                program.set_collation(collation_ctx);
+                (e1_reg, e2_reg)
             }
         };
-        program.set_collation(collation_ctx);
 
-        match emit_mode {
+        match node.emit_mode {
             BinaryEmitMode::Value => emit_binary_insn(
                 program,
-                op,
-                e1_reg,
-                e2_reg,
-                target_register,
-                e1,
-                e2,
+                node.op,
+                lhs_reg,
+                rhs_reg,
+                node.target,
+                node.lhs,
+                node.rhs,
                 referenced_tables,
                 Some(resolver),
             )?,
             BinaryEmitMode::Condition(metadata) => emit_binary_condition_insn(
                 program,
-                op,
-                e1_reg,
-                e2_reg,
-                target_register,
-                e1,
-                e2,
+                node.op,
+                lhs_reg,
+                rhs_reg,
+                node.target,
+                node.lhs,
+                node.rhs,
                 referenced_tables,
                 metadata,
                 Some(resolver),
@@ -176,11 +269,14 @@ pub(super) fn emit_binary_expr_scalar(
         // collation to the parent expression so that e.g.
         //   (name COLLATE NOCASE || '') <> 'admin'
         // correctly applies NOCASE to the Ne comparison.
-        if op.is_comparison() {
+        if node.op.is_comparison() {
             program.reset_collation();
         }
-        Ok(target_register)
+        if let Some(span) = node.constant_span {
+            program.constant_span_end(span);
+        }
     }
+    Ok(target_register)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -788,74 +884,90 @@ pub(super) fn emit_binary_insn(
 
 /// Check if an expression is known to produce an array value.
 pub(crate) fn expr_is_array(expr: &Expr, referenced_tables: Option<&TableReferences>) -> bool {
-    match expr {
-        Expr::Column { table, column, .. } => {
-            if let Some(tables) = referenced_tables {
-                tables
-                    .find_table_by_internal_id(*table)
-                    .map(|(_, t)| t)
-                    .and_then(|t| t.get_column_at(*column))
-                    .is_some_and(|col| col.is_array())
-            } else {
-                false
+    // Iterative (explicit work stack) because Concat chains can be up to
+    // MAX_EXPR_DEPTH links long, which recursion could not traverse within
+    // MAX_EXPR_NESTING-sized stack budgets.
+    let mut stack: smallvec::SmallVec<[&Expr; 8]> = smallvec::smallvec![expr];
+    while let Some(expr) = stack.pop() {
+        match expr {
+            Expr::Column { table, column, .. } => {
+                if let Some(tables) = referenced_tables {
+                    if tables
+                        .find_table_by_internal_id(*table)
+                        .map(|(_, t)| t)
+                        .and_then(|t| t.get_column_at(*column))
+                        .is_some_and(|col| col.is_array())
+                    {
+                        return true;
+                    }
+                }
             }
-        }
-        Expr::FunctionCall { name, args, .. } => {
-            if let Ok(Some(f)) = Func::resolve_function(name.as_str(), args.len()) {
-                match &f {
-                    Func::Scalar(sf) if sf.returns_array_blob() => return true,
-                    Func::Agg(AggFunc::ArrayAgg) => return true,
+            Expr::FunctionCall { name, args, .. } => {
+                if let Ok(Some(f)) = Func::resolve_function(name.as_str(), args.len()) {
+                    match &f {
+                        Func::Scalar(sf) if sf.returns_array_blob() => return true,
+                        Func::Agg(AggFunc::ArrayAgg) => return true,
+                        _ => {}
+                    }
+                }
+                // Wrapper functions that pass through an array value
+                match name.as_str().to_lowercase().as_str() {
+                    "coalesce" | "ifnull" | "min" | "max" => {
+                        for a in args {
+                            stack.push(a);
+                        }
+                    }
+                    "iif" => {
+                        // args: condition, then_val, else_val
+                        if let Some(a) = args.get(1) {
+                            stack.push(a);
+                        }
+                        if let Some(a) = args.get(2) {
+                            stack.push(a);
+                        }
+                    }
+                    "nullif" => {
+                        if let Some(a) = args.first() {
+                            stack.push(a);
+                        }
+                    }
+                    "array_element" => {
+                        // Subscripting a multi-dim array yields a lower-dim array
+                        if let Some(tables) = referenced_tables {
+                            if args
+                                .first()
+                                .is_some_and(|a| expr_array_dimensions(a, tables) > 1)
+                            {
+                                return true;
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
-            // Wrapper functions that pass through an array value
-            match name.as_str().to_lowercase().as_str() {
-                "coalesce" | "ifnull" | "min" | "max" => {
-                    args.iter().any(|a| expr_is_array(a, referenced_tables))
-                }
-                "iif" => {
-                    // args: condition, then_val, else_val
-                    args.get(1)
-                        .is_some_and(|a| expr_is_array(a, referenced_tables))
-                        || args
-                            .get(2)
-                            .is_some_and(|a| expr_is_array(a, referenced_tables))
-                }
-                "nullif" => args
-                    .first()
-                    .is_some_and(|a| expr_is_array(a, referenced_tables)),
-                "array_element" => {
-                    // Subscripting a multi-dim array yields a lower-dim array
-                    if let Some(tables) = referenced_tables {
-                        args.first()
-                            .is_some_and(|a| expr_array_dimensions(a, tables) > 1)
-                    } else {
-                        false
-                    }
-                }
-                _ => false,
+            Expr::Array { .. } | Expr::Subscript { .. } => {
+                unreachable!("Array and Subscript are desugared into function calls by the parser")
             }
+            Expr::Binary(lhs, ast::Operator::Concat, rhs) => {
+                stack.push(lhs);
+                stack.push(rhs);
+            }
+            Expr::Case {
+                when_then_pairs,
+                else_expr,
+                ..
+            } => {
+                for (_, then_expr) in when_then_pairs {
+                    stack.push(then_expr);
+                }
+                if let Some(e) = else_expr {
+                    stack.push(e);
+                }
+            }
+            _ => {}
         }
-        Expr::Array { .. } | Expr::Subscript { .. } => {
-            unreachable!("Array and Subscript are desugared into function calls by the parser")
-        }
-        Expr::Binary(lhs, ast::Operator::Concat, rhs) => {
-            expr_is_array(lhs, referenced_tables) || expr_is_array(rhs, referenced_tables)
-        }
-        Expr::Case {
-            when_then_pairs,
-            else_expr,
-            ..
-        } => {
-            when_then_pairs
-                .iter()
-                .any(|(_, then_expr)| expr_is_array(then_expr, referenced_tables))
-                || else_expr
-                    .as_ref()
-                    .is_some_and(|e| expr_is_array(e, referenced_tables))
-        }
-        _ => false,
     }
+    false
 }
 
 /// Return the number of array dimensions for an expression, or 0 for non-array.

--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -292,59 +292,61 @@ pub fn translate_condition_expr(
         ast::Expr::Name(_) => {
             crate::bail_parse_error!("Name as a direct predicate in WHERE clause is not supported");
         }
-        ast::Expr::Binary(lhs, ast::Operator::And, rhs) => {
-            // In a binary AND, never jump to the parent 'jump_target_when_true' label on the first condition, because
-            // the second condition MUST also be true. Instead we instruct the child expression to jump to a local
-            // true label.
-            let jump_target_when_true = program.allocate_label();
-            translate_condition_expr(
-                program,
-                referenced_tables,
-                lhs,
-                ConditionMetadata {
-                    jump_if_condition_is_true: false,
-                    jump_target_when_true,
-                    ..condition_metadata
-                },
-                resolver,
-            )?;
-            program.preassign_label_to_next_insn(jump_target_when_true);
-            translate_condition_expr(
-                program,
-                referenced_tables,
-                rhs,
-                condition_metadata,
-                resolver,
-            )?;
-        }
-        ast::Expr::Binary(lhs, ast::Operator::Or, rhs) => {
-            // In a binary OR, never jump to the parent 'jump_target_when_false' or
-            // 'jump_target_when_null' label on the first condition, because the second
-            // condition CAN also be true. Instead we instruct the child expression to
-            // jump to a local false label so the right side of OR gets evaluated.
-            // This is critical for cases like `x IN (NULL, 3) OR b` where the left side
-            // evaluates to NULL — we must still evaluate the right side.
-            let jump_target_when_false = program.allocate_label();
-            translate_condition_expr(
-                program,
-                referenced_tables,
-                lhs,
-                ConditionMetadata {
-                    jump_if_condition_is_true: true,
-                    jump_target_when_false,
-                    jump_target_when_null: jump_target_when_false,
-                    ..condition_metadata
-                },
-                resolver,
-            )?;
-            program.preassign_label_to_next_insn(jump_target_when_false);
-            translate_condition_expr(
-                program,
-                referenced_tables,
-                rhs,
-                condition_metadata,
-                resolver,
-            )?;
+        ast::Expr::Binary(_, ast::Operator::And | ast::Operator::Or, _) => {
+            // A left spine of AND/OR links can be up to MAX_EXPR_DEPTH long
+            // while recursion here must stay within MAX_EXPR_NESTING frames,
+            // so unroll the spine iteratively: descending, each spine node
+            // allocates the local label its lhs jumps to and derives the
+            // ConditionMetadata its lhs is translated with; ascending, terms
+            // are translated left to right, placing each node's local label
+            // right before its rhs term.
+            //
+            // In a binary AND, the lhs must never jump to the parent
+            // 'jump_target_when_true' label, because the rhs MUST also be
+            // true; it jumps to a local true label instead. In a binary OR,
+            // the lhs must never jump to the parent 'jump_target_when_false'
+            // or 'jump_target_when_null' labels, because the rhs CAN still be
+            // true (critical for cases like `x IN (NULL, 3) OR b` where the
+            // left side evaluates to NULL — the right side must still be
+            // evaluated); it jumps to a local false label instead.
+            let mut node = expr;
+            // Each spine node's rhs term, the metadata it is translated with,
+            // and the local label placed right before it.
+            let mut spine = vec![];
+            let mut metadata = condition_metadata;
+            while let ast::Expr::Binary(lhs, op @ (ast::Operator::And | ast::Operator::Or), rhs) =
+                node
+            {
+                let label = program.allocate_label();
+                let lhs_metadata = match op {
+                    ast::Operator::And => ConditionMetadata {
+                        jump_if_condition_is_true: false,
+                        jump_target_when_true: label,
+                        ..metadata
+                    },
+                    ast::Operator::Or => ConditionMetadata {
+                        jump_if_condition_is_true: true,
+                        jump_target_when_false: label,
+                        jump_target_when_null: label,
+                        ..metadata
+                    },
+                    _ => unreachable!(),
+                };
+                spine.push((rhs.as_ref(), metadata, label));
+                metadata = lhs_metadata;
+                node = lhs.as_ref();
+            }
+            translate_condition_expr(program, referenced_tables, node, metadata, resolver)?;
+            for (term, term_metadata, label) in spine.into_iter().rev() {
+                program.preassign_label_to_next_insn(label);
+                translate_condition_expr(
+                    program,
+                    referenced_tables,
+                    term,
+                    term_metadata,
+                    resolver,
+                )?;
+            }
         }
         // Handle IS TRUE/IS FALSE/IS NOT TRUE/IS NOT FALSE in conditions
         // Delegate to translate_expr which handles these correctly with IsTrue instruction

--- a/core/translate/expr/vectors.rs
+++ b/core/translate/expr/vectors.rs
@@ -1,8 +1,47 @@
 use super::*;
 
 /// Get the number of values returned by an expression
+///
+/// Binary chains (`a OR b OR c ...`) can be [`turso_parser::MAX_EXPR_DEPTH`]
+/// links long while recursion here must stay within
+/// [`turso_parser::MAX_EXPR_NESTING`] frames, so walk the left spine of
+/// binary operators iteratively and only recurse into the (nesting-bounded)
+/// operands hanging off it.
 pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
-    Ok(match unwrap_parens(expr)? {
+    let mut node = unwrap_parens(expr)?;
+    // Descend the Binary left spine iteratively, remembering each node so the
+    // per-node checks can run afterwards in the same (innermost-first) order
+    // the recursive formulation applied them.
+    let mut spine = vec![];
+    while let Expr::Binary(lhs, _, _) = node {
+        spine.push(node);
+        node = unwrap_parens(lhs)?;
+    }
+    let leaf_size = expr_vector_size_non_spine(node)?;
+    let mut size = leaf_size;
+    while let Some(spine_node) = spine.pop() {
+        let Expr::Binary(_, operator, rhs) = spine_node else {
+            unreachable!("only Binary nodes are pushed onto the spine");
+        };
+        let evs_left = size;
+        let evs_right = expr_vector_size(rhs)?;
+        if evs_left != evs_right {
+            crate::bail_parse_error!(
+                "all arguments to binary operator {operator} must return the same number of values. Got: ({evs_left}) {operator} ({evs_right})"
+            );
+        }
+        if evs_left > 1 && !supports_row_value_binary_comparison(operator) {
+            crate::bail_parse_error!("row value misused");
+        }
+        size = 1;
+    }
+    Ok(size)
+}
+
+/// Vector size of an expression that is already known not to be a
+/// (parenthesized) binary spine node.
+fn expr_vector_size_non_spine(expr: &Expr) -> Result<usize> {
+    Ok(match expr {
         Expr::Between {
             lhs, start, end, ..
         } => {
@@ -16,18 +55,8 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
             }
             1
         }
-        Expr::Binary(expr, operator, expr1) => {
-            let evs_left = expr_vector_size(expr)?;
-            let evs_right = expr_vector_size(expr1)?;
-            if evs_left != evs_right {
-                crate::bail_parse_error!(
-                    "all arguments to binary operator {operator} must return the same number of values. Got: ({evs_left}) {operator} ({evs_right})"
-                );
-            }
-            if evs_left > 1 && !supports_row_value_binary_comparison(operator) {
-                crate::bail_parse_error!("row value misused");
-            }
-            1
+        Expr::Binary(..) => {
+            unreachable!("Binary nodes are handled by expr_vector_size's spine walk")
         }
         Expr::Register(_) => 1,
         Expr::Case {

--- a/core/translate/optimizer/lift_common_subexpressions.rs
+++ b/core/translate/optimizer/lift_common_subexpressions.rs
@@ -137,21 +137,36 @@ pub(crate) fn lift_common_subexpressions_from_binary_or_terms(
 
 /// Flatten an ast::Expr::Binary(lhs, OR, rhs) into a list of disjuncts.
 fn flatten_or_expr_owned(expr: Expr) -> Result<Vec<Expr>> {
-    let Expr::Binary(lhs, Operator::Or, rhs) = expr else {
-        return Ok(vec![expr]);
-    };
-    let mut flattened = flatten_or_expr_owned(*lhs)?;
-    flattened.extend(flatten_or_expr_owned(*rhs)?);
+    // Iterative (explicit work stack) because OR chains can be up to
+    // MAX_EXPR_DEPTH links long, which recursion could not traverse within
+    // MAX_EXPR_NESTING-sized stack budgets. Popping the lhs before the rhs
+    // preserves left-to-right operand order.
+    let mut flattened = vec![];
+    let mut stack = vec![expr];
+    while let Some(expr) = stack.pop() {
+        if let Expr::Binary(lhs, Operator::Or, rhs) = expr {
+            stack.push(*rhs);
+            stack.push(*lhs);
+        } else {
+            flattened.push(expr);
+        }
+    }
     Ok(flattened)
 }
 
 /// Flatten an ast::Expr::Binary(lhs, AND, rhs) into a list of conjuncts.
 fn flatten_and_expr_owned(expr: Expr) -> Result<Vec<Expr>> {
-    let Expr::Binary(lhs, Operator::And, rhs) = expr else {
-        return Ok(vec![expr]);
-    };
-    let mut flattened = flatten_and_expr_owned(*lhs)?;
-    flattened.extend(flatten_and_expr_owned(*rhs)?);
+    // Iterative for the same reason as [`flatten_or_expr_owned`].
+    let mut flattened = vec![];
+    let mut stack = vec![expr];
+    while let Some(expr) = stack.pop() {
+        if let Expr::Binary(lhs, Operator::And, rhs) = expr {
+            stack.push(*rhs);
+            stack.push(*lhs);
+        } else {
+            flattened.push(expr);
+        }
+    }
     Ok(flattened)
 }
 

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3017,97 +3017,127 @@ impl Optimizable for ast::Expr {
         }
     }
     /// Returns true if the expression is a constant i.e. does not depend on columns and can be evaluated only once during the execution
+    ///
+    /// Iterative (explicit work stack) because it can be called on expression
+    /// trees up to [`turso_parser::MAX_EXPR_DEPTH`] deep (e.g. long binary
+    /// operator chains), which recursion could not traverse within
+    /// [`turso_parser::MAX_EXPR_NESTING`]-sized stack budgets.
     fn is_constant(&self, resolver: &Resolver<'_>) -> bool {
-        match self {
-            Expr::SubqueryResult { .. } => false,
-            Expr::Between {
-                lhs, start, end, ..
-            } => {
-                lhs.is_constant(resolver)
-                    && start.is_constant(resolver)
-                    && end.is_constant(resolver)
-            }
-            Expr::Binary(expr, _, expr1) => {
-                expr.is_constant(resolver) && expr1.is_constant(resolver)
-            }
-            Expr::Case {
-                base,
-                when_then_pairs,
-                else_expr,
-            } => {
-                base.as_ref().is_none_or(|base| base.is_constant(resolver))
-                    && when_then_pairs.iter().all(|(when, then)| {
-                        when.is_constant(resolver) && then.is_constant(resolver)
-                    })
-                    && else_expr
-                        .as_ref()
-                        .is_none_or(|else_expr| else_expr.is_constant(resolver))
-            }
-            Expr::Cast { expr, .. } => expr.is_constant(resolver),
-            Expr::Collate(expr, _) => expr.is_constant(resolver),
-            // Not constant. Normally rewritten to Expr::Column by the optimizer,
-            // but CHECK constraints bypass the rewrite pass and legitimately
-            // contain DoublyQualified nodes.
-            Expr::DoublyQualified(_, _, _) => false,
-            Expr::Exists(_) => false,
-            Expr::FunctionCall {
-                args,
-                name,
-                filter_over,
-                ..
-            } => {
-                if filter_over.over_clause.is_some() {
-                    return false;
+        let mut stack: smallvec::SmallVec<[&Expr; 8]> = smallvec::smallvec![self];
+        while let Some(expr) = stack.pop() {
+            match expr {
+                Expr::SubqueryResult { .. } => return false,
+                Expr::Between {
+                    lhs, start, end, ..
+                } => {
+                    stack.push(lhs);
+                    stack.push(start);
+                    stack.push(end);
                 }
-                let Some(func) = resolver
-                    .resolve_function(name.as_str(), args.len())
-                    .ok()
-                    .flatten()
-                else {
-                    return false;
-                };
-                func.is_deterministic() && args.iter().all(|arg| arg.is_constant(resolver))
-            }
-            Expr::FunctionCallStar { .. } => false,
-            Expr::Id(_) => true,
-            Expr::Column { .. } => false,
-            Expr::RowId { .. } => false,
-            Expr::InList { lhs, rhs, .. } => {
-                lhs.is_constant(resolver)
-                    && (rhs.is_empty() || rhs.iter().all(|v| v.is_constant(resolver)))
-            }
-            Expr::InSelect { .. } => {
-                false // might be constant, too annoying to check subqueries etc. implement later
-            }
-            Expr::InTable { .. } => false,
-            Expr::IsNull(expr) => expr.is_constant(resolver),
-            Expr::Like {
-                lhs, rhs, escape, ..
-            } => {
-                lhs.is_constant(resolver)
-                    && rhs.is_constant(resolver)
-                    && escape
-                        .as_ref()
-                        .is_none_or(|escape| escape.is_constant(resolver))
-            }
-            Expr::Literal(_) => true,
-            Expr::Name(_) => false,
-            Expr::NotNull(expr) => expr.is_constant(resolver),
-            Expr::Parenthesized(exprs) => exprs.iter().all(|expr| expr.is_constant(resolver)),
-            // Not constant. Normally rewritten to Expr::Column by the optimizer,
-            // but CHECK constraints bypass the rewrite pass and legitimately
-            // contain Qualified nodes.
-            Expr::Qualified(_, _) | Expr::FieldAccess { .. } => false,
-            Expr::Raise(_, expr) => expr.as_ref().is_none_or(|expr| expr.is_constant(resolver)),
-            Expr::Subquery(_) => false,
-            Expr::Unary(_, expr) => expr.is_constant(resolver),
-            Expr::Variable(_) => true,
-            Expr::Register(_) => false,
-            Expr::Default => true,
-            Expr::Array { .. } | Expr::Subscript { .. } => {
-                unreachable!("Array and Subscript are desugared into function calls by the parser")
+                Expr::Binary(expr, _, expr1) => {
+                    stack.push(expr);
+                    stack.push(expr1);
+                }
+                Expr::Case {
+                    base,
+                    when_then_pairs,
+                    else_expr,
+                } => {
+                    if let Some(base) = base {
+                        stack.push(base);
+                    }
+                    for (when, then) in when_then_pairs {
+                        stack.push(when);
+                        stack.push(then);
+                    }
+                    if let Some(else_expr) = else_expr {
+                        stack.push(else_expr);
+                    }
+                }
+                Expr::Cast { expr, .. } => stack.push(expr),
+                Expr::Collate(expr, _) => stack.push(expr),
+                // Not constant. Normally rewritten to Expr::Column by the optimizer,
+                // but CHECK constraints bypass the rewrite pass and legitimately
+                // contain DoublyQualified nodes.
+                Expr::DoublyQualified(_, _, _) => return false,
+                Expr::Exists(_) => return false,
+                Expr::FunctionCall {
+                    args,
+                    name,
+                    filter_over,
+                    ..
+                } => {
+                    if filter_over.over_clause.is_some() {
+                        return false;
+                    }
+                    let Some(func) = resolver
+                        .resolve_function(name.as_str(), args.len())
+                        .ok()
+                        .flatten()
+                    else {
+                        return false;
+                    };
+                    if !func.is_deterministic() {
+                        return false;
+                    }
+                    for arg in args {
+                        stack.push(arg);
+                    }
+                }
+                Expr::FunctionCallStar { .. } => return false,
+                Expr::Id(_) => {}
+                Expr::Column { .. } => return false,
+                Expr::RowId { .. } => return false,
+                Expr::InList { lhs, rhs, .. } => {
+                    stack.push(lhs);
+                    for v in rhs {
+                        stack.push(v);
+                    }
+                }
+                Expr::InSelect { .. } => {
+                    return false; // might be constant, too annoying to check subqueries etc. implement later
+                }
+                Expr::InTable { .. } => return false,
+                Expr::IsNull(expr) => stack.push(expr),
+                Expr::Like {
+                    lhs, rhs, escape, ..
+                } => {
+                    stack.push(lhs);
+                    stack.push(rhs);
+                    if let Some(escape) = escape {
+                        stack.push(escape);
+                    }
+                }
+                Expr::Literal(_) => {}
+                Expr::Name(_) => return false,
+                Expr::NotNull(expr) => stack.push(expr),
+                Expr::Parenthesized(exprs) => {
+                    for expr in exprs {
+                        stack.push(expr);
+                    }
+                }
+                // Not constant. Normally rewritten to Expr::Column by the optimizer,
+                // but CHECK constraints bypass the rewrite pass and legitimately
+                // contain Qualified nodes.
+                Expr::Qualified(_, _) | Expr::FieldAccess { .. } => return false,
+                Expr::Raise(_, expr) => {
+                    if let Some(expr) = expr {
+                        stack.push(expr);
+                    }
+                }
+                Expr::Subquery(_) => return false,
+                Expr::Unary(_, expr) => stack.push(expr),
+                Expr::Variable(_) => {}
+                Expr::Register(_) => return false,
+                Expr::Default => {}
+                Expr::Array { .. } | Expr::Subscript { .. } => {
+                    unreachable!(
+                        "Array and Subscript are desugared into function calls by the parser"
+                    )
+                }
             }
         }
+        true
     }
     /// Returns true if the expression is a constant expression that, when evaluated as a condition, is always true or false
     fn check_always_true_or_false(&self) -> Result<Option<AlwaysTrueOrFalse>> {
@@ -3170,40 +3200,53 @@ impl Optimizable for ast::Expr {
 
                 Ok(None)
             }
-            Self::Binary(lhs, op, rhs) => {
-                let lhs_trivial = lhs.check_always_true_or_false()?;
-                let rhs_trivial = rhs.check_always_true_or_false()?;
-                match op {
-                    ast::Operator::And => {
-                        if lhs_trivial == Some(AlwaysTrueOrFalse::AlwaysFalse)
-                            || rhs_trivial == Some(AlwaysTrueOrFalse::AlwaysFalse)
-                        {
-                            return Ok(Some(AlwaysTrueOrFalse::AlwaysFalse));
-                        }
-                        if lhs_trivial == Some(AlwaysTrueOrFalse::AlwaysTrue)
-                            && rhs_trivial == Some(AlwaysTrueOrFalse::AlwaysTrue)
-                        {
-                            return Ok(Some(AlwaysTrueOrFalse::AlwaysTrue));
-                        }
-
-                        Ok(None)
-                    }
-                    ast::Operator::Or => {
-                        if lhs_trivial == Some(AlwaysTrueOrFalse::AlwaysTrue)
-                            || rhs_trivial == Some(AlwaysTrueOrFalse::AlwaysTrue)
-                        {
-                            return Ok(Some(AlwaysTrueOrFalse::AlwaysTrue));
-                        }
-                        if lhs_trivial == Some(AlwaysTrueOrFalse::AlwaysFalse)
-                            && rhs_trivial == Some(AlwaysTrueOrFalse::AlwaysFalse)
-                        {
-                            return Ok(Some(AlwaysTrueOrFalse::AlwaysFalse));
-                        }
-
-                        Ok(None)
-                    }
-                    _ => Ok(None),
+            Self::Binary(..) => {
+                // Evaluate Binary left spines iteratively (descent, then a
+                // bottom-up fold of the same per-level logic the recursive
+                // formulation used): chains can be MAX_EXPR_DEPTH links long,
+                // which recursion could not traverse within
+                // MAX_EXPR_NESTING-sized stack budgets. The rhs evaluations
+                // re-enter this arm for any spine nested inside them.
+                let mut spine = vec![];
+                let mut node = self;
+                while let Self::Binary(lhs, op, rhs) = node {
+                    spine.push((op, rhs));
+                    node = lhs;
                 }
+                let mut lhs_trivial = node.check_always_true_or_false()?;
+                for (op, rhs) in spine.into_iter().rev() {
+                    let rhs_trivial = rhs.check_always_true_or_false()?;
+                    lhs_trivial = match op {
+                        ast::Operator::And => {
+                            if lhs_trivial == Some(AlwaysTrueOrFalse::AlwaysFalse)
+                                || rhs_trivial == Some(AlwaysTrueOrFalse::AlwaysFalse)
+                            {
+                                Some(AlwaysTrueOrFalse::AlwaysFalse)
+                            } else if lhs_trivial == Some(AlwaysTrueOrFalse::AlwaysTrue)
+                                && rhs_trivial == Some(AlwaysTrueOrFalse::AlwaysTrue)
+                            {
+                                Some(AlwaysTrueOrFalse::AlwaysTrue)
+                            } else {
+                                None
+                            }
+                        }
+                        ast::Operator::Or => {
+                            if lhs_trivial == Some(AlwaysTrueOrFalse::AlwaysTrue)
+                                || rhs_trivial == Some(AlwaysTrueOrFalse::AlwaysTrue)
+                            {
+                                Some(AlwaysTrueOrFalse::AlwaysTrue)
+                            } else if lhs_trivial == Some(AlwaysTrueOrFalse::AlwaysFalse)
+                                && rhs_trivial == Some(AlwaysTrueOrFalse::AlwaysFalse)
+                            {
+                                Some(AlwaysTrueOrFalse::AlwaysFalse)
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
+                    };
+                }
+                Ok(lhs_trivial)
             }
             _ => Ok(None),
         }

--- a/core/util.rs
+++ b/core/util.rs
@@ -769,12 +769,29 @@ pub fn exprs_are_equivalent(expr1: &Expr, expr2: &Expr) -> bool {
                 && exprs_are_equivalent(start1, start2)
                 && exprs_are_equivalent(end1, end2)
         }
-        (Expr::Binary(lhs1, op1, rhs1), Expr::Binary(lhs2, op2, rhs2)) => {
-            op1 == op2
-                && ((exprs_are_equivalent(lhs1, lhs2) && exprs_are_equivalent(rhs1, rhs2))
-                    || (op1.is_commutative()
-                        && exprs_are_equivalent(lhs1, rhs2)
-                        && exprs_are_equivalent(rhs1, lhs2)))
+        (Expr::Binary(..), Expr::Binary(..)) => {
+            // Compare Binary left spines iteratively (lockstep descent, then a
+            // bottom-up fold over the same per-level condition the recursive
+            // formulation used): chains can be MAX_EXPR_DEPTH links long,
+            // which recursion could not traverse within MAX_EXPR_NESTING-sized
+            // stack budgets. The rhs/swap comparisons below re-enter this arm
+            // for any spines nested inside them.
+            let mut levels = vec![];
+            let (mut a, mut b) = (expr1, expr2);
+            while let (Expr::Binary(lhs1, op1, rhs1), Expr::Binary(lhs2, op2, rhs2)) = (a, b) {
+                levels.push((lhs1, op1, rhs1, lhs2, op2, rhs2));
+                a = lhs1;
+                b = lhs2;
+            }
+            let mut equivalent = exprs_are_equivalent(a, b);
+            for (lhs1, op1, rhs1, lhs2, op2, rhs2) in levels.into_iter().rev() {
+                equivalent = op1 == op2
+                    && ((equivalent && exprs_are_equivalent(rhs1, rhs2))
+                        || (op1.is_commutative()
+                            && exprs_are_equivalent(lhs1, rhs2)
+                            && exprs_are_equivalent(rhs1, lhs2)));
+            }
+            equivalent
         }
         (
             Expr::Case {

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -421,7 +421,10 @@ pub enum FieldAccessResolution {
 }
 
 // https://sqlite.org/syntax/expr.html
-#[derive(Clone, Debug, PartialEq, Eq)]
+// Clone and PartialEq are implemented manually (below the enum) so that
+// Binary left spines are traversed iteratively; the derived impls would
+// recurse once per chain link.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Expr {
     /// `BETWEEN`
@@ -612,6 +615,437 @@ pub enum Expr {
 impl Default for Expr {
     fn default() -> Self {
         Self::Literal(Literal::Null)
+    }
+}
+
+impl PartialEq for Expr {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare Binary left spines iteratively so that equality recursion
+        // depth tracks expression *nesting* (MAX_EXPR_NESTING), not chain
+        // length (MAX_EXPR_DEPTH). The rhs comparisons re-enter this loop for
+        // any spine nested inside them.
+        let (mut a, mut b) = (self, other);
+        loop {
+            match (a, b) {
+                (Expr::Binary(lhs1, op1, rhs1), Expr::Binary(lhs2, op2, rhs2)) => {
+                    if op1 != op2 || rhs1 != rhs2 {
+                        return false;
+                    }
+                    a = lhs1;
+                    b = lhs2;
+                }
+                _ => return a.eq_non_binary(b),
+            }
+        }
+    }
+}
+
+impl Eq for Expr {}
+
+impl Expr {
+    /// Field-wise equality of every variant pairing except
+    /// (`Binary`, `Binary`), which [`Expr::eq`] handles iteratively.
+    fn eq_non_binary(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Expr::Binary(..), _) | (_, Expr::Binary(..)) => false,
+            (
+                Expr::Between {
+                    lhs: lhs1,
+                    not: not1,
+                    start: start1,
+                    end: end1,
+                },
+                Expr::Between {
+                    lhs: lhs2,
+                    not: not2,
+                    start: start2,
+                    end: end2,
+                },
+            ) => lhs1 == lhs2 && not1 == not2 && start1 == start2 && end1 == end2,
+            (Expr::Register(reg1), Expr::Register(reg2)) => reg1 == reg2,
+            (
+                Expr::Case {
+                    base: base1,
+                    when_then_pairs: pairs1,
+                    else_expr: else1,
+                },
+                Expr::Case {
+                    base: base2,
+                    when_then_pairs: pairs2,
+                    else_expr: else2,
+                },
+            ) => base1 == base2 && pairs1 == pairs2 && else1 == else2,
+            (
+                Expr::Cast {
+                    expr: expr1,
+                    type_name: type1,
+                },
+                Expr::Cast {
+                    expr: expr2,
+                    type_name: type2,
+                },
+            ) => expr1 == expr2 && type1 == type2,
+            (Expr::Collate(expr1, name1), Expr::Collate(expr2, name2)) => {
+                expr1 == expr2 && name1 == name2
+            }
+            (Expr::DoublyQualified(db1, tbl1, col1), Expr::DoublyQualified(db2, tbl2, col2)) => {
+                db1 == db2 && tbl1 == tbl2 && col1 == col2
+            }
+            (Expr::Exists(select1), Expr::Exists(select2)) => select1 == select2,
+            (
+                Expr::FieldAccess {
+                    base: base1,
+                    field: field1,
+                    resolved: resolved1,
+                },
+                Expr::FieldAccess {
+                    base: base2,
+                    field: field2,
+                    resolved: resolved2,
+                },
+            ) => base1 == base2 && field1 == field2 && resolved1 == resolved2,
+            (
+                Expr::FunctionCall {
+                    name: name1,
+                    distinctness: distinctness1,
+                    args: args1,
+                    order_by: order_by1,
+                    within_group: within_group1,
+                    filter_over: filter_over1,
+                },
+                Expr::FunctionCall {
+                    name: name2,
+                    distinctness: distinctness2,
+                    args: args2,
+                    order_by: order_by2,
+                    within_group: within_group2,
+                    filter_over: filter_over2,
+                },
+            ) => {
+                name1 == name2
+                    && distinctness1 == distinctness2
+                    && args1 == args2
+                    && order_by1 == order_by2
+                    && within_group1 == within_group2
+                    && filter_over1 == filter_over2
+            }
+            (
+                Expr::FunctionCallStar {
+                    name: name1,
+                    filter_over: filter_over1,
+                },
+                Expr::FunctionCallStar {
+                    name: name2,
+                    filter_over: filter_over2,
+                },
+            ) => name1 == name2 && filter_over1 == filter_over2,
+            (Expr::Id(name1), Expr::Id(name2)) => name1 == name2,
+            (
+                Expr::Column {
+                    database: database1,
+                    table: table1,
+                    column: column1,
+                    is_rowid_alias: is_rowid_alias1,
+                },
+                Expr::Column {
+                    database: database2,
+                    table: table2,
+                    column: column2,
+                    is_rowid_alias: is_rowid_alias2,
+                },
+            ) => {
+                database1 == database2
+                    && table1 == table2
+                    && column1 == column2
+                    && is_rowid_alias1 == is_rowid_alias2
+            }
+            (
+                Expr::RowId {
+                    database: database1,
+                    table: table1,
+                },
+                Expr::RowId {
+                    database: database2,
+                    table: table2,
+                },
+            ) => database1 == database2 && table1 == table2,
+            (
+                Expr::InList {
+                    lhs: lhs1,
+                    not: not1,
+                    rhs: rhs1,
+                },
+                Expr::InList {
+                    lhs: lhs2,
+                    not: not2,
+                    rhs: rhs2,
+                },
+            ) => lhs1 == lhs2 && not1 == not2 && rhs1 == rhs2,
+            (
+                Expr::InSelect {
+                    lhs: lhs1,
+                    not: not1,
+                    rhs: rhs1,
+                },
+                Expr::InSelect {
+                    lhs: lhs2,
+                    not: not2,
+                    rhs: rhs2,
+                },
+            ) => lhs1 == lhs2 && not1 == not2 && rhs1 == rhs2,
+            (
+                Expr::InTable {
+                    lhs: lhs1,
+                    not: not1,
+                    rhs: rhs1,
+                    args: args1,
+                },
+                Expr::InTable {
+                    lhs: lhs2,
+                    not: not2,
+                    rhs: rhs2,
+                    args: args2,
+                },
+            ) => lhs1 == lhs2 && not1 == not2 && rhs1 == rhs2 && args1 == args2,
+            (Expr::IsNull(expr1), Expr::IsNull(expr2)) => expr1 == expr2,
+            (
+                Expr::Like {
+                    lhs: lhs1,
+                    not: not1,
+                    op: op1,
+                    rhs: rhs1,
+                    escape: escape1,
+                },
+                Expr::Like {
+                    lhs: lhs2,
+                    not: not2,
+                    op: op2,
+                    rhs: rhs2,
+                    escape: escape2,
+                },
+            ) => lhs1 == lhs2 && not1 == not2 && op1 == op2 && rhs1 == rhs2 && escape1 == escape2,
+            (Expr::Literal(lit1), Expr::Literal(lit2)) => lit1 == lit2,
+            (Expr::Name(name1), Expr::Name(name2)) => name1 == name2,
+            (Expr::NotNull(expr1), Expr::NotNull(expr2)) => expr1 == expr2,
+            (Expr::Parenthesized(exprs1), Expr::Parenthesized(exprs2)) => exprs1 == exprs2,
+            (Expr::Qualified(qual1, name1), Expr::Qualified(qual2, name2)) => {
+                qual1 == qual2 && name1 == name2
+            }
+            (Expr::Raise(resolve1, expr1), Expr::Raise(resolve2, expr2)) => {
+                resolve1 == resolve2 && expr1 == expr2
+            }
+            (Expr::Subquery(select1), Expr::Subquery(select2)) => select1 == select2,
+            (Expr::Unary(op1, expr1), Expr::Unary(op2, expr2)) => op1 == op2 && expr1 == expr2,
+            (Expr::Variable(var1), Expr::Variable(var2)) => var1 == var2,
+            (
+                Expr::SubqueryResult {
+                    subquery_id: subquery_id1,
+                    lhs: lhs1,
+                    not_in: not_in1,
+                    query_type: query_type1,
+                },
+                Expr::SubqueryResult {
+                    subquery_id: subquery_id2,
+                    lhs: lhs2,
+                    not_in: not_in2,
+                    query_type: query_type2,
+                },
+            ) => {
+                subquery_id1 == subquery_id2
+                    && lhs1 == lhs2
+                    && not_in1 == not_in2
+                    && query_type1 == query_type2
+            }
+            (Expr::Default, Expr::Default) => true,
+            (
+                Expr::Array {
+                    elements: elements1,
+                },
+                Expr::Array {
+                    elements: elements2,
+                },
+            ) => elements1 == elements2,
+            (
+                Expr::Subscript {
+                    base: base1,
+                    index: index1,
+                },
+                Expr::Subscript {
+                    base: base2,
+                    index: index2,
+                },
+            ) => base1 == base2 && index1 == index2,
+            _ => false,
+        }
+    }
+}
+
+impl Clone for Expr {
+    fn clone(&self) -> Self {
+        // Left spines of Binary nodes (`a OR b OR c ...`) can be up to
+        // MAX_EXPR_DEPTH links long; clone them iteratively so that clone
+        // recursion depth tracks expression *nesting* (MAX_EXPR_NESTING), not
+        // chain length. The rhs clones below re-enter this loop for any
+        // spine nested inside them, so every spine anywhere in the tree is
+        // cloned iteratively.
+        let mut links = Vec::new();
+        let mut node = self;
+        while let Expr::Binary(lhs, op, rhs) = node {
+            links.push((*op, rhs.as_ref().clone()));
+            node = lhs;
+        }
+        let mut cloned = node.clone_non_binary();
+        for (op, rhs) in links.into_iter().rev() {
+            cloned = Expr::Binary(Box::new(cloned), op, Box::new(rhs));
+        }
+        cloned
+    }
+}
+
+impl Expr {
+    /// Field-wise clone of every variant except `Binary`, which
+    /// [`Expr::clone`] handles iteratively.
+    fn clone_non_binary(&self) -> Self {
+        match self {
+            Expr::Binary(..) => unreachable!("Binary nodes are cloned by Expr::clone's spine walk"),
+            Expr::Between {
+                lhs,
+                not,
+                start,
+                end,
+            } => Expr::Between {
+                lhs: lhs.clone(),
+                not: *not,
+                start: start.clone(),
+                end: end.clone(),
+            },
+            Expr::Register(reg) => Expr::Register(*reg),
+            Expr::Case {
+                base,
+                when_then_pairs,
+                else_expr,
+            } => Expr::Case {
+                base: base.clone(),
+                when_then_pairs: when_then_pairs.clone(),
+                else_expr: else_expr.clone(),
+            },
+            Expr::Cast { expr, type_name } => Expr::Cast {
+                expr: expr.clone(),
+                type_name: type_name.clone(),
+            },
+            Expr::Collate(expr, name) => Expr::Collate(expr.clone(), name.clone()),
+            Expr::DoublyQualified(db, tbl, col) => {
+                Expr::DoublyQualified(db.clone(), tbl.clone(), col.clone())
+            }
+            Expr::Exists(select) => Expr::Exists(select.clone()),
+            Expr::FieldAccess {
+                base,
+                field,
+                resolved,
+            } => Expr::FieldAccess {
+                base: base.clone(),
+                field: field.clone(),
+                resolved: *resolved,
+            },
+            Expr::FunctionCall {
+                name,
+                distinctness,
+                args,
+                order_by,
+                within_group,
+                filter_over,
+            } => Expr::FunctionCall {
+                name: name.clone(),
+                distinctness: *distinctness,
+                args: args.clone(),
+                order_by: order_by.clone(),
+                within_group: within_group.clone(),
+                filter_over: filter_over.clone(),
+            },
+            Expr::FunctionCallStar { name, filter_over } => Expr::FunctionCallStar {
+                name: name.clone(),
+                filter_over: filter_over.clone(),
+            },
+            Expr::Id(name) => Expr::Id(name.clone()),
+            Expr::Column {
+                database,
+                table,
+                column,
+                is_rowid_alias,
+            } => Expr::Column {
+                database: *database,
+                table: *table,
+                column: *column,
+                is_rowid_alias: *is_rowid_alias,
+            },
+            Expr::RowId { database, table } => Expr::RowId {
+                database: *database,
+                table: *table,
+            },
+            Expr::InList { lhs, not, rhs } => Expr::InList {
+                lhs: lhs.clone(),
+                not: *not,
+                rhs: rhs.clone(),
+            },
+            Expr::InSelect { lhs, not, rhs } => Expr::InSelect {
+                lhs: lhs.clone(),
+                not: *not,
+                rhs: rhs.clone(),
+            },
+            Expr::InTable {
+                lhs,
+                not,
+                rhs,
+                args,
+            } => Expr::InTable {
+                lhs: lhs.clone(),
+                not: *not,
+                rhs: rhs.clone(),
+                args: args.clone(),
+            },
+            Expr::IsNull(expr) => Expr::IsNull(expr.clone()),
+            Expr::Like {
+                lhs,
+                not,
+                op,
+                rhs,
+                escape,
+            } => Expr::Like {
+                lhs: lhs.clone(),
+                not: *not,
+                op: *op,
+                rhs: rhs.clone(),
+                escape: escape.clone(),
+            },
+            Expr::Literal(literal) => Expr::Literal(literal.clone()),
+            Expr::Name(name) => Expr::Name(name.clone()),
+            Expr::NotNull(expr) => Expr::NotNull(expr.clone()),
+            Expr::Parenthesized(exprs) => Expr::Parenthesized(exprs.clone()),
+            Expr::Qualified(qualifier, name) => Expr::Qualified(qualifier.clone(), name.clone()),
+            Expr::Raise(resolve_type, expr) => Expr::Raise(*resolve_type, expr.clone()),
+            Expr::Subquery(select) => Expr::Subquery(select.clone()),
+            Expr::Unary(op, expr) => Expr::Unary(*op, expr.clone()),
+            Expr::Variable(variable) => Expr::Variable(variable.clone()),
+            Expr::SubqueryResult {
+                subquery_id,
+                lhs,
+                not_in,
+                query_type,
+            } => Expr::SubqueryResult {
+                subquery_id: *subquery_id,
+                lhs: lhs.clone(),
+                not_in: *not_in,
+                query_type: query_type.clone(),
+            },
+            Expr::Default => Expr::Default,
+            Expr::Array { elements } => Expr::Array {
+                elements: elements.clone(),
+            },
+            Expr::Subscript { base, index } => Expr::Subscript {
+                base: base.clone(),
+                index: index.clone(),
+            },
+        }
     }
 }
 

--- a/sqlite/parser/src/lib.rs
+++ b/sqlite/parser/src/lib.rs
@@ -4,6 +4,6 @@ pub mod lexer;
 pub mod parser;
 pub mod token;
 
-pub use parser::MAX_EXPR_DEPTH;
+pub use parser::{MAX_EXPR_DEPTH, MAX_EXPR_NESTING};
 
 type Result<T, E = error::Error> = std::result::Result<T, E>;

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -156,18 +156,85 @@ pub struct Parser<'a> {
     named_variables: HashMap<&'a [u8], NonZeroU32>,
     /// Tracks STRUCT/UNION nesting depth to prevent stack overflow from deeply nested types
     type_nesting_depth: u32,
-    /// Current expression recursion depth of the parser, bounded by [`MAX_EXPR_DEPTH`]
+    /// Current expression recursion depth of the parser, bounded by
+    /// [`MAX_EXPR_NESTING`]
     expr_nesting_depth: u32,
-    /// Height of the most recently parsed expression (`1 + max(child heights)`,
-    /// like SQLite's `Expr.nHeight`), bounded by [`MAX_EXPR_DEPTH`]
-    last_expr_height: usize,
+    /// Size of the most recently parsed expression, bounded by
+    /// [`MAX_EXPR_DEPTH`] / [`MAX_EXPR_NESTING`]
+    last_expr_height: ExprSize,
 }
 
 /// Maximum query expression depth, our equivalent of SQLite's
-/// `SQLITE_MAX_EXPR_DEPTH` (default 1000). Kept lower because our recursive
-/// translator/optimizer uses larger stack frames per nesting level, so a
-/// 1000-deep tree still overflows a default 8 MiB thread stack in debug builds.
-pub const MAX_EXPR_DEPTH: usize = 100;
+/// `SQLITE_MAX_EXPR_DEPTH`, matching its default of 1000 and counting the same
+/// way (every tree level, including one level per operator in a flat chain
+/// like `a OR b OR c ...`). This bounds the passes that walk the tree with
+/// small per-level state (e.g. derived `Drop`/`Clone`/`PartialEq` glue).
+pub const MAX_EXPR_DEPTH: usize = 1000;
+
+/// Maximum expression *nesting*, a stricter bound than [`MAX_EXPR_DEPTH`] that
+/// does not count contiguous binary-operator chain links: the parser consumes
+/// those iteratively and the translator folds them iteratively, so only truly
+/// nested constructs (parentheses, CASE, subqueries, function calls, ...) add
+/// a recursion level in the fat-frame recursive passes. Those passes overflow
+/// small fixed-size stacks (e.g. coroutine stacks) far below 1000 levels,
+/// hence the lower bound.
+pub const MAX_EXPR_NESTING: usize = 100;
+
+/// Size metrics of a parsed expression tree, tracked during parsing so that
+/// over-sized input is rejected deterministically before any recursive pass
+/// can overflow the native stack.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub(crate) struct ExprSize {
+    /// True tree depth (`1 + max(child depths)`, like SQLite's `Expr.nHeight`),
+    /// counting every binary chain link. Bounded by [`MAX_EXPR_DEPTH`].
+    depth: usize,
+    /// Nesting height: like `depth`, except contiguous `Expr::Binary` spine
+    /// links share one level, mirroring the translator's iterative spine
+    /// traversal. Bounded by [`MAX_EXPR_NESTING`].
+    nesting: usize,
+}
+
+impl ExprSize {
+    const ZERO: ExprSize = ExprSize {
+        depth: 0,
+        nesting: 0,
+    };
+    const LEAF: ExprSize = ExprSize {
+        depth: 1,
+        nesting: 1,
+    };
+
+    /// Memberwise max, for merging sibling subexpression sizes.
+    fn max(self, other: ExprSize) -> ExprSize {
+        ExprSize {
+            depth: self.depth.max(other.depth),
+            nesting: self.nesting.max(other.nesting),
+        }
+    }
+
+    /// The size of a node wrapping children of this merged size.
+    fn add_level(self) -> ExprSize {
+        ExprSize {
+            depth: self.depth + 1,
+            nesting: self.nesting + 1,
+        }
+    }
+
+    /// Reject expressions over either limit.
+    fn check(self) -> Result<()> {
+        if self.depth > MAX_EXPR_DEPTH {
+            return Err(Error::ParseError(format!(
+                "Expression tree is too large (maximum depth {MAX_EXPR_DEPTH})"
+            )));
+        }
+        if self.nesting > MAX_EXPR_NESTING {
+            return Err(Error::ParseError(format!(
+                "Expression tree is too deeply nested (maximum nesting {MAX_EXPR_NESTING})"
+            )));
+        }
+        Ok(())
+    }
+}
 
 impl<'a> Iterator for Parser<'a> {
     type Item = Result<Cmd>;
@@ -193,7 +260,7 @@ impl<'a> Parser<'a> {
             named_variables: HashMap::new(),
             type_nesting_depth: 0,
             expr_nesting_depth: 0,
-            last_expr_height: 0,
+            last_expr_height: ExprSize::ZERO,
         }
     }
 
@@ -1362,7 +1429,7 @@ impl<'a> Parser<'a> {
     fn parse_filter_clause(&mut self) -> Result<Option<Box<Expr>>> {
         // Report height 0 when there is no FILTER clause so callers folding this
         // into their own height are not misled by a stale value.
-        self.last_expr_height = 0;
+        self.last_expr_height = ExprSize::ZERO;
         match self.peek()? {
             None => return Ok(None),
             Some(tok) => match tok.token_type {
@@ -1384,9 +1451,9 @@ impl<'a> Parser<'a> {
     fn parse_frame_opt(&mut self) -> Result<Option<FrameClause>> {
         // Tallest frame-bound expression, reported via `last_expr_height`; the
         // non-expression bounds (`UNBOUNDED`, `CURRENT ROW`) contribute nothing.
-        let mut max_h = 0usize;
+        let mut max_h = ExprSize::ZERO;
         // No frame clause parsed yet: report height 0 for the early returns below.
-        self.last_expr_height = 0;
+        self.last_expr_height = ExprSize::ZERO;
         let range_or_rows = match self.peek()? {
             None => return Ok(None),
             Some(tok) => match tok.token_type {
@@ -1514,7 +1581,7 @@ impl<'a> Parser<'a> {
         // Tallest sub-expression across PARTITION BY / ORDER BY / frame bounds,
         // reported via `last_expr_height` so a function's window clause folds into
         // its height (later passes recurse through the window's expressions).
-        let mut max_h = 0usize;
+        let mut max_h = ExprSize::ZERO;
         let partition_by = match self.peek()? {
             Some(tok) if tok.token_type == TK_PARTITION => {
                 eat_assert!(self, TK_PARTITION);
@@ -1541,7 +1608,7 @@ impl<'a> Parser<'a> {
 
     fn parse_over_clause(&mut self) -> Result<Option<Over>> {
         // Report height 0 unless a window definition with expressions is parsed.
-        self.last_expr_height = 0;
+        self.last_expr_height = ExprSize::ZERO;
         match self.peek()? {
             None => return Ok(None),
             Some(tok) => match tok.token_type {
@@ -1584,7 +1651,7 @@ impl<'a> Parser<'a> {
     fn parse_within_group(&mut self) -> Result<Vec<SortedColumn>> {
         // Report height 0 unless a WITHIN GROUP (ORDER BY ...) is parsed, in which
         // case `parse_order_by` leaves the tallest sort expression's height.
-        self.last_expr_height = 0;
+        self.last_expr_height = ExprSize::ZERO;
         match self.peek()? {
             Some(tok) if tok.token_type == TK_WITHIN => {
                 eat_assert!(self, TK_WITHIN);
@@ -1618,7 +1685,7 @@ impl<'a> Parser<'a> {
         // Height of the operand. Leaves keep this default; branches that recurse
         // into sub-expressions overwrite it with `1 + max(child heights)` so the
         // enclosing chain guard (see `parse_expr_inner`) sees their true depth.
-        self.last_expr_height = 1;
+        self.last_expr_height = ExprSize::LEAF;
 
         let tok = peek_expect!(
             self,
@@ -1657,14 +1724,14 @@ impl<'a> Parser<'a> {
                         let select = self.parse_select()?;
                         eat_expect!(self, TK_RP);
                         // Subquery is compiled separately: a leaf for height.
-                        self.last_expr_height = 1;
+                        self.last_expr_height = ExprSize::LEAF;
                         Ok(Box::new(Expr::Subquery(select)))
                     }
                     _ => {
                         let exprs = self.parse_nexpr_list()?;
                         eat_expect!(self, TK_RP);
                         // `parse_nexpr_list` left the tallest element's height.
-                        self.last_expr_height += 1;
+                        self.last_expr_height = self.last_expr_height.add_level();
                         Ok(Box::new(Expr::Parenthesized(exprs)))
                     }
                 }
@@ -1702,7 +1769,7 @@ impl<'a> Parser<'a> {
                 eat_expect!(self, TK_AS);
                 let typ = self.parse_type()?;
                 eat_expect!(self, TK_RP);
-                self.last_expr_height += 1;
+                self.last_expr_height = self.last_expr_height.add_level();
                 Ok(Box::new(Expr::Cast {
                     expr,
                     type_name: typ,
@@ -1720,25 +1787,25 @@ impl<'a> Parser<'a> {
             TK_NOT => {
                 eat_assert!(self, TK_NOT);
                 let expr = self.parse_expr(2)?; // NOT precedence is 2
-                self.last_expr_height += 1;
+                self.last_expr_height = self.last_expr_height.add_level();
                 Ok(Box::new(Expr::Unary(UnaryOperator::Not, expr)))
             }
             TK_BITNOT => {
                 eat_assert!(self, TK_BITNOT);
                 let expr = self.parse_expr(11)?; // BITNOT precedence is 11
-                self.last_expr_height += 1;
+                self.last_expr_height = self.last_expr_height.add_level();
                 Ok(Box::new(Expr::Unary(UnaryOperator::BitwiseNot, expr)))
             }
             TK_PLUS => {
                 eat_assert!(self, TK_PLUS);
                 let expr = self.parse_expr(11)?; // PLUS precedence is 11
-                self.last_expr_height += 1;
+                self.last_expr_height = self.last_expr_height.add_level();
                 Ok(Box::new(Expr::Unary(UnaryOperator::Positive, expr)))
             }
             TK_MINUS => {
                 eat_assert!(self, TK_MINUS);
                 let expr = self.parse_expr(11)?; // MINUS precedence is 11
-                self.last_expr_height += 1;
+                self.last_expr_height = self.last_expr_height.add_level();
                 Ok(Box::new(Expr::Unary(UnaryOperator::Negative, expr)))
             }
             TK_EXISTS => {
@@ -1747,13 +1814,13 @@ impl<'a> Parser<'a> {
                 let select = self.parse_select()?;
                 eat_expect!(self, TK_RP);
                 // Subquery is compiled separately: a leaf for height.
-                self.last_expr_height = 1;
+                self.last_expr_height = ExprSize::LEAF;
                 Ok(Box::new(Expr::Exists(select)))
             }
             TK_CASE => {
                 eat_assert!(self, TK_CASE);
                 // Tallest of the base/when/then/else sub-expressions.
-                let mut max_h = 0usize;
+                let mut max_h = ExprSize::ZERO;
                 let base = if self.peek_no_eof()?.token_type != TK_WHEN {
                     let base = self.parse_expr(0)?;
                     max_h = max_h.max(self.last_expr_height);
@@ -1798,7 +1865,7 @@ impl<'a> Parser<'a> {
                 };
 
                 eat_expect!(self, TK_END);
-                self.last_expr_height = 1 + max_h;
+                self.last_expr_height = max_h.add_level();
                 Ok(Box::new(Expr::Case {
                     base,
                     when_then_pairs,
@@ -1830,7 +1897,7 @@ impl<'a> Parser<'a> {
 
                 eat_expect!(self, TK_RP);
                 if expr.is_some() {
-                    self.last_expr_height += 1;
+                    self.last_expr_height = self.last_expr_height.add_level();
                 }
                 Ok(Box::new(Expr::Raise(resolve, expr)))
             }
@@ -1875,7 +1942,7 @@ impl<'a> Parser<'a> {
                             let elements = self.parse_expr_list()?;
                             eat_expect!(self, TK_RBRACKET);
                             // `parse_expr_list` left the tallest element's height.
-                            self.last_expr_height += 1;
+                            self.last_expr_height = self.last_expr_height.add_level();
                             // Desugar ARRAY[...] into array(...) function call
                             return Ok(Box::new(Expr::FunctionCall {
                                 name: Name::from_bytes(b"array"),
@@ -1923,7 +1990,7 @@ impl<'a> Parser<'a> {
                                 // No arguments, but later passes still walk any
                                 // FILTER/OVER sub-expressions, so fold their
                                 // height into this node's height.
-                                self.last_expr_height += 1;
+                                self.last_expr_height = self.last_expr_height.add_level();
                                 return Ok(Box::new(Expr::FunctionCallStar {
                                     name: Name::from_bytes(name),
                                     filter_over,
@@ -1943,7 +2010,7 @@ impl<'a> Parser<'a> {
                                 clause_height = clause_height.max(self.last_expr_height);
                                 let filter_over = self.parse_filter_over()?;
                                 clause_height = clause_height.max(self.last_expr_height);
-                                self.last_expr_height = 1 + clause_height;
+                                self.last_expr_height = clause_height.add_level();
                                 return Ok(Box::new(Expr::FunctionCall {
                                     name: Name::from_bytes(name),
                                     distinctness: distinct,
@@ -2008,7 +2075,7 @@ impl<'a> Parser<'a> {
         let mut exprs = vec![];
         // Tallest element, reported via `last_expr_height` so the enclosing node
         // (function call, IN list, ...) can fold it into its own height.
-        let mut max_h = 0usize;
+        let mut max_h = ExprSize::ZERO;
         while let Some(tok) = self.peek()? {
             match tok.token_type.fallback_id_if_ok() {
                 TK_LP | TK_CAST | TK_ID | TK_STRING | TK_INDEXED | TK_JOIN_KW | TK_NULL
@@ -2031,15 +2098,16 @@ impl<'a> Parser<'a> {
         Ok(exprs)
     }
 
-    /// Parse an expression, bounding both the parser's recursion depth and the
-    /// height of the resulting tree by [`MAX_EXPR_DEPTH`]. On return,
-    /// `last_expr_height` holds the height of the returned expression.
+    /// Parse an expression, bounding the parser's recursion depth by
+    /// [`MAX_EXPR_NESTING`] and the size of the resulting tree by
+    /// [`MAX_EXPR_DEPTH`] / [`MAX_EXPR_NESTING`]. On return,
+    /// `last_expr_height` holds the size of the returned expression.
     fn parse_expr(&mut self, precedence: u8) -> Result<Box<Expr>> {
         self.expr_nesting_depth += 1;
-        if self.expr_nesting_depth as usize > MAX_EXPR_DEPTH {
+        if self.expr_nesting_depth as usize > MAX_EXPR_NESTING {
             self.expr_nesting_depth -= 1;
             return Err(Error::ParseError(format!(
-                "Expression tree is too large (maximum depth {MAX_EXPR_DEPTH})"
+                "Expression tree is too deeply nested (maximum nesting {MAX_EXPR_NESTING})"
             )));
         }
         let result = self.parse_expr_inner(precedence);
@@ -2049,16 +2117,17 @@ impl<'a> Parser<'a> {
 
     fn parse_expr_inner(&mut self, precedence: u8) -> Result<Box<Expr>> {
         let mut result = self.parse_expr_operand()?;
-        // Running height of `result`, maintained bottom-up so that a left-deep
+        // Running size of `result`, maintained bottom-up so that a left-deep
         // chain (`a OR b OR c ...`), which this loop consumes iteratively, is
         // bounded too. Check the operand up front: it can already be over the
         // limit on its own without being followed by an operator.
         let mut result_height = self.last_expr_height;
-        if result_height > MAX_EXPR_DEPTH {
-            return Err(Error::ParseError(format!(
-                "Expression tree is too large (maximum depth {MAX_EXPR_DEPTH})"
-            )));
-        }
+        result_height.check()?;
+        // Nesting of the tallest direct component (leftmost operand or any
+        // rhs) of the current contiguous run of `Expr::Binary` links ("spine");
+        // only meaningful while `in_spine` is true.
+        let mut spine_component_nesting = 0usize;
+        let mut in_spine = false;
 
         loop {
             let pre = match self.current_token_precedence()? {
@@ -2180,7 +2249,7 @@ impl<'a> Parser<'a> {
                                     eat_expect!(self, TK_RP);
                                     // The subquery is compiled separately, so it
                                     // counts as a leaf for this expression's height.
-                                    self.last_expr_height = 1;
+                                    self.last_expr_height = ExprSize::LEAF;
                                     Box::new(Expr::InSelect {
                                         lhs: result,
                                         not,
@@ -2458,19 +2527,41 @@ impl<'a> Parser<'a> {
                 }
                 _ => unreachable!(),
             };
-            // Each iteration wraps the previous `result` in a new node, growing
-            // the tree by one level; `last_expr_height` holds the height of the
-            // tallest sub-expression parsed in this iteration.
+            // Each iteration wraps the previous `result` in a new node;
+            // `last_expr_height` holds the size of the tallest sub-expression
+            // parsed in this iteration. `depth` always grows by one level.
+            // `nesting` only grows when the new node is NOT a plain
+            // `Expr::Binary` chain link: the translator folds contiguous
+            // Binary spines iteratively, so links share one recursion level.
+            // `x IS TRUE`-style forms are Binary in the AST but are emitted
+            // through a dedicated non-foldable path, so they count as nesting.
+            let is_spine_link = matches!(
+                result.as_ref(),
+                Expr::Binary(_, op, rhs) if !(matches!(op, Operator::Is | Operator::IsNot)
+                    && matches!(
+                        rhs.as_ref(),
+                        Expr::Literal(Literal::True) | Expr::Literal(Literal::False)
+                    ))
+            );
             result_height = if leaf {
-                1
+                in_spine = false;
+                ExprSize::LEAF
+            } else if is_spine_link {
+                spine_component_nesting = if in_spine {
+                    spine_component_nesting.max(self.last_expr_height.nesting)
+                } else {
+                    result_height.nesting.max(self.last_expr_height.nesting)
+                };
+                in_spine = true;
+                ExprSize {
+                    depth: 1 + result_height.depth.max(self.last_expr_height.depth),
+                    nesting: 1 + spine_component_nesting,
+                }
             } else {
-                1 + result_height.max(self.last_expr_height)
+                in_spine = false;
+                result_height.max(self.last_expr_height).add_level()
             };
-            if result_height > MAX_EXPR_DEPTH {
-                return Err(Error::ParseError(format!(
-                    "Expression tree is too large (maximum depth {MAX_EXPR_DEPTH})"
-                )));
-            }
+            result_height.check()?;
         }
 
         self.last_expr_height = result_height;
@@ -3221,7 +3312,7 @@ impl<'a> Parser<'a> {
     fn parse_order_by(&mut self) -> Result<Vec<SortedColumn>> {
         // No sort expressions parsed yet: report height 0 so callers folding this
         // clause in do not pick up a stale height from an earlier expression.
-        self.last_expr_height = 0;
+        self.last_expr_height = ExprSize::ZERO;
         if let Some(tok) = self.peek()? {
             if tok.token_type == TK_ORDER {
                 eat_assert!(self, TK_ORDER);

--- a/testing/sqltests/src/parser/mod.rs
+++ b/testing/sqltests/src/parser/mod.rs
@@ -29,24 +29,29 @@ fn eval_block_macro_count(expr: &str) -> Result<usize, String> {
         .filter(|ch| !ch.is_whitespace())
         .collect::<String>();
 
-    if expr == "expr_depth_limit" {
-        return Ok(turso_parser::MAX_EXPR_DEPTH);
-    }
+    for (name, limit) in [
+        ("expr_depth_limit", turso_parser::MAX_EXPR_DEPTH),
+        ("expr_nesting_limit", turso_parser::MAX_EXPR_NESTING),
+    ] {
+        if expr == name {
+            return Ok(limit);
+        }
 
-    if let Some(rest) = expr.strip_prefix("expr_depth_limit+") {
-        let delta = rest
-            .parse::<usize>()
-            .map_err(|_| format!("invalid repeat count expression: {expr}"))?;
-        return Ok(turso_parser::MAX_EXPR_DEPTH + delta);
-    }
+        if let Some(rest) = expr.strip_prefix(&format!("{name}+")) {
+            let delta = rest
+                .parse::<usize>()
+                .map_err(|_| format!("invalid repeat count expression: {expr}"))?;
+            return Ok(limit + delta);
+        }
 
-    if let Some(rest) = expr.strip_prefix("expr_depth_limit-") {
-        let delta = rest
-            .parse::<usize>()
-            .map_err(|_| format!("invalid repeat count expression: {expr}"))?;
-        return turso_parser::MAX_EXPR_DEPTH
-            .checked_sub(delta)
-            .ok_or_else(|| format!("repeat count underflow in expression: {expr}"));
+        if let Some(rest) = expr.strip_prefix(&format!("{name}-")) {
+            let delta = rest
+                .parse::<usize>()
+                .map_err(|_| format!("invalid repeat count expression: {expr}"))?;
+            return limit
+                .checked_sub(delta)
+                .ok_or_else(|| format!("repeat count underflow in expression: {expr}"));
+        }
     }
 
     expr.parse::<usize>()

--- a/testing/sqltests/tests/expr-depth-stack-overflow.sqltest
+++ b/testing/sqltests/tests/expr-depth-stack-overflow.sqltest
@@ -1,14 +1,16 @@
 @database :memory:
 
-# Turso-only: these tests exercise Turso's MAX_EXPR_DEPTH limit. SQLite's own
-# recursion limit is much higher (1000), so it accepts these expressions and
-# produces different results.
-@skip-file-if sqlite "Turso enforces MAX_EXPR_DEPTH; SQLite's own limit is 1000, so sqlite3 behaves differently"
+# Turso-only: these tests exercise Turso's expression size limits.
+# MAX_EXPR_DEPTH matches SQLite's SQLITE_MAX_EXPR_DEPTH (1000), but Turso
+# additionally enforces MAX_EXPR_NESTING (100) on truly nested shapes, so
+# sqlite3 behaves differently on the nesting cases.
+@skip-file-if sqlite "Turso enforces MAX_EXPR_NESTING; SQLite allows nesting up to its 1000 depth limit"
 
 # CLI backend only: the rust backend executes queries on tokio worker threads
-# whose small stacks cannot hold an at-limit expression in a debug build. The
-# in-process boundary coverage lives in tests/integration/expr_depth_stack_overflow.rs,
-# which runs on a thread with a controlled stack size.
+# whose small stacks cannot hold an at-nesting-limit expression in a debug
+# build. The in-process boundary coverage lives in
+# tests/integration/expr_depth_stack_overflow.rs, which runs on a thread with
+# a controlled stack size.
 @backend cli
 test expr_depth_or_chain_at_limit {
     SELECT 1{{repeat:expr_depth_limit-1: OR 1}};
@@ -23,4 +25,20 @@ test expr_depth_or_chain_over_limit {
 }
 expect error {
     Parse error: Expression tree is too large \(maximum depth {{expr_depth_limit}}\)
+}
+
+@backend cli
+test expr_nesting_parens_at_limit {
+    SELECT {{repeat:expr_nesting_limit-1:(}}1{{repeat:expr_nesting_limit-1:)}};
+}
+expect {
+    1
+}
+
+@backend cli
+test expr_nesting_parens_over_limit {
+    SELECT {{repeat:expr_nesting_limit:(}}1{{repeat:expr_nesting_limit:)}};
+}
+expect error {
+    Parse error: Expression tree is too deeply nested \(maximum nesting {{expr_nesting_limit}}\)
 }

--- a/tests/integration/expr_depth_stack_overflow.rs
+++ b/tests/integration/expr_depth_stack_overflow.rs
@@ -1,11 +1,23 @@
 use std::sync::Arc;
 
 use turso_core::{Database, MemoryIO, IO};
-use turso_parser::MAX_EXPR_DEPTH;
+use turso_parser::{MAX_EXPR_DEPTH, MAX_EXPR_NESTING};
+
+/// Which of the two expression-size limits a generated shape exhausts, and
+/// therefore which graceful error it must produce at its limit.
+enum Limit {
+    /// True tree depth ([`MAX_EXPR_DEPTH`]): flat operator chains, which the
+    /// parser and translator both consume iteratively.
+    Depth,
+    /// Nesting ([`MAX_EXPR_NESTING`]): shapes that add a recursion level per
+    /// step in the parser/translator.
+    Nesting,
+}
 
 struct GenExpr {
     name: &'static str,
     build: fn(depth: usize) -> String,
+    limit: Limit,
 }
 
 fn nest(prefix: &str, leaf: &str, suffix: &str, depth: usize) -> String {
@@ -24,42 +36,72 @@ const GEN_EXPRS: &[GenExpr] = &[
     GenExpr {
         name: "or-chain",
         build: |depth| chain("OR", depth),
+        limit: Limit::Depth,
     },
     GenExpr {
         name: "and-chain",
         build: |depth| chain("AND", depth),
+        limit: Limit::Depth,
     },
     GenExpr {
         name: "arithmetic-chain",
         build: |depth| chain("+", depth),
+        limit: Limit::Depth,
+    },
+    GenExpr {
+        name: "comparison-chain",
+        build: |depth| chain("=", depth),
+        limit: Limit::Depth,
+    },
+    GenExpr {
+        name: "concat-chain",
+        build: |depth| chain("||", depth),
+        limit: Limit::Depth,
+    },
+    // IS TRUE forms are Binary in the AST but the translator emits them
+    // through a dedicated non-foldable path, so they count as nesting.
+    GenExpr {
+        name: "is-true-chain",
+        build: |depth| format!("SELECT 1{}", " IS TRUE".repeat(depth)),
+        limit: Limit::Nesting,
     },
     GenExpr {
         name: "parentheses",
         build: |depth| nest("(", "1", ")", depth),
+        limit: Limit::Nesting,
     },
     GenExpr {
         name: "case",
         build: |depth| nest("CASE WHEN 1 THEN ", "1", " ELSE 0 END", depth),
+        limit: Limit::Nesting,
     },
     GenExpr {
         name: "scalar-subquery",
         build: |depth| nest("(SELECT ", "1", ")", depth),
+        limit: Limit::Nesting,
     },
     GenExpr {
         name: "function-call",
         build: |depth| nest("abs(", "1", ")", depth),
+        limit: Limit::Nesting,
+    },
+    GenExpr {
+        name: "unary-not",
+        build: |depth| format!("SELECT {}1", "NOT ".repeat(depth)),
+        limit: Limit::Nesting,
     },
     // A wide chain wrapped in a single node whose parse recursion is shallow: the
     // parser consumes the `OR` chain iteratively (so the recursion guard never
     // fires) and the resulting operand is not followed by another operator, so it
-    // is only rejected if the operand's own height is checked up front.
+    // is only rejected if the operand's own size is checked up front.
     GenExpr {
         name: "parenthesized-or-chain",
         build: |depth| format!("SELECT (1{})", " OR 1".repeat(depth - 1)),
+        limit: Limit::Depth,
     },
     // Deep expressions that live inside FILTER / OVER (ORDER BY | PARTITION BY)
     // clauses: later passes walk these, so they must count toward the enclosing
-    // function call's height even though they are not plain arguments.
+    // function call's size even though they are not plain arguments.
     GenExpr {
         name: "filter-clause-star",
         build: |depth| {
@@ -68,6 +110,7 @@ const GEN_EXPRS: &[GenExpr] = &[
                 " OR 1".repeat(depth - 1)
             )
         },
+        limit: Limit::Depth,
     },
     GenExpr {
         name: "filter-clause-args",
@@ -77,6 +120,7 @@ const GEN_EXPRS: &[GenExpr] = &[
                 " OR 1".repeat(depth - 1)
             )
         },
+        limit: Limit::Depth,
     },
     GenExpr {
         name: "window-order-by",
@@ -86,6 +130,7 @@ const GEN_EXPRS: &[GenExpr] = &[
                 " OR 1".repeat(depth - 1)
             )
         },
+        limit: Limit::Depth,
     },
     GenExpr {
         name: "window-partition-by",
@@ -95,19 +140,20 @@ const GEN_EXPRS: &[GenExpr] = &[
                 " OR 1".repeat(depth - 1)
             )
         },
+        limit: Limit::Depth,
     },
 ];
 
-const WORKER_STACK: usize = 64 << 20;
-
-fn run_on_big_stack(sql: String) -> turso_core::Result<()> {
+fn run_on_stack(stack_size: usize, sqls: Vec<String>) -> turso_core::Result<()> {
     std::thread::Builder::new()
-        .stack_size(WORKER_STACK)
+        .stack_size(stack_size)
         .spawn(move || -> turso_core::Result<()> {
             let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
             let db = Database::open_file(io, ":memory:")?;
             let conn = db.connect()?;
-            conn.execute(&sql)?;
+            for sql in &sqls {
+                conn.execute(sql)?;
+            }
             Ok(())
         })
         .expect("failed to spawn worker thread")
@@ -115,16 +161,96 @@ fn run_on_big_stack(sql: String) -> turso_core::Result<()> {
         .expect("worker thread panicked while executing expression depth test")
 }
 
+const WORKER_STACK: usize = 64 << 20;
+
 #[test]
 fn over_limit_is_a_graceful_depth_error() {
-    let expected =
-        format!("Parse error: Expression tree is too large (maximum depth {MAX_EXPR_DEPTH})");
-
     for gen_expr in GEN_EXPRS {
-        let err = run_on_big_stack((gen_expr.build)(MAX_EXPR_DEPTH)).expect_err(gen_expr.name);
+        let (limit, expected) = match gen_expr.limit {
+            Limit::Depth => (
+                MAX_EXPR_DEPTH,
+                format!("Parse error: Expression tree is too large (maximum depth {MAX_EXPR_DEPTH})"),
+            ),
+            Limit::Nesting => (
+                MAX_EXPR_NESTING,
+                format!(
+                    "Parse error: Expression tree is too deeply nested (maximum nesting {MAX_EXPR_NESTING})"
+                ),
+            ),
+        };
+
+        let err =
+            run_on_stack(WORKER_STACK, vec![(gen_expr.build)(limit)]).expect_err(gen_expr.name);
         assert_eq!(err.to_string(), expected, "{}: {err:?}", gen_expr.name);
 
-        run_on_big_stack((gen_expr.build)(MAX_EXPR_DEPTH - 1))
+        run_on_stack(WORKER_STACK, vec![(gen_expr.build)(limit - 1)])
             .unwrap_or_else(|err| panic!("{}: under-limit query failed: {err:?}", gen_expr.name));
+    }
+}
+
+/// A reproducer-shaped disjunctive predicate: `code = k AND (g1 OR g2 OR ...)`
+/// where every group is a small conjunction. Wide, not nested.
+fn or_of_and_groups(groups: usize) -> Vec<String> {
+    let ors = (0..groups)
+        .map(|i| format!("(p1 = {i} AND p2 = {i} AND p3 = {i})"))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    vec![
+        "CREATE TABLE parts (code, p1, p2, p3)".to_string(),
+        "INSERT INTO parts VALUES (1, 5, 5, 5)".to_string(),
+        format!("SELECT * FROM parts WHERE code = 1 AND ({ors})"),
+    ]
+}
+
+// real SQLITE_SUSPENDABLE_STACK_SIZE found in the wild
+#[cfg(not(debug_assertions))]
+const EXAMPLE_STACK_SIZE: usize = 147_456;
+
+/// Chain-shaped expressions stay within a coroutine-sized stack all
+/// the way to the depth limit: the parser and translator consume binary
+/// operator spines iteratively, so their stack use scales with nesting, not
+/// chain length. Debug builds inflate the fixed per-statement frames past
+/// this budget, so the exact server budget is only asserted in release.
+#[cfg(not(debug_assertions))]
+#[test]
+fn chains_at_limit_prepare_on_server_sized_stack() {
+    // Each OR group adds one link to the OR spine (one depth level), so this
+    // is close to the widest predicate of this shape that fits MAX_EXPR_DEPTH.
+    let groups = MAX_EXPR_DEPTH - 8;
+    run_on_stack(EXAMPLE_STACK_SIZE, or_of_and_groups(groups))
+        .unwrap_or_else(|err| panic!("customer-shaped OR-of-ANDs failed: {err:?}"));
+
+    for gen_expr in GEN_EXPRS {
+        if matches!(gen_expr.limit, Limit::Nesting) {
+            continue;
+        }
+        run_on_stack(
+            EXAMPLE_STACK_SIZE,
+            vec![(gen_expr.build)(MAX_EXPR_DEPTH - 1)],
+        )
+        .unwrap_or_else(|err| panic!("{}: chain at limit failed: {err:?}", gen_expr.name));
+    }
+}
+
+/// the same chain shapes must prepare on a modest fixed stack even with debug frame
+/// inflation, so a regression that makes stack use scale with chain length
+/// again fails loudly in regular CI too.
+#[cfg(debug_assertions)]
+#[test]
+fn chains_at_limit_prepare_on_small_stack() {
+    const DEBUG_SMALL_STACK: usize = 4 << 20;
+    let groups = MAX_EXPR_DEPTH - 8;
+    run_on_stack(DEBUG_SMALL_STACK, or_of_and_groups(groups))
+        .unwrap_or_else(|err| panic!("customer-shaped OR-of-ANDs failed: {err:?}"));
+
+    for gen_expr in GEN_EXPRS {
+        if matches!(gen_expr.limit, Limit::Nesting) {
+            continue;
+        }
+        run_on_stack(
+            DEBUG_SMALL_STACK,
+            vec![(gen_expr.build)(MAX_EXPR_DEPTH - 1)],
+        )
+        .unwrap_or_else(|err| panic!("{}: chain at limit failed: {err:?}", gen_expr.name));
     }
 }


### PR DESCRIPTION
### Problem

A query with 100 OR-groups (`WHERE code = ? AND ((p1=? AND p2=? AND p3=?) OR ...)`)
failed with `Parse error: Expression tree is too large (maximum depth 100)`. 

`MAX_EXPR_DEPTH = 100` was added in #5071 to stop deep expression trees from overflowing
the native stack in the recursive parser/translator

This is a pretty reasonable query and we should try to get much closer to SQLite's limit of `1000`
for their max-depth expression tree limit.

## Approach

Split the single limit into two bounds that mirror how recursion actually consumes stack:

- **`MAX_EXPR_DEPTH = 1000`**: true tree depth, counted like SQLite's `Expr.nHeight`
  (one level per chain link). SQLite-parity default. Bounds the cheap per-node glue
  (manual `Clone`/`PartialEq`, drop glue).
- **`MAX_EXPR_NESTING = 100`** (new): contiguous `Expr::Binary` spine links share one level.
  Bounds all fat-frame recursion (parser `parse_expr`, `translate_expr`, planner). 
  Truly nested shapes (parens, CASE, subqueries, function calls) keep today's 100-level bound, 
  failing with: `Expression tree is too deeply nested (maximum nesting 100)`.

For the nesting bound to be honest, every pass that recursed once per chain link now
traverses `Expr::Binary` left spines iteratively.

- `emit_binary_expr_scalar`: iterative spine fold reproducing the recursive translation
  exactly: same register allocation order, constant-span bookkeeping, collation rules,
  and equivalent-operand optimization. Non-foldable nodes (IS TRUE/FALSE forms,
  custom-type operators, cached subexpressions, row-valued comparisons) terminate the
  spine and take their dedicated paths; all are bounded or terminal.
- `translate_condition_expr` AND/OR arm: iterative label/metadata unroll of the spine.
- `expr_vector_size`, `is_constant`, `expr_is_array`, `exprs_are_equivalent`,
  `check_always_true_or_false`, `flatten_or/and_expr_owned`: explicit-work-stack rewrites.
- Manual `Clone`/`PartialEq` for `ast::Expr` (replacing derives), iterating spines; the
  derived glue recursed once per link and alone could overflow a 144 KiB stack.

NOTE: derived `Debug` and serde impls on `Expr` still recurse per link; only
reachable via debug-level expr logging or simulator serialization.
