### PR TITLE
docs: refresh SQL reference for Turso 0.7

### DIFF
--- a/docs/sql-reference/cli/command-line-options.mdx
+++ b/docs/sql-reference/cli/command-line-options.mdx
@@ -141,24 +141,32 @@ Experimental features may have incomplete implementations or known limitations. 
 
 | Flag | Description |
 |------|-------------|
-| `--experimental-views` | Enable views (`CREATE VIEW` / `DROP VIEW`) |
-| `--experimental-custom-types` | Enable custom types (`CREATE TYPE` / `DROP TYPE`) |
+| `--experimental-views` | Enable views (`CREATE VIEW` / `CREATE MATERIALIZED VIEW`) |
+| `--experimental-custom-types` | Enable custom types (`CREATE TYPE` / `DROP TYPE` / `CREATE DOMAIN` / `DROP DOMAIN`) |
 | `--experimental-encryption` | Enable at-rest database encryption |
-| `--experimental-index-method` | Enable custom index methods. Necessary for FTS and Sparse Vector indexes |
+| `--experimental-index-method` | Enable custom index methods. Necessary for FTS and sparse vector indexes |
 | `--experimental-autovacuum` | Enable automatic database vacuuming |
 | `--experimental-vacuum` | Enable in-place `VACUUM` |
-| `--experimental-triggers` | Enable triggers (`CREATE TRIGGER` / `DROP TRIGGER`) |
 | `--experimental-attach` | Enable `ATTACH DATABASE` / `DETACH DATABASE` |
+| `--experimental-generated-columns` | Enable virtual `GENERATED ALWAYS AS` columns |
+| `--experimental-without-rowid` | Enable `WITHOUT ROWID` tables |
+| `--experimental-multiprocess-wal` | Enable sharing a database between processes via a shared WAL coordinator |
+| `--experimental-mvcc-passive-checkpoint` | Enable passive checkpointing under MVCC (`journal_mode=mvcc`) |
+
+<Info>
+Triggers (`CREATE TRIGGER` / `DROP TRIGGER`) are stable as of Turso 0.7 and no longer require a flag.
+</Info>
 
 ```bash
-# Enable views, triggers, and in-place VACUUM
-tursodb --experimental-views --experimental-triggers --experimental-vacuum mydata.db
+# Enable views, custom types, and in-place VACUUM
+tursodb --experimental-views --experimental-custom-types --experimental-vacuum mydata.db
 ```
 
 ## Other Flags
 
 | Flag | Description |
 |------|-------------|
+| `--mvcc` | Start the MVCC concurrent-transaction harness instead of the normal shell |
 | `--unsafe-testing` | Enable unsafe testing features (e.g., `sqlite_dbpage` writes) |
 | `-h, --help` | Print usage help |
 | `-V, --version` | Print version information |

--- a/docs/sql-reference/experimental-features.mdx
+++ b/docs/sql-reference/experimental-features.mdx
@@ -14,20 +14,26 @@ Some Turso features are still experimental and must be explicitly enabled before
 |---------|------|-------------|
 | Views | `views` | [CREATE VIEW](/docs/sql-reference/statements/create-view) and [CREATE MATERIALIZED VIEW](/docs/sql-reference/statements/create-materialized-view) |
 | Custom Types | `custom_types` | [CREATE TYPE](/docs/sql-reference/statements/create-type), [DROP TYPE](/docs/sql-reference/statements/drop-type), [CREATE DOMAIN](/docs/sql-reference/statements/create-domain), and [DROP DOMAIN](/docs/sql-reference/statements/drop-domain) for STRICT tables |
-| Triggers | `triggers` | [CREATE TRIGGER](/docs/sql-reference/statements/create-trigger) and [DROP TRIGGER](/docs/sql-reference/statements/drop-trigger) |
 | Encryption | `encryption` | At-rest encryption via [PRAGMA cipher / hexkey](/docs/sql-reference/pragmas#encryption) |
 | Index Methods | `index_method` | [CREATE INDEX ... USING](/docs/sql-reference/statements/create-index#using-clause) for FTS and custom index types |
 | Autovacuum | `autovacuum` | Automatic database file compaction |
 | Vacuum | `vacuum` | In-place [VACUUM](/docs/sql-reference/statements/vacuum) compaction |
 | Attach | `attach` | [ATTACH DATABASE](/docs/sql-reference/statements/attach-database) and [DETACH DATABASE](/docs/sql-reference/statements/detach-database) |
+| Generated Columns | `generated_columns` | Virtual [`GENERATED ALWAYS AS`](/docs/sql-reference/statements/create-table) columns |
+| Without Rowid | `without_rowid` | `WITHOUT ROWID` tables |
 | Multi-Process WAL | `multiprocess_wal` | [Multi-Process Access](/docs/sql-reference/multiprocess-access) — share a database file between OS processes via a shared WAL coordinator |
+| MVCC Passive Checkpoint | `mvcc_passive_checkpoint` | Passive checkpointing under MVCC (`journal_mode=mvcc`) |
+
+<Info>
+Triggers are no longer experimental as of Turso 0.7 — [CREATE TRIGGER](/docs/sql-reference/statements/create-trigger) and [DROP TRIGGER](/docs/sql-reference/statements/drop-trigger) work without any flag.
+</Info>
 
 ## CLI
 
 Pass `--experimental-<feature>` flags when starting `tursodb`:
 
 ```bash
-tursodb --experimental-views --experimental-triggers database.db
+tursodb --experimental-views --experimental-custom-types database.db
 ```
 
 Multiple flags can be combined:
@@ -36,7 +42,6 @@ Multiple flags can be combined:
 tursodb \
   --experimental-views \
   --experimental-custom-types \
-  --experimental-triggers \
   --experimental-encryption \
   --experimental-index-method \
   --experimental-vacuum \
@@ -52,7 +57,6 @@ use turso::Builder;
 
 let db = Builder::new_local("database.db")
     .experimental_encryption(true)
-    .experimental_triggers(true)
     .experimental_materialized_views(true)
     .experimental_custom_types(true)
     .experimental_index_method(true)
@@ -71,7 +75,7 @@ import turso
 
 conn = turso.connect(
     "database.db",
-    experimental_features="views,triggers,custom_types,vacuum",
+    experimental_features="views,custom_types,vacuum",
 )
 ```
 
@@ -83,7 +87,7 @@ Pass an array of feature strings to the `experimental` option:
 import { Database } from "@tursodatabase/libsql";
 
 const db = new Database("file:database.db", {
-    experimental: ["views", "triggers", "custom_types", "encryption", "vacuum"],
+    experimental: ["views", "custom_types", "encryption", "vacuum"],
 });
 ```
 
@@ -94,14 +98,14 @@ Set the `ExperimentalFeatures` field as a comma-separated string:
 ```go
 db, err := turso.NewDatabase(turso.TursoDatabaseConfig{
     Path: "database.db",
-    ExperimentalFeatures: "views,triggers,custom_types,vacuum",
+    ExperimentalFeatures: "views,custom_types,vacuum",
 })
 ```
 
 The Go driver also supports DSN query parameters:
 
 ```go
-db, err := sql.Open("turso", "database.db?experimental=views,triggers,vacuum")
+db, err := sql.Open("turso", "database.db?experimental=views,vacuum")
 ```
 
 ## Java SDK

--- a/docs/sql-reference/extensions.mdx
+++ b/docs/sql-reference/extensions.mdx
@@ -302,6 +302,83 @@ SELECT percentile_cont(value, 0.25) FROM scores;
 -- 20.0
 ```
 
+## Crypto Extension
+
+The crypto extension provides hashing and encoding functions, compatible with [sqlean-crypto](https://github.com/nalgeon/sqlean/blob/main/docs/crypto.md).
+
+### Functions
+
+| Function | Parameters | Return Type | Description |
+|----------|-----------|-------------|-------------|
+| `crypto_md5(data)` | TEXT/BLOB | BLOB | MD5 hash |
+| `crypto_sha1(data)` | TEXT/BLOB | BLOB | SHA-1 hash |
+| `crypto_sha256(data)` | TEXT/BLOB | BLOB | SHA-256 hash |
+| `crypto_sha384(data)` | TEXT/BLOB | BLOB | SHA-384 hash |
+| `crypto_sha512(data)` | TEXT/BLOB | BLOB | SHA-512 hash |
+| `crypto_blake3(data)` | TEXT/BLOB | BLOB | BLAKE3 hash |
+| `crypto_encode(data, format)` | BLOB, TEXT | TEXT | Encode a blob as text using `format` (e.g. `hex`, `base32`, `base64`, `url`) |
+| `crypto_decode(text, format)` | TEXT, TEXT | BLOB | Decode text in the given `format` back into a blob |
+
+```sql
+-- Hash a value and encode it as hex
+SELECT crypto_encode(crypto_sha256('hello'), 'hex');
+
+-- Base64 round-trip
+SELECT crypto_decode(crypto_encode(x'CAFE', 'base64'), 'base64');
+```
+
+## Fuzzy Extension
+
+The fuzzy extension provides string-similarity, distance, and phonetic functions, compatible with [sqlean-fuzzy](https://github.com/nalgeon/sqlean/blob/main/docs/fuzzy.md).
+
+### Functions
+
+| Function | Parameters | Return Type | Description |
+|----------|-----------|-------------|-------------|
+| `fuzzy_editdist(a, b)` | TEXT, TEXT | INTEGER | Spellcheck-style edit distance |
+| `fuzzy_leven(a, b)` | TEXT, TEXT | INTEGER | Levenshtein distance |
+| `fuzzy_damlev(a, b)` | TEXT, TEXT | INTEGER | Damerau-Levenshtein distance |
+| `fuzzy_osadist(a, b)` | TEXT, TEXT | INTEGER | Optimal string alignment distance |
+| `fuzzy_hamming(a, b)` | TEXT, TEXT | INTEGER | Hamming distance |
+| `fuzzy_jarowin(a, b)` | TEXT, TEXT | REAL | Jaro-Winkler similarity |
+| `fuzzy_soundex(s)` | TEXT | TEXT | Soundex phonetic code |
+| `fuzzy_rsoundex(s)` | TEXT | TEXT | Refined Soundex code |
+| `fuzzy_caver(s)` | TEXT | TEXT | Caverphone phonetic code |
+| `fuzzy_phonetic(s)` | TEXT | TEXT | US Census phonetic code |
+| `fuzzy_translit(s)` | TEXT | TEXT | Transliterate Unicode text to ASCII |
+| `fuzzy_script(s)` | TEXT | INTEGER | Identify the writing script of the text |
+| `phonetics(a, b)` | TEXT, TEXT | INTEGER | 1 if two strings are phonetically equal |
+
+```sql
+-- Distance between two strings
+SELECT fuzzy_leven('awesome', 'aewsime');
+-- 3
+
+-- Phonetic encoding
+SELECT fuzzy_soundex('Robert');
+-- 'R163'
+```
+
+## IP Address Extension
+
+The ipaddr extension provides functions for working with IPv4 and IPv6 addresses and networks.
+
+### Functions
+
+| Function | Parameters | Return Type | Description |
+|----------|-----------|-------------|-------------|
+| `ipfamily(ip)` | TEXT | INTEGER | Returns 4 for IPv4 or 6 for IPv6 |
+| `iphost(ip)` | TEXT | TEXT | The host portion of an address (strips any netmask) |
+| `ipmasklen(cidr)` | TEXT | INTEGER | The prefix (mask) length of a CIDR network |
+| `ipnetwork(cidr)` | TEXT | TEXT | The network address of a CIDR value |
+| `ipcontains(network, ip)` | TEXT, TEXT | INTEGER | 1 if the CIDR network contains the given address |
+
+```sql
+SELECT ipfamily('192.168.1.1');            -- 4
+SELECT ipnetwork('192.168.1.42/24');       -- '192.168.1.0/24'
+SELECT ipcontains('10.0.0.0/8', '10.1.2.3'); -- 1
+```
+
 ## generate_series
 
 The `generate_series` table-valued function generates a sequence of integers.

--- a/docs/sql-reference/functions/scalar.mdx
+++ b/docs/sql-reference/functions/scalar.mdx
@@ -62,6 +62,8 @@ Scalar functions accept one or more arguments and return a single value. They ca
 | `unhex(X)` | Converts hexadecimal string X to a blob. Returns NULL if X contains non-hex characters |
 | `unhex(X, Y)` | Like `unhex(X)`, but characters in Y are silently ignored in X |
 | `unicode(X)` | Returns the Unicode code point of the first character of string X |
+| `unistr(X)` | Evaluates PostgreSQL-style Unicode escapes in X (`\XXXX`, `\+XXXXXX`, `\uXXXX`, `\UXXXXXXXX`, `\\`) |
+| `unistr_quote(X)` | Returns X as a quoted string literal with non-ASCII characters written as `unistr` escapes |
 | `upper(X)` | Returns an uppercase copy of string X |
 | `zeroblob(N)` | Returns a blob consisting of N zero bytes |
 
@@ -115,6 +117,7 @@ Scalar functions accept one or more arguments and return a single value. They ca
 | `total_changes()` | Returns the total number of rows modified since the database connection was opened |
 | `sqlite_version()` | Returns the version string `"3.42.0"` |
 | `sqlite_source_id()` | Returns the source identifier string for the SQLite-compatible engine |
+| `turso_version()` | Returns the Turso engine version string (e.g. `"0.7.0"`) |
 | `load_extension(X)` | Loads a Turso-native extension from the shared library at path X |
 
 ## Detailed Descriptions and Examples
@@ -522,6 +525,14 @@ Returns the SQLite-compatible version string.
 
 ```sql
 SELECT sqlite_version();  -- '3.42.0'
+```
+
+### turso_version()
+
+Returns the version string of the Turso engine.
+
+```sql
+SELECT turso_version();  -- e.g. '0.7.0'
 ```
 
 ### load_extension(X)

--- a/docs/sql-reference/functions/vector.mdx
+++ b/docs/sql-reference/functions/vector.mdx
@@ -125,6 +125,28 @@ Use this format for extremely compact representations. Eight dimensions are pack
 SELECT vector1bit('[1, 0, 1, 1, 0, 0, 1, 0]');
 ```
 
+### vector32_sparse
+
+Creates a 32-bit floating-point **sparse** vector from a JSON array. Only non-zero components are stored, which is efficient for high-dimensional vectors that are mostly zero.
+
+```sql
+vector32_sparse(json_array)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `json_array` | TEXT | A JSON array of numbers, typically with many zeros |
+
+**Returns:** BLOB -- the vector in 32-bit float sparse binary format.
+
+```sql
+SELECT vector32_sparse('[0.0, 0.0, 1.5, 0.0, 0.0, 2.5]');
+```
+
+<Info>
+Sparse vectors can be indexed with the experimental sparse vector index method (enable `--experimental-index-method`). See [CREATE INDEX](/docs/sql-reference/statements/create-index).
+</Info>
+
 ---
 
 ## Distance Functions
@@ -390,7 +412,7 @@ SELECT vector_extract(
 ```
 
 <Note>
-Vector indexes are not yet supported. All similarity searches use a linear scan over the table. For large datasets, consider limiting search to a subset of rows with a WHERE clause.
+By default, similarity searches use a linear scan over the table. An experimental sparse vector index method is available behind the `--experimental-index-method` flag; without it, consider limiting search to a subset of rows with a WHERE clause for large datasets.
 </Note>
 
 ## See Also

--- a/docs/sql-reference/functions/window.mdx
+++ b/docs/sql-reference/functions/window.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Window
 Window functions perform calculations across a set of rows that are related to the current row. Unlike aggregate functions with GROUP BY, window functions do not collapse rows into a single output row. Every input row produces a corresponding output row, with the window function result appended.
 
 <Info>
-Turso supports aggregate functions used as window functions with the default frame definition. Custom frame specifications (ROWS, RANGE, or GROUPS with explicit bounds) and dedicated window functions (row_number, rank, dense_rank, ntile, lag, lead, first_value, last_value, nth_value) are not yet supported.
+Turso supports aggregate functions used as window functions with the default frame definition, the `row_number()` ranking function, and the `FILTER (WHERE ...)` clause. The remaining dedicated window functions (`rank`, `dense_rank`, `ntile`, `lag`, `lead`, `first_value`, `last_value`, `nth_value`) and custom frame specifications (ROWS, RANGE, or GROUPS with explicit bounds) are not yet supported.
 </Info>
 
 ## Syntax
@@ -54,6 +54,42 @@ Any aggregate function can be used as a window function by adding an OVER clause
 | `max(expression)` | Maximum value in the frame |
 | `total(expression)` | Sum as REAL (returns 0.0 for empty frames instead of NULL) |
 | `group_concat(expression, separator)` | Concatenation of values in the frame |
+
+## Ranking Functions
+
+### row_number()
+
+Assigns a sequential integer (starting at 1) to each row within its partition, in the order defined by the window's `ORDER BY`. This is the one dedicated ranking function supported in Turso.
+
+```sql
+SELECT
+    department,
+    name,
+    salary,
+    ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary DESC) AS rank_in_dept
+FROM employees;
+```
+
+| department | name | salary | rank_in_dept |
+|------------|------|--------|--------------|
+| Engineering | Alice | 90000 | 1 |
+| Engineering | Bob | 85000 | 2 |
+| Engineering | Carol | 75000 | 3 |
+| Marketing | Dave | 70000 | 1 |
+| Marketing | Eve | 60000 | 2 |
+
+## FILTER (WHERE ...)
+
+A `FILTER (WHERE ...)` clause restricts which rows an aggregate window function includes, without affecting the rows returned by the query.
+
+```sql
+SELECT
+    department,
+    name,
+    salary,
+    SUM(salary) FILTER (WHERE salary > 70000) OVER (PARTITION BY department) AS high_earner_total
+FROM employees;
+```
 
 ## PARTITION BY
 
@@ -240,7 +276,6 @@ The following window function features are not yet supported in Turso:
 
 | Feature | Status |
 |---------|--------|
-| `row_number()` | Not supported |
 | `rank()` | Not supported |
 | `dense_rank()` | Not supported |
 | `ntile(N)` | Not supported |
@@ -255,7 +290,8 @@ The following window function features are not yet supported in Turso:
 | Custom frame: `RANGE BETWEEN ... AND ...` | Not supported |
 | Custom frame: `GROUPS BETWEEN ...` | Not supported |
 | `EXCLUDE` clause | Not supported |
-| `FILTER (WHERE ...)` on window functions | Not supported |
+
+`row_number()` and `FILTER (WHERE ...)` are supported — see the sections above.
 
 ## See Also
 

--- a/docs/sql-reference/pragmas.mdx
+++ b/docs/sql-reference/pragmas.mdx
@@ -318,6 +318,31 @@ PRAGMA ignore_check_constraints = 1;   -- disable CHECK constraints
 PRAGMA ignore_check_constraints = 0;   -- enable CHECK constraints
 ```
 
+### data_sync_retry
+
+Controls whether Turso retries a disk sync (fsync) after a failure instead of treating it as fatal.
+
+```sql
+PRAGMA data_sync_retry = 1;   -- retry on sync failure
+PRAGMA data_sync_retry = 0;   -- do not retry (default)
+```
+
+### require_where
+
+<Info>
+**Turso Extension**: a safety pragma with no SQLite equivalent.
+</Info>
+
+When enabled, Turso rejects any `UPDATE` or `DELETE` that does not include a `WHERE` clause, guarding against accidental full-table modifications. `i_am_a_dummy` is an alias that enables the same behavior.
+
+```sql
+PRAGMA require_where = 1;
+DELETE FROM users;            -- rejected: no WHERE clause
+DELETE FROM users WHERE id = 1;  -- allowed
+
+PRAGMA i_am_a_dummy = 1;      -- equivalent to require_where = 1
+```
+
 ## Integrity Checks
 
 ### integrity_check
@@ -352,6 +377,28 @@ PRAGMA wal_checkpoint;
 ```
 
 A checkpoint writes pages from the WAL file back to the database file.
+
+## MVCC Tuning
+
+<Info>
+**Turso Extension**: these pragmas apply only when MVCC mode is enabled (`PRAGMA journal_mode = mvcc`).
+</Info>
+
+### mvcc_checkpoint_threshold
+
+Sets the amount of committed work that accumulates before Turso triggers an MVCC checkpoint.
+
+```sql
+PRAGMA mvcc_checkpoint_threshold = 1000;
+```
+
+### mvcc_gc_threshold
+
+Sets the threshold that controls how aggressively Turso garbage-collects obsolete MVCC row versions.
+
+```sql
+PRAGMA mvcc_gc_threshold = 1000;
+```
 
 ## Change Data Capture
 

--- a/docs/sql-reference/statements/create-index.mdx
+++ b/docs/sql-reference/statements/create-index.mdx
@@ -12,7 +12,7 @@ Create an index on a table to improve query performance for lookups, joins, and 
 
 ```sql
 CREATE [UNIQUE] INDEX [IF NOT EXISTS] [schema-name.]index-name
-    ON table-name (column-or-expr [ASC|DESC], ...)
+    ON table-name (column-or-expr [COLLATE collation-name] [ASC|DESC], ...)
     [WHERE filter-expression];
 ```
 
@@ -30,6 +30,7 @@ CREATE [UNIQUE] INDEX [IF NOT EXISTS] [schema-name.]index-name
 | `index-name` | A unique name for the index within the database. |
 | `table-name` | The table to index. |
 | `column-or-expr` | A column name or an expression to include in the index. Multiple entries are separated by commas. |
+| `COLLATE collation-name` | An optional collation sequence applied to the indexed column (e.g. `NOCASE`). |
 | `ASC` / `DESC` | Sort direction for the indexed column. Default is `ASC`. |
 | `WHERE filter-expression` | An optional filter that creates a partial index. Only rows matching the expression are included in the index. |
 
@@ -178,5 +179,6 @@ CREATE INDEX idx_pending_tasks ON tasks (assignee, due_date)
 ## See Also
 
 - [DROP INDEX](/docs/sql-reference/statements/drop-index) for removing indexes
+- [REINDEX](/docs/sql-reference/statements/reindex) for rebuilding indexes
 - [CREATE TABLE](/docs/sql-reference/statements/create-table) for inline UNIQUE and PRIMARY KEY constraints
 - [EXPLAIN](/docs/sql-reference/statements/explain) for verifying index usage in query plans

--- a/docs/sql-reference/statements/create-table.mdx
+++ b/docs/sql-reference/statements/create-table.mdx
@@ -196,6 +196,8 @@ Specifies the collation sequence used for text comparisons and sorting on the co
 | `NOCASE` | Case-insensitive comparison for ASCII characters |
 | `RTRIM` | Like `BINARY`, but ignores trailing spaces |
 
+Turso also resolves locale-aware collations and custom collations registered on the connection. An unknown collation name now raises a `no such collation sequence` error rather than being silently ignored.
+
 ```sql
 CREATE TABLE contacts (
     id INTEGER PRIMARY KEY,
@@ -356,9 +358,16 @@ The following CREATE TABLE features are not yet supported:
 |---------|-------|
 | `CREATE TEMPORARY TABLE` | Temporary tables are not supported |
 | `CREATE TABLE ... AS SELECT` | Creating a table from a query result is not supported |
-| `WITHOUT ROWID` | WITHOUT ROWID tables are not supported |
-| `GENERATED ALWAYS AS` | Generated (computed) columns are not supported |
 | `ON CONFLICT` clause on column constraints | The column-level ON CONFLICT clause (e.g., `NOT NULL ON CONFLICT REPLACE`) is not supported. Use the [INSERT ... ON CONFLICT](/docs/sql-reference/statements/upsert) syntax instead |
+
+### Experimental Features
+
+The following are available behind [experimental feature flags](/docs/sql-reference/experimental-features):
+
+| Feature | Flag | Notes |
+|---------|------|-------|
+| `WITHOUT ROWID` | `--experimental-without-rowid` | WITHOUT ROWID tables have limitations; see the experimental features page |
+| `GENERATED ALWAYS AS` | `--experimental-generated-columns` | Virtual generated (computed) columns only; stored columns are not yet supported |
 
 ## Examples
 

--- a/docs/sql-reference/statements/create-trigger.mdx
+++ b/docs/sql-reference/statements/create-trigger.mdx
@@ -6,10 +6,6 @@ sidebarTitle: CREATE TRIGGER
 
 # CREATE TRIGGER
 
-<Info>
-This feature is experimental and must be [enabled before use](/docs/sql-reference/experimental-features).
-</Info>
-
 Create a trigger that automatically executes one or more SQL statements when a row is inserted into, updated in, or deleted from a table.
 
 ## Syntax
@@ -39,7 +35,7 @@ A trigger defines a set of SQL statements that run automatically when a specifie
 | `IF NOT EXISTS` | Prevents an error if a trigger with the same name already exists. |
 | `schema-name` | The name of the attached database containing the trigger. Defaults to the main database if omitted. Cannot be used with `TEMPORARY`. |
 | `trigger-name` | A unique name for the trigger within the database. |
-| `BEFORE` / `AFTER` / `INSTEAD OF` | When the trigger fires relative to the triggering event. Default is `BEFORE`. |
+| `BEFORE` / `AFTER` / `INSTEAD OF` | When the trigger fires relative to the triggering event. Default is `BEFORE`. `INSTEAD OF` triggers are not yet supported. |
 | `INSERT` / `UPDATE` / `DELETE` | The data modification event that fires the trigger. |
 | `OF column-name, ...` | For UPDATE triggers only. Restricts the trigger to fire only when the specified columns are modified. |
 | `table-name` | The table (or view, for INSTEAD OF triggers) that the trigger monitors. |
@@ -65,9 +61,11 @@ An `AFTER` trigger fires after the triggering statement has modified the row. Us
 
 ### INSTEAD OF Triggers
 
-An `INSTEAD OF` trigger can only be created on a view. It fires in place of the triggering INSERT, UPDATE, or DELETE, allowing you to make views writable.
+<Warning>
+`INSTEAD OF` triggers are not yet supported in Turso. `CREATE TRIGGER ... INSTEAD OF ...` returns an error.
+</Warning>
 
-- The actual INSERT, UPDATE, or DELETE on the view does not execute. The trigger body is responsible for performing the desired changes on the underlying tables.
+In SQLite, an `INSTEAD OF` trigger can only be created on a view and fires in place of the triggering INSERT, UPDATE, or DELETE, allowing you to make views writable. Turso parses this syntax but does not yet execute it.
 
 ## Row References
 

--- a/docs/sql-reference/statements/reindex.mdx
+++ b/docs/sql-reference/statements/reindex.mdx
@@ -1,0 +1,60 @@
+---
+title: REINDEX
+description: Rebuild indexes from scratch
+sidebarTitle: REINDEX
+---
+
+# REINDEX
+
+The REINDEX statement deletes and recreates indexes from scratch. It is useful when a collation sequence definition has changed, or to rebuild an index that may have become out of date.
+
+## Syntax
+
+```sql
+REINDEX;
+REINDEX collation-name;
+REINDEX [schema-name.]table-name;
+REINDEX [schema-name.]index-name;
+```
+
+## Description
+
+| Form | Description |
+|------|-------------|
+| `REINDEX` | Rebuild all indexes in all attached databases |
+| `REINDEX collation-name` | Rebuild every index that uses the named collation sequence |
+| `REINDEX table-name` | Rebuild all indexes associated with the named table |
+| `REINDEX index-name` | Rebuild the named index |
+
+When a single unqualified name is given, Turso resolves it in the order **collation → table → index**: if the name matches a collation sequence, all indexes using that collation are rebuilt; otherwise it is treated as a table or index name.
+
+## Examples
+
+```sql
+-- Rebuild every index in the database
+REINDEX;
+
+-- Rebuild all indexes on a table
+REINDEX orders;
+
+-- Rebuild a single index
+REINDEX idx_customer;
+
+-- Rebuild all indexes that use a collation
+REINDEX NOCASE;
+```
+
+## Limitations
+
+REINDEX returns an error in the following cases:
+
+- When the connection is in MVCC mode (`journal_mode=mvcc`).
+- On `WITHOUT ROWID` tables.
+- For custom index methods that have no backing B-tree, such as FTS and vector indexes.
+- When `PRAGMA query_only` is enabled.
+
+## See Also
+
+- [CREATE INDEX](/docs/sql-reference/statements/create-index) for creating indexes
+- [DROP INDEX](/docs/sql-reference/statements/drop-index) for removing indexes
+- [ANALYZE](/docs/sql-reference/statements/analyze) for collecting index statistics

--- a/docs/sql-reference/statements/select.mdx
+++ b/docs/sql-reference/statements/select.mdx
@@ -474,7 +474,7 @@ function_name() OVER (
 Standard aggregate functions (`SUM`, `AVG`, `COUNT`, `MIN`, `MAX`, `TOTAL`, `GROUP_CONCAT`) can all be used as window functions.
 
 <Info>
-Window functions in Turso use the default frame definition (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW). Custom frame specifications (ROWS, RANGE, GROUPS with explicit bounds) are not supported. Built-in ranking functions (row_number, rank, dense_rank) are not yet available.
+Window functions in Turso use the default frame definition (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW). Custom frame specifications (ROWS, RANGE, GROUPS with explicit bounds) are not supported. The `row_number()` ranking function and the `FILTER (WHERE ...)` clause are supported; other ranking and navigation functions (`rank`, `dense_rank`, `lag`, `lead`, and so on) are not yet available.
 </Info>
 
 ## Set Operations

--- a/docs/sql-reference/statements/transactions.mdx
+++ b/docs/sql-reference/statements/transactions.mdx
@@ -16,7 +16,10 @@ BEGIN [DEFERRED | IMMEDIATE | EXCLUSIVE] [TRANSACTION];
 COMMIT [TRANSACTION];
 END [TRANSACTION];
 
-ROLLBACK [TRANSACTION];
+ROLLBACK [TRANSACTION] [TO [SAVEPOINT] savepoint-name];
+
+SAVEPOINT savepoint-name;
+RELEASE [SAVEPOINT] savepoint-name;
 ```
 
 ## BEGIN
@@ -104,8 +107,35 @@ COMMIT;
 ROLLBACK;
 ```
 
+Each connection can have at most one active top-level transaction at a time. For finer-grained rollback within a transaction, use savepoints.
+
+## Savepoints
+
+Savepoints are named markers within a transaction that let you roll back part of the work without aborting the whole transaction. They can be nested.
+
+| Statement | Description |
+|-----------|-------------|
+| `SAVEPOINT name` | Establishes a new savepoint with the given name |
+| `RELEASE [SAVEPOINT] name` | Removes the savepoint (and any savepoints created after it), keeping its changes as part of the enclosing transaction |
+| `ROLLBACK [TRANSACTION] TO [SAVEPOINT] name` | Undoes all changes made since the savepoint, but keeps the savepoint and the transaction open |
+
+```sql
+BEGIN;
+INSERT INTO accounts (name, balance) VALUES ('Alice', 1000);
+
+SAVEPOINT before_bonus;
+UPDATE accounts SET balance = balance + 500 WHERE name = 'Alice';
+
+-- Undo just the bonus, keep the insert
+ROLLBACK TO before_bonus;
+
+-- Discard the savepoint and keep the rest
+RELEASE before_bonus;
+COMMIT;
+```
+
 <Info>
-Turso does not support SAVEPOINT or nested transactions. Each connection can have at most one active transaction at a time.
+While a write statement on the same connection is still in progress, `SAVEPOINT`, `RELEASE`, and `ROLLBACK TO` may return `SQLITE_BUSY`.
 </Info>
 
 ## BEGIN CONCURRENT


### PR DESCRIPTION
Updates the SQL reference docs to match Turso 0.7. All changes were verified against the v0.7.0 source (`COMPAT.md`, `core/function.rs`, the parser AST, and `cli/`).

## Functions
- `window`: document that `row_number()` and `FILTER (WHERE ...)` are supported; remove them from the "not supported" list
- `scalar`: add `unistr`, `unistr_quote`, `turso_version()`
- `vector`: add `vector32_sparse`; note the experimental sparse vector index

## Statements
- add a **REINDEX** page
- `transactions`: document `SAVEPOINT` / `RELEASE` / `ROLLBACK TO`
- `create-trigger`: drop the "experimental" banner (triggers are stable); note that `INSTEAD OF` triggers are not yet supported
- `create-table`: move `WITHOUT ROWID` and `GENERATED ALWAYS AS` from "unsupported" to the experimental-flags list; note locale/custom collations
- `create-index`: document `COLLATE` and link REINDEX
- `select`: correct the window ranking note (`row_number()` is available)

## Reference & CLI
- `experimental-features`: triggers are no longer experimental; add `generated_columns`, `without_rowid`, `mvcc_passive_checkpoint`
- `extensions`: document the crypto, fuzzy, and ipaddr extensions
- `pragmas`: add `data_sync_retry`, `require_where` / `i_am_a_dummy`, `mvcc_checkpoint_threshold`, `mvcc_gc_threshold`
- `cli/command-line-options`: remove `--experimental-triggers`; add `--experimental-generated-columns`, `--experimental-without-rowid`, `--experimental-multiprocess-wal`, `--experimental-mvcc-passive-checkpoint`, and `--mvcc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)