### PR TITLE
Add PostgreSQL-compatible get_byte and set_byte functions

### DIFF
--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -380,6 +380,8 @@ pub fn resolve_builtin_function(name: &str, arg_count: usize) -> crate::Result<O
         "julianday" => Ok(Some(Func::Scalar(ScalarFunc::JulianDay))),
         "hex" => Ok(Some(Func::Scalar(ScalarFunc::Hex))),
         "unhex" => Ok(Some(Func::Scalar(ScalarFunc::Unhex))),
+        "get_byte" => Ok(Some(Func::Scalar(ScalarFunc::GetByte))),
+        "set_byte" => Ok(Some(Func::Scalar(ScalarFunc::SetByte))),
         "zeroblob" => Ok(Some(Func::Scalar(ScalarFunc::ZeroBlob))),
         "soundex" => Ok(Some(Func::Scalar(ScalarFunc::Soundex))),
         "table_columns_json_array" => Ok(Some(Func::Scalar(ScalarFunc::TableColumnsJsonArray))),

--- a/core/function.rs
+++ b/core/function.rs
@@ -763,6 +763,8 @@ pub enum ScalarFunc {
     JulianDay,
     Hex,
     Unhex,
+    GetByte,
+    SetByte,
     ZeroBlob,
     LastInsertRowid,
     Replace,
@@ -896,6 +898,8 @@ impl Deterministic for ScalarFunc {
             ScalarFunc::JulianDay => false,
             ScalarFunc::Hex => true,
             ScalarFunc::Unhex => true,
+            ScalarFunc::GetByte => true,
+            ScalarFunc::SetByte => true,
             ScalarFunc::ZeroBlob => true,
             ScalarFunc::LastInsertRowid => false,
             ScalarFunc::Replace => true,
@@ -1040,6 +1044,8 @@ impl Display for ScalarFunc {
             Self::UnixEpoch => "unixepoch",
             Self::Hex => "hex",
             Self::Unhex => "unhex",
+            Self::GetByte => "get_byte",
+            Self::SetByte => "set_byte",
             Self::ZeroBlob => "zeroblob",
             Self::LastInsertRowid => "last_insert_rowid",
             Self::Replace => "replace",
@@ -1179,9 +1185,10 @@ impl ScalarFunc {
             | Self::Nullif
             | Self::IfNull
             | Self::Likelihood
+            | Self::GetByte
             | Self::TimeDiff => &[2],
             // 3-arg
-            Self::Iif | Self::Replace => &[3],
+            Self::Iif | Self::Replace | Self::SetByte => &[3],
             // Multi-arity (one row per valid arity)
             Self::Like => &[2, 3],
             Self::Trim | Self::LTrim | Self::RTrim | Self::Round | Self::Unhex => &[1, 2],

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -1670,6 +1670,14 @@ pub fn translate_expr(
                             target_register,
                             func_ctx,
                         ),
+                        ScalarFunc::GetByte | ScalarFunc::SetByte => translate_function(
+                            program,
+                            args,
+                            referenced_tables,
+                            resolver,
+                            target_register,
+                            func_ctx,
+                        ),
                         ScalarFunc::Likely => {
                             if args.len() != 1 {
                                 crate::bail_parse_error!(

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -431,6 +431,7 @@ fn resolve_scalar_func_return_type(
         | ScalarFunc::NumericLt
         | ScalarFunc::NumericEq
         | ScalarFunc::ValidateIpAddr
+        | ScalarFunc::GetByte
         | ScalarFunc::UnixEpoch => Ok(CheckExprType::Integer),
 
         // Functions that always return TEXT
@@ -464,7 +465,7 @@ fn resolve_scalar_func_return_type(
         ScalarFunc::Round | ScalarFunc::JulianDay => Ok(CheckExprType::Real),
 
         // Functions that always return BLOB
-        ScalarFunc::RandomBlob | ScalarFunc::ZeroBlob | ScalarFunc::Unhex => {
+        ScalarFunc::RandomBlob | ScalarFunc::ZeroBlob | ScalarFunc::Unhex | ScalarFunc::SetByte => {
             Ok(CheckExprType::Blob)
         }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8061,6 +8061,19 @@ pub fn op_function(
                     .exec_unhex(ignored_chars.map(|x| x.get_value()));
                 state.registers[*dest].set_value(result);
             }
+            ScalarFunc::GetByte => {
+                let value = state.registers[*start_reg].get_value();
+                let offset = state.registers[*start_reg + 1].get_value();
+                let result = value.exec_get_byte(offset)?;
+                state.registers[*dest].set_value(result);
+            }
+            ScalarFunc::SetByte => {
+                let value = state.registers[*start_reg].get_value();
+                let offset = state.registers[*start_reg + 1].get_value();
+                let new_value = state.registers[*start_reg + 2].get_value();
+                let result = value.exec_set_byte(offset, new_value)?;
+                state.registers[*dest].set_value(result);
+            }
             ScalarFunc::Random => {
                 state.registers[*dest].set_int(pager.io.generate_random_number());
             }

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -707,6 +707,71 @@ impl Value {
         }
     }
 
+    /// Returns the raw bytes backing this value for the byte-manipulation
+    /// functions (`get_byte`/`set_byte`). Blobs are used verbatim; text is
+    /// interpreted as its UTF-8 bytes; numbers use their textual form (matching
+    /// how `hex()` coerces). `NULL` has no byte view.
+    fn byte_view(&self) -> Option<std::borrow::Cow<'_, [u8]>> {
+        match self {
+            Value::Null => None,
+            Value::Blob(b) => Some(std::borrow::Cow::Borrowed(b)),
+            Value::Text(t) => Some(std::borrow::Cow::Borrowed(t.as_str().as_bytes())),
+            Value::Numeric(_) => Some(std::borrow::Cow::Owned(self.to_string().into_bytes())),
+        }
+    }
+
+    /// PostgreSQL `get_byte(bytea, offset)`: returns the byte at the 0-based
+    /// `offset` as an integer in the range 0..=255. Raises an error when the
+    /// offset falls outside `0..length-1`, matching PostgreSQL exactly. A `NULL`
+    /// input or offset yields `NULL`.
+    pub fn exec_get_byte(&self, offset: &Value) -> Result<Value> {
+        let Value::Numeric(Numeric::Integer(offset)) = offset.exec_cast("INT")? else {
+            return Ok(Value::Null);
+        };
+        let Some(bytes) = self.byte_view() else {
+            return Ok(Value::Null);
+        };
+        let len = bytes.len() as i64;
+        if offset < 0 || offset >= len {
+            return Err(LimboError::InvalidArgument(format!(
+                "index {offset} out of valid range, 0..{}",
+                len - 1
+            )));
+        }
+        Ok(Value::from_i64(i64::from(bytes[offset as usize])))
+    }
+
+    /// PostgreSQL `set_byte(bytea, offset, newvalue)`: returns a blob with the
+    /// byte at the 0-based `offset` replaced by the low 8 bits of `newvalue`.
+    /// Raises an error when the offset falls outside `0..length-1`, matching
+    /// PostgreSQL exactly. A `NULL` input, offset, or value yields `NULL`.
+    pub fn exec_set_byte(&self, offset: &Value, new_value: &Value) -> Result<Value> {
+        let Value::Numeric(Numeric::Integer(offset)) = offset.exec_cast("INT")? else {
+            return Ok(Value::Null);
+        };
+        let Value::Numeric(Numeric::Integer(new_value)) = new_value.exec_cast("INT")? else {
+            return Ok(Value::Null);
+        };
+        let Some(bytes) = self.byte_view() else {
+            return Ok(Value::Null);
+        };
+        let len = bytes.len() as i64;
+        if offset < 0 || offset >= len {
+            return Err(LimboError::InvalidArgument(format!(
+                "index {offset} out of valid range, 0..{}",
+                len - 1
+            )));
+        }
+        // Copy into a Turso-allocated blob, then overwrite the target byte in place.
+        let mut result = Value::from_slice(&bytes)?;
+        if let Value::Blob(out) = &mut result {
+            // PostgreSQL truncates the new value to its low 8 bits (int32 stored
+            // into an unsigned char), so e.g. 6555 becomes 155 and -1 becomes 255.
+            out[offset as usize] = new_value as u8;
+        }
+        Ok(result)
+    }
+
     pub fn exec_unicode(&self) -> Value {
         match self {
             Value::Text(_) | Value::Numeric(_) | Value::Blob(_) => {
@@ -1780,6 +1845,94 @@ mod tests {
                 "Wrong subtract for lhs: {lhs}, rhs: {rhs}"
             );
         }
+    }
+
+    #[test]
+    fn test_exec_get_byte() {
+        // PostgreSQL: get_byte('\x1234567890'::bytea, 4) = 144.
+        let input = blob(&[0x12, 0x34, 0x56, 0x78, 0x90]);
+        assert_eq!(
+            input.exec_get_byte(&Value::from_i64(4)).unwrap(),
+            Value::from_i64(144)
+        );
+        assert_eq!(
+            input.exec_get_byte(&Value::from_i64(0)).unwrap(),
+            Value::from_i64(0x12)
+        );
+        // Text is read as its UTF-8 bytes ('A' == 65).
+        assert_eq!(
+            Value::build_text("ABC")
+                .exec_get_byte(&Value::from_i64(0))
+                .unwrap(),
+            Value::from_i64(65)
+        );
+        // A text offset that casts to an integer is accepted.
+        assert_eq!(
+            input.exec_get_byte(&Value::build_text("4")).unwrap(),
+            Value::from_i64(144)
+        );
+        // NULL input or offset yields NULL.
+        assert_eq!(
+            Value::Null.exec_get_byte(&Value::from_i64(0)).unwrap(),
+            Value::Null
+        );
+        assert_eq!(input.exec_get_byte(&Value::Null).unwrap(), Value::Null);
+        // Out-of-range and negative offsets raise an error, as does an empty blob.
+        assert!(input.exec_get_byte(&Value::from_i64(5)).is_err());
+        assert!(input.exec_get_byte(&Value::from_i64(-1)).is_err());
+        assert!(blob(&[]).exec_get_byte(&Value::from_i64(0)).is_err());
+    }
+
+    #[test]
+    fn test_exec_set_byte() {
+        let input = blob(&[0x12, 0x34, 0x56, 0x78, 0x90]);
+        // PostgreSQL: set_byte('\x1234567890'::bytea, 4, 64) = '\x1234567840'.
+        assert_eq!(
+            input
+                .exec_set_byte(&Value::from_i64(4), &Value::from_i64(64))
+                .unwrap(),
+            blob(&[0x12, 0x34, 0x56, 0x78, 0x40])
+        );
+        // Values wrap to their low 8 bits: 6555 & 0xff == 0x9b.
+        assert_eq!(
+            input
+                .exec_set_byte(&Value::from_i64(4), &Value::from_i64(6555))
+                .unwrap(),
+            blob(&[0x12, 0x34, 0x56, 0x78, 0x9b])
+        );
+        // Negative values wrap too: -1 -> 0xff.
+        assert_eq!(
+            input
+                .exec_set_byte(&Value::from_i64(4), &Value::from_i64(-1))
+                .unwrap(),
+            blob(&[0x12, 0x34, 0x56, 0x78, 0xff])
+        );
+        // NULL in any argument yields NULL.
+        assert_eq!(
+            Value::Null
+                .exec_set_byte(&Value::from_i64(0), &Value::from_i64(1))
+                .unwrap(),
+            Value::Null
+        );
+        assert_eq!(
+            input
+                .exec_set_byte(&Value::Null, &Value::from_i64(1))
+                .unwrap(),
+            Value::Null
+        );
+        assert_eq!(
+            input
+                .exec_set_byte(&Value::from_i64(0), &Value::Null)
+                .unwrap(),
+            Value::Null
+        );
+        // Out-of-range and negative offsets raise an error.
+        assert!(input
+            .exec_set_byte(&Value::from_i64(5), &Value::from_i64(0))
+            .is_err());
+        assert!(input
+            .exec_set_byte(&Value::from_i64(-1), &Value::from_i64(0))
+            .is_err());
     }
 
     #[test]

--- a/testing/sqltests/turso-tests/get-set-byte.sqltest
+++ b/testing/sqltests/turso-tests/get-set-byte.sqltest
@@ -1,0 +1,166 @@
+# get_byte / set_byte — PostgreSQL-compatible byte access on blobs.
+# These functions do not exist in SQLite, so they live in turso-tests.
+@database :memory:
+
+# --- get_byte -------------------------------------------------------------
+
+# PostgreSQL: get_byte('\x1234567890'::bytea, 4) = 144
+test get-byte-basic {
+    SELECT get_byte(x'1234567890', 4);
+}
+expect {
+    144
+}
+
+test get-byte-first {
+    SELECT get_byte(x'1234567890', 0);
+}
+expect {
+    18
+}
+
+test get-byte-last {
+    SELECT get_byte(x'1234567890', 4);
+}
+expect {
+    144
+}
+
+# Text input is read as its UTF-8 bytes ('A' == 65).
+test get-byte-text-input {
+    SELECT get_byte('ABC', 0);
+}
+expect {
+    65
+}
+
+# A text offset that casts to an integer is accepted.
+test get-byte-text-offset {
+    SELECT get_byte(x'1234567890', '4');
+}
+expect {
+    144
+}
+
+# NULL input or offset yields NULL.
+test get-byte-null-input {
+    SELECT get_byte(NULL, 4);
+}
+expect {
+
+}
+
+test get-byte-null-offset {
+    SELECT get_byte(x'1234567890', NULL);
+}
+expect {
+
+}
+
+# Out-of-range and negative offsets raise an error (PostgreSQL parity).
+test get-byte-offset-too-large {
+    SELECT get_byte(x'1234567890', 99);
+}
+expect error {
+    index 99 out of valid range, 0..4
+}
+
+test get-byte-offset-at-length {
+    SELECT get_byte(x'1234567890', 5);
+}
+expect error {
+    index 5 out of valid range, 0..4
+}
+
+test get-byte-offset-negative {
+    SELECT get_byte(x'1234567890', -1);
+}
+expect error {
+    index -1 out of valid range, 0..4
+}
+
+# Empty blob: valid range is 0..-1, so any offset errors.
+test get-byte-empty-blob {
+    SELECT get_byte(x'', 0);
+}
+expect error {
+    index 0 out of valid range, 0..-1
+}
+
+# --- set_byte -------------------------------------------------------------
+
+# PostgreSQL: set_byte('\x1234567890'::bytea, 4, 64) = '\x1234567840'
+test set-byte-basic {
+    SELECT hex(set_byte(x'1234567890', 4, 64));
+}
+expect {
+    1234567840
+}
+
+test set-byte-first {
+    SELECT hex(set_byte(x'1234567890', 0, 255));
+}
+expect {
+    FF34567890
+}
+
+# Values wrap to their low 8 bits: 6555 & 0xff == 0x9b.
+test set-byte-wraps-high {
+    SELECT hex(set_byte(x'1234567890', 4, 6555));
+}
+expect {
+    123456789B
+}
+
+# Negative values wrap too: -1 -> 0xff.
+test set-byte-wraps-negative {
+    SELECT hex(set_byte(x'1234567890', 4, -1));
+}
+expect {
+    12345678FF
+}
+
+# set_byte always returns a blob, even for text input.
+test set-byte-text-input {
+    SELECT hex(set_byte('ABC', 0, 90));
+}
+expect {
+    5A4243
+}
+
+# NULL in any argument yields NULL.
+test set-byte-null-input {
+    SELECT hex(set_byte(NULL, 4, 64));
+}
+expect {
+
+}
+
+test set-byte-null-offset {
+    SELECT hex(set_byte(x'1234567890', NULL, 64));
+}
+expect {
+
+}
+
+test set-byte-null-value {
+    SELECT hex(set_byte(x'1234567890', 4, NULL));
+}
+expect {
+
+}
+
+# Out-of-range and negative offsets raise an error (PostgreSQL parity).
+test set-byte-offset-too-large {
+    SELECT set_byte(x'1234567890', 99, 11);
+}
+expect error {
+    index 99 out of valid range, 0..4
+}
+
+test set-byte-offset-negative {
+    SELECT set_byte(x'1234567890', -1, 11);
+}
+expect error {
+    index -1 out of valid range, 0..4
+}


### PR DESCRIPTION
## What

Adds two scalar functions that read and write individual bytes of a blob, matching PostgreSQL's [binary-string functions](https://www.postgresql.org/docs/current/functions-binarystring.html) exactly:

```sql
get_byte('\x1234567890', 4)     -- 144   (byte at 0-based offset, as int 0..255)
set_byte('\x1234567890', 4, 64) -- \x1234567840  (blob with that byte replaced)
```

## Semantics (PostgreSQL parity)

- Offset is **0-based**; an out-of-range or negative offset raises `index N out of valid range, 0..len-1` (an empty blob reports `0..-1`, matching PG).
- `set_byte` stores the **low 8 bits** of the new value (`6555` → `0x9B`, `-1` → `0xFF`) and always returns a blob.
- `NULL` in any argument yields `NULL`.
- Text inputs are read as their UTF-8 bytes and numeric inputs as their textual form, consistent with how `hex()` / `octet_length()` coerce.

## Implementation

- `core/vdbe/value.rs` — `exec_get_byte` / `exec_set_byte` plus a small `byte_view()` helper.
- `core/function.rs` — new `ScalarFunc` variants, name resolution, arities (`[2]` / `[3]`), determinism.
- `core/vdbe/execute.rs` — dispatch arms.
- `core/translate/expr/translator.rs` — routed through the existing generic `translate_function` arg-loader (no new plumbing).
- `core/translate/schema.rs` — CHECK-expression return types (`get_byte` → Integer, `set_byte` → Blob).

## Tests

- Unit tests in `core/vdbe/value.rs` covering the happy path, wrap-around, text/numeric coercion, NULL propagation, and error cases.
- `testing/sqltests/turso-tests/get-set-byte.sqltest` — 21 tests. Placed in `turso-tests/` (not run against SQLite) since SQLite has no equivalent function.

`cargo fmt`, `cargo clippy --workspace --all-features --all-targets -- --deny=warnings`, and the new tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
