### PR TITLE
cli: align box output with SQLite and DuckDB

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -119,6 +119,19 @@ pub struct Opts {
 
 const PROMPT: &str = "turso> ";
 
+// Keep only the outer border, column dividers, and header separator, matching
+// the box layouts produced by the SQLite and DuckDB shells.
+const BOX_TABLE_STYLE: &str = "││──├─┼┤│    ┬┴┌┐└┘";
+
+fn new_box_table() -> Table {
+    let mut table = Table::new();
+    table
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_truncation_indicator("…")
+        .apply_modifier(BOX_TABLE_STYLE);
+    table
+}
+
 pub struct Limbo {
     pub prompt: String,
     io: Arc<dyn turso_core::IO>,
@@ -517,12 +530,19 @@ impl Limbo {
     }
 
     fn set_mode(&mut self, mode: OutputMode) -> Result<(), String> {
-        if mode == OutputMode::Pretty && !self.opts.is_stdout {
-            Err("pretty output can only be written to a tty".to_string())
-        } else {
-            self.opts.output_mode = mode;
-            Ok(())
+        if !self.opts.is_stdout {
+            match mode {
+                OutputMode::Pretty => {
+                    return Err("pretty output can only be written to a tty".to_string());
+                }
+                OutputMode::Box => {
+                    return Err("box output can only be written to a tty".to_string());
+                }
+                OutputMode::List | OutputMode::Line => {}
+            }
         }
+        self.opts.output_mode = mode;
+        Ok(())
     }
 
     fn write_fmt(&mut self, fmt: std::fmt::Arguments) -> io::Result<()> {
@@ -989,7 +1009,7 @@ impl Limbo {
                     (_, QueryMode::Explain) => {
                         self.print_explain(rows, statistics)?;
                     }
-                    (OutputMode::Pretty, _) => {
+                    (OutputMode::Pretty | OutputMode::Box, _) => {
                         self.print_pretty_mode(rows, statistics)?;
                     }
                     (OutputMode::Line, _) => {
@@ -1242,11 +1262,7 @@ impl Limbo {
             .map(|c| c.as_comfy_table_color())
             .collect();
 
-        let mut table = Table::new();
-        table
-            .set_content_arrangement(ContentArrangement::Dynamic)
-            .set_truncation_indicator("…")
-            .apply_modifier("││──├─┼┤│─┼├┤┬┴┌┐└┘");
+        let mut table = new_box_table();
 
         if num_columns > 0 {
             let header = column_names
@@ -2377,6 +2393,19 @@ fn normalize_db_path(db_file: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn box_table_omits_separators_between_data_rows() {
+        let mut table = new_box_table();
+        table.set_header(["value"]);
+        table.add_row(["1"]);
+        table.add_row(["2"]);
+
+        assert_eq!(
+            table.to_string(),
+            "┌───────┐\n│ value │\n├───────┤\n│ 1     │\n│ 2     │\n└───────┘"
+        );
+    }
 
     #[test]
     fn test_normalize_db_path_adds_file_prefix_for_query_params() {

--- a/cli/commands/mod.rs
+++ b/cli/commands/mod.rs
@@ -115,11 +115,23 @@ const _HELP_TEMPLATE: &str = "{before-help}{name}
 
 #[cfg(test)]
 mod tests {
-    use super::CommandParser;
+    use super::{Command, CommandParser};
+    use crate::input::OutputMode;
+    use clap::Parser;
 
     #[test]
     fn cli_assert() {
         use clap::CommandFactory;
         CommandParser::command().debug_assert();
+    }
+
+    #[test]
+    fn parses_box_output_mode() {
+        let parsed = CommandParser::try_parse_from(["mode", "box"]).expect("box mode must parse");
+
+        assert!(matches!(
+            parsed.command,
+            Command::OutputMode(args) if args.mode == OutputMode::Box
+        ));
     }
 }

--- a/cli/config/mod.rs
+++ b/cli/config/mod.rs
@@ -82,7 +82,7 @@ impl Config {
     }
 
     pub fn for_output_mode(mode: OutputMode) -> Self {
-        let table = if mode == OutputMode::Pretty {
+        let table = if matches!(mode, OutputMode::Pretty | OutputMode::Box) {
             TableConfig::adaptive_colors()
         } else {
             TableConfig::no_colors()

--- a/cli/input.rs
+++ b/cli/input.rs
@@ -67,6 +67,7 @@ impl Default for Io {
 pub enum OutputMode {
     List,
     Pretty,
+    Box,
     Line,
 }
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -146,7 +146,7 @@ The SQL shell supports the following command line options:
 
 | Option | Description |
 |--------|-------------|
-| `-m`, `--output-mode` `<mode>` | Configure output mode. Supported values for `<mode>`: <ul><li>`pretty` for pretty output (default)</li><li>`list` for minimal SQLite compatible format</li></ul>
+| `-m`, `--output-mode` `<mode>` | Configure output mode. Supported values for `<mode>`: <ul><li>`pretty` for pretty output (default)</li><li>`box` for SQLite/DuckDB-style box output</li><li>`list` for minimal SQLite compatible format</li><li>`line` for one column per line</li></ul>
 | `-q`, `--quiet` | Don't display program information at startup |
 | `-e`, `--echo` | Print commands before execution |
 | `--readonly` | Open database in read-only mode |
@@ -1139,13 +1139,9 @@ SELECT * FROM turso_cdc;
 │ change_id │ change_time │ change_type │ table_name    │ id │ before   │ after                                                                        │ updates       │
 ├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
 │         1 │  1756713161 │           1 │ sqlite_schema │  2 │          │ ytableusersusersCREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT) │               │
-├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
 │         2 │  1756713176 │           1 │ users         │  1 │          │       John                                                                      │               │
-├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
 │         3 │  1756713176 │           1 │ users         │  2 │          │ Jane                                                                     │               │
-├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
 │         4 │  1756713176 │           0 │ users         │  1 │  John  │         John Doe                                                                  │     John Doe │
-├───────────┼─────────────┼─────────────┼───────────────┼────┼──────────┼──────────────────────────────────────────────────────────────────────────────┼───────────────┤
 │         5 │  1756713176 │          -1 │ users         │  2 │ Jane │                                                                              │               │
 └───────────┴─────────────┴─────────────┴───────────────┴────┴──────────┴──────────────────────────────────────────────────────────────────────────────┴───────────────┘
 turso>

--- a/docs/sql-reference/cli/command-line-options.mdx
+++ b/docs/sql-reference/cli/command-line-options.mdx
@@ -42,6 +42,7 @@ Set the output display format.
 | Mode | Description |
 |------|-------------|
 | `pretty` | Table with borders (default) |
+| `box` | SQLite/DuckDB-style box table |
 | `list` | Pipe-delimited values |
 | `line` | One column per line with column names |
 

--- a/docs/sql-reference/cli/getting-started.mdx
+++ b/docs/sql-reference/cli/getting-started.mdx
@@ -62,7 +62,7 @@ Use `.quit` or `.exit` to leave the shell. Pressing Ctrl+C twice also exits.
 
 ## Output Modes
 
-Turso supports three output modes, selectable with the `-m` flag or the `.mode` dot command.
+Turso supports four output modes, selectable with the `-m` flag or the `.mode` dot command.
 
 ### Pretty (Default)
 
@@ -72,12 +72,17 @@ Human-readable table with borders:
 tursodb -q -m pretty
 ```
 
+The equivalent `box` mode follows the SQLite and DuckDB shell interface:
+
+```bash
+tursodb -q -m box
+```
+
 ```
 ┌────┬─────────┬─────────────┬─────────┐
 │ id │ name    │ department  │ salary  │
 ├────┼─────────┼─────────────┼─────────┤
 │  1 │ Alice   │ Engineering │ 95000.0 │
-├────┼─────────┼─────────────┼─────────┤
 │  2 │ Bob     │ Marketing   │ 72000.0 │
 └────┴─────────┴─────────────┴─────────┘
 ```
@@ -141,4 +146,3 @@ Start a sync server for database replication:
 ```bash
 tursodb --sync-server 0.0.0.0:8080 mydata.db
 ```
-

--- a/docs/sql-reference/cli/shell-commands.mdx
+++ b/docs/sql-reference/cli/shell-commands.mdx
@@ -147,6 +147,7 @@ Set the output display mode.
 | Mode | Description |
 |------|-------------|
 | `pretty` | Table with borders (default) |
+| `box` | SQLite/DuckDB-style box table |
 | `list` | Pipe-delimited values |
 | `line` | One column per line with column names |
 
@@ -167,6 +168,13 @@ tursodb> SELECT 1 AS a, 2 AS b;
 ├───┼───┤
 │ 1 │ 2 │
 └───┴───┘
+```
+
+`box` uses the same table renderer as `pretty` and follows the SQLite and DuckDB
+shell interface:
+
+```
+tursodb> .mode box
 ```
 
 ### .headers
@@ -378,9 +386,7 @@ tursodb> SELECT * FROM people;
 │ name    │ age │
 ├─────────┼─────┤
 │ Alice   │  30 │
-├─────────┼─────┤
 │ Bob     │  25 │
-├─────────┼─────┤
 │ Charlie │  35 │
 └─────────┴─────┘
 ```


### PR DESCRIPTION
## Summary

- render pretty tables without horizontal separators between data rows
- add `box` as an output mode that shares the pretty table renderer
- preserve the outer border, column dividers, and header separator
- document the new mode and add focused renderer and parser coverage

## Why

The pretty table modifier configured all middle-row border components, causing a horizontal rule to be drawn after every result row. SQLite and DuckDB box output only draws horizontal rules around the table and below the header, which is more compact and easier to scan.

## User impact

Both `.mode pretty` and `.mode box` now produce the compact SQLite/DuckDB-style layout. Existing `pretty` usage remains supported, while `box` provides the familiar shell interface.

## Validation

- `cargo fmt`
- `git diff --check`
- focused tests added but not run locally

Fixes #7652
