### PR TITLE
ci: run Nyrkiö benchmark workflow only on push to main

### DIFF
--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: ["main", "master", "notmain"]
-  pull_request:
-    branches: ["main", "notmain", "master"]
 
 env:
   CARGO_TERM_COLOR: never


### PR DESCRIPTION
The rust_perf.yml jobs ran on every pull request, adding 15 jobs and the five slowest checks on a PR (tpc-h-criterion 24+ min, tpc-h and vfs-bench-compile ~19 min each, plus a 9-entry bench matrix), all on shared 2-core ubuntu-latest runners where timings are too noisy to mean anything.

The PR results were already discarded by configuration: fail-on-alert, comment-on-alert and comment-always are all false and never-fail is true, so no one ever saw them. Nyrkiö change detection operates on the time series of main pushes, which this keeps, and CodSpeed continues to provide per-PR performance regression detection. workflow_dispatch remains for benchmarking a branch on demand.

main has no required status checks, so dropping the trigger cannot leave PRs waiting on an expected check.