### PR TITLE
core: propagate incremental blob allocation failures

### DIFF
--- a/core/incremental_blob.rs
+++ b/core/incremental_blob.rs
@@ -168,7 +168,7 @@ impl Blob {
     fn bind_blob(&mut self, index: usize, value: Vec<u8>) -> Result<()> {
         self.stmt.bind_at(
             NonZero::new(index).unwrap(),
-            Value::Blob(crate::types::value_blob_from_slice(&value)),
+            Value::Blob(crate::types::value_blob_from_slice(&value)?),
         )
     }
 

--- a/core/vdbe/blob_io_tests.rs
+++ b/core/vdbe/blob_io_tests.rs
@@ -139,7 +139,8 @@ fn blob_write_local_persists() {
             dest: r_off,
         });
         b.emit_insn(Insn::Blob {
-            value: crate::types::value_blob_from_slice(&[0xAA, 0xBB, 0xCC]),
+            value: crate::types::value_blob_from_slice(&[0xAA, 0xBB, 0xCC])
+                .expect(crate::alloc::ALLOC_ERR_MSG),
             dest: r_src,
         });
         let r_ack = b.alloc_register();
@@ -183,7 +184,8 @@ fn blob_read_write_across_overflow() {
     // Write a marker straddling the local/overflow boundary region (offset 3000, which
     // is well past the ~4KB local cap for a page, and spanning into deeper overflow).
     let pattern: Vec<u8> = (0u16..600).map(|i| (i % 251) as u8).collect();
-    let pat_for_move = crate::types::value_blob_from_slice(&pattern);
+    let pat_for_move =
+        crate::types::value_blob_from_slice(&pattern).expect(crate::alloc::ALLOC_ERR_MSG);
     let rows = run_blob_program(&conn, root, move |b, cursor| {
         let r_off = b.alloc_register();
         let r_src = b.alloc_register();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2873,7 +2873,7 @@ pub fn op_blob_read(
         Err(LimboError::BlobHandleExpired) => return Ok(blob_expired_ack(state, *dest)),
         Err(err) => return Err(err),
     }
-    state.registers[*dest].set_value(Value::Blob(crate::types::value_blob_from_slice(&out)));
+    state.registers[*dest].set_value(Value::Blob(crate::types::value_blob_from_slice(&out)?));
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }


### PR DESCRIPTION
## Summary

Propagate the new fallible `ValueBlob` copy API through incremental blob binding and the `BlobRead` VDBE opcode.

## Root cause

The incremental-blob code and its opcode fixtures still passed `Result<ValueBlob, TryReserveError>` directly to `Value::Blob`, so the Android/nightly builds failed with E0308 after `value_blob_from_slice` became fallible.