### PR TITLE
testing/sqltests: replace param-hoisting timing test with bytecode snapshot

### DIFF
--- a/testing/sqltests/tests/snapshot_tests/expressions/expressions.sqltest
+++ b/testing/sqltests/tests/snapshot_tests/expressions/expressions.sqltest
@@ -1,0 +1,21 @@
+# Expression Evaluation Bytecode Snapshots
+# These snapshots capture EXPLAIN output to pin down where expressions are
+# evaluated: constant subexpressions (including bound parameters, which are
+# constant within a single execution) must be hoisted out of scan loops.
+
+@database :memory:
+@skip-file-if mvcc "mvcc has slightly different cursor ids, so skipping it for now"
+
+setup schema {
+    CREATE TABLE t (x);
+}
+
+# Parameters are constant within a query, so the WHERE clause below is fully
+# constant: the zeroblob()/length() calls and the comparison must be emitted
+# in the prologue, before the Rewind/Next scan loop, and evaluated exactly
+# once. If they show up inside the loop, a query binding a large blob would
+# re-allocate it for every row.
+@setup schema
+snapshot constant-parameter-hoisted-out-of-scan {
+    SELECT COUNT(*) FROM t WHERE LENGTH(zeroblob(?)) = ?;
+}

--- a/testing/sqltests/tests/snapshot_tests/expressions/snapshots/expressions__constant-parameter-hoisted-out-of-scan.snap
+++ b/testing/sqltests/tests/snapshot_tests/expressions/snapshots/expressions__constant-parameter-hoisted-out-of-scan.snap
@@ -1,0 +1,34 @@
+---
+source: expressions.sqltest
+expression: SELECT COUNT(*) FROM t WHERE LENGTH(zeroblob(?)) = ?;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4        p5  comment
+   0  Init          0  11   0             0  Start at 11
+   1  Null          0   2   0             0  r[2]=NULL
+   2  OpenRead      0   2   0  k(2,B)     0  table=t, root=2, iDb=0
+   3  Ne            4   5   7             0  if r[4]!=r[5] goto 7
+   4  Rewind        0   7   0             0  Rewind table t
+   5    AggStep     0   8   2  count      0  accum=r[2] step(r[8])
+   6  Next          0   5   0             0
+   7  AggFinal      0   2   0  count      0  accum=r[2]
+   8  Copy          2   1   0             0  r[1]=r[2]
+   9  ResultRow     1   1   0             0  output=r[1]
+  10  Halt          0   0   0             0
+  11  Transaction   0   1   1             0  iDb=0 tx_mode=Read
+  12  Variable      1   7   0             0  r[7]=parameter(1)
+  13  Function      0   7   6  zeroblob   0  r[6]=func(r[7])
+  14  Function      0   6   4  length     0  r[4]=func(r[6])
+  15  Variable      2   5   0             0  r[5]=parameter(2)
+  16  Integer       1   8   0             0  r[8]=1
+  17  Goto          0   1   0             0

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -909,40 +909,6 @@ fn test_many_columns(tmp_db: TempDatabase) {
     );
 }
 
-#[turso_macros::test]
-fn test_eval_param_only_once(tmp_db: TempDatabase) {
-    let conn = tmp_db.connect_limbo();
-    conn.execute("CREATE TABLE t(x)").unwrap();
-    conn.execute("INSERT INTO t SELECT value FROM generate_series(1, 10000)")
-        .unwrap();
-    let mut stmt = conn
-        .query("SELECT COUNT(*) FROM t WHERE LENGTH(zeroblob(?)) = ?")
-        .unwrap()
-        .unwrap();
-    stmt.bind_at(
-        1.try_into().unwrap(),
-        turso_core::Value::from_i64(100_000_000),
-    )
-    .unwrap();
-    stmt.bind_at(
-        2.try_into().unwrap(),
-        turso_core::Value::from_i64(100_000_000),
-    )
-    .unwrap();
-    let start_time = std::time::Instant::now();
-    stmt.run_with_row_callback(|row| {
-        let values = row.get_values().cloned().collect::<Vec<_>>();
-        assert_eq!(values, vec![turso_core::Value::from_i64(10000)]);
-        Ok(())
-    })
-    .unwrap();
-
-    let end_time = std::time::Instant::now();
-    let elapsed = end_time.duration_since(start_time);
-    // the test will allocate 10^8 * 10^4 bytes in case if parameter will be evaluated for every row
-    assert!(elapsed < std::time::Duration::from_millis(500));
-}
-
 /// Regression test for https://github.com/tursodatabase/turso/issues/5232
 /// SELECT with more than SQLITE_MAX_COLUMN (2000) columns should return an error,
 /// not panic from u16 overflow.


### PR DESCRIPTION
test_eval_param_only_once guarded against re-evaluating bound parameters per row (https://github.com/tursodatabase/turso/commit/b3380bc398776d36c78d572be76cea1994f12086) by asserting wall-clock time, which is flaky on loaded CI runners regardless of the threshold. The property is directly
visible in bytecode: the zeroblob()/length() calls and the comparison must sit in the prologue, outside the Rewind/Next scan loop. Pin that with an EXPLAIN snapshot instead and drop the timing test.