### PR TITLE
sync: support partial sync on macOS via presence-bitmap sparse IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6865,6 +6865,7 @@ dependencies = [
 name = "turso_sync_engine"
 version = "0.7.0"
 dependencies = [
+ "antithesis_sdk",
  "base64 0.22.1",
  "bytes",
  "crc32c",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7656,6 +7656,7 @@ dependencies = [
 name = "turso_sync_engine"
 version = "0.8.0-pre.7"
 dependencies = [
+ "antithesis_sdk",
  "base64 0.22.1",
  "bytes",
  "crc32c",

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -219,7 +219,10 @@ impl SyncEngine {
         let io: Arc<dyn turso_core::IO> = if is_memory {
             Arc::new(turso_core::MemoryIO::new())
         } else {
-            #[cfg(all(target_os = "linux", not(feature = "browser")))]
+            #[cfg(all(
+                any(target_os = "linux", target_os = "macos"),
+                not(feature = "browser")
+            ))]
             {
                 if opts.partial_sync_opts.is_none() {
                     Arc::new(turso_core::PlatformIO::new().map_err(|e| {
@@ -229,18 +232,39 @@ impl SyncEngine {
                         )
                     })?)
                 } else {
-                    use turso_sync_engine::sparse_io::SparseLinuxIo;
-
-                    Arc::new(SparseLinuxIo::new().map_err(|e| {
+                    let sparse_io_error = |e| {
                         napi::Error::new(
                             napi::Status::GenericFailure,
                             format!("Failed to create sparse IO: {e}"),
                         )
-                    })?)
+                    };
+                    #[cfg(target_os = "linux")]
+                    {
+                        use turso_sync_engine::sparse_io::SparseLinuxIo;
+                        Arc::new(SparseLinuxIo::new().map_err(sparse_io_error)?)
+                    }
+                    #[cfg(target_os = "macos")]
+                    {
+                        use turso_sync_engine::sparse_io::SparseBitmapIo;
+                        Arc::new(SparseBitmapIo::new(&opts.path).map_err(sparse_io_error)?)
+                    }
                 }
             }
-            #[cfg(all(not(target_os = "linux"), not(feature = "browser")))]
+            #[cfg(all(
+                not(any(target_os = "linux", target_os = "macos")),
+                not(feature = "browser")
+            ))]
             {
+                if opts.partial_sync_opts.is_some() {
+                    // Partial sync stores lazily fetched pages in a sparse file
+                    // and probes them with `File::has_hole`, which `PlatformIO`
+                    // does not implement. Fail here instead of panicking later
+                    // in the lazy storage path.
+                    return Err(napi::Error::new(
+                        napi::Status::GenericFailure,
+                        "partial sync requires sparse-file IO, which is not supported on this platform",
+                    ));
+                }
                 Arc::new(turso_core::PlatformIO::new().map_err(|e| {
                     napi::Error::new(
                         napi::Status::GenericFailure,
@@ -250,6 +274,15 @@ impl SyncEngine {
             }
             #[cfg(feature = "browser")]
             {
+                if opts.partial_sync_opts.is_some() {
+                    // OPFS files implement neither `has_hole` nor
+                    // `punch_hole`; partial sync would panic in the lazy
+                    // storage path. Fail at configuration time instead.
+                    return Err(napi::Error::new(
+                        napi::Status::GenericFailure,
+                        "partial sync requires sparse-file IO, which is not supported in the browser",
+                    ));
+                }
                 turso_node::browser::opfs()
             }
         };

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -258,10 +258,7 @@ impl SyncEngine {
             ))]
             {
                 if opts.partial_sync_opts.is_some() {
-                    // Partial sync stores lazily fetched pages in a sparse file
-                    // and probes them with `File::has_hole`, which `PlatformIO`
-                    // does not implement. Fail here instead of panicking later
-                    // in the lazy storage path.
+                    // `PlatformIO` has no sparse-page presence operations.
                     return Err(napi::Error::new(
                         napi::Status::GenericFailure,
                         "partial sync requires sparse-file IO, which is not supported on this platform",
@@ -277,9 +274,7 @@ impl SyncEngine {
             #[cfg(feature = "browser")]
             {
                 if opts.partial_sync_opts.is_some() {
-                    // OPFS files implement neither `has_hole` nor
-                    // `punch_hole`; partial sync would panic in the lazy
-                    // storage path. Fail at configuration time instead.
+                    // OPFS has no sparse-page presence operations.
                     return Err(napi::Error::new(
                         napi::Status::GenericFailure,
                         "partial sync requires sparse-file IO, which is not supported in the browser",

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -221,7 +221,10 @@ impl SyncEngine {
         let io: Arc<dyn turso_core::IO> = if is_memory {
             Arc::new(turso_core::MemoryIO::new())
         } else {
-            #[cfg(all(target_os = "linux", not(feature = "browser")))]
+            #[cfg(all(
+                any(target_os = "linux", target_os = "macos"),
+                not(feature = "browser")
+            ))]
             {
                 if opts.partial_sync_opts.is_none() {
                     Arc::new(turso_core::PlatformIO::new().map_err(|e| {
@@ -231,18 +234,39 @@ impl SyncEngine {
                         )
                     })?)
                 } else {
-                    use turso_sync_engine::sparse_io::SparseLinuxIo;
-
-                    Arc::new(SparseLinuxIo::new().map_err(|e| {
+                    let sparse_io_error = |e| {
                         napi::Error::new(
                             napi::Status::GenericFailure,
                             format!("Failed to create sparse IO: {e}"),
                         )
-                    })?)
+                    };
+                    #[cfg(target_os = "linux")]
+                    {
+                        use turso_sync_engine::sparse_io::SparseLinuxIo;
+                        Arc::new(SparseLinuxIo::new().map_err(sparse_io_error)?)
+                    }
+                    #[cfg(target_os = "macos")]
+                    {
+                        use turso_sync_engine::sparse_io::SparseBitmapIo;
+                        Arc::new(SparseBitmapIo::new(&opts.path).map_err(sparse_io_error)?)
+                    }
                 }
             }
-            #[cfg(all(not(target_os = "linux"), not(feature = "browser")))]
+            #[cfg(all(
+                not(any(target_os = "linux", target_os = "macos")),
+                not(feature = "browser")
+            ))]
             {
+                if opts.partial_sync_opts.is_some() {
+                    // Partial sync stores lazily fetched pages in a sparse file
+                    // and probes them with `File::has_hole`, which `PlatformIO`
+                    // does not implement. Fail here instead of panicking later
+                    // in the lazy storage path.
+                    return Err(napi::Error::new(
+                        napi::Status::GenericFailure,
+                        "partial sync requires sparse-file IO, which is not supported on this platform",
+                    ));
+                }
                 Arc::new(turso_core::PlatformIO::new().map_err(|e| {
                     napi::Error::new(
                         napi::Status::GenericFailure,
@@ -252,6 +276,15 @@ impl SyncEngine {
             }
             #[cfg(feature = "browser")]
             {
+                if opts.partial_sync_opts.is_some() {
+                    // OPFS files implement neither `has_hole` nor
+                    // `punch_hole`; partial sync would panic in the lazy
+                    // storage path. Fail at configuration time instead.
+                    return Err(napi::Error::new(
+                        napi::Status::GenericFailure,
+                        "partial sync requires sparse-file IO, which is not supported in the browser",
+                    ));
+                }
                 turso_node::browser::opfs()
             }
         };

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1555,6 +1555,129 @@ mod tests {
         }
     }
 
+    /// Partial sync against a file-backed database, exercising the persistent
+    /// sparse IO backend (SparseLinuxIo on Linux, SparseBitmapIo on macOS)
+    /// instead of MemoryIO, including hydration persistence across reopen.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    pub async fn test_sync_partial_file_backed() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("partial.db");
+        let path = path.to_str().unwrap();
+        let server = TursoServer::new().await.unwrap();
+        server.db_sql("CREATE TABLE t(x)").await.unwrap();
+        server
+            .db_sql("INSERT INTO t SELECT randomblob(1024) FROM generate_series(1, 2000)")
+            .await
+            .unwrap();
+        let opts = PartialSyncOpts {
+            bootstrap_strategy: Some(PartialBootstrapStrategy::Prefix { length: 128 * 1024 }),
+            segment_size: 128 * 1024,
+            prefetch: false,
+        };
+        {
+            let partial_db = crate::sync::Builder::new_remote(path)
+                .with_remote_url(server.db_url())
+                .with_partial_sync_opts_experimental(opts.clone())
+                .build()
+                .await
+                .unwrap();
+            let conn = partial_db.connect().await.unwrap();
+            let _ = all_rows(
+                conn.query("SELECT LENGTH(x) FROM t LIMIT 1", ())
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+            assert!(partial_db.stats().await.unwrap().network_received_bytes < 256 * (1024 + 10));
+            let all = all_rows(
+                conn.query("SELECT SUM(LENGTH(x)) FROM t", ())
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(all, vec![vec![Value::Integer(2000 * 1024)]]);
+            assert!(partial_db.stats().await.unwrap().network_received_bytes > 2000 * 1024);
+        }
+        {
+            // Reopen: the previously hydrated pages must be served from the
+            // local sparse file, not re-fetched from the server.
+            let partial_db = crate::sync::Builder::new_remote(path)
+                .with_remote_url(server.db_url())
+                .with_partial_sync_opts_experimental(opts)
+                .build()
+                .await
+                .unwrap();
+            let conn = partial_db.connect().await.unwrap();
+            let all = all_rows(
+                conn.query("SELECT SUM(LENGTH(x)) FROM t", ())
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(all, vec![vec![Value::Integer(2000 * 1024)]]);
+            assert!(
+                partial_db.stats().await.unwrap().network_received_bytes < 512 * 1024,
+                "reopen re-fetched the database instead of serving hydrated pages: {} bytes",
+                partial_db.stats().await.unwrap().network_received_bytes
+            );
+        }
+    }
+
+    /// Query bootstrap against a file-backed database. NOTE: the local test
+    /// server ignores `server_query_selector` (only Turso Cloud implements
+    /// it) and answers the empty page bitmap with a full bootstrap, so this
+    /// exercises the Query strategy end to end for correctness but cannot
+    /// assert reduced bootstrap traffic.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    pub async fn test_sync_partial_query_bootstrap_file_backed() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("partial.db");
+        let path = path.to_str().unwrap();
+        let server = TursoServer::new().await.unwrap();
+        server.db_sql("CREATE TABLE t(x)").await.unwrap();
+        server
+            .db_sql("INSERT INTO t SELECT randomblob(1024) FROM generate_series(1, 2000)")
+            .await
+            .unwrap();
+        let partial_db = crate::sync::Builder::new_remote(path)
+            .with_remote_url(server.db_url())
+            .with_partial_sync_opts_experimental(PartialSyncOpts {
+                bootstrap_strategy: Some(PartialBootstrapStrategy::Query {
+                    query: "SELECT x FROM t LIMIT 16".to_string(),
+                }),
+                segment_size: 128 * 1024,
+                prefetch: false,
+            })
+            .build()
+            .await
+            .unwrap();
+        let conn = partial_db.connect().await.unwrap();
+        let first = all_rows(
+            conn.query("SELECT LENGTH(x) FROM t LIMIT 1", ())
+                .await
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(first, vec![vec![Value::Integer(1024)]]);
+        let all = all_rows(
+            conn.query("SELECT SUM(LENGTH(x)) FROM t", ())
+                .await
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(all, vec![vec![Value::Integer(2000 * 1024)]]);
+        assert!(partial_db.stats().await.unwrap().network_received_bytes > 2000 * 1024);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn test_sync_partial_prefetch() {
         let _ = tracing_subscriber::fmt::try_init();

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1707,9 +1707,6 @@ mod tests {
         }
     }
 
-    /// Partial sync against a file-backed database, exercising the persistent
-    /// sparse IO backend (SparseLinuxIo on Linux, SparseBitmapIo on macOS)
-    /// instead of MemoryIO, including hydration persistence across reopen.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[tokio::test]
     pub async fn test_sync_partial_file_backed() {
@@ -1755,8 +1752,7 @@ mod tests {
             assert!(partial_db.stats().await.unwrap().network_received_bytes > 2000 * 1024);
         }
         {
-            // Reopen: the previously hydrated pages must be served from the
-            // local sparse file, not re-fetched from the server.
+            // Reopen without re-fetching hydrated pages.
             let partial_db = crate::sync::Builder::new_remote(path)
                 .with_remote_url(server.db_url())
                 .with_partial_sync_opts_experimental(opts)
@@ -1780,11 +1776,8 @@ mod tests {
         }
     }
 
-    /// Query bootstrap against a file-backed database. NOTE: the local test
-    /// server ignores `server_query_selector` (only Turso Cloud implements
-    /// it) and answers the empty page bitmap with a full bootstrap, so this
-    /// exercises the Query strategy end to end for correctness but cannot
-    /// assert reduced bootstrap traffic.
+    // The local server ignores `server_query_selector` and returns a full
+    // bootstrap, so this checks correctness but not traffic reduction.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[tokio::test]
     pub async fn test_sync_partial_query_bootstrap_file_backed() {

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1707,6 +1707,129 @@ mod tests {
         }
     }
 
+    /// Partial sync against a file-backed database, exercising the persistent
+    /// sparse IO backend (SparseLinuxIo on Linux, SparseBitmapIo on macOS)
+    /// instead of MemoryIO, including hydration persistence across reopen.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    pub async fn test_sync_partial_file_backed() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("partial.db");
+        let path = path.to_str().unwrap();
+        let server = TursoServer::new().await.unwrap();
+        server.db_sql("CREATE TABLE t(x)").await.unwrap();
+        server
+            .db_sql("INSERT INTO t SELECT randomblob(1024) FROM generate_series(1, 2000)")
+            .await
+            .unwrap();
+        let opts = PartialSyncOpts {
+            bootstrap_strategy: Some(PartialBootstrapStrategy::Prefix { length: 128 * 1024 }),
+            segment_size: 128 * 1024,
+            prefetch: false,
+        };
+        {
+            let partial_db = crate::sync::Builder::new_remote(path)
+                .with_remote_url(server.db_url())
+                .with_partial_sync_opts_experimental(opts.clone())
+                .build()
+                .await
+                .unwrap();
+            let conn = partial_db.connect().await.unwrap();
+            let _ = all_rows(
+                conn.query("SELECT LENGTH(x) FROM t LIMIT 1", ())
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+            assert!(partial_db.stats().await.unwrap().network_received_bytes < 256 * (1024 + 10));
+            let all = all_rows(
+                conn.query("SELECT SUM(LENGTH(x)) FROM t", ())
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(all, vec![vec![Value::Integer(2000 * 1024)]]);
+            assert!(partial_db.stats().await.unwrap().network_received_bytes > 2000 * 1024);
+        }
+        {
+            // Reopen: the previously hydrated pages must be served from the
+            // local sparse file, not re-fetched from the server.
+            let partial_db = crate::sync::Builder::new_remote(path)
+                .with_remote_url(server.db_url())
+                .with_partial_sync_opts_experimental(opts)
+                .build()
+                .await
+                .unwrap();
+            let conn = partial_db.connect().await.unwrap();
+            let all = all_rows(
+                conn.query("SELECT SUM(LENGTH(x)) FROM t", ())
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(all, vec![vec![Value::Integer(2000 * 1024)]]);
+            assert!(
+                partial_db.stats().await.unwrap().network_received_bytes < 512 * 1024,
+                "reopen re-fetched the database instead of serving hydrated pages: {} bytes",
+                partial_db.stats().await.unwrap().network_received_bytes
+            );
+        }
+    }
+
+    /// Query bootstrap against a file-backed database. NOTE: the local test
+    /// server ignores `server_query_selector` (only Turso Cloud implements
+    /// it) and answers the empty page bitmap with a full bootstrap, so this
+    /// exercises the Query strategy end to end for correctness but cannot
+    /// assert reduced bootstrap traffic.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    pub async fn test_sync_partial_query_bootstrap_file_backed() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("partial.db");
+        let path = path.to_str().unwrap();
+        let server = TursoServer::new().await.unwrap();
+        server.db_sql("CREATE TABLE t(x)").await.unwrap();
+        server
+            .db_sql("INSERT INTO t SELECT randomblob(1024) FROM generate_series(1, 2000)")
+            .await
+            .unwrap();
+        let partial_db = crate::sync::Builder::new_remote(path)
+            .with_remote_url(server.db_url())
+            .with_partial_sync_opts_experimental(PartialSyncOpts {
+                bootstrap_strategy: Some(PartialBootstrapStrategy::Query {
+                    query: "SELECT x FROM t LIMIT 16".to_string(),
+                }),
+                segment_size: 128 * 1024,
+                prefetch: false,
+            })
+            .build()
+            .await
+            .unwrap();
+        let conn = partial_db.connect().await.unwrap();
+        let first = all_rows(
+            conn.query("SELECT LENGTH(x) FROM t LIMIT 1", ())
+                .await
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(first, vec![vec![Value::Integer(1024)]]);
+        let all = all_rows(
+            conn.query("SELECT SUM(LENGTH(x)) FROM t", ())
+                .await
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(all, vec![vec![Value::Integer(2000 * 1024)]]);
+        assert!(partial_db.stats().await.unwrap().network_received_bytes > 2000 * 1024);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn test_sync_partial_prefetch() {
         let _ = tracing_subscriber::fmt::try_init();

--- a/sync/engine/Cargo.toml
+++ b/sync/engine/Cargo.toml
@@ -7,6 +7,13 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+# Declare the antithesis cfg (set by the Antithesis build) so the
+# `turso_assert_*` macro expansions pass check-cfg. Scoped narrowly rather
+# than `[lints] workspace = true` because the workspace's deny-level clippy
+# lints do not yet pass on this crate.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(antithesis)'] }
+
 [dependencies]
 turso_core = { workspace = true, features = ["conn_raw_api"] }
 turso_parser = { workspace = true }
@@ -23,8 +30,11 @@ prost = "0.14.1"
 roaring = "0.11.2"
 crc32c = "0.6.8"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.172" }
+
+[target.'cfg(antithesis)'.dependencies]
+antithesis_sdk = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 ctor = "0.4.2"

--- a/sync/engine/src/lib.rs
+++ b/sync/engine/src/lib.rs
@@ -12,7 +12,7 @@ pub mod server_proto;
 pub mod types;
 pub mod wal_session;
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 pub mod sparse_io;
 
 pub type Result<T> = std::result::Result<T, errors::Error>;

--- a/sync/engine/src/sparse_io.rs
+++ b/sync/engine/src/sparse_io.rs
@@ -1,3 +1,47 @@
+//! Sparse-file IO backends for partial sync.
+//!
+//! The lazy page storage tracks which pages are locally present via
+//! [`File::has_hole`] and evicts them via [`File::punch_hole`]. Two backends
+//! implement that contract for persistent files:
+//!
+//! * [`SparseLinuxIo`] (Linux only) uses the filesystem as the source of
+//!   truth: never-written ranges of a sparse file are holes, `lseek(SEEK_DATA)`
+//!   reports them exactly, and `fallocate(PUNCH_HOLE)` restores them.
+//! * [`SparseBitmapIo`] (portable across Unix) keeps an explicit presence
+//!   bitmap for the lazily-populated database file, mirroring the presence-map
+//!   semantics of `MemoryIO`, and persists it to a sidecar file. Filesystem
+//!   hole punching is only best-effort space reclamation. Files other than the
+//!   tracked database file (WAL, metadata) are delegated to `PlatformIO`
+//!   untouched.
+//!
+//! The bitmap backend exists because APFS on macOS cannot carry the Linux
+//! contract. Delayed allocation rounds writes up to multi-block extents and
+//! materializes neighbouring never-written (and even previously punched)
+//! ranges as allocated zeros when dirty data is flushed, so `lseek(SEEK_DATA)`
+//! reports absent pages as data. For lazy page storage that error direction is
+//! fatal: an absent page reported present is served as zeros instead of being
+//! fetched from the server. An explicit bitmap makes presence exact on any
+//! filesystem; it is also fully exercisable on Linux, where the simulator,
+//! stress, and Antithesis workloads run.
+//!
+//! # Crash consistency of the presence bitmap
+//!
+//! Presence bits protect two different things: fetched server pages (where a
+//! lost bit only costs a re-fetch) and locally modified pages checkpointed
+//! into the database file (where a lost bit would let the lazy storage
+//! overwrite local data with an older server page). The backend therefore
+//! maintains two properties:
+//!
+//! 1. The on-disk bitmap never *over*-claims: the data file is synced before
+//!    every bitmap persist, and punched bits are made durable (temp file +
+//!    fsync + rename + parent-directory fsync) before the bytes are released.
+//! 2. The on-disk bitmap can lag the data file only within a single
+//!    [`File::sync`] call. Because the pager only treats a checkpoint as
+//!    complete once `sync` returns — and the WAL is truncated after that —
+//!    a crash inside the window is repaired by WAL replay. Outside normal
+//!    operation (sidecar deleted, corrupted, or belonging to a different
+//!    file generation) the backend refuses to open rather than guess.
+
 use std::{
     os::{fd::AsRawFd, unix::fs::FileExt},
     sync::{Arc, RwLock},
@@ -10,145 +54,796 @@ use turso_core::{
     WallClockInstant, IO,
 };
 
-pub struct SparseLinuxIo {}
-
-impl SparseLinuxIo {
-    pub fn new() -> Result<Self> {
-        Ok(Self {})
-    }
+fn completion_error(e: std::io::Error, op: &'static str) -> turso_core::LimboError {
+    turso_core::LimboError::CompletionError(turso_core::CompletionError::IOError(e.kind(), op))
 }
 
-impl IO for SparseLinuxIo {
-    #[instrument(skip_all, level = Level::TRACE)]
-    fn open_file(&self, path: &str, flags: OpenFlags, _direct: bool) -> Result<Arc<dyn File>> {
-        let mut file = std::fs::File::options();
-        file.read(true);
+#[cfg(target_os = "linux")]
+pub use linux::{SparseLinuxFile, SparseLinuxIo};
 
-        if !flags.contains(OpenFlags::ReadOnly) {
-            file.write(true);
-            file.create(flags.contains(OpenFlags::Create));
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::*;
+
+    pub struct SparseLinuxIo {}
+
+    impl SparseLinuxIo {
+        pub fn new() -> Result<Self> {
+            Ok(Self {})
+        }
+    }
+
+    impl IO for SparseLinuxIo {
+        #[instrument(skip_all, level = Level::TRACE)]
+        fn open_file(&self, path: &str, flags: OpenFlags, _direct: bool) -> Result<Arc<dyn File>> {
+            let mut file = std::fs::File::options();
+            file.read(true);
+
+            if !flags.contains(OpenFlags::ReadOnly) {
+                file.write(true);
+                file.create(flags.contains(OpenFlags::Create));
+            }
+
+            let file = file.open(path).map_err(|e| io_error(e, "open"))?;
+            Ok(Arc::new(SparseLinuxFile {
+                file: RwLock::new(file),
+            }))
         }
 
-        let file = file.open(path).map_err(|e| io_error(e, "open"))?;
-        Ok(Arc::new(SparseLinuxFile {
-            file: RwLock::new(file),
-        }))
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn remove_file(&self, path: &str) -> Result<()> {
+            std::fs::remove_file(path).map_err(|e| io_error(e, "remove_file"))?;
+            Ok(())
+        }
+
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn step(&self) -> Result<()> {
+            Ok(())
+        }
     }
 
-    #[instrument(err, skip_all, level = Level::TRACE)]
-    fn remove_file(&self, path: &str) -> Result<()> {
-        std::fs::remove_file(path).map_err(|e| io_error(e, "remove_file"))?;
-        Ok(())
+    impl Clock for SparseLinuxIo {
+        fn current_time_monotonic(&self) -> MonotonicInstant {
+            DefaultClock.current_time_monotonic()
+        }
+
+        fn current_time_wall_clock(&self) -> WallClockInstant {
+            DefaultClock.current_time_wall_clock()
+        }
     }
 
-    #[instrument(err, skip_all, level = Level::TRACE)]
-    fn step(&self) -> Result<()> {
-        Ok(())
-    }
-}
-
-impl Clock for SparseLinuxIo {
-    fn current_time_monotonic(&self) -> MonotonicInstant {
-        DefaultClock.current_time_monotonic()
+    pub struct SparseLinuxFile {
+        file: RwLock<std::fs::File>,
     }
 
-    fn current_time_wall_clock(&self) -> WallClockInstant {
-        DefaultClock.current_time_wall_clock()
-    }
-}
+    #[allow(clippy::readonly_write_lock)]
+    impl File for SparseLinuxFile {
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn lock_file(&self, _exclusive: bool) -> Result<()> {
+            Ok(())
+        }
 
-pub struct SparseLinuxFile {
-    file: RwLock<std::fs::File>,
-}
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn unlock_file(&self) -> Result<()> {
+            Ok(())
+        }
 
-#[allow(clippy::readonly_write_lock)]
-impl File for SparseLinuxFile {
-    #[instrument(err, skip_all, level = Level::TRACE)]
-    fn lock_file(&self, _exclusive: bool) -> Result<()> {
-        Ok(())
-    }
+        #[instrument(skip(self, c), level = Level::TRACE)]
+        fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
+            let file = self.file.read().unwrap();
+            let nr = {
+                let r = c.as_read();
+                let buf = r.buf();
+                let buf = buf.as_mut_slice();
+                file.read_exact_at(buf, pos)
+                    .map_err(|e| io_error(e, "pread"))?;
+                buf.len() as i32
+            };
+            c.complete(nr);
+            Ok(c)
+        }
 
-    #[instrument(err, skip_all, level = Level::TRACE)]
-    fn unlock_file(&self) -> Result<()> {
-        Ok(())
-    }
+        #[instrument(skip(self, c, buffer), level = Level::TRACE)]
+        fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
+            let file = self.file.write().unwrap();
+            let buf = buffer.as_slice();
+            file.write_all_at(buf, pos)
+                .map_err(|e| io_error(e, "pwrite"))?;
+            c.complete(buffer.len() as i32);
+            Ok(c)
+        }
 
-    #[instrument(skip(self, c), level = Level::TRACE)]
-    fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
-        let file = self.file.read().unwrap();
-        let nr = {
-            let r = c.as_read();
-            let buf = r.buf();
-            let buf = buf.as_mut_slice();
-            file.read_exact_at(buf, pos)
-                .map_err(|e| io_error(e, "pread"))?;
-            buf.len() as i32
-        };
-        c.complete(nr);
-        Ok(c)
-    }
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
+            let file = self.file.write().unwrap();
+            file.sync_all().map_err(|e| io_error(e, "sync"))?;
+            c.complete(0);
+            Ok(c)
+        }
 
-    #[instrument(skip(self, c, buffer), level = Level::TRACE)]
-    fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
-        let file = self.file.write().unwrap();
-        let buf = buffer.as_slice();
-        file.write_all_at(buf, pos)
-            .map_err(|e| io_error(e, "pwrite"))?;
-        c.complete(buffer.len() as i32);
-        Ok(c)
-    }
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+            let file = self.file.write().unwrap();
+            file.set_len(len).map_err(|e| io_error(e, "truncate"))?;
+            c.complete(0);
+            Ok(c)
+        }
 
-    #[instrument(err, skip_all, level = Level::TRACE)]
-    fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
-        let file = self.file.write().unwrap();
-        file.sync_all().map_err(|e| io_error(e, "sync"))?;
-        c.complete(0);
-        Ok(c)
-    }
+        fn size(&self) -> Result<u64> {
+            let file = self.file.read().unwrap();
+            Ok(file.metadata().map_err(|e| io_error(e, "metadata"))?.len())
+        }
 
-    #[instrument(err, skip_all, level = Level::TRACE)]
-    fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
-        let file = self.file.write().unwrap();
-        file.set_len(len).map_err(|e| io_error(e, "truncate"))?;
-        c.complete(0);
-        Ok(c)
-    }
+        fn has_hole(&self, pos: usize, len: usize) -> turso_core::Result<bool> {
+            let file = self.file.read().unwrap();
+            // SEEK_DATA: Adjust the file offset to the next location in the file
+            // greater than or equal to offset containing data.  If offset
+            // points to data, then the file offset is set to offset
+            // (see https://man7.org/linux/man-pages/man2/lseek.2.html#DESCRIPTION)
+            let res = unsafe { libc::lseek(file.as_raw_fd(), pos as i64, libc::SEEK_DATA) };
+            if res == -1 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::ENXIO) {
+                    // ENXIO: whence is SEEK_DATA or SEEK_HOLE, and offset is beyond the
+                    // end of the file, or whence is SEEK_DATA and offset is
+                    // within a hole at the end of the file.
+                    // (see https://man7.org/linux/man-pages/man2/lseek.2.html#ERRORS)
+                    return Ok(true);
+                } else {
+                    return Err(completion_error(err, "lseek"));
+                }
+            }
+            // lseek succeeded - the hole is here if next data is strictly before pos + len - 1 (the last byte of the checked region
+            Ok(res as usize >= pos + len)
+        }
 
-    fn size(&self) -> Result<u64> {
-        let file = self.file.read().unwrap();
-        Ok(file.metadata().map_err(|e| io_error(e, "metadata"))?.len())
-    }
-
-    fn has_hole(&self, pos: usize, len: usize) -> turso_core::Result<bool> {
-        let file = self.file.read().unwrap();
-        // SEEK_DATA: Adjust the file offset to the next location in the file
-        // greater than or equal to offset containing data.  If offset
-        // points to data, then the file offset is set to offset
-        // (see https://man7.org/linux/man-pages/man2/lseek.2.html#DESCRIPTION)
-        let res = unsafe { libc::lseek(file.as_raw_fd(), pos as i64, libc::SEEK_DATA) };
-        if res == -1 {
-            let errno = unsafe { *libc::__errno_location() };
-            if errno == libc::ENXIO {
-                // ENXIO: whence is SEEK_DATA or SEEK_HOLE, and offset is beyond the
-                // end of the file, or whence is SEEK_DATA and offset is
-                // within a hole at the end of the file.
-                // (see https://man7.org/linux/man-pages/man2/lseek.2.html#ERRORS)
-                return Ok(true);
+        fn punch_hole(&self, pos: usize, len: usize) -> turso_core::Result<()> {
+            let file = self.file.write().unwrap();
+            let res = unsafe {
+                libc::fallocate(
+                    file.as_raw_fd(),
+                    libc::FALLOC_FL_PUNCH_HOLE | libc::FALLOC_FL_KEEP_SIZE,
+                    pos as i64,
+                    len as i64,
+                )
+            };
+            if res == -1 {
+                Err(completion_error(
+                    std::io::Error::last_os_error(),
+                    "fallocate",
+                ))
             } else {
-                return Err(turso_core::LimboError::CompletionError(
-                    turso_core::CompletionError::IOError(
-                        std::io::Error::from_raw_os_error(errno).kind(),
-                        "lseek",
-                    ),
-                ));
+                Ok(())
             }
         }
-        // lseek succeeded - the hole is here if next data is strictly before pos + len - 1 (the last byte of the checked region
-        Ok(res as usize >= pos + len)
+    }
+}
+
+pub use bitmap::{SparseBitmapFile, SparseBitmapIo};
+
+mod bitmap {
+    use super::*;
+    use std::collections::HashMap;
+    use std::io::Write;
+    use std::os::unix::fs::MetadataExt;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use turso_core::{turso_assert, turso_assert_reachable, turso_assert_sometimes};
+
+    /// Presence is tracked per 4 KiB granule, matching `MemoryIO`'s
+    /// `PAGE_SIZE` presence map and the minimum database page size. Like
+    /// `MemoryIO` and the Linux backend (where any write allocates its whole
+    /// block), a write marks every granule it touches; the untouched
+    /// remainder of an edge granule reads as zeros — enforced by explicit
+    /// zero-fill when the granule was absent, so a punched granule whose
+    /// physical reclamation did not survive a crash can never leak stale
+    /// bytes back through a later partial write.
+    const GRANULE: u64 = 4096;
+
+    const SIDECAR_SUFFIX: &str = ".present";
+    const SIDECAR_MAGIC: &[u8; 4] = b"TPRB";
+    const SIDECAR_VERSION: u8 = 3;
+    /// magic + version + granule (u32) + dev (u64) + ino (u64) + crc32c (u32)
+    const SIDECAR_HEADER_LEN: usize = 4 + 1 + 4 + 8 + 8 + 4;
+
+    /// File identity: `(dev, ino)`. Keying the registry by identity rather
+    /// than path string means alias spellings of one file (case-insensitive
+    /// volumes, symlinks) share one presence state; a spelling that differs
+    /// from the one the sidecar was persisted under fails closed at the next
+    /// open (missing-sidecar anomaly) instead of corrupting.
+    type FileId = (u64, u64);
+
+    /// All handles to a tracked file share one [`FileEntry`], process-wide —
+    /// across `SparseBitmapIo` instances too — mirroring how `MemoryIO`
+    /// shares one store per path and how the Linux backend shares filesystem
+    /// state between descriptors. Handle counting (instead of `Weak`) makes
+    /// the last-close flush deterministic: it runs under the registry lock,
+    /// so a concurrent reopen serializes after it.
+    struct RegistryEntry {
+        entry: Arc<FileEntry>,
+        handles: usize,
     }
 
-    fn punch_hole(&self, pos: usize, len: usize) -> turso_core::Result<()> {
-        let file = self.file.write().unwrap();
+    fn registry() -> MutexGuard<'static, HashMap<FileId, RegistryEntry>> {
+        static REGISTRY: OnceLock<Mutex<HashMap<FileId, RegistryEntry>>> = OnceLock::new();
+        match REGISTRY.get_or_init(|| Mutex::new(HashMap::new())).lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    /// Canonicalize the parent directory (the file itself may not exist yet)
+    /// so relative/absolute spellings and symlinked directories compare
+    /// equal for the tracked-path decision.
+    fn canonical_key(path: &str) -> std::io::Result<std::path::PathBuf> {
+        let p = std::path::Path::new(path);
+        let name = p.file_name().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no file name")
+        })?;
+        let dir = p
+            .parent()
+            .filter(|dir| !dir.as_os_str().is_empty())
+            .unwrap_or_else(|| std::path::Path::new("."));
+        Ok(std::fs::canonicalize(dir)?.join(name))
+    }
+
+    /// Sparse IO for one lazily-populated database file.
+    ///
+    /// `open_file` returns presence-tracked handles for `tracked_path` only;
+    /// every other path (WAL, metadata, …) is delegated to [`PlatformIO`]
+    /// so it keeps stock durability behavior and pays no sidecar overhead.
+    ///
+    /// [`PlatformIO`]: turso_core::PlatformIO
+    pub struct SparseBitmapIo {
+        tracked_key: std::path::PathBuf,
+        /// The canonical spelling used for the sidecar name and entry path,
+        /// so every alias spelling of the tracked file maps to one sidecar.
+        tracked_path: String,
+        inner: Arc<dyn IO>,
+    }
+
+    impl SparseBitmapIo {
+        /// The tracked file's parent directory must already exist (the
+        /// engine creates its metadata files alongside before opening the
+        /// database), so the tracked-path comparison is stable for the
+        /// lifetime of this IO.
+        pub fn new(tracked_path: &str) -> Result<Self> {
+            let tracked_key = canonical_key(tracked_path).map_err(|e| {
+                turso_core::LimboError::InvalidArgument(format!(
+                    "cannot resolve database directory for {tracked_path}: {e}"
+                ))
+            })?;
+            let tracked_path = tracked_key.to_string_lossy().into_owned();
+            Ok(Self {
+                tracked_key,
+                tracked_path,
+                inner: Arc::new(turso_core::PlatformIO::new()?),
+            })
+        }
+
+        fn is_tracked(&self, path: &str) -> bool {
+            canonical_key(path).is_ok_and(|key| key == self.tracked_key)
+        }
+
+        /// Alias spellings of the tracked file (final-component symlinks,
+        /// hard links, case aliases on case-insensitive volumes) are
+        /// rejected rather than silently bypassing presence tracking.
+        /// Detection is best-effort — it cannot be raced-proof against
+        /// external renames — but the engine only ever uses the configured
+        /// spelling, so any alias access is caller error, and an undetected
+        /// alias is unsupported external interference.
+        fn reject_alias(&self, path: &str, op: &'static str) -> Result<()> {
+            let tracked = std::fs::metadata(&self.tracked_key).ok();
+            let this = std::fs::metadata(path).ok();
+            if let (Some(tracked), Some(this)) = (tracked, this) {
+                if (tracked.dev(), tracked.ino()) == (this.dev(), this.ino()) {
+                    return Err(turso_core::LimboError::InvalidArgument(format!(
+                        "{op}: {path} is an alias of the presence-tracked database file;                          use the configured spelling"
+                    )));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    impl IO for SparseBitmapIo {
+        #[instrument(skip_all, level = Level::TRACE)]
+        fn open_file(&self, path: &str, flags: OpenFlags, direct: bool) -> Result<Arc<dyn File>> {
+            if !self.is_tracked(path) {
+                self.reject_alias(path, "open")?;
+                return self.inner.open_file(path, flags, direct);
+            }
+            let read_only = flags.contains(OpenFlags::ReadOnly);
+            let mut options = std::fs::File::options();
+            options.read(true);
+            if !read_only {
+                options.write(true);
+                options.create(flags.contains(OpenFlags::Create));
+            }
+            let file = options.open(path).map_err(|e| io_error(e, "open"))?;
+            let meta = file.metadata().map_err(|e| io_error(e, "metadata"))?;
+            let id: FileId = (meta.dev(), meta.ino());
+
+            let mut registry = registry();
+            // Re-verify under the registry lock that the path still names the
+            // inode we opened: `remove_file` holds this lock across its
+            // unlinks, so an open racing a removal must not register (and
+            // later persist presence for) an already-unlinked inode.
+            let still_named = std::fs::metadata(path)
+                .map(|current| (current.dev(), current.ino()) == id)
+                .unwrap_or(false);
+            if !still_named {
+                return Err(io_error(
+                    std::io::Error::from(std::io::ErrorKind::NotFound),
+                    "open",
+                ));
+            }
+            if let Some(reg_entry) = registry.get_mut(&id) {
+                // The freshly opened descriptor names the same inode by
+                // construction; if it is writable and the shared one is not,
+                // upgrade in place.
+                if !read_only && !reg_entry.entry.fd_writable.load(Ordering::Acquire) {
+                    *reg_entry.entry.file.write().unwrap() = file;
+                    reg_entry.entry.fd_writable.store(true, Ordering::Release);
+                }
+                reg_entry.handles += 1;
+                return Ok(Arc::new(SparseBitmapFile {
+                    entry: reg_entry.entry.clone(),
+                    id,
+                    read_only,
+                }));
+            }
+            let entry = Arc::new(FileEntry::new(&self.tracked_path, file, &meta, read_only)?);
+            registry.insert(
+                id,
+                RegistryEntry {
+                    entry: entry.clone(),
+                    handles: 1,
+                },
+            );
+            Ok(Arc::new(SparseBitmapFile {
+                entry,
+                id,
+                read_only,
+            }))
+        }
+
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn remove_file(&self, path: &str) -> Result<()> {
+            if !self.is_tracked(path) {
+                self.reject_alias(path, "remove_file")?;
+                return self.inner.remove_file(path);
+            }
+            // Hold the registry lock across the whole removal so a concurrent
+            // open cannot observe a half-removed file, and the entry's
+            // persist lock so an in-flight sidecar persist either completes
+            // before the unlinks or observes `defunct` after them.
+            //
+            // Failure ordering keeps every exit internally consistent: the
+            // data unlink goes first (failure leaves all state untouched);
+            // a sidecar-unlink failure afterwards leaves residue that the
+            // identity binding fails closed on; registry state is only
+            // mutated once the files are gone.
+            let mut registry = registry();
+            let entry = std::fs::metadata(path)
+                .ok()
+                .map(|meta| (meta.dev(), meta.ino()))
+                .and_then(|id| {
+                    registry
+                        .get(&id)
+                        .map(|reg_entry| (id, reg_entry.entry.clone()))
+                });
+            let _persist_guard = entry
+                .as_ref()
+                .map(|(_, entry)| match entry.persist_lock.lock() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => poisoned.into_inner(),
+                });
+            std::fs::remove_file(path).map_err(|e| io_error(e, "remove_file"))?;
+            if let Some((id, entry)) = entry.as_ref() {
+                entry.defunct.store(true, Ordering::Release);
+                registry.remove(id);
+            }
+            match std::fs::remove_file(sidecar_path(&self.tracked_path)) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(io_error(e, "remove_file")),
+            }
+            // Make both unlinks durable together.
+            sync_parent_dir(&self.tracked_path, FileSyncType::Fsync)
+                .map_err(|e| completion_error(e, "sync dir after remove"))?;
+            Ok(())
+        }
+
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn step(&self) -> Result<()> {
+            self.inner.step()
+        }
+    }
+
+    impl Clock for SparseBitmapIo {
+        fn current_time_monotonic(&self) -> MonotonicInstant {
+            DefaultClock.current_time_monotonic()
+        }
+
+        fn current_time_wall_clock(&self) -> WallClockInstant {
+            DefaultClock.current_time_wall_clock()
+        }
+    }
+
+    fn sidecar_path(path: &str) -> String {
+        format!("{path}{SIDECAR_SUFFIX}")
+    }
+
+    fn sync_parent_dir(path: &str, sync_type: FileSyncType) -> std::io::Result<()> {
+        let dir = std::path::Path::new(path)
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let dir = std::fs::File::open(dir)?;
+        barrier_sync(&dir, sync_type)
+    }
+
+    /// Fsync honoring [`FileSyncType`]: on Apple platforms `FullFsync` maps
+    /// to `fcntl(F_FULLFSYNC)` per the `File::sync` contract; elsewhere it
+    /// is a plain fsync (mirrors `UnixFile`).
+    fn barrier_sync(file: &std::fs::File, sync_type: FileSyncType) -> std::io::Result<()> {
+        #[cfg(target_vendor = "apple")]
+        {
+            let res = match sync_type {
+                FileSyncType::Fsync => unsafe { libc::fsync(file.as_raw_fd()) },
+                FileSyncType::FullFsync => unsafe {
+                    libc::fcntl(file.as_raw_fd(), libc::F_FULLFSYNC)
+                },
+            };
+            if res == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        }
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            let _ = sync_type;
+            file.sync_all()
+        }
+    }
+
+    struct PresenceState {
+        present: roaring::RoaringTreemap,
+        dirty: bool,
+    }
+
+    struct FileEntry {
+        path: String,
+        sidecar_path: String,
+        file: RwLock<std::fs::File>,
+        state: RwLock<PresenceState>,
+        /// Serializes sidecar persistence against `remove_file`, closing the
+        /// window where an in-flight persist could re-create the sidecar of
+        /// a just-removed file. No cycle: `sync`/`punch_hole`/`Drop` acquire
+        /// it while holding file/state locks, but `remove_file` (registry →
+        /// persist_lock) never takes file/state locks, and the final `Drop`
+        /// cannot overlap another operation on the same handle.
+        persist_lock: Mutex<()>,
+        /// Whether the shared descriptor was opened with write access.
+        fd_writable: AtomicBool,
+        /// Set by `remove_file`: presence persistence stops, data operations
+        /// keep POSIX unlinked-file semantics.
+        defunct: AtomicBool,
+    }
+
+    /// A presence-tracked handle to the lazily-populated database file. All
+    /// handles to one file share a [`FileEntry`]; the access mode is tracked
+    /// per handle.
+    pub struct SparseBitmapFile {
+        entry: Arc<FileEntry>,
+        id: FileId,
+        read_only: bool,
+    }
+
+    impl FileEntry {
+        fn new(
+            path: &str,
+            file: std::fs::File,
+            meta: &std::fs::Metadata,
+            read_only: bool,
+        ) -> Result<Self> {
+            let sidecar = sidecar_path(path);
+            if !read_only {
+                sweep_orphan_tmp_files(&sidecar);
+            }
+            let present = load_sidecar(&sidecar, meta.len(), meta.dev(), meta.ino(), read_only)?;
+            Ok(Self {
+                path: path.to_string(),
+                sidecar_path: sidecar,
+                file: RwLock::new(file),
+                state: RwLock::new(PresenceState {
+                    present,
+                    dirty: false,
+                }),
+                persist_lock: Mutex::new(()),
+                fd_writable: AtomicBool::new(!read_only),
+                defunct: AtomicBool::new(false),
+            })
+        }
+    }
+
+    impl SparseBitmapFile {
+        fn reject_if_read_only(&self, op: &'static str) -> Result<()> {
+            if self.read_only {
+                return Err(completion_error(
+                    std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+                    op,
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    /// Deterministic last-close flush: the handle count lives in the global
+    /// registry, and the final flush runs under the registry lock, so a
+    /// concurrent reopen serializes after it. Pure read hydration never
+    /// triggers [`File::sync`]; without this flush a clean close would leave
+    /// the fetched pages on disk (OS writeback) but not the bitmap — the
+    /// Linux backend gets that coupling from the filesystem for free. A hard
+    /// crash between syncs still loses hydration state and re-fetches, which
+    /// is the safe direction.
+    impl Drop for SparseBitmapFile {
+        fn drop(&mut self) {
+            let mut registry = registry();
+            let Some(reg_entry) = registry.get_mut(&self.id) else {
+                return; // removed via remove_file
+            };
+            if !Arc::ptr_eq(&reg_entry.entry, &self.entry) {
+                return; // the file was removed and re-registered
+            }
+            reg_entry.handles -= 1;
+            if reg_entry.handles > 0 {
+                return;
+            }
+            let Some(reg_entry) = registry.remove(&self.id) else {
+                return;
+            };
+            let entry = reg_entry.entry;
+            if entry.defunct.load(Ordering::Acquire) {
+                return;
+            }
+            let mut state = match entry.state.write() {
+                Ok(state) => state,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            if !state.dirty {
+                return;
+            }
+            let file = match entry.file.read() {
+                Ok(file) => file,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            if let Err(e) = barrier_sync(&file, FileSyncType::Fsync) {
+                tracing::warn!(
+                    "failed to sync {} on close; leaving presence sidecar stale: {e}",
+                    entry.path
+                );
+                return;
+            }
+            if let Err(e) = persist_presence(&entry, &file, &mut state, FileSyncType::Fsync) {
+                tracing::warn!("failed to persist presence sidecar on close: {e}");
+            }
+        }
+    }
+
+    /// Load and validate the sidecar against the opened data file.
+    ///
+    /// An empty data file is fresh by definition: any sidecar found next to
+    /// it is stale and discarded. For a non-empty data file the sidecar is
+    /// required and must match this file's identity and checksum — the bits
+    /// may guard locally modified pages, so guessing "all absent" could let
+    /// the lazy storage overwrite local data with older server pages. Refuse
+    /// instead.
+    fn load_sidecar(
+        path: &str,
+        data_len: u64,
+        dev: u64,
+        ino: u64,
+        read_only: bool,
+    ) -> Result<roaring::RoaringTreemap> {
+        let anomaly = |reason: &str| {
+            turso_core::LimboError::Corrupt(format!(
+                "presence sidecar {path} {reason}; refusing to guess page presence for a \
+                 non-empty database file (delete the database file and its sidecar to \
+                 re-bootstrap)"
+            ))
+        };
+        let discard_stale = |bytes_existed: bool| {
+            if bytes_existed && !read_only {
+                turso_assert_reachable!("stale presence sidecar discarded for fresh file");
+                if let Err(e) = std::fs::remove_file(path) {
+                    tracing::warn!("failed to remove stale presence sidecar {path}: {e}");
+                }
+            }
+            roaring::RoaringTreemap::new()
+        };
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if data_len == 0 {
+                    return Ok(discard_stale(false));
+                }
+                return Err(anomaly("is missing"));
+            }
+            Err(e) => return Err(io_error(e, "read presence sidecar")),
+        };
+        if data_len == 0 {
+            return Ok(discard_stale(true));
+        }
+        match parse_sidecar(&bytes) {
+            Some((sidecar_dev, sidecar_ino, bitmap)) => {
+                if sidecar_dev != dev || sidecar_ino != ino {
+                    turso_assert_reachable!("presence sidecar belongs to another file generation");
+                    return Err(anomaly("belongs to a different file generation"));
+                }
+                Ok(bitmap)
+            }
+            None => {
+                turso_assert_reachable!("presence sidecar is corrupt");
+                Err(anomaly("is corrupt or has an unknown format"))
+            }
+        }
+    }
+
+    fn parse_sidecar(bytes: &[u8]) -> Option<(u64, u64, roaring::RoaringTreemap)> {
+        if bytes.len() < SIDECAR_HEADER_LEN {
+            return None;
+        }
+        let (header, payload) = bytes.split_at(SIDECAR_HEADER_LEN);
+        if &header[0..4] != SIDECAR_MAGIC || header[4] != SIDECAR_VERSION {
+            return None;
+        }
+        let granule = u32::from_le_bytes(header[5..9].try_into().ok()?);
+        if u64::from(granule) != GRANULE {
+            return None;
+        }
+        let dev = u64::from_le_bytes(header[9..17].try_into().ok()?);
+        let ino = u64::from_le_bytes(header[17..25].try_into().ok()?);
+        let crc = u32::from_le_bytes(header[25..29].try_into().ok()?);
+        if crc32c::crc32c(payload) != crc {
+            return None;
+        }
+        let bitmap = roaring::RoaringTreemap::deserialize_from(payload).ok()?;
+        Some((dev, ino, bitmap))
+    }
+
+    /// Remove leftovers of persists interrupted by a crash or failure. The
+    /// temp names are namespaced by the sidecar path, so this can only touch
+    /// this backend's own files.
+    fn sweep_orphan_tmp_files(sidecar: &str) {
+        let path = std::path::Path::new(sidecar);
+        let (Some(dir), Some(name)) = (path.parent(), path.file_name()) else {
+            return;
+        };
+        let dir = if dir.as_os_str().is_empty() {
+            std::path::Path::new(".")
+        } else {
+            dir
+        };
+        let Ok(dir_entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        let prefix = format!("{}.", name.to_string_lossy());
+        for dir_entry in dir_entries.flatten() {
+            let file_name = dir_entry.file_name();
+            let file_name = file_name.to_string_lossy();
+            let Some(middle) = file_name
+                .strip_prefix(&prefix)
+                .and_then(|rest| rest.strip_suffix(".tmp"))
+            else {
+                continue;
+            };
+            // Names are `<sidecar>.<pid>.<seq>.tmp`; only sweep our own
+            // leftovers or those of processes that no longer exist, so an
+            // in-flight persist elsewhere is never deleted.
+            let Some(pid) = middle
+                .split('.')
+                .next()
+                .and_then(|pid| pid.parse::<u32>().ok())
+            else {
+                continue;
+            };
+            let orphaned = pid == std::process::id()
+                || unsafe { libc::kill(pid as libc::pid_t, 0) } == -1
+                    && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH);
+            if orphaned {
+                let _ = std::fs::remove_file(dir_entry.path());
+            }
+        }
+    }
+
+    /// Persist the bitmap via write-to-temp + fsync + rename + parent
+    /// directory fsync, so a crash leaves either the old or the new sidecar
+    /// — durably — and never a torn one. Fsyncing the renamed file alone
+    /// would not make the new *directory entry* durable. The temp name is
+    /// unique per process and per persist, so concurrent writers can never
+    /// interleave inside one temp file.
+    ///
+    /// Ordering invariant: the caller must sync the data file BEFORE the
+    /// bitmap is persisted. The on-disk bitmap may then lag the data file
+    /// (safe: within a `File::sync` call the pager has not yet completed
+    /// its checkpoint, so WAL replay repairs a crash) but never lead it
+    /// (which could serve unfetched bytes as zeros).
+    fn persist_presence(
+        entry: &FileEntry,
+        file: &std::fs::File,
+        state: &mut PresenceState,
+        sync_type: FileSyncType,
+    ) -> Result<()> {
+        if !state.dirty {
+            return Ok(());
+        }
+        // Serialize against `remove_file`: it holds this lock across its
+        // unlinks, so we either finish the rename before removal starts or
+        // observe `defunct` after it finished.
+        let _persist_guard = match entry.persist_lock.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if entry.defunct.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        // If the path no longer names this entry's inode (removed or replaced
+        // externally), renaming the sidecar into place would attach this
+        // entry's bits to some other file's name. Skip; the identity binding
+        // makes any stale on-disk sidecar fail closed at the next open.
+        let fd_meta = file.metadata().map_err(|e| io_error(e, "metadata"))?;
+        let still_named = std::fs::metadata(&entry.path)
+            .map(|current| (current.dev(), current.ino()) == (fd_meta.dev(), fd_meta.ino()))
+            .unwrap_or(false);
+        if !still_named {
+            return Err(turso_core::LimboError::Corrupt(format!(
+                "presence sidecar for {} not persisted: the path no longer names this file",
+                entry.path
+            )));
+        }
+        let mut payload = Vec::with_capacity(state.present.serialized_size());
+        state
+            .present
+            .serialize_into(&mut payload)
+            .map_err(|e| completion_error(e, "serialize presence sidecar"))?;
+        let meta = file.metadata().map_err(|e| io_error(e, "metadata"))?;
+        let mut buf = Vec::with_capacity(SIDECAR_HEADER_LEN + payload.len());
+        buf.extend_from_slice(SIDECAR_MAGIC);
+        buf.push(SIDECAR_VERSION);
+        buf.extend_from_slice(&(GRANULE as u32).to_le_bytes());
+        buf.extend_from_slice(&meta.dev().to_le_bytes());
+        buf.extend_from_slice(&meta.ino().to_le_bytes());
+        buf.extend_from_slice(&crc32c::crc32c(&payload).to_le_bytes());
+        buf.extend_from_slice(&payload);
+
+        static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+        let tmp_path = format!(
+            "{}.{}.{}.tmp",
+            entry.sidecar_path,
+            std::process::id(),
+            TMP_SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut tmp = std::fs::File::create(&tmp_path)
+            .map_err(|e| completion_error(e, "create presence sidecar"))?;
+        tmp.write_all(&buf)
+            .map_err(|e| completion_error(e, "write presence sidecar"))?;
+        barrier_sync(&tmp, sync_type).map_err(|e| completion_error(e, "sync presence sidecar"))?;
+        std::fs::rename(&tmp_path, &entry.sidecar_path)
+            .map_err(|e| completion_error(e, "rename presence sidecar"))?;
+        sync_parent_dir(&entry.sidecar_path, sync_type)
+            .map_err(|e| completion_error(e, "sync sidecar dir"))?;
+        state.dirty = false;
+        Ok(())
+    }
+
+    /// Release the punched byte range back to the filesystem. Best-effort:
+    /// the bitmap is the source of truth, so failure (or a filesystem that
+    /// later re-materializes the range, as APFS does next to flushed writes)
+    /// costs space, never correctness.
+    #[cfg(target_os = "linux")]
+    fn reclaim_range(file: &std::fs::File, pos: u64, len: u64) -> std::io::Result<()> {
         let res = unsafe {
             libc::fallocate(
                 file.as_raw_fd(),
@@ -158,14 +853,219 @@ impl File for SparseLinuxFile {
             )
         };
         if res == -1 {
-            let errno = unsafe { *libc::__errno_location() };
-            Err(turso_core::LimboError::CompletionError(
-                turso_core::CompletionError::IOError(
-                    std::io::Error::from_raw_os_error(errno).kind(),
-                    "fallocate",
-                ),
-            ))
+            Err(std::io::Error::last_os_error())
         } else {
+            Ok(())
+        }
+    }
+
+    /// Release the punched byte range back to the filesystem. Best-effort:
+    /// the bitmap is the source of truth, so failure (or a filesystem that
+    /// later re-materializes the range, as APFS does next to flushed writes)
+    /// costs space, never correctness.
+    ///
+    /// `F_PUNCHHOLE` requires block-size alignment (4096 on APFS); callers
+    /// punch at granule alignment, which satisfies it.
+    #[cfg(target_vendor = "apple")]
+    fn reclaim_range(file: &std::fs::File, pos: u64, len: u64) -> std::io::Result<()> {
+        let args = libc::fpunchhole_t {
+            fp_flags: 0,
+            reserved: 0,
+            fp_offset: pos as libc::off_t,
+            fp_length: len as libc::off_t,
+        };
+        let res = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_PUNCHHOLE, &args) };
+        if res == -1 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
+    fn reclaim_range(_file: &std::fs::File, _pos: u64, _len: u64) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    /// Granule indices overlapping `[pos, pos + len)`: a write marks all of
+    /// them (any touched block is allocated, like `MemoryIO` and Linux).
+    fn overlapping(pos: u64, len: u64) -> Result<std::ops::Range<u64>> {
+        let end = pos.checked_add(len).ok_or_else(|| {
+            turso_core::LimboError::InvalidArgument(format!(
+                "byte range overflows: pos={pos} len={len}"
+            ))
+        })?;
+        Ok(pos / GRANULE..end.div_ceil(GRANULE))
+    }
+
+    #[allow(clippy::readonly_write_lock)]
+    impl File for SparseBitmapFile {
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn lock_file(&self, _exclusive: bool) -> Result<()> {
+            Ok(())
+        }
+
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn unlock_file(&self) -> Result<()> {
+            Ok(())
+        }
+
+        #[instrument(skip(self, c), level = Level::TRACE)]
+        fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
+            let nr = {
+                let file = self.entry.file.read().unwrap();
+                let r = c.as_read();
+                let buf = r.buf();
+                let buf = buf.as_mut_slice();
+                file.read_exact_at(buf, pos)
+                    .map_err(|e| io_error(e, "pread"))?;
+                buf.len() as i32
+                // Guards drop here: completion callbacks may reopen or drop
+                // other handles, which takes the registry lock.
+            };
+            c.complete(nr);
+            Ok(c)
+        }
+
+        #[instrument(skip(self, c, buffer), level = Level::TRACE)]
+        fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
+            self.reject_if_read_only("pwrite")?;
+            let buf = buffer.as_slice();
+            if buf.is_empty() {
+                // An empty write allocates nothing (matches `MemoryIO`).
+                c.complete(0);
+                return Ok(c);
+            }
+            {
+                let file = self.entry.file.write().unwrap();
+                let range = overlapping(pos, buf.len() as u64)?;
+                let mut state = self.entry.state.write().unwrap();
+                // A previously absent edge granule must not leak whatever
+                // bytes physically precede/follow the written span (e.g. a
+                // punched range whose physical reclamation did not happen or
+                // did not survive a crash): zero the uncovered remainder so
+                // "present" always means fully defined bytes, exactly like a
+                // fresh `MemoryIO` page.
+                let file_len = file.metadata().map_err(|e| io_error(e, "metadata"))?.len();
+                if let Some(first) = range.clone().next() {
+                    let granule_start = first * GRANULE;
+                    if pos > granule_start && !state.present.contains(first) {
+                        let zeros = vec![0u8; (pos - granule_start) as usize];
+                        file.write_all_at(&zeros, granule_start)
+                            .map_err(|e| io_error(e, "pwrite"))?;
+                    }
+                }
+                if let Some(last) = range.clone().next_back() {
+                    let span_end = pos + buf.len() as u64;
+                    let granule_end = (last + 1)
+                        .checked_mul(GRANULE)
+                        .unwrap_or(u64::MAX)
+                        .min(file_len.max(span_end));
+                    if granule_end > span_end && !state.present.contains(last) {
+                        let zeros = vec![0u8; (granule_end - span_end) as usize];
+                        file.write_all_at(&zeros, span_end)
+                            .map_err(|e| io_error(e, "pwrite"))?;
+                    }
+                }
+                file.write_all_at(buf, pos)
+                    .map_err(|e| io_error(e, "pwrite"))?;
+                if !range.is_empty() && state.present.insert_range(range) > 0 {
+                    state.dirty = true;
+                }
+                // Guards drop here, before the completion callback runs.
+            }
+            c.complete(buffer.len() as i32);
+            Ok(c)
+        }
+
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn sync(&self, c: Completion, sync_type: FileSyncType) -> Result<Completion> {
+            {
+                let file = self.entry.file.write().unwrap();
+                barrier_sync(&file, sync_type).map_err(|e| io_error(e, "sync"))?;
+                let mut state = self.entry.state.write().unwrap();
+                persist_presence(&self.entry, &file, &mut state, sync_type)?;
+                // Guards drop here, before the completion callback runs.
+            }
+            c.complete(0);
+            Ok(c)
+        }
+
+        #[instrument(err, skip_all, level = Level::TRACE)]
+        fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+            self.reject_if_read_only("truncate")?;
+            {
+                let file = self.entry.file.write().unwrap();
+                file.set_len(len).map_err(|e| io_error(e, "truncate"))?;
+                let mut state = self.entry.state.write().unwrap();
+                // Granules wholly beyond the new end are gone; the boundary
+                // granule keeps its bit (its in-range prefix still holds
+                // data, and the extension reads back as zeros).
+                let first_gone = len.div_ceil(GRANULE);
+                if state.present.remove_range(first_gone..=u64::MAX) > 0 {
+                    state.dirty = true;
+                }
+                // Guards drop here, before the completion callback runs.
+            }
+            c.complete(0);
+            Ok(c)
+        }
+
+        fn size(&self) -> Result<u64> {
+            let file = self.entry.file.read().unwrap();
+            Ok(file.metadata().map_err(|e| io_error(e, "metadata"))?.len())
+        }
+
+        /// Whether `[pos, pos + len)` is entirely absent, per the trait
+        /// contract ("if there is a single byte which is allocated within a
+        /// given range - method must return false") and matching `MemoryIO`:
+        /// any overlapping present granule means data. Takes the file lock so
+        /// the answer is atomic with a concurrent `pwrite`'s data-plus-bits
+        /// installation, as it is for the Linux and memory backends.
+        fn has_hole(&self, pos: usize, len: usize) -> turso_core::Result<bool> {
+            if len == 0 {
+                return Ok(true);
+            }
+            let range = overlapping(pos as u64, len as u64)?;
+            let _file = self.entry.file.read().unwrap();
+            let state = self.entry.state.read().unwrap();
+            // Present-count within [start, end) via rank difference.
+            let below_end = state.present.rank(range.end - 1);
+            let below_start = match range.start.checked_sub(1) {
+                Some(prev) => state.present.rank(prev),
+                None => 0,
+            };
+            let hole = below_end == below_start;
+            turso_assert_sometimes!(hole, "sparse bitmap: probed range is absent");
+            turso_assert_sometimes!(!hole, "sparse bitmap: probed range is present");
+            Ok(hole)
+        }
+
+        fn punch_hole(&self, pos: usize, len: usize) -> turso_core::Result<()> {
+            self.reject_if_read_only("punch_hole")?;
+            turso_assert!(
+                pos as u64 % GRANULE == 0 && len as u64 % GRANULE == 0,
+                "hole must be granule aligned"
+            );
+            let range = overlapping(pos as u64, len as u64)?;
+            let file = self.entry.file.write().unwrap();
+            let mut state = self.entry.state.write().unwrap();
+            if !range.is_empty() && state.present.remove_range(range) > 0 {
+                state.dirty = true;
+            }
+            // The cleared bits must be durable before the bytes are released:
+            // sync the data file (persist ordering invariant), then the
+            // sidecar. A crash in between leaves extra "absent" bits — safe,
+            // because evicted pages are re-fetchable cache by definition, and
+            // stale physical bytes cannot resurface: a later write into an
+            // absent granule zero-fills its uncovered remainder.
+            barrier_sync(&file, FileSyncType::Fsync).map_err(|e| io_error(e, "sync"))?;
+            persist_presence(&self.entry, &file, &mut state, FileSyncType::Fsync)?;
+            drop(state);
+
+            if let Err(e) = reclaim_range(&file, pos as u64, len as u64) {
+                tracing::warn!("failed to reclaim punched range ({pos}, {len}): {e}");
+            }
             Ok(())
         }
     }
@@ -177,36 +1077,53 @@ mod tests {
 
     use turso_core::{Buffer, Completion, OpenFlags, IO};
 
-    use crate::sparse_io::SparseLinuxIo;
+    use crate::sparse_io::SparseBitmapIo;
 
-    #[test]
-    pub fn sparse_io_test() {
-        let tmp = tempfile::NamedTempFile::new().unwrap();
-        let tmp_path = tmp.into_temp_path();
-        let tmp_path = tmp_path.as_os_str().to_str().unwrap();
-        let io = SparseLinuxIo::new().unwrap();
-        let file = io.open_file(tmp_path, OpenFlags::default(), false).unwrap();
+    const G: u64 = 4096;
+
+    fn truncate(file: &Arc<dyn turso_core::File>, len: u64) {
+        #[expect(clippy::let_underscore_future)]
+        let _ = file.truncate(len, Completion::new_trunc(|_| {})).unwrap();
+    }
+
+    fn write(file: &Arc<dyn turso_core::File>, pos: u64, len: usize, fill: u8) {
+        let buffer = Arc::new(Buffer::new_temporary(len));
+        buffer.as_mut_slice().fill(fill);
         #[expect(clippy::let_underscore_future)]
         let _ = file
-            .truncate(1024 * 1024, Completion::new_trunc(|_| {}))
+            .pwrite(pos, buffer, Completion::new_write(|_| {}))
             .unwrap();
+    }
+
+    fn sync(file: &Arc<dyn turso_core::File>, sync_type: turso_core::io::FileSyncType) {
+        #[expect(clippy::let_underscore_future)]
+        let _ = file.sync(Completion::new_sync(|_| {}), sync_type).unwrap();
+    }
+
+    fn fsync(file: &Arc<dyn turso_core::File>) {
+        sync(file, turso_core::io::FileSyncType::Fsync);
+    }
+
+    fn tracked_io_and_path() -> (SparseBitmapIo, tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sparse.db").to_str().unwrap().to_string();
+        let io = SparseBitmapIo::new(&path).unwrap();
+        (io, dir, path)
+    }
+
+    /// The `has_hole`/`punch_hole` contract every sparse backend must satisfy.
+    fn check_sparse_semantics(io: &dyn IO, path: &str) {
+        let file = io.open_file(path, OpenFlags::default(), false).unwrap();
+        truncate(&file, 1024 * 1024);
         assert!(file.has_hole(0, 4096).unwrap());
 
-        let buffer = Arc::new(Buffer::new_temporary(4096));
-        buffer.as_mut_slice().fill(1);
-        #[expect(clippy::let_underscore_future)]
-        let _ = file
-            .pwrite(0, buffer.clone(), Completion::new_write(|_| {}))
-            .unwrap();
+        write(&file, 0, 4096, 1);
         assert!(!file.has_hole(0, 4096).unwrap());
 
         assert!(file.has_hole(4096, 4096).unwrap());
         assert!(file.has_hole(4096 * 2, 4096).unwrap());
 
-        #[expect(clippy::let_underscore_future)]
-        let _ = file
-            .pwrite(4096 * 2, buffer.clone(), Completion::new_write(|_| {}))
-            .unwrap();
+        write(&file, 4096 * 2, 4096, 1);
         assert!(file.has_hole(4096, 4096).unwrap());
         assert!(!file.has_hole(4096 * 2, 4096).unwrap());
 
@@ -215,5 +1132,368 @@ mod tests {
         file.punch_hole(2 * 4096, 4096).unwrap();
         assert!(file.has_hole(4096 * 2, 4096).unwrap());
         assert!(file.has_hole(4096, 4097).unwrap());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    pub fn sparse_io_test() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let tmp_path = tmp.into_temp_path();
+        let io = crate::sparse_io::SparseLinuxIo::new().unwrap();
+        check_sparse_semantics(&io, tmp_path.as_os_str().to_str().unwrap());
+    }
+
+    #[test]
+    pub fn sparse_bitmap_io_test() {
+        let (io, _dir, path) = tracked_io_and_path();
+        check_sparse_semantics(&io, &path);
+    }
+
+    /// Sub-granule writes must mark their granule present, per the trait
+    /// contract ("a single allocated byte within a given range" ⇒ `false`)
+    /// and matching Linux/MemoryIO allocation semantics.
+    #[test]
+    pub fn sparse_bitmap_partial_write_marks_presence() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        truncate(&file, 16 * G);
+        write(&file, 1, 1, 7);
+        assert!(!file.has_hole(0, G as usize).unwrap());
+        // A write straddling a granule boundary marks both granules.
+        write(&file, 2 * G - 1, 2, 7);
+        assert!(!file.has_hole(G as usize, G as usize).unwrap());
+        assert!(!file.has_hole(2 * G as usize, G as usize).unwrap());
+        assert!(file.has_hole(3 * G as usize, G as usize).unwrap());
+    }
+
+    /// A write into an absent granule must not expose stale physical bytes
+    /// (e.g. a punched range whose reclamation did not survive): the
+    /// uncovered remainder of the granule reads as zeros, like a fresh
+    /// `MemoryIO` page.
+    #[test]
+    pub fn sparse_bitmap_partial_write_zero_fills_absent_granule() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        truncate(&file, 16 * G);
+        write(&file, 0, G as usize, 0xAA);
+        fsync(&file);
+        file.punch_hole(0, G as usize).unwrap();
+        // Simulate reclamation not surviving: put stale bytes back on disk
+        // behind the backend's back.
+        {
+            use std::os::unix::fs::FileExt;
+            let raw = std::fs::File::options().write(true).open(&path).unwrap();
+            raw.write_all_at(&[0xAA; 4096], 0).unwrap();
+        }
+        // A one-byte write marks the granule present; the other 4095 bytes
+        // must read as zeros, not the stale 0xAA.
+        write(&file, 7, 1, 0xBB);
+        assert!(!file.has_hole(0, G as usize).unwrap());
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(bytes[7], 0xBB);
+        assert!(bytes[..7].iter().all(|b| *b == 0));
+        assert!(bytes[8..G as usize].iter().all(|b| *b == 0));
+    }
+
+    /// A zero-length write allocates nothing, matching `MemoryIO`: it must
+    /// not zero-fill or mark any granule present.
+    #[test]
+    pub fn sparse_bitmap_empty_write_is_noop() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        truncate(&file, 16 * G);
+        write(&file, 7, 0, 0);
+        assert!(file.has_hole(0, G as usize).unwrap());
+    }
+
+    /// Alias spellings of the tracked file are rejected: presence tracking
+    /// is keyed to the configured spelling, so a symlink or hard link that
+    /// bypasses it must error rather than silently splitting state.
+    #[test]
+    pub fn sparse_bitmap_alias_spellings_are_rejected() {
+        let (io, dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            truncate(&file, 16 * G);
+            write(&file, 0, G as usize, 1);
+            fsync(&file);
+        }
+        let symlink = dir.path().join("symlink.db").to_str().unwrap().to_string();
+        std::os::unix::fs::symlink(&path, &symlink).unwrap();
+        assert!(io.open_file(&symlink, OpenFlags::default(), false).is_err());
+        assert!(io.remove_file(&symlink).is_err());
+        let hardlink = dir.path().join("hardlink.db").to_str().unwrap().to_string();
+        std::fs::hard_link(&path, &hardlink).unwrap();
+        assert!(io
+            .open_file(&hardlink, OpenFlags::default(), false)
+            .is_err());
+        assert!(io.remove_file(&hardlink).is_err());
+        // The configured spelling keeps working.
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        assert!(!file.has_hole(0, G as usize).unwrap());
+    }
+
+    /// Untracked paths must be plain `PlatformIO` files: full durability
+    /// semantics, no sidecar, no presence overhead.
+    #[test]
+    pub fn sparse_bitmap_untracked_paths_have_no_sidecar() {
+        let (io, dir, _path) = tracked_io_and_path();
+        let other = dir.path().join("other-wal").to_str().unwrap().to_string();
+        let file = io.open_file(&other, OpenFlags::default(), false).unwrap();
+        write(&file, 0, 4096, 1);
+        fsync(&file);
+        drop(file);
+        assert!(!std::path::Path::new(&format!("{other}.present")).exists());
+    }
+
+    /// All handles to the tracked path share presence state — across
+    /// separate `SparseBitmapIo` instances too: a punch through one handle
+    /// must not be resurrected by a sync through another.
+    #[test]
+    pub fn sparse_bitmap_handles_share_state() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let io2 = SparseBitmapIo::new(&path).unwrap();
+        let a = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        let b = io2.open_file(&path, OpenFlags::default(), false).unwrap();
+        truncate(&a, 16 * G);
+        write(&a, 0, G as usize, 1);
+        write(&a, G, G as usize, 1);
+        fsync(&a);
+        a.punch_hole(0, G as usize).unwrap();
+        // The second instance's handle sees the punch immediately…
+        assert!(b.has_hole(0, G as usize).unwrap());
+        write(&b, 2 * G, G as usize, 2);
+        fsync(&b);
+        drop(a);
+        drop(b);
+
+        // …and the persisted state is the merged view, not a stale snapshot.
+        let io = SparseBitmapIo::new(&path).unwrap();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        assert!(file.has_hole(0, G as usize).unwrap());
+        assert!(!file.has_hole(G as usize, G as usize).unwrap());
+        assert!(!file.has_hole(2 * G as usize, G as usize).unwrap());
+    }
+
+    /// Presence must survive reopen exactly as persisted: pages written and
+    /// synced stay present, punched pages stay absent.
+    #[test]
+    pub fn sparse_bitmap_presence_survives_reopen() {
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            truncate(&file, 1024 * 1024);
+            for pos in [0, G, 2 * G] {
+                write(&file, pos, G as usize, 1);
+            }
+            file.punch_hole(G as usize, G as usize).unwrap();
+            sync(&file, turso_core::io::FileSyncType::FullFsync);
+        }
+
+        let io = SparseBitmapIo::new(&path).unwrap();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        assert!(!file.has_hole(0, G as usize).unwrap());
+        assert!(file.has_hole(G as usize, G as usize).unwrap());
+        assert!(!file.has_hole(2 * G as usize, G as usize).unwrap());
+        assert!(file.has_hole(3 * G as usize, G as usize).unwrap());
+    }
+
+    /// Hydration that never triggers an explicit sync must still be present
+    /// after a clean close: the last handle's drop flushes the bitmap.
+    #[test]
+    pub fn sparse_bitmap_drop_flushes_presence() {
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            truncate(&file, 16 * G);
+            write(&file, 0, G as usize, 1);
+        }
+        let io = SparseBitmapIo::new(&path).unwrap();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        assert!(!file.has_hole(0, G as usize).unwrap());
+        assert!(file.has_hole(G as usize, G as usize).unwrap());
+    }
+
+    /// A live handle must not resurrect the sidecar of a removed file, and
+    /// removal deletes the sidecar together with the data file.
+    #[test]
+    pub fn sparse_bitmap_remove_fences_live_handles() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        truncate(&file, 16 * G);
+        write(&file, 0, G as usize, 1);
+        fsync(&file);
+        io.remove_file(&path).unwrap();
+        assert!(!std::path::Path::new(&path).exists());
+        assert!(!std::path::Path::new(&format!("{path}.present")).exists());
+        // Writes keep POSIX unlinked-file semantics; presence must not be
+        // persisted again.
+        write(&file, G, G as usize, 2);
+        fsync(&file);
+        drop(file);
+        assert!(!std::path::Path::new(&format!("{path}.present")).exists());
+    }
+
+    /// A non-empty data file whose sidecar is missing, corrupt, or belongs
+    /// to a different file must refuse to open: its bits may guard locally
+    /// modified pages, so "all absent" could overwrite local data with older
+    /// server pages.
+    #[test]
+    pub fn sparse_bitmap_anomalies_refuse_to_open() {
+        // Missing sidecar.
+        let (io, _dir, path) = tracked_io_and_path();
+        std::fs::write(&path, vec![1u8; 4096]).unwrap();
+        assert!(io.open_file(&path, OpenFlags::default(), false).is_err());
+
+        // Corrupt sidecar (fails header parse).
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            write(&file, 0, 4096, 1);
+            fsync(&file);
+        }
+        std::fs::write(format!("{path}.present"), b"garbage").unwrap();
+        assert!(io.open_file(&path, OpenFlags::default(), false).is_err());
+
+        // Bit rot in a structurally valid payload (fails the checksum).
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            write(&file, 0, 4096, 1);
+            fsync(&file);
+        }
+        let sidecar = format!("{path}.present");
+        let mut bytes = std::fs::read(&sidecar).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0x01;
+        std::fs::write(&sidecar, bytes).unwrap();
+        assert!(io.open_file(&path, OpenFlags::default(), false).is_err());
+
+        // Sidecar from a different file generation: replace the data file.
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            write(&file, 0, 4096, 1);
+            fsync(&file);
+        }
+        std::fs::remove_file(&path).unwrap();
+        std::fs::write(&path, vec![2u8; 4096]).unwrap();
+        assert!(io.open_file(&path, OpenFlags::default(), false).is_err());
+    }
+
+    /// A stale sidecar next to a fresh (empty) data file is discarded.
+    #[test]
+    pub fn sparse_bitmap_fresh_file_discards_stale_sidecar() {
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::Create, false).unwrap();
+            truncate(&file, 16 * G);
+            write(&file, 0, G as usize, 1);
+            fsync(&file);
+        }
+        // Replace the data file with a new empty one; the old sidecar is stale.
+        std::fs::remove_file(&path).unwrap();
+        std::fs::write(&path, b"").unwrap();
+        let io = SparseBitmapIo::new(&path).unwrap();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        assert!(file.has_hole(0, G as usize).unwrap());
+    }
+
+    /// Access mode is per handle: a read-only handle may probe presence but
+    /// must not mutate it, even while a writable handle to the same file
+    /// exists.
+    #[test]
+    pub fn sparse_bitmap_read_only_is_per_handle() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let rw = io.open_file(&path, OpenFlags::Create, false).unwrap();
+        truncate(&rw, 16 * G);
+        write(&rw, 0, G as usize, 1);
+        fsync(&rw);
+
+        let ro = io.open_file(&path, OpenFlags::ReadOnly, false).unwrap();
+        assert!(!ro.has_hole(0, G as usize).unwrap());
+        assert!(ro.has_hole(G as usize, G as usize).unwrap());
+        let buffer = Arc::new(Buffer::new_temporary(G as usize));
+        assert!(ro.pwrite(0, buffer, Completion::new_write(|_| {})).is_err());
+        assert!(ro.truncate(G, Completion::new_trunc(|_| {})).is_err());
+        assert!(ro.punch_hole(0, G as usize).is_err());
+
+        // The writable handle is unaffected.
+        write(&rw, G, G as usize, 2);
+        assert!(!rw.has_hole(G as usize, G as usize).unwrap());
+    }
+
+    /// Differential check against `MemoryIO`, whose in-memory presence map is
+    /// the reference model for the `has_hole`/`punch_hole` contract: run
+    /// random (including unaligned) write and aligned punch sequences against
+    /// both backends and require identical `has_hole` answers throughout —
+    /// including after the bitmap file is synced, dropped, and reopened.
+    #[test]
+    pub fn sparse_bitmap_matches_memory_io() {
+        use rand::{Rng, SeedableRng};
+
+        const GRANULES: u64 = 64;
+
+        for seed in 0..16u64 {
+            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+
+            let (io, _dir, path) = tracked_io_and_path();
+            let mut bitmap_file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+
+            let memory_io = turso_core::MemoryIO::new();
+            let oracle_file = memory_io
+                .open_file("oracle.db", OpenFlags::Create, false)
+                .unwrap();
+
+            truncate(&bitmap_file, GRANULES * G);
+            truncate(&oracle_file, GRANULES * G);
+
+            let check_all = |bitmap: &Arc<dyn turso_core::File>,
+                             oracle: &Arc<dyn turso_core::File>,
+                             step: usize| {
+                for granule in 0..GRANULES {
+                    for (pos, len) in [
+                        (granule * G, G),
+                        (granule * G, 2 * G),
+                        (granule * G + 1, G / 2),
+                        (granule * G + G - 1, 2),
+                    ] {
+                        let (pos, len) = (pos as usize, len as usize);
+                        assert_eq!(
+                            bitmap.has_hole(pos, len).unwrap(),
+                            oracle.has_hole(pos, len).unwrap(),
+                            "seed={seed} step={step} pos={pos} len={len}"
+                        );
+                    }
+                }
+            };
+
+            for step in 0..96 {
+                let granule = rng.random_range(0..GRANULES);
+                let count = rng.random_range(1..=4).min(GRANULES - granule);
+                if rng.random_bool(0.7) {
+                    // Writes may be unaligned and sub-granule.
+                    let jitter = rng.random_range(0..G);
+                    let pos = (granule * G + jitter).min(GRANULES * G - 1);
+                    let max_len = (count * G - jitter).max(1);
+                    let len = rng.random_range(1..=max_len).min(GRANULES * G - pos);
+                    write(&bitmap_file, pos, len as usize, step as u8);
+                    write(&oracle_file, pos, len as usize, step as u8);
+                } else {
+                    // Punches stay granule-aligned per the punch contract.
+                    let (pos, len) = ((granule * G) as usize, (count * G) as usize);
+                    bitmap_file.punch_hole(pos, len).unwrap();
+                    oracle_file.punch_hole(pos, len).unwrap();
+                }
+                check_all(&bitmap_file, &oracle_file, step);
+            }
+
+            // The persisted bitmap must reproduce the oracle after reopen.
+            fsync(&bitmap_file);
+            drop(bitmap_file);
+            let io = SparseBitmapIo::new(&path).unwrap();
+            bitmap_file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            check_all(&bitmap_file, &oracle_file, usize::MAX);
+        }
     }
 }

--- a/sync/engine/src/sparse_io.rs
+++ b/sync/engine/src/sparse_io.rs
@@ -4,6 +4,8 @@
 //! `PUNCH_HOLE`. [`SparseBitmapIo`] uses an explicit sidecar on filesystems
 //! where allocation cannot represent page presence reliably. It tracks only
 //! the configured database path, rejects aliases, and delegates other files.
+//! In particular, APFS may materialize neighboring holes as allocated zeros,
+//! making allocation probes over-claim pages that were never fetched.
 //!
 //! Data is durable before new presence bits; cleared bits are durable before
 //! space reclamation. A bitmap may under-claim until sync or clean close:
@@ -205,6 +207,7 @@ mod bitmap {
     const ANCHOR_SUFFIX: &str = ".anchor";
     const SIDECAR_MAGIC: &[u8; 4] = b"TPRB";
     const SIDECAR_VERSION: u8 = 4;
+    // Header fields: magic, version, granule, device, inode, payload CRC.
     const SIDECAR_HEADER_LEN: usize = 4 + 1 + 4 + 8 + 8 + 4;
     static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -819,6 +822,8 @@ mod bitmap {
             else {
                 continue;
             };
+            // This branch has no live registry entry; final Drop also holds the
+            // registry lock.
             let orphaned = pid == std::process::id()
                 || unsafe { libc::kill(pid as libc::pid_t, 0) } == -1
                     && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH);
@@ -926,6 +931,7 @@ mod bitmap {
     // Best-effort: the bitmap, not allocation state, is authoritative.
     #[cfg(target_vendor = "apple")]
     fn reclaim_range(file: &std::fs::File, pos: u64, len: u64) -> std::io::Result<()> {
+        // APFS uses 4096-byte blocks, matching `GRANULE`; failures are best-effort.
         let args = libc::fpunchhole_t {
             fp_flags: 0,
             reserved: 0,
@@ -1047,15 +1053,22 @@ mod bitmap {
             self.reject_if_read_only("truncate")?;
             {
                 let file = self.entry.file.write().unwrap();
-                file.set_len(len).map_err(|e| io_error(e, "truncate"))?;
-                let mut state = self.entry.state.write().unwrap();
-                // Granules wholly beyond the new end are gone; the boundary
-                // granule keeps its bit (its in-range prefix still holds
-                // data, and the extension reads back as zeros).
-                let first_gone = len.div_ceil(GRANULE);
-                if state.present.remove_range(first_gone..=u64::MAX) > 0 {
-                    state.dirty = true;
+                let old_len = file.metadata().map_err(|e| io_error(e, "metadata"))?.len();
+                if len < old_len {
+                    let mut state = self.entry.state.write().unwrap();
+                    // Keep the boundary granule, matching `MemoryIO`, and
+                    // publish removed tail bits before `set_len` reclaims data.
+                    let first_gone = len.div_ceil(GRANULE);
+                    if state.present.remove_range(first_gone..=u64::MAX) > 0 {
+                        state.dirty = true;
+                    }
+                    if state.dirty {
+                        barrier_sync(&file, FileSyncType::Fsync)
+                            .map_err(|e| io_error(e, "sync"))?;
+                        persist_presence(&self.entry, &file, &mut state, FileSyncType::Fsync)?;
+                    }
                 }
+                file.set_len(len).map_err(|e| io_error(e, "truncate"))?;
             }
             c.complete(0);
             Ok(c)
@@ -1071,6 +1084,7 @@ mod bitmap {
                 return Ok(true);
             }
             let range = overlapping(pos as u64, len as u64)?;
+            // Serialize with `pwrite`'s data-plus-bitmap update.
             let _file = self.entry.file.read().unwrap();
             let state = self.entry.state.read().unwrap();
             let below_end = state.present.rank(range.end - 1);
@@ -1359,6 +1373,58 @@ mod tests {
         assert!(file.has_hole(G as usize, G as usize).unwrap());
         assert!(!file.has_hole(2 * G as usize, G as usize).unwrap());
         assert!(file.has_hole(3 * G as usize, G as usize).unwrap());
+    }
+
+    #[test]
+    pub fn sparse_bitmap_truncate_persists_absent_tail_before_reclaim() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        truncate(&file, 100 * G);
+        write(&file, 0, (100 * G) as usize, 1);
+        fsync(&file);
+
+        truncate(&file, 50 * G + 1);
+        let sidecar = std::fs::read(format!("{path}.present")).unwrap();
+        let present = roaring::RoaringTreemap::deserialize_from(&sidecar[29..]).unwrap();
+        assert_eq!(present.len(), 51);
+        assert!(present.contains(50));
+        assert!(!present.contains(51));
+
+        truncate(&file, 80 * G);
+        drop(file);
+        let io = SparseBitmapIo::new(&path).unwrap();
+        let reopened = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        assert!(!reopened.has_hole((50 * G) as usize, G as usize).unwrap());
+        assert!(reopened
+            .has_hole((51 * G) as usize, (29 * G) as usize)
+            .unwrap());
+    }
+
+    #[test]
+    pub fn sparse_bitmap_truncate_retry_persists_dirty_tail() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        truncate(&file, 100 * G);
+        write(&file, 0, (100 * G) as usize, 1);
+        fsync(&file);
+
+        let sidecar = format!("{path}.present");
+        let persisted = std::fs::read(&sidecar).unwrap();
+        // Block sidecar replacement with a directory, then restore it for retry.
+        std::fs::remove_file(&sidecar).unwrap();
+        std::fs::create_dir(&sidecar).unwrap();
+        assert!(file
+            .truncate(50 * G, Completion::new_trunc(|_| {}))
+            .is_err());
+        assert_eq!(file.size().unwrap(), 100 * G);
+
+        std::fs::remove_dir(&sidecar).unwrap();
+        std::fs::write(&sidecar, persisted).unwrap();
+        truncate(&file, 50 * G);
+        let sidecar = std::fs::read(&sidecar).unwrap();
+        let present = roaring::RoaringTreemap::deserialize_from(&sidecar[29..]).unwrap();
+        assert_eq!(present.len(), 50);
+        assert_eq!(file.size().unwrap(), 50 * G);
     }
 
     #[test]

--- a/sync/engine/src/sparse_io.rs
+++ b/sync/engine/src/sparse_io.rs
@@ -1,45 +1,14 @@
-//! Sparse-file IO backends for partial sync.
+//! Persistent sparse-file IO for partial sync.
 //!
-//! The lazy page storage tracks which pages are locally present via
-//! [`File::has_hole`] and evicts them via [`File::punch_hole`]. Two backends
-//! implement that contract for persistent files:
+//! Linux derives page presence from `SEEK_DATA` and reclaims space with
+//! `PUNCH_HOLE`. [`SparseBitmapIo`] uses an explicit sidecar on filesystems
+//! where allocation cannot represent page presence reliably. It tracks only
+//! the configured database path, rejects aliases, and delegates other files.
 //!
-//! * [`SparseLinuxIo`] (Linux only) uses the filesystem as the source of
-//!   truth: never-written ranges of a sparse file are holes, `lseek(SEEK_DATA)`
-//!   reports them exactly, and `fallocate(PUNCH_HOLE)` restores them.
-//! * [`SparseBitmapIo`] (portable across Unix) keeps an explicit presence
-//!   bitmap for the lazily-populated database file, mirroring the presence-map
-//!   semantics of `MemoryIO`, and persists it to a sidecar file. A hard-link
-//!   anchor binds that sidecar to the database inode. Filesystem hole punching
-//!   is only best-effort space reclamation. Files other than the tracked
-//!   database file (WAL, metadata) are delegated to `PlatformIO` untouched.
-//!
-//! The bitmap backend exists because APFS on macOS cannot carry the Linux
-//! contract. Delayed allocation rounds writes up to multi-block extents and
-//! materializes neighbouring never-written (and even previously punched)
-//! ranges as allocated zeros when dirty data is flushed, so `lseek(SEEK_DATA)`
-//! reports absent pages as data. For lazy page storage that error direction is
-//! fatal: an absent page reported present is served as zeros instead of being
-//! fetched from the server. An explicit bitmap makes presence exact on any
-//! filesystem; it is also fully exercisable on Linux, where the simulator,
-//! stress, and Antithesis workloads run.
-//!
-//! # Crash consistency of the presence bitmap
-//!
-//! Presence bits protect two different things: fetched server pages (where a
-//! lost bit only costs a re-fetch) and locally modified pages checkpointed
-//! into the database file (where a lost bit would let the lazy storage
-//! overwrite local data with an older server page). The backend therefore
-//! maintains two properties:
-//!
-//! 1. The on-disk bitmap never *over*-claims: the data file is synced before
-//!    every bitmap persist, and punched bits are made durable (temp file +
-//!    fsync + rename + parent-directory fsync) before the bytes are released.
-//! 2. The on-disk bitmap may lag fetched data until a sync or clean close;
-//!    those pages are safe to re-fetch. Checkpointed local changes remain in
-//!    the WAL until [`File::sync`] returns, so WAL replay repairs a crash in
-//!    that window. On a cold open of a non-empty file, missing, corrupt, or
-//!    mismatched metadata is rejected rather than guessed.
+//! Data is durable before new presence bits; cleared bits are durable before
+//! space reclamation. A bitmap may under-claim until sync or clean close:
+//! fetched pages are re-fetched, while local checkpoints remain WAL-protected.
+//! Cold non-empty opens reject missing, corrupt, or mismatched metadata.
 
 use std::{
     os::{fd::AsRawFd, unix::fs::FileExt},
@@ -229,21 +198,13 @@ mod bitmap {
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use turso_core::{turso_assert, turso_assert_reachable, turso_assert_sometimes};
 
-    /// Presence is tracked per sync-protocol page, matching `MemoryIO`'s
-    /// presence map. Like
-    /// `MemoryIO` and the Linux backend (where any write allocates its whole
-    /// block), a write marks every granule it touches; the untouched
-    /// remainder of an edge granule reads as zeros — enforced by explicit
-    /// zero-fill when the granule was absent, so a punched granule whose
-    /// physical reclamation did not survive a crash can never leak stale
-    /// bytes back through a later partial write.
+    // Partial-sync transport and `MemoryIO` both track `PAGE_SIZE` chunks.
     const GRANULE: u64 = crate::database_sync_operations::PAGE_SIZE as u64;
 
     const SIDECAR_SUFFIX: &str = ".present";
     const ANCHOR_SUFFIX: &str = ".anchor";
     const SIDECAR_MAGIC: &[u8; 4] = b"TPRB";
     const SIDECAR_VERSION: u8 = 4;
-    /// magic + version + granule (u32) + dev (u64) + ino (u64) + crc32c (u32)
     const SIDECAR_HEADER_LEN: usize = 4 + 1 + 4 + 8 + 8 + 4;
     static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -296,21 +257,12 @@ mod bitmap {
         }
     }
 
-    /// File identity: `(dev, ino)`. Keying the registry by identity rather
-    /// than path string means alias spellings of one file (case-insensitive
-    /// volumes, symlinks) share one presence state; a spelling that differs
-    /// from the one the sidecar was persisted under fails closed at the next
-    /// open (missing-sidecar anomaly) instead of corrupting. The sidecar's
-    /// hard-link anchor keeps the inode allocated, so this identity cannot be
-    /// reused while its presence metadata survives.
+    // The anchor pins the database inode while its sidecar exists, preventing
+    // `(dev, ino)` reuse from attaching stale presence state to a new file.
     type FileId = (u64, u64);
 
-    /// All handles to a tracked file share one [`FileEntry`], process-wide —
-    /// across `SparseBitmapIo` instances too — mirroring how `MemoryIO`
-    /// shares one store per path and how the Linux backend shares filesystem
-    /// state between descriptors. Handle counting (instead of `Weak`) makes
-    /// the last-close flush deterministic: it runs under the registry lock,
-    /// so a concurrent reopen serializes after it.
+    // Live handles share state process-wide. Counting them makes final-close
+    // persistence serialize with a concurrent reopen under the registry lock.
     struct RegistryEntry {
         entry: Arc<FileEntry>,
         handles: usize,
@@ -324,9 +276,7 @@ mod bitmap {
         }
     }
 
-    /// Canonicalize the parent directory (the file itself may not exist yet)
-    /// so relative/absolute spellings and symlinked directories compare
-    /// equal for the tracked-path decision.
+    // The file may not exist yet, so canonicalize only its parent.
     fn canonical_key(path: &str) -> std::io::Result<std::path::PathBuf> {
         let p = std::path::Path::new(path);
         let name = p.file_name().ok_or_else(|| {
@@ -339,26 +289,16 @@ mod bitmap {
         Ok(std::fs::canonicalize(dir)?.join(name))
     }
 
-    /// Sparse IO for one lazily-populated database file.
-    ///
-    /// `open_file` returns presence-tracked handles for `tracked_path` only;
-    /// every other path (WAL, metadata, …) is delegated to [`PlatformIO`]
-    /// so it keeps stock durability behavior and pays no sidecar overhead.
-    ///
-    /// [`PlatformIO`]: turso_core::PlatformIO
+    /// Presence-tracked IO for one lazily populated database file.
     pub struct SparseBitmapIo {
         tracked_key: std::path::PathBuf,
-        /// The canonical spelling used for the sidecar name and entry path,
-        /// so every alias spelling of the tracked file maps to one sidecar.
+        // Canonical configured spelling; final-component aliases are rejected.
         tracked_path: String,
         inner: Arc<dyn IO>,
     }
 
     impl SparseBitmapIo {
-        /// The tracked file's parent directory must already exist (the
-        /// engine creates its metadata files alongside before opening the
-        /// database), so the tracked-path comparison is stable for the
-        /// lifetime of this IO.
+        /// The tracked file's parent directory must exist.
         pub fn new(tracked_path: &str) -> Result<Self> {
             let tracked_key = canonical_key(tracked_path).map_err(|e| {
                 turso_core::LimboError::InvalidArgument(format!(
@@ -377,13 +317,7 @@ mod bitmap {
             canonical_key(path).is_ok_and(|key| key == self.tracked_key)
         }
 
-        /// Alias spellings of the tracked file (final-component symlinks,
-        /// hard links, case aliases on case-insensitive volumes) are
-        /// rejected rather than silently bypassing presence tracking.
-        /// Detection is best-effort — it cannot be raced-proof against
-        /// external renames — but the engine only ever uses the configured
-        /// spelling, so any alias access is caller error, and an undetected
-        /// alias is unsupported external interference.
+        // Reject final-component aliases instead of bypassing presence state.
         fn reject_alias(&self, path: &str, op: &'static str) -> Result<()> {
             let tracked = std::fs::metadata(&self.tracked_key).ok();
             let this = std::fs::metadata(path).ok();
@@ -427,9 +361,8 @@ mod bitmap {
             }
             let sidecar = sidecar_path(&self.tracked_path);
             if let Some(entry) = registry.get(&id).map(|entry| entry.entry.clone()) {
-                // File operations do not take the registry lock. Serialize
-                // with them and re-read length so an empty snapshot cannot
-                // erase a sidecar persisted by a concurrent write and sync.
+                // Re-read length under the file lock so empty-file setup cannot
+                // overwrite a sidecar persisted by a concurrent write.
                 let existing_file = entry.file.read().unwrap();
                 let current_meta = existing_file
                     .metadata()
@@ -444,8 +377,6 @@ mod bitmap {
                 )?;
             } else {
                 if !read_only {
-                    // No live same-process persist can own a temp file: final
-                    // `Drop` also holds the registry lock.
                     sweep_orphan_tmp_files(&sidecar);
                 }
                 prepare_presence_metadata(
@@ -457,10 +388,8 @@ mod bitmap {
                     read_only,
                 )?;
             }
-            // Re-verify under the registry lock that the path still names the
-            // inode we opened: `remove_file` holds this lock across its
-            // unlinks, so an open racing a removal must not register (and
-            // later persist presence for) an already-unlinked inode.
+            // Re-check under the registry lock so an open racing `remove_file`
+            // cannot register an already-unlinked inode.
             let still_named = path_names_file(&self.tracked_path, id);
             if !still_named {
                 return Err(io_error(
@@ -469,9 +398,6 @@ mod bitmap {
                 ));
             }
             if let Some(reg_entry) = registry.get_mut(&id) {
-                // The freshly opened descriptor names the same inode by
-                // construction; if it is writable and the shared one is not,
-                // upgrade in place.
                 if !read_only && !reg_entry.entry.fd_writable.load(Ordering::Acquire) {
                     *reg_entry.entry.file.write().unwrap() = file;
                     reg_entry.entry.fd_writable.store(true, Ordering::Release);
@@ -504,15 +430,8 @@ mod bitmap {
                 self.reject_alias(path, "remove_file")?;
                 return self.inner.remove_file(path);
             }
-            // Hold the registry lock across the whole removal so a concurrent
-            // open cannot observe a half-removed file, and the entry's
-            // persist lock so an in-flight sidecar persist either completes
-            // before the unlinks or observes `defunct` after them.
-            //
-            // Failure ordering keeps every exit internally consistent: a hard
-            // data-unlink failure leaves its required metadata untouched. Once
-            // the data is gone, finish removing both owned metadata paths even
-            // on a retry after partial cleanup.
+            // Serialize open, persistence, and removal. Do not remove metadata
+            // unless the data unlink succeeds; after that, clean up both paths.
             let mut registry = registry();
             let entry = std::fs::symlink_metadata(path)
                 .ok()
@@ -600,10 +519,8 @@ mod bitmap {
             .is_ok_and(|meta| meta.file_type().is_file() && file_id(&meta) == id)
     }
 
-    /// Writable initialization anchors an empty database before it can gain
-    /// data. Every non-empty open instead requires the existing anchor: it
-    /// keeps the sidecar's inode alive across an external unlink, making inode
-    /// reuse impossible rather than relying on filesystem timestamp quality.
+    // Writable empty initialization syncs the data inode before publishing its
+    // anchor and empty sidecar. A cold non-empty open requires that anchor.
     fn prepare_presence_metadata(
         data_path: &str,
         sidecar: &str,
@@ -677,9 +594,7 @@ mod bitmap {
         barrier_sync(&dir, sync_type)
     }
 
-    /// Fsync honoring [`FileSyncType`]: on Apple platforms `FullFsync` maps
-    /// to `fcntl(F_FULLFSYNC)` per the `File::sync` contract; elsewhere it
-    /// is a plain fsync (mirrors `UnixFile`).
+    // Honor `FullFsync` with `F_FULLFSYNC` on Apple platforms.
     fn barrier_sync(file: &std::fs::File, sync_type: FileSyncType) -> std::io::Result<()> {
         #[cfg(target_vendor = "apple")]
         {
@@ -712,23 +627,17 @@ mod bitmap {
         anchor_path: String,
         file: RwLock<std::fs::File>,
         state: RwLock<PresenceState>,
-        /// Serializes sidecar persistence against `remove_file`, closing the
-        /// window where an in-flight persist could re-create the sidecar of
-        /// a just-removed file. No cycle: `sync`/`punch_hole`/`Drop` acquire
-        /// it while holding file/state locks, but `remove_file` (registry →
-        /// persist_lock) never takes file/state locks, and the final `Drop`
-        /// cannot overlap another operation on the same handle.
+        // Serialize persistence with removal. No lock cycle: `remove_file` takes
+        // registry → persist_lock but never file/state; sync and punch take
+        // file/state → persist_lock but never registry. Final Drop owns the last
+        // live handle.
         persist_lock: Mutex<()>,
-        /// Whether the shared descriptor was opened with write access.
         fd_writable: AtomicBool,
-        /// Set by `remove_file`: presence persistence stops, data operations
-        /// keep POSIX unlinked-file semantics.
+        // Data handles retain POSIX unlink semantics, but metadata must stay gone.
         defunct: AtomicBool,
     }
 
-    /// A presence-tracked handle to the lazily-populated database file. All
-    /// handles to one file share a [`FileEntry`]; the access mode is tracked
-    /// per handle.
+    /// A presence-tracked database handle with per-handle access mode.
     pub struct SparseBitmapFile {
         entry: Arc<FileEntry>,
         id: FileId,
@@ -772,14 +681,7 @@ mod bitmap {
         }
     }
 
-    /// Deterministic last-close flush: the handle count lives in the global
-    /// registry, and the final flush runs under the registry lock, so a
-    /// concurrent reopen serializes after it. Pure read hydration never
-    /// triggers [`File::sync`]; without this flush a clean close would leave
-    /// the fetched pages on disk (OS writeback) but not the bitmap — the
-    /// Linux backend gets that coupling from the filesystem for free. A hard
-    /// crash between syncs still loses hydration state and re-fetches, which
-    /// is the safe direction.
+    // Persist hydration on final close; a crash may instead cause a safe re-fetch.
     impl Drop for SparseBitmapFile {
         fn drop(&mut self) {
             let mut registry = registry();
@@ -824,12 +726,8 @@ mod bitmap {
         }
     }
 
-    /// Load and validate the sidecar against the opened data file.
-    ///
-    /// A read-only empty file is treated as absent without changing metadata;
-    /// writable initialization has already published a valid empty sidecar.
-    /// A cold open of a non-empty file requires a sidecar with matching
-    /// identity and checksum because its bits may protect local changes.
+    // Empty read-only opens do not mutate metadata. Other cold opens require a
+    // sidecar bound to this data inode.
     fn load_sidecar(
         path: &str,
         data_len: u64,
@@ -890,9 +788,7 @@ mod bitmap {
         Some((dev, ino, bitmap))
     }
 
-    /// Remove leftovers of persists interrupted by a crash or failure. The
-    /// temp names are namespaced by the sidecar path, so this can only touch
-    /// this backend's own files.
+    // Sweep this sidecar's temp files from this process or dead processes.
     fn sweep_orphan_tmp_files(sidecar: &str) {
         let path = std::path::Path::new(sidecar);
         let (Some(dir), Some(name)) = (path.parent(), path.file_name()) else {
@@ -916,9 +812,6 @@ mod bitmap {
             else {
                 continue;
             };
-            // Names are `<sidecar>.<pid>.<seq>.tmp`; only sweep our own
-            // leftovers or those of processes that no longer exist, so an
-            // in-flight persist elsewhere is never deleted.
             let Some(pid) = middle
                 .split('.')
                 .next()
@@ -935,18 +828,8 @@ mod bitmap {
         }
     }
 
-    /// Persist the bitmap via write-to-temp + fsync + rename + parent
-    /// directory fsync, so a crash leaves either the old or the new sidecar
-    /// — durably — and never a torn one. Fsyncing the renamed file alone
-    /// would not make the new *directory entry* durable. The temp name is
-    /// unique per process and per persist, so concurrent writers can never
-    /// interleave inside one temp file.
-    ///
-    /// Ordering invariant: the caller must sync the data file BEFORE the
-    /// bitmap is persisted. The on-disk bitmap may then lag the data file
-    /// (safe: within a `File::sync` call the pager has not yet completed
-    /// its checkpoint, so WAL replay repairs a crash) but never lead it
-    /// (which could serve unfetched bytes as zeros).
+    // Callers sync data before publishing new bits. Cleared bits are published
+    // before physical reclamation, so the durable bitmap never over-claims.
     fn persist_presence(
         entry: &FileEntry,
         file: &std::fs::File,
@@ -956,9 +839,6 @@ mod bitmap {
         if !state.dirty {
             return Ok(());
         }
-        // Serialize against `remove_file`: it holds this lock across its
-        // unlinks, so we either finish the rename before removal starts or
-        // observe `defunct` after it finished.
         let _persist_guard = match entry.persist_lock.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -966,10 +846,7 @@ mod bitmap {
         if entry.defunct.load(Ordering::Acquire) {
             return Ok(());
         }
-        // If the path no longer names this entry's inode (removed or replaced
-        // externally), renaming the sidecar into place would attach this
-        // entry's bits to some other file's name. Skip; the identity binding
-        // makes any stale on-disk sidecar fail closed at the next open.
+        // Never attach this entry's bitmap to an externally replaced path.
         let fd_meta = file.metadata().map_err(|e| io_error(e, "metadata"))?;
         let id = file_id(&fd_meta);
         if !path_names_file(&entry.path, id) || !path_names_file(&entry.anchor_path, id) {
@@ -989,6 +866,7 @@ mod bitmap {
         present: &roaring::RoaringTreemap,
         sync_type: FileSyncType,
     ) -> Result<()> {
+        // Rename prevents torn replacement; the two barriers make it durable.
         let mut payload = Vec::with_capacity(present.serialized_size());
         present
             .serialize_into(&mut payload)
@@ -1027,10 +905,7 @@ mod bitmap {
         result
     }
 
-    /// Release the punched byte range back to the filesystem. Best-effort:
-    /// the bitmap is the source of truth, so failure (or a filesystem that
-    /// later re-materializes the range, as APFS does next to flushed writes)
-    /// costs space, never correctness.
+    // Best-effort: the bitmap, not allocation state, is authoritative.
     #[cfg(target_os = "linux")]
     fn reclaim_range(file: &std::fs::File, pos: u64, len: u64) -> std::io::Result<()> {
         let res = unsafe {
@@ -1048,13 +923,7 @@ mod bitmap {
         }
     }
 
-    /// Release the punched byte range back to the filesystem. Best-effort:
-    /// the bitmap is the source of truth, so failure (or a filesystem that
-    /// later re-materializes the range, as APFS does next to flushed writes)
-    /// costs space, never correctness.
-    ///
-    /// `F_PUNCHHOLE` requires block-size alignment (4096 on APFS); callers
-    /// punch at granule alignment, which satisfies it.
+    // Best-effort: the bitmap, not allocation state, is authoritative.
     #[cfg(target_vendor = "apple")]
     fn reclaim_range(file: &std::fs::File, pos: u64, len: u64) -> std::io::Result<()> {
         let args = libc::fpunchhole_t {
@@ -1076,8 +945,6 @@ mod bitmap {
         Ok(())
     }
 
-    /// Granule indices overlapping `[pos, pos + len)`: a write marks all of
-    /// them (any touched block is allocated, like `MemoryIO` and Linux).
     fn overlapping(pos: u64, len: u64) -> Result<std::ops::Range<u64>> {
         let end = pos.checked_add(len).ok_or_else(|| {
             turso_core::LimboError::InvalidArgument(format!(
@@ -1109,8 +976,6 @@ mod bitmap {
                 file.read_exact_at(buf, pos)
                     .map_err(|e| io_error(e, "pread"))?;
                 buf.len() as i32
-                // Guards drop here: completion callbacks may reopen or drop
-                // other handles, which takes the registry lock.
             };
             c.complete(nr);
             Ok(c)
@@ -1121,7 +986,6 @@ mod bitmap {
             self.reject_if_read_only("pwrite")?;
             let buf = buffer.as_slice();
             if buf.is_empty() {
-                // An empty write allocates nothing (matches `MemoryIO`).
                 c.complete(0);
                 return Ok(c);
             }
@@ -1161,7 +1025,6 @@ mod bitmap {
                 if !range.is_empty() && state.present.insert_range(range) > 0 {
                     state.dirty = true;
                 }
-                // Guards drop here, before the completion callback runs.
             }
             c.complete(buffer.len() as i32);
             Ok(c)
@@ -1174,7 +1037,6 @@ mod bitmap {
                 barrier_sync(&file, sync_type).map_err(|e| io_error(e, "sync"))?;
                 let mut state = self.entry.state.write().unwrap();
                 persist_presence(&self.entry, &file, &mut state, sync_type)?;
-                // Guards drop here, before the completion callback runs.
             }
             c.complete(0);
             Ok(c)
@@ -1194,7 +1056,6 @@ mod bitmap {
                 if state.present.remove_range(first_gone..=u64::MAX) > 0 {
                     state.dirty = true;
                 }
-                // Guards drop here, before the completion callback runs.
             }
             c.complete(0);
             Ok(c)
@@ -1205,12 +1066,6 @@ mod bitmap {
             Ok(file.metadata().map_err(|e| io_error(e, "metadata"))?.len())
         }
 
-        /// Whether `[pos, pos + len)` is entirely absent, per the trait
-        /// contract ("if there is a single byte which is allocated within a
-        /// given range - method must return false") and matching `MemoryIO`:
-        /// any overlapping present granule means data. Takes the file lock so
-        /// the answer is atomic with a concurrent `pwrite`'s data-plus-bits
-        /// installation, as it is for the Linux and memory backends.
         fn has_hole(&self, pos: usize, len: usize) -> turso_core::Result<bool> {
             if len == 0 {
                 return Ok(true);
@@ -1218,7 +1073,6 @@ mod bitmap {
             let range = overlapping(pos as u64, len as u64)?;
             let _file = self.entry.file.read().unwrap();
             let state = self.entry.state.read().unwrap();
-            // Present-count within [start, end) via rank difference.
             let below_end = state.present.rank(range.end - 1);
             let below_start = match range.start.checked_sub(1) {
                 Some(prev) => state.present.rank(prev),
@@ -1242,12 +1096,7 @@ mod bitmap {
             if !range.is_empty() && state.present.remove_range(range) > 0 {
                 state.dirty = true;
             }
-            // The cleared bits must be durable before the bytes are released:
-            // sync the data file (persist ordering invariant), then the
-            // sidecar. A crash in between leaves extra "absent" bits — safe,
-            // because evicted pages are re-fetchable cache by definition, and
-            // stale physical bytes cannot resurface: a later write into an
-            // absent granule zero-fills its uncovered remainder.
+            // Publish absent bits before reclamation; stale bytes remain hidden.
             barrier_sync(&file, FileSyncType::Fsync).map_err(|e| io_error(e, "sync"))?;
             persist_presence(&self.entry, &file, &mut state, FileSyncType::Fsync)?;
             drop(state);
@@ -1301,7 +1150,6 @@ mod tests {
         (io, dir, path)
     }
 
-    /// The `has_hole`/`punch_hole` contract every sparse backend must satisfy.
     fn check_sparse_semantics(io: &dyn IO, path: &str) {
         let file = io.open_file(path, OpenFlags::default(), false).unwrap();
         truncate(&file, 1024 * 1024);
@@ -1339,9 +1187,6 @@ mod tests {
         check_sparse_semantics(&io, &path);
     }
 
-    /// Sub-granule writes must mark their granule present, per the trait
-    /// contract ("a single allocated byte within a given range" ⇒ `false`)
-    /// and matching Linux/MemoryIO allocation semantics.
     #[test]
     pub fn sparse_bitmap_partial_write_marks_presence() {
         let (io, _dir, path) = tracked_io_and_path();
@@ -1349,17 +1194,12 @@ mod tests {
         truncate(&file, 16 * G);
         write(&file, 1, 1, 7);
         assert!(!file.has_hole(0, G as usize).unwrap());
-        // A write straddling a granule boundary marks both granules.
         write(&file, 2 * G - 1, 2, 7);
         assert!(!file.has_hole(G as usize, G as usize).unwrap());
         assert!(!file.has_hole(2 * G as usize, G as usize).unwrap());
         assert!(file.has_hole(3 * G as usize, G as usize).unwrap());
     }
 
-    /// A write into an absent granule must not expose stale physical bytes
-    /// (e.g. a punched range whose reclamation did not survive): the
-    /// uncovered remainder of the granule reads as zeros, like a fresh
-    /// `MemoryIO` page.
     #[test]
     pub fn sparse_bitmap_partial_write_zero_fills_absent_granule() {
         let (io, _dir, path) = tracked_io_and_path();
@@ -1375,8 +1215,6 @@ mod tests {
             let raw = std::fs::File::options().write(true).open(&path).unwrap();
             raw.write_all_at(&[0xAA; 4096], 0).unwrap();
         }
-        // A one-byte write marks the granule present; the other 4095 bytes
-        // must read as zeros, not the stale 0xAA.
         write(&file, 7, 1, 0xBB);
         assert!(!file.has_hole(0, G as usize).unwrap());
         let bytes = std::fs::read(&path).unwrap();
@@ -1385,8 +1223,6 @@ mod tests {
         assert!(bytes[8..G as usize].iter().all(|b| *b == 0));
     }
 
-    /// A zero-length write allocates nothing, matching `MemoryIO`: it must
-    /// not zero-fill or mark any granule present.
     #[test]
     pub fn sparse_bitmap_empty_write_is_noop() {
         let (io, _dir, path) = tracked_io_and_path();
@@ -1396,9 +1232,6 @@ mod tests {
         assert!(file.has_hole(0, G as usize).unwrap());
     }
 
-    /// Alias spellings of the tracked file are rejected: presence tracking
-    /// is keyed to the configured spelling, so a symlink or hard link that
-    /// bypasses it must error rather than silently splitting state.
     #[test]
     pub fn sparse_bitmap_alias_spellings_are_rejected() {
         let (io, dir, path) = tracked_io_and_path();
@@ -1418,7 +1251,6 @@ mod tests {
             .open_file(&hardlink, OpenFlags::default(), false)
             .is_err());
         assert!(io.remove_file(&hardlink).is_err());
-        // The configured spelling keeps working.
         let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
         assert!(!file.has_hole(0, G as usize).unwrap());
     }
@@ -1437,8 +1269,6 @@ mod tests {
         assert!(!std::path::Path::new(&format!("{path}.present.anchor")).exists());
     }
 
-    /// Untracked paths must be plain `PlatformIO` files: full durability
-    /// semantics, no sidecar, no presence overhead.
     #[test]
     pub fn sparse_bitmap_untracked_paths_have_no_sidecar() {
         let (io, dir, _path) = tracked_io_and_path();
@@ -1450,9 +1280,6 @@ mod tests {
         assert!(!std::path::Path::new(&format!("{other}.present")).exists());
     }
 
-    /// All handles to the tracked path share presence state — across
-    /// separate `SparseBitmapIo` instances too: a punch through one handle
-    /// must not be resurrected by a sync through another.
     #[test]
     pub fn sparse_bitmap_handles_share_state() {
         let (io, _dir, path) = tracked_io_and_path();
@@ -1464,14 +1291,12 @@ mod tests {
         write(&a, G, G as usize, 1);
         fsync(&a);
         a.punch_hole(0, G as usize).unwrap();
-        // The second instance's handle sees the punch immediately…
         assert!(b.has_hole(0, G as usize).unwrap());
         write(&b, 2 * G, G as usize, 2);
         fsync(&b);
         drop(a);
         drop(b);
 
-        // …and the persisted state is the merged view, not a stale snapshot.
         let io = SparseBitmapIo::new(&path).unwrap();
         let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
         assert!(file.has_hole(0, G as usize).unwrap());
@@ -1512,8 +1337,6 @@ mod tests {
         assert!(!reopened.has_hole(0, G as usize).unwrap());
     }
 
-    /// Presence must survive reopen exactly as persisted: pages written and
-    /// synced stay present, punched pages stay absent.
     #[test]
     pub fn sparse_bitmap_presence_survives_reopen() {
         let (io, _dir, path) = tracked_io_and_path();
@@ -1587,8 +1410,6 @@ mod tests {
         assert!(reopened.has_hole(0, G as usize).unwrap());
     }
 
-    /// Hydration that never triggers an explicit sync must still be present
-    /// after a clean close: the last handle's drop flushes the bitmap.
     #[test]
     pub fn sparse_bitmap_drop_flushes_presence() {
         let (io, _dir, path) = tracked_io_and_path();
@@ -1603,8 +1424,6 @@ mod tests {
         assert!(file.has_hole(G as usize, G as usize).unwrap());
     }
 
-    /// A live handle must not resurrect the sidecar of a removed file, and
-    /// removal deletes the sidecar together with the data file.
     #[test]
     pub fn sparse_bitmap_remove_fences_live_handles() {
         let (io, _dir, path) = tracked_io_and_path();
@@ -1709,10 +1528,6 @@ mod tests {
         assert!(!std::path::Path::new(&sidecar).exists());
     }
 
-    /// A non-empty data file whose sidecar is missing, corrupt, or belongs
-    /// to a different file must refuse to open: its bits may guard locally
-    /// modified pages, so "all absent" could overwrite local data with older
-    /// server pages.
     #[test]
     pub fn sparse_bitmap_anomalies_refuse_to_open() {
         // Missing sidecar.
@@ -1823,7 +1638,6 @@ mod tests {
         assert!(io.open_file(&path, OpenFlags::default(), false).is_ok());
     }
 
-    /// A stale sidecar next to a fresh (empty) data file is discarded.
     #[test]
     pub fn sparse_bitmap_fresh_file_discards_stale_sidecar() {
         let (io, _dir, path) = tracked_io_and_path();
@@ -1888,9 +1702,6 @@ mod tests {
         assert_eq!((anchor_meta.dev(), anchor_meta.ino()), anchor_id_before);
     }
 
-    /// Access mode is per handle: a read-only handle may probe presence but
-    /// must not mutate it, even while a writable handle to the same file
-    /// exists.
     #[test]
     pub fn sparse_bitmap_read_only_is_per_handle() {
         let (io, _dir, path) = tracked_io_and_path();
@@ -1907,16 +1718,11 @@ mod tests {
         assert!(ro.truncate(G, Completion::new_trunc(|_| {})).is_err());
         assert!(ro.punch_hole(0, G as usize).is_err());
 
-        // The writable handle is unaffected.
         write(&rw, G, G as usize, 2);
         assert!(!rw.has_hole(G as usize, G as usize).unwrap());
     }
 
-    /// Differential check against `MemoryIO`, whose in-memory presence map is
-    /// the reference model for the `has_hole`/`punch_hole` contract: run
-    /// random (including unaligned) write and aligned punch sequences against
-    /// both backends and require identical `has_hole` answers throughout —
-    /// including after the bitmap file is synced, dropped, and reopened.
+    // Compare random operations with `MemoryIO`, including persisted reopen.
     #[test]
     pub fn sparse_bitmap_matches_memory_io() {
         use rand::{Rng, SeedableRng};
@@ -1961,7 +1767,6 @@ mod tests {
                 let granule = rng.random_range(0..GRANULES);
                 let count = rng.random_range(1..=4).min(GRANULES - granule);
                 if rng.random_bool(0.7) {
-                    // Writes may be unaligned and sub-granule.
                     let jitter = rng.random_range(0..G);
                     let pos = (granule * G + jitter).min(GRANULES * G - 1);
                     let max_len = (count * G - jitter).max(1);
@@ -1969,7 +1774,6 @@ mod tests {
                     write(&bitmap_file, pos, len as usize, step as u8);
                     write(&oracle_file, pos, len as usize, step as u8);
                 } else {
-                    // Punches stay granule-aligned per the punch contract.
                     let (pos, len) = ((granule * G) as usize, (count * G) as usize);
                     bitmap_file.punch_hole(pos, len).unwrap();
                     oracle_file.punch_hole(pos, len).unwrap();
@@ -1977,7 +1781,6 @@ mod tests {
                 check_all(&bitmap_file, &oracle_file, step);
             }
 
-            // The persisted bitmap must reproduce the oracle after reopen.
             fsync(&bitmap_file);
             drop(bitmap_file);
             let io = SparseBitmapIo::new(&path).unwrap();

--- a/sync/engine/src/sparse_io.rs
+++ b/sync/engine/src/sparse_io.rs
@@ -35,12 +35,11 @@
 //! 1. The on-disk bitmap never *over*-claims: the data file is synced before
 //!    every bitmap persist, and punched bits are made durable (temp file +
 //!    fsync + rename + parent-directory fsync) before the bytes are released.
-//! 2. The on-disk bitmap can lag the data file only within a single
-//!    [`File::sync`] call. Because the pager only treats a checkpoint as
-//!    complete once `sync` returns — and the WAL is truncated after that —
-//!    a crash inside the window is repaired by WAL replay. Outside normal
-//!    operation (sidecar deleted, corrupted, or belonging to a different
-//!    file generation) the backend refuses to open rather than guess.
+//! 2. The on-disk bitmap may lag fetched data until a sync or clean close;
+//!    those pages are safe to re-fetch. Checkpointed local changes remain in
+//!    the WAL until [`File::sync`] returns, so WAL replay repairs a crash in
+//!    that window. On a cold open of a non-empty file, missing, corrupt, or
+//!    mismatched metadata is rejected rather than guessed.
 
 use std::{
     os::{fd::AsRawFd, unix::fs::FileExt},
@@ -230,15 +229,15 @@ mod bitmap {
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use turso_core::{turso_assert, turso_assert_reachable, turso_assert_sometimes};
 
-    /// Presence is tracked per 4 KiB granule, matching `MemoryIO`'s
-    /// `PAGE_SIZE` presence map and the minimum database page size. Like
+    /// Presence is tracked per sync-protocol page, matching `MemoryIO`'s
+    /// presence map. Like
     /// `MemoryIO` and the Linux backend (where any write allocates its whole
     /// block), a write marks every granule it touches; the untouched
     /// remainder of an edge granule reads as zeros — enforced by explicit
     /// zero-fill when the granule was absent, so a punched granule whose
     /// physical reclamation did not survive a crash can never leak stale
     /// bytes back through a later partial write.
-    const GRANULE: u64 = 4096;
+    const GRANULE: u64 = crate::database_sync_operations::PAGE_SIZE as u64;
 
     const SIDECAR_SUFFIX: &str = ".present";
     const ANCHOR_SUFFIX: &str = ".anchor";
@@ -438,6 +437,7 @@ mod bitmap {
                 prepare_presence_metadata(
                     &self.tracked_path,
                     &sidecar,
+                    &existing_file,
                     id,
                     current_meta.len(),
                     read_only,
@@ -448,7 +448,14 @@ mod bitmap {
                     // `Drop` also holds the registry lock.
                     sweep_orphan_tmp_files(&sidecar);
                 }
-                prepare_presence_metadata(&self.tracked_path, &sidecar, id, meta.len(), read_only)?;
+                prepare_presence_metadata(
+                    &self.tracked_path,
+                    &sidecar,
+                    &file,
+                    id,
+                    meta.len(),
+                    read_only,
+                )?;
             }
             // Re-verify under the registry lock that the path still names the
             // inode we opened: `remove_file` holds this lock across its
@@ -600,6 +607,7 @@ mod bitmap {
     fn prepare_presence_metadata(
         data_path: &str,
         sidecar: &str,
+        data_file: &std::fs::File,
         id: FileId,
         data_len: u64,
         read_only: bool,
@@ -611,6 +619,9 @@ mod bitmap {
             return Ok(());
         }
 
+        barrier_sync(data_file, FileSyncType::Fsync)
+            .map_err(|e| completion_error(e, "sync empty database file"))?;
+
         let anchor = anchor_path(sidecar);
         if !path_names_file(&anchor, id) {
             let tmp_anchor = format!(
@@ -620,18 +631,18 @@ mod bitmap {
             );
             std::fs::hard_link(data_path, &tmp_anchor)
                 .map_err(|e| completion_error(e, "create presence anchor"))?;
-            std::fs::rename(&tmp_anchor, &anchor)
-                .map_err(|e| completion_error(e, "install presence anchor"))?;
-        }
-        match std::fs::remove_file(sidecar) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => return Err(io_error(e, "remove stale presence sidecar")),
+            if let Err(e) = std::fs::rename(&tmp_anchor, &anchor) {
+                let _ = std::fs::remove_file(&tmp_anchor);
+                return Err(completion_error(e, "install presence anchor"));
+            }
         }
         require_matching_anchor(sidecar, id)?;
-        sync_parent_dir(sidecar, FileSyncType::Fsync)
-            .map_err(|e| completion_error(e, "sync presence metadata dir"))?;
-        Ok(())
+        write_sidecar(
+            sidecar,
+            id,
+            &roaring::RoaringTreemap::new(),
+            FileSyncType::Fsync,
+        )
     }
 
     fn require_matching_anchor(sidecar: &str, id: FileId) -> Result<()> {
@@ -652,9 +663,8 @@ mod bitmap {
 
     fn presence_anomaly(path: &str, reason: &str) -> turso_core::LimboError {
         turso_core::LimboError::Corrupt(format!(
-            "presence metadata {path} {reason}; refusing to guess page presence for a \
-             non-empty database file (delete the database file and its presence metadata to \
-             re-bootstrap)"
+            "presence metadata {path} {reason}; refusing to guess page presence (delete the \
+             database file and its presence metadata to re-bootstrap)"
         ))
     }
 
@@ -816,12 +826,10 @@ mod bitmap {
 
     /// Load and validate the sidecar against the opened data file.
     ///
-    /// An empty data file is fresh by definition: any sidecar found next to
-    /// it is stale and discarded. For a non-empty data file the sidecar is
-    /// required and must match this file's identity and checksum — the bits
-    /// may guard locally modified pages, so guessing "all absent" could let
-    /// the lazy storage overwrite local data with older server pages. Refuse
-    /// instead.
+    /// A read-only empty file is treated as absent without changing metadata;
+    /// writable initialization has already published a valid empty sidecar.
+    /// A cold open of a non-empty file requires a sidecar with matching
+    /// identity and checksum because its bits may protect local changes.
     fn load_sidecar(
         path: &str,
         data_len: u64,
@@ -829,28 +837,16 @@ mod bitmap {
         ino: u64,
         read_only: bool,
     ) -> Result<roaring::RoaringTreemap> {
-        let discard_stale = |bytes_existed: bool| {
-            if bytes_existed && !read_only {
-                turso_assert_reachable!("stale presence sidecar discarded for fresh file");
-                if let Err(e) = std::fs::remove_file(path) {
-                    tracing::warn!("failed to remove stale presence sidecar {path}: {e}");
-                }
-            }
-            roaring::RoaringTreemap::new()
-        };
+        if data_len == 0 && read_only {
+            return Ok(roaring::RoaringTreemap::new());
+        }
         let bytes = match std::fs::read(path) {
             Ok(bytes) => bytes,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                if data_len == 0 {
-                    return Ok(discard_stale(false));
-                }
                 return Err(presence_anomaly(path, "is missing"));
             }
             Err(e) => return Err(io_error(e, "read presence sidecar")),
         };
-        if data_len == 0 {
-            return Ok(discard_stale(true));
-        }
         match parse_sidecar(&bytes) {
             Some((sidecar_dev, sidecar_ino, bitmap)) => {
                 if sidecar_dev != dev || sidecar_ino != ino {
@@ -982,9 +978,19 @@ mod bitmap {
                 entry.path
             )));
         }
-        let mut payload = Vec::with_capacity(state.present.serialized_size());
-        state
-            .present
+        write_sidecar(&entry.sidecar_path, id, &state.present, sync_type)?;
+        state.dirty = false;
+        Ok(())
+    }
+
+    fn write_sidecar(
+        sidecar: &str,
+        id: FileId,
+        present: &roaring::RoaringTreemap,
+        sync_type: FileSyncType,
+    ) -> Result<()> {
+        let mut payload = Vec::with_capacity(present.serialized_size());
+        present
             .serialize_into(&mut payload)
             .map_err(|e| completion_error(e, "serialize presence sidecar"))?;
         let mut buf = Vec::with_capacity(SIDECAR_HEADER_LEN + payload.len());
@@ -998,21 +1004,27 @@ mod bitmap {
 
         let tmp_path = format!(
             "{}.{}.{}.tmp",
-            entry.sidecar_path,
+            sidecar,
             std::process::id(),
             TMP_SEQ.fetch_add(1, Ordering::Relaxed)
         );
-        let mut tmp = std::fs::File::create(&tmp_path)
-            .map_err(|e| completion_error(e, "create presence sidecar"))?;
-        tmp.write_all(&buf)
-            .map_err(|e| completion_error(e, "write presence sidecar"))?;
-        barrier_sync(&tmp, sync_type).map_err(|e| completion_error(e, "sync presence sidecar"))?;
-        std::fs::rename(&tmp_path, &entry.sidecar_path)
-            .map_err(|e| completion_error(e, "rename presence sidecar"))?;
-        sync_parent_dir(&entry.sidecar_path, sync_type)
-            .map_err(|e| completion_error(e, "sync sidecar dir"))?;
-        state.dirty = false;
-        Ok(())
+        let result = (|| {
+            let mut tmp = std::fs::File::create(&tmp_path)
+                .map_err(|e| completion_error(e, "create presence sidecar"))?;
+            tmp.write_all(&buf)
+                .map_err(|e| completion_error(e, "write presence sidecar"))?;
+            barrier_sync(&tmp, sync_type)
+                .map_err(|e| completion_error(e, "sync presence sidecar"))?;
+            std::fs::rename(&tmp_path, sidecar)
+                .map_err(|e| completion_error(e, "rename presence sidecar"))?;
+            sync_parent_dir(sidecar, sync_type)
+                .map_err(|e| completion_error(e, "sync sidecar dir"))?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&tmp_path);
+        }
+        result
     }
 
     /// Release the punched byte range back to the filesystem. Best-effort:
@@ -1257,7 +1269,7 @@ mod tests {
 
     use crate::sparse_io::SparseBitmapIo;
 
-    const G: u64 = 4096;
+    const G: u64 = crate::database_sync_operations::PAGE_SIZE as u64;
 
     fn truncate(file: &Arc<dyn turso_core::File>, len: u64) {
         #[expect(clippy::let_underscore_future)]
@@ -1524,6 +1536,55 @@ mod tests {
         assert!(file.has_hole(G as usize, G as usize).unwrap());
         assert!(!file.has_hole(2 * G as usize, G as usize).unwrap());
         assert!(file.has_hole(3 * G as usize, G as usize).unwrap());
+    }
+
+    #[test]
+    pub fn sparse_bitmap_incomplete_bootstrap_reopens_as_absent() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let file = io.open_file(&path, OpenFlags::Create, false).unwrap();
+        let sidecar = format!("{path}.present");
+        let anchor = format!("{sidecar}.anchor");
+
+        let data_meta = std::fs::metadata(&path).unwrap();
+        let anchor_meta = std::fs::metadata(&anchor).unwrap();
+        assert_eq!(
+            (anchor_meta.dev(), anchor_meta.ino()),
+            (data_meta.dev(), data_meta.ino())
+        );
+        let sidecar_bytes = std::fs::read(&sidecar).unwrap();
+        assert_eq!(&sidecar_bytes[..4], b"TPRB");
+        assert_eq!(sidecar_bytes[4], 4);
+        assert_eq!(
+            u32::from_le_bytes(sidecar_bytes[5..9].try_into().unwrap()),
+            G as u32
+        );
+        assert_eq!(
+            u64::from_le_bytes(sidecar_bytes[9..17].try_into().unwrap()),
+            data_meta.dev()
+        );
+        assert_eq!(
+            u64::from_le_bytes(sidecar_bytes[17..25].try_into().unwrap()),
+            data_meta.ino()
+        );
+        assert_eq!(
+            u32::from_le_bytes(sidecar_bytes[25..29].try_into().unwrap()),
+            crc32c::crc32c(&sidecar_bytes[29..])
+        );
+        let present = roaring::RoaringTreemap::deserialize_from(&sidecar_bytes[29..]).unwrap();
+        assert!(present.is_empty());
+        drop(file);
+
+        {
+            use std::os::unix::fs::FileExt;
+            let raw = std::fs::File::options().write(true).open(&path).unwrap();
+            raw.write_all_at(&[0xAA; 4096], 0).unwrap();
+            raw.sync_all().unwrap();
+        }
+        assert_eq!(std::fs::read(&sidecar).unwrap(), sidecar_bytes);
+
+        let io = SparseBitmapIo::new(&path).unwrap();
+        let reopened = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        assert!(reopened.has_hole(0, G as usize).unwrap());
     }
 
     /// Hydration that never triggers an explicit sync must still be present
@@ -1800,6 +1861,31 @@ mod tests {
         drop(writable);
         drop(read_only);
         assert!(io.open_file(&path, OpenFlags::default(), false).is_ok());
+    }
+
+    #[test]
+    pub fn sparse_bitmap_empty_read_only_open_preserves_metadata() {
+        let (io, _dir, path) = tracked_io_and_path();
+        std::fs::write(&path, b"").unwrap();
+        let sidecar = format!("{path}.present");
+        let anchor = format!("{sidecar}.anchor");
+        std::fs::write(&sidecar, b"stale sidecar").unwrap();
+        std::fs::write(&anchor, b"stale anchor").unwrap();
+        let sidecar_before = std::fs::read(&sidecar).unwrap();
+        let anchor_before = std::fs::read(&anchor).unwrap();
+        let anchor_id_before = {
+            let meta = std::fs::metadata(&anchor).unwrap();
+            (meta.dev(), meta.ino())
+        };
+
+        let file = io.open_file(&path, OpenFlags::ReadOnly, false).unwrap();
+        assert!(file.has_hole(0, G as usize).unwrap());
+        drop(file);
+
+        assert_eq!(std::fs::read(&sidecar).unwrap(), sidecar_before);
+        assert_eq!(std::fs::read(&anchor).unwrap(), anchor_before);
+        let anchor_meta = std::fs::metadata(&anchor).unwrap();
+        assert_eq!((anchor_meta.dev(), anchor_meta.ino()), anchor_id_before);
     }
 
     /// Access mode is per handle: a read-only handle may probe presence but

--- a/sync/engine/src/sparse_io.rs
+++ b/sync/engine/src/sparse_io.rs
@@ -9,10 +9,10 @@
 //!   reports them exactly, and `fallocate(PUNCH_HOLE)` restores them.
 //! * [`SparseBitmapIo`] (portable across Unix) keeps an explicit presence
 //!   bitmap for the lazily-populated database file, mirroring the presence-map
-//!   semantics of `MemoryIO`, and persists it to a sidecar file. Filesystem
-//!   hole punching is only best-effort space reclamation. Files other than the
-//!   tracked database file (WAL, metadata) are delegated to `PlatformIO`
-//!   untouched.
+//!   semantics of `MemoryIO`, and persists it to a sidecar file. A hard-link
+//!   anchor binds that sidecar to the database inode. Filesystem hole punching
+//!   is only best-effort space reclamation. Files other than the tracked
+//!   database file (WAL, metadata) are delegated to `PlatformIO` untouched.
 //!
 //! The bitmap backend exists because APFS on macOS cannot carry the Linux
 //! contract. Delayed allocation rounds writes up to multi-block extents and
@@ -241,16 +241,69 @@ mod bitmap {
     const GRANULE: u64 = 4096;
 
     const SIDECAR_SUFFIX: &str = ".present";
+    const ANCHOR_SUFFIX: &str = ".anchor";
     const SIDECAR_MAGIC: &[u8; 4] = b"TPRB";
-    const SIDECAR_VERSION: u8 = 3;
+    const SIDECAR_VERSION: u8 = 4;
     /// magic + version + granule (u32) + dev (u64) + ino (u64) + crc32c (u32)
     const SIDECAR_HEADER_LEN: usize = 4 + 1 + 4 + 8 + 8 + 4;
+    static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    #[cfg(test)]
+    struct OpenMetadataPause {
+        path: String,
+        reached: Arc<std::sync::Barrier>,
+        resume: Arc<std::sync::Barrier>,
+    }
+
+    #[cfg(test)]
+    fn open_metadata_pause() -> &'static Mutex<Option<OpenMetadataPause>> {
+        static PAUSE: OnceLock<Mutex<Option<OpenMetadataPause>>> = OnceLock::new();
+        PAUSE.get_or_init(|| Mutex::new(None))
+    }
+
+    #[cfg(test)]
+    pub(super) fn pause_next_open_after_metadata(
+        path: String,
+        reached: Arc<std::sync::Barrier>,
+        resume: Arc<std::sync::Barrier>,
+    ) {
+        let previous = open_metadata_pause()
+            .lock()
+            .unwrap()
+            .replace(OpenMetadataPause {
+                path,
+                reached,
+                resume,
+            });
+        assert!(
+            previous.is_none(),
+            "an open metadata pause is already installed"
+        );
+    }
+
+    #[cfg(test)]
+    fn maybe_pause_after_open_metadata(path: &str) {
+        let pause = {
+            let mut slot = open_metadata_pause().lock().unwrap();
+            if slot.as_ref().is_some_and(|pause| pause.path == path) {
+                slot.take()
+            } else {
+                None
+            }
+        };
+        if let Some(pause) = pause {
+            pause.reached.wait();
+            pause.resume.wait();
+        }
+    }
 
     /// File identity: `(dev, ino)`. Keying the registry by identity rather
     /// than path string means alias spellings of one file (case-insensitive
     /// volumes, symlinks) share one presence state; a spelling that differs
     /// from the one the sidecar was persisted under fails closed at the next
-    /// open (missing-sidecar anomaly) instead of corrupting.
+    /// open (missing-sidecar anomaly) instead of corrupting. The sidecar's
+    /// hard-link anchor keeps the inode allocated, so this identity cannot be
+    /// reused while its presence metadata survives.
     type FileId = (u64, u64);
 
     /// All handles to a tracked file share one [`FileEntry`], process-wide —
@@ -362,16 +415,46 @@ mod bitmap {
             }
             let file = options.open(path).map_err(|e| io_error(e, "open"))?;
             let meta = file.metadata().map_err(|e| io_error(e, "metadata"))?;
-            let id: FileId = (meta.dev(), meta.ino());
+            #[cfg(test)]
+            maybe_pause_after_open_metadata(path);
+            let id = file_id(&meta);
 
             let mut registry = registry();
+            if !path_names_file(&self.tracked_path, id) {
+                return Err(io_error(
+                    std::io::Error::from(std::io::ErrorKind::NotFound),
+                    "open",
+                ));
+            }
+            let sidecar = sidecar_path(&self.tracked_path);
+            if let Some(entry) = registry.get(&id).map(|entry| entry.entry.clone()) {
+                // File operations do not take the registry lock. Serialize
+                // with them and re-read length so an empty snapshot cannot
+                // erase a sidecar persisted by a concurrent write and sync.
+                let existing_file = entry.file.read().unwrap();
+                let current_meta = existing_file
+                    .metadata()
+                    .map_err(|e| io_error(e, "metadata"))?;
+                prepare_presence_metadata(
+                    &self.tracked_path,
+                    &sidecar,
+                    id,
+                    current_meta.len(),
+                    read_only,
+                )?;
+            } else {
+                if !read_only {
+                    // No live same-process persist can own a temp file: final
+                    // `Drop` also holds the registry lock.
+                    sweep_orphan_tmp_files(&sidecar);
+                }
+                prepare_presence_metadata(&self.tracked_path, &sidecar, id, meta.len(), read_only)?;
+            }
             // Re-verify under the registry lock that the path still names the
             // inode we opened: `remove_file` holds this lock across its
             // unlinks, so an open racing a removal must not register (and
             // later persist presence for) an already-unlinked inode.
-            let still_named = std::fs::metadata(path)
-                .map(|current| (current.dev(), current.ino()) == id)
-                .unwrap_or(false);
+            let still_named = path_names_file(&self.tracked_path, id);
             if !still_named {
                 return Err(io_error(
                     std::io::Error::from(std::io::ErrorKind::NotFound),
@@ -419,19 +502,24 @@ mod bitmap {
             // persist lock so an in-flight sidecar persist either completes
             // before the unlinks or observes `defunct` after them.
             //
-            // Failure ordering keeps every exit internally consistent: the
-            // data unlink goes first (failure leaves all state untouched);
-            // a sidecar-unlink failure afterwards leaves residue that the
-            // identity binding fails closed on; registry state is only
-            // mutated once the files are gone.
+            // Failure ordering keeps every exit internally consistent: a hard
+            // data-unlink failure leaves its required metadata untouched. Once
+            // the data is gone, finish removing both owned metadata paths even
+            // on a retry after partial cleanup.
             let mut registry = registry();
-            let entry = std::fs::metadata(path)
+            let entry = std::fs::symlink_metadata(path)
                 .ok()
-                .map(|meta| (meta.dev(), meta.ino()))
+                .map(|meta| file_id(&meta))
                 .and_then(|id| {
                     registry
                         .get(&id)
                         .map(|reg_entry| (id, reg_entry.entry.clone()))
+                })
+                .or_else(|| {
+                    registry.iter().find_map(|(id, reg_entry)| {
+                        (reg_entry.entry.path == self.tracked_path)
+                            .then(|| (*id, reg_entry.entry.clone()))
+                    })
                 });
             let _persist_guard = entry
                 .as_ref()
@@ -439,19 +527,36 @@ mod bitmap {
                     Ok(guard) => guard,
                     Err(poisoned) => poisoned.into_inner(),
                 });
-            std::fs::remove_file(path).map_err(|e| io_error(e, "remove_file"))?;
-            if let Some((id, entry)) = entry.as_ref() {
-                entry.defunct.store(true, Ordering::Release);
-                registry.remove(id);
-            }
-            match std::fs::remove_file(sidecar_path(&self.tracked_path)) {
+            match std::fs::remove_file(path) {
                 Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => return Err(io_error(e, "remove_file")),
             }
-            // Make both unlinks durable together.
-            sync_parent_dir(&self.tracked_path, FileSyncType::Fsync)
-                .map_err(|e| completion_error(e, "sync dir after remove"))?;
+            if let Some((id, entry)) = entry.as_ref() {
+                entry.defunct.store(true, Ordering::Release);
+                registry.remove(id);
+            }
+            let sidecar = sidecar_path(&self.tracked_path);
+            let anchor = anchor_path(&sidecar);
+            let mut first_error = None;
+            for metadata_path in [&sidecar, &anchor] {
+                match std::fs::remove_file(metadata_path) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) if first_error.is_none() => {
+                        first_error = Some(io_error(e, "remove_file"));
+                    }
+                    Err(_) => {}
+                }
+            }
+            if let Err(e) = sync_parent_dir(&self.tracked_path, FileSyncType::Fsync) {
+                if first_error.is_none() {
+                    first_error = Some(completion_error(e, "sync dir after remove"));
+                }
+            }
+            if let Some(error) = first_error {
+                return Err(error);
+            }
             Ok(())
         }
 
@@ -473,6 +578,84 @@ mod bitmap {
 
     fn sidecar_path(path: &str) -> String {
         format!("{path}{SIDECAR_SUFFIX}")
+    }
+
+    fn anchor_path(sidecar: &str) -> String {
+        format!("{sidecar}{ANCHOR_SUFFIX}")
+    }
+
+    fn file_id(meta: &std::fs::Metadata) -> FileId {
+        (meta.dev(), meta.ino())
+    }
+
+    fn path_names_file(path: &str, id: FileId) -> bool {
+        std::fs::symlink_metadata(path)
+            .is_ok_and(|meta| meta.file_type().is_file() && file_id(&meta) == id)
+    }
+
+    /// Writable initialization anchors an empty database before it can gain
+    /// data. Every non-empty open instead requires the existing anchor: it
+    /// keeps the sidecar's inode alive across an external unlink, making inode
+    /// reuse impossible rather than relying on filesystem timestamp quality.
+    fn prepare_presence_metadata(
+        data_path: &str,
+        sidecar: &str,
+        id: FileId,
+        data_len: u64,
+        read_only: bool,
+    ) -> Result<()> {
+        if data_len != 0 {
+            return require_matching_anchor(sidecar, id);
+        }
+        if read_only {
+            return Ok(());
+        }
+
+        let anchor = anchor_path(sidecar);
+        if !path_names_file(&anchor, id) {
+            let tmp_anchor = format!(
+                "{sidecar}.{}.{}.anchor.tmp",
+                std::process::id(),
+                TMP_SEQ.fetch_add(1, Ordering::Relaxed)
+            );
+            std::fs::hard_link(data_path, &tmp_anchor)
+                .map_err(|e| completion_error(e, "create presence anchor"))?;
+            std::fs::rename(&tmp_anchor, &anchor)
+                .map_err(|e| completion_error(e, "install presence anchor"))?;
+        }
+        match std::fs::remove_file(sidecar) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(io_error(e, "remove stale presence sidecar")),
+        }
+        require_matching_anchor(sidecar, id)?;
+        sync_parent_dir(sidecar, FileSyncType::Fsync)
+            .map_err(|e| completion_error(e, "sync presence metadata dir"))?;
+        Ok(())
+    }
+
+    fn require_matching_anchor(sidecar: &str, id: FileId) -> Result<()> {
+        let anchor = anchor_path(sidecar);
+        match std::fs::symlink_metadata(&anchor) {
+            Ok(meta) if meta.file_type().is_file() && file_id(&meta) == id => Ok(()),
+            Ok(_) => Err(presence_anomaly(
+                sidecar,
+                "has an anchor for a different database file",
+            )),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(presence_anomaly(
+                sidecar,
+                "is missing its database-file anchor",
+            )),
+            Err(e) => Err(io_error(e, "read presence anchor metadata")),
+        }
+    }
+
+    fn presence_anomaly(path: &str, reason: &str) -> turso_core::LimboError {
+        turso_core::LimboError::Corrupt(format!(
+            "presence metadata {path} {reason}; refusing to guess page presence for a \
+             non-empty database file (delete the database file and its presence metadata to \
+             re-bootstrap)"
+        ))
     }
 
     fn sync_parent_dir(path: &str, sync_type: FileSyncType) -> std::io::Result<()> {
@@ -516,6 +699,7 @@ mod bitmap {
     struct FileEntry {
         path: String,
         sidecar_path: String,
+        anchor_path: String,
         file: RwLock<std::fs::File>,
         state: RwLock<PresenceState>,
         /// Serializes sidecar persistence against `remove_file`, closing the
@@ -549,12 +733,10 @@ mod bitmap {
             read_only: bool,
         ) -> Result<Self> {
             let sidecar = sidecar_path(path);
-            if !read_only {
-                sweep_orphan_tmp_files(&sidecar);
-            }
             let present = load_sidecar(&sidecar, meta.len(), meta.dev(), meta.ino(), read_only)?;
             Ok(Self {
                 path: path.to_string(),
+                anchor_path: anchor_path(&sidecar),
                 sidecar_path: sidecar,
                 file: RwLock::new(file),
                 state: RwLock::new(PresenceState {
@@ -647,13 +829,6 @@ mod bitmap {
         ino: u64,
         read_only: bool,
     ) -> Result<roaring::RoaringTreemap> {
-        let anomaly = |reason: &str| {
-            turso_core::LimboError::Corrupt(format!(
-                "presence sidecar {path} {reason}; refusing to guess page presence for a \
-                 non-empty database file (delete the database file and its sidecar to \
-                 re-bootstrap)"
-            ))
-        };
         let discard_stale = |bytes_existed: bool| {
             if bytes_existed && !read_only {
                 turso_assert_reachable!("stale presence sidecar discarded for fresh file");
@@ -669,7 +844,7 @@ mod bitmap {
                 if data_len == 0 {
                     return Ok(discard_stale(false));
                 }
-                return Err(anomaly("is missing"));
+                return Err(presence_anomaly(path, "is missing"));
             }
             Err(e) => return Err(io_error(e, "read presence sidecar")),
         };
@@ -680,13 +855,19 @@ mod bitmap {
             Some((sidecar_dev, sidecar_ino, bitmap)) => {
                 if sidecar_dev != dev || sidecar_ino != ino {
                     turso_assert_reachable!("presence sidecar belongs to another file generation");
-                    return Err(anomaly("belongs to a different file generation"));
+                    return Err(presence_anomaly(
+                        path,
+                        "belongs to a different file generation",
+                    ));
                 }
                 Ok(bitmap)
             }
             None => {
                 turso_assert_reachable!("presence sidecar is corrupt");
-                Err(anomaly("is corrupt or has an unknown format"))
+                Err(presence_anomaly(
+                    path,
+                    "is corrupt or has an unknown format",
+                ))
             }
         }
     }
@@ -794,12 +975,10 @@ mod bitmap {
         // entry's bits to some other file's name. Skip; the identity binding
         // makes any stale on-disk sidecar fail closed at the next open.
         let fd_meta = file.metadata().map_err(|e| io_error(e, "metadata"))?;
-        let still_named = std::fs::metadata(&entry.path)
-            .map(|current| (current.dev(), current.ino()) == (fd_meta.dev(), fd_meta.ino()))
-            .unwrap_or(false);
-        if !still_named {
+        let id = file_id(&fd_meta);
+        if !path_names_file(&entry.path, id) || !path_names_file(&entry.anchor_path, id) {
             return Err(turso_core::LimboError::Corrupt(format!(
-                "presence sidecar for {} not persisted: the path no longer names this file",
+                "presence sidecar for {} not persisted: its path or anchor no longer names this file",
                 entry.path
             )));
         }
@@ -808,17 +987,15 @@ mod bitmap {
             .present
             .serialize_into(&mut payload)
             .map_err(|e| completion_error(e, "serialize presence sidecar"))?;
-        let meta = file.metadata().map_err(|e| io_error(e, "metadata"))?;
         let mut buf = Vec::with_capacity(SIDECAR_HEADER_LEN + payload.len());
         buf.extend_from_slice(SIDECAR_MAGIC);
         buf.push(SIDECAR_VERSION);
         buf.extend_from_slice(&(GRANULE as u32).to_le_bytes());
-        buf.extend_from_slice(&meta.dev().to_le_bytes());
-        buf.extend_from_slice(&meta.ino().to_le_bytes());
+        buf.extend_from_slice(&id.0.to_le_bytes());
+        buf.extend_from_slice(&id.1.to_le_bytes());
         buf.extend_from_slice(&crc32c::crc32c(&payload).to_le_bytes());
         buf.extend_from_slice(&payload);
 
-        static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
         let tmp_path = format!(
             "{}.{}.{}.tmp",
             entry.sidecar_path,
@@ -1073,6 +1250,7 @@ mod bitmap {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::MetadataExt;
     use std::sync::Arc;
 
     use turso_core::{Buffer, Completion, OpenFlags, IO};
@@ -1233,6 +1411,20 @@ mod tests {
         assert!(!file.has_hole(0, G as usize).unwrap());
     }
 
+    #[test]
+    pub fn sparse_bitmap_configured_symlink_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.db");
+        std::fs::write(&target, b"").unwrap();
+        let path = dir.path().join("sparse.db");
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+        let path = path.to_str().unwrap();
+        let io = SparseBitmapIo::new(path).unwrap();
+
+        assert!(io.open_file(path, OpenFlags::default(), false).is_err());
+        assert!(!std::path::Path::new(&format!("{path}.present.anchor")).exists());
+    }
+
     /// Untracked paths must be plain `PlatformIO` files: full durability
     /// semantics, no sidecar, no presence overhead.
     #[test]
@@ -1275,6 +1467,39 @@ mod tests {
         assert!(!file.has_hole(2 * G as usize, G as usize).unwrap());
     }
 
+    #[test]
+    pub fn sparse_bitmap_open_preserves_concurrently_persisted_sidecar() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let io = Arc::new(io);
+        let writer = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        let reached = Arc::new(std::sync::Barrier::new(2));
+        let resume = Arc::new(std::sync::Barrier::new(2));
+        crate::sparse_io::bitmap::pause_next_open_after_metadata(
+            path.clone(),
+            reached.clone(),
+            resume.clone(),
+        );
+
+        let opener = {
+            let io = io.clone();
+            let path = path.clone();
+            std::thread::spawn(move || io.open_file(&path, OpenFlags::default(), false).unwrap())
+        };
+        reached.wait();
+        write(&writer, 0, G as usize, 1);
+        fsync(&writer);
+        let sidecar = format!("{path}.present");
+        assert!(std::path::Path::new(&sidecar).exists());
+        resume.wait();
+
+        let second = opener.join().unwrap();
+        assert!(std::path::Path::new(&sidecar).exists());
+        drop(second);
+        drop(writer);
+        let reopened = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        assert!(!reopened.has_hole(0, G as usize).unwrap());
+    }
+
     /// Presence must survive reopen exactly as persisted: pages written and
     /// synced stay present, punched pages stay absent.
     #[test]
@@ -1290,6 +1515,9 @@ mod tests {
             sync(&file, turso_core::io::FileSyncType::FullFsync);
         }
 
+        let data = std::fs::metadata(&path).unwrap();
+        let anchor = std::fs::metadata(format!("{path}.present.anchor")).unwrap();
+        assert_eq!((anchor.dev(), anchor.ino()), (data.dev(), data.ino()));
         let io = SparseBitmapIo::new(&path).unwrap();
         let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
         assert!(!file.has_hole(0, G as usize).unwrap());
@@ -1323,15 +1551,101 @@ mod tests {
         truncate(&file, 16 * G);
         write(&file, 0, G as usize, 1);
         fsync(&file);
+        let sidecar = format!("{path}.present");
+        let anchor = format!("{sidecar}.anchor");
         io.remove_file(&path).unwrap();
         assert!(!std::path::Path::new(&path).exists());
-        assert!(!std::path::Path::new(&format!("{path}.present")).exists());
+        assert!(!std::path::Path::new(&sidecar).exists());
+        assert!(!std::path::Path::new(&anchor).exists());
         // Writes keep POSIX unlinked-file semantics; presence must not be
         // persisted again.
         write(&file, G, G as usize, 2);
         fsync(&file);
         drop(file);
-        assert!(!std::path::Path::new(&format!("{path}.present")).exists());
+        assert!(!std::path::Path::new(&sidecar).exists());
+        assert!(!std::path::Path::new(&anchor).exists());
+    }
+
+    #[test]
+    pub fn sparse_bitmap_external_replacement_cannot_receive_old_handle_sidecar() {
+        let (io, _dir, path) = tracked_io_and_path();
+        let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        write(&file, 0, G as usize, 1);
+        fsync(&file);
+        let sidecar = format!("{path}.present");
+        let persisted = std::fs::read(&sidecar).unwrap();
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::write(&path, vec![2u8; G as usize]).unwrap();
+        write(&file, G, G as usize, 3);
+        assert!(file
+            .sync(
+                Completion::new_sync(|_| {}),
+                turso_core::io::FileSyncType::Fsync,
+            )
+            .is_err());
+        drop(file);
+
+        assert_eq!(std::fs::read(&sidecar).unwrap(), persisted);
+        assert!(io.open_file(&path, OpenFlags::default(), false).is_err());
+    }
+
+    #[test]
+    pub fn sparse_bitmap_remove_finishes_partial_cleanup() {
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            write(&file, 0, G as usize, 1);
+            fsync(&file);
+        }
+        let sidecar = format!("{path}.present");
+        let anchor = format!("{sidecar}.anchor");
+        std::fs::remove_file(&path).unwrap();
+
+        io.remove_file(&path).unwrap();
+        assert!(!std::path::Path::new(&sidecar).exists());
+        assert!(!std::path::Path::new(&anchor).exists());
+        io.remove_file(&path).unwrap();
+    }
+
+    #[test]
+    pub fn sparse_bitmap_remove_failure_order_is_retryable() {
+        // A hard data-path unlink error must leave required metadata intact.
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            write(&file, 0, G as usize, 1);
+            fsync(&file);
+        }
+        let sidecar = format!("{path}.present");
+        let anchor = format!("{sidecar}.anchor");
+        std::fs::remove_file(&path).unwrap();
+        std::fs::create_dir(&path).unwrap();
+        assert!(io.remove_file(&path).is_err());
+        assert!(std::path::Path::new(&sidecar).is_file());
+        assert!(std::path::Path::new(&anchor).is_file());
+
+        // Failure on the first metadata path must not skip the anchor, and a
+        // later call must be able to finish cleanup after the obstacle clears.
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            write(&file, 0, G as usize, 1);
+            fsync(&file);
+        }
+        let sidecar = format!("{path}.present");
+        let anchor = format!("{sidecar}.anchor");
+        std::fs::remove_file(&sidecar).unwrap();
+        std::fs::create_dir(&sidecar).unwrap();
+        assert!(io.remove_file(&path).is_err());
+        assert!(!std::path::Path::new(&path).exists());
+        assert!(std::path::Path::new(&sidecar).is_dir());
+        assert!(!std::path::Path::new(&anchor).exists());
+
+        std::fs::remove_dir(&sidecar).unwrap();
+        std::fs::write(&sidecar, b"residue").unwrap();
+        io.remove_file(&path).unwrap();
+        assert!(!std::path::Path::new(&sidecar).exists());
     }
 
     /// A non-empty data file whose sidecar is missing, corrupt, or belongs
@@ -1343,6 +1657,17 @@ mod tests {
         // Missing sidecar.
         let (io, _dir, path) = tracked_io_and_path();
         std::fs::write(&path, vec![1u8; 4096]).unwrap();
+        std::fs::hard_link(&path, format!("{path}.present.anchor")).unwrap();
+        assert!(io.open_file(&path, OpenFlags::default(), false).is_err());
+
+        // Missing anchor.
+        let (io, _dir, path) = tracked_io_and_path();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            write(&file, 0, 4096, 1);
+            fsync(&file);
+        }
+        std::fs::remove_file(format!("{path}.present.anchor")).unwrap();
         assert!(io.open_file(&path, OpenFlags::default(), false).is_err());
 
         // Corrupt sidecar (fails header parse).
@@ -1381,6 +1706,62 @@ mod tests {
         assert!(io.open_file(&path, OpenFlags::default(), false).is_err());
     }
 
+    #[test]
+    pub fn sparse_bitmap_anchor_refuses_stale_sidecar_with_matching_stat_identity() {
+        let (io, _dir, path) = tracked_io_and_path();
+        std::fs::write(&path, b"").unwrap();
+        let anchor = format!("{path}.present.anchor");
+        std::fs::hard_link(&path, &anchor).unwrap();
+        {
+            let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
+            write(&file, 0, 4096, 1);
+            fsync(&file);
+        }
+        let original = std::fs::metadata(&path).unwrap();
+        let anchor_meta = std::fs::symlink_metadata(&anchor).unwrap();
+        assert_eq!(
+            (anchor_meta.dev(), anchor_meta.ino()),
+            (original.dev(), original.ino())
+        );
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::write(&path, vec![2u8; 4096]).unwrap();
+        let replacement = std::fs::metadata(&path).unwrap();
+        assert_ne!(
+            (replacement.dev(), replacement.ino()),
+            (original.dev(), original.ino())
+        );
+
+        // Simulate complete reuse of the stat identity serialized by the
+        // sidecar. The hard-link anchor remains an independent witness for
+        // the original inode.
+        let sidecar = format!("{path}.present");
+        let mut bytes = std::fs::read(&sidecar).unwrap();
+        assert_eq!(
+            u32::from_le_bytes(bytes[25..29].try_into().unwrap()),
+            crc32c::crc32c(&bytes[29..])
+        );
+        bytes[9..17].copy_from_slice(&replacement.dev().to_le_bytes());
+        bytes[17..25].copy_from_slice(&replacement.ino().to_le_bytes());
+        std::fs::write(&sidecar, &bytes).unwrap();
+
+        assert_eq!(
+            (
+                u64::from_le_bytes(bytes[9..17].try_into().unwrap()),
+                u64::from_le_bytes(bytes[17..25].try_into().unwrap()),
+            ),
+            (replacement.dev(), replacement.ino())
+        );
+
+        assert!(io.open_file(&path, OpenFlags::default(), false).is_err());
+
+        // The same sidecar is otherwise valid for the replacement: retargeting
+        // the anchor is the only change needed for it to open.
+        std::fs::remove_file(&anchor).unwrap();
+        std::fs::hard_link(&path, &anchor).unwrap();
+        assert!(io.open_file(&path, OpenFlags::default(), false).is_ok());
+    }
+
     /// A stale sidecar next to a fresh (empty) data file is discarded.
     #[test]
     pub fn sparse_bitmap_fresh_file_discards_stale_sidecar() {
@@ -1397,6 +1778,28 @@ mod tests {
         let io = SparseBitmapIo::new(&path).unwrap();
         let file = io.open_file(&path, OpenFlags::default(), false).unwrap();
         assert!(file.has_hole(0, G as usize).unwrap());
+        let data = std::fs::metadata(&path).unwrap();
+        let anchor = std::fs::metadata(format!("{path}.present.anchor")).unwrap();
+        assert_eq!((anchor.dev(), anchor.ino()), (data.dev(), data.ino()));
+    }
+
+    #[test]
+    pub fn sparse_bitmap_writable_upgrade_initializes_empty_read_only_file() {
+        let (io, _dir, path) = tracked_io_and_path();
+        std::fs::write(&path, b"").unwrap();
+        let read_only = io.open_file(&path, OpenFlags::ReadOnly, false).unwrap();
+        assert!(!std::path::Path::new(&format!("{path}.present.anchor")).exists());
+
+        let writable = io.open_file(&path, OpenFlags::default(), false).unwrap();
+        let data = std::fs::metadata(&path).unwrap();
+        let anchor = std::fs::metadata(format!("{path}.present.anchor")).unwrap();
+        assert_eq!((anchor.dev(), anchor.ino()), (data.dev(), data.ino()));
+
+        write(&writable, 0, G as usize, 1);
+        fsync(&writable);
+        drop(writable);
+        drop(read_only);
+        assert!(io.open_file(&path, OpenFlags::default(), false).is_ok());
     }
 
     /// Access mode is per handle: a read-only handle may probe presence but

--- a/sync/sdk-kit/src/rsapi.rs
+++ b/sync/sdk-kit/src/rsapi.rs
@@ -172,34 +172,49 @@ pub struct TursoDatabaseSync<TBytes: AsRef<[u8]> + Send + Sync + 'static> {
     sync_busy: Arc<SyncBusyGate>,
 }
 
-#[allow(unused_variables)]
-fn persistent_io(partial: bool) -> Result<Arc<dyn IO>, turso_sync_engine::errors::Error> {
-    #[cfg(target_os = "linux")]
-    {
-        if !partial {
-            Ok(Arc::new(turso_core::PlatformIO::new().map_err(|e| {
-                turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
-                    "Failed to create platform IO: {e}"
-                ))
-            })?))
-        } else {
-            use turso_sync_engine::sparse_io::SparseLinuxIo;
-
-            Ok(Arc::new(SparseLinuxIo::new().map_err(|e| {
-                turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
-                    "Failed to create sparse IO: {e}"
-                ))
-            })?))
-        }
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = partial;
-        Ok(Arc::new(turso_core::PlatformIO::new().map_err(|e| {
+fn persistent_io(
+    partial: bool,
+    main_db_path: &str,
+) -> Result<Arc<dyn IO>, turso_sync_engine::errors::Error> {
+    let _ = main_db_path;
+    if !partial {
+        return Ok(Arc::new(turso_core::PlatformIO::new().map_err(|e| {
             turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
                 "Failed to create platform IO: {e}"
             ))
+        })?));
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use turso_sync_engine::sparse_io::SparseLinuxIo;
+
+        Ok(Arc::new(SparseLinuxIo::new().map_err(|e| {
+            turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
+                "Failed to create sparse IO: {e}"
+            ))
         })?))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        use turso_sync_engine::sparse_io::SparseBitmapIo;
+
+        Ok(Arc::new(SparseBitmapIo::new(main_db_path).map_err(
+            |e| {
+                turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
+                    "Failed to create sparse IO: {e}"
+                ))
+            },
+        )?))
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        // Partial sync stores lazily fetched pages in a sparse file and probes
+        // them with `File::has_hole`, which `PlatformIO` does not implement.
+        // Fail here instead of panicking later in the lazy storage path.
+        Err(turso_sync_engine::errors::Error::DatabaseSyncEngineError(
+            "partial sync requires sparse-file IO, which is not supported on this platform"
+                .to_string(),
+        ))
     }
 }
 
@@ -301,7 +316,10 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
                 };
                 let io = match io {
                     Some(io) => io,
-                    None => persistent_io(metadata.partial_bootstrap_server_revision.is_some())?,
+                    None => persistent_io(
+                        metadata.partial_bootstrap_server_revision.is_some(),
+                        &main_db_path,
+                    )?,
                 };
                 let db_file = database_sync_engine::DatabaseSyncEngine::init_db_storage(
                     io.clone(),
@@ -351,11 +369,14 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
                 .await?;
                 let io = match io {
                     Some(io) => io,
-                    None => persistent_io(if let Some(metadata) = &metadata {
-                        metadata.partial_sync_opts().is_some()
-                    } else {
-                        sync_engine_opts.partial_sync_opts.is_some()
-                    })?,
+                    None => persistent_io(
+                        if let Some(metadata) = &metadata {
+                            metadata.partial_sync_opts().is_some()
+                        } else {
+                            sync_engine_opts.partial_sync_opts.is_some()
+                        },
+                        &main_db_path,
+                    )?,
                 };
                 let metadata = database_sync_engine::DatabaseSyncEngine::bootstrap_db(
                     &coro,

--- a/sync/sdk-kit/src/rsapi.rs
+++ b/sync/sdk-kit/src/rsapi.rs
@@ -180,34 +180,49 @@ pub struct TursoDatabaseSync<TBytes: AsRef<[u8]> + Send + Sync + 'static> {
     sync_busy: Arc<SyncBusyGate>,
 }
 
-#[allow(unused_variables)]
-fn persistent_io(partial: bool) -> Result<Arc<dyn IO>, turso_sync_engine::errors::Error> {
-    #[cfg(target_os = "linux")]
-    {
-        if !partial {
-            Ok(Arc::new(turso_core::PlatformIO::new().map_err(|e| {
-                turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
-                    "Failed to create platform IO: {e}"
-                ))
-            })?))
-        } else {
-            use turso_sync_engine::sparse_io::SparseLinuxIo;
-
-            Ok(Arc::new(SparseLinuxIo::new().map_err(|e| {
-                turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
-                    "Failed to create sparse IO: {e}"
-                ))
-            })?))
-        }
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = partial;
-        Ok(Arc::new(turso_core::PlatformIO::new().map_err(|e| {
+fn persistent_io(
+    partial: bool,
+    main_db_path: &str,
+) -> Result<Arc<dyn IO>, turso_sync_engine::errors::Error> {
+    let _ = main_db_path;
+    if !partial {
+        return Ok(Arc::new(turso_core::PlatformIO::new().map_err(|e| {
             turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
                 "Failed to create platform IO: {e}"
             ))
+        })?));
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use turso_sync_engine::sparse_io::SparseLinuxIo;
+
+        Ok(Arc::new(SparseLinuxIo::new().map_err(|e| {
+            turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
+                "Failed to create sparse IO: {e}"
+            ))
         })?))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        use turso_sync_engine::sparse_io::SparseBitmapIo;
+
+        Ok(Arc::new(SparseBitmapIo::new(main_db_path).map_err(
+            |e| {
+                turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
+                    "Failed to create sparse IO: {e}"
+                ))
+            },
+        )?))
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        // Partial sync stores lazily fetched pages in a sparse file and probes
+        // them with `File::has_hole`, which `PlatformIO` does not implement.
+        // Fail here instead of panicking later in the lazy storage path.
+        Err(turso_sync_engine::errors::Error::DatabaseSyncEngineError(
+            "partial sync requires sparse-file IO, which is not supported on this platform"
+                .to_string(),
+        ))
     }
 }
 
@@ -309,7 +324,10 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
                 };
                 let io = match io {
                     Some(io) => io,
-                    None => persistent_io(metadata.partial_bootstrap_server_revision.is_some())?,
+                    None => persistent_io(
+                        metadata.partial_bootstrap_server_revision.is_some(),
+                        &main_db_path,
+                    )?,
                 };
                 let db_file = database_sync_engine::DatabaseSyncEngine::init_db_storage(
                     io.clone(),
@@ -359,11 +377,14 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
                 .await?;
                 let io = match io {
                     Some(io) => io,
-                    None => persistent_io(if let Some(metadata) = &metadata {
-                        metadata.partial_sync_opts().is_some()
-                    } else {
-                        sync_engine_opts.partial_sync_opts.is_some()
-                    })?,
+                    None => persistent_io(
+                        if let Some(metadata) = &metadata {
+                            metadata.partial_sync_opts().is_some()
+                        } else {
+                            sync_engine_opts.partial_sync_opts.is_some()
+                        },
+                        &main_db_path,
+                    )?,
                 };
                 let fresh_bootstrap = metadata.is_none() && sync_engine_opts.bootstrap_if_empty;
                 let metadata = database_sync_engine::DatabaseSyncEngine::bootstrap_db(

--- a/sync/sdk-kit/src/rsapi.rs
+++ b/sync/sdk-kit/src/rsapi.rs
@@ -216,9 +216,7 @@ fn persistent_io(
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
-        // Partial sync stores lazily fetched pages in a sparse file and probes
-        // them with `File::has_hole`, which `PlatformIO` does not implement.
-        // Fail here instead of panicking later in the lazy storage path.
+        // `PlatformIO` has no sparse-page presence operations.
         Err(turso_sync_engine::errors::Error::DatabaseSyncEngineError(
             "partial sync requires sparse-file IO, which is not supported on this platform"
                 .to_string(),


### PR DESCRIPTION
## Description

Adds a macOS backend for partial sync's sparse-file page storage, and makes unsupported platforms (including the browser binding) fail at configuration time instead of panicking later.

- **`sync/engine/src/sparse_io.rs`** — reorganized into two backends behind the same contract:
  - `mod linux`: the existing `SparseLinuxIo`, byte-for-byte behavior preserved (only errno handling switched to `std::io::Error::last_os_error()`).
  - `mod bitmap`: new portable `SparseBitmapIo(tracked_path)`, which tracks page presence **for the lazily-populated database file only** in a `roaring::RoaringTreemap` at 4 KiB granularity — the same presence-map semantics `MemoryIO` implements — persisted to a checksummed, identity-bound `<file>.present` sidecar. Every other path (WAL, metadata) is **delegated to `PlatformIO` untouched**.
- **`sync/sdk-kit/src/rsapi.rs`**, **`bindings/javascript/sync/src/lib.rs`** — partial sync selects `SparseLinuxIo` on Linux (unchanged) and `SparseBitmapIo` on macOS; any other platform — and the browser/OPFS build — now returns an error when partial sync is requested, instead of silently downgrading to an IO whose default `File::has_hole` panics.
- **`bindings/rust/src/sync.rs`** — two file-backed integration tests: prefix bootstrap with hydration persistence across reopen, and query bootstrap (correctness only — the local dev server ignores `server_query_selector`, see companion issue).
- **`sync/engine/Cargo.toml`** — `libc` widened to `cfg(unix)` (the barrier/reclaim hooks gate on `target_vendor = "apple"`, so iOS builds of the react-native binding compile); `cfg(antithesis)` declared for check-cfg; `antithesis_sdk` target dependency added (mirroring `core`).

### Concurrency and identity model

- Presence state is **shared process-wide per file identity (`dev`, `ino`)** — across handles and across `SparseBitmapIo` instances. The tracked file must be addressed by its configured spelling, as the engine always does; alias spellings (symlinks, hard links, case aliases) are detected best-effort and **rejected with an error** rather than silently bypassing presence tracking. Handle counting (not `Weak`) makes the last-close flush deterministic: it runs under the registry lock, a concurrent open re-verifies under that lock that the path still names the opened inode, and sidecar persistence fails loudly if the path no longer names the file.
- `has_hole` takes the file lock, so its answer is atomic with a concurrent `pwrite`'s data-plus-bits installation, as it is for the Linux and memory backends. Lock guards are released before completion callbacks run.
- Access mode is enforced **per handle**; a writable open of a read-only-shared descriptor swaps in the freshly opened (identity-verified by construction) descriptor.
- `remove_file` fences live handles (`defunct`: data ops keep POSIX unlinked-file semantics, presence persistence stops — serialized via a per-entry persist lock so an in-flight persist cannot resurrect the sidecar), unlinks data-then-sidecar with a directory sync, and keeps every error path internally consistent (later opens fail closed on any residue).

### Semantics and crash consistency

- **`has_hole` follows the trait contract exactly** ("a single allocated byte within a given range" ⇒ `false`): a write marks every granule it touches, matching `MemoryIO` and Linux block-allocation behavior, so sub-granule and vectored writes are covered (empty writes allocate nothing). A write into an *absent* granule zero-fills the uncovered remainder first, so "present" always means fully defined bytes — stale physical bytes from an unreclaimed punch can never resurface.
- **The on-disk bitmap never over-claims.** The data file is synced before every bitmap persist; the sidecar is replaced by temp-file + fsync + rename + parent-directory fsync; punched bits are made durable before the bytes are released.
- **Lag is bounded by WAL replay.** Within a single `File::sync` call the on-disk bitmap may lag the data file; because the pager completes a checkpoint only after `sync` returns (and truncates the WAL after that), a crash inside the window is repaired by WAL replay. Pure read hydration is additionally flushed at last close.
- **Anomalies refuse to open rather than guess.** The sidecar carries the data file's `dev`/`ino` and a `crc32c` of the bitmap payload; a missing, corrupt, checksum-failing, or generation-mismatched sidecar next to a **non-empty** database file is an open error — its bits may guard locally modified pages, and assuming "absent" could overwrite local data with older server pages. A fresh (empty) file discards stale sidecars.
- **`FileSyncType` is honored** (`F_FULLFSYNC` on Apple platforms, mirroring `UnixFile`) for the data file, the sidecar, and the directory syncs. Granule arithmetic is checked `u64` within the backend (the `File` trait's `usize` parameters bound 32-bit callers, as pre-existing). Orphaned persist temp files are swept at open.

### Known limitations — engine-lifecycle integration left for maintainer direction

Three gaps cannot be closed below the `IO` trait because they involve engine lifecycle the IO layer cannot see. Each is disclosed in the commit message; none is silently mishandled — they surface as the strict open error. Proposed remedies are small engine-side changes I'd be happy to follow up on under guidance:

1. **Replace-base recovery.** `ReplaceBaseGuard` atomically backs up/restores `[main-db, main-wal, main-log, revert-wal, metadata]`; the sidecar is not in the set, and restore-in-place preserves the inode. Remedy: add the sidecar to `file_specs` (restore order: sidecar before data, mirroring the create order).
2. **In-place re-bootstrap.** Bootstrap truncates the existing inode to the new size, so in-range presence bits from the previous generation would survive. Remedy: the engine truncates to zero (or `remove_file`s) before re-bootstrapping a partial database — that resets presence through the existing truncate semantics.
3. **Interrupted first bootstrap.** A crash after bootstrap makes the file non-empty but before the first sync/metadata write leaves no sidecar, and the strict policy then refuses to open. Remedy: when engine metadata is absent, the engine removes the partial database file before retrying bootstrap (it re-downloads either way).

If maintainers prefer, the same three points argue for eventually moving presence tracking into the engine's own metadata (it already has atomic multi-file recovery and generation knowledge); this backend keeps the semantics importable into that future without changing the `File` contract.

### Verification hooks

The backend is platform-independent so the exact logic macOS ships runs under the Linux-based test and verification infrastructure:

- differential test against `MemoryIO` as the reference model: randomized **including unaligned** writes across 16 seeds, `has_hole` equality at every step and after sync → drop → reopen;
- dedicated tests per hazard class: cross-instance shared state (punch not resurrected by another instance's sync), sidecar anomalies (missing / corrupt / **checksum bit-rot** / wrong generation ⇒ open error), stale-sidecar discard, remove-fencing of live handles, drop-flush without explicit sync, per-handle read-only enforcement, sub-granule and straddling writes, untracked paths acquiring no sidecar;
- `turso_assert!` alignment invariant on `punch_hole` (mirroring `MemoryIO`), `turso_assert_sometimes!` on both `has_hole` outcomes, `turso_assert_reachable!` on the sidecar-degradation paths, so Antithesis workloads verify branch coverage if/when they exercise the sync engine.

## Motivation and context

Closes #7841.

Partial sync currently works only on Linux; on macOS the partial flag is silently ignored and the engine panics in `File::has_hole`'s default implementation on first use.

A direct port of `SparseLinuxIo` to macOS is unsound, not merely incomplete: APFS delayed allocation rounds writes up to multi-block extents, materializes never-written gaps as allocated zeros on flush, and swallows punched holes adjacent to flushed writes — so `lseek(SEEK_DATA)` reports absent pages as data, which lazy storage would serve as zeros instead of fetching. (Full probe data in the companion issue.) Hence the explicit presence bitmap, with filesystem hole punching demoted to best-effort space reclamation.

**Fail-without-change proof** (new file-backed test on unpatched v0.7.0, macOS arm64):

```
thread 'sync::tests::test_sync_partial_file_backed' panicked at core/io/mod.rs:207:9:
has_hole is not supported for the given IO implementation
test result: FAILED. 0 passed; 1 failed
```

**Test results with this change** (macOS arm64 / APFS, local `tursodb` sync server, no cloud creds):

- `cargo test -p turso_sync_engine --lib` — 90 passed (14 sparse-IO tests covering the hazard classes above, including stale-byte zero-fill, empty-write no-op, and symlink/hard-link alias rejection)
- `LOCAL_SYNC_SERVER=target/debug/tursodb cargo test -p turso --features sync --lib sync` — 20 passed, 1 ignored (all 5 partial-sync tests: 3 existing in-memory + 2 new file-backed)
- `cargo clippy -p turso_sync_engine --lib` clean; `cargo fmt --all -- --check` clean
- Not verified locally: Linux compilation of the reorganized module (cross-compile from this host is blocked by `libaegis` cc flags; the `mod linux` body is unchanged apart from errno handling) and Windows/browser binding builds — relying on CI for those.

Remaining accepted tradeoffs: pure-hydration state since the last sync is lost by a hard crash (re-fetch — bandwidth, never correctness; a "persist every N bytes" knob is a natural follow-up), and the strict anomaly policy trades availability for safety (the error message names the recovery).

## Description of AI Usage

This PR was developed with an AI coding agent (Claude Code) working under my direction; I have reviewed the code and analysis and can speak to all of it. The agent performed the initial investigation (bisecting the platform gating, probing APFS `SEEK_DATA`/`F_PUNCHHOLE` semantics with standalone reproducers), drafted the implementation and tests, and ran the verification matrix above. The design was then hardened through five adversarial review rounds with a second, independent AI reviewer instructed to act as a skeptical maintainer; its findings drove the current architecture (identity-keyed process-global presence state, checksummed sidecar, zero-fill of absent granules, rename + directory-fsync durability, `F_FULLFSYNC` conformance, the `has_hole` contract for partial writes, per-handle access modes) and identified the three engine-lifecycle limitations disclosed above, which I chose to surface for maintainer direction rather than resolve unilaterally in recovery code I don't own. I'm happy to discuss any of these decisions.
