### PR TITLE
core: kill Connection::prepare_stmt()

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -17,7 +17,7 @@ use crate::util::{OpenMode, OpenOptions};
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::Page;
 use crate::{
-    ast, function,
+    function,
     io::{MemoryIO, IO},
     progress::{ProgressHandler, ProgressHandlerCallback},
     translate,
@@ -1000,55 +1000,6 @@ impl Connection {
                 pager,
                 mode,
                 byte_offset_end,
-                origin,
-                needs_nested_guard,
-            ))
-        })();
-        if result.is_err() && needs_nested_guard {
-            self.end_nested();
-        }
-        result
-    }
-
-    /// Prepare a statement from an AST node directly, skipping SQL parsing.
-    /// This is more efficient when AST is already available or constructed programmatically.
-    pub fn prepare_stmt(self: &Arc<Connection>, stmt: ast::Stmt) -> Result<Statement> {
-        self.prepare_stmt_with_origin(stmt, StatementOrigin::Root)
-    }
-
-    #[turso_macros::trace_stack]
-    fn prepare_stmt_with_origin(
-        self: &Arc<Connection>,
-        stmt: ast::Stmt,
-        origin: StatementOrigin,
-    ) -> Result<Statement> {
-        if self.is_closed() {
-            return Err(LimboError::InternalError("Connection closed".to_string()));
-        }
-        let needs_nested_guard = origin.needs_nested_guard();
-        if needs_nested_guard {
-            self.start_nested();
-        }
-        let result = (|| {
-            self.maybe_update_schema();
-            let syms = self.syms.read();
-            let pager = self.pager.load().clone();
-            let mode = QueryMode::Normal;
-            let schema = self.schema.read().clone();
-            let program = translate::translate(
-                &schema,
-                stmt,
-                pager.clone(),
-                self.clone(),
-                &syms,
-                mode,
-                "<ast>", // No SQL input string available
-            )?;
-            Ok(Statement::new_with_origin(
-                program,
-                pager,
-                mode,
-                0,
                 origin,
                 needs_nested_guard,
             ))

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     translate::collate::CollationSeq,
     types::{IOResult, ImmutableRecord, IndexInfo, KeyInfo, SeekKey, SeekOp, SeekResult, Text},
+    util::quote_identifier,
     vdbe::Register,
     Connection, LimboError, Result, Value,
 };
@@ -37,7 +38,7 @@ use tantivy::{
     },
     DocAddress, HasLen, Index, IndexReader, IndexSettings, IndexWriter, Searcher, TantivyDocument,
 };
-use turso_parser::ast::{self, Select, SortOrder};
+use turso_parser::ast::{Select, SortOrder};
 
 /// Name identifier for the FTS index method, used in `CREATE INDEX ... USING fts`.
 pub const FTS_INDEX_METHOD_NAME: &str = "fts";
@@ -1349,11 +1350,6 @@ fn key_info() -> KeyInfo {
     }
 }
 
-/// Creates an AST `Name` node from a string.
-fn name(name: impl ToString) -> ast::Name {
-    ast::Name::exact(name.to_string())
-}
-
 /// Parse field weights from a string like "body=2.0,title=1.0"
 /// Returns a HashMap mapping column names to tantivy 'boost factors'
 fn parse_field_weights(weights_str: &str, columns: &[IndexColumn]) -> Result<HashMap<String, f32>> {
@@ -1640,109 +1636,34 @@ impl IndexMethodAttachment for FtsIndexAttachment {
     }
 }
 
-const NOTNULL_CONSTRAINT: ast::NamedColumnConstraint = ast::NamedColumnConstraint {
-    name: None,
-    constraint: ast::ColumnConstraint::NotNull {
-        nullable: false,
-        conflict_clause: None,
-    },
-};
-
 fn initialize_btree_storage_table(
     conn: &Arc<Connection>,
     database_id: usize,
     table_name: &str,
 ) -> Result<()> {
-    const PATH_COLUMN: &str = "path";
-    const CHUNK_NO_COLUMN: &str = "chunk_no";
-    const BYTES_COLUMN: &str = "bytes";
-    let db_name = conn
+    let db_prefix = conn
         .get_database_name_by_index(database_id)
-        .filter(|name| name != "main");
-    let qualified_name = ast::QualifiedName {
-        db_name: db_name.clone().map(ast::Name::from_string),
-        name: name(table_name),
-        alias: None,
-    };
-    let qualified_index_name = ast::QualifiedName {
-        db_name: db_name.map(ast::Name::from_string),
-        name: name(format!("{table_name}_key")),
-        alias: None,
-    };
-    // inline ast to reduce parsing overhead
-    // CREATE TABLE table_name (path TEXT NOT NULL, chunk_no INTEGER NOT NULL, bytes BLOB NOT NULL);
-    let create_table_stmt = ast::Stmt::CreateTable {
-        body: ast::CreateTableBody::ColumnsAndConstraints {
-            columns: vec![
-                ast::ColumnDefinition {
-                    col_name: name(PATH_COLUMN),
-                    col_type: Some(ast::Type {
-                        name: "TEXT".to_string(),
-                        size: None,
-                        array_dimensions: 0,
-                    }),
-                    constraints: vec![NOTNULL_CONSTRAINT],
-                },
-                ast::ColumnDefinition {
-                    col_name: name(CHUNK_NO_COLUMN),
-                    col_type: Some(ast::Type {
-                        name: "INTEGER".to_string(),
-                        size: None,
-                        array_dimensions: 0,
-                    }),
-                    constraints: vec![NOTNULL_CONSTRAINT],
-                },
-                ast::ColumnDefinition {
-                    col_name: name(BYTES_COLUMN),
-                    col_type: Some(ast::Type {
-                        name: "BLOB".to_string(),
-                        size: None,
-                        array_dimensions: 0,
-                    }),
-                    constraints: vec![NOTNULL_CONSTRAINT],
-                },
-            ],
-            constraints: vec![],
-            options: ast::TableOptions::empty(),
-        },
-        temporary: false,
-        if_not_exists: true,
-        tbl_name: qualified_name,
-    };
-    // "CREATE INDEX IF NOT EXISTS idx_name ON table_name USING backing_btree (path, chunk_no, bytes);"
-    // Use backing_btree to create a BTree that stores all columns without rowid indirection
-    // This allows direct cursor access with the exact key structure
-    let create_index_stmt = ast::Stmt::CreateIndex {
-        unique: false, // backing_btree doesn't use unique constraint
-        if_not_exists: true,
-        idx_name: qualified_index_name,
-        tbl_name: name(table_name),
-        using: Some(name(super::BACKING_BTREE_INDEX_METHOD_NAME)),
-        columns: vec![
-            ast::SortedColumn {
-                expr: Box::new(ast::Expr::Name(name(PATH_COLUMN))),
-                order: None,
-                nulls: None,
-            },
-            ast::SortedColumn {
-                expr: Box::new(ast::Expr::Name(name(CHUNK_NO_COLUMN))),
-                order: None,
-                nulls: None,
-            },
-            ast::SortedColumn {
-                expr: Box::new(ast::Expr::Name(name(BYTES_COLUMN))),
-                order: None,
-                nulls: None,
-            },
-        ],
-        where_clause: None,
-        with_clause: vec![],
-    };
+        .filter(|name| name != "main")
+        .map(|name| format!("{}.", quote_identifier(&name)))
+        .unwrap_or_default();
+    let table_ident = quote_identifier(table_name);
+    let create_table_sql = format!(
+        "CREATE TABLE IF NOT EXISTS {db_prefix}{table_ident} \
+         (path TEXT NOT NULL, chunk_no INTEGER NOT NULL, bytes BLOB NOT NULL)"
+    );
+    // Use backing_btree to create a BTree that stores all columns without rowid
+    // indirection, allowing direct cursor access with the exact key structure.
+    let create_index_sql = format!(
+        "CREATE INDEX IF NOT EXISTS {db_prefix}{index_ident} ON {table_ident} \
+         USING {method} (path, chunk_no, bytes)",
+        index_ident = quote_identifier(&format!("{table_name}_key")),
+        method = super::BACKING_BTREE_INDEX_METHOD_NAME,
+    );
     // Execute nested statements without subtransactions to avoid DatabaseBusy
     // (we're already inside a transaction from the parent CREATE INDEX statement)
     {
         conn.start_nested();
-        let mut stmt = conn.prepare_stmt(create_table_stmt)?;
+        let mut stmt = conn.prepare(create_table_sql)?;
         stmt.program
             .prepared
             .needs_stmt_subtransactions
@@ -1753,7 +1674,7 @@ fn initialize_btree_storage_table(
     }
     {
         conn.start_nested();
-        let mut stmt = conn.prepare_stmt(create_index_stmt)?;
+        let mut stmt = conn.prepare(create_index_sql)?;
         stmt.program
             .prepared
             .needs_stmt_subtransactions
@@ -2724,19 +2645,17 @@ impl IndexMethodCursor for FtsCursor {
         // The backing_btree index will be dropped automatically when the table is dropped
         // Use start_nested() before prepare() to bypass system table protection,
         // then use prepare/run_ignore_rows pattern and disable subtransactions to avoid Busy error
-        let drop_table_ast = ast::Stmt::DropTable {
-            if_exists: true,
-            tbl_name: ast::QualifiedName {
-                db_name: conn
-                    .get_database_name_by_index(database_id)
-                    .filter(|name| name != "main")
-                    .map(ast::Name::from_string),
-                name: ast::Name::exact(self.dir_table_name.clone()),
-                alias: None,
-            },
-        };
+        let db_prefix = conn
+            .get_database_name_by_index(database_id)
+            .filter(|name| name != "main")
+            .map(|name| format!("{}.", quote_identifier(&name)))
+            .unwrap_or_default();
+        let drop_table_sql = format!(
+            "DROP TABLE IF EXISTS {db_prefix}{}",
+            quote_identifier(&self.dir_table_name)
+        );
         conn.start_nested();
-        let mut stmt = conn.prepare_stmt(drop_table_ast)?;
+        let mut stmt = conn.prepare(drop_table_sql)?;
         // Disable subtransactions since we're already inside a transaction from the parent DROP INDEX
         stmt.program
             .prepared


### PR DESCRIPTION
Statements prepared from an AST carried the placeholder string "<ast>"
as their SQL text. Statement::reprepare() re-derives the program by
re-parsing program.sql, so any schema change between prepare and step
(concurrent DDL, or an MVCC checkpoint publishing new roots) made such
statements fail with a parse error on the "<" token. The SQL text is a
statement's durable identity throughout the engine -- reprepare, the
post-ANALYZE stats refresh, and diagnostics all read it -- so an
AST-only prepare breaks a structural invariant rather than just one
code path.

The API's stated benefit, skipping the parse, was negligible: prepare
cost is dominated by translation, and the only callers were the
once-per-DDL FTS shadow table statements. Rather than teach the
reprepare path about AST-born statements, remove the API. The FTS
index method still builds its DDL as ASTs (which keeps identifier
quoting correct) but renders them to SQL text and goes through the
normal prepare path, leaving a single prepare pipeline where every
statement can be reprepared from its text.
