### PR TITLE
ci: run whopper simulator iterations concurrently

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -410,11 +410,24 @@ jobs:
       - name: Run turso_whopper (${{ matrix.toolchain.label }}, ${{ matrix.profile.name }})
         env:
           RUSTFLAGS: ${{ matrix.toolchain.rustflags }}
+          WHOPPER_ARGS: ${{ matrix.profile.args }}
         run: |
           cargo +${{ matrix.toolchain.version }} build -p turso_whopper --release
-          for i in $(seq 1 ${{ matrix.profile.iterations }}); do
-            ./target/release/turso_whopper ${{ matrix.profile.args }} || exit 1
-          done
+          # A single whopper run drives its connections serially (one blocking
+          # step at a time), so it only keeps about one core busy. Run
+          # iterations concurrently to use the whole runner; per-iteration log
+          # files keep output readable and preserve the failing seed.
+          seq 1 ${{ matrix.profile.iterations }} | xargs -P 4 -n 1 bash -c '
+            i="$1"
+            log="whopper-run-$i.log"
+            if ./target/release/turso_whopper $WHOPPER_ARGS >"$log" 2>&1; then
+              echo "iteration $i ok: $(grep -m1 "^seed = " "$log")"
+            else
+              echo "iteration $i FAILED ($(grep -m1 "^seed = " "$log")):"
+              cat "$log"
+              exit 255
+            fi
+          ' _
 
   concurrent-simulator-windows:
     runs-on: windows-latest


### PR DESCRIPTION
The multiprocess and multiprocess-kill concurrent-simulator jobs took 24-38 minutes because iterations ran sequentially, while each whopper simulation only keeps about one core busy: the coordinator drives every step as a blocking IPC round-trip to one worker at a time, so a 4-vCPU runner sat mostly idle.

Run iterations 4 at a time with xargs -P instead. Per-run database paths are already unique (seed + pid + timestamp + counter), and a local test of four concurrent runs shows near-linear scaling (2.48s solo vs 2.72s for four). Per-iteration log files keep output readable; on failure the full log, including the seed needed to reproduce, is printed and remaining iterations are aborted.

Expected effect: multiprocess-kill drops from ~36 min of iterations to ~11 min, multiprocess from ~22 to ~7 min, with identical coverage.