### PR TITLE
core/mvcc: transfer write set during rollback

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -924,6 +924,10 @@ impl<A: RowVersionAllocator> WriteSet<A> {
         self.entries.iter()
     }
 
+    fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
+
     /// Retain entries where `keep(rowid, row_versions)` returns true.
     fn retain<F: FnMut(&RowID, &RowVersions<A>) -> bool>(&mut self, mut keep: F) {
         let seen = &mut self.seen;
@@ -935,11 +939,6 @@ impl<A: RowVersionAllocator> WriteSet<A> {
                 false
             }
         });
-    }
-
-    /// Clones the write set into a [Vec].
-    fn to_vec(&self) -> Vec<(RowID, RowVersions<A>)> {
-        self.entries.clone()
     }
 }
 
@@ -1015,6 +1014,11 @@ impl<A: RowVersionAllocator> Transaction<A> {
     }
 
     fn insert_to_write_set(&self, id: RowID, row_versions: RowVersions<A>) {
+        turso_assert_eq!(
+            self.state,
+            TransactionState::Active,
+            "write set cannot be modified unless transaction is active"
+        );
         // Always record in the current savepoint's `newly_added_to_write_set`.
         // Duplicates here are harmless: `rollback_savepoint_changes` collects
         // touched rowids into a BTreeSet (dedup), and the actual write_set
@@ -6318,6 +6322,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         self.rollback_tx_inner(tx_id, Some(connection), db);
     }
 
+    #[aristo::intent(
+        "Rollback freezes the transaction before transferring its complete write set; every \
+         recorded row-version chain is then visited from the transferred storage without cloning \
+         or allocating a snapshot.",
+        verify = "test",
+        id = "rollback_transfers_frozen_write_set"
+    )]
     fn rollback_tx_inner(&self, tx_id: TxID, connection: Option<&Connection>, db: usize) {
         let tx_unlocked = self
             .txs
@@ -6355,10 +6366,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             self.release_exclusive_tx(&tx_id);
         }
 
-        // Snapshot under the lock so we can drop it before recursing into
-        // `rollback_rowid` (which may take other locks).
-        let write_set_snapshot: Vec<(RowID, RowVersions<A>)> = tx.write_set.lock().to_vec();
-        for (_rowid, row_versions) in &write_set_snapshot {
+        // Transfer ownership under the lock so we can drop it before taking
+        // row-version-chain locks.
+        let write_set = tx.write_set.lock().take();
+        for (_rowid, row_versions) in write_set.entries {
             for rv in row_versions.write().iter_mut() {
                 rollback_row_version(tx_id, rv);
             }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -175,6 +175,38 @@ impl FailOnDemandAlloc {
     }
 }
 
+#[test]
+fn write_set_take_transfers_entries_without_cloning() {
+    let mut write_set = WriteSet::<TursoAllocator>::new();
+    let row_versions: RowVersions<TursoAllocator> = Arc::new(RwLock::new(crate::alloc::vec![]));
+    let row_id = RowID::new(MVTableId::from(-2), RowKey::Int(1));
+
+    assert!(write_set.insert(row_id, Arc::clone(&row_versions)));
+    let entries_ptr = write_set.entries.as_ptr();
+    let entries_capacity = write_set.entries.capacity();
+    let strong_count = Arc::strong_count(&row_versions);
+
+    let transferred = write_set.take();
+
+    assert!(write_set.entries.is_empty());
+    assert!(write_set.seen.is_empty());
+    assert_eq!(transferred.entries.as_ptr(), entries_ptr);
+    assert_eq!(transferred.entries.capacity(), entries_capacity);
+    assert_eq!(transferred.seen.len(), 1);
+    assert_eq!(Arc::strong_count(&row_versions), strong_count);
+    assert!(Arc::ptr_eq(&transferred.entries[0].1, &row_versions));
+}
+
+#[test]
+#[should_panic(expected = "write set cannot be modified unless transaction is active")]
+fn aborted_transaction_rejects_write_set_insert() {
+    let tx = new_tx(1, 1, TransactionState::Aborted);
+    let row_versions: RowVersions<TursoAllocator> = Arc::new(RwLock::new(crate::alloc::vec![]));
+    let row_id = RowID::new(MVTableId::from(-2), RowKey::Int(1));
+
+    tx.insert_to_write_set(row_id, row_versions);
+}
+
 unsafe impl crate::alloc::ApiAllocator for FailOnDemandAlloc {
     fn allocate(
         &self,


### PR DESCRIPTION
## Description

- transfer ownership of an aborted transaction's write set instead of cloning it during dropped-commit cleanup
- reject write-set mutation once a transaction is no longer active
- document the freeze-and-transfer invariant with an Aristo intent
- cover ownership transfer and aborted-state rejection with focused unit tests

## Context

`cleanup_unfinished_commit` can run while handling another failure, so allocating a write-set snapshot there is unsafe. The rollback path already has exclusive ownership of mutations from the transaction's connection. Moving the complete write set out under its mutex preserves the existing storage, releases the mutex before taking row-version-chain locks, and avoids the snapshot allocation.