### PR TITLE
Initial pass on SQL dialect support

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -6,6 +6,7 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use tracing::trace;
+use turso_core::SqliteDialect;
 use turso_core::{CheckpointMode, DatabaseOpts, LimboError, Value};
 use turso_ext::ScalarFunction;
 use turso_ext::Value as ExtValue;
@@ -394,6 +395,7 @@ pub unsafe extern "C" fn sqlite3_open(
         turso_core::OpenFlags::default(),
         default_db_opts(),
         None,
+        Arc::new(SqliteDialect),
     ) {
         Ok(db) => {
             let conn = db.connect().unwrap();
@@ -554,7 +556,8 @@ pub unsafe extern "C" fn sqlite3_open_v2(
     let use_shared_memory = use_memory && cache_shared;
 
     let (io, db) = if use_shared_memory {
-        match turso_core::Database::open_shared_memory(&effective_filename) {
+        match turso_core::Database::open_shared_memory(&effective_filename, Arc::new(SqliteDialect))
+        {
             Ok(db) => (db.io.clone(), db),
             Err(e) => {
                 trace!("error opening shared memory database {effective_filename}: {e:?}");
@@ -569,6 +572,7 @@ pub unsafe extern "C" fn sqlite3_open_v2(
             turso_core::OpenFlags::default(),
             default_db_opts(),
             None,
+            Arc::new(SqliteDialect),
         ) {
             Ok(db) => (io, db),
             Err(e) => {
@@ -587,6 +591,7 @@ pub unsafe extern "C" fn sqlite3_open_v2(
             turso_core::OpenFlags::default(),
             default_db_opts(),
             None,
+            Arc::new(SqliteDialect),
         ) {
             Ok(db) => (io, db),
             Err(e) => {

--- a/bindings/java/rs_src/turso_db.rs
+++ b/bindings/java/rs_src/turso_db.rs
@@ -5,6 +5,7 @@ use jni::objects::{JByteArray, JObject, JString};
 use jni::sys::{jint, jlong};
 use jni::JNIEnv;
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 use turso_core::{Database, DatabaseOpts, EncryptionKey, EncryptionOpts, OpenFlags};
 
 struct TursoDB {
@@ -78,7 +79,7 @@ pub extern "system" fn Java_tech_turso_core_TursoDB_openUtf8<'local>(
         }
     };
 
-    let db = match Database::open_file(io.clone(), &path) {
+    let db = match Database::open_file(io.clone(), &path, Arc::new(SqliteDialect)) {
         Ok(db) => db,
         Err(e) => {
             set_err_msg_and_throw_exception(&mut env, obj, TURSO_ETC, e.to_string());
@@ -167,6 +168,7 @@ pub extern "system" fn Java_tech_turso_core_TursoDB_openWithEncryptionUtf8<'loca
         OpenFlags::Create,
         db_opts,
         encryption_opts,
+        Arc::new(SqliteDialect),
     ) {
         Ok(db) => db,
         Err(e) => {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -24,6 +24,7 @@ use std::{
 };
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::format::FmtSpan;
+use turso_core::SqliteDialect;
 
 /// Shared ownership of a `turso_core::Statement` that can be explicitly finalized.
 ///
@@ -332,6 +333,7 @@ fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
         flags,
         core_opts,
         encryption_opts,
+        Arc::new(SqliteDialect),
     )
     .map_err(|e| to_generic_error(&format!("failed to open database {}", db.path), e))?;
 

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -35,7 +35,8 @@ use std::{
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use turso_core::{
-    io_error, Connection, Database, LimboError, Numeric, OpenFlags, QueryMode, Statement, Value,
+    io_error, Connection, Database, LimboError, Numeric, OpenFlags, QueryMode, SqliteDialect,
+    Statement, Value,
 };
 
 #[derive(Parser, Debug)]
@@ -256,7 +257,7 @@ impl Limbo {
         let db_file = normalize_db_path(db_file);
 
         let (io, conn) = if db_file.starts_with("file:") {
-            Connection::from_uri(&db_file, db_opts)?
+            Connection::from_uri(&db_file, db_opts, Arc::new(SqliteDialect))?
         } else {
             let flags = if opts.readonly {
                 OpenFlags::default().union(OpenFlags::ReadOnly)
@@ -269,6 +270,7 @@ impl Limbo {
                 flags,
                 db_opts.turso_cli(),
                 None,
+                Arc::new(SqliteDialect),
             )?;
             let conn = db.connect()?;
             (io, conn)
@@ -468,7 +470,8 @@ impl Limbo {
     fn open_db(&mut self, path: &str, vfs_name: Option<&str>) -> anyhow::Result<()> {
         self.conn.close()?;
         let (io, db) = if let Some(vfs_name) = vfs_name {
-            self.conn.open_new(path, vfs_name)?
+            self.conn
+                .open_new(path, vfs_name, Arc::new(SqliteDialect))?
         } else {
             let io = {
                 match path {
@@ -484,6 +487,7 @@ impl Limbo {
                     OpenFlags::default(),
                     self.db_opts,
                     None,
+                    Arc::new(SqliteDialect),
                 )?,
             )
         };
@@ -2028,7 +2032,7 @@ impl Limbo {
             anyhow::bail!("Refusing to overwrite existing file: {output_file}");
         }
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new()?);
-        let db = Database::open_file(io.clone(), output_file)?;
+        let db = Database::open_file(io.clone(), output_file, Arc::new(SqliteDialect))?;
         let target = db.connect()?;
 
         let mut applier = ApplyWriter::new(&target);

--- a/cli/mcp_server.rs
+++ b/cli/mcp_server.rs
@@ -8,7 +8,9 @@ use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-use turso_core::{Connection, Database, DatabaseOpts, Numeric, OpenFlags, Value as DbValue};
+use turso_core::{
+    Connection, Database, DatabaseOpts, Numeric, OpenFlags, SqliteDialect, Value as DbValue,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct JsonRpcRequest {
@@ -408,7 +410,7 @@ impl TursoMcpServer {
 
         // Open the new database connection
         let conn = if path == ":memory:" || path.contains([':', '?', '&', '#']) {
-            match Connection::from_uri(&path, DatabaseOpts::default()) {
+            match Connection::from_uri(&path, DatabaseOpts::default(), Arc::new(SqliteDialect)) {
                 Ok((_io, c)) => c,
                 Err(e) => return format!("Failed to open database '{path}': {e}"),
             }
@@ -419,6 +421,7 @@ impl TursoMcpServer {
                 OpenFlags::default(),
                 DatabaseOpts::new().with_autovacuum(false),
                 None,
+                Arc::new(SqliteDialect),
             ) {
                 Ok((_io, db)) => match db.connect() {
                     Ok(c) => c,

--- a/cli/mvcc_repl.rs
+++ b/cli/mvcc_repl.rs
@@ -37,7 +37,7 @@
 use anyhow::Context as _;
 use rustyline::DefaultEditor;
 use std::{collections::HashMap, sync::Arc};
-use turso_core::{Connection, Database, DatabaseOpts, LimboError, OpenFlags, Value};
+use turso_core::{Connection, Database, DatabaseOpts, LimboError, OpenFlags, SqliteDialect, Value};
 
 pub fn run(path: &str, passive_checkpoint: bool) -> anyhow::Result<()> {
     let interactive_stdin = std::io::IsTerminal::is_terminal(&std::io::stdin());
@@ -97,6 +97,7 @@ fn open_mvcc_db(path: &str, passive_checkpoint: bool) -> anyhow::Result<Arc<Data
         OpenFlags::default(),
         DatabaseOpts::default().with_experimental_mvcc_passive_checkpoint(passive_checkpoint),
         None,
+        Arc::new(SqliteDialect),
     )
     .context("failed to open database")?;
 

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -106,6 +106,7 @@ fn database_open_with_allocator_uses_allocator_for_mvstore_skiplist() {
         None,
         None,
         alloc,
+        StdArc::new(crate::SqliteDialect),
     )
     .unwrap();
     let conn = db.connect().unwrap();

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -2,6 +2,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(not(feature = "codspeed"))]
 use pprof::criterion::{Output, PProfProfiler};
+use turso_core::SqliteDialect;
 
 #[cfg(feature = "codspeed")]
 use codspeed_criterion_compat::{
@@ -83,7 +84,12 @@ fn bench_open(criterion: &mut Criterion) {
     if !std::fs::exists("../testing/system/schema_5k.db").unwrap() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
+        let db = Database::open_file(
+            io,
+            "../testing/system/schema_5k.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let conn = db.connect().unwrap();
 
         for i in 0..5000 {
@@ -99,7 +105,12 @@ fn bench_open(criterion: &mut Criterion) {
         b.iter(|| {
             #[allow(clippy::arc_with_non_send_sync)]
             let io = Arc::new(PlatformIO::new().unwrap());
-            let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
+            let db = Database::open_file(
+                io,
+                "../testing/system/schema_5k.db",
+                Arc::new(SqliteDialect),
+            )
+            .unwrap();
             let conn = db.connect().unwrap();
             conn.execute("SELECT * FROM table_0").unwrap();
         });
@@ -126,7 +137,12 @@ fn bench_alter(criterion: &mut Criterion) {
     if !std::fs::exists("../testing/system/schema_5k.db").unwrap() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
+        let db = Database::open_file(
+            io,
+            "../testing/system/schema_5k.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let conn = db.connect().unwrap();
 
         for i in 0..5000 {
@@ -141,7 +157,12 @@ fn bench_alter(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo_rename_table", ""), |b| {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
+        let db = Database::open_file(
+            io,
+            "../testing/system/schema_5k.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let conn = db.connect().unwrap();
         iter_custom_or_iter!(b, |iters| {
             (0..iters)
@@ -186,7 +207,12 @@ fn bench_alter(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo_rename_column", ""), |b| {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
+        let db = Database::open_file(
+            io,
+            "../testing/system/schema_5k.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let conn = db.connect().unwrap();
         iter_custom_or_iter!(b, |iters| {
             (0..iters)
@@ -232,7 +258,12 @@ fn bench_alter(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo_add_column", ""), |b| {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
+        let db = Database::open_file(
+            io,
+            "../testing/system/schema_5k.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let conn = db.connect().unwrap();
         iter_custom_or_iter!(b, |iters| {
             (0..iters)
@@ -277,7 +308,12 @@ fn bench_alter(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo_drop_column", ""), |b| {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
+        let db = Database::open_file(
+            io,
+            "../testing/system/schema_5k.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let conn = db.connect().unwrap();
         iter_custom_or_iter!(b, |iters| {
             (0..iters)
@@ -326,7 +362,8 @@ fn bench_prepare_query(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, "../testing/system/testing.db").unwrap();
+    let db =
+        Database::open_file(io, "../testing/system/testing.db", Arc::new(SqliteDialect)).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let queries = [
@@ -409,7 +446,8 @@ fn bench_execute_select_rows(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, "../testing/system/testing.db").unwrap();
+    let db =
+        Database::open_file(io, "../testing/system/testing.db", Arc::new(SqliteDialect)).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT * FROM users LIMIT ?`");
@@ -478,7 +516,8 @@ fn bench_execute_select_1(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, "../testing/system/testing.db").unwrap();
+    let db =
+        Database::open_file(io, "../testing/system/testing.db", Arc::new(SqliteDialect)).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT 1`");
@@ -531,7 +570,8 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, "../testing/system/testing.db").unwrap();
+    let db =
+        Database::open_file(io, "../testing/system/testing.db", Arc::new(SqliteDialect)).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT count() FROM users`");
@@ -593,7 +633,12 @@ fn bench_insert_rows(criterion: &mut Criterion) {
 
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), db_path.to_str().unwrap()).unwrap();
+        let db = Database::open_file(
+            io.clone(),
+            db_path.to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let limbo_conn = db.connect().unwrap();
         if disable_checkpoint {
             limbo_conn.wal_auto_actions_disable();
@@ -657,7 +702,12 @@ fn bench_insert_rows(criterion: &mut Criterion) {
 
         #[allow(clippy::arc_with_non_send_sync)]
         let mvcc_io = Arc::new(PlatformIO::new().unwrap());
-        let mvcc_db = Database::open_file(mvcc_io.clone(), mvcc_db_path.to_str().unwrap()).unwrap();
+        let mvcc_db = Database::open_file(
+            mvcc_io.clone(),
+            mvcc_db_path.to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let mvcc_conn = mvcc_db.connect().unwrap();
         mvcc_conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
         if disable_checkpoint {
@@ -792,7 +842,7 @@ fn bench_limbo(
     let io = Arc::new(PlatformIO::new().unwrap());
     let temp_dir = tempfile::tempdir().unwrap();
     let path = temp_dir.path().join("bench.db");
-    let db = Database::open_file(io, path.to_str().unwrap()).unwrap();
+    let db = Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
     let mut connecitons = Vec::new();
     {
         let conn = db.connect().unwrap();
@@ -878,7 +928,7 @@ fn bench_limbo_mvcc(
     let io = Arc::new(PlatformIO::new().unwrap());
     let temp_dir = tempfile::tempdir().unwrap();
     let path = temp_dir.path().join("bench.db");
-    let db = Database::open_file(io, path.to_str().unwrap()).unwrap();
+    let db = Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
     let mut connecitons = Vec::new();
     let conn0 = db.connect().unwrap();
     if mvcc {
@@ -1064,7 +1114,12 @@ fn bench_insert_randomblob(criterion: &mut Criterion) {
 
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), db_path.to_str().unwrap()).unwrap();
+        let db = Database::open_file(
+            io.clone(),
+            db_path.to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let limbo_conn = db.connect().unwrap();
 
         let mut stmt = limbo_conn.query("CREATE TABLE test(x)").unwrap().unwrap();

--- a/core/benches/count_benchmark.rs
+++ b/core/benches/count_benchmark.rs
@@ -22,7 +22,7 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
-use turso_core::{Database, PlatformIO, StepResult};
+use turso_core::{Database, PlatformIO, SqliteDialect, StepResult};
 
 #[cfg(not(target_family = "wasm"))]
 #[global_allocator]
@@ -105,7 +105,7 @@ fn bench_count(criterion: &mut Criterion) {
     for (label, sql) in QUERIES {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, path.to_str().unwrap()).unwrap();
+        let db = Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         // Cache sized to hold the ~15MB covering index (the queries' whole working set) so the
         // measurement is CPU-bound, while staying small enough to avoid paging under memory

--- a/core/benches/create_index_benchmark.rs
+++ b/core/benches/create_index_benchmark.rs
@@ -27,6 +27,7 @@ use criterion::{
 };
 #[cfg(not(feature = "codspeed"))]
 use pprof::criterion::{Output, PProfProfiler};
+use turso_core::SqliteDialect;
 
 #[cfg(feature = "codspeed")]
 use codspeed_criterion_compat::{
@@ -90,7 +91,7 @@ fn open_turso(temp_dir: &TempDir) -> (Arc<Database>, Arc<turso_core::Connection>
     let db_path = temp_dir.path().join("create_index_bench.db");
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let db = Database::open_file(io, db_path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
     exec_turso(&conn, &db, "PRAGMA journal_mode = 'mvcc'");
     exec_turso(&conn, &db, "PRAGMA mvcc_checkpoint_threshold = -1");

--- a/core/benches/fts_benchmark.rs
+++ b/core/benches/fts_benchmark.rs
@@ -11,6 +11,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(not(feature = "codspeed"))]
 use pprof::criterion::{Output, PProfProfiler};
+use turso_core::SqliteDialect;
 
 #[cfg(feature = "codspeed")]
 use codspeed_criterion_compat::{criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -95,6 +96,7 @@ fn setup_fts_db(temp_dir: &TempDir, row_count: usize) -> Arc<Database> {
         OpenFlags::default(),
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
     let conn = db.connect().unwrap();

--- a/core/benches/graph_queries_benchmark.rs
+++ b/core/benches/graph_queries_benchmark.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 #[cfg(not(feature = "codspeed"))]
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode};
@@ -37,10 +38,10 @@ fn bench_graph_queries(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), DB_PATH).unwrap();
+    let db = Database::open_file(io.clone(), DB_PATH, Arc::new(SqliteDialect)).unwrap();
     let limbo_conn = db.connect().unwrap();
 
-    let db_analyzed = Database::open_file(io, DB_PATH_ANALYZED).unwrap();
+    let db_analyzed = Database::open_file(io, DB_PATH_ANALYZED, Arc::new(SqliteDialect)).unwrap();
     let limbo_conn_analyzed = db_analyzed.connect().unwrap();
 
     let queries = [

--- a/core/benches/json_benchmark.rs
+++ b/core/benches/json_benchmark.rs
@@ -9,7 +9,7 @@ use pprof::{
 #[cfg(feature = "codspeed")]
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 use std::sync::Arc;
-use turso_core::{Database, PlatformIO};
+use turso_core::{Database, PlatformIO, SqliteDialect};
 
 // Title: JSONB Function Benchmarking
 
@@ -28,7 +28,8 @@ fn bench(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, "../testing/system/testing.db").unwrap();
+    let db =
+        Database::open_file(io, "../testing/system/testing.db", Arc::new(SqliteDialect)).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     // Benchmark JSONB with different payload sizes
@@ -497,7 +498,8 @@ fn bench_sequential_jsonb(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, "../testing/system/testing.db").unwrap();
+    let db =
+        Database::open_file(io, "../testing/system/testing.db", Arc::new(SqliteDialect)).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     // Select a subset of JSON payloads to use in the sequential test
@@ -654,7 +656,8 @@ fn bench_json_patch(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, "../testing/system/testing.db").unwrap();
+    let db =
+        Database::open_file(io, "../testing/system/testing.db", Arc::new(SqliteDialect)).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let json_patch_cases = [

--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use turso_core::SqliteDialect;
 
 #[cfg(not(feature = "codspeed"))]
 use criterion::{
@@ -28,7 +29,7 @@ struct BenchDb {
 
 fn bench_db() -> BenchDb {
     let io = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io, ":memory:").unwrap();
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
     // Enable MVCC via PRAGMA
     conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
@@ -320,7 +321,7 @@ impl HugeMultiWriteHarness {
         // In-memory IO: no fsync per commit, so the measurement reflects the
         // CPU-bound index-probe path the eq-only seek bound affects.
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, ":memory:").unwrap();
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
         // Keep everything in MvStore so the measurement reflects the in-memory

--- a/core/benches/mvcc_recovery_benchmark.rs
+++ b/core/benches/mvcc_recovery_benchmark.rs
@@ -5,6 +5,7 @@ use std::hint::black_box;
 use std::sync::Arc;
 #[cfg(not(feature = "codspeed"))]
 use std::time::Duration;
+use turso_core::SqliteDialect;
 
 #[cfg(not(feature = "codspeed"))]
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
@@ -35,6 +36,7 @@ impl RecoveryFixture {
             OpenFlags::default(),
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         black_box(&db);
@@ -57,6 +59,7 @@ fn build_mvcc_db_with_log(populate: impl FnOnce(&Arc<turso_core::Connection>)) -
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
     let conn = db.connect().unwrap();

--- a/core/benches/prepare_params_benchmark.rs
+++ b/core/benches/prepare_params_benchmark.rs
@@ -14,6 +14,7 @@
 
 #[cfg(not(feature = "codspeed"))]
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use turso_core::SqliteDialect;
 
 #[cfg(feature = "codspeed")]
 use codspeed_criterion_compat::{
@@ -40,7 +41,7 @@ fn run_to_completion(stmt: &mut turso_core::Statement, db: &Arc<Database>) {
 
 fn open_with_table() -> (Arc<Database>, Arc<turso_core::Connection>) {
     let io = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io, ":memory:").unwrap();
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
     let mut stmt = conn
         .query(

--- a/core/benches/struct_union_benchmark.rs
+++ b/core/benches/struct_union_benchmark.rs
@@ -10,6 +10,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(not(feature = "codspeed"))]
 use pprof::criterion::{Output, PProfProfiler};
+use turso_core::SqliteDialect;
 
 #[cfg(feature = "codspeed")]
 use codspeed_criterion_compat::{
@@ -30,8 +31,15 @@ fn setup_db() -> (Arc<Database>, Arc<turso_core::Connection>) {
     let opts = DatabaseOpts::new().with_custom_types(true);
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(MemoryIO::new());
-    let db =
-        Database::open_file_with_flags(io, ":memory:", OpenFlags::default(), opts, None).unwrap();
+    let db = Database::open_file_with_flags(
+        io,
+        ":memory:",
+        OpenFlags::default(),
+        opts,
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
     let conn = db.connect().unwrap();
     (db, conn)
 }

--- a/core/benches/struct_union_profile.rs
+++ b/core/benches/struct_union_profile.rs
@@ -7,14 +7,22 @@
 
 use std::sync::Arc;
 use turso_core::io::MemoryIO;
+use turso_core::SqliteDialect;
 use turso_core::{Database, DatabaseOpts, OpenFlags, StepResult};
 
 fn setup_db() -> (Arc<Database>, Arc<turso_core::Connection>) {
     let opts = DatabaseOpts::new().with_custom_types(true);
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(MemoryIO::new());
-    let db =
-        Database::open_file_with_flags(io, ":memory:", OpenFlags::default(), opts, None).unwrap();
+    let db = Database::open_file_with_flags(
+        io,
+        ":memory:",
+        OpenFlags::default(),
+        opts,
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
     let conn = db.connect().unwrap();
     (db, conn)
 }

--- a/core/benches/tpc_h_benchmark.rs
+++ b/core/benches/tpc_h_benchmark.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 #[cfg(not(feature = "codspeed"))]
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode};
@@ -39,7 +40,7 @@ fn bench_tpc_h_queries(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, TPC_H_PATH).unwrap();
+    let db = Database::open_file(io, TPC_H_PATH, Arc::new(SqliteDialect)).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let queries = [

--- a/core/benches/triggers.rs
+++ b/core/benches/triggers.rs
@@ -2,6 +2,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 #[cfg(not(feature = "codspeed"))]
 use pprof::criterion::{Output, PProfProfiler};
+use turso_core::SqliteDialect;
 
 #[cfg(feature = "codspeed")]
 use codspeed_criterion_compat::{
@@ -56,7 +57,7 @@ fn setup_limbo(temp_dir: &TempDir, stmts: &[&str]) -> Arc<Database> {
     let db_path = temp_dir.path().join("bench.db");
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let db = Database::open_file(io, db_path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
 
     let mut stmt = conn.query("PRAGMA synchronous = OFF").unwrap().unwrap();

--- a/core/benches/write_perf_benchmark.rs
+++ b/core/benches/write_perf_benchmark.rs
@@ -13,6 +13,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 #[cfg(not(feature = "codspeed"))]
 use pprof::criterion::{Output, PProfProfiler};
+use turso_core::SqliteDialect;
 
 #[cfg(feature = "codspeed")]
 use codspeed_criterion_compat::{
@@ -74,7 +75,7 @@ fn setup_limbo_with_sync(temp_dir: &TempDir, schema: &str, sync_on: bool) -> Arc
     let db_path = temp_dir.path().join("bench.db");
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let db = Database::open_file(io, db_path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
 
     // Set synchronous mode

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -18,7 +18,7 @@ use crate::util::{OpenMode, OpenOptions};
 use crate::Page;
 use crate::SqliteDialect;
 use crate::{
-    function,
+    ast, function,
     io::{MemoryIO, IO},
     progress::{ProgressHandler, ProgressHandlerCallback},
     translate,
@@ -1003,6 +1003,52 @@ impl Connection {
                 pager,
                 mode,
                 byte_offset_end,
+                origin,
+                needs_nested_guard,
+            ))
+        })();
+        if result.is_err() && needs_nested_guard {
+            self.end_nested();
+        }
+        result
+    }
+
+    /// Prepare an already-translated statement while keeping the original
+    /// SQL text.
+    ///
+    /// A frontend that already has an engine AST can call this instead of
+    /// parsing through [`Dialect::parse`](crate::Dialect::parse), while the
+    /// original text remains available for schema storage, diagnostics, and
+    /// later re-preparation through the dialect.
+    pub fn prepare_translated_stmt(
+        self: &Arc<Connection>,
+        stmt: ast::Stmt,
+        input: &str,
+    ) -> Result<Statement> {
+        self.prepare_stmt_with_input_and_origin(stmt, input, StatementOrigin::Root)
+    }
+
+    #[turso_macros::trace_stack]
+    fn prepare_stmt_with_input_and_origin(
+        self: &Arc<Connection>,
+        stmt: ast::Stmt,
+        input: &str,
+        origin: StatementOrigin,
+    ) -> Result<Statement> {
+        if self.is_closed() {
+            return Err(LimboError::InternalError("Connection closed".to_string()));
+        }
+        let needs_nested_guard = origin.needs_nested_guard();
+        if needs_nested_guard {
+            self.start_nested();
+        }
+        let result = (|| {
+            let (program, pager, mode) = self.compile_cmd(Cmd::Stmt(stmt), input)?;
+            Ok(Statement::new_with_origin(
+                program,
+                pager,
+                mode,
+                0,
                 origin,
                 needs_nested_guard,
             ))

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -28,8 +28,8 @@ use crate::{
     BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
     Completion, ConnectionMetrics, Database, DatabaseCatalog, DatabaseOpts, Duration,
     EncryptionKey, EncryptionOpts, IOResult, IndexMethod, LimboError, MvStore, OpenFlags, PageSize,
-    Pager, Parser, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode,
-    TransactionMode, Trigger, Value, VirtualTable, WalAutoActions,
+    Pager, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode, TransactionMode,
+    Trigger, Value, VirtualTable, WalAutoActions,
 };
 use crate::{is_memory_like, turso_assert};
 use crate::{MAIN_DB_ID, TEMP_DB_ID};
@@ -915,8 +915,8 @@ impl Connection {
                 drop(syms);
                 let cmd = {
                     crate::stack::trace_stack!("schema_retry_parse");
-                    let mut parser = Parser::new(input.as_bytes());
-                    let Some(cmd) = parser.next_cmd()? else {
+                    let (cmd, _) = self.parse_sql(input)?;
+                    let Some(cmd) = cmd else {
                         return Err(err);
                     };
                     cmd
@@ -1638,10 +1638,9 @@ impl Connection {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
         let sql = sql.as_ref();
-        let mut parser = Parser::new(sql.as_bytes());
-        while let Some(cmd) = parser.next_cmd()? {
-            let byte_offset_end = parser.offset();
-            let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
+        let mut remaining = sql;
+        while let (Some(cmd), byte_offset_end) = self.parse_sql(remaining)? {
+            let input = str::from_utf8(&remaining.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
             let (program, pager, mode) = self.compile_cmd(cmd, input)?;
@@ -1649,6 +1648,7 @@ impl Connection {
                 crate::stack::trace_stack!("run");
                 Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
             }
+            remaining = &remaining[byte_offset_end..];
         }
         Ok(())
     }
@@ -1670,11 +1670,8 @@ impl Connection {
         Ok(Some((stmt, byte_offset_end)))
     }
 
-    fn parse_sql(&self, sql: &str) -> Result<(Option<Cmd>, usize)> {
-        let mut parser = Parser::new(sql.as_bytes());
-        let cmd = parser.next_cmd()?;
-        let offset = parser.offset();
-        Ok((cmd, offset))
+    pub(crate) fn parse_sql(&self, sql: &str) -> Result<(Option<Cmd>, usize)> {
+        self.db.dialect().parse(sql)
     }
 
     #[cfg(feature = "fs")]

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -16,6 +16,7 @@ use crate::types::{WalFrameInfo, WalState};
 use crate::util::{OpenMode, OpenOptions};
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::Page;
+use crate::SqliteDialect;
 use crate::{
     function,
     io::{MemoryIO, IO},
@@ -617,6 +618,7 @@ impl Connection {
                 OpenFlags::Create,
                 db_opts,
                 None,
+                Arc::new(SqliteDialect),
             )?;
             let pager = Arc::new(db._init(None)?);
             pager.set_initial_page_size(page_size)?;
@@ -647,6 +649,7 @@ impl Connection {
                 OpenFlags::Create,
                 db_opts,
                 None,
+                Arc::new(SqliteDialect),
             )?;
             let pager = Arc::new(db._init(None)?);
             pager.set_initial_page_size(page_size)?;
@@ -1341,6 +1344,7 @@ impl Connection {
                         &mut inner.fresh,
                         &self.syms.read(),
                         &attached_resolver,
+                        self.db.dialect().as_ref(),
                     ));
 
                     // Rehydrate built-in table-valued functions captured at init.
@@ -1674,13 +1678,24 @@ impl Connection {
     }
 
     #[cfg(feature = "fs")]
-    pub fn from_uri(uri: &str, db_opts: DatabaseOpts) -> Result<(Arc<dyn IO>, Arc<Connection>)> {
+    pub fn from_uri(
+        uri: &str,
+        db_opts: DatabaseOpts,
+        dialect: Arc<dyn crate::Dialect>,
+    ) -> Result<(Arc<dyn IO>, Arc<Connection>)> {
         use crate::util::MEMORY_PATH;
         let opts = OpenOptions::parse(uri)?;
         let flags = opts.get_flags()?;
         if opts.path == MEMORY_PATH || matches!(opts.mode, OpenMode::Memory) {
             let io = Arc::new(MemoryIO::new());
-            let db = Database::open_file_with_flags(io.clone(), MEMORY_PATH, flags, db_opts, None)?;
+            let db = Database::open_file_with_flags(
+                io.clone(),
+                MEMORY_PATH,
+                flags,
+                db_opts,
+                None,
+                dialect,
+            )?;
             let conn = db.connect()?;
             return Ok((io, conn));
         }
@@ -1704,6 +1719,7 @@ impl Connection {
             flags,
             db_opts,
             encryption_opts,
+            dialect,
         )?;
         if let Some(modeof) = opts.modeof {
             let perms = std::fs::metadata(modeof).map_err(|e| io_error(e, "metadata"))?;
@@ -1726,6 +1742,7 @@ impl Connection {
         mut db_opts: DatabaseOpts,
         main_db_flags: OpenFlags,
         io: Arc<dyn IO>,
+        dialect: Arc<dyn crate::Dialect>,
     ) -> Result<(Arc<Database>, Option<EncryptionOpts>)> {
         let opts = OpenOptions::parse(uri)?;
         let mut flags = opts.get_flags()?;
@@ -1756,6 +1773,7 @@ impl Connection {
             flags,
             db_opts,
             encryption_opts.clone(),
+            dialect,
         )?;
         if let Some(modeof) = opts.modeof {
             let perms = std::fs::metadata(modeof).map_err(|e| io_error(e, "metadata"))?;
@@ -2578,8 +2596,13 @@ impl Connection {
     }
 
     #[cfg(feature = "fs")]
-    pub fn open_new(&self, path: &str, vfs: &str) -> Result<(Arc<dyn IO>, Arc<Database>)> {
-        Database::open_with_vfs(&self.db, path, vfs)
+    pub fn open_new(
+        &self,
+        path: &str,
+        vfs: &str,
+        dialect: Arc<dyn crate::Dialect>,
+    ) -> Result<(Arc<dyn IO>, Arc<Database>)> {
+        Database::open_with_vfs(&self.db, path, vfs, dialect)
     }
 
     pub fn list_vfs(&self) -> Vec<String> {
@@ -2690,6 +2713,7 @@ impl Connection {
                     &mut dbsp_state_index_roots,
                     &mut materialized_view_info,
                     &attached_resolver,
+                    self.db.dialect().as_ref(),
                 ) {
                     Ok(()) => {}
                     Err(LimboError::ParseError(msg)) if msg.contains("already exists") => {}
@@ -2745,6 +2769,11 @@ impl Connection {
         let pragma = format!("PRAGMA {pragma_name} = {pragma_value}");
         let mut stmt = self.prepare(pragma)?;
         stmt.run_collect_rows()
+    }
+
+    /// The SQL dialect of the database this connection belongs to.
+    pub fn dialect(&self) -> Arc<dyn crate::Dialect> {
+        self.db.dialect()
     }
 
     pub fn experimental_views_enabled(&self) -> bool {
@@ -3250,8 +3279,13 @@ impl Connection {
                         self.db.io.clone()
                     };
                     let main_db_flags = self.db.open_flags;
-                    let (db, encryption_opts) =
-                        Self::from_uri_attached(path, db_opts, main_db_flags, io)?;
+                    let (db, encryption_opts) = Self::from_uri_attached(
+                        path,
+                        db_opts,
+                        main_db_flags,
+                        io,
+                        self.db.dialect(),
+                    )?;
                     let attached_is_fresh = !db.initialized();
                     if !is_memory_db {
                         Self::validate_attach_target(&db, attached_is_fresh, alias)?;
@@ -4926,6 +4960,7 @@ impl SymbolTable {
 #[cfg(all(test, feature = "fs"))]
 mod tests {
     use super::*;
+    use crate::SqliteDialect;
     use tempfile::TempDir;
 
     fn open_connection_with_opts(path: &std::path::Path, opts: DatabaseOpts) -> Arc<Connection> {
@@ -4936,6 +4971,7 @@ mod tests {
             OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         db.connect().unwrap()
@@ -4995,8 +5031,10 @@ mod tests {
     #[test]
     fn test_named_memory_databases_on_same_io_are_distinct() {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let draft_db = Database::open_file(io.clone(), ":memory:sync-draft").unwrap();
-        let synced_db = Database::open_file(io, ":memory:sync-synced").unwrap();
+        let draft_db =
+            Database::open_file(io.clone(), ":memory:sync-draft", Arc::new(SqliteDialect)).unwrap();
+        let synced_db =
+            Database::open_file(io, ":memory:sync-synced", Arc::new(SqliteDialect)).unwrap();
         assert!(!Arc::ptr_eq(&draft_db, &synced_db));
 
         let draft = draft_db.connect().unwrap();
@@ -5025,13 +5063,14 @@ mod tests {
     fn test_named_memory_database_reopened_on_same_io_sees_same_rows() {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
 
-        let first_db = Database::open_file(io.clone(), ":memory:reopen").unwrap();
+        let first_db =
+            Database::open_file(io.clone(), ":memory:reopen", Arc::new(SqliteDialect)).unwrap();
         let first = first_db.connect().unwrap();
         first
             .execute("CREATE TABLE t(x INTEGER); INSERT INTO t VALUES(99)")
             .unwrap();
 
-        let second_db = Database::open_file(io, ":memory:reopen").unwrap();
+        let second_db = Database::open_file(io, ":memory:reopen", Arc::new(SqliteDialect)).unwrap();
         let second = second_db.connect().unwrap();
         assert_eq!(query_single_i64(&second, "SELECT x FROM t"), 99);
     }
@@ -5066,6 +5105,7 @@ mod tests {
             OpenFlags::default(),
             DatabaseOpts::new().with_attach(true),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -894,6 +894,7 @@ impl Connection {
         self: &Arc<Connection>,
         cmd: Cmd,
         input: &str,
+        origin: StatementOrigin,
     ) -> Result<(Program, Arc<Pager>, QueryMode)> {
         self.maybe_update_schema();
 
@@ -910,6 +911,7 @@ impl Connection {
             &syms,
             mode,
             input,
+            origin,
         ) {
             Ok(program) => Ok((program, pager, mode)),
             Err(err) if self.should_retry_cross_process_schema_lookup(&err)? => {
@@ -939,6 +941,7 @@ impl Connection {
                     &syms,
                     mode,
                     input,
+                    origin,
                 )
                 .map(|program| (program, pager, mode))
             }
@@ -1000,7 +1003,7 @@ impl Connection {
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
+            let (program, pager, mode) = self.compile_cmd(cmd, input, origin)?;
 
             Ok(Statement::new_with_origin(
                 program,
@@ -1047,7 +1050,7 @@ impl Connection {
             self.start_nested();
         }
         let result = (|| {
-            let (program, pager, mode) = self.compile_cmd(Cmd::Stmt(stmt), input)?;
+            let (program, pager, mode) = self.compile_cmd(Cmd::Stmt(stmt), input, origin)?;
             Ok(Statement::new_with_origin(
                 program,
                 pager,
@@ -1639,7 +1642,7 @@ impl Connection {
             let input = str::from_utf8(&remaining.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
+            let (program, pager, mode) = self.compile_cmd(cmd, input, StatementOrigin::Root)?;
             Statement::new(program, pager, mode, 0).run_ignore_rows()?;
             remaining = &remaining[byte_offset_end..];
         }
@@ -1673,7 +1676,7 @@ impl Connection {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
-        let (program, pager, mode) = self.compile_cmd(cmd, input)?;
+        let (program, pager, mode) = self.compile_cmd(cmd, input, StatementOrigin::Root)?;
         let stmt = Statement::new(program, pager, mode, 0);
         Ok(Some(stmt))
     }
@@ -1696,7 +1699,7 @@ impl Connection {
             let input = str::from_utf8(&remaining.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
+            let (program, pager, mode) = self.compile_cmd(cmd, input, StatementOrigin::Root)?;
             {
                 crate::stack::trace_stack!("run");
                 Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
@@ -1718,7 +1721,7 @@ impl Connection {
         let input = str::from_utf8(&sql.as_ref().as_bytes()[..byte_offset_end])
             .unwrap()
             .trim();
-        let (program, pager, mode) = self.compile_cmd(cmd, input)?;
+        let (program, pager, mode) = self.compile_cmd(cmd, input, StatementOrigin::Root)?;
         let stmt = Statement::new(program, pager, mode, 0);
         Ok(Some((stmt, byte_offset_end)))
     }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -16,7 +16,6 @@ use crate::types::{WalFrameInfo, WalState};
 use crate::util::{OpenMode, OpenOptions};
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::Page;
-use crate::SqliteDialect;
 use crate::{
     ast, function,
     io::{MemoryIO, IO},
@@ -575,8 +574,11 @@ impl Connection {
 
     pub(crate) fn empty_temp_schema(&self) -> Arc<Schema> {
         // with_options only fails if built-in type SQL is malformed (programmer bug).
-        let mut schema = Schema::with_options(self.db.experimental_custom_types_enabled())
-            .expect("built-in type definitions are malformed");
+        let mut schema = Schema::with_options(
+            self.db.experimental_custom_types_enabled(),
+            self.db.dialect().as_ref(),
+        )
+        .expect("built-in type definitions are malformed");
         schema.generated_columns_enabled = self.db.experimental_generated_columns_enabled();
         Arc::new(schema)
     }
@@ -618,7 +620,7 @@ impl Connection {
                 OpenFlags::Create,
                 db_opts,
                 None,
-                Arc::new(SqliteDialect),
+                self.db.dialect(),
             )?;
             let pager = Arc::new(db._init(None)?);
             pager.set_initial_page_size(page_size)?;
@@ -649,7 +651,7 @@ impl Connection {
                 OpenFlags::Create,
                 db_opts,
                 None,
-                Arc::new(SqliteDialect),
+                self.db.dialect(),
             )?;
             let pager = Arc::new(db._init(None)?);
             pager.set_initial_page_size(page_size)?;
@@ -669,6 +671,7 @@ impl Connection {
                 OpenFlags::Create,
                 db_opts,
                 None,
+                self.db.dialect(),
             )?;
             let pager = Arc::new(db._init(None)?);
             pager.set_initial_page_size(page_size)?;
@@ -685,6 +688,7 @@ impl Connection {
             OpenFlags::Create,
             self.make_temp_database_opts(),
             None,
+            self.db.dialect(),
         )?;
         let pager = Arc::new(db._init(None)?);
         pager.set_initial_page_size(self.get_page_size())?;
@@ -1313,7 +1317,10 @@ impl Connection {
         let guard = self.schema_reparse_guard();
         self.pager.load().set_schema_cookie(Some(cookie));
         // create fresh schema as some objects can be deleted
-        let mut fresh = Schema::with_options(self.experimental_custom_types_enabled())?;
+        let mut fresh = Schema::with_options(
+            self.experimental_custom_types_enabled(),
+            self.db.dialect().as_ref(),
+        )?;
         fresh.generated_columns_enabled = self.db.experimental_generated_columns_enabled();
         fresh.schema_version = cookie;
 

--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -1,11 +1,168 @@
-//! Per-dialect built-in catalog tables.
+//! SQL dialects.
 //!
-//! The single [`sqlite`] module here owns the set of catalog tables that ship
-//! with every Turso build (`pragma_*`, `json_each`/`json_tree`,
-//! `sqlite_dbpage`, `btree_dump`, `sqlite_turso_types`). `Schema::with_options`
-//! reaches them through this module rather than touching the implementations
-//! directly, so an alternative catalog set can be substituted — by a
-//! downstream crate or a future feature gate — without churning the shared
-//! schema-construction path.
+//! The [`Dialect`] trait is the boundary between the engine and the SQL
+//! dialect a frontend speaks. The engine owns the mechanics — pages,
+//! B-trees, the `sqlite_schema` table itself, bytecode — and consults the
+//! dialect wherever the meaning of SQL text is dialect-specific. The
+//! [`sqlite`] module owns [`SqliteDialect`], the SQLite implementation,
+//! and the catalog tables that ship with every Turso build (`pragma_*`,
+//! `json_each`/`json_tree`, `sqlite_dbpage`, `btree_dump`,
+//! `sqlite_turso_types`).
 
 pub mod sqlite;
+
+pub use sqlite::SqliteDialect;
+
+/// SQL dialect layered on top of the engine.
+///
+/// Every [`crate::Database`] carries a dialect, supplied explicitly by
+/// every open path and fixed for the lifetime of the database;
+/// SQLite-compatible callers pass [`SqliteDialect`]. The engine consults
+/// the dialect on every schema load — database open, connection schema
+/// reparse, the `ParseSchema` opcode after DDL, and MVCC schema rebuild —
+/// so a frontend can store its own schema SQL in `sqlite_schema` and
+/// reparse it here.
+pub trait Dialect: Send + Sync + 'static {
+    /// Stable identifier for this dialect (e.g. "sqlite", "postgres").
+    ///
+    /// A database file must always be opened with the same dialect it was
+    /// created with; the process-wide database registry uses this name to
+    /// reject an open whose dialect differs from the already-open instance.
+    fn name(&self) -> &'static str;
+
+    /// Parse a `sqlite_schema` `type='table'` row's SQL into a table
+    /// definition.
+    ///
+    /// Rows written by internal engine paths (sequence backing tables,
+    /// `sqlite_sequence`) are plain SQLite text and carry no frontend
+    /// marker, so every implementation must fall back to SQLite parsing
+    /// for text it does not recognize as its own.
+    fn parse_table_sql(
+        &self,
+        sql: &str,
+        root_page: i64,
+    ) -> crate::Result<crate::schema::BTreeTable>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::BTreeTable;
+    use crate::storage::database::DatabaseFile;
+    use crate::sync::atomic::{AtomicUsize, Ordering};
+    use crate::{Database, DatabaseOpts, MemoryIO, OpenFlags, IO};
+    use std::sync::Arc;
+
+    /// A dialect that counts schema-row parses and strips a `/* test */ `
+    /// marker before delegating to SQLite parsing, mirroring how a frontend
+    /// dialect recognizes its own stored text and falls back to SQLite for
+    /// unmarked rows.
+    #[derive(Default)]
+    struct TestDialect {
+        parse_calls: AtomicUsize,
+    }
+
+    impl Dialect for TestDialect {
+        fn name(&self) -> &'static str {
+            "test"
+        }
+
+        fn parse_table_sql(&self, sql: &str, root_page: i64) -> crate::Result<BTreeTable> {
+            self.parse_calls.fetch_add(1, Ordering::SeqCst);
+            let sql = sql.strip_prefix("/* test */ ").unwrap_or(sql);
+            BTreeTable::from_sql(sql, root_page)
+        }
+    }
+
+    fn open_db(
+        io: &Arc<dyn IO>,
+        path: &str,
+        dialect: Arc<dyn Dialect>,
+    ) -> crate::Result<Arc<Database>> {
+        let file = io.open_file(path, OpenFlags::Create, true)?;
+        let db_file = Arc::new(DatabaseFile::new(file));
+        Database::open_with_flags_with_allocator(
+            io.clone(),
+            path,
+            db_file,
+            OpenFlags::default(),
+            DatabaseOpts::new(),
+            None,
+            None,
+            crate::alloc::DynAllocator::default(),
+            dialect,
+        )
+    }
+
+    #[test]
+    fn schema_load_routes_through_dialect() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        {
+            let db = open_db(&io, "dialect-load.db", Arc::new(SqliteDialect)).unwrap();
+            let conn = db.connect().unwrap();
+            conn.execute("CREATE TABLE t (x INTEGER)").unwrap();
+            conn.close().unwrap();
+        }
+
+        // Reopening the database parses the stored schema row for `t`
+        // through the dialect.
+        let dialect = Arc::new(TestDialect::default());
+        let db = open_db(&io, "dialect-load.db", dialect.clone()).unwrap();
+        assert!(dialect.parse_calls.load(Ordering::SeqCst) >= 1);
+
+        // DDL reparses the schema via the ParseSchema opcode, again through
+        // the dialect.
+        let conn = db.connect().unwrap();
+        let before = dialect.parse_calls.load(Ordering::SeqCst);
+        conn.execute("CREATE TABLE u (y INTEGER)").unwrap();
+        assert!(dialect.parse_calls.load(Ordering::SeqCst) > before);
+
+        // Both tables are usable under the dialect.
+        conn.execute("INSERT INTO t VALUES (1)").unwrap();
+        conn.execute("INSERT INTO u VALUES (2)").unwrap();
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn registry_rejects_dialect_mismatch() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let _db = open_db(&io, "dialect-mismatch.db", Arc::new(SqliteDialect)).unwrap();
+
+        let err =
+            open_db(&io, "dialect-mismatch.db", Arc::new(TestDialect::default())).unwrap_err();
+        assert!(
+            err.to_string().contains("already open with dialect"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn registry_rejects_default_open_of_dialect_database() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let _db = open_db(
+            &io,
+            "dialect-mismatch-reverse.db",
+            Arc::new(TestDialect::default()),
+        )
+        .unwrap();
+
+        let err = open_db(&io, "dialect-mismatch-reverse.db", Arc::new(SqliteDialect)).unwrap_err();
+        assert!(
+            err.to_string().contains("already open with dialect"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn shared_memory_registry_rejects_dialect_mismatch() {
+        let name = "dialect-shared-memory-mismatch";
+        let _db = Database::open_shared_memory(name, Arc::new(SqliteDialect)).unwrap();
+
+        let err = Database::open_shared_memory(name, Arc::new(TestDialect::default())).unwrap_err();
+        assert!(
+            err.to_string().contains("already open with dialect"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -51,6 +51,57 @@ pub trait Dialect: Send + Sync + 'static {
         sql: &str,
         root_page: i64,
     ) -> crate::Result<crate::schema::BTreeTable>;
+
+    /// Decode a storage-backed table's persisted SQL into its `CREATE TABLE`
+    /// AST.
+    ///
+    /// Unlike [`Dialect::parse`], this method receives SQL read from
+    /// `sqlite_schema` and must recognize the representation produced by
+    /// [`Dialect::format_table_sql`] and
+    /// [`Dialect::format_rewritten_table_sql`]. Internal engine tables use
+    /// plain SQLite text, so implementations must retain the same SQLite
+    /// fallback required by [`Dialect::parse_table_sql`].
+    fn parse_table_sql_ast(&self, sql: &str) -> crate::Result<turso_parser::ast::Stmt>;
+
+    /// Recover SQL that can be prepared to recreate a persisted table.
+    ///
+    /// Dialects that wrap original frontend DDL in their stored representation
+    /// must unwrap it here so replay preserves that DDL. The returned statement
+    /// must create the table in the connection's main schema, even when the
+    /// persisted statement originally qualified the source database. Unmarked
+    /// internal engine tables must retain the SQLite fallback used by the
+    /// schema parsing methods.
+    fn table_sql_for_replay(&self, sql: &str) -> crate::Result<String>;
+
+    /// Produce the SQL text to store in `sqlite_schema` for a
+    /// `CREATE TABLE`.
+    ///
+    /// `input` is the original statement text as the user wrote it, in the
+    /// frontend's dialect; `tbl_name` and `body` are the translated AST.
+    /// The SQLite dialect formats canonical SQLite text from the AST; a
+    /// frontend dialect typically stores `input` with a marker it can
+    /// recognize in [`Dialect::parse_table_sql`].
+    fn format_table_sql(
+        &self,
+        input: &str,
+        tbl_name: &turso_parser::ast::QualifiedName,
+        body: &turso_parser::ast::CreateTableBody,
+    ) -> crate::Result<String>;
+
+    /// Produce stored SQL after the engine rewrites a `CREATE TABLE` AST.
+    ///
+    /// Schema rewrites cannot reuse the original frontend text because it no
+    /// longer describes the rewritten table. Dialects that need syntax beyond
+    /// a marker around canonical SQL can override this to render their native
+    /// table definition from the rewritten AST.
+    fn format_rewritten_table_sql(&self, stmt: &turso_parser::ast::Stmt) -> crate::Result<String> {
+        let turso_parser::ast::Stmt::CreateTable { tbl_name, body, .. } = stmt else {
+            return Err(crate::LimboError::InternalError(
+                "format_rewritten_table_sql requires CREATE TABLE".to_string(),
+            ));
+        };
+        self.format_table_sql(&stmt.to_string(), tbl_name, body)
+    }
 }
 
 #[cfg(test)]
@@ -91,6 +142,67 @@ mod tests {
             self.parse_calls.fetch_add(1, Ordering::SeqCst);
             let sql = sql.strip_prefix("/* test */ ").unwrap_or(sql);
             BTreeTable::from_sql(sql, root_page)
+        }
+
+        fn parse_table_sql_ast(&self, sql: &str) -> crate::Result<turso_parser::ast::Stmt> {
+            let sql = sql.strip_prefix("/* test */ ").unwrap_or(sql);
+            sqlite::parse_table_sql_ast(sql)
+        }
+
+        fn table_sql_for_replay(&self, sql: &str) -> crate::Result<String> {
+            let sql = sql.strip_prefix("/* test */ ").unwrap_or(sql);
+            sqlite::table_sql_for_replay(sql)
+        }
+
+        fn format_table_sql(
+            &self,
+            input: &str,
+            _tbl_name: &turso_parser::ast::QualifiedName,
+            _body: &turso_parser::ast::CreateTableBody,
+        ) -> crate::Result<String> {
+            Ok(format!("/* test */ {input}"))
+        }
+    }
+
+    /// Stores table definitions in syntax that SQLite cannot parse and always
+    /// adds its marker, so replay tests detect repeated storage formatting.
+    struct StrictTestDialect;
+
+    impl StrictTestDialect {
+        const PREFIX: &'static str = "strict: ";
+    }
+
+    impl Dialect for StrictTestDialect {
+        fn name(&self) -> &'static str {
+            "strict-test"
+        }
+
+        fn parse(&self, sql: &str) -> crate::Result<(Option<turso_parser::ast::Cmd>, usize)> {
+            sqlite::parse(sql)
+        }
+
+        fn parse_table_sql(&self, sql: &str, root_page: i64) -> crate::Result<BTreeTable> {
+            let sql = sql.strip_prefix(Self::PREFIX).unwrap_or(sql);
+            BTreeTable::from_sql(sql, root_page)
+        }
+
+        fn parse_table_sql_ast(&self, sql: &str) -> crate::Result<turso_parser::ast::Stmt> {
+            let sql = sql.strip_prefix(Self::PREFIX).unwrap_or(sql);
+            sqlite::parse_table_sql_ast(sql)
+        }
+
+        fn table_sql_for_replay(&self, sql: &str) -> crate::Result<String> {
+            let sql = sql.strip_prefix(Self::PREFIX).unwrap_or(sql);
+            sqlite::table_sql_for_replay(sql)
+        }
+
+        fn format_table_sql(
+            &self,
+            input: &str,
+            _tbl_name: &turso_parser::ast::QualifiedName,
+            _body: &turso_parser::ast::CreateTableBody,
+        ) -> crate::Result<String> {
+            Ok(format!("{}{input}", Self::PREFIX))
         }
     }
 
@@ -191,6 +303,112 @@ mod tests {
     }
 
     #[test]
+    fn create_table_stores_dialect_formatted_sql() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        {
+            let dialect = Arc::new(TestDialect::default());
+            let db = open_db(&io, "dialect-store.db", dialect).unwrap();
+            let conn = db.connect().unwrap();
+
+            // A frontend prepares its translated AST while supplying the
+            // original statement text.
+            let input = "CREATE TABLE t (x INTEGER)";
+            let stmt = match turso_parser::parser::Parser::new(input.as_bytes())
+                .next_cmd()
+                .unwrap()
+                .unwrap()
+            {
+                turso_parser::ast::Cmd::Stmt(stmt) => stmt,
+                other => panic!("unexpected command: {other:?}"),
+            };
+            conn.prepare_translated_stmt(stmt, input)
+                .unwrap()
+                .run_ignore_rows()
+                .unwrap();
+
+            // The stored schema row carries the dialect marker and the
+            // original text.
+            let rows = conn
+                .prepare("SELECT sql FROM sqlite_schema WHERE name = 't'")
+                .unwrap()
+                .run_collect_rows()
+                .unwrap();
+            assert_eq!(rows.len(), 1);
+            let stored = rows[0][0].to_string();
+            assert_eq!(stored.trim_matches('\''), format!("/* test */ {input}"));
+            conn.close().unwrap();
+        }
+
+        // Round-trip: reopening parses the marked row back through the
+        // dialect and the table stays usable.
+        let dialect = Arc::new(TestDialect::default());
+        let db = open_db(&io, "dialect-store.db", dialect.clone()).unwrap();
+        assert!(dialect.parse_calls.load(Ordering::SeqCst) >= 1);
+        let conn = db.connect().unwrap();
+        conn.execute("INSERT INTO t VALUES (1)").unwrap();
+        let rows = conn
+            .prepare("SELECT x FROM t")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn alter_table_rewrites_dialect_formatted_sql() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(&io, "dialect-alter-table.db", Arc::new(StrictTestDialect)).unwrap();
+        let conn = db.connect().unwrap();
+
+        conn.execute("CREATE TABLE t (x INTEGER)").unwrap();
+        conn.execute("ALTER TABLE t RENAME TO u").unwrap();
+
+        let rows = conn
+            .prepare("SELECT sql FROM sqlite_schema WHERE name = 'u'")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0][0].to_string().trim_matches('\''),
+            "strict: CREATE TABLE u (x INTEGER)"
+        );
+        conn.execute("INSERT INTO u VALUES (1)").unwrap();
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn alter_table_rename_column_decodes_dialect_formatted_sql() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(&io, "dialect-alter-column.db", Arc::new(StrictTestDialect)).unwrap();
+        let conn = db.connect().unwrap();
+
+        conn.execute("CREATE TABLE t (x INTEGER)").unwrap();
+        conn.execute("ALTER TABLE t RENAME COLUMN x TO y").unwrap();
+
+        let rows = conn
+            .prepare("SELECT sql FROM sqlite_schema WHERE name = 't'")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0][0].to_string().trim_matches('\''),
+            "strict: CREATE TABLE t (y INTEGER)"
+        );
+        conn.execute("INSERT INTO t VALUES (1)").unwrap();
+        assert_eq!(
+            conn.prepare("SELECT y FROM t")
+                .unwrap()
+                .run_collect_rows()
+                .unwrap(),
+            vec![vec![crate::Value::from_i64(1)]]
+        );
+        conn.close().unwrap();
+    }
+
+    #[test]
     fn registry_rejects_dialect_mismatch() {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
         let _db = open_db(&io, "dialect-mismatch.db", Arc::new(SqliteDialect)).unwrap();
@@ -230,6 +448,142 @@ mod tests {
         assert!(
             err.to_string().contains("already open with dialect"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(all(feature = "fs", not(target_family = "wasm")))]
+    #[test]
+    fn vacuum_into_replays_schema_with_source_dialect() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("source.db");
+        let output_path = dir.path().join("output.db");
+        let io: Arc<dyn IO> = Arc::new(crate::io::PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            source_path.to_str().unwrap(),
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+            Arc::new(StrictTestDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(x INTEGER)").unwrap();
+        conn.execute("INSERT INTO t VALUES (42)").unwrap();
+
+        conn.execute(format!("VACUUM INTO '{}'", output_path.display()))
+            .unwrap();
+
+        let output_db = Database::open_file(
+            io,
+            output_path.to_str().unwrap(),
+            Arc::new(StrictTestDialect),
+        )
+        .unwrap();
+        let output_conn = output_db.connect().unwrap();
+        let schema_rows = output_conn
+            .prepare("SELECT sql FROM sqlite_schema WHERE name = 't'")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(schema_rows.len(), 1);
+        assert_eq!(
+            schema_rows[0][0].to_string().trim_matches('\''),
+            "strict: CREATE TABLE t(x INTEGER)"
+        );
+        assert_eq!(
+            output_conn
+                .prepare("SELECT x FROM t")
+                .unwrap()
+                .run_collect_rows()
+                .unwrap(),
+            vec![vec![crate::Value::from_i64(42)]]
+        );
+    }
+
+    #[cfg(all(feature = "fs", not(target_family = "wasm")))]
+    #[test]
+    fn vacuum_attached_database_strips_source_schema_from_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("source.db");
+        let attached_path = dir.path().join("attached.db");
+        let output_path = dir.path().join("output.db");
+        let io: Arc<dyn IO> = Arc::new(crate::io::PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            source_path.to_str().unwrap(),
+            OpenFlags::Create,
+            DatabaseOpts::new().with_attach(true),
+            None,
+            Arc::new(StrictTestDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute(format!(
+            "ATTACH DATABASE '{}' AS aux",
+            attached_path.display()
+        ))
+        .unwrap();
+        conn.execute("CREATE TABLE aux.t (x INTEGER)").unwrap();
+        conn.execute("INSERT INTO aux.t VALUES (42)").unwrap();
+
+        conn.execute(format!("VACUUM aux INTO '{}'", output_path.display()))
+            .unwrap();
+
+        let output_db = Database::open_file(
+            io,
+            output_path.to_str().unwrap(),
+            Arc::new(StrictTestDialect),
+        )
+        .unwrap();
+        let output_conn = output_db.connect().unwrap();
+        assert_eq!(
+            output_conn
+                .prepare("SELECT x FROM t")
+                .unwrap()
+                .run_collect_rows()
+                .unwrap(),
+            vec![vec![crate::Value::from_i64(42)]]
+        );
+    }
+
+    #[cfg(all(feature = "fs", not(target_family = "wasm")))]
+    #[test]
+    fn in_place_vacuum_replays_schema_with_source_dialect() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("source.db");
+        let io: Arc<dyn IO> = Arc::new(crate::io::PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io,
+            path.to_str().unwrap(),
+            OpenFlags::Create,
+            DatabaseOpts::new().with_vacuum(true),
+            None,
+            Arc::new(StrictTestDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(x INTEGER)").unwrap();
+        conn.execute("INSERT INTO t VALUES (42)").unwrap();
+
+        conn.execute("VACUUM").unwrap();
+
+        let schema_rows = conn
+            .prepare("SELECT sql FROM sqlite_schema WHERE name = 't'")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(schema_rows.len(), 1);
+        assert_eq!(
+            schema_rows[0][0].to_string().trim_matches('\''),
+            "strict: CREATE TABLE t(x INTEGER)"
+        );
+        assert_eq!(
+            conn.prepare("SELECT x FROM t")
+                .unwrap()
+                .run_collect_rows()
+                .unwrap(),
+            vec![vec![crate::Value::from_i64(42)]]
         );
     }
 }

--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -102,6 +102,23 @@ pub trait Dialect: Send + Sync + 'static {
         };
         self.format_table_sql(&stmt.to_string(), tbl_name, body)
     }
+
+    /// Install the dialect's catalog tables into a freshly constructed
+    /// schema.
+    ///
+    /// Called by [`crate::schema::Schema::with_options`] on every schema
+    /// construction and rebuild, so catalog tables survive rebuilds
+    /// structurally instead of being re-registered by hand. The SQLite
+    /// dialect registers the standard built-in catalog here; other
+    /// dialects typically compose with it via
+    /// [`sqlite::register_builtin_catalog`] and then add their own tables
+    /// (constructed with [`crate::VirtualTable::new_internal`], which
+    /// requires no connection).
+    fn register_catalog(
+        &self,
+        schema: &mut crate::schema::Schema,
+        enable_custom_types: bool,
+    ) -> crate::Result<()>;
 }
 
 #[cfg(test)]
@@ -162,6 +179,21 @@ mod tests {
         ) -> crate::Result<String> {
             Ok(format!("/* test */ {input}"))
         }
+
+        fn register_catalog(
+            &self,
+            schema: &mut crate::schema::Schema,
+            enable_custom_types: bool,
+        ) -> crate::Result<()> {
+            sqlite::register_builtin_catalog(schema, enable_custom_types)?;
+            let vtab = crate::VirtualTable::new_internal(
+                "test_catalog".to_string(),
+                "CREATE TABLE test_catalog (value INTEGER)".to_string(),
+                turso_ext::VTabKind::VirtualTable,
+                Arc::new(crate::sync::RwLock::new(TestCatalogTable)),
+            )?;
+            schema.add_virtual_table(Arc::new(vtab))
+        }
     }
 
     /// Stores table definitions in syntax that SQLite cannot parse and always
@@ -203,6 +235,92 @@ mod tests {
             _body: &turso_parser::ast::CreateTableBody,
         ) -> crate::Result<String> {
             Ok(format!("{}{input}", Self::PREFIX))
+        }
+
+        fn register_catalog(
+            &self,
+            schema: &mut crate::schema::Schema,
+            enable_custom_types: bool,
+        ) -> crate::Result<()> {
+            sqlite::register_builtin_catalog(schema, enable_custom_types)
+        }
+    }
+
+    /// A one-row catalog table installed by [`TestDialect`],
+    /// standing in for a frontend catalog surface like `pg_class`.
+    #[derive(Debug)]
+    struct TestCatalogTable;
+
+    impl crate::InternalVirtualTable for TestCatalogTable {
+        fn name(&self) -> String {
+            "test_catalog".to_string()
+        }
+
+        fn sql(&self) -> String {
+            "CREATE TABLE test_catalog (value INTEGER)".to_string()
+        }
+
+        fn open(
+            &self,
+            _conn: Arc<crate::Connection>,
+        ) -> crate::Result<Arc<crate::sync::RwLock<dyn crate::InternalVirtualTableCursor>>>
+        {
+            Ok(Arc::new(crate::sync::RwLock::new(TestCatalogCursor {
+                row: 0,
+            })))
+        }
+
+        fn best_index(
+            &self,
+            constraints: &[turso_ext::ConstraintInfo],
+            _order_by: &[turso_ext::OrderByInfo],
+        ) -> std::result::Result<turso_ext::IndexInfo, turso_ext::ResultCode> {
+            Ok(turso_ext::IndexInfo {
+                idx_num: 0,
+                idx_str: None,
+                order_by_consumed: false,
+                estimated_cost: 1.0,
+                estimated_rows: 1,
+                constraint_usages: constraints
+                    .iter()
+                    .map(|_| turso_ext::ConstraintUsage {
+                        argv_index: None,
+                        omit: false,
+                    })
+                    .collect(),
+            })
+        }
+    }
+
+    struct TestCatalogCursor {
+        row: usize,
+    }
+
+    impl crate::InternalVirtualTableCursor for TestCatalogCursor {
+        fn filter(
+            &mut self,
+            _args: &[crate::Value],
+            _idx_str: Option<String>,
+            _idx_num: i32,
+        ) -> crate::Result<bool> {
+            self.row = 0;
+            Ok(true)
+        }
+
+        fn next(&mut self) -> crate::Result<bool> {
+            self.row += 1;
+            Ok(self.row < 1)
+        }
+
+        fn rowid(&self) -> i64 {
+            self.row as i64
+        }
+
+        fn column(&self, column: usize) -> crate::Result<crate::Value> {
+            match column {
+                0 => Ok(crate::Value::Numeric(crate::numeric::Numeric::Integer(42))),
+                _ => Ok(crate::Value::Null),
+            }
         }
     }
 
@@ -300,6 +418,129 @@ mod tests {
         assert!(runner.next().is_some_and(|result| result.is_err()));
         assert!(runner.next().is_none());
         conn.close().unwrap();
+    }
+
+    #[test]
+    fn dialect_catalog_available_on_every_schema_and_rebuild() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(&io, "dialect-catalog.db", Arc::new(TestDialect::default())).unwrap();
+
+        let query_catalog = |conn: &Arc<crate::Connection>| -> Vec<Vec<crate::Value>> {
+            conn.prepare("SELECT value FROM test_catalog")
+                .unwrap()
+                .run_collect_rows()
+                .unwrap()
+        };
+
+        let conn1 = db.connect().unwrap();
+        let conn2 = db.connect().unwrap();
+        assert_eq!(
+            query_catalog(&conn1),
+            vec![vec![crate::Value::Numeric(
+                crate::numeric::Numeric::Integer(42)
+            )]]
+        );
+        assert_eq!(
+            query_catalog(&conn2),
+            vec![vec![crate::Value::Numeric(
+                crate::numeric::Numeric::Integer(42)
+            )]]
+        );
+
+        // DDL on another connection forces conn1 to rebuild its schema from
+        // sqlite_schema; the catalog table must survive because schema
+        // construction re-registers it.
+        conn2.execute("CREATE TABLE t (x INTEGER)").unwrap();
+        assert_eq!(
+            query_catalog(&conn1),
+            vec![vec![crate::Value::Numeric(
+                crate::numeric::Numeric::Integer(42)
+            )]]
+        );
+
+        conn1.close().unwrap();
+        conn2.close().unwrap();
+    }
+
+    #[test]
+    fn dialect_catalog_cannot_be_dropped() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(
+            &io,
+            "dialect-catalog-drop.db",
+            Arc::new(TestDialect::default()),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+
+        let error = conn.execute("DROP TABLE test_catalog").unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("table test_catalog may not be dropped"),
+            "unexpected error: {error}"
+        );
+
+        let new_conn = db.connect().unwrap();
+        for catalog_conn in [&conn, &new_conn] {
+            let rows = catalog_conn
+                .prepare("SELECT value FROM test_catalog")
+                .unwrap()
+                .run_collect_rows()
+                .unwrap();
+            assert_eq!(rows, vec![vec![crate::Value::from_i64(42)]]);
+        }
+        conn.close().unwrap();
+        new_conn.close().unwrap();
+    }
+
+    #[test]
+    fn dialect_catalog_survives_mvcc_recovery() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let path = "dialect-catalog-mvcc-recovery.db";
+
+        {
+            let db = open_db(&io, path, Arc::new(TestDialect::default())).unwrap();
+            let conn = db.connect().unwrap();
+            conn.execute("PRAGMA journal_mode = mvcc").unwrap();
+            conn.execute("CREATE TABLE t (x INTEGER)").unwrap();
+            conn.close().unwrap();
+        }
+
+        let db = open_db(&io, path, Arc::new(TestDialect::default())).unwrap();
+        let conn = db.connect().unwrap();
+        let rows = conn
+            .prepare("SELECT value FROM test_catalog")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(rows, vec![vec![crate::Value::from_i64(42)]]);
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn dialect_catalog_available_in_initialized_temp_schema() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(
+            &io,
+            "dialect-catalog-temp.db",
+            Arc::new(TestDialect::default()),
+        )
+        .unwrap();
+
+        for temp_store in ["MEMORY", "FILE"] {
+            let conn = db.connect().unwrap();
+            conn.execute(format!("PRAGMA temp_store = {temp_store}"))
+                .unwrap();
+            conn.execute("CREATE TEMP TABLE t (x INTEGER)").unwrap();
+            let rows = conn
+                .prepare("SELECT value FROM temp.test_catalog")
+                .unwrap()
+                .run_collect_rows()
+                .unwrap();
+            assert_eq!(rows, vec![vec![crate::Value::from_i64(42)]]);
+            conn.close().unwrap();
+        }
     }
 
     #[test]

--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -119,6 +119,36 @@ pub trait Dialect: Send + Sync + 'static {
         schema: &mut crate::schema::Schema,
         enable_custom_types: bool,
     ) -> crate::Result<()>;
+
+    /// Resolve a function name in user SQL to the engine's function IR.
+    ///
+    /// The dialect owns its scalar function surface: the SQLite dialect
+    /// resolves the built-in set, another dialect resolves its own —
+    /// mapping names onto engine primitives where it wants them (usually
+    /// by composing with [`sqlite::resolve_builtin_function`]) and onto
+    /// [`crate::Func::Dialect`] for functions it executes
+    /// itself via [`Dialect::exec_scalar_function`]. Consulted
+    /// before extension functions; engine-generated helper statements
+    /// always resolve with SQLite semantics instead.
+    fn resolve_function(&self, name: &str, arg_count: usize) -> crate::Result<Option<crate::Func>>;
+
+    /// Execute a dialect scalar function at runtime.
+    ///
+    /// Receives the connection — unlike extension functions — because
+    /// catalog functions (e.g. `pg_get_tabledef`) need to inspect the
+    /// schema. Only reached through [`crate::Func::Dialect`],
+    /// so a dialect that never resolves to that variant can keep the
+    /// default "no such function" error.
+    fn exec_scalar_function(
+        &self,
+        _conn: &crate::Connection,
+        name: &str,
+        _args: &[crate::Value],
+    ) -> crate::Result<crate::Value> {
+        Err(crate::LimboError::ParseError(format!(
+            "no such function: {name}"
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -178,6 +208,39 @@ mod tests {
             _body: &turso_parser::ast::CreateTableBody,
         ) -> crate::Result<String> {
             Ok(format!("/* test */ {input}"))
+        }
+
+        fn resolve_function(
+            &self,
+            name: &str,
+            arg_count: usize,
+        ) -> crate::Result<Option<crate::function::Func>> {
+            if name.eq_ignore_ascii_case("nvl") {
+                return sqlite::resolve_builtin_function("coalesce", arg_count);
+            }
+            if name.eq_ignore_ascii_case("test_add_one") && arg_count == 1 {
+                return Ok(Some(crate::function::Func::Dialect(
+                    "test_add_one".to_string(),
+                )));
+            }
+            sqlite::resolve_builtin_function(name, arg_count)
+        }
+
+        fn exec_scalar_function(
+            &self,
+            _conn: &crate::Connection,
+            name: &str,
+            args: &[crate::Value],
+        ) -> crate::Result<crate::Value> {
+            assert_eq!(name, "test_add_one");
+            let crate::Value::Numeric(crate::numeric::Numeric::Integer(v)) = args[0] else {
+                return Err(crate::LimboError::InvalidArgument(
+                    "test_add_one expects an integer".to_string(),
+                ));
+            };
+            Ok(crate::Value::Numeric(crate::numeric::Numeric::Integer(
+                v + 1,
+            )))
         }
 
         fn register_catalog(
@@ -243,6 +306,14 @@ mod tests {
             enable_custom_types: bool,
         ) -> crate::Result<()> {
             sqlite::register_builtin_catalog(schema, enable_custom_types)
+        }
+
+        fn resolve_function(
+            &self,
+            name: &str,
+            arg_count: usize,
+        ) -> crate::Result<Option<crate::function::Func>> {
+            sqlite::resolve_builtin_function(name, arg_count)
         }
     }
 
@@ -593,6 +664,189 @@ mod tests {
             .run_collect_rows()
             .unwrap();
         assert_eq!(rows.len(), 1);
+        conn.close().unwrap();
+    }
+
+    /// A dialect that resolves no functions at all, proving the dialect —
+    /// not the engine — owns the function name surface of user SQL.
+    struct NoFunctionsDialect;
+
+    impl Dialect for NoFunctionsDialect {
+        fn name(&self) -> &'static str {
+            "nofuncs"
+        }
+
+        fn parse(&self, sql: &str) -> crate::Result<(Option<turso_parser::ast::Cmd>, usize)> {
+            sqlite::parse(sql)
+        }
+
+        fn parse_table_sql(&self, sql: &str, root_page: i64) -> crate::Result<BTreeTable> {
+            BTreeTable::from_sql(sql, root_page)
+        }
+
+        fn parse_table_sql_ast(&self, sql: &str) -> crate::Result<turso_parser::ast::Stmt> {
+            sqlite::parse_table_sql_ast(sql)
+        }
+
+        fn table_sql_for_replay(&self, sql: &str) -> crate::Result<String> {
+            sqlite::table_sql_for_replay(sql)
+        }
+
+        fn format_table_sql(
+            &self,
+            _input: &str,
+            tbl_name: &turso_parser::ast::QualifiedName,
+            body: &turso_parser::ast::CreateTableBody,
+        ) -> crate::Result<String> {
+            Ok(format!(
+                "CREATE TABLE {} {}",
+                tbl_name.name.as_ident(),
+                body
+            ))
+        }
+
+        fn register_catalog(
+            &self,
+            schema: &mut crate::schema::Schema,
+            enable_custom_types: bool,
+        ) -> crate::Result<()> {
+            sqlite::register_builtin_catalog(schema, enable_custom_types)
+        }
+
+        fn resolve_function(
+            &self,
+            _name: &str,
+            _arg_count: usize,
+        ) -> crate::Result<Option<crate::function::Func>> {
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn dialect_scalar_function_resolves_and_executes() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(&io, "dialect-funcs.db", Arc::new(TestDialect::default())).unwrap();
+        let conn = db.connect().unwrap();
+
+        // Dialect-provided scalar executes through exec_scalar_function.
+        let rows = conn
+            .prepare("SELECT test_add_one(41)")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![vec![crate::Value::Numeric(
+                crate::numeric::Numeric::Integer(42)
+            )]]
+        );
+
+        // Built-ins still resolve because the dialect composes with the
+        // shared table.
+        let rows = conn
+            .prepare("SELECT abs(-7)")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![vec![crate::Value::Numeric(
+                crate::numeric::Numeric::Integer(7)
+            )]]
+        );
+
+        // Unknown names still error.
+        let err = conn.prepare("SELECT no_such_function(1)").unwrap_err();
+        assert!(err.to_string().contains("no such function"));
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn dialect_function_alias_preserves_outer_join() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(
+            &io,
+            "dialect-outer-join.db",
+            Arc::new(TestDialect::default()),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+
+        conn.execute("CREATE TABLE lhs (id INTEGER)").unwrap();
+        conn.execute("CREATE TABLE rhs (id INTEGER, value INTEGER)")
+            .unwrap();
+        conn.execute("INSERT INTO lhs VALUES (1), (2)").unwrap();
+        conn.execute("INSERT INTO rhs VALUES (1, 0)").unwrap();
+
+        let rows = conn
+            .prepare(
+                "SELECT lhs.id FROM lhs LEFT JOIN rhs ON rhs.id = lhs.id \
+                 WHERE nvl(rhs.value, 1) = 1 ORDER BY lhs.id",
+            )
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(rows, vec![vec![crate::Value::from_i64(2)]]);
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn dialect_owns_the_function_surface() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(&io, "dialect-nofuncs.db", Arc::new(NoFunctionsDialect)).unwrap();
+        let conn = db.connect().unwrap();
+
+        // Function-free SQL works, including DDL (whose internal helper
+        // statements resolve with SQLite semantics regardless of dialect).
+        conn.execute("CREATE TABLE t (x INTEGER)").unwrap();
+        conn.execute("INSERT INTO t VALUES (-7)").unwrap();
+
+        // A SQLite built-in is not part of this dialect's surface.
+        let err = conn.prepare("SELECT abs(x) FROM t").unwrap_err();
+        assert!(
+            err.to_string().contains("no such function"),
+            "unexpected error: {err}"
+        );
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn cdc_generated_functions_bypass_the_dialect() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(&io, "dialect-cdc.db", Arc::new(NoFunctionsDialect)).unwrap();
+        let conn = db.connect().unwrap();
+
+        conn.execute("CREATE TABLE t (x INTEGER)").unwrap();
+        conn.execute("PRAGMA capture_data_changes_conn('full')")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (7)").unwrap();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("INSERT INTO t VALUES (8)").unwrap();
+        conn.execute("COMMIT").unwrap();
+
+        let rows = conn
+            .prepare(
+                "SELECT change_type, table_name, id, change_txn_id \
+                 FROM turso_cdc ORDER BY change_id",
+            )
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows[0][0], crate::Value::from_i64(1));
+        assert_eq!(rows[0][1], crate::Value::build_text("t"));
+        assert_eq!(rows[0][2], crate::Value::from_i64(1));
+        assert_eq!(rows[1][0], crate::Value::from_i64(2));
+        assert_eq!(rows[1][1], crate::Value::Null);
+        assert_eq!(rows[1][2], crate::Value::Null);
+        assert_eq!(rows[0][3], rows[1][3]);
+        assert_eq!(rows[2][0], crate::Value::from_i64(1));
+        assert_eq!(rows[2][1], crate::Value::build_text("t"));
+        assert_eq!(rows[2][2], crate::Value::from_i64(2));
+        assert_eq!(rows[3][0], crate::Value::from_i64(2));
+        assert_eq!(rows[3][1], crate::Value::Null);
+        assert_eq!(rows[3][2], crate::Value::Null);
+        assert_eq!(rows[2][3], rows[3][3]);
         conn.close().unwrap();
     }
 

--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -149,6 +149,14 @@ pub trait Dialect: Send + Sync + 'static {
             "no such function: {name}"
         )))
     }
+
+    /// Whether this dialect needs the custom-type machinery (DECODE/ENCODE,
+    /// affinity metadata) regardless of the experimental database flag.
+    /// A dialect whose type system leans on custom types (e.g. PostgreSQL)
+    /// returns true so its databases never open with the machinery off.
+    fn requires_custom_types(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -3,11 +3,12 @@
 //! The [`Dialect`] trait is the boundary between the engine and the SQL
 //! dialect a frontend speaks. The engine owns the mechanics — pages,
 //! B-trees, the `sqlite_schema` table itself, bytecode — and consults the
-//! dialect wherever the meaning of SQL text is dialect-specific. The
-//! [`sqlite`] module owns [`SqliteDialect`], the SQLite implementation,
-//! and the catalog tables that ship with every Turso build (`pragma_*`,
-//! `json_each`/`json_tree`, `sqlite_dbpage`, `btree_dump`,
-//! `sqlite_turso_types`).
+//! dialect wherever the meaning of SQL text is dialect-specific: parsing
+//! statements into the engine AST and interpreting persisted schema text.
+//! The [`sqlite`] module owns [`SqliteDialect`], the SQLite
+//! implementation, and the catalog tables that ship with every Turso
+//! build (`pragma_*`, `json_each`/`json_tree`, `sqlite_dbpage`,
+//! `btree_dump`, `sqlite_turso_types`).
 
 pub mod sqlite;
 
@@ -17,11 +18,9 @@ pub use sqlite::SqliteDialect;
 ///
 /// Every [`crate::Database`] carries a dialect, supplied explicitly by
 /// every open path and fixed for the lifetime of the database;
-/// SQLite-compatible callers pass [`SqliteDialect`]. The engine consults
-/// the dialect on every schema load — database open, connection schema
-/// reparse, the `ParseSchema` opcode after DDL, and MVCC schema rebuild —
-/// so a frontend can store its own schema SQL in `sqlite_schema` and
-/// reparse it here.
+/// SQLite-compatible callers pass [`SqliteDialect`]. Initial statement
+/// preparation, re-preparation, and every schema load go through this
+/// interface.
 pub trait Dialect: Send + Sync + 'static {
     /// Stable identifier for this dialect (e.g. "sqlite", "postgres").
     ///
@@ -29,6 +28,16 @@ pub trait Dialect: Send + Sync + 'static {
     /// created with; the process-wide database registry uses this name to
     /// reject an open whose dialect differs from the already-open instance.
     fn name(&self) -> &'static str;
+
+    /// Parse the first statement in `sql` into the engine AST.
+    ///
+    /// Returns the parsed command, if any, and the number of input bytes
+    /// consumed. The engine uses the same method for initial preparation and
+    /// re-preparation, so dialect-specific SQL remains valid after schema or
+    /// connection compilation state changes. Implementations must accept the
+    /// canonical SQLite text produced by the engine AST formatter because
+    /// engine-generated and AST-only statements use that representation.
+    fn parse(&self, sql: &str) -> crate::Result<(Option<turso_parser::ast::Cmd>, usize)>;
 
     /// Parse a `sqlite_schema` `type='table'` row's SQL into a table
     /// definition.
@@ -60,11 +69,22 @@ mod tests {
     #[derive(Default)]
     struct TestDialect {
         parse_calls: AtomicUsize,
+        statement_parse_calls: AtomicUsize,
     }
 
     impl Dialect for TestDialect {
         fn name(&self) -> &'static str {
             "test"
+        }
+
+        fn parse(&self, sql: &str) -> crate::Result<(Option<turso_parser::ast::Cmd>, usize)> {
+            self.statement_parse_calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(sql) = sql.strip_prefix("test: ") {
+                let (cmd, offset) = sqlite::parse(sql)?;
+                Ok((cmd, "test: ".len() + offset))
+            } else {
+                sqlite::parse(sql)
+            }
         }
 
         fn parse_table_sql(&self, sql: &str, root_page: i64) -> crate::Result<BTreeTable> {
@@ -120,6 +140,53 @@ mod tests {
         // Both tables are usable under the dialect.
         conn.execute("INSERT INTO t VALUES (1)").unwrap();
         conn.execute("INSERT INTO u VALUES (2)").unwrap();
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn dialect_parser_is_used_for_reprepare() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let dialect = Arc::new(TestDialect::default());
+        let db = open_db(&io, "dialect-reprepare.db", dialect.clone()).unwrap();
+        let conn = db.connect().unwrap();
+
+        let mut stmt = conn.prepare("test: SELECT 42").unwrap();
+        conn.set_full_column_names(true);
+        let rows = stmt.run_collect_rows().unwrap();
+
+        assert_eq!(rows, vec![vec![crate::Value::from_i64(42)]]);
+        assert_eq!(
+            stmt.stmt_status(crate::StatementStatusCounter::Reprepare),
+            1
+        );
+        assert_eq!(dialect.statement_parse_calls.load(Ordering::SeqCst), 2);
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn query_runner_reports_invalid_utf8_once() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(&io, "query-runner-invalid-utf8.db", Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        let mut runner = conn.query_runner(b"SELECT 1;\xff");
+
+        let Some(Err(crate::LimboError::ParseError(message))) = runner.next() else {
+            panic!("invalid UTF-8 must produce a parse error");
+        };
+        assert!(message.contains("invalid UTF-8"));
+        assert!(runner.next().is_none());
+        conn.close().unwrap();
+    }
+
+    #[test]
+    fn query_runner_reports_parse_error_once() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = open_db(&io, "query-runner-parse-error.db", Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        let mut runner = conn.query_runner(b"SELECT * FROM");
+
+        assert!(runner.next().is_some_and(|result| result.is_err()));
+        assert!(runner.next().is_none());
         conn.close().unwrap();
     }
 

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -55,6 +55,14 @@ impl super::Dialect for SqliteDialect {
             }
         }
     }
+
+    fn register_catalog(
+        &self,
+        schema: &mut Schema,
+        enable_custom_types: bool,
+    ) -> crate::Result<()> {
+        register_builtin_catalog(schema, enable_custom_types)
+    }
 }
 
 /// Parse the first SQLite statement in `sql` and return its consumed byte count.
@@ -152,6 +160,7 @@ fn pragma_vtabs() -> Vec<Arc<VirtualTable>> {
                 kind: VTabKind::TableValuedFunction,
                 vtab_type: VirtualTableType::Pragma(tab),
                 vtab_id: 0,
+                is_droppable: false,
                 innocuous: true,
             })
         })

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -13,6 +13,13 @@ use crate::sync::Arc;
 use crate::vtab::{VirtualTable, VirtualTableType};
 use turso_ext::VTabKind;
 
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+use crate::function::FtsFunc;
+#[cfg(feature = "json")]
+use crate::function::JsonFunc;
+#[allow(unused_imports)]
+use crate::function::{AggFunc, Func, MathFunc, ScalarFunc, VectorFunc, WindowFunc};
+
 /// The SQLite dialect: statements are SQLite SQL and `sqlite_schema`
 /// rows are canonical SQLite text.
 pub struct SqliteDialect;
@@ -62,6 +69,10 @@ impl super::Dialect for SqliteDialect {
         enable_custom_types: bool,
     ) -> crate::Result<()> {
         register_builtin_catalog(schema, enable_custom_types)
+    }
+
+    fn resolve_function(&self, name: &str, arg_count: usize) -> crate::Result<Option<Func>> {
+        resolve_builtin_function(name, arg_count)
     }
 }
 
@@ -165,4 +176,327 @@ fn pragma_vtabs() -> Vec<Arc<VirtualTable>> {
             })
         })
         .collect()
+}
+
+/// Resolve a name against the built-in SQLite function set.
+///
+/// This table is the SQLite dialect's scalar/aggregate/window name surface,
+/// and doubles as the shared helper other dialects compose with when they
+/// want a built-in under the same name. Engine mechanics that classify
+/// already-translated AST (aggregate/window detection in the planner,
+/// determinism checks on schema expressions) also resolve against it
+/// directly, because the translated AST always references the engine
+/// surface regardless of the frontend dialect.
+pub fn resolve_builtin_function(name: &str, arg_count: usize) -> crate::Result<Option<Func>> {
+    let normalized_name = crate::util::normalize_ident(name);
+    match normalized_name.as_str() {
+        "avg" => {
+            if arg_count != 1 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Agg(AggFunc::Avg)))
+        }
+        "count" => {
+            // Handle both COUNT() and COUNT(expr) cases
+            if arg_count == 0 {
+                Ok(Some(Func::Agg(AggFunc::Count0))) // COUNT() case
+            } else if arg_count == 1 {
+                Ok(Some(Func::Agg(AggFunc::Count))) // COUNT(expr) case
+            } else {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+        }
+        "group_concat" => {
+            if arg_count != 1 && arg_count != 2 {
+                println!("{arg_count}");
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Agg(AggFunc::GroupConcat)))
+        }
+        "max" if arg_count > 1 => Ok(Some(Func::Scalar(ScalarFunc::Max))),
+        "max" => {
+            if arg_count < 1 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Agg(AggFunc::Max)))
+        }
+        "min" if arg_count > 1 => Ok(Some(Func::Scalar(ScalarFunc::Min))),
+        "min" => {
+            if arg_count < 1 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Agg(AggFunc::Min)))
+        }
+        "nullif" if arg_count == 2 => Ok(Some(Func::Scalar(ScalarFunc::Nullif))),
+        "string_agg" => {
+            if arg_count != 2 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Agg(AggFunc::StringAgg)))
+        }
+        "sum" => {
+            if arg_count != 1 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Agg(AggFunc::Sum)))
+        }
+        "total" => {
+            if arg_count != 1 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Agg(AggFunc::Total)))
+        }
+        "row_number" => {
+            if arg_count != 0 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::RowNumber)))
+        }
+        "timediff" => {
+            if arg_count != 2 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Scalar(ScalarFunc::TimeDiff)))
+        }
+        "array_agg" => Ok(Some(Func::Agg(AggFunc::ArrayAgg))),
+        #[cfg(feature = "json")]
+        "jsonb_group_array" => Ok(Some(Func::Agg(AggFunc::JsonbGroupArray))),
+        #[cfg(feature = "json")]
+        "json_group_array" => Ok(Some(Func::Agg(AggFunc::JsonGroupArray))),
+        #[cfg(feature = "json")]
+        "jsonb_group_object" => Ok(Some(Func::Agg(AggFunc::JsonbGroupObject))),
+        #[cfg(feature = "json")]
+        "json_group_object" => Ok(Some(Func::Agg(AggFunc::JsonGroupObject))),
+        "char" | "chr" => Ok(Some(Func::Scalar(ScalarFunc::Char))),
+        "coalesce" => Ok(Some(Func::Scalar(ScalarFunc::Coalesce))),
+        "concat" => {
+            if arg_count == 0 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Scalar(ScalarFunc::Concat)))
+        }
+        "concat_ws" => {
+            if arg_count < 2 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Scalar(ScalarFunc::ConcatWs)))
+        }
+        "changes" => Ok(Some(Func::Scalar(ScalarFunc::Changes))),
+        "total_changes" => Ok(Some(Func::Scalar(ScalarFunc::TotalChanges))),
+        "glob" => Ok(Some(Func::Scalar(ScalarFunc::Glob))),
+        "ifnull" => Ok(Some(Func::Scalar(ScalarFunc::IfNull))),
+        "if" | "iif" => Ok(Some(Func::Scalar(ScalarFunc::Iif))),
+        "instr" | "strpos" => Ok(Some(Func::Scalar(ScalarFunc::Instr))),
+        "like" => Ok(Some(Func::Scalar(ScalarFunc::Like))),
+        "abs" => Ok(Some(Func::Scalar(ScalarFunc::Abs))),
+        "upper" => Ok(Some(Func::Scalar(ScalarFunc::Upper))),
+        "lower" => Ok(Some(Func::Scalar(ScalarFunc::Lower))),
+        "random" => Ok(Some(Func::Scalar(ScalarFunc::Random))),
+        "randomblob" => Ok(Some(Func::Scalar(ScalarFunc::RandomBlob))),
+        "trim" | "btrim" => Ok(Some(Func::Scalar(ScalarFunc::Trim))),
+        "ltrim" => Ok(Some(Func::Scalar(ScalarFunc::LTrim))),
+        "rtrim" => Ok(Some(Func::Scalar(ScalarFunc::RTrim))),
+        "round" => Ok(Some(Func::Scalar(ScalarFunc::Round))),
+        "length" | "char_length" | "character_length" => Ok(Some(Func::Scalar(ScalarFunc::Length))),
+        "octet_length" => Ok(Some(Func::Scalar(ScalarFunc::OctetLength))),
+        "sign" => Ok(Some(Func::Scalar(ScalarFunc::Sign))),
+        "substr" => {
+            if arg_count != 2 && arg_count != 3 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Scalar(ScalarFunc::Substr)))
+        }
+        "substring" => {
+            if arg_count != 2 && arg_count != 3 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Scalar(ScalarFunc::Substring)))
+        }
+        "date" => Ok(Some(Func::Scalar(ScalarFunc::Date))),
+        "time" => Ok(Some(Func::Scalar(ScalarFunc::Time))),
+        "datetime" => Ok(Some(Func::Scalar(ScalarFunc::DateTime))),
+        "typeof" => Ok(Some(Func::Scalar(ScalarFunc::Typeof))),
+        "last_insert_rowid" => Ok(Some(Func::Scalar(ScalarFunc::LastInsertRowid))),
+        "unicode" => Ok(Some(Func::Scalar(ScalarFunc::Unicode))),
+        "unistr" => Ok(Some(Func::Scalar(ScalarFunc::Unistr))),
+        "unistr_quote" => Ok(Some(Func::Scalar(ScalarFunc::UnistrQuote))),
+        "quote" => Ok(Some(Func::Scalar(ScalarFunc::Quote))),
+        "sqlite_version" => Ok(Some(Func::Scalar(ScalarFunc::SqliteVersion))),
+        "turso_version" => Ok(Some(Func::Scalar(ScalarFunc::TursoVersion))),
+        "sqlite_source_id" => Ok(Some(Func::Scalar(ScalarFunc::SqliteSourceId))),
+        "replace" => Ok(Some(Func::Scalar(ScalarFunc::Replace))),
+        "likely" => Ok(Some(Func::Scalar(ScalarFunc::Likely))),
+        "likelihood" => Ok(Some(Func::Scalar(ScalarFunc::Likelihood))),
+        "unlikely" => Ok(Some(Func::Scalar(ScalarFunc::Unlikely))),
+        #[cfg(feature = "json")]
+        "json" => Ok(Some(Func::Json(JsonFunc::Json))),
+        #[cfg(feature = "json")]
+        "jsonb" => Ok(Some(Func::Json(JsonFunc::Jsonb))),
+        #[cfg(feature = "json")]
+        "json_array_length" => Ok(Some(Func::Json(JsonFunc::JsonArrayLength))),
+        #[cfg(feature = "json")]
+        "json_array" => Ok(Some(Func::Json(JsonFunc::JsonArray))),
+        #[cfg(feature = "json")]
+        "jsonb_array" => Ok(Some(Func::Json(JsonFunc::JsonbArray))),
+        #[cfg(feature = "json")]
+        "json_extract" => Ok(Some(Func::Json(JsonFunc::JsonExtract))),
+        #[cfg(feature = "json")]
+        "jsonb_extract" => Ok(Some(Func::Json(JsonFunc::JsonbExtract))),
+        #[cfg(feature = "json")]
+        "json_object" => Ok(Some(Func::Json(JsonFunc::JsonObject))),
+        #[cfg(feature = "json")]
+        "jsonb_object" => Ok(Some(Func::Json(JsonFunc::JsonbObject))),
+        #[cfg(feature = "json")]
+        "json_type" => Ok(Some(Func::Json(JsonFunc::JsonType))),
+        #[cfg(feature = "json")]
+        "json_error_position" => Ok(Some(Func::Json(JsonFunc::JsonErrorPosition))),
+        #[cfg(feature = "json")]
+        "json_valid" => Ok(Some(Func::Json(JsonFunc::JsonValid))),
+        #[cfg(feature = "json")]
+        "json_patch" => Ok(Some(Func::Json(JsonFunc::JsonPatch))),
+        #[cfg(feature = "json")]
+        "jsonb_patch" => Ok(Some(Func::Json(JsonFunc::JsonbPatch))),
+        #[cfg(feature = "json")]
+        "json_remove" => Ok(Some(Func::Json(JsonFunc::JsonRemove))),
+        #[cfg(feature = "json")]
+        "jsonb_remove" => Ok(Some(Func::Json(JsonFunc::JsonbRemove))),
+        #[cfg(feature = "json")]
+        "json_replace" => Ok(Some(Func::Json(JsonFunc::JsonReplace))),
+        #[cfg(feature = "json")]
+        "json_insert" => Ok(Some(Func::Json(JsonFunc::JsonInsert))),
+        #[cfg(feature = "json")]
+        "jsonb_insert" => Ok(Some(Func::Json(JsonFunc::JsonbInsert))),
+        #[cfg(feature = "json")]
+        "jsonb_replace" => Ok(Some(Func::Json(JsonFunc::JsonbReplace))),
+        #[cfg(feature = "json")]
+        "json_pretty" => Ok(Some(Func::Json(JsonFunc::JsonPretty))),
+        #[cfg(feature = "json")]
+        "json_set" => Ok(Some(Func::Json(JsonFunc::JsonSet))),
+        #[cfg(feature = "json")]
+        "jsonb_set" => Ok(Some(Func::Json(JsonFunc::JsonbSet))),
+        #[cfg(feature = "json")]
+        "json_quote" => Ok(Some(Func::Json(JsonFunc::JsonQuote))),
+        "unixepoch" => Ok(Some(Func::Scalar(ScalarFunc::UnixEpoch))),
+        "julianday" => Ok(Some(Func::Scalar(ScalarFunc::JulianDay))),
+        "hex" => Ok(Some(Func::Scalar(ScalarFunc::Hex))),
+        "unhex" => Ok(Some(Func::Scalar(ScalarFunc::Unhex))),
+        "zeroblob" => Ok(Some(Func::Scalar(ScalarFunc::ZeroBlob))),
+        "soundex" => Ok(Some(Func::Scalar(ScalarFunc::Soundex))),
+        "table_columns_json_array" => Ok(Some(Func::Scalar(ScalarFunc::TableColumnsJsonArray))),
+        "bin_record_json_object" => Ok(Some(Func::Scalar(ScalarFunc::BinRecordJsonObject))),
+        "conn_txn_id" => Ok(Some(Func::Scalar(ScalarFunc::ConnTxnId))),
+        "is_autocommit" => Ok(Some(Func::Scalar(ScalarFunc::IsAutocommit))),
+        "sequence_watermark_experimental" => Ok(Some(Func::Scalar(ScalarFunc::SequenceWatermark))),
+        "acos" => Ok(Some(Func::Math(MathFunc::Acos))),
+        "acosh" => Ok(Some(Func::Math(MathFunc::Acosh))),
+        "asin" => Ok(Some(Func::Math(MathFunc::Asin))),
+        "asinh" => Ok(Some(Func::Math(MathFunc::Asinh))),
+        "atan" => Ok(Some(Func::Math(MathFunc::Atan))),
+        "atan2" => Ok(Some(Func::Math(MathFunc::Atan2))),
+        "atanh" => Ok(Some(Func::Math(MathFunc::Atanh))),
+        "ceil" => Ok(Some(Func::Math(MathFunc::Ceil))),
+        "ceiling" => Ok(Some(Func::Math(MathFunc::Ceiling))),
+        "cos" => Ok(Some(Func::Math(MathFunc::Cos))),
+        "cosh" => Ok(Some(Func::Math(MathFunc::Cosh))),
+        "degrees" => Ok(Some(Func::Math(MathFunc::Degrees))),
+        "exp" => Ok(Some(Func::Math(MathFunc::Exp))),
+        "floor" => Ok(Some(Func::Math(MathFunc::Floor))),
+        "ln" => Ok(Some(Func::Math(MathFunc::Ln))),
+        "log" => Ok(Some(Func::Math(MathFunc::Log))),
+        "log10" => Ok(Some(Func::Math(MathFunc::Log10))),
+        "log2" => Ok(Some(Func::Math(MathFunc::Log2))),
+        "mod" => Ok(Some(Func::Math(MathFunc::Mod))),
+        "pi" => Ok(Some(Func::Math(MathFunc::Pi))),
+        "pow" => Ok(Some(Func::Math(MathFunc::Pow))),
+        "power" => Ok(Some(Func::Math(MathFunc::Power))),
+        "radians" => Ok(Some(Func::Math(MathFunc::Radians))),
+        "sin" => Ok(Some(Func::Math(MathFunc::Sin))),
+        "sinh" => Ok(Some(Func::Math(MathFunc::Sinh))),
+        "sqrt" => Ok(Some(Func::Math(MathFunc::Sqrt))),
+        "tan" => Ok(Some(Func::Math(MathFunc::Tan))),
+        "tanh" => Ok(Some(Func::Math(MathFunc::Tanh))),
+        "trunc" => Ok(Some(Func::Math(MathFunc::Trunc))),
+        #[cfg(feature = "fs")]
+        #[cfg(not(target_family = "wasm"))]
+        "load_extension" => Ok(Some(Func::Scalar(ScalarFunc::LoadExtension))),
+        "strftime" => Ok(Some(Func::Scalar(ScalarFunc::StrfTime))),
+        "printf" | "format" => Ok(Some(Func::Scalar(ScalarFunc::Printf))),
+        "vector" => Ok(Some(Func::Vector(VectorFunc::Vector))),
+        "vector32" => Ok(Some(Func::Vector(VectorFunc::Vector32))),
+        "vector32_sparse" => Ok(Some(Func::Vector(VectorFunc::Vector32Sparse))),
+        "vector64" => Ok(Some(Func::Vector(VectorFunc::Vector64))),
+        "vector8" => Ok(Some(Func::Vector(VectorFunc::Vector8))),
+        "vector1bit" => Ok(Some(Func::Vector(VectorFunc::Vector1Bit))),
+        "vector_extract" => Ok(Some(Func::Vector(VectorFunc::VectorExtract))),
+        "vector_distance_cos" => Ok(Some(Func::Vector(VectorFunc::VectorDistanceCos))),
+        "vector_distance_l2" => Ok(Some(Func::Vector(VectorFunc::VectorDistanceL2))),
+        "vector_distance_jaccard" => Ok(Some(Func::Vector(VectorFunc::VectorDistanceJaccard))),
+        "vector_distance_dot" => Ok(Some(Func::Vector(VectorFunc::VectorDistanceDot))),
+        "vector_concat" => Ok(Some(Func::Vector(VectorFunc::VectorConcat))),
+        "vector_slice" => Ok(Some(Func::Vector(VectorFunc::VectorSlice))),
+        // FTS functions
+        #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+        "fts_score" => Ok(Some(Func::Fts(FtsFunc::Score))),
+        #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+        "fts_match" => Ok(Some(Func::Fts(FtsFunc::Match))),
+        #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+        "fts_highlight" => Ok(Some(Func::Fts(FtsFunc::Highlight))),
+        // Test type functions (for custom type system testing)
+        "test_uint_encode" => Ok(Some(Func::Scalar(ScalarFunc::TestUintEncode))),
+        "test_uint_decode" => Ok(Some(Func::Scalar(ScalarFunc::TestUintDecode))),
+        "test_uint_add" => Ok(Some(Func::Scalar(ScalarFunc::TestUintAdd))),
+        "test_uint_sub" => Ok(Some(Func::Scalar(ScalarFunc::TestUintSub))),
+        "test_uint_mul" => Ok(Some(Func::Scalar(ScalarFunc::TestUintMul))),
+        "test_uint_div" => Ok(Some(Func::Scalar(ScalarFunc::TestUintDiv))),
+        "test_uint_lt" => Ok(Some(Func::Scalar(ScalarFunc::TestUintLt))),
+        "test_uint_eq" => Ok(Some(Func::Scalar(ScalarFunc::TestUintEq))),
+        #[cfg(feature = "test_helper")]
+        "test_nondet_counter" => Ok(Some(Func::Scalar(ScalarFunc::TestNondetCounter))),
+        "string_reverse" | "reverse" => Ok(Some(Func::Scalar(ScalarFunc::StringReverse))),
+        "gcd" => Ok(Some(Func::Scalar(ScalarFunc::Gcd))),
+        "lcm" => Ok(Some(Func::Scalar(ScalarFunc::Lcm))),
+        "repeat" => Ok(Some(Func::Scalar(ScalarFunc::Repeat))),
+        "lpad" => Ok(Some(Func::Scalar(ScalarFunc::Lpad))),
+        "rpad" => Ok(Some(Func::Scalar(ScalarFunc::Rpad))),
+        // Built-in type support functions
+        "boolean_to_int" => Ok(Some(Func::Scalar(ScalarFunc::BooleanToInt))),
+        "int_to_boolean" => Ok(Some(Func::Scalar(ScalarFunc::IntToBoolean))),
+        "validate_ipaddr" => Ok(Some(Func::Scalar(ScalarFunc::ValidateIpAddr))),
+        "numeric_encode" => Ok(Some(Func::Scalar(ScalarFunc::NumericEncode))),
+        "numeric_decode" => Ok(Some(Func::Scalar(ScalarFunc::NumericDecode))),
+        "numeric_add" => Ok(Some(Func::Scalar(ScalarFunc::NumericAdd))),
+        "numeric_sub" => Ok(Some(Func::Scalar(ScalarFunc::NumericSub))),
+        "numeric_mul" => Ok(Some(Func::Scalar(ScalarFunc::NumericMul))),
+        "numeric_div" => Ok(Some(Func::Scalar(ScalarFunc::NumericDiv))),
+        "numeric_lt" => Ok(Some(Func::Scalar(ScalarFunc::NumericLt))),
+        "numeric_eq" => Ok(Some(Func::Scalar(ScalarFunc::NumericEq))),
+        // Array construction / element access (desugared from syntax)
+        "array" => Ok(Some(Func::Scalar(ScalarFunc::Array))),
+        "array_element" => Ok(Some(Func::Scalar(ScalarFunc::ArrayElement))),
+        "array_set_element" => Ok(Some(Func::Scalar(ScalarFunc::ArraySetElement))),
+        // Array functions
+        "array_length" | "array_upper" => Ok(Some(Func::Scalar(ScalarFunc::ArrayLength))),
+        "array_append" => Ok(Some(Func::Scalar(ScalarFunc::ArrayAppend))),
+        "array_prepend" => Ok(Some(Func::Scalar(ScalarFunc::ArrayPrepend))),
+        "array_cat" => Ok(Some(Func::Scalar(ScalarFunc::ArrayCat))),
+        "array_remove" => Ok(Some(Func::Scalar(ScalarFunc::ArrayRemove))),
+        "array_contains" => Ok(Some(Func::Scalar(ScalarFunc::ArrayContains))),
+        "array_position" => Ok(Some(Func::Scalar(ScalarFunc::ArrayPosition))),
+        "array_slice" => Ok(Some(Func::Scalar(ScalarFunc::ArraySlice))),
+        "string_to_array" => Ok(Some(Func::Scalar(ScalarFunc::StringToArray))),
+        "array_to_string" => Ok(Some(Func::Scalar(ScalarFunc::ArrayToString))),
+        "array_overlap" | "array_overlaps" => Ok(Some(Func::Scalar(ScalarFunc::ArrayOverlap))),
+        "array_contains_all" => Ok(Some(Func::Scalar(ScalarFunc::ArrayContainsAll))),
+        // Struct/Union functions
+        "struct_pack" => Ok(Some(Func::Scalar(ScalarFunc::StructPack))),
+        "struct_extract" => Ok(Some(Func::Scalar(ScalarFunc::StructExtractFunc))),
+        "union_value" => Ok(Some(Func::Scalar(ScalarFunc::UnionValueFunc))),
+        "union_tag" => Ok(Some(Func::Scalar(ScalarFunc::UnionTagFunc))),
+        "union_extract" => Ok(Some(Func::Scalar(ScalarFunc::UnionExtractFunc))),
+        // Sequence functions
+        "nextval" => Ok(Some(Func::Scalar(ScalarFunc::NextVal))),
+        "currval" => Ok(Some(Func::Scalar(ScalarFunc::CurrVal))),
+        "setval" => Ok(Some(Func::Scalar(ScalarFunc::SetVal))),
+        _ => Ok(None),
+    }
 }

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -29,6 +29,32 @@ impl super::Dialect for SqliteDialect {
     fn parse_table_sql(&self, sql: &str, root_page: i64) -> crate::Result<BTreeTable> {
         BTreeTable::from_sql(sql, root_page)
     }
+
+    fn parse_table_sql_ast(&self, sql: &str) -> crate::Result<turso_parser::ast::Stmt> {
+        parse_table_sql_ast(sql)
+    }
+
+    fn table_sql_for_replay(&self, sql: &str) -> crate::Result<String> {
+        table_sql_for_replay(sql)
+    }
+
+    fn format_table_sql(
+        &self,
+        _input: &str,
+        tbl_name: &turso_parser::ast::QualifiedName,
+        body: &turso_parser::ast::CreateTableBody,
+    ) -> crate::Result<String> {
+        match body {
+            turso_parser::ast::CreateTableBody::ColumnsAndConstraints { .. } => Ok(format!(
+                "CREATE TABLE {} {}",
+                tbl_name.name.as_ident(),
+                body
+            )),
+            turso_parser::ast::CreateTableBody::AsSelect(_) => {
+                crate::bail_parse_error!("CREATE TABLE AS SELECT is not supported")
+            }
+        }
+    }
 }
 
 /// Parse the first SQLite statement in `sql` and return its consumed byte count.
@@ -36,6 +62,49 @@ pub fn parse(sql: &str) -> crate::Result<(Option<turso_parser::ast::Cmd>, usize)
     let mut parser = turso_parser::parser::Parser::new(sql.as_bytes());
     let cmd = parser.next_cmd()?;
     Ok((cmd, parser.offset()))
+}
+
+/// Parse persisted SQLite table SQL into a `CREATE TABLE` statement.
+pub fn parse_table_sql_ast(sql: &str) -> crate::Result<turso_parser::ast::Stmt> {
+    let (cmd, _) = parse(sql)?;
+    match cmd {
+        Some(turso_parser::ast::Cmd::Stmt(stmt @ turso_parser::ast::Stmt::CreateTable { .. })) => {
+            Ok(stmt)
+        }
+        other => Err(crate::LimboError::Corrupt(format!(
+            "persisted table SQL is not CREATE TABLE: {other:?}"
+        ))),
+    }
+}
+
+/// Recover persisted SQLite table SQL for schema replay.
+///
+/// SQLite text without a database qualifier can be replayed unchanged. A
+/// qualified name must be removed because the vacuum target only exposes its
+/// main schema.
+pub fn table_sql_for_replay(sql: &str) -> crate::Result<String> {
+    let stmt = parse_table_sql_ast(sql)?;
+    let turso_parser::ast::Stmt::CreateTable {
+        mut tbl_name,
+        temporary,
+        if_not_exists,
+        body,
+    } = stmt
+    else {
+        unreachable!("parse_table_sql_ast returned a non-CREATE TABLE statement");
+    };
+
+    if tbl_name.db_name.take().is_none() {
+        return Ok(sql.to_string());
+    }
+
+    Ok(turso_parser::ast::Stmt::CreateTable {
+        tbl_name,
+        temporary,
+        if_not_exists,
+        body,
+    }
+    .to_string())
 }
 
 /// Insert the standard SQLite-style catalog tables into `schema`.

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -1,15 +1,30 @@
-//! Built-in SQLite-style catalog tables.
+//! The SQLite dialect and built-in SQLite-style catalog tables.
 //!
-//! `pragma_*` table-valued functions, `json_each`/`json_tree`,
-//! `sqlite_dbpage`, `btree_dump`, and `sqlite_turso_types`. Registered into
-//! every fresh schema by [`crate::schema::Schema::with_options`] through
-//! [`register_builtin_catalog`].
+//! [`SqliteDialect`] is the [`super::Dialect`] for SQLite: schema
+//! rows are plain SQLite text parsed with the SQLite parser. The catalog
+//! tables here (`pragma_*` table-valued functions, `json_each`/`json_tree`,
+//! `sqlite_dbpage`, `btree_dump`, and `sqlite_turso_types`) are registered
+//! into every fresh schema by [`crate::schema::Schema::with_options`]
+//! through [`register_builtin_catalog`].
 
 use crate::pragma::PragmaVirtualTable;
-use crate::schema::{Schema, Table};
+use crate::schema::{BTreeTable, Schema, Table};
 use crate::sync::Arc;
 use crate::vtab::{VirtualTable, VirtualTableType};
 use turso_ext::VTabKind;
+
+/// The SQLite dialect: `sqlite_schema` rows are canonical SQLite text.
+pub struct SqliteDialect;
+
+impl super::Dialect for SqliteDialect {
+    fn name(&self) -> &'static str {
+        "sqlite"
+    }
+
+    fn parse_table_sql(&self, sql: &str, root_page: i64) -> crate::Result<BTreeTable> {
+        BTreeTable::from_sql(sql, root_page)
+    }
+}
 
 /// Insert the standard SQLite-style catalog tables into `schema`.
 ///

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -13,7 +13,8 @@ use crate::sync::Arc;
 use crate::vtab::{VirtualTable, VirtualTableType};
 use turso_ext::VTabKind;
 
-/// The SQLite dialect: `sqlite_schema` rows are canonical SQLite text.
+/// The SQLite dialect: statements are SQLite SQL and `sqlite_schema`
+/// rows are canonical SQLite text.
 pub struct SqliteDialect;
 
 impl super::Dialect for SqliteDialect {
@@ -21,9 +22,20 @@ impl super::Dialect for SqliteDialect {
         "sqlite"
     }
 
+    fn parse(&self, sql: &str) -> crate::Result<(Option<turso_parser::ast::Cmd>, usize)> {
+        parse(sql)
+    }
+
     fn parse_table_sql(&self, sql: &str, root_page: i64) -> crate::Result<BTreeTable> {
         BTreeTable::from_sql(sql, root_page)
     }
+}
+
+/// Parse the first SQLite statement in `sql` and return its consumed byte count.
+pub fn parse(sql: &str) -> crate::Result<(Option<turso_parser::ast::Cmd>, usize)> {
+    let mut parser = turso_parser::parser::Parser::new(sql.as_bytes());
+    let cmd = parser.next_cmd()?;
+    Ok((cmd, parser.offset()))
 }
 
 /// Insert the standard SQLite-style catalog tables into `schema`.

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -216,6 +216,7 @@ impl Database {
         &self,
         path: &str,
         vfs: &str,
+        dialect: Arc<dyn crate::Dialect>,
     ) -> crate::Result<(Arc<dyn IO>, Arc<Database>)> {
         use crate::{MemoryIO, SyscallIO};
         use dynamic::get_vfs_modules;
@@ -236,7 +237,7 @@ impl Database {
                 }
             },
         };
-        let db = Self::open_file(io.clone(), path)?;
+        let db = Self::open_file(io.clone(), path, dialect)?;
         Ok((io, db))
     }
 

--- a/core/function.rs
+++ b/core/function.rs
@@ -1435,6 +1435,10 @@ pub enum Func {
     Json(JsonFunc),
     AlterTable(AlterTableFunc),
     External(Arc<ExternalFunc>),
+    /// Scalar function provided by the database's schema dialect (e.g. a
+    /// PostgreSQL catalog function). Resolved and executed through
+    /// [`crate::dialect::Dialect`]; the engine only carries the name.
+    Dialect(String),
 }
 
 impl Display for Func {
@@ -1451,6 +1455,7 @@ impl Display for Func {
             Self::Json(json_func) => write!(f, "{json_func}"),
             Self::External(generic_func) => write!(f, "{generic_func}"),
             Self::AlterTable(alter_func) => write!(f, "{alter_func}"),
+            Self::Dialect(name) => write!(f, "{name}"),
         }
     }
 }
@@ -1475,6 +1480,10 @@ impl Deterministic for Func {
             Self::Json(json_func) => json_func.is_deterministic(),
             Self::External(external_func) => external_func.is_deterministic(),
             Self::AlterTable(_) => true,
+            // Dialect scalars are catalog readers (stable within a
+            // statement); a dialect that adds a nondeterministic function
+            // should register it as an extension function instead.
+            Self::Dialect(_) => true,
         }
     }
 }
@@ -1537,322 +1546,12 @@ impl Func {
     pub fn needs_star_expansion(&self) -> bool {
         false
     }
+    /// Resolve a built-in function name. Thin wrapper over
+    /// [`crate::dialect::sqlite::resolve_builtin_function`], where the
+    /// SQLite name table lives; kept on `Func` for the engine call sites
+    /// that classify translated AST.
     pub fn resolve_function(name: &str, arg_count: usize) -> Result<Option<Self>, LimboError> {
-        let normalized_name = crate::util::normalize_ident(name);
-        match normalized_name.as_str() {
-            "avg" => {
-                if arg_count != 1 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Agg(AggFunc::Avg)))
-            }
-            "count" => {
-                // Handle both COUNT() and COUNT(expr) cases
-                if arg_count == 0 {
-                    Ok(Some(Self::Agg(AggFunc::Count0))) // COUNT() case
-                } else if arg_count == 1 {
-                    Ok(Some(Self::Agg(AggFunc::Count))) // COUNT(expr) case
-                } else {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-            }
-            "group_concat" => {
-                if arg_count != 1 && arg_count != 2 {
-                    println!("{arg_count}");
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Agg(AggFunc::GroupConcat)))
-            }
-            "max" if arg_count > 1 => Ok(Some(Self::Scalar(ScalarFunc::Max))),
-            "max" => {
-                if arg_count < 1 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Agg(AggFunc::Max)))
-            }
-            "min" if arg_count > 1 => Ok(Some(Self::Scalar(ScalarFunc::Min))),
-            "min" => {
-                if arg_count < 1 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Agg(AggFunc::Min)))
-            }
-            "nullif" if arg_count == 2 => Ok(Some(Self::Scalar(ScalarFunc::Nullif))),
-            "string_agg" => {
-                if arg_count != 2 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Agg(AggFunc::StringAgg)))
-            }
-            "sum" => {
-                if arg_count != 1 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Agg(AggFunc::Sum)))
-            }
-            "total" => {
-                if arg_count != 1 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Agg(AggFunc::Total)))
-            }
-            "row_number" => {
-                if arg_count != 0 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Window(WindowFunc::RowNumber)))
-            }
-            "timediff" => {
-                if arg_count != 2 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Scalar(ScalarFunc::TimeDiff)))
-            }
-            "array_agg" => Ok(Some(Self::Agg(AggFunc::ArrayAgg))),
-            #[cfg(feature = "json")]
-            "jsonb_group_array" => Ok(Some(Self::Agg(AggFunc::JsonbGroupArray))),
-            #[cfg(feature = "json")]
-            "json_group_array" => Ok(Some(Self::Agg(AggFunc::JsonGroupArray))),
-            #[cfg(feature = "json")]
-            "jsonb_group_object" => Ok(Some(Self::Agg(AggFunc::JsonbGroupObject))),
-            #[cfg(feature = "json")]
-            "json_group_object" => Ok(Some(Self::Agg(AggFunc::JsonGroupObject))),
-            "char" | "chr" => Ok(Some(Self::Scalar(ScalarFunc::Char))),
-            "coalesce" => Ok(Some(Self::Scalar(ScalarFunc::Coalesce))),
-            "concat" => {
-                if arg_count == 0 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Scalar(ScalarFunc::Concat)))
-            }
-            "concat_ws" => {
-                if arg_count < 2 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Scalar(ScalarFunc::ConcatWs)))
-            }
-            "changes" => Ok(Some(Self::Scalar(ScalarFunc::Changes))),
-            "total_changes" => Ok(Some(Self::Scalar(ScalarFunc::TotalChanges))),
-            "glob" => Ok(Some(Self::Scalar(ScalarFunc::Glob))),
-            "ifnull" => Ok(Some(Self::Scalar(ScalarFunc::IfNull))),
-            "if" | "iif" => Ok(Some(Self::Scalar(ScalarFunc::Iif))),
-            "instr" | "strpos" => Ok(Some(Self::Scalar(ScalarFunc::Instr))),
-            "like" => Ok(Some(Self::Scalar(ScalarFunc::Like))),
-            "abs" => Ok(Some(Self::Scalar(ScalarFunc::Abs))),
-            "upper" => Ok(Some(Self::Scalar(ScalarFunc::Upper))),
-            "lower" => Ok(Some(Self::Scalar(ScalarFunc::Lower))),
-            "random" => Ok(Some(Self::Scalar(ScalarFunc::Random))),
-            "randomblob" => Ok(Some(Self::Scalar(ScalarFunc::RandomBlob))),
-            "trim" | "btrim" => Ok(Some(Self::Scalar(ScalarFunc::Trim))),
-            "ltrim" => Ok(Some(Self::Scalar(ScalarFunc::LTrim))),
-            "rtrim" => Ok(Some(Self::Scalar(ScalarFunc::RTrim))),
-            "round" => Ok(Some(Self::Scalar(ScalarFunc::Round))),
-            "length" | "char_length" | "character_length" => {
-                Ok(Some(Self::Scalar(ScalarFunc::Length)))
-            }
-            "octet_length" => Ok(Some(Self::Scalar(ScalarFunc::OctetLength))),
-            "sign" => Ok(Some(Self::Scalar(ScalarFunc::Sign))),
-            "substr" => {
-                if arg_count != 2 && arg_count != 3 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Scalar(ScalarFunc::Substr)))
-            }
-            "substring" => {
-                if arg_count != 2 && arg_count != 3 {
-                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
-                }
-                Ok(Some(Self::Scalar(ScalarFunc::Substring)))
-            }
-            "date" => Ok(Some(Self::Scalar(ScalarFunc::Date))),
-            "time" => Ok(Some(Self::Scalar(ScalarFunc::Time))),
-            "datetime" => Ok(Some(Self::Scalar(ScalarFunc::DateTime))),
-            "typeof" => Ok(Some(Self::Scalar(ScalarFunc::Typeof))),
-            "last_insert_rowid" => Ok(Some(Self::Scalar(ScalarFunc::LastInsertRowid))),
-            "unicode" => Ok(Some(Self::Scalar(ScalarFunc::Unicode))),
-            "unistr" => Ok(Some(Self::Scalar(ScalarFunc::Unistr))),
-            "unistr_quote" => Ok(Some(Self::Scalar(ScalarFunc::UnistrQuote))),
-            "quote" => Ok(Some(Self::Scalar(ScalarFunc::Quote))),
-            "sqlite_version" => Ok(Some(Self::Scalar(ScalarFunc::SqliteVersion))),
-            "turso_version" => Ok(Some(Self::Scalar(ScalarFunc::TursoVersion))),
-            "sqlite_source_id" => Ok(Some(Self::Scalar(ScalarFunc::SqliteSourceId))),
-            "replace" => Ok(Some(Self::Scalar(ScalarFunc::Replace))),
-            "likely" => Ok(Some(Self::Scalar(ScalarFunc::Likely))),
-            "likelihood" => Ok(Some(Self::Scalar(ScalarFunc::Likelihood))),
-            "unlikely" => Ok(Some(Self::Scalar(ScalarFunc::Unlikely))),
-            #[cfg(feature = "json")]
-            "json" => Ok(Some(Self::Json(JsonFunc::Json))),
-            #[cfg(feature = "json")]
-            "jsonb" => Ok(Some(Self::Json(JsonFunc::Jsonb))),
-            #[cfg(feature = "json")]
-            "json_array_length" => Ok(Some(Self::Json(JsonFunc::JsonArrayLength))),
-            #[cfg(feature = "json")]
-            "json_array" => Ok(Some(Self::Json(JsonFunc::JsonArray))),
-            #[cfg(feature = "json")]
-            "jsonb_array" => Ok(Some(Self::Json(JsonFunc::JsonbArray))),
-            #[cfg(feature = "json")]
-            "json_extract" => Ok(Some(Func::Json(JsonFunc::JsonExtract))),
-            #[cfg(feature = "json")]
-            "jsonb_extract" => Ok(Some(Func::Json(JsonFunc::JsonbExtract))),
-            #[cfg(feature = "json")]
-            "json_object" => Ok(Some(Func::Json(JsonFunc::JsonObject))),
-            #[cfg(feature = "json")]
-            "jsonb_object" => Ok(Some(Func::Json(JsonFunc::JsonbObject))),
-            #[cfg(feature = "json")]
-            "json_type" => Ok(Some(Func::Json(JsonFunc::JsonType))),
-            #[cfg(feature = "json")]
-            "json_error_position" => Ok(Some(Self::Json(JsonFunc::JsonErrorPosition))),
-            #[cfg(feature = "json")]
-            "json_valid" => Ok(Some(Self::Json(JsonFunc::JsonValid))),
-            #[cfg(feature = "json")]
-            "json_patch" => Ok(Some(Self::Json(JsonFunc::JsonPatch))),
-            #[cfg(feature = "json")]
-            "jsonb_patch" => Ok(Some(Self::Json(JsonFunc::JsonbPatch))),
-            #[cfg(feature = "json")]
-            "json_remove" => Ok(Some(Self::Json(JsonFunc::JsonRemove))),
-            #[cfg(feature = "json")]
-            "jsonb_remove" => Ok(Some(Self::Json(JsonFunc::JsonbRemove))),
-            #[cfg(feature = "json")]
-            "json_replace" => Ok(Some(Self::Json(JsonFunc::JsonReplace))),
-            #[cfg(feature = "json")]
-            "json_insert" => Ok(Some(Self::Json(JsonFunc::JsonInsert))),
-            #[cfg(feature = "json")]
-            "jsonb_insert" => Ok(Some(Self::Json(JsonFunc::JsonbInsert))),
-            #[cfg(feature = "json")]
-            "jsonb_replace" => Ok(Some(Self::Json(JsonFunc::JsonbReplace))),
-            #[cfg(feature = "json")]
-            "json_pretty" => Ok(Some(Self::Json(JsonFunc::JsonPretty))),
-            #[cfg(feature = "json")]
-            "json_set" => Ok(Some(Self::Json(JsonFunc::JsonSet))),
-            #[cfg(feature = "json")]
-            "jsonb_set" => Ok(Some(Self::Json(JsonFunc::JsonbSet))),
-            #[cfg(feature = "json")]
-            "json_quote" => Ok(Some(Self::Json(JsonFunc::JsonQuote))),
-            "unixepoch" => Ok(Some(Self::Scalar(ScalarFunc::UnixEpoch))),
-            "julianday" => Ok(Some(Self::Scalar(ScalarFunc::JulianDay))),
-            "hex" => Ok(Some(Self::Scalar(ScalarFunc::Hex))),
-            "unhex" => Ok(Some(Self::Scalar(ScalarFunc::Unhex))),
-            "zeroblob" => Ok(Some(Self::Scalar(ScalarFunc::ZeroBlob))),
-            "soundex" => Ok(Some(Self::Scalar(ScalarFunc::Soundex))),
-            "table_columns_json_array" => Ok(Some(Self::Scalar(ScalarFunc::TableColumnsJsonArray))),
-            "bin_record_json_object" => Ok(Some(Self::Scalar(ScalarFunc::BinRecordJsonObject))),
-            "conn_txn_id" => Ok(Some(Self::Scalar(ScalarFunc::ConnTxnId))),
-            "is_autocommit" => Ok(Some(Self::Scalar(ScalarFunc::IsAutocommit))),
-            "sequence_watermark_experimental" => {
-                Ok(Some(Self::Scalar(ScalarFunc::SequenceWatermark)))
-            }
-            "acos" => Ok(Some(Self::Math(MathFunc::Acos))),
-            "acosh" => Ok(Some(Self::Math(MathFunc::Acosh))),
-            "asin" => Ok(Some(Self::Math(MathFunc::Asin))),
-            "asinh" => Ok(Some(Self::Math(MathFunc::Asinh))),
-            "atan" => Ok(Some(Self::Math(MathFunc::Atan))),
-            "atan2" => Ok(Some(Self::Math(MathFunc::Atan2))),
-            "atanh" => Ok(Some(Self::Math(MathFunc::Atanh))),
-            "ceil" => Ok(Some(Self::Math(MathFunc::Ceil))),
-            "ceiling" => Ok(Some(Self::Math(MathFunc::Ceiling))),
-            "cos" => Ok(Some(Self::Math(MathFunc::Cos))),
-            "cosh" => Ok(Some(Self::Math(MathFunc::Cosh))),
-            "degrees" => Ok(Some(Self::Math(MathFunc::Degrees))),
-            "exp" => Ok(Some(Self::Math(MathFunc::Exp))),
-            "floor" => Ok(Some(Self::Math(MathFunc::Floor))),
-            "ln" => Ok(Some(Self::Math(MathFunc::Ln))),
-            "log" => Ok(Some(Self::Math(MathFunc::Log))),
-            "log10" => Ok(Some(Self::Math(MathFunc::Log10))),
-            "log2" => Ok(Some(Self::Math(MathFunc::Log2))),
-            "mod" => Ok(Some(Self::Math(MathFunc::Mod))),
-            "pi" => Ok(Some(Self::Math(MathFunc::Pi))),
-            "pow" => Ok(Some(Self::Math(MathFunc::Pow))),
-            "power" => Ok(Some(Self::Math(MathFunc::Power))),
-            "radians" => Ok(Some(Self::Math(MathFunc::Radians))),
-            "sin" => Ok(Some(Self::Math(MathFunc::Sin))),
-            "sinh" => Ok(Some(Self::Math(MathFunc::Sinh))),
-            "sqrt" => Ok(Some(Self::Math(MathFunc::Sqrt))),
-            "tan" => Ok(Some(Self::Math(MathFunc::Tan))),
-            "tanh" => Ok(Some(Self::Math(MathFunc::Tanh))),
-            "trunc" => Ok(Some(Self::Math(MathFunc::Trunc))),
-            #[cfg(feature = "fs")]
-            #[cfg(not(target_family = "wasm"))]
-            "load_extension" => Ok(Some(Self::Scalar(ScalarFunc::LoadExtension))),
-            "strftime" => Ok(Some(Self::Scalar(ScalarFunc::StrfTime))),
-            "printf" | "format" => Ok(Some(Self::Scalar(ScalarFunc::Printf))),
-            "vector" => Ok(Some(Self::Vector(VectorFunc::Vector))),
-            "vector32" => Ok(Some(Self::Vector(VectorFunc::Vector32))),
-            "vector32_sparse" => Ok(Some(Self::Vector(VectorFunc::Vector32Sparse))),
-            "vector64" => Ok(Some(Self::Vector(VectorFunc::Vector64))),
-            "vector8" => Ok(Some(Self::Vector(VectorFunc::Vector8))),
-            "vector1bit" => Ok(Some(Self::Vector(VectorFunc::Vector1Bit))),
-            "vector_extract" => Ok(Some(Self::Vector(VectorFunc::VectorExtract))),
-            "vector_distance_cos" => Ok(Some(Self::Vector(VectorFunc::VectorDistanceCos))),
-            "vector_distance_l2" => Ok(Some(Self::Vector(VectorFunc::VectorDistanceL2))),
-            "vector_distance_jaccard" => Ok(Some(Self::Vector(VectorFunc::VectorDistanceJaccard))),
-            "vector_distance_dot" => Ok(Some(Self::Vector(VectorFunc::VectorDistanceDot))),
-            "vector_concat" => Ok(Some(Self::Vector(VectorFunc::VectorConcat))),
-            "vector_slice" => Ok(Some(Self::Vector(VectorFunc::VectorSlice))),
-            // FTS functions
-            #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-            "fts_score" => Ok(Some(Self::Fts(FtsFunc::Score))),
-            #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-            "fts_match" => Ok(Some(Self::Fts(FtsFunc::Match))),
-            #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-            "fts_highlight" => Ok(Some(Self::Fts(FtsFunc::Highlight))),
-            // Test type functions (for custom type system testing)
-            "test_uint_encode" => Ok(Some(Self::Scalar(ScalarFunc::TestUintEncode))),
-            "test_uint_decode" => Ok(Some(Self::Scalar(ScalarFunc::TestUintDecode))),
-            "test_uint_add" => Ok(Some(Self::Scalar(ScalarFunc::TestUintAdd))),
-            "test_uint_sub" => Ok(Some(Self::Scalar(ScalarFunc::TestUintSub))),
-            "test_uint_mul" => Ok(Some(Self::Scalar(ScalarFunc::TestUintMul))),
-            "test_uint_div" => Ok(Some(Self::Scalar(ScalarFunc::TestUintDiv))),
-            "test_uint_lt" => Ok(Some(Self::Scalar(ScalarFunc::TestUintLt))),
-            "test_uint_eq" => Ok(Some(Self::Scalar(ScalarFunc::TestUintEq))),
-            #[cfg(feature = "test_helper")]
-            "test_nondet_counter" => Ok(Some(Self::Scalar(ScalarFunc::TestNondetCounter))),
-            "string_reverse" | "reverse" => Ok(Some(Self::Scalar(ScalarFunc::StringReverse))),
-            "gcd" => Ok(Some(Self::Scalar(ScalarFunc::Gcd))),
-            "lcm" => Ok(Some(Self::Scalar(ScalarFunc::Lcm))),
-            "repeat" => Ok(Some(Self::Scalar(ScalarFunc::Repeat))),
-            "lpad" => Ok(Some(Self::Scalar(ScalarFunc::Lpad))),
-            "rpad" => Ok(Some(Self::Scalar(ScalarFunc::Rpad))),
-            // Built-in type support functions
-            "boolean_to_int" => Ok(Some(Self::Scalar(ScalarFunc::BooleanToInt))),
-            "int_to_boolean" => Ok(Some(Self::Scalar(ScalarFunc::IntToBoolean))),
-            "validate_ipaddr" => Ok(Some(Self::Scalar(ScalarFunc::ValidateIpAddr))),
-            "numeric_encode" => Ok(Some(Self::Scalar(ScalarFunc::NumericEncode))),
-            "numeric_decode" => Ok(Some(Self::Scalar(ScalarFunc::NumericDecode))),
-            "numeric_add" => Ok(Some(Self::Scalar(ScalarFunc::NumericAdd))),
-            "numeric_sub" => Ok(Some(Self::Scalar(ScalarFunc::NumericSub))),
-            "numeric_mul" => Ok(Some(Self::Scalar(ScalarFunc::NumericMul))),
-            "numeric_div" => Ok(Some(Self::Scalar(ScalarFunc::NumericDiv))),
-            "numeric_lt" => Ok(Some(Self::Scalar(ScalarFunc::NumericLt))),
-            "numeric_eq" => Ok(Some(Self::Scalar(ScalarFunc::NumericEq))),
-            // Array construction / element access (desugared from syntax)
-            "array" => Ok(Some(Self::Scalar(ScalarFunc::Array))),
-            "array_element" => Ok(Some(Self::Scalar(ScalarFunc::ArrayElement))),
-            "array_set_element" => Ok(Some(Self::Scalar(ScalarFunc::ArraySetElement))),
-            // Array functions
-            "array_length" | "array_upper" => Ok(Some(Self::Scalar(ScalarFunc::ArrayLength))),
-            "array_append" => Ok(Some(Self::Scalar(ScalarFunc::ArrayAppend))),
-            "array_prepend" => Ok(Some(Self::Scalar(ScalarFunc::ArrayPrepend))),
-            "array_cat" => Ok(Some(Self::Scalar(ScalarFunc::ArrayCat))),
-            "array_remove" => Ok(Some(Self::Scalar(ScalarFunc::ArrayRemove))),
-            "array_contains" => Ok(Some(Self::Scalar(ScalarFunc::ArrayContains))),
-            "array_position" => Ok(Some(Self::Scalar(ScalarFunc::ArrayPosition))),
-            "array_slice" => Ok(Some(Self::Scalar(ScalarFunc::ArraySlice))),
-            "string_to_array" => Ok(Some(Self::Scalar(ScalarFunc::StringToArray))),
-            "array_to_string" => Ok(Some(Self::Scalar(ScalarFunc::ArrayToString))),
-            "array_overlap" | "array_overlaps" => Ok(Some(Self::Scalar(ScalarFunc::ArrayOverlap))),
-            "array_contains_all" => Ok(Some(Self::Scalar(ScalarFunc::ArrayContainsAll))),
-            // Struct/Union functions
-            "struct_pack" => Ok(Some(Self::Scalar(ScalarFunc::StructPack))),
-            "struct_extract" => Ok(Some(Self::Scalar(ScalarFunc::StructExtractFunc))),
-            "union_value" => Ok(Some(Self::Scalar(ScalarFunc::UnionValueFunc))),
-            "union_tag" => Ok(Some(Self::Scalar(ScalarFunc::UnionTagFunc))),
-            "union_extract" => Ok(Some(Self::Scalar(ScalarFunc::UnionExtractFunc))),
-            // Sequence functions
-            "nextval" => Ok(Some(Self::Scalar(ScalarFunc::NextVal))),
-            "currval" => Ok(Some(Self::Scalar(ScalarFunc::CurrVal))),
-            "setval" => Ok(Some(Self::Scalar(ScalarFunc::SetVal))),
-            _ => Ok(None),
-        }
+        crate::dialect::sqlite::resolve_builtin_function(name, arg_count)
     }
 
     /// Returns a list of all built-in functions for PRAGMA function_list.

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -14,6 +14,7 @@ use crate::incremental::operator::{
 };
 use crate::schema::Type;
 use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
+use crate::SqliteDialect;
 // Note: logical module must be made pub(crate) in translate/mod.rs
 use crate::numeric::Numeric;
 use crate::sync::{atomic::Ordering, Arc};
@@ -1636,7 +1637,7 @@ impl DbspCompiler {
 
         // Create an internal connection for expression compilation
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, ":memory:")?;
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect))?;
         let internal_conn = db.connect()?;
         internal_conn.set_query_only(true);
         internal_conn.auto_commit.store(false, Ordering::SeqCst);
@@ -2276,6 +2277,7 @@ mod tests {
     use crate::sync::Arc;
     use crate::translate::logical::{ColumnInfo, LogicalPlanBuilder, LogicalSchema};
     use crate::util::IOExt;
+    use crate::SqliteDialect;
     use crate::{Database, MemoryIO, Pager, IO};
     use rustc_hash::FxHashSet as HashSet;
     use turso_parser::ast;
@@ -2562,7 +2564,7 @@ mod tests {
 
     fn setup_btree_for_circuit() -> (Arc<Pager>, i64, i64, i64) {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io.clone(), ":memory:").unwrap();
+        let db = Database::open_file(io.clone(), ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         let pager = conn.pager.load().clone();
 

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -378,6 +378,7 @@ mod tests {
     use crate::storage::btree::BTreeCursor;
     use crate::sync::Arc;
     use crate::util::IOExt;
+    use crate::SqliteDialect;
     use crate::{Connection, Database, OpenFlags};
 
     /// Helper to create a test connection with a table and materialized view
@@ -404,6 +405,7 @@ mod tests {
                 unsafe_testing: false,
             },
             None,
+            Arc::new(SqliteDialect),
         )?;
         let conn = db.connect()?;
 

--- a/core/incremental/expr_compiler.rs
+++ b/core/incremental/expr_compiler.rs
@@ -332,6 +332,7 @@ impl CompiledExpression {
             syms,
             true,
             DoubleQuotedDml::Enabled,
+            std::sync::Arc::new(crate::dialect::SqliteDialect),
         );
 
         // Translate the transformed expression to bytecode

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -261,6 +261,7 @@ pub trait IncrementalOperator: Debug + Send {
 
 #[cfg(test)]
 mod tests {
+    use crate::SqliteDialect;
     use rustc_hash::FxHashSet as HashSet;
 
     use super::*;
@@ -278,7 +279,7 @@ mod tests {
     /// Create a test pager for operator tests with both table and index
     fn create_test_pager() -> (crate::sync::Arc<crate::Pager>, i64, i64) {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io.clone(), ":memory:").unwrap();
+        let db = Database::open_file(io.clone(), ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
 
         let pager = conn.pager.load().clone();

--- a/core/incremental/project_operator.rs
+++ b/core/incremental/project_operator.rs
@@ -9,6 +9,7 @@ use crate::incremental::operator::{
 use crate::sync::Mutex;
 use crate::sync::{atomic::Ordering, Arc};
 use crate::types::IOResult;
+use crate::SqliteDialect;
 use crate::{Connection, Database, Result, Value};
 
 #[derive(Debug, Clone)]
@@ -57,7 +58,7 @@ impl ProjectOperator {
     ) -> crate::Result<Self> {
         // Set up internal connection for expression evaluation
         let io = Arc::new(crate::MemoryIO::new());
-        let db = Database::open_file(io, ":memory:")?;
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect))?;
         let internal_conn = db.connect()?;
         // Set to read-only mode and disable auto-commit since we're only evaluating expressions
         internal_conn.set_query_only(true);

--- a/core/io/memory_yield.rs
+++ b/core/io/memory_yield.rs
@@ -211,6 +211,7 @@ impl File for MemoryYieldFile {
 mod tests {
     use super::*;
     use crate::vdbe::StepResult;
+    use crate::SqliteDialect;
     use crate::{Database, IOResult, OpenFlags};
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -356,7 +357,8 @@ mod tests {
     fn engine_yields_and_round_trips() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io: Arc<dyn IO> = Arc::new(MemoryYieldIO::new());
-        let db = Database::open_file(io.clone(), "memory_yield_test.db").unwrap();
+        let db = Database::open_file(io.clone(), "memory_yield_test.db", Arc::new(SqliteDialect))
+            .unwrap();
         let conn = db.connect().unwrap();
 
         // Step statements manually so we can observe the cooperative-yield path.
@@ -403,7 +405,12 @@ mod tests {
     fn journal_mode_mvcc_bootstrap_yields_without_internal_step() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(StepGuardedIO::new());
-        let db = Database::open_file(io.clone(), "journal_mode_mvcc_yield.db").unwrap();
+        let db = Database::open_file(
+            io.clone(),
+            "journal_mode_mvcc_yield.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let conn = db.connect().unwrap();
         let mut stmt = conn.prepare("PRAGMA journal_mode = 'mvcc'").unwrap();
 
@@ -446,6 +453,7 @@ mod tests {
             OpenFlags::Create,
             crate::DatabaseOpts::new().with_attach(true),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();
@@ -488,7 +496,8 @@ mod tests {
     fn pager_allocate_and_free_yield_for_header_reads_without_internal_step() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(StepGuardedIO::new());
-        let db = Database::open_file(io.clone(), "pager_header_yield.db").unwrap();
+        let db = Database::open_file(io.clone(), "pager_header_yield.db", Arc::new(SqliteDialect))
+            .unwrap();
         let conn = db.connect().unwrap();
         conn.execute("CREATE TABLE t(x)").unwrap();
 
@@ -516,7 +525,12 @@ mod tests {
     fn overflow_delete_yields_for_header_validation_without_internal_step() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(StepGuardedIO::new());
-        let db = Database::open_file(io.clone(), "overflow_delete_yield.db").unwrap();
+        let db = Database::open_file(
+            io.clone(),
+            "overflow_delete_yield.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let conn = db.connect().unwrap();
         conn.execute("CREATE TABLE t(x BLOB)").unwrap();
         conn.execute("INSERT INTO t VALUES (zeroblob(20000))")
@@ -572,7 +586,12 @@ mod tests {
     fn wasm_opfs_cache_spill_insert_hang() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(StepGuardedIO::new());
-        let db = Database::open_file(io.clone(), "wasm_opfs_spill_hang.db").unwrap();
+        let db = Database::open_file(
+            io.clone(),
+            "wasm_opfs_spill_hang.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let conn = db.connect().unwrap();
 
         // Drive one statement to completion exactly like the WASM/OPFS JS

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -112,7 +112,6 @@ use crate::{
     },
     translate::{emitter::TransactionMode, pragma::TURSO_CDC_DEFAULT_TABLE_NAME},
     vdbe::metrics::ConnectionMetrics,
-    vtab::VirtualTable,
 };
 use arc_swap::{ArcSwap, ArcSwapOption};
 use core::str;
@@ -186,7 +185,7 @@ pub use vdbe::{
     builder::QueryMode, explain::EXPLAIN_COLUMNS, explain::EXPLAIN_QUERY_PLAN_COLUMNS,
     FromValueRow, PrepareContext, PreparedProgram, Program, Register,
 };
-pub use vtab::{InternalVirtualTable, InternalVirtualTableCursor};
+pub use vtab::{InternalVirtualTable, InternalVirtualTableCursor, VirtualTable};
 
 /// Database index for the main database (always 0 in SQLite).
 pub const MAIN_DB_ID: usize = 0;
@@ -750,7 +749,7 @@ impl Database {
             path,
             wal_path,
             schema: Arc::new(Mutex::new(Arc::new({
-                let mut s = Schema::with_options(opts.enable_custom_types)?;
+                let mut s = Schema::with_options(opts.enable_custom_types, dialect.as_ref())?;
                 s.generated_columns_enabled = opts.enable_generated_columns;
                 s
             }))),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -86,6 +86,7 @@ mod uuid;
 mod vdbe;
 mod vtab;
 
+pub use function::Func;
 #[cfg(any(feature = "fuzz", feature = "bench"))]
 pub use function::MathFunc;
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -48,7 +48,7 @@ pub(crate) mod thread;
 
 mod assert;
 mod connection;
-mod dialect;
+pub mod dialect;
 mod error;
 mod ext;
 mod fast_lock;
@@ -138,6 +138,7 @@ use turso_parser::{ast, ast::Cmd, parser::Parser};
 
 pub use connection::{resolve_ext_path, Connection, Row, StepResult, SymbolTable};
 pub(crate) use connection::{AtomicTransactionState, TransactionState};
+pub use dialect::{Dialect, SqliteDialect};
 pub use error::{io_error, CompletionError, LimboError};
 pub use function::ContextCollationFunction;
 #[cfg(feature = "io_memory_yield")]
@@ -624,6 +625,11 @@ pub struct Database<A: alloc::ConcurrentAllocator = alloc::DynAllocator> {
     // Use parking lot RwLock here and not `crate::sync::RwLock` because it relies on `data_ptr` and that is experimental
     // in std.
     builtin_syms: parking_lot::RwLock<SymbolTable>,
+    /// SQL dialect this database runs under, interpreting `sqlite_schema`
+    /// SQL rows. Passed explicitly by every open path, fixed at open time,
+    /// and shared by all connections because the parsed [`Schema`] is
+    /// shared per database.
+    dialect: Arc<dyn Dialect>,
     opts: DatabaseOpts,
     n_connections: AtomicUsize,
 
@@ -707,6 +713,7 @@ impl Database {
         db_file: Arc<dyn DatabaseStorage>,
         encryption_opts: Option<EncryptionOpts>,
         mv_store_allocator: alloc::DynAllocator,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<Self> {
         let path = path.into();
         let wal_path = wal_path.into();
@@ -753,6 +760,7 @@ impl Database {
             shared_wal_coordination: OnceLock::new(),
             db_file,
             builtin_syms: parking_lot::RwLock::new(syms),
+            dialect,
             io: io.clone(),
             open_flags: flags,
             init_lock: Arc::new(Mutex::new(())),
@@ -775,32 +783,45 @@ impl Database {
     }
 
     #[cfg(feature = "fs")]
-    pub fn open_file(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
-        Self::open_file_with_flags(io, path, OpenFlags::default(), DatabaseOpts::new(), None)
+    pub fn open_file(
+        io: Arc<dyn IO>,
+        path: &str,
+        dialect: Arc<dyn Dialect>,
+    ) -> Result<Arc<Database>> {
+        Self::open_file_with_flags(
+            io,
+            path,
+            OpenFlags::default(),
+            DatabaseOpts::new(),
+            None,
+            dialect,
+        )
     }
 
     /// Open or retrieve a shared named in-memory database.
     /// Multiple connections to the same `name` share a single `Database`,
     /// matching SQLite's `file:name?mode=memory&cache=shared` semantics.
     #[cfg(feature = "fs")]
-    pub fn open_shared_memory(name: &str) -> Result<Arc<Database>> {
+    pub fn open_shared_memory(name: &str, dialect: Arc<dyn Dialect>) -> Result<Arc<Database>> {
         let key = DatabaseKey::SharedMemory(name.to_string());
 
         {
             let registry = DATABASE_MANAGER.lock();
             if let Some(RegistryEntry::Ready(weak)) = registry.get(&key) {
                 if let Some(db) = weak.upgrade() {
+                    Self::check_registry_dialect(&db, dialect.as_ref())?;
                     return Ok(db);
                 }
             }
         }
         // `:memory:` paths bypass DATABASE_MANAGER internally, so no deadlock.
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Self::open_file(io, ":memory:")?;
+        let db = Self::open_file(io, ":memory:", dialect.clone())?;
 
         let mut registry = DATABASE_MANAGER.lock();
         if let Some(RegistryEntry::Ready(weak)) = registry.get(&key) {
             if let Some(existing) = weak.upgrade() {
+                Self::check_registry_dialect(&existing, dialect.as_ref())?;
                 return Ok(existing);
             }
         }
@@ -935,6 +956,22 @@ impl Database {
         Ok(())
     }
 
+    /// Check that a registry hit was opened with the dialect the caller
+    /// requested. The dialect is fixed at open time and shared by every
+    /// user of the registered instance, so a mismatch is an error rather
+    /// than a silent share.
+    fn check_registry_dialect(db: &Database, requested: &dyn Dialect) -> Result<()> {
+        let requested_name = requested.name();
+        if db.dialect.name() != requested_name {
+            return Err(LimboError::InvalidArgument(format!(
+                "database is already open with dialect '{}'; requested '{}'",
+                db.dialect.name(),
+                requested_name
+            )));
+        }
+        Ok(())
+    }
+
     /// Look up a database in the process-wide registry by file identity.
     /// Returns the cached Database if found, with encryption validation.
     /// This avoids opening a file (and acquiring a file lock) when the
@@ -942,6 +979,7 @@ impl Database {
     fn lookup_in_registry(
         path: &str,
         encryption_opts: &Option<EncryptionOpts>,
+        dialect: &dyn Dialect,
     ) -> Result<Option<Arc<Database>>> {
         if is_memory_like(path) {
             return Ok(None);
@@ -969,6 +1007,8 @@ impl Database {
             ));
         }
 
+        Self::check_registry_dialect(&db, dialect)?;
+
         Ok(Some(db))
     }
 
@@ -979,11 +1019,21 @@ impl Database {
         flags: OpenFlags,
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<Arc<Database>> {
-        Self::open_file_with_flags_and_durable_storage(io, path, flags, opts, encryption_opts, None)
+        Self::open_file_with_flags_and_durable_storage(
+            io,
+            path,
+            flags,
+            opts,
+            encryption_opts,
+            None,
+            dialect,
+        )
     }
 
     #[cfg(feature = "fs")]
+    #[allow(clippy::too_many_arguments)]
     pub fn open_file_with_flags_and_durable_storage(
         io: Arc<dyn IO>,
         path: &str,
@@ -991,10 +1041,11 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<Arc<Database>> {
         // Check the registry before opening the file to avoid acquiring a file
         // lock that would conflict with an already-open Database in this process.
-        if let Some(db) = Self::lookup_in_registry(path, &encryption_opts)? {
+        if let Some(db) = Self::lookup_in_registry(path, &encryption_opts, dialect.as_ref())? {
             if durable_storage.is_some() && db.durable_storage.is_none() {
                 return Err(LimboError::InvalidArgument(
                     "database already open without custom durable storage; \
@@ -1021,7 +1072,7 @@ impl Database {
         //    authority appeared between the initial probe and the actual open
         Self::reject_live_multiprocess_wal_for_legacy_open(&io, path, opts)?;
         let db_file = Arc::new(DatabaseFile::new(file));
-        Self::open_with_flags(
+        Self::open_with_flags_with_allocator(
             io,
             path,
             db_file,
@@ -1029,6 +1080,8 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
+            alloc::DynAllocator::default(),
+            dialect,
         )
     }
 
@@ -1036,6 +1089,7 @@ impl Database {
         io: Arc<dyn IO>,
         path: &str,
         db_file: Arc<dyn DatabaseStorage>,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<Arc<Database>> {
         Self::open_with_flags(
             io,
@@ -1045,6 +1099,7 @@ impl Database {
             DatabaseOpts::new(),
             None,
             None,
+            dialect,
         )
     }
 
@@ -1057,6 +1112,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<Arc<Database>> {
         Self::open_with_flags_with_allocator(
             io,
@@ -1067,6 +1123,7 @@ impl Database {
             encryption_opts,
             durable_storage,
             alloc::DynAllocator::default(),
+            dialect,
         )
     }
 
@@ -1080,6 +1137,7 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
         allocator: alloc::DynAllocator,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<Arc<Database>> {
         let mut state = OpenDbAsyncState::new();
         loop {
@@ -1093,6 +1151,7 @@ impl Database {
                 encryption_opts.clone(),
                 durable_storage.clone(),
                 allocator.clone(),
+                dialect.clone(),
             )? {
                 IOResult::Done(db) => return Ok(db),
                 IOResult::IO(io_completion) => {
@@ -1120,6 +1179,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
         // Re-derive lock-mode flags from opts the same way the sync
         // `open_file_with_flags` path does: multiprocess WAL must open the
@@ -1136,6 +1196,7 @@ impl Database {
             encryption_opts,
             durable_storage,
             alloc::DynAllocator::default(),
+            dialect,
         )
     }
 
@@ -1150,6 +1211,7 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
         allocator: alloc::DynAllocator,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
         let result = Self::open_with_flags_async_internal(
             state,
@@ -1161,6 +1223,7 @@ impl Database {
             encryption_opts,
             durable_storage,
             allocator,
+            dialect,
         );
         if result.is_err() {
             // On error, remove the Opening sentinel so other callers can proceed.
@@ -1183,6 +1246,7 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
         allocator: alloc::DynAllocator,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
         // turso-sync-engine creates 2 databases with different names in the same IO if MemoryIO is used
         // in this case we need to bypass registry (as this is MemoryIO DB) but also preserve original distinction in names (e.g. :memory:-draft and :memory:-synced)
@@ -1209,6 +1273,7 @@ impl Database {
                                         .to_string(),
                                 ));
                             }
+                            Self::check_registry_dialect(&db, dialect.as_ref())?;
                             return Ok(IOResult::Done(db));
                         }
                         // Weak ref expired — treat as absent, fall through to insert Opening.
@@ -1244,6 +1309,7 @@ impl Database {
             encryption_opts,
             durable_storage,
             allocator,
+            dialect,
         )?;
 
         if let IOResult::Done(ref db) = result {
@@ -1269,6 +1335,7 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
         allocator: alloc::DynAllocator,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
         let result = Self::open_with_flags_bypass_registry_async_internal(
             state,
@@ -1281,6 +1348,7 @@ impl Database {
             encryption_opts,
             durable_storage,
             allocator,
+            dialect,
         );
         if result.is_err() {
             let _ = state.schema_guard.take();
@@ -1290,6 +1358,7 @@ impl Database {
 
     /// method for tests - for all other code we must use async alternative
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
+    #[allow(clippy::too_many_arguments)]
     pub fn open_with_flags_bypass_registry(
         io: Arc<dyn IO>,
         path: &str,
@@ -1298,6 +1367,7 @@ impl Database {
         flags: OpenFlags,
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<Arc<Database>> {
         let mut state = OpenDbAsyncState::new();
         loop {
@@ -1311,6 +1381,7 @@ impl Database {
                 opts,
                 encryption_opts.clone(),
                 None,
+                dialect.clone(),
             )? {
                 IOResult::Done(db) => return Ok(db),
                 IOResult::IO(io_completion) => {
@@ -1334,6 +1405,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
         let result = Self::open_with_flags_bypass_registry_async_internal(
             state,
@@ -1346,6 +1418,7 @@ impl Database {
             encryption_opts,
             durable_storage,
             alloc::DynAllocator::default(),
+            dialect,
         );
         if result.is_err() {
             // schema_guard is set by the open_with_flags_bypass_registry_async_internal - so we release it in case of error
@@ -1367,6 +1440,7 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
         allocator: alloc::DynAllocator,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
         loop {
             tracing::debug!(
@@ -1396,6 +1470,7 @@ impl Database {
                         db_file.clone(),
                         encryption_opts.clone(),
                         allocator.clone(),
+                        dialect.clone(),
                     )?;
                     db.durable_storage.clone_from(&durable_storage);
 
@@ -1500,11 +1575,13 @@ impl Database {
                     // it's not ideal but correctness is OK - before prepare connection call maybe_update_schema and in case of divergence update schema ref from the db + we always check connection cookie in the VDBE program itself
                     let schema = Schema::try_make_mut(guard)?;
 
+                    let dialect = conn.dialect();
                     let result = schema.make_from_btree(
                         &mut state.make_from_btree_state,
                         None,
                         pager,
                         &syms,
+                        dialect.as_ref(),
                     );
 
                     match result {
@@ -2848,6 +2925,7 @@ impl Database {
         flags: OpenFlags,
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
+        dialect: Arc<dyn Dialect>,
     ) -> Result<(Arc<dyn IO>, Arc<Database>)>
     where
         S: AsRef<str> + std::fmt::Display,
@@ -2857,7 +2935,8 @@ impl Database {
             .or_else(|| Some(Self::io_for_path(path)))
             .transpose()?
             .unwrap();
-        let db = Self::open_file_with_flags(io.clone(), path, flags, opts, encryption_opts)?;
+        let db =
+            Self::open_file_with_flags(io.clone(), path, flags, opts, encryption_opts, dialect)?;
         Ok((io, db))
     }
 
@@ -2898,6 +2977,11 @@ impl Database {
     {
         self.with_schema_mut(|schema| schema.register_internal_vtab(table))
     }
+    /// The SQL dialect this database was opened with.
+    pub fn dialect(&self) -> Arc<dyn Dialect> {
+        self.dialect.clone()
+    }
+
     pub(crate) fn clone_schema(&self) -> Arc<Schema> {
         let schema = self.schema.lock();
         schema.clone()

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -134,7 +134,7 @@ use storage::shared_wal_coordination::MappedSharedWalCoordination;
 use storage::{page_cache::PageCache, sqlite3_ondisk::PageSize};
 use tracing::{instrument, Level};
 use turso_macros::AtomicEnum;
-use turso_parser::{ast, ast::Cmd, parser::Parser};
+use turso_parser::{ast, ast::Cmd};
 
 pub use connection::{resolve_ext_path, Connection, Row, StepResult, SymbolTable};
 pub(crate) use connection::{AtomicTransactionState, TransactionState};
@@ -3315,18 +3315,27 @@ impl DatabaseCatalog {
 }
 
 pub struct QueryRunner<'a> {
-    parser: Parser<'a>,
     conn: &'a Arc<Connection>,
-    statements: &'a [u8],
+    statements: &'a str,
+    pending_error: Option<LimboError>,
     last_offset: usize,
 }
 
 impl<'a> QueryRunner<'a> {
     pub(crate) fn new(conn: &'a Arc<Connection>, statements: &'a [u8]) -> Self {
+        let (statements, pending_error) = match str::from_utf8(statements) {
+            Ok(statements) => (statements, None),
+            Err(err) => (
+                "",
+                Some(LimboError::ParseError(format!(
+                    "invalid UTF-8 in SQL input: {err}"
+                ))),
+            ),
+        };
         Self {
-            parser: Parser::new(statements),
             conn,
             statements,
+            pending_error,
             last_offset: 0,
         }
     }
@@ -3336,17 +3345,22 @@ impl Iterator for QueryRunner<'_> {
     type Item = Result<Option<Statement>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.parser.next_cmd() {
-            Ok(Some(cmd)) => {
-                let byte_offset_end = self.parser.offset();
-                let input = str::from_utf8(&self.statements[self.last_offset..byte_offset_end])
-                    .unwrap()
-                    .trim();
-                self.last_offset = byte_offset_end;
+        if let Some(err) = self.pending_error.take() {
+            return Some(Err(err));
+        }
+
+        let remaining = &self.statements[self.last_offset..];
+        match self.conn.parse_sql(remaining) {
+            Ok((Some(cmd), byte_offset_end)) => {
+                let input = remaining[..byte_offset_end].trim();
+                self.last_offset += byte_offset_end;
                 Some(self.conn.run_cmd(cmd, input))
             }
-            Ok(None) => None,
-            Err(err) => Some(Result::Err(LimboError::from(err))),
+            Ok((None, _)) => None,
+            Err(err) => {
+                self.last_offset = self.statements.len();
+                Some(Err(err))
+            }
         }
     }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -744,13 +744,15 @@ impl Database {
             None
         };
 
+        let enable_custom_types = opts.enable_custom_types || dialect.requires_custom_types();
+
         let db = Database {
             mv_store,
             mv_store_allocator,
             path,
             wal_path,
             schema: Arc::new(Mutex::new(Arc::new({
-                let mut s = Schema::with_options(opts.enable_custom_types, dialect.as_ref())?;
+                let mut s = Schema::with_options(enable_custom_types, dialect.as_ref())?;
                 s.generated_columns_enabled = opts.enable_generated_columns;
                 s
             }))),
@@ -1605,11 +1607,11 @@ impl Database {
                     // contents. We need to read the stored type definitions so
                     // that DECODE/ENCODE and affinity metadata are available to
                     // all subsequent connections.
-                    if opts.enable_custom_types {
-                        let conn = state
-                            .conn
-                            .as_ref()
-                            .expect("conn must be initialized in Init phase");
+                    let conn = state
+                        .conn
+                        .as_ref()
+                        .expect("conn must be initialized in Init phase");
+                    if conn.experimental_custom_types_enabled() {
                         // Sync the connection's schema from the database so it
                         // can query __turso_internal_types.
                         conn.maybe_update_schema();
@@ -3018,7 +3020,7 @@ impl Database {
     }
 
     pub fn experimental_custom_types_enabled(&self) -> bool {
-        self.opts.enable_custom_types
+        self.opts.enable_custom_types || self.dialect.requires_custom_types()
     }
 
     pub fn experimental_encryption_enabled(&self) -> bool {

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -1300,6 +1300,50 @@ fn subprocess_database_open_parent_directly_uses_child_created_table() {
 }
 
 #[test]
+fn subprocess_database_open_parent_translated_stmt_uses_child_created_table() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir
+        .path()
+        .join("coordination-translated-child-table-use.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = multiprocess_test_io();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("create table t(value integer)").unwrap();
+
+    let current_exe = std::env::current_exe().unwrap();
+    let schema_output = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_SCHEMA_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .output()
+        .unwrap();
+    assert!(
+        schema_output.status.success(),
+        "child schema process failed: stdout={}; stderr={}",
+        String::from_utf8_lossy(&schema_output.stdout),
+        String::from_utf8_lossy(&schema_output.stderr)
+    );
+
+    let input = "insert into child_table(value) values ('parent-schema')";
+    let (cmd, _) = crate::dialect::sqlite::parse(input).unwrap();
+    let Some(turso_parser::ast::Cmd::Stmt(stmt)) = cmd else {
+        panic!("translated statement input did not parse as a statement");
+    };
+    conn.prepare_translated_stmt(stmt, input)
+        .unwrap()
+        .run_ignore_rows()
+        .unwrap();
+
+    let child_rows =
+        get_rows_without_schema_retry(&conn, "select value from child_table order by rowid");
+    assert_eq!(child_rows.len(), 2);
+    assert_eq!(child_rows[0][0].to_string(), "child-schema");
+    assert_eq!(child_rows[1][0].to_string(), "parent-schema");
+}
+
+#[test]
 fn subprocess_database_open_parent_execute_uses_child_created_table() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("coordination-execute-child-table-use.db");

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -132,6 +132,7 @@ fn open_multiprocess_db(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
         OpenFlags::default(),
         multiprocess_wal_db_opts(),
         None,
+        Arc::new(SqliteDialect),
     )
 }
 
@@ -153,6 +154,7 @@ fn open_multiprocess_db_async(io: Arc<dyn IO>, path: &str) -> Result<Arc<Databas
             multiprocess_wal_db_opts(),
             None,
             None,
+            Arc::new(SqliteDialect),
         )? {
             IOResult::Done(db) => return Ok(db),
             IOResult::IO(io_completion) => io_completion.wait(&*io)?,
@@ -165,7 +167,14 @@ fn open_multiprocess_db_with_flags(
     path: &str,
     flags: OpenFlags,
 ) -> Result<Arc<Database>> {
-    Database::open_file_with_flags(io, path, flags, multiprocess_wal_db_opts(), None)
+    Database::open_file_with_flags(
+        io,
+        path,
+        flags,
+        multiprocess_wal_db_opts(),
+        None,
+        Arc::new(SqliteDialect),
+    )
 }
 
 #[test]
@@ -255,7 +264,7 @@ fn database_open_without_experimental_multiprocess_wal_uses_in_process_backend()
     let db_path = dir.path().join("coordination-default-off.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = multiprocess_test_io();
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = Database::open_file(io, db_path_str, Arc::new(SqliteDialect)).unwrap();
 
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
@@ -275,7 +284,7 @@ fn database_open_without_experimental_multiprocess_wal_rejects_second_process() 
     let db_path = dir.path().join("coordination-default-locked.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = multiprocess_test_io();
-    let _db = Database::open_file(io, db_path_str).unwrap();
+    let _db = Database::open_file(io, db_path_str, Arc::new(SqliteDialect)).unwrap();
 
     let current_exe = std::env::current_exe().unwrap();
     let child_output = Command::new(&current_exe)
@@ -302,6 +311,7 @@ fn database_open_with_experimental_multiprocess_wal_rejects_unsupported_io_backe
         OpenFlags::default(),
         multiprocess_wal_db_opts(),
         None,
+        Arc::new(SqliteDialect),
     )
     .expect_err("multiprocess WAL should reject IO backends without shared coordination");
     assert!(
@@ -336,7 +346,7 @@ fn multiprocess_wal_rejects_opening_mvcc_database() {
     let io: Arc<dyn IO> = multiprocess_test_io();
 
     {
-        let db = Database::open_file(io.clone(), db_path_str).unwrap();
+        let db = Database::open_file(io.clone(), db_path_str, Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         conn.execute("create table test(id integer primary key, value text)")
             .unwrap();
@@ -361,7 +371,7 @@ fn readonly_open_with_experimental_multiprocess_wal_allows_missing_coordination_
     let io: Arc<dyn IO> = multiprocess_test_io();
 
     {
-        let db = Database::open_file(io.clone(), db_path_str).unwrap();
+        let db = Database::open_file(io.clone(), db_path_str, Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         conn.execute("create table test(id integer primary key, value text)")
             .unwrap();
@@ -406,7 +416,7 @@ fn database_open_without_experimental_multiprocess_wal_rejects_second_multiproce
         .join("coordination-default-parent-multiprocess-child.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = multiprocess_test_io();
-    let _db = Database::open_file(io, db_path_str).unwrap();
+    let _db = Database::open_file(io, db_path_str, Arc::new(SqliteDialect)).unwrap();
 
     let current_exe = std::env::current_exe().unwrap();
     let child_output = Command::new(&current_exe)
@@ -830,7 +840,7 @@ fn default_locked_db_child_process() {
     };
 
     let io: Arc<dyn IO> = multiprocess_test_io();
-    let err = Database::open_file(io, db_path.to_str().unwrap())
+    let err = Database::open_file(io, db_path.to_str().unwrap(), Arc::new(SqliteDialect))
         .expect_err("default non-multiprocess open should stay DB-file locked across processes");
     assert!(
         matches!(err, LimboError::LockingError(_)),
@@ -1054,6 +1064,7 @@ fn plain_vacuum_rejects_multiprocess_wal_database() {
         OpenFlags::default(),
         multiprocess_wal_db_opts().with_vacuum(true),
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
     let conn = db.connect().unwrap();
@@ -1841,7 +1852,7 @@ fn database_open_rebuilds_from_disk_scan_when_shared_frame_index_overflowed() {
 #[test]
 fn memory_database_keeps_in_process_wal_backend() {
     let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io, ":memory:").unwrap();
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
 
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
@@ -1854,7 +1865,7 @@ fn memory_database_keeps_in_process_wal_backend() {
 #[test]
 fn memory_database_query_can_close_without_checkpointing() {
     let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io, ":memory:").unwrap();
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
 
     conn.query("VALUES ('ok')").unwrap();

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -8233,7 +8233,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     .block(|| pager.with_header(|header| header.schema_cookie))?
                     .get(),
             );
-        let mut fresh = Schema::new();
+        let mut fresh = Schema::with_options(
+            connection.db.experimental_custom_types_enabled(),
+            connection.db.dialect().as_ref(),
+        )?;
         fresh.generated_columns_enabled = connection.db.experimental_generated_columns_enabled();
         fresh.schema_version = cookie;
         let mut from_sql_indexes = crate::alloc::vec![];
@@ -9172,7 +9175,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             .as_ref()
             .map(|header| header.schema_cookie.get())
             .unwrap_or(fallback_cookie);
-        let mut fresh = Schema::new();
+        let mut fresh = Schema::with_options(
+            connection.db.experimental_custom_types_enabled(),
+            connection.db.dialect().as_ref(),
+        )?;
         fresh.generated_columns_enabled = connection.db.experimental_generated_columns_enabled();
         fresh.schema_version = cookie;
         let mut from_sql_indexes =

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -8318,6 +8318,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 &mut dbsp_state_index_roots,
                 &mut materialized_view_info,
                 &attached_resolver,
+                connection.dialect().as_ref(),
             )?;
         }
         fresh.populate_indices(
@@ -9258,6 +9259,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 &mut dbsp_state_index_roots,
                 &mut materialized_view_info,
                 &attached_resolver,
+                connection.dialect().as_ref(),
             )?;
         }
         fresh.populate_indices(

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1,3 +1,4 @@
+use crate::SqliteDialect;
 use rustc_hash::FxHashSet as HashSet;
 
 use super::*;
@@ -299,7 +300,7 @@ fn mv_store_insert_allocation_failure_leaves_tx_state_untouched() {
 impl MvccTestDb {
     pub fn new() -> Self {
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, ":memory:").unwrap();
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         // Enable MVCC via PRAGMA
         conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
@@ -886,8 +887,15 @@ impl MvccTestDbNoConn {
     pub fn new() -> Self {
         let io = Arc::new(MemoryIO::new());
         let opts = DatabaseOpts::new();
-        let db = Database::open_file_with_flags(io, ":memory:", OpenFlags::default(), opts, None)
-            .unwrap();
+        let db = Database::open_file_with_flags(
+            io,
+            ":memory:",
+            OpenFlags::default(),
+            opts,
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         // Enable MVCC via PRAGMA
         let conn = db.connect().unwrap();
         conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
@@ -929,6 +937,7 @@ impl MvccTestDbNoConn {
             OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         // Enable MVCC via PRAGMA
@@ -960,6 +969,7 @@ impl MvccTestDbNoConn {
             OpenFlags::default(),
             opts,
             Some(enc_opts.clone()),
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let encryption_key = EncryptionKey::from_hex_string(hex_key).unwrap();
@@ -1017,6 +1027,7 @@ impl MvccTestDbNoConn {
             OpenFlags::default(),
             opts,
             Some(enc_opts.clone()),
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let encryption_key = EncryptionKey::from_hex_string(hex_key).unwrap();
@@ -1050,6 +1061,7 @@ impl MvccTestDbNoConn {
             OpenFlags::default(),
             self.opts,
             self.enc_opts.clone(),
+            Arc::new(SqliteDialect),
         )?;
         self.db.replace(db);
         Ok(())
@@ -2059,7 +2071,7 @@ fn test_bootstrap_repairs_torn_short_log_before_metadata_init() {
 
     {
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, &db_path_str).unwrap();
+        let db = Database::open_file(io, &db_path_str, Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
             .unwrap();
@@ -2075,7 +2087,7 @@ fn test_bootstrap_repairs_torn_short_log_before_metadata_init() {
     }
     {
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, &db_path_str).unwrap();
+        let db = Database::open_file(io, &db_path_str, Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
         conn.close().unwrap();
@@ -2086,7 +2098,7 @@ fn test_bootstrap_repairs_torn_short_log_before_metadata_init() {
         manager.clear();
     }
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, &db_path_str).unwrap();
+    let db = Database::open_file(io, &db_path_str, Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
     let meta = get_rows(
         &conn,
@@ -2386,6 +2398,7 @@ fn test_bootstrap_recovers_committed_wal_without_log_file() {
         OpenFlags::default(),
         DatabaseOpts::new().with_experimental_mvcc_passive_checkpoint(true),
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("open should recover, not fail closed");
     let conn = db
@@ -2419,7 +2432,8 @@ fn test_full_checkpoint_reopen_recovers_truncate_mode() {
     }
 
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, &db_path).expect("FULL checkpoint reopen should recover");
+    let db = Database::open_file(io, &db_path, Arc::new(SqliteDialect))
+        .expect("FULL checkpoint reopen should recover");
     let conn = db
         .connect()
         .expect("connect should recover after FULL checkpoint");
@@ -2521,7 +2535,7 @@ fn test_bootstrap_rejects_torn_log_header_with_committed_wal() {
     }
 
     let io = Arc::new(PlatformIO::new().unwrap());
-    match Database::open_file(io, &db_path) {
+    match Database::open_file(io, &db_path, Arc::new(SqliteDialect)) {
         Ok(db) => match db.connect() {
             Ok(_) => panic!("expected connect to fail with Corrupt"),
             Err(err) => assert!(matches!(err, LimboError::Corrupt(_))),
@@ -2562,7 +2576,7 @@ fn test_bootstrap_rejects_corrupt_log_header_without_wal() {
     }
 
     let io = Arc::new(PlatformIO::new().unwrap());
-    match Database::open_file(io, &db_path) {
+    match Database::open_file(io, &db_path, Arc::new(SqliteDialect)) {
         Ok(db) => match db.connect() {
             Ok(_) => panic!("expected connect to fail with Corrupt"),
             Err(err) => assert!(matches!(err, LimboError::Corrupt(_))),
@@ -2632,7 +2646,8 @@ fn test_bootstrap_ignores_wal_frames_without_commit_marker() {
         manager.clear();
     }
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db2 = Database::open_file(io, &db_path).expect("open should succeed");
+    let db2 =
+        Database::open_file(io, &db_path, Arc::new(SqliteDialect)).expect("open should succeed");
     let conn2 = db2.connect().expect("connect should succeed");
     let rows = get_rows(&conn2, "SELECT id, v FROM t ORDER BY id");
     assert_eq!(rows.len(), 1);
@@ -2897,7 +2912,7 @@ fn test_meta_recovery_case_3_no_wal_log_frames_without_valid_metadata_fails_clos
         manager.clear();
     }
     let io = Arc::new(PlatformIO::new().unwrap());
-    match Database::open_file(io, &db_path) {
+    match Database::open_file(io, &db_path, Arc::new(SqliteDialect)) {
         Ok(db2) => match db2.connect() {
             Ok(_) => panic!("expected connect to fail with Corrupt"),
             Err(err) => assert!(
@@ -2982,7 +2997,7 @@ fn test_meta_recovery_case_5_committed_wal_missing_metadata_fails_closed() {
         manager.clear();
     }
     let io = Arc::new(PlatformIO::new().unwrap());
-    match Database::open_file(io, &db_path) {
+    match Database::open_file(io, &db_path, Arc::new(SqliteDialect)) {
         Ok(db2) => match db2.connect() {
             Ok(_) => panic!("expected connect to fail closed"),
             Err(err) => assert!(matches!(err, LimboError::Corrupt(_))),
@@ -3021,7 +3036,9 @@ fn test_meta_recovery_case_6_committed_wal_corrupt_metadata_fails_closed() {
         manager.clear();
     }
     let io = Arc::new(PlatformIO::new().unwrap());
-    if Database::open_file(io, &db_path).is_ok_and(|db2| db2.connect().is_ok()) {
+    if Database::open_file(io, &db_path, Arc::new(SqliteDialect))
+        .is_ok_and(|db2| db2.connect().is_ok())
+    {
         panic!("expected connect to fail closed")
     }
 }
@@ -3052,7 +3069,9 @@ fn test_meta_recovery_case_7_metadata_table_shape_violation_fails_closed() {
         manager.clear();
     }
     let io = Arc::new(PlatformIO::new().unwrap());
-    if Database::open_file(io, &db_path).is_ok_and(|db2| db2.connect().is_ok()) {
+    if Database::open_file(io, &db_path, Arc::new(SqliteDialect))
+        .is_ok_and(|db2| db2.connect().is_ok())
+    {
         panic!("expected connect to fail closed")
     }
 }
@@ -3087,7 +3106,7 @@ fn test_meta_recovery_case_9_metadata_row_deleted_fails_closed() {
         manager.clear();
     }
     let io = Arc::new(PlatformIO::new().unwrap());
-    match Database::open_file(io, &db_path) {
+    match Database::open_file(io, &db_path, Arc::new(SqliteDialect)) {
         Ok(db2) => match db2.connect() {
             Ok(_) => panic!("expected connect to fail closed"),
             Err(err) => assert!(matches!(err, LimboError::Corrupt(_))),
@@ -9083,7 +9102,7 @@ fn test_integrity_check_after_drop_index_before_checkpoint() {
 fn test_interrupted_drop_table_rolls_back_schema_table_and_indexes() {
     let io = Arc::new(MemoryIO::new());
     let path = ":memory:interrupted-drop-table-schema-rollback";
-    let db = Database::open_file(io.clone(), path).unwrap();
+    let db = Database::open_file(io.clone(), path, Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
 
     conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
@@ -9129,7 +9148,7 @@ fn test_interrupted_drop_table_rolls_back_schema_table_and_indexes() {
 
     // Reopening used to fail here because the same-connection SELECT could
     // commit the interrupted DROP TABLE's partial sqlite_schema delete.
-    let db = Database::open_file(io, path).unwrap();
+    let db = Database::open_file(io, path, Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
     let target_schema_rows = get_rows(
         &conn,
@@ -12208,6 +12227,7 @@ fn test_abandoned_journal_mode_mvcc_bootstrap_restores_connection() {
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
     let conn = db.connect().unwrap();
@@ -13345,7 +13365,7 @@ fn test_abandoned_drop() {
     let _ = tracing_subscriber::fmt::try_init();
     let io = Arc::new(MemoryIO::new());
     let path = ":memory:";
-    let db = Database::open_file(io.clone(), path).unwrap();
+    let db = Database::open_file(io.clone(), path, Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
 
     conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
@@ -13379,7 +13399,7 @@ fn test_abandoned_drop() {
     drop(conn);
     drop(db);
 
-    let db = Database::open_file(io, path).expect(
+    let db = Database::open_file(io, path, Arc::new(SqliteDialect)).expect(
         "reopen should not fail; abandoned DROP must not have committed its partial Delete",
     );
     let conn = db.connect().unwrap();
@@ -13735,6 +13755,7 @@ fn test_autoincrement_insert_works_for_preexisting_table() {
             OpenFlags::default(),
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();
@@ -13759,6 +13780,7 @@ fn test_autoincrement_insert_works_for_preexisting_table() {
             OpenFlags::default(),
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();
@@ -14527,6 +14549,7 @@ fn test_mvcc_late_encryption_setup_keeps_metadata_bootstrapped() {
         OpenFlags::default(),
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
     let conn = db.connect().unwrap();
@@ -15019,7 +15042,7 @@ fn test_mvcc_portable_changes_encoder_matches_metadata_wire_golden() {
 #[test]
 fn test_mvcc_portable_changes_disabled_by_default() {
     let io = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io, ":memory:").unwrap();
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
     conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
     conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
@@ -15157,7 +15180,7 @@ fn test_mvcc_portable_changes_resolve_rows_through_object_map_in_same_txn() {
 #[test]
 fn test_mvcc_mode_supports_cdc_for_client_push() {
     let io = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io, ":memory:").unwrap();
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
     conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
     conn.execute("PRAGMA capture_data_changes_conn('full,turso_cdc')")
@@ -15348,7 +15371,7 @@ fn test_mvcc_portable_changes_use_checkpointed_schema_after_restart() {
 #[test]
 fn test_mvcc_portable_changes_resolve_user_table_after_cross_connection_checkpoint() {
     let io = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io, ":memory:").unwrap();
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
     let creator = db.connect().unwrap();
     creator.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
     creator.set_portable_logical_changes_enabled(true);
@@ -15550,7 +15573,7 @@ fn test_mvcc_portable_changes_do_not_infer_origin_from_application_table() {
 #[test]
 fn test_mvcc_portable_changes_metadata_does_not_auto_enable_or_get_consumed() {
     let io = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io, ":memory:").unwrap();
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
     conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
     conn.set_mvcc_log_meta("client".to_string(), Some("client-a".to_string()));
@@ -17785,6 +17808,7 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
             OpenFlags::default(),
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();
@@ -17812,6 +17836,7 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         DatabaseOpts::new(),
         None,
         Some(busy_storage.clone() as Arc<dyn DurableStorage>),
+        Arc::new(SqliteDialect),
     )
     .unwrap();
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -890,10 +890,14 @@ impl Schema {
     /// bug). Production code that opens user databases should prefer
     /// [`Schema::with_options`] which returns `Result`.
     pub fn new() -> Self {
-        Self::with_options(true).expect("built-in type definitions are malformed")
+        Self::with_options(true, &crate::dialect::SqliteDialect)
+            .expect("built-in type definitions are malformed")
     }
 
-    pub fn with_options(enable_custom_types: bool) -> crate::Result<Self> {
+    pub fn with_options(
+        enable_custom_types: bool,
+        dialect: &dyn crate::dialect::Dialect,
+    ) -> crate::Result<Self> {
         let mut tables: HashMap<String, Arc<Table>> = HashMap::default();
         #[cfg(feature = "conn_raw_api")]
         let mut table_names_by_root_page = HashMap::default();
@@ -938,7 +942,7 @@ impl Schema {
             generated_columns_enabled: false,
             sequences: HashMap::default(),
         };
-        crate::dialect::sqlite::register_builtin_catalog(&mut schema, enable_custom_types)?;
+        dialect.register_catalog(&mut schema, enable_custom_types)?;
         Ok(schema)
     }
 
@@ -2670,6 +2674,7 @@ impl TryClone for VirtualTable {
             kind: self.kind,
             vtab_type: self.vtab_type.clone(),
             vtab_id: self.vtab_id,
+            is_droppable: self.is_droppable,
             innocuous: self.innocuous,
         })
     }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2081,115 +2081,113 @@ impl Schema {
         match ty {
             "table" => {
                 let sql = maybe_sql.expect("sql should be present for table");
-                // Classify the row by parsing its schema SQL, mirroring
-                // SQLite, where sqlite3InitCallback feeds the sql column to
-                // the parser and a row becomes a virtual table purely as a
-                // byproduct of the create_vtab grammar rule.
-                match Parser::new(sql.as_bytes()).next_cmd()? {
-                    Some(Cmd::Stmt(Stmt::CreateVirtualTable(_))) => {
-                        if root_page != 0 {
+                // In the SQLite file format a `type='table'` row describes a
+                // virtual table iff its rootpage is 0: virtual tables have no
+                // B-tree, while every real table stores a nonzero root (MVCC
+                // uses negative logical ids, which are still B-tree tables).
+                // Classify on the root page before touching the SQL text so
+                // only the B-tree arm needs to parse the row's stored SQL.
+                if root_page == 0 {
+                    match Parser::new(sql.as_bytes()).next_cmd()? {
+                        Some(Cmd::Stmt(Stmt::CreateVirtualTable(_))) => {}
+                        other => {
                             return Err(LimboError::Corrupt(format!(
-                                "sqlite_schema root_page must be 0 for virtual table {name}, got {root_page}"
+                                "sqlite_schema table row {name} with root page 0 has unexpected SQL {sql:?}: parsed as {other:?}"
                             )));
                         }
-                        // a virtual table is found in the sqlite_schema, but it's no
-                        // longer in the in-memory schema. We need to recreate it if
-                        // the module is loaded in the symbol table.
-                        let vtab = if let Some(vtab) = syms.vtabs.get(name) {
-                            vtab.clone()
-                        } else {
-                            let mod_name = module_name_from_sql(sql)?;
-                            crate::VirtualTable::table(
-                                Some(name),
-                                mod_name,
-                                module_args_from_sql(sql)?,
-                                syms,
-                            )?
-                        };
-                        self.add_virtual_table(vtab)?;
                     }
-                    Some(Cmd::Stmt(Stmt::CreateTable { tbl_name, body, .. })) => {
-                        let table = create_table(tbl_name.name.as_str(), &body, root_page)?;
 
-                        if table.has_virtual_columns && !self.generated_columns_enabled {
-                            return Err(LimboError::ParseError(format!(
+                    // a virtual table is found in the sqlite_schema, but it's no
+                    // longer in the in-memory schema. We need to recreate it if
+                    // the module is loaded in the symbol table.
+                    let vtab = if let Some(vtab) = syms.vtabs.get(name) {
+                        vtab.clone()
+                    } else {
+                        let mod_name = module_name_from_sql(sql)?;
+                        crate::VirtualTable::table(
+                            Some(name),
+                            mod_name,
+                            module_args_from_sql(sql)?,
+                            syms,
+                        )?
+                    };
+                    self.add_virtual_table(vtab)?;
+                } else {
+                    let table = BTreeTable::from_sql(sql, root_page)?;
+
+                    if table.has_virtual_columns && !self.generated_columns_enabled {
+                        return Err(LimboError::ParseError(format!(
                             "table '{}' uses generated columns but the generated_columns feature is not enabled",
                             table.name
                         )));
-                        }
+                    }
 
-                        // Detect sequence-backing tables by name prefix.
-                        // Just add the table (for B-tree access); sequences are created by
-                        // AddSequence at CREATE time or initialize_sequences at open time.
-                        if table.name.starts_with(SEQ_BACKING_TABLE_PREFIX) {
-                            self.add_btree_table(Arc::new(table))?;
-                            return Ok(());
-                        }
+                    // Detect sequence-backing tables by name prefix.
+                    // Just add the table (for B-tree access); sequences are created by
+                    // AddSequence at CREATE time or initialize_sequences at open time.
+                    if table.name.starts_with(SEQ_BACKING_TABLE_PREFIX) {
+                        self.add_btree_table(Arc::new(table))?;
+                        return Ok(());
+                    }
 
-                        // Check if this is a DBSP state table
-                        if table.name.starts_with(DBSP_TABLE_PREFIX) {
-                            // Extract version and view name from __turso_internal_dbsp_state_v<version>_<viewname>
-                            let suffix = table.name.strip_prefix(DBSP_TABLE_PREFIX).unwrap();
+                    // Check if this is a DBSP state table
+                    if table.name.starts_with(DBSP_TABLE_PREFIX) {
+                        // Extract version and view name from __turso_internal_dbsp_state_v<version>_<viewname>
+                        let suffix = table.name.strip_prefix(DBSP_TABLE_PREFIX).unwrap();
 
-                            // Parse version and view name (format: "<version>_<viewname>")
-                            if let Some(underscore_pos) = suffix.find('_') {
-                                let version_str = &suffix[..underscore_pos];
-                                let view_name = &suffix[underscore_pos + 1..];
+                        // Parse version and view name (format: "<version>_<viewname>")
+                        if let Some(underscore_pos) = suffix.find('_') {
+                            let version_str = &suffix[..underscore_pos];
+                            let view_name = &suffix[underscore_pos + 1..];
 
-                                // Check version compatibility
-                                if let Ok(stored_version) = version_str.parse::<u32>() {
-                                    if stored_version == DBSP_CIRCUIT_VERSION {
-                                        // Version matches, store the root page
-                                        dbsp_state_roots.insert(view_name.to_string(), root_page);
-                                    } else {
-                                        // Version mismatch - DO NOT insert into dbsp_state_roots
-                                        // This will cause populate_materialized_views to skip this view
-                                        tracing::warn!(
+                            // Check version compatibility
+                            if let Ok(stored_version) = version_str.parse::<u32>() {
+                                if stored_version == DBSP_CIRCUIT_VERSION {
+                                    // Version matches, store the root page
+                                    dbsp_state_roots.insert(view_name.to_string(), root_page);
+                                } else {
+                                    // Version mismatch - DO NOT insert into dbsp_state_roots
+                                    // This will cause populate_materialized_views to skip this view
+                                    tracing::warn!(
                                         "Skipping materialized view '{}' - has version {} but current version is {}. DROP and recreate the view to use it.",
                                         view_name,
                                         stored_version,
                                         DBSP_CIRCUIT_VERSION
                                     );
-                                        // We can't track incompatible views here since we're in handle_schema_row
-                                        // which doesn't have mutable access to self
-                                    }
+                                    // We can't track incompatible views here since we're in handle_schema_row
+                                    // which doesn't have mutable access to self
                                 }
                             }
                         }
-
-                        let mut table = table;
-                        table.resolve_custom_type_affinities(self);
-                        table.propagate_domain_constraints(self)?;
-                        let has_autoinc = table.has_autoincrement;
-                        let tbl_name = table.name.clone();
-                        self.add_btree_table(Arc::new(table))?;
-
-                        // Create the hidden sequence object owned by this
-                        // AUTOINCREMENT table. The `__turso_internal_autoincrement_`
-                        // prefix is a sequence namespace marker, not a table name;
-                        // the physical table is the corresponding
-                        // `__turso_internal_seq_<sequence-name>` backing table.
-                        if has_autoinc {
-                            let seq_name = autoincrement_sequence_name(&tbl_name);
-                            if let std::collections::hash_map::Entry::Vacant(e) =
-                                self.sequences.entry(normalize_ident(&seq_name))
-                            {
-                                let seq = Sequence::new(
-                                    seq_name.clone(),
-                                    Some(1),
-                                    Some(1),
-                                    None,
-                                    None,
-                                    false,
-                                )?;
-                                e.insert(Arc::new(seq));
-                            }
-                        }
                     }
-                    other => {
-                        return Err(LimboError::Corrupt(format!(
-                            "sqlite_schema table row {name} has unexpected SQL {sql:?}: parsed as {other:?}"
-                        )));
+
+                    let mut table = table;
+                    table.resolve_custom_type_affinities(self);
+                    table.propagate_domain_constraints(self)?;
+                    let has_autoinc = table.has_autoincrement;
+                    let tbl_name = table.name.clone();
+                    self.add_btree_table(Arc::new(table))?;
+
+                    // Create the hidden sequence object owned by this
+                    // AUTOINCREMENT table. The `__turso_internal_autoincrement_`
+                    // prefix is a sequence namespace marker, not a table name;
+                    // the physical table is the corresponding
+                    // `__turso_internal_seq_<sequence-name>` backing table.
+                    if has_autoinc {
+                        let seq_name = autoincrement_sequence_name(&tbl_name);
+                        if let std::collections::hash_map::Entry::Vacant(e) =
+                            self.sequences.entry(normalize_ident(&seq_name))
+                        {
+                            let seq = Sequence::new(
+                                seq_name.clone(),
+                                Some(1),
+                                Some(1),
+                                None,
+                                None,
+                                false,
+                            )?;
+                            e.insert(Arc::new(seq));
+                        }
                     }
                 }
             }
@@ -3504,10 +3502,27 @@ impl BTreeTable {
         let cmd = parser.next_cmd()?;
         match cmd {
             Some(Cmd::Stmt(Stmt::CreateTable { tbl_name, body, .. })) => {
-                create_table(tbl_name.name.as_str(), &body, root_page)
+                Self::from_create_table_ast(&tbl_name, &body, root_page)
             }
-            _ => unreachable!("Expected CREATE TABLE statement"),
+            Some(Cmd::Stmt(Stmt::CreateVirtualTable(vtab))) => Err(LimboError::Corrupt(format!(
+                "sqlite_schema root_page must be 0 for virtual table {}, got {root_page}",
+                vtab.tbl_name.name.as_str()
+            ))),
+            other => Err(LimboError::Corrupt(format!(
+                "sqlite_schema table row has unexpected SQL {sql:?}: parsed as {other:?}"
+            ))),
         }
+    }
+
+    /// Build a table definition from an already-parsed `CREATE TABLE`
+    /// statement. This is the single AST-to-table lowering path shared by
+    /// [`BTreeTable::from_sql`] and callers that hold a translated AST.
+    pub fn from_create_table_ast(
+        tbl_name: &ast::QualifiedName,
+        body: &CreateTableBody,
+        root_page: i64,
+    ) -> Result<BTreeTable> {
+        create_table(tbl_name.name.as_str(), body, root_page)
     }
 
     /// Reconstruct the SQL for the table.
@@ -6726,6 +6741,103 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("generated columns"));
+    }
+
+    #[test]
+    fn test_schema_row_vtab_with_nonzero_root_page_is_corrupt() {
+        let mut schema = Schema::new();
+
+        let result = schema.handle_schema_row(
+            "table",
+            "v1",
+            "v1",
+            2,
+            Some("CREATE VIRTUAL TABLE v1 USING somemodule"),
+            &SymbolTable::default(),
+            &mut vec![],
+            &mut HashMap::default(),
+            &mut HashMap::default(),
+            &mut HashMap::default(),
+            &mut HashMap::default(),
+            &|_| None,
+        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("root_page must be 0 for virtual table v1"));
+    }
+
+    #[test]
+    fn test_schema_row_with_zero_root_page_takes_virtual_table_path() {
+        let mut schema = Schema::new();
+
+        // Root page 0 must route to virtual-table handling; with no such
+        // module registered, that path fails module resolution instead of
+        // creating a B-tree table with an invalid root page.
+        let result = schema.handle_schema_row(
+            "table",
+            "v1",
+            "v1",
+            0,
+            Some("CREATE VIRTUAL TABLE v1 USING nosuchmodule"),
+            &SymbolTable::default(),
+            &mut vec![],
+            &mut HashMap::default(),
+            &mut HashMap::default(),
+            &mut HashMap::default(),
+            &mut HashMap::default(),
+            &|_| None,
+        );
+        assert!(result.is_err());
+        assert!(schema.get_table("v1").is_none());
+    }
+
+    #[test]
+    fn test_schema_row_with_zero_root_page_rejects_malformed_sql() {
+        let mut schema = Schema::new();
+
+        let result = schema.handle_schema_row(
+            "table",
+            "v1",
+            "v1",
+            0,
+            Some("CREATE VIRTUAL TABLE v1 USING"),
+            &SymbolTable::default(),
+            &mut vec![],
+            &mut HashMap::default(),
+            &mut HashMap::default(),
+            &mut HashMap::default(),
+            &mut HashMap::default(),
+            &|_| None,
+        );
+        assert!(result.is_err());
+        assert!(schema.get_table("v1").is_none());
+    }
+
+    #[test]
+    fn test_schema_row_table_with_virtual_table_substring_is_btree() {
+        let mut schema = Schema::new();
+
+        // A regular table whose SQL merely contains virtual-table syntax
+        // (e.g. in a DEFAULT literal) must classify as a B-tree table.
+        schema
+            .handle_schema_row(
+                "table",
+                "t1",
+                "t1",
+                2,
+                Some("CREATE TABLE t1(x TEXT DEFAULT 'create virtual table')"),
+                &SymbolTable::default(),
+                &mut vec![],
+                &mut HashMap::default(),
+                &mut HashMap::default(),
+                &mut HashMap::default(),
+                &mut HashMap::default(),
+                &|_| None,
+            )
+            .unwrap();
+        let table = schema.get_btree_table("t1").unwrap();
+        assert_eq!(table.root_page, 2);
     }
 
     fn indices(mask: &ColumnMask) -> Vec<usize> {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1519,8 +1519,9 @@ impl Schema {
         mv_cursor: Option<Arc<RwLock<MvCursor>>>,
         pager: &Arc<Pager>,
         syms: &SymbolTable,
+        dialect: &dyn crate::dialect::Dialect,
     ) -> Result<IOResult<()>> {
-        let result = self.make_from_btree_internal(state, mv_cursor, pager, syms);
+        let result = self.make_from_btree_internal(state, mv_cursor, pager, syms, dialect);
         if result.is_err() {
             state.cleanup(pager);
         } else if let Ok(IOResult::Done(..)) = result {
@@ -1538,6 +1539,7 @@ impl Schema {
         mv_cursor: Option<Arc<RwLock<MvCursor>>>,
         pager: &Arc<Pager>,
         syms: &SymbolTable,
+        dialect: &dyn crate::dialect::Dialect,
     ) -> Result<IOResult<()>> {
         loop {
             tracing::debug!("make_from_btree: state.phase={:?}", state.phase);
@@ -1644,6 +1646,7 @@ impl Schema {
                         &mut acc.dbsp_state_index_roots,
                         &mut acc.materialized_view_info,
                         &|_| None,
+                        dialect,
                     )?;
 
                     state.phase = MakeFromBtreePhase::Advancing;
@@ -2077,6 +2080,7 @@ impl Schema {
         // `&|_| None`; unresolvable names become `Some(INVALID_DB_ID)`
         // so the trigger never fires against a real db.
         resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
+        dialect: &dyn crate::dialect::Dialect,
     ) -> Result<()> {
         match ty {
             "table" => {
@@ -2113,7 +2117,7 @@ impl Schema {
                     };
                     self.add_virtual_table(vtab)?;
                 } else {
-                    let table = BTreeTable::from_sql(sql, root_page)?;
+                    let table = dialect.parse_table_sql(sql, root_page)?;
 
                     if table.has_virtual_columns && !self.generated_columns_enabled {
                         return Err(LimboError::ParseError(format!(
@@ -6736,6 +6740,7 @@ mod tests {
             &mut HashMap::default(),
             &mut HashMap::default(),
             &|_| None,
+            &crate::dialect::SqliteDialect,
         );
         assert!(result
             .unwrap_err()
@@ -6760,6 +6765,7 @@ mod tests {
             &mut HashMap::default(),
             &mut HashMap::default(),
             &|_| None,
+            &crate::dialect::SqliteDialect,
         );
         assert!(result
             .unwrap_err()
@@ -6787,6 +6793,7 @@ mod tests {
             &mut HashMap::default(),
             &mut HashMap::default(),
             &|_| None,
+            &crate::dialect::SqliteDialect,
         );
         assert!(result.is_err());
         assert!(schema.get_table("v1").is_none());
@@ -6809,6 +6816,7 @@ mod tests {
             &mut HashMap::default(),
             &mut HashMap::default(),
             &|_| None,
+            &crate::dialect::SqliteDialect,
         );
         assert!(result.is_err());
         assert!(schema.get_table("v1").is_none());
@@ -6834,6 +6842,7 @@ mod tests {
                 &mut HashMap::default(),
                 &mut HashMap::default(),
                 &|_| None,
+                &crate::dialect::SqliteDialect,
             )
             .unwrap();
         let table = schema.get_btree_table("t1").unwrap();

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -8,10 +8,7 @@ use std::{
 };
 
 use tracing::{instrument, Level};
-use turso_parser::{
-    ast::{fmt::ToTokens, Cmd},
-    parser::Parser,
-};
+use turso_parser::ast::{fmt::ToTokens, Cmd};
 
 use crate::alloc::TursoIteratorExt;
 use crate::{
@@ -866,8 +863,7 @@ impl Statement {
         // same-version reprepare still refreshes it.
         conn.refresh_schema_from_shared_for_reprepare();
         let new_program = {
-            let mut parser = Parser::new(self.program.sql.as_bytes());
-            let cmd = parser.next_cmd()?;
+            let (cmd, _) = conn.parse_sql(&self.program.sql)?;
             let cmd = cmd.expect("Same SQL string should be able to be parsed");
 
             let syms = conn.syms.read();

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -1495,6 +1495,7 @@ impl Drop for Statement {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SqliteDialect;
     use crate::{Database, DatabaseOpts, MemoryIO, OpenFlags, IO};
 
     fn open_test_connection() -> crate::Result<Arc<crate::Connection>> {
@@ -1505,6 +1506,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )?;
         db.connect()
     }

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -880,6 +880,7 @@ impl Statement {
                 &syms,
                 mode,
                 &self.program.sql,
+                self.origin,
             )?
         };
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -9766,6 +9766,7 @@ fn shift_pointers_left(page: &mut PageContent, cell_idx: usize) {
 
 #[cfg(test)]
 mod tests {
+    use crate::SqliteDialect;
     use rand::{rng, Rng};
     use rand_chacha::{
         rand_core::{RngCore, SeedableRng},
@@ -9889,7 +9890,8 @@ mod tests {
                 .unwrap();
         }
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), path.to_str().unwrap()).unwrap();
+        let db = Database::open_file(io.clone(), path.to_str().unwrap(), Arc::new(SqliteDialect))
+            .unwrap();
 
         db
     }
@@ -9898,7 +9900,8 @@ mod tests {
     fn wal_reuses_freelist_leaf_after_abandoned_overflowing_insert() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, "freelist-stale-overflow.db").unwrap();
+        let db =
+            Database::open_file(io, "freelist-stale-overflow.db", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
 
         conn.execute("PRAGMA journal_mode = WAL").unwrap();
@@ -10020,7 +10023,8 @@ mod tests {
     fn wal_overflowing_insert_resumes_after_yield_before_balance() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, "resume-overflow-yield.db").unwrap();
+        let db =
+            Database::open_file(io, "resume-overflow-yield.db", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
 
         conn.execute("PRAGMA journal_mode = WAL").unwrap();
@@ -10394,7 +10398,7 @@ mod tests {
     fn empty_btree() -> (Arc<Pager>, i64, Arc<Database>, Arc<Connection>) {
         #[allow(clippy::arc_with_non_send_sync)]
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io.clone(), ":memory:").unwrap();
+        let db = Database::open_file(io.clone(), ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         let pager = conn.pager.load().clone();
 
@@ -10418,7 +10422,7 @@ mod tests {
     fn btree_with_virtual_page_1() -> Result<()> {
         #[allow(clippy::arc_with_non_send_sync)]
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io.clone(), ":memory:").unwrap();
+        let db = Database::open_file(io.clone(), ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         let pager = conn.pager.load().clone();
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -6510,6 +6510,7 @@ mod checkpoint_phase_tests {
     use crate::sync::atomic::Ordering;
     use crate::types::IOResult;
     use crate::Database;
+    use crate::SqliteDialect;
 
     /// Returns an IO backend that supports shared WAL coordination on the host.
     /// On Windows the default `PlatformIO` (`WindowsIO`) lacks the byte-locking
@@ -6542,6 +6543,7 @@ mod checkpoint_phase_tests {
             crate::OpenFlags::default(),
             crate::DatabaseOpts::new().with_multiprocess_wal(true),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         (db, dir)

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -5824,6 +5824,7 @@ pub mod test {
     };
     use crate::sync::{atomic::Ordering, Arc};
     use crate::sync::{Mutex, RwLock};
+    use crate::SqliteDialect;
     use crate::{
         io::FileSyncType,
         storage::{
@@ -5874,6 +5875,7 @@ pub mod test {
             crate::OpenFlags::default(),
             crate::DatabaseOpts::new().with_multiprocess_wal(true),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         // db + tmp directory

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -480,7 +480,9 @@ impl<'a> Resolver<'a> {
         func_name: &str,
         arg_count: usize,
     ) -> Result<Option<Func>, LimboError> {
-        match Func::resolve_function(func_name, arg_count)? {
+        // The dialect owns the function name surface of user SQL; extension
+        // functions resolve after it.
+        match self.dialect.resolve_function(func_name, arg_count)? {
             Some(func) => Ok(Some(func)),
             None => Ok(self
                 .symbol_table

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -37,7 +37,6 @@ use crate::vdbe::{
     BranchOffset, CursorID,
 };
 use crate::{
-    bail_parse_error,
     error::SQLITE_CONSTRAINT_CHECK,
     function::Func,
     sync::Arc,
@@ -1568,11 +1567,8 @@ pub fn emit_cdc_commit_insns(
     program.mark_last_insn_constant();
 
     // reg+1: change_time = unixepoch()
-    let Some(unixepoch_fn) = resolver.resolve_function("unixepoch", 0)? else {
-        bail_parse_error!("no function {}", "unixepoch");
-    };
     let unixepoch_fn_ctx = crate::function::FuncCtx {
-        func: unixepoch_fn,
+        func: Func::Scalar(crate::function::ScalarFunc::UnixEpoch),
         arg_count: 0,
     };
     program.emit_insn(Insn::Function {
@@ -1586,11 +1582,8 @@ pub fn emit_cdc_commit_insns(
     // Pass -1 as candidate: if a txn_id exists, return it; if not, -1 is stored (and will be reset).
     let minus_one_reg = program.alloc_register();
     program.emit_int(-1, minus_one_reg);
-    let Some(conn_txn_id_fn) = resolver.resolve_function("conn_txn_id", 1)? else {
-        bail_parse_error!("no function {}", "conn_txn_id");
-    };
     let conn_txn_id_fn_ctx = crate::function::FuncCtx {
-        func: conn_txn_id_fn,
+        func: Func::Scalar(crate::function::ScalarFunc::ConnTxnId),
         arg_count: 1,
     };
     program.emit_insn(Insn::Function {
@@ -1648,11 +1641,8 @@ pub fn emit_cdc_autocommit_commit(
     let cdc_info = program.capture_data_changes_info().as_ref();
     if cdc_info.is_some_and(|info| info.cdc_version().has_commit_record()) {
         // Check if we're in autocommit mode; if so, emit a COMMIT record.
-        let Some(is_autocommit_fn) = resolver.resolve_function("is_autocommit", 0)? else {
-            bail_parse_error!("no function {}", "is_autocommit");
-        };
         let is_autocommit_fn_ctx = crate::function::FuncCtx {
-            func: is_autocommit_fn,
+            func: Func::Scalar(crate::function::ScalarFunc::IsAutocommit),
             arg_count: 0,
         };
         let autocommit_reg = program.alloc_register();
@@ -1702,16 +1692,13 @@ pub fn emit_cdc_explicit_commit_insns(
 ) -> Result<()> {
     let minus_one_reg = program.alloc_register();
     program.emit_int(-1, minus_one_reg);
-    let Some(conn_txn_id_fn) = resolver.resolve_function("conn_txn_id", 1)? else {
-        bail_parse_error!("no function {}", "conn_txn_id");
-    };
     let txn_id_reg = program.alloc_register();
     program.emit_insn(Insn::Function {
         constant_mask: 0,
         start_reg: minus_one_reg,
         dest: txn_id_reg,
         func: crate::function::FuncCtx {
-            func: conn_txn_id_fn,
+            func: Func::Scalar(crate::function::ScalarFunc::ConnTxnId),
             arg_count: 1,
         },
     });

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -169,6 +169,9 @@ pub struct Resolver<'a> {
     /// Controls whether unresolved double-quoted identifiers fall back to string
     /// literals (SQLite's DQS misfeature) in DML statements.
     pub dqs_dml: DoubleQuotedDml,
+    /// Schema dialect of the database being compiled against; used when a
+    /// fresh placeholder schema must be constructed during resolution.
+    pub(crate) dialect: Arc<dyn crate::dialect::Dialect>,
     /// When set, we are compiling a trigger subprogram for this database.
     /// Ordinary triggers are restricted to their own database, but temp-backed
     /// triggers follow SQLite's looser resolution rules and may access objects
@@ -273,6 +276,7 @@ impl<'a> Resolver<'a> {
     const MAIN_DB: &'static str = "main";
     const TEMP_DB: &'static str = "temp";
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         schema: &'a Schema,
         database_schemas: &'a RwLock<HashMap<usize, Arc<Schema>>>,
@@ -281,6 +285,7 @@ impl<'a> Resolver<'a> {
         symbol_table: &'a SymbolTable,
         enable_custom_types: bool,
         dqs_dml: DoubleQuotedDml,
+        dialect: Arc<dyn crate::dialect::Dialect>,
     ) -> Self {
         let has_temp_schema = temp_database.read().is_some();
         Self {
@@ -298,6 +303,7 @@ impl<'a> Resolver<'a> {
             self_table_scope: RefCell::new(None),
             enable_custom_types,
             dqs_dml,
+            dialect,
             trigger_context: None,
             has_temp_schema,
             fk_action_compile_stack: FkActionCompileStack::default(),
@@ -328,6 +334,7 @@ impl<'a> Resolver<'a> {
             self_table_scope: RefCell::new(self.self_table_scope.borrow().clone()),
             enable_custom_types: self.enable_custom_types,
             dqs_dml: self.dqs_dml,
+            dialect: self.dialect.clone(),
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,
             fk_action_compile_stack: self.fk_action_compile_stack.clone(),
@@ -350,6 +357,7 @@ impl<'a> Resolver<'a> {
             self_table_scope: RefCell::new(self.self_table_scope.borrow().clone()),
             enable_custom_types: self.enable_custom_types,
             dqs_dml: self.dqs_dml,
+            dialect: self.dialect.clone(),
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,
             fk_action_compile_stack: self.fk_action_compile_stack.clone(),
@@ -439,7 +447,7 @@ impl<'a> Resolver<'a> {
                 .unwrap_or_else(|| {
                     // with_options only fails if built-in type SQL is malformed (programmer bug).
                     Arc::new(
-                        Schema::with_options(self.enable_custom_types)
+                        Schema::with_options(self.enable_custom_types, self.dialect.as_ref())
                             .expect("built-in type definitions are malformed"),
                     )
                 }),

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -689,7 +689,7 @@ pub fn translate_expr(
                 Func::Window(_) => {
                     crate::bail_parse_error!("misuse of window function {}()", name.as_str())
                 }
-                Func::External(_) => {
+                Func::External(_) | Func::Dialect(_) => {
                     let regs = program.alloc_registers(args_count);
                     for (i, arg_expr) in args.iter().enumerate() {
                         translate_expr(program, referenced_tables, arg_expr, regs + i, resolver)?;

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -70,6 +70,7 @@ use update::translate_update;
 #[instrument(skip_all, level = Level::DEBUG)]
 #[allow(clippy::too_many_arguments)]
 #[turso_macros::trace_stack]
+#[allow(clippy::too_many_arguments)]
 pub fn translate(
     schema: &Schema,
     stmt: ast::Stmt,
@@ -78,6 +79,7 @@ pub fn translate(
     syms: &SymbolTable,
     query_mode: QueryMode,
     input: &str,
+    origin: crate::statement::StatementOrigin,
 ) -> Result<Program> {
     tracing::trace!("querying {}", input);
     let change_cnt_on = matches!(
@@ -111,7 +113,14 @@ pub fn translate(
         syms,
         connection.experimental_custom_types_enabled(),
         connection.get_dqs_dml().into(),
-        connection.dialect(),
+        // Engine-generated helper statements are always SQLite text and
+        // must resolve functions with SQLite semantics regardless of the
+        // database's dialect — the same invariant as unmarked schema rows.
+        if matches!(origin, crate::statement::StatementOrigin::InternalHelper) {
+            Arc::new(crate::dialect::SqliteDialect) as Arc<dyn crate::dialect::Dialect>
+        } else {
+            connection.dialect()
+        },
     );
 
     match stmt {
@@ -541,6 +550,7 @@ mod tests {
             &empty_syms,
             QueryMode::Normal,
             "",
+            crate::statement::StatementOrigin::Root,
         );
         let err = result.unwrap_err().to_string();
         assert!(
@@ -580,8 +590,17 @@ mod tests {
             _ => panic!("expected statement"),
         };
 
-        let err = translate(&schema, stmt, pager, conn, &syms, QueryMode::Normal, "")
-            .expect_err("translation should fail with malformed sqlite_sequence");
+        let err = translate(
+            &schema,
+            stmt,
+            pager,
+            conn,
+            &syms,
+            QueryMode::Normal,
+            "",
+            crate::statement::StatementOrigin::Root,
+        )
+        .expect_err("translation should fail with malformed sqlite_sequence");
         match err {
             crate::LimboError::Corrupt(msg) => {
                 assert!(
@@ -614,8 +633,17 @@ mod tests {
             _ => panic!("expected statement"),
         };
 
-        let err = translate(&schema, stmt, pager, conn, &syms, QueryMode::Normal, "")
-            .expect_err("translation should fail with missing sqlite_sequence");
+        let err = translate(
+            &schema,
+            stmt,
+            pager,
+            conn,
+            &syms,
+            QueryMode::Normal,
+            "",
+            crate::statement::StatementOrigin::Root,
+        )
+        .expect_err("translation should fail with missing sqlite_sequence");
         match err {
             crate::LimboError::Corrupt(msg) => {
                 assert!(

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -111,6 +111,7 @@ pub fn translate(
         syms,
         connection.experimental_custom_types_enabled(),
         connection.get_dqs_dml().into(),
+        connection.dialect(),
     );
 
     match stmt {

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -511,12 +511,13 @@ mod tests {
     use crate::io::MemoryIO;
     use crate::schema::{BTreeTable, Table, SQLITE_SEQUENCE_TABLE_NAME};
     use crate::Database;
+    use crate::SqliteDialect;
 
     /// Verify that REGEXP produces the correct error when no regexp function is registered.
     #[test]
     fn test_regexp_no_function_registered() {
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, ":memory:").unwrap();
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         let schema = db.schema.lock().clone();
         let pager = conn.pager.load().clone();
@@ -549,7 +550,7 @@ mod tests {
     #[test]
     fn test_insert_autoincrement_with_malformed_sqlite_sequence_is_corrupt() {
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, ":memory:").unwrap();
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)")
             .unwrap();
@@ -593,7 +594,7 @@ mod tests {
     #[test]
     fn test_insert_autoincrement_with_missing_sqlite_sequence_is_corrupt() {
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, ":memory:").unwrap();
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)")
             .unwrap();
@@ -627,7 +628,7 @@ mod tests {
     #[test]
     fn test_trigger_compile_error_does_not_poison_future_insert_compilation() {
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, ":memory:").unwrap();
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
 
         conn.execute("CREATE TABLE ref(x);").unwrap();

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -208,6 +208,7 @@ pub fn translate_inner(
             body,
             program,
             connection,
+            input,
         )?,
         ast::Stmt::CreateTrigger {
             temporary,

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -774,6 +774,7 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
     plan.simple_aggregate = detect_simple_aggregate(plan);
     let best_join_order = optimize_table_access(
         schema,
+        resolver.dialect.as_ref(),
         &mut plan.result_columns,
         &mut plan.table_references,
         &available_indexes,
@@ -853,6 +854,7 @@ fn optimize_delete_plan(plan: &mut DeletePlan, resolver: &Resolver) -> Result<()
 
     let _ = optimize_table_access(
         schema,
+        resolver.dialect.as_ref(),
         &mut plan.result_columns,
         &mut plan.table_references,
         &available_indexes,
@@ -914,6 +916,7 @@ fn optimize_update_plan(
     let available_indexes = AvailableIndexes::for_table_references(resolver, &target_tables);
     let optimize_result = optimize_table_access(
         schema,
+        resolver.dialect.as_ref(),
         &mut [],
         &mut target_tables,
         &available_indexes,
@@ -1647,6 +1650,7 @@ fn where_term_is_null_rejecting_for_table(
     expr: &ast::Expr,
     operator: ConstraintOperator,
     table_id: ast::TableInternalId,
+    dialect: &dyn crate::dialect::Dialect,
 ) -> bool {
     if matches!(
         operator,
@@ -1655,7 +1659,7 @@ fn where_term_is_null_rejecting_for_table(
         return false;
     }
 
-    !expr_has_null_masking_for_table(expr, table_id)
+    !expr_has_null_masking_for_table(expr, table_id, dialect)
 }
 
 /// Returns true if an expression references a column from `table_id`.
@@ -1697,15 +1701,17 @@ fn is_null_check_on_table(expr: &ast::Expr, table_id: ast::TableInternalId) -> b
 /// Returns true if an expression uses a NULL-masking construct over columns from `table_id`.
 /// This includes NULL-masking functions (COALESCE, IFNULL) and CASE/IIF expressions
 /// that explicitly handle the NULL case for columns from the target table.
-fn expr_has_null_masking_for_table(expr: &ast::Expr, table_id: ast::TableInternalId) -> bool {
+fn expr_has_null_masking_for_table(
+    expr: &ast::Expr,
+    table_id: ast::TableInternalId,
+    dialect: &dyn crate::dialect::Dialect,
+) -> bool {
     use crate::translate::expr::{walk_expr, WalkControl};
     let mut found = false;
     let _ = walk_expr(expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
         match e {
             ast::Expr::FunctionCall { name, args, .. } => {
-                if let Ok(Some(func)) =
-                    crate::function::Func::resolve_function(name.as_str(), args.len())
-                {
+                if let Ok(Some(func)) = dialect.resolve_function(name.as_str(), args.len()) {
                     // IIF(cond, then, else) is like CASE WHEN cond THEN then ELSE else END.
                     // If the condition is a null check on the target table, IIF masks nulls.
                     if matches!(
@@ -1833,6 +1839,7 @@ fn enforce_indexed_by_hints(
 #[allow(clippy::too_many_arguments)]
 fn optimize_table_access(
     schema: &Schema,
+    dialect: &dyn crate::dialect::Dialect,
     result_columns: &mut [ResultSetColumn],
     table_references: &mut TableReferences,
     available_indexes: &AvailableIndexes,
@@ -1988,6 +1995,7 @@ fn optimize_table_access(
                     &where_clause[c.where_clause_pos.0].expr,
                     c.operator,
                     t.internal_id,
+                    dialect,
                 );
                 is_from_where && is_null_rejecting
             }) {
@@ -3848,7 +3856,8 @@ mod tests {
         assert!(!where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::GreaterEquals.into(),
-            table
+            table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 
@@ -3876,7 +3885,8 @@ mod tests {
         assert!(where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::Greater.into(),
-            target_table
+            target_table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 
@@ -3909,7 +3919,8 @@ mod tests {
         assert!(!where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::Equals.into(),
-            table
+            table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 
@@ -3930,7 +3941,8 @@ mod tests {
         assert!(!where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::Is.into(),
-            table
+            table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 
@@ -3956,7 +3968,8 @@ mod tests {
         assert!(!where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::Is.into(),
-            table
+            table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 
@@ -3977,7 +3990,8 @@ mod tests {
         assert!(!where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::Is.into(),
-            table
+            table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 
@@ -3998,7 +4012,8 @@ mod tests {
         assert!(!where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::IsNot.into(),
-            table
+            table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 
@@ -4032,7 +4047,8 @@ mod tests {
         assert!(!where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::Greater.into(),
-            table
+            table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 
@@ -4071,7 +4087,8 @@ mod tests {
         assert!(where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::Greater.into(),
-            table
+            table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 
@@ -4105,7 +4122,8 @@ mod tests {
         assert!(!where_term_is_null_rejecting_for_table(
             &expr,
             ast::Operator::Greater.into(),
-            table
+            table,
+            &crate::dialect::SqliteDialect,
         ));
     }
 }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3739,6 +3739,7 @@ mod tests {
             syms,
             true,
             DoubleQuotedDml::Enabled,
+            crate::sync::Arc::new(crate::dialect::SqliteDialect),
         )
     }
 

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1093,6 +1093,7 @@ fn emit_ctas_insert(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn translate_create_table(
     tbl_name: ast::QualifiedName,
     resolver: &Resolver,
@@ -1101,6 +1102,7 @@ pub fn translate_create_table(
     body: ast::CreateTableBody,
     program: &mut ProgramBuilder,
     connection: &Arc<Connection>,
+    input: &str,
 ) -> Result<()> {
     // For CTAS, extract the SELECT, determine column info, and convert to a
     // regular ColumnsAndConstraints body + separate SELECT for data insertion.
@@ -1291,11 +1293,16 @@ pub fn translate_create_table(
         false
     };
 
-    // For CTAS, use the pre-built SQL string; for regular CREATE TABLE, build it from the body.
+    // For CTAS, use the pre-built SQL string; for regular CREATE TABLE, let
+    // the schema dialect format the SQL to store (the SQLite dialect renders
+    // canonical text from the AST, a frontend dialect preserves its own
+    // input text).
     let sql = if let Some(ref info) = ctas_info {
         info.schema_sql.clone()
     } else {
-        create_table_body_to_str(&tbl_name, &body)?
+        connection
+            .dialect()
+            .format_table_sql(input, &tbl_name, &body)?
     };
 
     let parse_schema_label = program.allocate_label();
@@ -1619,25 +1626,6 @@ fn collect_autoindexes(
     } else {
         Ok(Some(regs))
     }
-}
-
-fn create_table_body_to_str(
-    tbl_name: &ast::QualifiedName,
-    body: &ast::CreateTableBody,
-) -> crate::Result<String> {
-    let mut sql = String::new();
-    sql.push_str(format!("CREATE TABLE {} {}", tbl_name.name.as_ident(), body).as_str());
-    match body {
-        ast::CreateTableBody::ColumnsAndConstraints {
-            columns: _,
-            constraints: _,
-            options: _,
-        } => {}
-        ast::CreateTableBody::AsSelect(_select) => {
-            crate::bail_parse_error!("CREATE TABLE AS SELECT is not supported")
-        }
-    }
-    Ok(sql)
 }
 
 fn create_vtable_body_to_str(vtab: &ast::CreateVirtualTable, module: Arc<VTabImpl>) -> String {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -2077,10 +2077,7 @@ pub fn translate_drop_table(
             });
         }
         Table::Virtual(vtab) => {
-            // From what I see, TableValuedFunction is not stored in the schema as a table.
-            // But this line here below is a safeguard in case this behavior changes in the future
-            // And mirrors what SQLite does.
-            if matches!(vtab.kind, turso_ext::VTabKind::TableValuedFunction) {
+            if !vtab.is_droppable {
                 return Err(crate::LimboError::ParseError(format!(
                     "table {} may not be dropped",
                     vtab.name

--- a/core/util.rs
+++ b/core/util.rs
@@ -203,6 +203,7 @@ pub fn parse_schema_rows(
     schema: &mut Schema,
     syms: &SymbolTable,
     resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
+    dialect: &dyn crate::dialect::Dialect,
 ) -> Result<IOResult<()>> {
     {
         let inner = state
@@ -238,6 +239,7 @@ pub fn parse_schema_rows(
                 dbsp_state_index_roots,
                 materialized_view_info,
                 resolve_attached_db,
+                dialect,
             )
         }));
     }

--- a/core/vdbe/blob_io_tests.rs
+++ b/core/vdbe/blob_io_tests.rs
@@ -8,18 +8,27 @@ use std::sync::Arc;
 use crate::vdbe::builder::{CursorType, ProgramBuilder, ProgramBuilderOpts, QueryMode};
 use crate::vdbe::insn::{Insn, RegisterOrLiteral};
 use crate::{
-    Connection, Database, DatabaseOpts, LimboError, MemoryIO, OpenFlags, Statement, Value, IO,
+    Connection, Database, DatabaseOpts, LimboError, MemoryIO, OpenFlags, SqliteDialect, Statement,
+    Value, IO,
 };
 
 fn fresh_db() -> Arc<Connection> {
     let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io, ":memory:").unwrap();
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
     db.connect().unwrap()
 }
 
 fn fresh_db_with_opts(opts: DatabaseOpts) -> Arc<Connection> {
     let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-    let db = Database::open_file_with_flags(io, ":memory:", OpenFlags::Create, opts, None).unwrap();
+    let db = Database::open_file_with_flags(
+        io,
+        ":memory:",
+        OpenFlags::Create,
+        opts,
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
     db.connect().unwrap()
 }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -56,7 +56,6 @@ use crate::vector::{
     vector1bit, vector32, vector32_sparse, vector64, vector8, vector_concat, vector_distance_cos,
     vector_distance_dot, vector_distance_jaccard, vector_distance_l2, vector_extract, vector_slice,
 };
-use crate::SqliteDialect;
 use crate::{
     connection::Row,
     get_cursor, info, is_attached_db,
@@ -7454,6 +7453,24 @@ pub fn op_rowset_test(
     Ok(InsnFunctionStepResult::Step)
 }
 
+fn parse_schema_sql_for_alter(
+    dialect: &dyn crate::Dialect,
+    entry_type: &str,
+    root_page: i64,
+    sql: &str,
+) -> Result<Option<ast::Cmd>> {
+    if entry_type == "table" && root_page != 0 {
+        let stmt = dialect.parse_table_sql_ast(sql)?;
+        if !matches!(stmt, ast::Stmt::CreateTable { .. }) {
+            return Err(LimboError::Corrupt(
+                "storage-backed table schema is not CREATE TABLE".to_string(),
+            ));
+        }
+        return Ok(Some(ast::Cmd::Stmt(stmt)));
+    }
+    dialect.parse(sql).map(|(cmd, _)| cmd)
+}
+
 pub fn op_function(
     program: &Program,
     state: &mut ProgramState,
@@ -9142,6 +9159,9 @@ pub fn op_function(
         },
         crate::function::Func::AlterTable(alter_func) => {
             let r#type = &state.registers[*start_reg].get_value().clone();
+            let Value::Text(entry_type) = r#type else {
+                panic!("sqlite_schema.type should be TEXT")
+            };
 
             let Value::Text(name) = &state.registers[*start_reg + 1].get_value() else {
                 panic!("sqlite_schema.name should be TEXT")
@@ -9199,10 +9219,13 @@ pub fn op_function(
                             break 'sql None;
                         };
 
-                        let mut parser = Parser::new(sql.as_str().as_bytes());
-                        let ast::Cmd::Stmt(stmt) =
-                            parser.next().expect("parser should have next item")?
-                        else {
+                        let cmd = parse_schema_sql_for_alter(
+                            program.connection.dialect().as_ref(),
+                            entry_type.as_str(),
+                            *root_page,
+                            sql.as_str(),
+                        )?;
+                        let Some(ast::Cmd::Stmt(stmt)) = cmd else {
                             return Err(LimboError::InternalError(
                                 "Unexpected command during ALTER TABLE RENAME processing"
                                     .to_string(),
@@ -9327,24 +9350,32 @@ pub fn op_function(
                                             options,
                                         },
                                     };
-                                    Some(new_stmt.to_string())
+                                    Some(
+                                        program
+                                            .connection
+                                            .dialect()
+                                            .format_rewritten_table_sql(&new_stmt)?,
+                                    )
                                 } else {
                                     // Other tables: only emit if we actually changed their FK targets.
                                     if !any_change {
                                         break 'sql None;
                                     }
+                                    let new_stmt = ast::Stmt::CreateTable {
+                                        tbl_name,
+                                        temporary,
+                                        if_not_exists,
+                                        body: ast::CreateTableBody::ColumnsAndConstraints {
+                                            columns,
+                                            constraints,
+                                            options,
+                                        },
+                                    };
                                     Some(
-                                        ast::Stmt::CreateTable {
-                                            tbl_name,
-                                            temporary,
-                                            if_not_exists,
-                                            body: ast::CreateTableBody::ColumnsAndConstraints {
-                                                columns,
-                                                constraints,
-                                                options,
-                                            },
-                                        }
-                                        .to_string(),
+                                        program
+                                            .connection
+                                            .dialect()
+                                            .format_rewritten_table_sql(&new_stmt)?,
                                     )
                                 }
                             }
@@ -9470,10 +9501,13 @@ pub fn op_function(
                             break 'sql None;
                         };
 
-                        let mut parser = Parser::new(sql.as_str().as_bytes());
-                        let ast::Cmd::Stmt(stmt) =
-                            parser.next().expect("parser should have next item")?
-                        else {
+                        let cmd = parse_schema_sql_for_alter(
+                            program.connection.dialect().as_ref(),
+                            entry_type.as_str(),
+                            *root_page,
+                            sql.as_str(),
+                        )?;
+                        let Some(ast::Cmd::Stmt(stmt)) = cmd else {
                             return Err(LimboError::InternalError(
                                 "Unexpected command during ALTER TABLE RENAME COLUMN processing"
                                     .to_string(),
@@ -9695,18 +9729,21 @@ pub fn op_function(
                                         break 'sql None;
                                     }
                                 }
+                                let new_stmt = ast::Stmt::CreateTable {
+                                    tbl_name,
+                                    body: ast::CreateTableBody::ColumnsAndConstraints {
+                                        columns,
+                                        constraints,
+                                        options,
+                                    },
+                                    temporary,
+                                    if_not_exists,
+                                };
                                 Some(
-                                    ast::Stmt::CreateTable {
-                                        tbl_name,
-                                        body: ast::CreateTableBody::ColumnsAndConstraints {
-                                            columns,
-                                            constraints,
-                                            options,
-                                        },
-                                        temporary,
-                                        if_not_exists,
-                                    }
-                                    .to_string(),
+                                    program
+                                        .connection
+                                        .dialect()
+                                        .format_rewritten_table_sql(&new_stmt)?,
                                 )
                             }
                             // Trigger SQL is rewritten by separate UPDATE statements
@@ -16878,7 +16915,7 @@ fn op_vacuum_into_inner(
                     OpenFlags::Create,
                     output_opts,
                     None,
-                    Arc::new(SqliteDialect),
+                    source_db.dialect(),
                 )?;
                 let output_conn = output_db.connect()?;
                 output_conn.reset_page_size(page_size)?;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -56,6 +56,7 @@ use crate::vector::{
     vector1bit, vector32, vector32_sparse, vector64, vector8, vector_concat, vector_distance_cos,
     vector_distance_dot, vector_distance_jaccard, vector_distance_l2, vector_extract, vector_slice,
 };
+use crate::SqliteDialect;
 use crate::{
     connection::Row,
     get_cursor, info, is_attached_db,
@@ -12824,6 +12825,7 @@ fn op_parse_schema_step(
                     &mut inner.dbsp_state_index_roots,
                     &mut inner.materialized_view_info,
                     &attached_resolver,
+                    conn.dialect().as_ref(),
                 )?;
                 continue;
             }
@@ -16876,6 +16878,7 @@ fn op_vacuum_into_inner(
                     OpenFlags::Create,
                     output_opts,
                     None,
+                    Arc::new(SqliteDialect),
                 )?;
                 let output_conn = output_db.connect()?;
                 output_conn.reset_page_size(page_size)?;
@@ -17075,6 +17078,7 @@ mod tests {
     use crate::alloc::vec;
     use crate::translate::collate::CollationSeq;
     use crate::vdbe::BranchOffset;
+    use crate::SqliteDialect;
     use crate::{Database, DatabaseOpts, MemoryIO, IO};
 
     fn prepare_test_statement() -> Statement {
@@ -17085,6 +17089,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();
@@ -17145,6 +17150,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();
@@ -17209,6 +17215,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new().with_attach(true),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();
@@ -17270,6 +17277,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new().with_vacuum(true),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();
@@ -17314,6 +17322,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new().with_vacuum(true),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();
@@ -17865,6 +17874,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let conn = db.connect().unwrap();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -9157,6 +9157,18 @@ pub fn op_function(
                 ),
             },
         },
+        crate::function::Func::Dialect(name) => {
+            let args: Vec<Value> = state.registers[*start_reg..*start_reg + arg_count]
+                .iter()
+                .map(|r| r.get_value().clone())
+                .collect();
+            let result = program.connection.dialect().exec_scalar_function(
+                &program.connection,
+                name,
+                &args,
+            )?;
+            state.registers[*dest].set_value(result);
+        }
         crate::function::Func::AlterTable(alter_func) => {
             let r#type = &state.registers[*start_reg].get_value().clone();
             let Value::Text(entry_type) = r#type else {

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -1,3 +1,4 @@
+use crate::SqliteDialect;
 use std::collections::HashSet;
 
 use crate::io::{MemoryIO, PlatformIO, IO};
@@ -50,7 +51,15 @@ fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
 
 fn open_mvcc_database_with_opts(path: &str, opts: DatabaseOpts) -> Arc<Database> {
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file_with_flags(io, path, OpenFlags::default(), opts, None).unwrap();
+    let db = Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        opts,
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
     let conn = db.connect().unwrap();
     conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
     conn.close().unwrap();
@@ -70,7 +79,7 @@ struct SameConnectionWal {
 impl SameConnectionWal {
     fn new(path: &str) -> Self {
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, path).unwrap();
+        let db = Database::open_file(io, path, Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         let observer = db.connect().unwrap();
         Self { conn, observer }
@@ -86,7 +95,7 @@ impl SameConnectionWal {
 impl SameConnectionMvcc {
     fn new(path: &str) -> Self {
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, path).unwrap();
+        let db = Database::open_file(io, path, Arc::new(SqliteDialect)).unwrap();
         let conn = db.connect().unwrap();
         conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
         let observer = db.connect().unwrap();
@@ -285,7 +294,7 @@ fn prepare_wal_update_yielding_on_table_read(
 fn test_returning_owner_drop_does_not_commit_interrupted_drop_table() {
     let io = Arc::new(MemoryIO::new());
     let path = ":memory:returning-owner-interrupted-drop-table";
-    let db = Database::open_file(io.clone(), path).unwrap();
+    let db = Database::open_file(io.clone(), path, Arc::new(SqliteDialect)).unwrap();
     let conn = db.connect().unwrap();
 
     conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
@@ -340,7 +349,7 @@ fn test_returning_owner_drop_does_not_commit_interrupted_drop_table() {
     drop(conn);
     drop(db);
 
-    let db = Database::open_file(io, path).expect(
+    let db = Database::open_file(io, path, Arc::new(SqliteDialect)).expect(
         "reopen should not fail; dropping a RETURNING owner must not commit another statement's interrupted DROP",
     );
     let conn = db.connect().unwrap();

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1,4 +1,3 @@
-use crate::SqliteDialect;
 use rustc_hash::FxHashMap;
 use std::sync::{atomic::Ordering, Arc};
 
@@ -299,7 +298,7 @@ pub(crate) fn open_vacuum_temp_db(
         OpenFlags::Create,
         vacuum_target_opts_from_source(source_db),
         encryption_opts,
-        Arc::new(SqliteDialect),
+        source_db.dialect(),
     )?;
     let conn = db.connect_with_encryption(encryption_key)?;
     conn.reset_page_size(page_size)?;
@@ -671,7 +670,7 @@ pub(crate) fn vacuum_target_build_step(
 
                 let entry_ordinal = state.tables_to_create[idx];
                 let entry = &state.schema_entries[entry_ordinal];
-                let sql_str = &entry.sql;
+                let sql = table_sql_for_vacuum_replay(&state.target_conn, &entry.sql)?;
 
                 // System tables (sqlite_stat1, __turso_internal_types, etc.) have
                 // reserved name prefixes that translate_create_table rejects for
@@ -684,7 +683,7 @@ pub(crate) fn vacuum_target_build_step(
                 if is_system {
                     state.target_conn.start_nested();
                 }
-                let target_stmt = state.target_conn.prepare(sql_str);
+                let target_stmt = state.target_conn.prepare(&sql);
                 if is_system {
                     state.target_conn.end_nested();
                 }
@@ -1002,6 +1001,10 @@ pub(crate) fn vacuum_target_build_step(
             }
         }
     }
+}
+
+fn table_sql_for_vacuum_replay(target_conn: &Arc<Connection>, sql: &str) -> Result<String> {
+    target_conn.dialect().table_sql_for_replay(sql)
 }
 
 // Build the SELECT and INSERT SQL strings for copying a table's data.

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1,3 +1,4 @@
+use crate::SqliteDialect;
 use rustc_hash::FxHashMap;
 use std::sync::{atomic::Ordering, Arc};
 
@@ -298,6 +299,7 @@ pub(crate) fn open_vacuum_temp_db(
         OpenFlags::Create,
         vacuum_target_opts_from_source(source_db),
         encryption_opts,
+        Arc::new(SqliteDialect),
     )?;
     let conn = db.connect_with_encryption(encryption_key)?;
     conn.reset_page_size(page_size)?;
@@ -2381,6 +2383,7 @@ mod tests {
     use crate::storage::pager::Page;
     use crate::util::IOExt;
     use crate::vdbe::execute::TransactionYieldPoint;
+    use crate::SqliteDialect;
     use crate::{
         Buffer, Clock, Completion, DatabaseOpts, File, MemoryIO, MonotonicInstant, OpenFlags,
         WallClockInstant, IO,
@@ -2697,7 +2700,7 @@ mod tests {
     #[test]
     fn replace_shared_schema_after_vacuum_replaces_wrapped_schema_cookie() -> Result<()> {
         let io: Arc<dyn crate::IO> = Arc::new(crate::MemoryIO::new());
-        let db = Database::open_file(io, ":memory:")?;
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect))?;
 
         db.with_schema_mut(|schema| {
             schema.schema_version = u32::MAX;
@@ -2721,7 +2724,7 @@ mod tests {
     #[test]
     fn install_committed_vacuum_image_updates_connection_and_shared_schema() -> Result<()> {
         let io: Arc<dyn crate::IO> = Arc::new(crate::MemoryIO::new());
-        let db = Database::open_file(io, ":memory:")?;
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect))?;
         let conn = db.connect()?;
 
         conn.with_schema_mut(|schema| {
@@ -2757,7 +2760,7 @@ mod tests {
     #[test]
     fn cleanup_after_published_vacuum_installs_committed_image() -> Result<()> {
         let io: Arc<dyn crate::IO> = Arc::new(crate::MemoryIO::new());
-        let db = Database::open_file(io, ":memory:")?;
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect))?;
         let conn = db.connect()?;
 
         conn.with_schema_mut(|schema| {
@@ -2810,6 +2813,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )?;
         let source_conn = source_db.connect()?;
         // Source is uninitialized so its header reserved_space isn't usable.
@@ -2880,6 +2884,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )?;
         let conn = db.connect()?;
         conn.set_sync_mode(crate::SyncMode::Off);
@@ -2923,6 +2928,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new().with_vacuum(true),
             None,
+            Arc::new(SqliteDialect),
         )?;
         let source_conn = source_db.connect()?;
         source_conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")?;
@@ -2944,6 +2950,7 @@ mod tests {
             OpenFlags::Create,
             vacuum_target_opts_from_source(&source_db),
             None,
+            Arc::new(SqliteDialect),
         )?;
         let target_conn = target_db.connect()?;
         mirror_symbols(&source_conn, &target_conn);
@@ -3006,6 +3013,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new().with_vacuum(true),
             None,
+            Arc::new(SqliteDialect),
         )?;
         let conn = db.connect()?;
         conn.set_sync_mode(crate::SyncMode::Off);
@@ -3047,6 +3055,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new().with_vacuum(true),
             None,
+            Arc::new(SqliteDialect),
         )?;
         let conn = db.connect()?;
         conn.set_sync_mode(crate::SyncMode::Off);
@@ -3087,6 +3096,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )?;
         let source_conn = source_db.connect()?;
         let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
@@ -3140,6 +3150,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )?;
         let source_conn = source_db.connect()?;
 
@@ -3175,6 +3186,7 @@ mod tests {
                 cipher: CipherMode::Aes256Gcm.to_string(),
                 hexkey: key_hex.to_string(),
             }),
+            Arc::new(SqliteDialect),
         )?;
         let source_conn = source_db.connect_with_encryption(Some(key))?;
         let reserved_space = source_conn
@@ -3207,6 +3219,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )?;
         let target_conn = target_db.connect()?;
         target_conn.execute("CREATE TABLE seed(x)")?;

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -601,6 +601,7 @@ pub trait InternalVirtualTableCursor: Send + Sync {
 #[cfg(all(test, feature = "fs"))]
 mod tests {
     use super::*;
+    use crate::SqliteDialect;
     use crate::{Database, DatabaseOpts, MemoryIO, OpenFlags};
 
     /// Minimal `InternalVirtualTable` that exposes a fixed two-row table. Used
@@ -692,6 +693,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let name = db
@@ -735,6 +737,7 @@ mod tests {
             OpenFlags::Create,
             DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let name = db

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -24,6 +24,8 @@ pub struct VirtualTable {
     pub(crate) vtab_type: VirtualTableType,
     // identifier to tie a cursor to a specific instantiated virtual table instance
     pub(crate) vtab_id: u64,
+    /// Whether `DROP TABLE` may remove this table from its schema.
+    pub(crate) is_droppable: bool,
     // Whether this virtual table is safe to use from within triggers and views.
     // Corresponds to SQLite's SQLITE_VTAB_INNOCUOUS flag.
     pub(crate) innocuous: bool,
@@ -51,15 +53,35 @@ impl VirtualTable {
     {
         let name = table.name();
         let sql = table.sql();
-        let columns = Self::resolve_columns(sql)?;
-        Ok(Arc::new(VirtualTable {
+        Ok(Arc::new(Self::new_internal(
             name,
-            columns,
-            kind: VTabKind::TableValuedFunction,
-            vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(table))),
+            sql,
+            VTabKind::TableValuedFunction,
+            Arc::new(RwLock::new(table)),
+        )?))
+    }
+
+    /// Build a virtual table around an [`InternalVirtualTable`]
+    /// implementation. `sql` must be a `CREATE TABLE` statement; it is
+    /// parsed to derive the column metadata. Schema dialects use this to
+    /// construct catalog tables (e.g. a `pg_catalog` surface) with a
+    /// non-table-valued-function kind and install them through
+    /// [`crate::dialect::Dialect::register_catalog`].
+    pub fn new_internal(
+        name: String,
+        sql: String,
+        kind: VTabKind,
+        table: Arc<RwLock<dyn InternalVirtualTable>>,
+    ) -> crate::Result<Self> {
+        Ok(VirtualTable {
+            name,
+            columns: Self::resolve_columns(sql)?,
+            kind,
+            vtab_type: VirtualTableType::Internal(table),
             vtab_id: 0,
+            is_droppable: false,
             innocuous: true,
-        }))
+        })
     }
 
     pub(crate) fn function(name: &str, syms: &SymbolTable) -> crate::Result<Arc<VirtualTable>> {
@@ -79,6 +101,7 @@ impl VirtualTable {
             kind: VTabKind::TableValuedFunction,
             vtab_type,
             vtab_id: 0,
+            is_droppable: false,
             innocuous: false,
         };
         Ok(Arc::new(vtab))
@@ -99,6 +122,7 @@ impl VirtualTable {
             kind: VTabKind::VirtualTable,
             vtab_type: VirtualTableType::External(table),
             vtab_id: VTAB_ID_COUNTER.fetch_add(1, Ordering::Acquire),
+            is_droppable: true,
             innocuous: false,
         };
         Ok(Arc::new(vtab))

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -10,6 +10,7 @@ use std::{
     task::Waker,
     time::Duration,
 };
+use turso_core::SqliteDialect;
 
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
@@ -801,6 +802,7 @@ impl TursoDatabase {
                         opts,
                         self.config.encryption.clone(),
                         None,
+                        Arc::new(SqliteDialect),
                     )? {
                         IOResult::Done(db) => {
                             let mut inner_db = self.db.lock().unwrap();

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -5,6 +5,7 @@ use std::{
         Arc, Mutex,
     },
 };
+use turso_core::SqliteDialect;
 
 use turso_core::{Buffer, Completion, DatabaseStorage, LimboError, OpenDbAsyncState, OpenFlags};
 
@@ -138,6 +139,7 @@ mod tests {
         time::Duration,
     };
     use tempfile::NamedTempFile;
+    use turso_core::SqliteDialect;
 
     #[test]
     fn logical_mvcc_pull_disabled_by_config_falls_back_to_page_pull() {
@@ -818,7 +820,9 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let main_path = temp_file.path().to_str().unwrap().to_string();
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let main_db = turso_core::Database::open_file(io.clone(), &main_path).unwrap();
+        let main_db =
+            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
+                .unwrap();
 
         let meta = DatabaseMetadata {
             version: DATABASE_METADATA_VERSION.to_string(),
@@ -941,8 +945,12 @@ mod tests {
         ];
         std::fs::write(changes_temp.path(), encoded_logical_txns(&txns)).unwrap();
 
-        let db =
-            turso_core::Database::open_file(io.clone(), db_temp.path().to_str().unwrap()).unwrap();
+        let db = turso_core::Database::open_file(
+            io.clone(),
+            db_temp.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let db_file = db.db_file.clone();
         let db_io = db.io.clone();
         let main_tape = DatabaseTape::new_with_opts(
@@ -1112,8 +1120,12 @@ mod tests {
         }];
         std::fs::write(changes_temp.path(), encoded_logical_txns(&txns)).unwrap();
 
-        let db =
-            turso_core::Database::open_file(io.clone(), db_temp.path().to_str().unwrap()).unwrap();
+        let db = turso_core::Database::open_file(
+            io.clone(),
+            db_temp.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let db_file = db.db_file.clone();
         let db_io = db.io.clone();
         let main_tape = DatabaseTape::new_with_opts(
@@ -1275,7 +1287,9 @@ mod tests {
         let changes_path = changes_file.path().to_str().unwrap().to_string();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let remote_db = turso_core::Database::open_file(io.clone(), &remote_path).unwrap();
+        let remote_db =
+            turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
+                .unwrap();
         let remote_conn = remote_db.connect().unwrap();
         remote_conn
             .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")
@@ -1388,10 +1402,14 @@ mod tests {
 
                 drop(conn);
                 drop(engine);
-                let verify_db =
-                    turso_core::Database::open_file(io.clone(), &main_path).map_err(|error| {
-                        Error::DatabaseSyncEngineError(format!("test verify open failed: {error}"))
-                    })?;
+                let verify_db = turso_core::Database::open_file(
+                    io.clone(),
+                    &main_path,
+                    Arc::new(SqliteDialect),
+                )
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test verify open failed: {error}"))
+                })?;
                 let verify_conn = verify_db.connect().map_err(|error| {
                     Error::DatabaseSyncEngineError(format!("test verify connect failed: {error}"))
                 })?;
@@ -2602,6 +2620,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 opts.db_opts,
                 None,
                 None,
+                Arc::new(SqliteDialect),
             )? {
                 turso_core::IOResult::Done(db) => break db,
                 turso_core::IOResult::IO(io_completion) => {
@@ -2632,6 +2651,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     self.opts.db_opts,
                     None,
                     None,
+                    Arc::new(SqliteDialect),
                 )? {
                     turso_core::IOResult::Done(db) => break db,
                     turso_core::IOResult::IO(io_completion) => {

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -3785,6 +3785,7 @@ mod tests {
         collections::BTreeMap,
         sync::{Arc, Mutex},
     };
+    use turso_core::SqliteDialect;
 
     use bytes::{Bytes, BytesMut};
     use prost::Message;
@@ -4157,8 +4158,12 @@ mod tests {
     fn max_local_change_id_reads_cdc_high_water_mark() {
         let temp_file = NamedTempFile::new().unwrap();
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db = turso_core::Database::open_file(io.clone(), temp_file.path().to_str().unwrap())
-            .unwrap();
+        let db = turso_core::Database::open_file(
+            io.clone(),
+            temp_file.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let db = Arc::new(DatabaseTape::new(db));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -5078,8 +5083,12 @@ mod tests {
         ];
         std::fs::write(txns_temp.path(), encoded_logical_txns(&txns)).unwrap();
 
-        let db =
-            turso_core::Database::open_file(io.clone(), db_temp.path().to_str().unwrap()).unwrap();
+        let db = turso_core::Database::open_file(
+            io.clone(),
+            db_temp.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let db = Arc::new(DatabaseTape::new(db));
         let txns_file = io
             .open_file(

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -871,6 +871,7 @@ fn quote_ident(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use turso_core::SqliteDialect;
 
     use tempfile::NamedTempFile;
 
@@ -890,7 +891,8 @@ mod tests {
         let db_path1 = temp_file1.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
         let mut gen = genawaiter::sync::Gen::new({
             let db1 = db1.clone();
@@ -920,7 +922,8 @@ mod tests {
         let db_path = temp_file.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db =
+            turso_core::Database::open_file(io.clone(), db_path, Arc::new(SqliteDialect)).unwrap();
         let db = Arc::new(DatabaseTape::new(db));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -972,7 +975,8 @@ mod tests {
         let db_path = temp_file.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db =
+            turso_core::Database::open_file(io.clone(), db_path, Arc::new(SqliteDialect)).unwrap();
         let db = Arc::new(DatabaseTape::new(db));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1025,7 +1029,8 @@ mod tests {
         let db_path = temp_file.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db =
+            turso_core::Database::open_file(io.clone(), db_path, Arc::new(SqliteDialect)).unwrap();
         let db = Arc::new(DatabaseTape::new(db));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1094,7 +1099,8 @@ mod tests {
         let db_path = temp_file.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db =
+            turso_core::Database::open_file(io.clone(), db_path, Arc::new(SqliteDialect)).unwrap();
         let db = Arc::new(DatabaseTape::new(db));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1175,7 +1181,8 @@ mod tests {
         let db_path1 = temp_file1.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1243,7 +1250,8 @@ mod tests {
         let db_path1 = temp_file1.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         db1.connect()
             .unwrap()
             .execute("PRAGMA journal_mode = 'mvcc'")
@@ -1330,7 +1338,8 @@ mod tests {
         let db_path1 = temp_file1.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         db1.connect()
             .unwrap()
             .execute("PRAGMA journal_mode = 'mvcc'")
@@ -1416,10 +1425,12 @@ mod tests {
         let db_path2 = temp_file2.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1495,10 +1506,12 @@ mod tests {
         let db_path2 = temp_file2.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1574,10 +1587,12 @@ mod tests {
         let db_path2 = temp_file2.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1639,13 +1654,16 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
-        let db3 = turso_core::Database::open_file(io.clone(), db_path3).unwrap();
+        let db3 =
+            turso_core::Database::open_file(io.clone(), db_path3, Arc::new(SqliteDialect)).unwrap();
         let db3 = Arc::new(DatabaseTape::new(db3));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1787,10 +1805,12 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1868,7 +1888,8 @@ mod tests {
         let db_path = temp_file.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db = turso_core::Database::open_file(io.clone(), db_path).unwrap();
+        let db =
+            turso_core::Database::open_file(io.clone(), db_path, Arc::new(SqliteDialect)).unwrap();
         let db = Arc::new(DatabaseTape::new(db));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1947,10 +1968,12 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2023,13 +2046,16 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
-        let db3 = turso_core::Database::open_file(io.clone(), db_path3).unwrap();
+        let db3 =
+            turso_core::Database::open_file(io.clone(), db_path3, Arc::new(SqliteDialect)).unwrap();
         let db3 = Arc::new(DatabaseTape::new(db3));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2118,13 +2144,16 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
-        let db3 = turso_core::Database::open_file(io.clone(), db_path3).unwrap();
+        let db3 =
+            turso_core::Database::open_file(io.clone(), db_path3, Arc::new(SqliteDialect)).unwrap();
         let db3 = Arc::new(DatabaseTape::new(db3));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2214,10 +2243,12 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2321,10 +2352,12 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2413,10 +2446,12 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2501,10 +2536,12 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2601,10 +2638,12 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2691,10 +2730,12 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2784,10 +2825,12 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -2881,13 +2924,16 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
+        let db1 =
+            turso_core::Database::open_file(io.clone(), db_path1, Arc::new(SqliteDialect)).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
+        let db2 =
+            turso_core::Database::open_file(io.clone(), db_path2, Arc::new(SqliteDialect)).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
-        let db3 = turso_core::Database::open_file(io.clone(), db_path3).unwrap();
+        let db3 =
+            turso_core::Database::open_file(io.clone(), db_path3, Arc::new(SqliteDialect)).unwrap();
         let db3 = Arc::new(DatabaseTape::new(db3));
 
         let mut gen = genawaiter::sync::Gen::new({

--- a/sync/engine/src/io_operations.rs
+++ b/sync/engine/src/io_operations.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 use turso_core::{Completion, LimboError, OpenFlags};
 
@@ -23,7 +24,7 @@ pub trait IoOperations {
 impl IoOperations for Arc<dyn turso_core::IO> {
     fn open_tape(&self, path: &str, capture: bool) -> Result<DatabaseTape> {
         let io = self.clone();
-        let clean = turso_core::Database::open_file(io, path).unwrap();
+        let clean = turso_core::Database::open_file(io, path, Arc::new(SqliteDialect)).unwrap();
         let opts = DatabaseTapeOpts {
             cdc_table: None,
             cdc_mode: Some(if capture { "full" } else { "off" }.to_string()),

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -16,6 +16,7 @@ use std::fmt::Write;
 use std::ops::Bound;
 use std::sync::Arc;
 use tracing::{debug, error, trace};
+use turso_core::SqliteDialect;
 #[cfg(target_os = "windows")]
 use turso_core::WindowsIOCP;
 use turso_core::schema::SEQ_BACKING_TABLE_PREFIX;
@@ -711,6 +712,7 @@ impl Whopper {
                 OpenFlags::default(),
                 db_opts,
                 encryption_opts.clone(),
+                Arc::new(SqliteDialect),
             ) {
                 Ok(db) => db,
                 Err(e) => {
@@ -1527,6 +1529,7 @@ impl Whopper {
             OpenFlags::default(),
             db_opts,
             self.encryption_opts.clone(),
+            Arc::new(SqliteDialect),
         )
         .map_err(|e| anyhow::anyhow!("Database open failed: {}", e))?;
 

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -12,9 +12,11 @@ use std::fs::{File, create_dir_all};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use turso_core::SqliteDialect;
 
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -271,6 +273,7 @@ impl MultiprocessWhopper {
                 OpenFlags::default(),
                 DatabaseOpts::new().with_multiprocess_wal(true),
                 None,
+                Arc::new(SqliteDialect),
             )?;
             let conn = db.connect()?;
 

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 use std::sync::Arc;
-use turso_core::{Connection, Database, DatabaseOpts, IO, LimboError, OpenFlags};
+use turso_core::{Connection, Database, DatabaseOpts, IO, LimboError, OpenFlags, SqliteDialect};
 use turso_whopper::multiprocess::{MultiprocessOpts, MultiprocessWhopper};
 use turso_whopper::multiprocess_platform_io;
 
@@ -234,6 +234,7 @@ fn read_simple_kv_length(db_path: &Path, table_name: &str, key: &str) -> Option<
         OpenFlags::ReadOnly,
         multiprocess_wal_db_opts(),
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("open observer database");
     let conn = reopened.connect().expect("connect observer db");
@@ -547,8 +548,12 @@ fn multiprocess_finalize_after_restart_preserves_simple_kv_rows() {
     whopper.finalize().expect("finalize multiprocess whopper");
 
     let io: Arc<dyn IO> = multiprocess_test_io();
-    let reopened = Database::open_file(io, db_path.to_str().expect("db path utf8"))
-        .expect("reopen finalized database");
+    let reopened = Database::open_file(
+        io,
+        db_path.to_str().expect("db path utf8"),
+        Arc::new(SqliteDialect),
+    )
+    .expect("reopen finalized database");
     let conn = reopened.connect().expect("connect reopened db");
     assert_eq!(
         count_rows_in_table(&conn, table_name),

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -1,7 +1,7 @@
 use rand_chacha::ChaCha8Rng;
 use rand_chacha::rand_core::SeedableRng;
 use std::sync::Arc;
-use turso_core::{Database, DatabaseOpts, IO, OpenFlags, Statement};
+use turso_core::{Database, DatabaseOpts, IO, OpenFlags, SqliteDialect, Statement};
 use turso_whopper::{IOFaultConfig, SimulatorIO};
 
 fn run_to_done(stmt: &mut Statement, io: &SimulatorIO) {
@@ -38,6 +38,7 @@ fn test_concurrent_commit_no_yield_spin() {
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("open db");
 

--- a/testing/concurrent-simulator/worker.rs
+++ b/testing/concurrent-simulator/worker.rs
@@ -8,6 +8,7 @@
 use std::io::{BufRead, BufReader, Write};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use turso_core::SqliteDialect;
 
 use turso_core::{
     CheckpointMode, Connection, Database, DatabaseOpts, LimboError, OpenFlags,
@@ -58,7 +59,8 @@ pub fn run_worker(
         db_path,
         OpenFlags::default(),
         db_opts,
-        None, // encryption_opts
+        None,
+        Arc::new(SqliteDialect),
     )?;
 
     if connections_per_process == 0 {

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -844,7 +844,7 @@ mod tests {
         generation::Opts,
         model::table::{Column, ColumnType, Table},
     };
-    use turso_core::{Database, MemoryIO};
+    use turso_core::{Database, MemoryIO, SqliteDialect};
 
     use super::*;
 
@@ -933,7 +933,7 @@ mod tests {
     #[test]
     fn json_workload_variants_execute() {
         let io = Arc::new(MemoryIO::new());
-        let database = Database::open_file(io, ":memory:").unwrap();
+        let database = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
         let connection = database.connect().unwrap();
         let document =
             r#"{"id":1,"meta":{"active":true},"items":[1,2,{"value":3}],"nullable":null}"#;

--- a/testing/differential-oracle/fuzzer/custom_types_fuzzer.rs
+++ b/testing/differential-oracle/fuzzer/custom_types_fuzzer.rs
@@ -23,7 +23,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
 use differential_fuzzer::memory::MemorySimIO;
-use turso_core::Database;
+use turso_core::{Database, SqliteDialect};
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -4020,6 +4020,7 @@ fn main() -> Result<()> {
         turso_core::OpenFlags::default(),
         turso_core::DatabaseOpts::default().with_custom_types(true),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let conn = turso_db.connect()?;
 

--- a/testing/differential-oracle/fuzzer/oracle.rs
+++ b/testing/differential-oracle/fuzzer/oracle.rs
@@ -393,6 +393,7 @@ pub fn check_differential(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use turso_core::SqliteDialect;
 
     use core::f64;
 
@@ -466,6 +467,7 @@ mod tests {
             turso_core::OpenFlags::default(),
             turso_core::DatabaseOpts::new(),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
         let turso_conn = turso_db.connect().unwrap();

--- a/testing/differential-oracle/fuzzer/printf_fuzzer.rs
+++ b/testing/differential-oracle/fuzzer/printf_fuzzer.rs
@@ -16,7 +16,7 @@ use rand::RngCore;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use sql_gen_prop::SqlValue;
-use turso_core::Database;
+use turso_core::{Database, SqliteDialect};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -275,8 +275,11 @@ impl FuzzerState {
         }
 
         let io = Arc::new(MemorySimIO::new(seed));
-        let turso_db =
-            Database::open_file(io.clone(), out_dir.join("printf-test.db").to_str().unwrap())?;
+        let turso_db = Database::open_file(
+            io.clone(),
+            out_dir.join("printf-test.db").to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )?;
         let turso_conn = turso_db.connect()?;
 
         let sqlite_conn =

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -13,6 +13,7 @@ use std::io::Write;
 use std::panic::RefUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 use anyhow::{Context, Result, bail};
 use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table};
@@ -204,6 +205,7 @@ impl Fuzzer {
             turso_core::OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         )?;
         let turso_conn = turso_db.connect()?;
 

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -7,6 +7,7 @@ use std::{
     rc::Rc,
     sync::Arc,
 };
+use turso_core::SqliteDialect;
 
 use indexmap::IndexSet;
 use itertools::Itertools;
@@ -930,6 +931,7 @@ fn reopen_database(env: &mut SimulatorEnv) {
                     .with_attach(true)
                     .with_generated_columns(true),
                 None,
+                Arc::new(SqliteDialect),
             ) {
                 Ok(db) => db,
                 Err(e) => {

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -5,6 +5,7 @@ use std::ops::{Deref, DerefMut};
 use std::panic::UnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 use bitmaps::Bitmap;
 use garde::Validate;
@@ -40,6 +41,7 @@ fn enable_mvcc_on_attached_dbs(io: &Arc<dyn SimIO>, aux_paths: impl Iterator<Ite
                 .with_attach(true)
                 .with_generated_columns(true),
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap_or_else(|e| panic!("Failed to open aux DB {aux_path:?}: {e}"));
         let aux_conn = aux_db
@@ -1172,6 +1174,7 @@ impl SimulatorEnv {
                 .with_attach(true)
                 .with_generated_columns(true),
             None,
+            Arc::new(SqliteDialect),
         ) {
             Ok(db) => db,
             Err(e) => {
@@ -1393,6 +1396,7 @@ impl SimulatorEnv {
                 .with_attach(true)
                 .with_generated_columns(true),
             None,
+            Arc::new(SqliteDialect),
         ) {
             Ok(db) => db,
             Err(e) => {

--- a/testing/simulator/runner/memory/mvcc_recovery.rs
+++ b/testing/simulator/runner/memory/mvcc_recovery.rs
@@ -1,5 +1,6 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 use anyhow::Result;
 use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
@@ -18,6 +19,7 @@ fn open_conn(io: Arc<MemorySimIO>, path: &str) -> Result<Arc<Connection>> {
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let conn = db.connect()?;
     Ok(conn)
@@ -30,6 +32,7 @@ fn open_two_conns(io: Arc<MemorySimIO>, path: &str) -> Result<(Arc<Connection>, 
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let conn1 = db.connect()?;
     let conn2 = db.connect()?;

--- a/testing/simulator/runner/memory/statement_abandon.rs
+++ b/testing/simulator/runner/memory/statement_abandon.rs
@@ -1,5 +1,6 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 use anyhow::Result;
 use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
@@ -35,6 +36,7 @@ fn open_conn(io: Arc<MemorySimIO>, path: &str) -> Result<Arc<Connection>> {
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let conn = db.connect()?;
     Ok(conn)
@@ -47,6 +49,7 @@ fn open_two_conns(io: Arc<MemorySimIO>, path: &str) -> Result<(Arc<Connection>, 
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let conn1 = db.connect()?;
     let conn2 = db.connect()?;

--- a/tests/integration/abandoned_create_index.rs
+++ b/tests/integration/abandoned_create_index.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use turso_core::{Database, MemoryYieldIO, StepResult, IO};
+use turso_core::{Database, MemoryYieldIO, SqliteDialect, StepResult, IO};
 
 fn exec_sql(conn: &Arc<turso_core::Connection>, io: &dyn IO, sql: &str) -> turso_core::Result<()> {
     let mut stmt = conn.prepare(sql)?;
@@ -48,7 +48,12 @@ fn drop_statement_at_io(
 #[test]
 fn test_abandoned_create_index_does_not_poison_later_allocation() {
     let io = Arc::new(MemoryYieldIO::new());
-    let db = Database::open_file(io.clone(), "repro_public_freelist_leaf_exact.db").unwrap();
+    let db = Database::open_file(
+        io.clone(),
+        "repro_public_freelist_leaf_exact.db",
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
     let setup_conn = db.connect().unwrap();
 
     exec_sql(&setup_conn, io.as_ref(), "PRAGMA page_size = 512").unwrap();

--- a/tests/integration/abandoned_statement_pager.rs
+++ b/tests/integration/abandoned_statement_pager.rs
@@ -14,10 +14,13 @@
 
 use std::sync::Arc;
 
-use turso_core::{Connection, Database, LimboError, MemoryYieldIO, StepResult, IO};
+use turso_core::{Connection, Database, LimboError, MemoryYieldIO, SqliteDialect, StepResult, IO};
 
 fn open_conn(io: Arc<MemoryYieldIO>, path: &str) -> Arc<Connection> {
-    Database::open_file(io, path).unwrap().connect().unwrap()
+    Database::open_file(io, path, Arc::new(SqliteDialect))
+        .unwrap()
+        .connect()
+        .unwrap()
 }
 
 fn integrity_check(conn: &Arc<Connection>) -> Vec<String> {

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -6,6 +6,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
+use turso_core::SqliteDialect;
 use turso_core::{Database, DatabaseOpts, OpenFlags};
 
 const PAGE_SIZE_OFFSET: u64 = 16;
@@ -163,6 +164,7 @@ fn test_fresh_attach_inherits_mvcc_before_first_write(_tmp_db: TempDatabase) -> 
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let aux_conn = aux_db.connect()?;
     assert!(aux_conn.mvcc_enabled());
@@ -184,6 +186,7 @@ fn test_attach_rejects_initialized_page_size_mismatch(_tmp_db: TempDatabase) -> 
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let aux_conn = aux_db.connect()?;
     aux_conn.execute("CREATE TABLE t(x INTEGER)")?;
@@ -289,6 +292,7 @@ fn test_fresh_mvcc_attach_rejects_custom_durable_storage_without_attached_backen
         DatabaseOpts::new().with_attach(true),
         None,
         Some(durable_storage),
+        Arc::new(SqliteDialect),
     )?;
     let conn = db.connect()?;
     conn.pragma_update("journal_mode", "'mvcc'")?;

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tempfile::TempDir;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use turso_core::{Clock, Connection, Database, FromValueRow, Row, IO};
+use turso_core::{Clock, Connection, Database, FromValueRow, Row, SqliteDialect, IO};
 
 pub struct TempDatabase {
     pub path: PathBuf,
@@ -220,6 +220,7 @@ impl TempDatabaseBuilder {
             flags,
             opts,
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
 
@@ -297,7 +298,12 @@ impl TempDatabase {
 
     pub fn limbo_database(&self) -> Arc<turso_core::Database> {
         log::debug!("conneting to limbo");
-        Database::open_file(self.io.clone(), self.path.to_str().unwrap()).unwrap()
+        Database::open_file(
+            self.io.clone(),
+            self.path.to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap()
     }
 
     #[allow(dead_code)]
@@ -672,6 +678,7 @@ impl_exec_rows_for_tuple!(T0: 0, T1: 1, T2: 2, T3: 3, T4: 4, T5: 5, T6: 6, T7: 7
 mod tests {
     use std::{sync::Arc, vec};
     use tempfile::{NamedTempFile, TempDir};
+    use turso_core::SqliteDialect;
     use turso_core::{Database, StepResult, IO};
 
     use crate::common::{do_flush, ExecRows};
@@ -948,7 +955,7 @@ mod tests {
         // Open database
         #[allow(clippy::arc_with_non_send_sync)]
         let io: Arc<dyn IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db = Database::open_file(io, &db_path)?;
+        let db = Database::open_file(io, &db_path, Arc::new(SqliteDialect))?;
 
         const NUM_CONNECTIONS: usize = 5;
         let mut connections = Vec::new();

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 use turso_core::{Database, OpenFlags};
 use turso_sdk_kit::rsapi::{TursoDatabase, TursoDatabaseConfig, TursoStatusCode};
 
@@ -26,6 +27,7 @@ fn test_database_rename_registry_stale() {
         OpenFlags::Create,
         turso_core::DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
 
@@ -57,6 +59,7 @@ fn test_database_rename_registry_stale() {
         OpenFlags::Create,
         turso_core::DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
 
@@ -148,6 +151,7 @@ fn test_sdk_close_finalizes_leaked_statements() {
         OpenFlags::Create,
         turso_core::DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
 

--- a/tests/integration/expr_depth_stack_overflow.rs
+++ b/tests/integration/expr_depth_stack_overflow.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 use turso_core::{Database, MemoryIO, IO};
 use turso_parser::MAX_EXPR_DEPTH;
@@ -105,7 +106,7 @@ fn run_on_big_stack(sql: String) -> turso_core::Result<()> {
         .stack_size(WORKER_STACK)
         .spawn(move || -> turso_core::Result<()> {
             let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-            let db = Database::open_file(io, ":memory:")?;
+            let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect))?;
             let conn = db.connect()?;
             conn.execute(&sql)?;
             Ok(())

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -1,4 +1,5 @@
 use std::{collections::HashSet, path::PathBuf, sync::Arc};
+use turso_core::SqliteDialect;
 
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -872,6 +873,7 @@ fn test_db_share_same_file() {
         turso_core::DatabaseOpts::new(),
         None,
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
     let conn1 = db1.connect().unwrap();
@@ -899,6 +901,7 @@ fn test_db_share_same_file() {
         turso_core::OpenFlags::default(),
         turso_core::DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )
     .unwrap();
     let conn2 = db2.connect().unwrap();

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1,6 +1,7 @@
 use crate::common::{ExecRows, TempDatabase};
 use std::path::Path;
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 use turso_core::{Database, DatabaseOpts, EncryptionKey, EncryptionOpts, OpenFlags, StepResult};
 
 /// Create a new database file at `path` with MVCC journal mode enabled.
@@ -13,6 +14,7 @@ fn create_mvcc_db(io: &Arc<dyn turso_core::io::IO + Send>, path: &Path) -> anyho
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let conn = db.connect()?;
     conn.pragma_update("journal_mode", "'mvcc'")?;
@@ -189,6 +191,7 @@ fn test_mvcc_custom_durable_storage_injected(tmp_db: TempDatabase) -> anyhow::Re
         DatabaseOpts::new(),
         None,
         Some(recording.clone()),
+        Arc::new(SqliteDialect),
     )?;
     let conn = db.connect()?;
     conn.pragma_update("journal_mode", "'mvcc'")?;
@@ -452,6 +455,7 @@ fn test_attach_rejects_incompatible_journal_mode(tmp_db: TempDatabase) -> anyhow
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let aux_conn = aux_db.connect()?;
     aux_conn.execute("CREATE TABLE t(x INTEGER)")?;
@@ -935,6 +939,7 @@ fn test_attach_memory_db_allowed_on_encrypted_mvcc_main(
         OpenFlags::default(),
         opts,
         enc_opts,
+        Arc::new(SqliteDialect),
     )?;
     let key = EncryptionKey::from_hex_string(hex_key)?;
     let conn = db.connect_with_encryption(Some(key))?;
@@ -973,7 +978,7 @@ fn test_add_then_drop_table_in_same_tx_then_recover(db: TempDatabase) -> anyhow:
     }
     drop(db);
 
-    Database::open_file(io, path.to_str().unwrap())?;
+    Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect))?;
 
     Ok(())
 }
@@ -1020,7 +1025,7 @@ fn test_create_insert_drop_checkpoint_recover(db: TempDatabase) -> anyhow::Resul
     drop(db);
 
     // Reopen — triggers bootstrap / log replay
-    Database::open_file(io.clone(), path.to_str().unwrap())?;
+    Database::open_file(io.clone(), path.to_str().unwrap(), Arc::new(SqliteDialect))?;
 
     Ok(())
 }
@@ -1044,7 +1049,7 @@ fn test_recover_table_with_create_virtual_substring_in_sql(db: TempDatabase) -> 
     drop(db);
 
     // Reopen — triggers bootstrap / log replay; must not report corruption.
-    let db = Database::open_file(io, path.to_str().unwrap())?;
+    let db = Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect))?;
     let conn = db.connect()?;
     let rows: Vec<(String,)> = conn.exec_rows("select x from t");
     assert_eq!(rows, vec![("create virtual".to_string(),)]);
@@ -1073,7 +1078,7 @@ fn test_create_drop_index_same_tx_recover(db: TempDatabase) -> anyhow::Result<()
     }
     drop(db);
 
-    Database::open_file(io, path.to_str().unwrap())?;
+    Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect))?;
 
     Ok(())
 }
@@ -1101,14 +1106,14 @@ fn test_create_rename_insert_same_tx_recover_then_checkpoint(
     drop(db);
 
     {
-        let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+        let db = Database::open_file(io.clone(), path.to_str().unwrap(), Arc::new(SqliteDialect))?;
         let conn = db.connect()?;
         let rows: Vec<(i64, String)> = conn.exec_rows("select id, v from t2 order by id");
         assert_eq!(rows, vec![(1, "one".to_string()), (2, "two".to_string())]);
         conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
     }
 
-    let db = Database::open_file(io, path.to_str().unwrap())?;
+    let db = Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect))?;
     let conn = db.connect()?;
     let rows: Vec<(i64, String)> = conn.exec_rows("select id, v from t2 order by id");
     assert_eq!(rows, vec![(1, "one".to_string()), (2, "two".to_string())]);
@@ -1183,7 +1188,11 @@ fn test_mvcc_same_tx_row_and_index_lifecycle_matrix(db: TempDatabase) -> anyhow:
                 );
 
                 {
-                    let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+                    let db = Database::open_file(
+                        io.clone(),
+                        path.to_str().unwrap(),
+                        Arc::new(SqliteDialect),
+                    )?;
                     let conn = db.connect()?;
                     conn.pragma_update("journal_mode", "'mvcc'")?;
                     conn.execute(format!(
@@ -1197,7 +1206,11 @@ fn test_mvcc_same_tx_row_and_index_lifecycle_matrix(db: TempDatabase) -> anyhow:
                 }
 
                 {
-                    let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+                    let db = Database::open_file(
+                        io.clone(),
+                        path.to_str().unwrap(),
+                        Arc::new(SqliteDialect),
+                    )?;
                     let conn = db.connect()?;
                     conn.pragma_update("journal_mode", "'mvcc'")?;
 
@@ -1233,7 +1246,11 @@ fn test_mvcc_same_tx_row_and_index_lifecycle_matrix(db: TempDatabase) -> anyhow:
                 }
 
                 for checkpoint_after_recovery in [true, false] {
-                    let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+                    let db = Database::open_file(
+                        io.clone(),
+                        path.to_str().unwrap(),
+                        Arc::new(SqliteDialect),
+                    )?;
                     let conn = db.connect()?;
 
                     let rows_sql = format!("SELECT id, v FROM {table} ORDER BY id");
@@ -1310,7 +1327,7 @@ fn test_create_insert_drop_same_tx_recover(db: TempDatabase) -> anyhow::Result<(
     }
     drop(db);
 
-    Database::open_file(io, path.to_str().unwrap())?;
+    Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect))?;
 
     Ok(())
 }
@@ -1359,7 +1376,7 @@ fn test_multiple_create_drop_cycles_recover(db: TempDatabase) -> anyhow::Result<
     }
     drop(db);
 
-    Database::open_file(io, path.to_str().unwrap())?;
+    Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect))?;
 
     Ok(())
 }
@@ -1402,7 +1419,7 @@ fn test_mvcc_update_btree_only_row_after_truncate_checkpoint(
 
     // Phase 2: reopen and UPDATE the btree-only row. Pre-fix this raised
     // a corruption error from MvccLazyCursor::delete().
-    let db = Database::open_file(io, path.to_str().unwrap())?;
+    let db = Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect))?;
     let conn = db.connect()?;
     conn.pragma_update("journal_mode", "'mvcc'")?;
     conn.execute("UPDATE quint_corrupt SET value = zeroblob(32) WHERE key = 'k0'")?;

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -3,6 +3,7 @@ use crate::common::{
 };
 use rand::{rng, RngCore};
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 use turso_core::{
     CipherMode, Database, DatabaseOpts, EncryptionKey, EncryptionOpts, OpenFlags, PlatformIO, Row,
     IO,
@@ -60,6 +61,7 @@ fn run_non_4k_page_size_encryption_test(
         let (_io, conn) = turso_core::Connection::from_uri(
             &uri,
             DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
+            Arc::new(SqliteDialect),
         )?;
         run_query_on_row(tmp_db, &conn, "SELECT * FROM test", |row: &Row| {
             assert_eq!(row.get::<i64>(0).unwrap(), 1);
@@ -139,6 +141,7 @@ fn run_corruption_associated_data_bytes_test(
         let (_io, conn) = turso_core::Connection::from_uri(
             &uri,
             DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
+            Arc::new(SqliteDialect),
         )
         .expect("opening the corrupted DB should not fail at the URI level");
 
@@ -194,7 +197,7 @@ fn test_per_page_encryption(tmp_db: TempDatabase) -> anyhow::Result<()> {
             "file:{}?cipher=aegis256&hexkey=b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327",
             db_path.to_str().unwrap()
         );
-        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts)?;
+        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts, Arc::new(SqliteDialect))?;
         let mut row_count = 0;
         run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |row: &Row| {
             assert_eq!(row.get::<i64>(0).unwrap(), 1);
@@ -209,7 +212,7 @@ fn test_per_page_encryption(tmp_db: TempDatabase) -> anyhow::Result<()> {
             "file:{}?cipher=aegis256&hexkey=b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327",
             db_path.to_str().unwrap()
         );
-        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts)?;
+        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts, Arc::new(SqliteDialect))?;
         run_query(
             &tmp_db,
             &conn,
@@ -223,7 +226,7 @@ fn test_per_page_encryption(tmp_db: TempDatabase) -> anyhow::Result<()> {
             "file:{}?cipher=aegis256&hexkey=b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327",
             db_path.to_str().unwrap()
         );
-        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts)?;
+        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts, Arc::new(SqliteDialect))?;
         run_query(
             &tmp_db,
             &conn,
@@ -245,7 +248,7 @@ fn test_per_page_encryption(tmp_db: TempDatabase) -> anyhow::Result<()> {
             "file:{}?cipher=aegis256&hexkey=b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76377",
             db_path.to_str().unwrap()
         );
-        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts)?;
+        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts, Arc::new(SqliteDialect))?;
         let result = run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |_row: &Row| {});
         assert!(
             result.is_err(),
@@ -255,7 +258,7 @@ fn test_per_page_encryption(tmp_db: TempDatabase) -> anyhow::Result<()> {
     {
         // test connecting to encrypted db using insufficient encryption parameters in URI.
         let uri = format!("file:{}?cipher=aegis256", db_path.to_str().unwrap());
-        let result = turso_core::Connection::from_uri(&uri, opts);
+        let result = turso_core::Connection::from_uri(&uri, opts, Arc::new(SqliteDialect));
         assert!(
             result.is_err(),
             "should return error when accessing encrypted DB without passing hexkey in URI"
@@ -266,7 +269,7 @@ fn test_per_page_encryption(tmp_db: TempDatabase) -> anyhow::Result<()> {
             "file:{}?hexkey=b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327",
             db_path.to_str().unwrap()
         );
-        let result = turso_core::Connection::from_uri(&uri, opts);
+        let result = turso_core::Connection::from_uri(&uri, opts, Arc::new(SqliteDialect));
         assert!(
             result.is_err(),
             "should return error when accessing encrypted DB without passing cipher in URI"
@@ -412,7 +415,7 @@ fn test_corruption_turso_magic_bytes(tmp_db: TempDatabase) -> anyhow::Result<()>
             db_path.to_str().unwrap()
         );
 
-        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts)?;
+        let (_io, conn) = turso_core::Connection::from_uri(&uri, opts, Arc::new(SqliteDialect))?;
         let result = run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |_row: &Row| {});
 
         assert!(
@@ -586,6 +589,7 @@ fn test_encryption_key_validation_with_cached_database(_db: TempDatabase) -> any
         OpenFlags::Create,
         opts,
         correct_encryption_opts.clone(),
+        Arc::new(SqliteDialect),
     )?;
 
     // step 1: Create encrypted database with correct key
@@ -616,6 +620,7 @@ fn test_encryption_key_validation_with_cached_database(_db: TempDatabase) -> any
             OpenFlags::default(),
             opts,
             correct_encryption_opts.clone(),
+            Arc::new(SqliteDialect),
         )?;
 
         let conn = db.connect()?;
@@ -656,6 +661,7 @@ fn test_encryption_key_validation_with_cached_database(_db: TempDatabase) -> any
                 cipher: "aegis256".to_string(),
                 hexkey: wrong_key.to_string(),
             }),
+            Arc::new(SqliteDialect),
         )?;
 
         // opening succeeds - the key is not validated at open time
@@ -693,6 +699,7 @@ fn test_encryption_key_validation_with_cached_database(_db: TempDatabase) -> any
             OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         );
 
         assert!(
@@ -718,6 +725,7 @@ fn test_encryption_key_validation_with_cached_database(_db: TempDatabase) -> any
             OpenFlags::default(),
             opts,
             correct_encryption_opts.clone(),
+            Arc::new(SqliteDialect),
         )?;
 
         let conn = db.connect()?;
@@ -783,6 +791,7 @@ fn create_encrypted_db(
         OpenFlags::Create,
         opts,
         encryption_opts,
+        Arc::new(SqliteDialect),
     )?;
 
     let conn = db.connect()?;
@@ -1191,6 +1200,7 @@ fn test_encrypted_db_then_enable_mvcc_large_payload_chunked() -> anyhow::Result<
             OpenFlags::Create,
             opts,
             enc_opts.clone(),
+            Arc::new(SqliteDialect),
         )?;
         let key = EncryptionKey::from_hex_string(hex_key)?;
         let conn = db.connect_with_encryption(Some(key))?;
@@ -1216,6 +1226,7 @@ fn test_encrypted_db_then_enable_mvcc_large_payload_chunked() -> anyhow::Result<
             OpenFlags::default(),
             opts,
             enc_opts,
+            Arc::new(SqliteDialect),
         )?;
         let key = EncryptionKey::from_hex_string(hex_key)?;
         let conn = db.connect_with_encryption(Some(key))?;
@@ -1264,6 +1275,7 @@ fn test_encrypted_db_with_data_then_enable_mvcc() -> anyhow::Result<()> {
             OpenFlags::Create,
             opts,
             enc_opts.clone(),
+            Arc::new(SqliteDialect),
         )?;
         let key = EncryptionKey::from_hex_string(hex_key)?;
         let conn = db.connect_with_encryption(Some(key))?;
@@ -1282,6 +1294,7 @@ fn test_encrypted_db_with_data_then_enable_mvcc() -> anyhow::Result<()> {
             OpenFlags::default(),
             opts,
             enc_opts.clone(),
+            Arc::new(SqliteDialect),
         )?;
         let key = EncryptionKey::from_hex_string(hex_key)?;
         let conn = db.connect_with_encryption(Some(key))?;
@@ -1324,6 +1337,7 @@ fn test_encrypted_db_with_data_then_enable_mvcc() -> anyhow::Result<()> {
             OpenFlags::default(),
             opts,
             enc_opts.clone(),
+            Arc::new(SqliteDialect),
         )?;
         let key = EncryptionKey::from_hex_string(hex_key)?;
         let conn = db.connect_with_encryption(Some(key))?;

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -6,6 +6,7 @@ use crate::queued_io::{QueuedIo, QueuedIoOpKind};
 use rusqlite::Connection as SqliteConnection;
 use std::{path::Path, sync::Arc};
 use tempfile::TempDir;
+use turso_core::SqliteDialect;
 use turso_core::{Connection, Database, DatabaseOpts, LimboError, StepResult, Value};
 use turso_parser::{ast::Cmd, parser::Parser};
 
@@ -2589,6 +2590,7 @@ fn test_vacuum_into_from_memory_database() -> anyhow::Result<()> {
         OpenFlags::Create,
         turso_core::DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?;
     let conn = db.connect()?;
 
@@ -6065,6 +6067,7 @@ fn open_queued_db(io: Arc<QueuedIo>, path: &str) -> anyhow::Result<Arc<Database>
         Default::default(),
         DatabaseOpts::new().with_vacuum(true),
         None,
+        Arc::new(SqliteDialect),
     )?)
 }
 

--- a/tests/integration/reindex.rs
+++ b/tests/integration/reindex.rs
@@ -1,5 +1,6 @@
 use crate::queued_io::{QueuedIo, QueuedIoOpKind};
 use std::sync::{atomic::Ordering, Arc};
+use turso_core::SqliteDialect;
 use turso_core::{Connection, Database, DatabaseOpts, OpenFlags, StepResult};
 
 /// Opens a database on `QueuedIo` so tests can control when pending writes complete.
@@ -10,6 +11,7 @@ fn open_queued_db(io: Arc<QueuedIo>, path: &str) -> anyhow::Result<Arc<Database>
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
+        Arc::new(SqliteDialect),
     )?)
 }
 

--- a/tests/integration/statement_reset.rs
+++ b/tests/integration/statement_reset.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 use crate::common::{limbo_exec_rows, sqlite_exec_rows, TempDatabase};
 use crate::queued_io::QueuedIo;
@@ -381,7 +382,11 @@ fn plain_insert_step_to_done_commits(tmp_db: TempDatabase) -> anyhow::Result<()>
 #[test]
 fn dropping_explicit_commit_waiting_on_io_rolls_back_transaction() -> anyhow::Result<()> {
     let io = Arc::new(QueuedIo::new());
-    let db = Database::open_file(io, "queued-explicit-commit-drop.db")?;
+    let db = Database::open_file(
+        io,
+        "queued-explicit-commit-drop.db",
+        Arc::new(SqliteDialect),
+    )?;
     let conn = db.connect()?;
 
     conn.execute("CREATE TABLE t(x INTEGER)")?;

--- a/tests/integration/storage/autovacuum.rs
+++ b/tests/integration/storage/autovacuum.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use tempfile::TempDir;
+use turso_core::SqliteDialect;
 use turso_core::{Database, DatabaseOpts, OpenFlags, PlatformIO};
 
 #[test]
@@ -33,6 +34,7 @@ fn test_autovacuum_readonly_behavior() {
             OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         )
         .unwrap();
 

--- a/tests/integration/storage/header_version.rs
+++ b/tests/integration/storage/header_version.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
+use std::sync::Arc;
 use tempfile::TempDir;
+use turso_core::SqliteDialect;
 use turso_core::{Database, DatabaseOpts, OpenFlags};
 
 use crate::common::ExecRows;
@@ -67,6 +69,7 @@ fn open_with_limbo_and_check(db_path: &Path, enable_mvcc: bool) -> (u8, u8) {
         OpenFlags::default(),
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("Failed to open database with limbo");
 
@@ -315,6 +318,7 @@ fn test_pragma_journal_mode_wal_to_mvcc_with_pending_wal() {
             OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         )
         .expect("Failed to open database with limbo (non-MVCC)");
 
@@ -348,6 +352,7 @@ fn test_pragma_journal_mode_wal_to_mvcc_with_pending_wal() {
         OpenFlags::default(),
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("Failed to open database with limbo (MVCC enabled)");
 
@@ -424,6 +429,7 @@ fn test_pragma_journal_mode_mvcc_to_wal() {
             OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         )
         .expect("Failed to open database with limbo");
 
@@ -457,6 +463,7 @@ fn test_pragma_journal_mode_mvcc_to_wal() {
         OpenFlags::default(),
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("Failed to open MVCC database with limbo");
 
@@ -533,6 +540,7 @@ fn test_pragma_journal_mode_multiple_switches() {
         OpenFlags::default(),
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("Failed to open database");
 
@@ -642,6 +650,7 @@ fn test_pragma_journal_mode_query() {
         OpenFlags::default(),
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("Failed to open database");
 
@@ -669,6 +678,7 @@ fn test_pragma_journal_mode_query() {
         OpenFlags::default(),
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("Failed to open database");
 
@@ -715,6 +725,7 @@ fn test_pragma_journal_mode_data_persistence_after_switch() {
             OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         )
         .expect("Failed to open database");
 
@@ -743,6 +754,7 @@ fn test_pragma_journal_mode_data_persistence_after_switch() {
             OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         )
         .expect("Failed to reopen database");
 
@@ -776,6 +788,7 @@ fn open_with_limbo_readonly_and_check(db_path: &Path, enable_mvcc: bool) -> (u8,
         OpenFlags::ReadOnly,
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("Failed to open database with limbo in readonly mode");
 
@@ -904,6 +917,7 @@ fn test_readonly_pragma_journal_mode_cannot_change() {
         OpenFlags::ReadOnly,
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("Failed to open database in readonly mode");
 
@@ -954,6 +968,7 @@ fn test_readonly_mvcc_db_can_be_read() {
             OpenFlags::default(),
             opts,
             None,
+            Arc::new(SqliteDialect),
         )
         .expect("Failed to open database");
 
@@ -986,6 +1001,7 @@ fn test_readonly_mvcc_db_can_be_read() {
         OpenFlags::ReadOnly,
         opts,
         None,
+        Arc::new(SqliteDialect),
     )
     .expect("Failed to open MVCC database in readonly mode");
 
@@ -1058,6 +1074,7 @@ fn test_utf16_db_returns_unsupported_encoding_error() {
         OpenFlags::default(),
         opts,
         None,
+        Arc::new(SqliteDialect),
     );
 
     assert!(

--- a/tests/integration/wal/test_wal_publish_backfill_race.rs
+++ b/tests/integration/wal/test_wal_publish_backfill_race.rs
@@ -1,6 +1,7 @@
 use crate::queued_io::QueuedIo;
 use std::sync::Arc;
 use turso_core::vdbe::StepResult;
+use turso_core::SqliteDialect;
 use turso_core::{Connection, Database, Result};
 
 fn step_blocking(stmt: &mut turso_core::Statement) -> Result<StepResult> {
@@ -63,7 +64,12 @@ struct Setup {
 
 fn setup(park: usize) -> Setup {
     let io = Arc::new(QueuedIo::new());
-    let db = Database::open_file(io.clone(), "publish-backfill-race.db").unwrap();
+    let db = Database::open_file(
+        io.clone(),
+        "publish-backfill-race.db",
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
     let a = db.connect().unwrap();
     let b = db.connect().unwrap();
 
@@ -163,7 +169,12 @@ fn assert_integrity_ok(conn: &Arc<Connection>, context: &str) {
 
 fn setup_hidden_root_reuse(park: usize) -> Setup {
     let io = Arc::new(QueuedIo::new());
-    let db = Database::open_file(io.clone(), "publish-backfill-hidden-root-race.db").unwrap();
+    let db = Database::open_file(
+        io.clone(),
+        "publish-backfill-hidden-root-race.db",
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
     let a = db.connect().unwrap();
     let b = db.connect().unwrap();
 
@@ -237,7 +248,12 @@ fn setup_hidden_root_reuse(park: usize) -> Setup {
 
 fn total_commit_io_pumps_hidden_root_reuse() -> usize {
     let io = Arc::new(QueuedIo::new());
-    let db = Database::open_file(io.clone(), "publish-backfill-hidden-root-race-dry.db").unwrap();
+    let db = Database::open_file(
+        io.clone(),
+        "publish-backfill-hidden-root-race-dry.db",
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
     let a = db.connect().unwrap();
     let b = db.connect().unwrap();
 
@@ -293,7 +309,12 @@ fn total_commit_io_pumps_hidden_root_reuse() -> usize {
 fn wal_stale_publish_backfill_hides_committed_rows() {
     let total_yields = {
         let io = Arc::new(QueuedIo::new());
-        let db = Database::open_file(io.clone(), "publish-backfill-race-dry.db").unwrap();
+        let db = Database::open_file(
+            io.clone(),
+            "publish-backfill-race-dry.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let a = db.connect().unwrap();
         let b = db.connect().unwrap();
 
@@ -396,7 +417,8 @@ fn wal_stale_publish_backfill_hides_committed_rows() {
             drop(db);
             turso_core::clear_database_registry();
 
-            let db2 = Database::open_file(io, "publish-backfill-race.db").unwrap();
+            let db2 = Database::open_file(io, "publish-backfill-race.db", Arc::new(SqliteDialect))
+                .unwrap();
             let c = db2.connect().unwrap();
             let mut stmt = c.prepare("PRAGMA integrity_check").unwrap();
             let mut msgs = Vec::new();
@@ -537,7 +559,12 @@ fn wal_stale_publish_backfill_can_point_table_at_restarted_index_root() {
         drop(db);
         turso_core::clear_database_registry();
 
-        let db2 = Database::open_file(io, "publish-backfill-hidden-root-race.db").unwrap();
+        let db2 = Database::open_file(
+            io,
+            "publish-backfill-hidden-root-race.db",
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
         let c = db2.connect().unwrap();
         if exec_ints(
             &c,

--- a/tools/dbhash/src/lib.rs
+++ b/tools/dbhash/src/lib.rs
@@ -7,6 +7,7 @@
 mod encoder;
 
 use std::sync::Arc;
+use turso_core::SqliteDialect;
 
 use sha1::{Digest, Sha1};
 use std::num::NonZero;
@@ -66,6 +67,7 @@ pub fn hash_database_with_database_opts(
         OpenFlags::default(),
         database_opts,
         None,
+        Arc::new(SqliteDialect),
     )?;
     let conn = db.connect()?;
 


### PR DESCRIPTION
SQL dialect is bidirectional between the frontend and core. For example, statement re-preparing needs to parse statements and schema management is dialect specific. Therefore, add hooks in core to support dialects other than SQLite as a `Dialect` trait. Also refactor current SQLite dialect specific code into `core/dialect/sqlite.rs` module. In the future, we can extract the SQLite specifics to a `sqlite/frontend` crate to decouple `core` more, but that's for later.