### PR TITLE
core/json: propagate JSONB allocation failures

### DIFF
--- a/core/alloc/allocation_site.rs
+++ b/core/alloc/allocation_site.rs
@@ -14,6 +14,7 @@ pub enum AllocationSite {
 pub enum ValueBlobAllocationSite {
     Concat,
     FromSlice,
+    JsonbConstruction,
     JsonbCopy,
     Hash128,
     RecordDecode,

--- a/core/json/cache.rs
+++ b/core/json/cache.rs
@@ -1,6 +1,6 @@
 use std::cell::{Cell, UnsafeCell};
 
-use crate::alloc::TryReserveError;
+use crate::alloc::{TryClone, TryReserveError};
 use crate::types::AsValueRef;
 use crate::{Value, ValueRef};
 
@@ -46,35 +46,39 @@ impl JsonCache {
         value: &Jsonb,
     ) -> std::result::Result<(), TryReserveError> {
         let key = key.as_value_ref();
+        let entry = (key.to_owned()?, value.try_clone()?);
         if self.used < JSON_CACHE_SIZE {
-            self.entries[self.used] = Some((key.to_owned()?, value.clone()));
+            self.entries[self.used] = Some(entry);
             self.age[self.used] = self.counter;
             self.counter += 1;
             self.used += 1
         } else {
             let id = self.find_oldest_entry();
 
-            self.entries[id] = Some((key.to_owned()?, value.clone()));
+            self.entries[id] = Some(entry);
             self.age[id] = self.counter;
             self.counter += 1;
         }
         Ok(())
     }
 
-    pub fn lookup(&mut self, key: impl AsValueRef) -> Option<Jsonb> {
+    pub fn lookup(
+        &mut self,
+        key: impl AsValueRef,
+    ) -> std::result::Result<Option<Jsonb>, TryReserveError> {
         let key = key.as_value_ref();
         for i in (0..self.used).rev() {
             if let Some((stored_key, value)) = &self.entries[i] {
                 if key == *stored_key {
+                    let json = value.try_clone()?;
                     self.age[i] = self.counter;
                     self.counter += 1;
-                    let json = value.clone();
 
-                    return Some(json);
+                    return Ok(Some(json));
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     pub fn clear(&mut self) {
@@ -89,12 +93,20 @@ pub struct JsonCacheCell {
     accessed: Cell<bool>,
 }
 
-impl Default for JsonCacheCell {
-    fn default() -> Self {
-        Self::new()
+struct JsonCacheAccessGuard<'a> {
+    accessed: &'a Cell<bool>,
+}
+
+impl Drop for JsonCacheAccessGuard<'_> {
+    fn drop(&mut self) {
+        self.accessed.set(false);
     }
 }
 
+#[expect(
+    clippy::new_without_default,
+    reason = "callers should construct the cache explicitly"
+)]
 impl JsonCacheCell {
     pub fn new() -> Self {
         Self {
@@ -103,27 +115,29 @@ impl JsonCacheCell {
         }
     }
 
+    fn access_guard(&self) -> JsonCacheAccessGuard<'_> {
+        assert!(!self.accessed.replace(true));
+        JsonCacheAccessGuard {
+            accessed: &self.accessed,
+        }
+    }
+
     #[cfg(test)]
     pub fn lookup(&self, key: impl AsValueRef) -> Option<Jsonb> {
-        assert!(!self.accessed.get());
+        let _guard = self.access_guard();
 
-        self.accessed.set(true);
-
-        let result = unsafe {
+        unsafe {
             let cache_ptr = self.inner.get();
             if (*cache_ptr).is_none() {
                 *cache_ptr = Some(JsonCache::new());
             }
 
             if let Some(cache) = &mut (*cache_ptr) {
-                cache.lookup(key)
+                cache.lookup(key).expect(crate::alloc::ALLOC_ERR_MSG)
             } else {
                 None
             }
-        };
-
-        self.accessed.set(false);
-        result
+        }
     }
 
     pub fn get_or_insert_with(
@@ -131,18 +145,16 @@ impl JsonCacheCell {
         key: impl AsValueRef,
         value: impl FnOnce(ValueRef) -> crate::Result<Jsonb>,
     ) -> crate::Result<Jsonb> {
-        assert!(!self.accessed.get());
-
         let key = key.as_value_ref();
-        self.accessed.set(true);
-        let result = unsafe {
+        let _guard = self.access_guard();
+        unsafe {
             let cache_ptr = self.inner.get();
             if (*cache_ptr).is_none() {
                 *cache_ptr = Some(JsonCache::new());
             }
 
             if let Some(cache) = &mut (*cache_ptr) {
-                if let Some(jsonb) = cache.lookup(key) {
+                if let Some(jsonb) = cache.lookup(key)? {
                     Ok(jsonb)
                 } else {
                     let result = value(key);
@@ -157,19 +169,14 @@ impl JsonCacheCell {
             } else {
                 value(key)
             }
-        };
-        self.accessed.set(false);
-
-        result
+        }
     }
 
     pub fn clear(&mut self) {
-        assert!(!self.accessed.get());
-        self.accessed.set(true);
+        let _guard = self.access_guard();
         unsafe {
             let cache_ptr = self.inner.get();
             if (*cache_ptr).is_none() {
-                self.accessed.set(false);
                 return;
             }
 
@@ -177,7 +184,6 @@ impl JsonCacheCell {
                 cache.clear()
             }
         }
-        self.accessed.set(false);
     }
 }
 
@@ -222,7 +228,7 @@ mod tests {
         assert_eq!(cache.counter, 1);
 
         // Look it up
-        let result = cache.lookup(&key);
+        let result = cache.lookup(&key).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), value);
 
@@ -236,7 +242,7 @@ mod tests {
         let (key, _) = create_test_pair("{\"id\": 123}");
 
         // Look up a non-existent key
-        let result = cache.lookup(&key);
+        let result = cache.lookup(&key).unwrap();
         assert!(result.is_none());
 
         // Counter should remain unchanged
@@ -267,9 +273,9 @@ mod tests {
         assert_eq!(cache.counter, 3);
 
         // Look them up in reverse order
-        let result3 = cache.lookup(&key3);
-        let result2 = cache.lookup(&key2);
-        let result1 = cache.lookup(&key1);
+        let result3 = cache.lookup(&key3).unwrap();
+        let result2 = cache.lookup(&key2).unwrap();
+        let result1 = cache.lookup(&key1).unwrap();
 
         assert_eq!(result3.unwrap(), value3);
         assert_eq!(result2.unwrap(), value2);
@@ -307,7 +313,7 @@ mod tests {
         assert_eq!(cache.used, 4);
 
         // Look up key1 to make it the most recently used
-        let _ = cache.lookup(&key1);
+        let _ = cache.lookup(&key1).unwrap();
 
         // Insert one more entry - should evict the oldest (key2)
         cache
@@ -318,14 +324,14 @@ mod tests {
         assert_eq!(cache.used, 4);
 
         // key2 should have been evicted
-        let result2 = cache.lookup(&key2);
+        let result2 = cache.lookup(&key2).unwrap();
         assert!(result2.is_none());
 
         // Other entries should still be present
-        assert!(cache.lookup(&key1).is_some());
-        assert!(cache.lookup(&key3).is_some());
-        assert!(cache.lookup(&key4).is_some());
-        assert!(cache.lookup(&key5).is_some());
+        assert!(cache.lookup(&key1).unwrap().is_some());
+        assert!(cache.lookup(&key3).unwrap().is_some());
+        assert!(cache.lookup(&key4).unwrap().is_some());
+        assert!(cache.lookup(&key5).unwrap().is_some());
     }
 
     #[test]
@@ -351,7 +357,7 @@ mod tests {
         assert_eq!(cache.find_oldest_entry(), 0);
 
         // Access key1 to make it the newest
-        let _ = cache.lookup(&key1);
+        let _ = cache.lookup(&key1).unwrap();
 
         // Now key2 should be the oldest
         assert_eq!(cache.find_oldest_entry(), 1);

--- a/core/json/error.rs
+++ b/core/json/error.rs
@@ -15,6 +15,13 @@ pub enum Error {
         /// The location of the error, if applicable.
         location: Option<usize>,
     },
+    OutOfMemory,
+}
+
+impl From<crate::alloc::TryReserveError> for Error {
+    fn from(_: crate::alloc::TryReserveError) -> Self {
+        Self::OutOfMemory
+    }
 }
 
 impl From<std::io::Error> for Error {
@@ -39,6 +46,7 @@ impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Message { ref msg, .. } => write!(formatter, "{msg}"),
+            Self::OutOfMemory => formatter.write_str("out of memory"),
         }
     }
 }
@@ -49,6 +57,7 @@ impl From<Error> for crate::LimboError {
     fn from(err: Error) -> Self {
         match err {
             Error::Message { msg, .. } => crate::LimboError::ParseError(msg),
+            Error::OutOfMemory => crate::LimboError::OutOfMemory,
         }
     }
 }

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{TryReserveError, TursoVecExt};
+use crate::alloc::{TryClone, TryReserveError, TursoAllocExt, TursoTryWithCapacityExt};
 use crate::json::error::{Error as PError, Result as PResult};
 use crate::json::Conv;
 use crate::types::{value_blob_from_slice, ValueBlob};
@@ -179,6 +179,14 @@ static CHARACTER_TYPE_OK: [u8; 256] = make_character_type_ok_table();
 #[derive(Debug, Clone, PartialEq)]
 pub struct Jsonb {
     data: ValueBlob,
+}
+
+impl TryClone for Jsonb {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> std::result::Result<Self, Self::Error> {
+        Self::from_raw_data(&self.data)
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -635,11 +643,11 @@ pub struct SearchOperation {
 }
 
 impl SearchOperation {
-    pub fn new(capacity: usize) -> Self {
-        Self {
+    pub fn new(capacity: usize) -> std::result::Result<Self, TryReserveError> {
+        Ok(Self {
             mode: PathOperationMode::ReplaceExisting,
-            value: Jsonb::new(capacity),
-        }
+            value: Jsonb::new(capacity)?,
+        })
     }
 
     pub fn result(self) -> Jsonb {
@@ -909,34 +917,33 @@ pub type ArrayIteratorItem = ((usize, Jsonb), ArrayIteratorState);
 pub type ObjectIteratorItem = ((usize, Jsonb, Jsonb), ObjectIteratorState);
 
 impl Jsonb {
-    pub fn new(capacity: usize) -> Self {
+    pub fn empty() -> Self {
         Self {
-            data: <ValueBlob as TursoVecExt<u8>>::with_capacity(capacity),
+            data: <ValueBlob as TursoAllocExt>::new(),
         }
+    }
+
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::JsonbConstruction)]
+    pub fn new(capacity: usize) -> std::result::Result<Self, TryReserveError> {
+        Ok(Self {
+            data: <ValueBlob as TursoTryWithCapacityExt>::try_with_capacity_ext(capacity)?,
+        })
     }
 
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
-    pub fn make_empty_array(size: usize) -> Self {
-        let mut jsonb = Self {
-            data: <ValueBlob as TursoVecExt<u8>>::with_capacity(size),
-        };
-        jsonb
-            .write_element_header(0, ElementType::ARRAY, 0, false)
-            .expect("writing header to new vector should not fail");
-        jsonb
+    pub fn make_empty_array(size: usize) -> Result<Self> {
+        let mut jsonb = Self::new(size.max(1))?;
+        jsonb.write_element_header(0, ElementType::ARRAY, 0, false)?;
+        Ok(jsonb)
     }
 
-    pub fn make_empty_obj(size: usize) -> Self {
-        let mut jsonb = Self {
-            data: <ValueBlob as TursoVecExt<u8>>::with_capacity(size),
-        };
-        jsonb
-            .write_element_header(0, ElementType::OBJECT, 0, false)
-            .expect("writing header to new vector should not fail");
-        jsonb
+    pub fn make_empty_obj(size: usize) -> Result<Self> {
+        let mut jsonb = Self::new(size.max(1))?;
+        jsonb.write_element_header(0, ElementType::OBJECT, 0, false)?;
+        Ok(jsonb)
     }
 
     pub fn append_to_array_unsafe(&mut self, data: &[u8]) {
@@ -2335,7 +2342,7 @@ impl Jsonb {
     }
 
     fn from_str(input: &str) -> PResult<Self> {
-        let mut result = Self::new(input.len());
+        let mut result = Self::new(input.len())?;
         let input = input.as_bytes();
 
         if input.is_empty() {
@@ -3567,7 +3574,7 @@ mod tests {
     #[test]
     fn test_null_serialization() {
         // Create JSONB with null value
-        let mut jsonb = Jsonb::new(10);
+        let mut jsonb = Jsonb::new(10).unwrap();
         jsonb.data.push(ElementType::NULL as u8);
 
         // Test serialization
@@ -3582,12 +3589,12 @@ mod tests {
     #[test]
     fn test_boolean_serialization() {
         // True
-        let mut jsonb_true = Jsonb::new(10);
+        let mut jsonb_true = Jsonb::new(10).unwrap();
         jsonb_true.data.push(ElementType::TRUE as u8);
         assert_eq!(jsonb_true.to_string().unwrap(), "true");
 
         // False
-        let mut jsonb_false = Jsonb::new(10);
+        let mut jsonb_false = Jsonb::new(10).unwrap();
         jsonb_false.data.push(ElementType::FALSE as u8);
         assert_eq!(jsonb_false.to_string().unwrap(), "false");
 
@@ -4473,7 +4480,7 @@ mod path_operations_tests {
         let mut jsonb = Jsonb::from_str(json_str).unwrap();
 
         // Create a search operation
-        let mut operation = SearchOperation::new(100);
+        let mut operation = SearchOperation::new(100).unwrap();
 
         // Create a path to the "person" property
         let path = create_path(vec![

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -70,13 +70,14 @@ pub fn get_json(json_value: &Value, indent: Option<&str>) -> crate::Result<Value
 pub fn jsonb(json_value: &Value, cache: &JsonCacheCell) -> crate::Result<Value> {
     let json_conv_fn = curry_convert_dbtype_to_jsonb(Conv::Strict);
 
-    let jsonbin = cache.get_or_insert_with(json_value, json_conv_fn);
-    match jsonbin {
-        Ok(jsonbin) => Ok(Value::Blob(jsonbin.data())),
-        Err(_) => {
-            bail_parse_error!("malformed JSON")
-        }
-    }
+    let jsonbin =
+        cache
+            .get_or_insert_with(json_value, json_conv_fn)
+            .map_err(|error| match error {
+                LimboError::OutOfMemory => LimboError::OutOfMemory,
+                _ => LimboError::ParseError("malformed JSON".to_string()),
+            })?;
+    Ok(Value::Blob(jsonbin.data()))
 }
 
 pub fn convert_dbtype_to_raw_jsonb(data: &Value, strict: Conv) -> crate::Result<crate::ValueBlob> {
@@ -106,6 +107,13 @@ fn parse_as_json_text(slice: &[u8], mode: Conv) -> crate::Result<Jsonb> {
     let str = std::str::from_utf8(truncated)
         .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))?;
     Jsonb::from_str_with_mode(str, mode).map_err(Into::into)
+}
+
+fn malformed_json_error(error: JsonError) -> LimboError {
+    match error {
+        JsonError::OutOfMemory => LimboError::OutOfMemory,
+        JsonError::Message { .. } => LimboError::ParseError("malformed JSON".to_string()),
+    }
 }
 
 fn is_jsonb_blob(slice: &[u8]) -> Result<bool, TryReserveError> {
@@ -144,7 +152,7 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
                 str.push('"');
                 Jsonb::from_str(&str)
             };
-            res.map_err(|_| LimboError::ParseError("malformed JSON".to_string()))
+            res.map_err(malformed_json_error)
         }
         ValueRef::Blob(blob) => {
             let bytes = blob;
@@ -194,8 +202,7 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
         )?),
         ValueRef::Numeric(numeric) if matches!(strict, Conv::ToString) => {
             let text = Value::from(numeric).to_string();
-            Jsonb::from_str_with_mode(&text, strict)
-                .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))
+            Jsonb::from_str_with_mode(&text, strict).map_err(malformed_json_error)
         }
         ValueRef::Numeric(Numeric::Float(float)) => {
             let float: f64 = float.into();
@@ -206,8 +213,7 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
                 } else {
                     "9.0e+999"
                 };
-                Jsonb::from_str(json_str)
-                    .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))
+                Jsonb::from_str(json_str).map_err(malformed_json_error)
             } else {
                 let mut buff = ryu::Buffer::new();
                 let s_ryu = buff.format(float);
@@ -231,12 +237,12 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
                     inner.push_str(exponent);
                 }
 
-                Jsonb::from_str(&s)
-                    .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))
+                Jsonb::from_str(&s).map_err(malformed_json_error)
             }
         }
-        ValueRef::Numeric(Numeric::Integer(int)) => Jsonb::from_str(&int.to_string())
-            .map_err(|_| LimboError::ParseError("malformed JSON".to_string())),
+        ValueRef::Numeric(Numeric::Integer(int)) => {
+            Jsonb::from_str(&int.to_string()).map_err(malformed_json_error)
+        }
     }
 }
 
@@ -253,7 +259,7 @@ where
     I: IntoIterator<IntoIter = E, Item = V>,
 {
     let values = values.into_iter();
-    let mut json = Jsonb::make_empty_array(values.len());
+    let mut json = Jsonb::make_empty_array(values.len())?;
 
     for value in values {
         let value = value.as_value_ref();
@@ -275,7 +281,7 @@ where
     I: IntoIterator<IntoIter = E, Item = V>,
 {
     let values = values.into_iter();
-    let mut json = Jsonb::make_empty_array(values.len());
+    let mut json = Jsonb::make_empty_array(values.len())?;
 
     for value in values {
         let value = value.as_value_ref();
@@ -310,7 +316,7 @@ pub fn json_array_length(
     let path = json_path_from_db_value(path.expect("We already checked none"), true)?;
 
     if let Some(path) = path {
-        let mut op = SearchOperation::new(json.len() / 2);
+        let mut op = SearchOperation::new(json.len() / 2)?;
         let _ = json.operate_on_path(&path, &mut op);
         if let Ok(len) = op.result().array_len() {
             return Ok(Value::from_i64(len as i64));
@@ -423,7 +429,7 @@ pub fn json_arrow_extract(
     if let Some(path) = json_path_from_db_value(&path, false)? {
         let make_jsonb_fn = curry_convert_dbtype_to_jsonb(Conv::Strict);
         let mut json = json_cache.get_or_insert_with(value, make_jsonb_fn)?;
-        let mut op = SearchOperation::new(json.len());
+        let mut op = SearchOperation::new(json.len())?;
         let res = json.operate_on_path(&path, &mut op);
         let extracted = op.result();
         if res.is_ok() {
@@ -450,7 +456,7 @@ pub fn json_arrow_shift_extract(
     if let Some(path) = json_path_from_db_value(&path, false)? {
         let make_jsonb_fn = curry_convert_dbtype_to_jsonb(Conv::Strict);
         let mut json = json_cache.get_or_insert_with(value, make_jsonb_fn)?;
-        let mut op = SearchOperation::new(json.len());
+        let mut op = SearchOperation::new(json.len())?;
         let res = json.operate_on_path(&path, &mut op);
         let extracted = op.result();
         let element_type = match extracted.element_type() {
@@ -543,7 +549,7 @@ where
         if let Some(path) = json_path_from_db_value(&first_path, true)? {
             let mut json = value;
 
-            let mut op = SearchOperation::new(json.len());
+            let mut op = SearchOperation::new(json.len())?;
             let res = json.operate_on_path(&path, &mut op);
             let extracted = op.result();
             let element_type = match extracted.element_type() {
@@ -561,13 +567,13 @@ where
     }
 
     let mut json = value;
-    let mut result = Jsonb::make_empty_array(json.len());
+    let mut result = Jsonb::make_empty_array(json.len())?;
 
     // TODO: make an op to avoid creating new json for every path element
     for path in paths {
         let path = json_path_from_db_value(&path, true);
         if let Some(path) = path? {
-            let mut op = SearchOperation::new(json.len());
+            let mut op = SearchOperation::new(json.len())?;
             let res = json.operate_on_path(&path, &mut op);
             let extracted = op.result();
             if res.is_ok() {
@@ -747,6 +753,7 @@ pub fn json_error_position(json: impl AsValueRef) -> crate::Result<Value> {
                     ))
                 }
             }
+            Err(JsonError::OutOfMemory) => Err(LimboError::OutOfMemory),
         },
         ValueRef::Blob(_) => {
             bail_parse_error!("Unsupported")
@@ -769,7 +776,7 @@ where
     if values.len() % 2 != 0 {
         bail_constraint_error!("json_object() requires an even number of arguments")
     }
-    let mut json = Jsonb::make_empty_obj(values.len() * 50);
+    let mut json = Jsonb::make_empty_obj(values.len() * 50)?;
 
     // TODO: when `array_chunks` is stabilized we can chunk by 2 here
     while values.len() > 1 {
@@ -809,7 +816,7 @@ where
     if values.len() % 2 != 0 {
         bail_constraint_error!("json_object() requires an even number of arguments")
     }
-    let mut json = Jsonb::make_empty_obj(values.len() * 50);
+    let mut json = Jsonb::make_empty_obj(values.len() * 50)?;
 
     // TODO: when `array_chunks` is stabilized we can chunk by 2 here
     while values.len() > 1 {
@@ -914,6 +921,20 @@ mod tests {
     use super::*;
     use crate::numeric::Numeric;
     use crate::types::Value;
+
+    #[test]
+    fn test_jsonb_preserves_malformed_json_error_and_cache_reusability() {
+        let cache = JsonCacheCell::new();
+        let invalid = Value::build_text("{");
+
+        assert!(matches!(
+            jsonb(&invalid, &cache),
+            Err(LimboError::ParseError(message)) if message == "malformed JSON"
+        ));
+
+        let valid = Value::build_text(r#"{"key":"value"}"#);
+        assert!(jsonb(&valid, &cache).is_ok());
+    }
 
     #[test]
     fn test_get_json_valid_json5() {

--- a/core/json/ops.rs
+++ b/core/json/ops.rs
@@ -43,7 +43,7 @@ pub fn json_patch(
         target = patch;
     } else {
         if target.element_type()? != super::jsonb::ElementType::OBJECT {
-            target = super::jsonb::Jsonb::make_empty_obj(0);
+            target = super::jsonb::Jsonb::make_empty_obj(0)?;
         }
         target.patch(&patch)?;
     }
@@ -75,7 +75,7 @@ pub fn jsonb_patch(
         target = patch;
     } else {
         if target.element_type()? != super::jsonb::ElementType::OBJECT {
-            target = super::jsonb::Jsonb::make_empty_obj(0);
+            target = super::jsonb::Jsonb::make_empty_obj(0)?;
         }
         target.patch(&patch)?;
     }

--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -206,7 +206,7 @@ impl JsonEachCursor {
     fn empty(traversal_mode: JsonTraversalMode) -> Self {
         Self {
             rowid: 0,
-            json: Jsonb::new(0),
+            json: Jsonb::empty(),
             traversal_states: Vec::new(),
             path_to_current_value: InPlaceJsonPath::new_root(),
             columns: Columns::default(),
@@ -494,7 +494,7 @@ fn navigate_to_path(jsonb: &mut Jsonb, path: &Value) -> Result<Option<Jsonb>, Li
     let json_path = json_path_from_db_value(path, true)?.ok_or_else(|| {
         LimboError::InvalidArgument(format!("path '{path}' is not a valid json path"))
     })?;
-    let mut search_operation = SearchOperation::new(jsonb.len() / 2);
+    let mut search_operation = SearchOperation::new(jsonb.len() / 2)?;
     if jsonb
         .operate_on_path(&json_path, &mut search_operation)
         .is_err()
@@ -548,7 +548,7 @@ mod columns {
         fn default() -> Columns {
             Self {
                 key: Key::empty(),
-                value: Jsonb::new(0),
+                value: Jsonb::empty(),
                 fullkey: "".to_owned(),
                 parent_id: None,
                 innermost_container_path: "".to_owned(),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7000,7 +7000,7 @@ pub fn op_agg_final(
                 #[cfg(feature = "json")]
                 AggFunc::JsonbGroupArray => {
                     state.registers[dest_reg]
-                        .set_blob(json::jsonb::Jsonb::make_empty_array(1).data())?;
+                        .set_blob(json::jsonb::Jsonb::make_empty_array(1)?.data())?;
                 }
                 #[cfg(feature = "json")]
                 AggFunc::JsonGroupObject => {
@@ -7009,7 +7009,7 @@ pub fn op_agg_final(
                 #[cfg(feature = "json")]
                 AggFunc::JsonbGroupObject => {
                     state.registers[dest_reg]
-                        .set_blob(json::jsonb::Jsonb::make_empty_obj(1).data())?;
+                        .set_blob(json::jsonb::Jsonb::make_empty_obj(1)?.data())?;
                 }
                 AggFunc::External(ext_func) => {
                     let value = match ext_func.as_ref() {
@@ -8272,7 +8272,8 @@ pub fn op_function(
                         }
                     };
 
-                    let mut json = json::jsonb::Jsonb::make_empty_array(table.columns().len() * 10);
+                    let mut json =
+                        json::jsonb::Jsonb::make_empty_array(table.columns().len() * 10)?;
                     for column in table.columns() {
                         use crate::types::TextRef;
 
@@ -8329,9 +8330,9 @@ pub fn op_function(
 
                     let mut payload_iterator = ValueIterator::new(bin_record.as_slice())?;
 
-                    let mut json = json::jsonb::Jsonb::make_empty_obj(columns_len);
+                    let mut json = json::jsonb::Jsonb::make_empty_obj(columns_len)?;
                     for i in 0..columns_len {
-                        let mut op = json::jsonb::SearchOperation::new(0);
+                        let mut op = json::jsonb::SearchOperation::new(0)?;
                         let path = json::path::JsonPath {
                             elements: vec![
                                 json::path::PathElement::Root(),

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -227,6 +227,7 @@ fn allocation_site_id(site: AllocationSite) -> u64 {
             ValueBlobAllocationSite::FromSlice => 25,
             ValueBlobAllocationSite::JsonbCopy => 26,
             ValueBlobAllocationSite::Hash128 => 27,
+            ValueBlobAllocationSite::JsonbConstruction => 28,
         },
         AllocationSite::Vector(site) => match site {
             VectorAllocationSite::Parse => 15,
@@ -298,6 +299,7 @@ mod tests {
             ValueBlobAllocationSite::Concat,
             ValueBlobAllocationSite::RecordDecode,
             ValueBlobAllocationSite::FromSlice,
+            ValueBlobAllocationSite::JsonbConstruction,
             ValueBlobAllocationSite::JsonbCopy,
             ValueBlobAllocationSite::Hash128,
         ];

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -350,4 +350,131 @@ mod tests {
         assert!(INJECTOR.allocate(layout).is_err());
         assert_eq!(INJECTOR.injected_faults(), 1);
     }
+
+    #[cfg(nightly)]
+    #[test]
+    fn production_allocation_failures_propagate_and_leave_state_reusable() {
+        let injector =
+            install_global_allocation_fault_backend(AllocationFaultConfig { probability: 1.0 }, 29)
+                .unwrap()
+                .unwrap();
+
+        let lhs = turso_core::Value::from_slice(&[1, 2]).unwrap();
+        let rhs = turso_core::Value::from_slice(&[3, 4]).unwrap();
+        let blob = turso_core::Value::from_slice(&[1, 2, 3, 4]).unwrap();
+        let vector_bytes = 1.0f32.to_le_bytes();
+        let json = turso_core::Value::build_text(r#"{"key":"value"}"#);
+        let json_cache = turso_core::json::JsonCacheCell::new();
+        turso_core::json::jsonb(&json, &json_cache).unwrap();
+
+        let before = injector.injected_faults();
+        {
+            let _context = injector.enter_context(AllocationFaultContext {
+                step: 10,
+                fiber_idx: 11,
+                execution_id: 12,
+            });
+            assert!(lhs.exec_concat(&rhs).is_err());
+        }
+        assert_eq!(injector.injected_faults(), before + 1);
+        assert_eq!(
+            lhs.exec_concat(&rhs).unwrap().to_blob(),
+            Some([1, 2, 3, 4].as_slice())
+        );
+
+        let before = injector.injected_faults();
+        {
+            let _context = injector.enter_context(AllocationFaultContext {
+                step: 13,
+                fiber_idx: 14,
+                execution_id: 15,
+            });
+            assert!(blob.exec_cast("BLOB").is_err());
+        }
+        assert_eq!(injector.injected_faults(), before + 1);
+        assert_eq!(blob.exec_cast("BLOB").unwrap().to_blob(), blob.to_blob());
+
+        let before = injector.injected_faults();
+        {
+            let _context = injector.enter_context(AllocationFaultContext {
+                step: 16,
+                fiber_idx: 17,
+                execution_id: 18,
+            });
+            let vector =
+                turso_core::vector::vector_types::Vector::from_slice(&vector_bytes).unwrap();
+            assert!(turso_core::vector::operations::serialize::vector_serialize(vector).is_err());
+        }
+        assert_eq!(injector.injected_faults(), before + 1);
+        let vector = turso_core::vector::vector_types::Vector::from_slice(&vector_bytes).unwrap();
+        assert_eq!(
+            turso_core::vector::operations::serialize::vector_serialize(vector)
+                .unwrap()
+                .to_blob(),
+            Some(vector_bytes.as_slice())
+        );
+
+        let before = injector.injected_faults();
+        {
+            let _context = injector.enter_context(AllocationFaultContext {
+                step: 19,
+                fiber_idx: 20,
+                execution_id: 21,
+            });
+            assert!(matches!(
+                turso_core::json::jsonb(&json, &json_cache),
+                Err(turso_core::LimboError::OutOfMemory)
+            ));
+        }
+        assert_eq!(injector.injected_faults(), before + 1);
+        assert!(turso_core::json::jsonb(&json, &json_cache).is_ok());
+
+        let insert_key = turso_core::Value::build_text(r#"{"insert":"value"}"#);
+        let insert_cache = turso_core::json::JsonCacheCell::new();
+        let prepared_json =
+            turso_core::json::convert_dbtype_to_jsonb(&insert_key, turso_core::json::Conv::Strict)
+                .unwrap();
+        let before = injector.injected_faults();
+        {
+            let _context = injector.enter_context(AllocationFaultContext {
+                step: 22,
+                fiber_idx: 23,
+                execution_id: 24,
+            });
+            assert!(matches!(
+                insert_cache.get_or_insert_with(&insert_key, |_| Ok(prepared_json)),
+                Err(turso_core::LimboError::OutOfMemory)
+            ));
+        }
+        assert_eq!(injector.injected_faults(), before + 1);
+
+        let prepared_json =
+            turso_core::json::convert_dbtype_to_jsonb(&insert_key, turso_core::json::Conv::Strict)
+                .unwrap();
+        let insert_closure_called = Cell::new(false);
+        assert!(
+            insert_cache
+                .get_or_insert_with(&insert_key, |_| {
+                    insert_closure_called.set(true);
+                    Ok(prepared_json)
+                })
+                .is_ok()
+        );
+        assert!(insert_closure_called.get());
+
+        let before = injector.injected_faults();
+        {
+            let _context = injector.enter_context(AllocationFaultContext {
+                step: 25,
+                fiber_idx: 26,
+                execution_id: 27,
+            });
+            assert!(turso_core::json::is_json_valid(&json).is_err());
+        }
+        assert_eq!(injector.injected_faults(), before + 1);
+        assert_eq!(
+            turso_core::json::is_json_valid(&json).unwrap().as_int(),
+            Some(1)
+        );
+    }
 }

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -442,6 +442,7 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
             (10, Box::new(CreateSimpleTableWorkload)),
             (20, Box::new(SimpleSelectWorkload)),
             (20, Box::new(SimpleInsertWorkload)),
+            (20, Box::new(JsonWorkload)),
             (15, Box::new(UpdateWorkload)),
             (15, Box::new(DeleteWorkload)),
             (2, Box::new(CreateIndexWorkload)),

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -157,6 +157,102 @@ impl Workload for SelectWorkload {
     }
 }
 
+const JSON_WORKLOAD_VARIANT_COUNT: usize = 6;
+
+/// Exercise JSON text, JSONB, aggregate, and virtual-table functions.
+pub struct JsonWorkload;
+
+impl Workload for JsonWorkload {
+    fn generate(&self, _ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        let id = rng.random_range(0..1_000_000_i64);
+        let first = rng.random_range(-1_000_000..=1_000_000_i64);
+        let second = rng.random_range(-1_000_000..=1_000_000_i64);
+        let third = rng.random_range(-1_000_000..=1_000_000_i64);
+        let active = rng.random_bool(0.5);
+        let payload = "x".repeat(rng.random_range(8..=512));
+        let document = format!(
+            r#"{{"id":{id},"meta":{{"active":{active},"label":"item_{id}","payload":"{payload}"}},"items":[{first},{second},{{"value":{third}}}],"nullable":null}}"#
+        );
+        let replacement = rng.random_range(-1_000_000..=1_000_000_i64);
+        let patch = format!(r#"{{"patched":true,"revision":{replacement}}}"#);
+        let variant = rng.random_range(0..JSON_WORKLOAD_VARIANT_COUNT);
+
+        Some(Operation::Select {
+            sql: json_workload_sql(variant, &document, &patch, replacement),
+        })
+    }
+}
+
+fn json_workload_sql(variant: usize, document: &str, patch: &str, replacement: i64) -> String {
+    match variant {
+        0 => format!(
+            "WITH input(doc) AS (VALUES ('{document}')) \
+             SELECT json(doc), \
+                    json_extract(doc, '$.id'), \
+                    json_extract(doc, '$.items[2].value'), \
+                    json_type(doc, '$.meta.active'), \
+                    json_array_length(doc, '$.items'), \
+                    json_valid(doc), \
+                    json_error_position(doc) \
+             FROM input"
+        ),
+        1 => format!(
+            "WITH input(doc) AS (VALUES ('{document}')) \
+             SELECT json_set(doc, '$.meta.active', {}, '$.items[#]', {replacement}), \
+                    json_insert(doc, '$.created', json_object('step', {replacement})), \
+                    json_replace(doc, '$.meta.label', json_quote('label_{replacement}')), \
+                    json_remove(doc, '$.nullable'), \
+                    json_patch(doc, '{patch}'), \
+                    json_pretty(doc) \
+             FROM input",
+            replacement & 1
+        ),
+        2 => format!(
+            "WITH input(doc) AS (VALUES ('{document}')) \
+             SELECT hex(jsonb(doc)), \
+                    json(jsonb_extract(doc, '$.items')), \
+                    json(jsonb_set(doc, '$.id', {replacement})), \
+                    json(jsonb_insert(doc, '$.created', jsonb_object('step', {replacement}))), \
+                    json(jsonb_replace(doc, '$.meta.label', jsonb_array('label', {replacement}))), \
+                    json(jsonb_remove(doc, '$.nullable')), \
+                    json(jsonb_patch(doc, '{patch}')) \
+             FROM input"
+        ),
+        3 => format!(
+            "SELECT json_array({replacement}, 'item_{replacement}', NULL), \
+                    json_object('id', {replacement}, 'nested', json_array(1, 2, 3)), \
+                    json(jsonb_array({replacement}, json(jsonb_object('active', true)))), \
+                    json(jsonb_object('id', {replacement}, 'values', json(jsonb_array(1, 2, 3)))), \
+                    json_quote('payload_{replacement}')"
+        ),
+        4 => format!(
+            "WITH input(doc) AS (VALUES ('{document}')) \
+             SELECT jt.fullkey, jt.type, jt.atom \
+             FROM input, json_tree(input.doc) AS jt \
+             WHERE jt.atom IS NOT NULL \
+             UNION ALL \
+             SELECT '$.items[' || je.key || ']', je.type, je.atom \
+             FROM input, json_each(input.doc, '$.items') AS je \
+             WHERE je.atom IS NOT NULL"
+        ),
+        5 => format!(
+            "WITH input_rows(id, label) AS ( \
+                 VALUES ({replacement}, 'a_{replacement}'), \
+                        ({}, 'b_{replacement}'), \
+                        ({}, 'c_{replacement}') \
+             ) \
+             SELECT json_group_array(json_object('id', id, 'label', label)), \
+                    json_group_object(label, json_array(id, id + 1)), \
+                    json(jsonb_group_array(jsonb_object('id', id, 'label', label))), \
+                    json(jsonb_group_object(label, jsonb_array(id, id + 1))) \
+             FROM input_rows",
+            replacement + 1,
+            replacement + 2
+        ),
+        _ => unreachable!("JSON workload variant is selected from a bounded range"),
+    }
+}
+
 /// Execute an INSERT statement (works in both Idle and InTx states).
 pub struct InsertWorkload;
 
@@ -741,11 +837,14 @@ impl Workload for AutoincDeleteWorkload {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use rand::SeedableRng;
     use sql_generation::{
         generation::Opts,
         model::table::{Column, ColumnType, Table},
     };
+    use turso_core::{Database, MemoryIO};
 
     use super::*;
 
@@ -805,5 +904,64 @@ mod tests {
             sql,
             "CREATE INDEX IF NOT EXISTS schema_clone_existing_idx_table_0_9 ON table_0(col_0)"
         );
+    }
+
+    #[test]
+    fn json_workload_variants_cover_json_function_families() {
+        let document =
+            r#"{"id":1,"meta":{"active":true},"items":[1,2,{"value":3}],"nullable":null}"#;
+        let patch = r#"{"patched":true}"#;
+        let sql = (0..JSON_WORKLOAD_VARIANT_COUNT)
+            .map(|variant| json_workload_sql(variant, document, patch, 7))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for function in [
+            "json_extract(",
+            "json_set(",
+            "jsonb(",
+            "jsonb_set(",
+            "json_tree(",
+            "json_each(",
+            "json_group_array(",
+            "jsonb_group_object(",
+        ] {
+            assert!(sql.contains(function), "missing {function}");
+        }
+    }
+
+    #[test]
+    fn json_workload_variants_execute() {
+        let io = Arc::new(MemoryIO::new());
+        let database = Database::open_file(io, ":memory:").unwrap();
+        let connection = database.connect().unwrap();
+        let document =
+            r#"{"id":1,"meta":{"active":true},"items":[1,2,{"value":3}],"nullable":null}"#;
+        let patch = r#"{"patched":true}"#;
+
+        for variant in 0..JSON_WORKLOAD_VARIANT_COUNT {
+            let sql = json_workload_sql(variant, document, patch, 7);
+            connection
+                .execute(&sql)
+                .unwrap_or_else(|error| panic!("JSON workload variant {variant} failed: {error}"));
+        }
+    }
+
+    #[test]
+    fn json_workload_generates_select_operations() {
+        let state = SimulatorState::new(vec![], vec![]);
+        let opts = Opts::default();
+        let ctx = WorkloadContext {
+            fiber_state: &FiberState::Idle,
+            sim_state: &state,
+            opts: &opts,
+            enable_mvcc: false,
+            tables_vec: vec![],
+        };
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+
+        let operation = JsonWorkload.generate(&ctx, &mut rng).unwrap();
+
+        assert!(matches!(operation, Operation::Select { ref sql } if sql.contains("json")));
     }
 }


### PR DESCRIPTION
## Description

Depends on #7838. Please review the commits after `core: make blob affinity copies fallible`; once #7838 lands, GitHub will show only this follow-up's diff.

- make JSONB construction, search results, and cache copies propagate allocation failures
- use fallible cloning without mutating JSON cache state before the clone succeeds
- preserve out-of-memory errors instead of misclassifying them as malformed JSON
- add deterministic coverage for production allocation-failure paths
- expand Whopper workloads to generate and execute JSON scalar, aggregate, mutation, JSONB, and table-valued functions

## Context

The base PR establishes fallible `Value::Blob` allocation and updates its existing consumers. JSON adds another correctness boundary: cache lookup and construction paths must not panic, lose the allocation error, or leave cache bookkeeping mutated when a fallible clone fails.

Whopper also needs to generate JSON expressions so those allocation sites are exercised by normal randomized workloads rather than only targeted tests.
