### PR TITLE
core: use ValueBlob in blob functions

### DIFF
--- a/core/incremental_blob.rs
+++ b/core/incremental_blob.rs
@@ -29,6 +29,7 @@
 use std::num::NonZero;
 use std::sync::Arc;
 
+use crate::alloc::TursoSliceExt;
 use crate::schema::{BTreeTable, Column, Schema};
 use crate::storage::pager::Pager;
 use crate::vdbe::builder::{CursorType, ProgramBuilder, ProgramBuilderOpts, QueryMode};
@@ -127,7 +128,7 @@ impl Blob {
         // op=2 (write), offset, src blob.
         self.bind(1, 2)?;
         self.bind(2, offset as i64)?;
-        self.bind_blob(4, data.to_vec())?;
+        self.bind_blob(4, data.try_to_vec()?)?;
         match self.step_op()? {
             Value::Numeric(Numeric::Integer(1)) => Ok(()),
             other => Err(LimboError::InternalError(format!(
@@ -165,11 +166,9 @@ impl Blob {
         )
     }
 
-    fn bind_blob(&mut self, index: usize, value: Vec<u8>) -> Result<()> {
-        self.stmt.bind_at(
-            NonZero::new(index).unwrap(),
-            Value::Blob(crate::types::value_blob_from_slice(&value)?),
-        )
+    fn bind_blob(&mut self, index: usize, value: crate::alloc::Vec<u8>) -> Result<()> {
+        self.stmt
+            .bind_at(NonZero::new(index).unwrap(), Value::Blob(value))
     }
 
     /// Step the bound op to its result row and return the single acknowledging value.

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -655,7 +655,7 @@ pub trait CursorTrait: Any + Send + Sync {
         _column: usize,
         _off: usize,
         _len: usize,
-        _out: &mut Vec<u8>,
+        _out: &mut crate::ValueBlob,
     ) -> Result<IOResult<()>> {
         Err(LimboError::InternalError(
             "incremental blob I/O is only supported on table rows".to_string(),
@@ -5805,7 +5805,7 @@ impl BTreeCursor {
         column: usize,
         off: usize,
         len: usize,
-        out: &mut Vec<u8>,
+        out: &mut crate::ValueBlob,
     ) -> Result<IOResult<()>> {
         let payload_off = return_if_io!(self.blob_resolve_range(column, off, len));
         out.clear();
@@ -6228,7 +6228,7 @@ impl CursorTrait for BTreeCursor {
         column: usize,
         off: usize,
         len: usize,
-        out: &mut Vec<u8>,
+        out: &mut crate::ValueBlob,
     ) -> Result<IOResult<()>> {
         self.blob_read_column_inherent(column, off, len, out)
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1,5 +1,6 @@
 use crate::alloc::{
-    DynAllocator, TursoIteratorExt, TursoSliceExt, TursoTryWithCapacityExt, TursoVecExt,
+    DynAllocator, TursoAllocExt, TursoIteratorExt, TursoSliceExt, TursoTryWithCapacityExt,
+    TursoVecExt,
 };
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::{AccumulatorFunc, AlterTableFunc, WindowFunc};
@@ -2864,7 +2865,7 @@ pub fn op_blob_read(
     let amt = blob_reg_usize(state, *amount, "BlobRead", "amount")?;
     // The callee validates (off, amt) against the value's length before sizing `out`,
     // so a hostile amount register cannot force an allocation here.
-    let mut out = Vec::new();
+    let mut out: crate::ValueBlob = TursoAllocExt::new();
     match blob_btree_cursor(state, *cursor, "BlobRead")?
         .blob_read_column(*column, off, amt, &mut out)
     {
@@ -2873,7 +2874,7 @@ pub fn op_blob_read(
         Err(LimboError::BlobHandleExpired) => return Ok(blob_expired_ack(state, *dest)),
         Err(err) => return Err(err),
     }
-    state.registers[*dest].set_value(Value::Blob(crate::types::value_blob_from_slice(&out)?));
+    state.registers[*dest].set_value(Value::Blob(out));
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }


### PR DESCRIPTION
## Description
Change the Vec typing to use the TursoAllocator. This avoids intermediate allocations