### PR TITLE
core/vdbe: close vtab cursors before transaction finalization

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1095,6 +1095,26 @@ impl ProgramState {
             .unwrap_or_else(|| panic!("cursor id {cursor_id} is None"))
     }
 
+    /// Close all virtual table cursors owned by this program.
+    ///
+    /// A virtual table cursor can own a nested helper statement on the same
+    /// connection (e.g. `PragmaVirtualTableCursor` runs `PRAGMA ...` via
+    /// `Connection::prepare_internal`), and that helper holds the
+    /// connection's nested-statement guard until it is dropped. Both
+    /// `commit_txn` and `abort` consult `Connection::is_nested_stmt()` to
+    /// decide whether the current statement owns top-level transaction
+    /// finalization, so the helpers must be dropped first — otherwise a root
+    /// statement that scanned a pragma virtual table misclassifies itself as
+    /// nested, skips ending its implicit read transaction, and subsequent
+    /// writes on the connection never auto-commit (issue #7466).
+    pub(crate) fn close_virtual_table_cursors(&mut self) {
+        for slot in self.cursors.iter_mut() {
+            if matches!(slot, Some(Cursor::Virtual(_))) {
+                *slot = None;
+            }
+        }
+    }
+
     /// Begin a statement subtransaction.
     ///
     /// Creates a savepoint on the main DB's MvStore (or pager for WAL mode),
@@ -1983,6 +2003,11 @@ impl Program {
 
         // Reset state for next use
         program_state.view_delta_state = ViewDeltaCommitState::NotStarted;
+        // Drop virtual table cursors before the `is_nested_stmt()` check
+        // below: a pragma virtual table cursor owns a nested helper statement
+        // whose guard would otherwise make this top-level statement classify
+        // itself as nested and skip transaction finalization entirely.
+        program_state.close_virtual_table_cursors();
         let tx_state = self.connection.get_tx_state();
         if tx_state == TransactionState::None
             && matches!(program_state.commit_state, CommitState::Ready)
@@ -2484,6 +2509,11 @@ impl Program {
                 "Failed to clean up VACUUM state during abort",
             );
         }
+
+        // Virtual table cursors (pragma table-valued functions) also own
+        // nested helper statements whose drop releases nested guards. Drop
+        // them before the `is_nested_stmt()` check below for the same reason.
+        state.close_virtual_table_cursors();
 
         // Only end trigger execution if the subprogram was actually running.
         // Cached (pooled) statements may be dropped after their trigger execution

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -454,3 +454,122 @@ fn test_pragma_wal_checkpoint_targets_attached_database(db: TempDatabase) {
         "aux pager should have checkpointed frames (got {checkpointed})"
     );
 }
+
+// Regression tests for https://github.com/tursodatabase/turso/issues/7466:
+// querying a pragma virtual table (pragma_table_info, pragma_function_list, ...)
+// left the connection's implicit read transaction open, so every subsequent
+// write on that connection reported success but was never committed.
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_vtab_query_does_not_break_subsequent_writes(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER, b TEXT)").unwrap();
+
+    // Full scan of a pragma virtual table.
+    let mut stmt = conn
+        .query("SELECT * FROM pragma_table_info('t')")
+        .unwrap()
+        .unwrap();
+    while let StepResult::Row = stmt.step().unwrap() {}
+    drop(stmt);
+
+    assert!(
+        conn.get_auto_commit(),
+        "autocommit must survive a pragma vtab query"
+    );
+
+    // This write must auto-commit at Halt like any other statement.
+    conn.execute("INSERT INTO t VALUES (1, 'one')").unwrap();
+
+    // A second connection only sees committed data.
+    let conn2 = db.connect_limbo();
+    let rows = limbo_exec_rows(&conn2, "SELECT a, b FROM t");
+    assert_eq!(
+        rows,
+        vec![vec![RValue::Integer(1), RValue::Text("one".to_string())]],
+        "insert after pragma vtab query must be committed"
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_function_list_then_create_and_insert(db: TempDatabase) {
+    let conn = db.connect_limbo();
+
+    let mut stmt = conn
+        .query("SELECT name FROM pragma_function_list()")
+        .unwrap()
+        .unwrap();
+    let mut n = 0;
+    while let StepResult::Row = stmt.step().unwrap() {
+        n += 1;
+    }
+    assert!(n > 0, "pragma_function_list should return rows");
+    drop(stmt);
+
+    conn.execute("CREATE TABLE t (x)").unwrap();
+    conn.execute("INSERT INTO t VALUES (42)").unwrap();
+
+    let conn2 = db.connect_limbo();
+    let rows = limbo_exec_rows(&conn2, "SELECT x FROM t");
+    assert_eq!(
+        rows,
+        vec![vec![RValue::Integer(42)]],
+        "writes after pragma_function_list query must be committed"
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_vtab_partial_scan_does_not_break_subsequent_writes(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER, b TEXT, c REAL)")
+        .unwrap();
+
+    // Partial scan: step once, then abandon the statement mid-scan so cleanup
+    // goes through the abort path instead of Halt.
+    let mut stmt = conn
+        .query("SELECT * FROM pragma_table_info('t')")
+        .unwrap()
+        .unwrap();
+    let StepResult::Row = stmt.step().unwrap() else {
+        panic!("expected at least one row from pragma_table_info");
+    };
+    drop(stmt);
+
+    conn.execute("INSERT INTO t VALUES (1, 'one', 1.5)")
+        .unwrap();
+
+    let conn2 = db.connect_limbo();
+    let rows = limbo_exec_rows(&conn2, "SELECT a FROM t");
+    assert_eq!(
+        rows,
+        vec![vec![RValue::Integer(1)]],
+        "insert after abandoned pragma vtab scan must be committed"
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_vtab_query_with_limit_then_write(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER, b TEXT, c REAL)")
+        .unwrap();
+
+    // LIMIT terminates the scan before the virtual table cursor is exhausted,
+    // so the program halts while the cursor still holds its helper statement.
+    let mut stmt = conn
+        .query("SELECT * FROM pragma_table_info('t') LIMIT 1")
+        .unwrap()
+        .unwrap();
+    while let StepResult::Row = stmt.step().unwrap() {}
+    drop(stmt);
+
+    conn.execute("INSERT INTO t VALUES (2, 'two', 2.5)")
+        .unwrap();
+
+    let conn2 = db.connect_limbo();
+    let rows = limbo_exec_rows(&conn2, "SELECT a FROM t");
+    assert_eq!(
+        rows,
+        vec![vec![RValue::Integer(2)]],
+        "insert after LIMITed pragma vtab query must be committed"
+    );
+}


### PR DESCRIPTION
Fixes #7466

## Root cause

`PragmaVirtualTableCursor` runs its PRAGMA through a nested helper statement (`Connection::prepare_internal`) that holds the connection's nested-statement guard until the cursor drops. The cursor lives in `ProgramState.cursors`, which outlives Halt — so `commit_txn()`'s `is_nested_stmt()` check misclassifies the outer statement as nested and skips ending its implicit read transaction. Subsequent writes see `tx_state=Read, auto_commit=true` and never commit.

## Fix

Close vtab cursors in `commit_txn()` and `abort()` before the `is_nested_stmt()` checks — the same pattern the codebase already uses there for ParseSchema and VACUUM, and matches `sqlite3VdbeHalt()`.

## Tests

`tests/integration/pragma.rs`: pragma-then-write, `function_list` repro (#7466), mid-scan abort, LIMIT scan — each with an MVCC variant. All fail on main, pass with the fix.

## Not fixed

Writes issued while a pragma statement is *suspended mid-scan* (#7260's shape) — the helper's guard is scoped to the statement's lifetime, not individual steps.
