### PR TITLE
core/mvcc: allocate stored records through MVStore allocator

### DIFF
--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -563,7 +563,7 @@ impl AggregateEvalState {
 
                         // Seek in the index to find if this row exists
                         let seek_result = return_if_io!(cursors.index_cursor.seek(
-                            SeekKey::IndexKey(&index_record),
+                            SeekKey::IndexKey(index_record.as_record_ref()),
                             SeekOp::GE { eq_only: true }
                         ));
 
@@ -2302,7 +2302,7 @@ impl ScanState {
     ) -> Result<IOResult<Option<Value>>> {
         let seek_result = return_if_io!(cursors
             .index_cursor
-            .seek(SeekKey::IndexKey(index_record), seek_op));
+            .seek(SeekKey::IndexKey(index_record.as_record_ref()), seek_op));
         if !matches!(seek_result, SeekResult::Found) {
             return Ok(IOResult::Done(None));
         }
@@ -2733,7 +2733,7 @@ impl FetchDistinctState {
                     let index_record = ImmutableRecord::from_values(&index_key, index_key.len())?;
 
                     let seek_result = return_if_io!(cursors.index_cursor.seek(
-                        SeekKey::IndexKey(&index_record),
+                        SeekKey::IndexKey(index_record.as_record_ref()),
                         SeekOp::GE { eq_only: true }
                     ));
 

--- a/core/incremental/join_operator.rs
+++ b/core/incremental/join_operator.rs
@@ -58,7 +58,7 @@ fn read_next_join_row(
 
     let seek_result = return_if_io!(cursors
         .index_cursor
-        .seek(SeekKey::IndexKey(&index_record), seek_op));
+        .seek(SeekKey::IndexKey(index_record.as_record_ref()), seek_op));
 
     if !matches!(seek_result, SeekResult::Found) {
         return Ok(IOResult::Done(None));

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -116,7 +116,7 @@ impl WriteRow {
                         ImmutableRecord::from_values(&index_values, index_values.len())?;
 
                     let res = return_if_io!(cursors.index_cursor.seek(
-                        SeekKey::IndexKey(&index_record),
+                        SeekKey::IndexKey(index_record.as_record_ref()),
                         SeekOp::GE { eq_only: true }
                     ));
 
@@ -257,7 +257,7 @@ impl WriteRow {
                     // Create the index record with the rowid appended
                     let index_record =
                         ImmutableRecord::from_values(&index_values, index_values.len())?;
-                    let index_btree_key = BTreeKey::new_index_key(&index_record);
+                    let index_btree_key = BTreeKey::new_index_key(index_record.as_record_ref());
 
                     // Mark as Done before index insert to avoid retry on I/O
                     *self = WriteRow::Done;

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -713,7 +713,10 @@ impl HybridBTreeDirectory {
 
         // Blocking seek to first chunk
         loop {
-            match cursor.seek(SeekKey::IndexKey(&seek_key), SeekOp::GE { eq_only: false }) {
+            match cursor.seek(
+                SeekKey::IndexKey(seek_key.as_record_ref()),
+                SeekOp::GE { eq_only: false },
+            ) {
                 Ok(IOResult::Done(SeekResult::Found)) => break,
                 Ok(IOResult::Done(SeekResult::TryAdvance)) => {
                     loop {
@@ -892,7 +895,10 @@ impl HybridBTreeDirectory {
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         loop {
-            match cursor.seek(SeekKey::IndexKey(&seek_key), SeekOp::GE { eq_only: false }) {
+            match cursor.seek(
+                SeekKey::IndexKey(seek_key.as_record_ref()),
+                SeekOp::GE { eq_only: false },
+            ) {
                 Ok(IOResult::Done(SeekResult::Found)) => break,
                 Ok(IOResult::Done(SeekResult::TryAdvance)) => {
                     loop {
@@ -2049,9 +2055,10 @@ impl FtsCursor {
                         3,
                     )?;
 
-                    let seek_result =
-                        return_if_io!(cursor
-                            .seek(SeekKey::IndexKey(&seek_key), SeekOp::GE { eq_only: false }));
+                    let seek_result = return_if_io!(cursor.seek(
+                        SeekKey::IndexKey(seek_key.as_record_ref()),
+                        SeekOp::GE { eq_only: false },
+                    ));
 
                     match seek_result {
                         SeekResult::NotFound => {
@@ -2236,9 +2243,10 @@ impl FtsCursor {
 
                     // Seek to find the correct position using GE (not eq_only)
                     // This positions the cursor at or after where the record should be inserted
-                    let _result = return_if_io!(
-                        cursor.seek(SeekKey::IndexKey(&record), SeekOp::GE { eq_only: false })
-                    );
+                    let _result = return_if_io!(cursor.seek(
+                        SeekKey::IndexKey(record.as_record_ref()),
+                        SeekOp::GE { eq_only: false },
+                    ));
 
                     // don't do insert in same state to avoid re-seeking on IO
                     self.state = FtsState::InsertingWrite {
@@ -2259,7 +2267,7 @@ impl FtsCursor {
                     })?;
 
                     // the cursor should be positioned correctly after seek
-                    return_if_io!(cursor.insert(&BTreeKey::IndexKey(record)));
+                    return_if_io!(cursor.insert(&BTreeKey::IndexKey(record.as_record_ref())));
 
                     // Move to next chunk
                     self.state = FtsState::FlushingWrites {
@@ -2319,9 +2327,10 @@ impl FtsCursor {
                         3,
                     )?;
 
-                    let _result =
-                        return_if_io!(cursor
-                            .seek(SeekKey::IndexKey(&seek_key), SeekOp::GE { eq_only: false }));
+                    let _result = return_if_io!(cursor.seek(
+                        SeekKey::IndexKey(seek_key.as_record_ref()),
+                        SeekOp::GE { eq_only: false },
+                    ));
 
                     self.state = FtsState::DeletingRecord {
                         deletes: std::mem::take(deletes),

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -617,9 +617,10 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "key must be present in SeekInverted state".to_string(),
                         ));
                     };
-                    let result =
-                        return_if_io!(inverted_cursor
-                            .seek(SeekKey::IndexKey(k), SeekOp::GE { eq_only: true }));
+                    let result = return_if_io!(inverted_cursor.seek(
+                        SeekKey::IndexKey(k.as_record_ref()),
+                        SeekOp::GE { eq_only: true }
+                    ));
                     tracing::debug!("insert_state: seek: result={:?}", result);
                     self.insert_state = VectorSparseInvertedIndexInsertState::InsertInverted {
                         vector: vector.take(),
@@ -641,7 +642,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "key must be present in InsertInverted state".to_string(),
                         ));
                     };
-                    return_if_io!(inverted_cursor.insert(&BTreeKey::IndexKey(k)));
+                    return_if_io!(inverted_cursor.insert(&BTreeKey::IndexKey(k.as_record_ref())));
 
                     let Some(v) = vector.as_ref() else {
                         return Err(LimboError::InternalError(
@@ -670,9 +671,10 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "key must be present in SeekStats state".to_string(),
                         ));
                     };
-                    let result = return_if_io!(
-                        stats_cursor.seek(SeekKey::IndexKey(k), SeekOp::GE { eq_only: true })
-                    );
+                    let result = return_if_io!(stats_cursor.seek(
+                        SeekKey::IndexKey(k.as_record_ref()),
+                        SeekOp::GE { eq_only: true },
+                    ));
                     match result {
                         SeekResult::Found => {
                             self.insert_state = VectorSparseInvertedIndexInsertState::ReadStats {
@@ -767,7 +769,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "key must be present in UpdateStats state".to_string(),
                         ));
                     };
-                    return_if_io!(stats_cursor.insert(&BTreeKey::IndexKey(k)));
+                    return_if_io!(stats_cursor.insert(&BTreeKey::IndexKey(k.as_record_ref())));
 
                     self.insert_state = VectorSparseInvertedIndexInsertState::Prepare {
                         vector: vector.take(),
@@ -877,9 +879,10 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "key must be present in SeekInverted state".to_string(),
                         ));
                     };
-                    let result = return_if_io!(
-                        cursor.seek(SeekKey::IndexKey(k), SeekOp::GE { eq_only: true })
-                    );
+                    let result = return_if_io!(cursor.seek(
+                        SeekKey::IndexKey(k.as_record_ref()),
+                        SeekOp::GE { eq_only: true },
+                    ));
                     match result {
                         SeekResult::Found => {
                             self.delete_state =
@@ -957,9 +960,10 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "key must be present in SeekStats state".to_string(),
                         ));
                     };
-                    let result = return_if_io!(
-                        stats_cursor.seek(SeekKey::IndexKey(k), SeekOp::GE { eq_only: true })
-                    );
+                    let result = return_if_io!(stats_cursor.seek(
+                        SeekKey::IndexKey(k.as_record_ref()),
+                        SeekOp::GE { eq_only: true },
+                    ));
                     match result {
                         SeekResult::Found => {
                             self.delete_state = VectorSparseInvertedIndexDeleteState::ReadStats {
@@ -1026,7 +1030,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "key must be present in UpdateStats state".to_string(),
                         ));
                     };
-                    return_if_io!(stats_cursor.insert(&BTreeKey::IndexKey(k)));
+                    return_if_io!(stats_cursor.insert(&BTreeKey::IndexKey(k.as_record_ref())));
 
                     self.delete_state = VectorSparseInvertedIndexDeleteState::Prepare {
                         vector: vector.take(),
@@ -1162,9 +1166,10 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "key must be present in CollectComponentsSeek state".to_string(),
                         ));
                     };
-                    let result = return_if_io!(
-                        stats.seek(SeekKey::IndexKey(k), SeekOp::GE { eq_only: true })
-                    );
+                    let result = return_if_io!(stats.seek(
+                        SeekKey::IndexKey(k.as_record_ref()),
+                        SeekOp::GE { eq_only: true },
+                    ));
                     match result {
                         SeekResult::Found => {
                             self.search_state =
@@ -1308,9 +1313,10 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             "key must be present in Seek state".to_string(),
                         ));
                     };
-                    let result = return_if_io!(
-                        inverted.seek(SeekKey::IndexKey(k), SeekOp::GE { eq_only: false })
-                    );
+                    let result = return_if_io!(inverted.seek(
+                        SeekKey::IndexKey(k.as_record_ref()),
+                        SeekOp::GE { eq_only: false },
+                    ));
                     match result {
                         SeekResult::Found => {
                             let Some(comp) = component.take() else {

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -13,8 +13,8 @@ use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
 use crate::sync::Arc;
 use crate::translate::plan::IterationDirection;
 use crate::types::{
-    compare_immutable, IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekKey, SeekOp,
-    SeekResult, Value,
+    compare_immutable, IOCompletions, IOResult, ImmutableRecord, ImmutableRecordRef, IndexInfo,
+    SeekKey, SeekOp, SeekResult, Value,
 };
 use crate::vdbe::make_record;
 use crate::vdbe::Register;
@@ -170,9 +170,14 @@ fn current_pos_matches_seek_key(
     seek_key: &SeekKey<'_>,
     mv_cursor_type: &MvccCursorType,
 ) -> Result<bool> {
-    Ok(match (current_row_id, seek_key) {
-        (RowKey::Int(current), SeekKey::TableRowId(target)) => *current == *target,
-        (RowKey::Record(current), SeekKey::IndexKey(target)) => {
+    Ok(match current_row_id {
+        RowKey::Int(current) => {
+            matches!(seek_key, SeekKey::TableRowId(target) if current == target)
+        }
+        RowKey::Record(current) => {
+            let Some(target) = seek_key.index_record() else {
+                return Ok(false);
+            };
             let MvccCursorType::Index(index_info) = mv_cursor_type else {
                 return Ok(false);
             };
@@ -184,7 +189,6 @@ fn current_pos_matches_seek_key(
                 .collect();
             compare_immutable(target.get_values()?, current.key.get_values()?, &key_info).is_eq()
         }
-        _ => false,
     })
 }
 
@@ -1040,12 +1044,15 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                         }
                     }
                 };
-                Ok(maybe_record.map(|record| {
-                    RowKey::Record(Arc::new(SortableIndexKey {
-                        key: record.clone(),
-                        metadata: index_info.clone(),
-                    }))
-                }))
+                let Some(record) = maybe_record else {
+                    return Ok(None);
+                };
+                let key = SortableIndexKey::new_from_record_ref_in(
+                    ImmutableRecordRef::from_bin_record(record.get_payload()),
+                    index_info.clone(),
+                    self.db.allocator(),
+                )?;
+                Ok(Some(RowKey::Record(Arc::new(key))))
             }
         }
     }
@@ -1484,7 +1491,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         op: SeekOp,
     ) -> Result<IOResult<SeekResult>> {
         let record = make_record(registers, &0, &registers.len())?;
-        self.seek(SeekKey::IndexKey(&record), op)
+        self.seek(SeekKey::IndexKey(record.as_record_ref()), op)
     }
 
     fn seek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>> {
@@ -1598,7 +1605,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                                 };
                             }
                         }
-                        SeekKey::IndexKey(index_key) => {
+                        SeekKey::IndexKey(_) => {
+                            let index_key = seek_key.index_record().expect("index key");
                             let index_info = {
                                 let MvccCursorType::Index(index_info) = &self.mv_cursor_type else {
                                     panic!("SeekKey::IndexKey requires Index cursor type");
@@ -1611,8 +1619,11 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                                     self.db.allocator(),
                                 )?)
                             };
-                            let sortable_key =
-                                SortableIndexKey::new_from_record((*index_key).clone(), index_info);
+                            let sortable_key = SortableIndexKey::new_from_record_ref_in(
+                                index_key.clone(),
+                                index_info,
+                                self.db.allocator(),
+                            )?;
 
                             // Seek in MVCC (synchronous)
                             let mvcc_rowid = self.db.seek_index(
@@ -1673,7 +1684,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                             // Check if the winner matches the seek key
                             let found = match &seek_key {
                                 SeekKey::TableRowId(row_id) => winner_key == RowKey::Int(*row_id),
-                                SeekKey::IndexKey(index_key) => {
+                                SeekKey::IndexKey(_) => {
+                                    let index_key = seek_key.index_record().expect("index key");
                                     let RowKey::Record(found_key) = &winner_key else {
                                         panic!("Found rowid is not a record");
                                     };
@@ -1726,14 +1738,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     fn insert(&mut self, key: &BTreeKey) -> Result<IOResult<()>> {
         let row_id = match key {
             BTreeKey::TableRowId((rowid, _)) => RowID::new(self.table_id, RowKey::Int(*rowid)),
-            BTreeKey::IndexKey(record) => {
+            BTreeKey::IndexKey(_) => {
                 let MvccCursorType::Index(index_info) = &self.mv_cursor_type else {
                     panic!("BTreeKey::IndexKey requires Index cursor type");
                 };
-                let sortable_key = Arc::new(SortableIndexKey::new_from_record(
-                    (*record).clone(),
+                let record = key.get_record().expect("index key has a record");
+                let sortable_key = Arc::new(SortableIndexKey::new_from_record_ref_in(
+                    record,
                     index_info.clone(),
-                ));
+                    self.db.allocator(),
+                )?);
                 RowID::new(self.table_id, RowKey::Record(sortable_key))
             }
         };
@@ -1759,10 +1773,13 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 )
             }
             MvccCursorType::Index(_) => {
-                let BTreeKey::IndexKey(record) = key else {
-                    return Err(LimboError::InternalError(
-                        "Index cursor requires an IndexKey".to_string(),
-                    ));
+                let record = match key {
+                    BTreeKey::IndexKey(_) => key.get_record().expect("index key has a record"),
+                    BTreeKey::TableRowId(_) => {
+                        return Err(LimboError::InternalError(
+                            "Index cursor requires an IndexKey".to_string(),
+                        ));
+                    }
                 };
                 Ok(Row::new_index_row(row_id, record.column_count()))
             }

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -13,8 +13,8 @@ use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
 use crate::sync::Arc;
 use crate::translate::plan::IterationDirection;
 use crate::types::{
-    compare_immutable, IOCompletions, IOResult, ImmutableRecord, ImmutableRecordRef, IndexInfo,
-    SeekKey, SeekOp, SeekResult, Value,
+    compare_immutable, IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekKey, SeekOp,
+    SeekResult, Value,
 };
 use crate::vdbe::make_record;
 use crate::vdbe::Register;
@@ -1047,8 +1047,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                 let Some(record) = maybe_record else {
                     return Ok(None);
                 };
-                let key = SortableIndexKey::new_from_record_ref_in(
-                    ImmutableRecordRef::from_bin_record(record.get_payload()),
+                let key = SortableIndexKey::new_from_payload_in(
+                    record,
                     index_info.clone(),
                     self.db.allocator(),
                 )?;
@@ -1619,8 +1619,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                                     self.db.allocator(),
                                 )?)
                             };
-                            let sortable_key = SortableIndexKey::new_from_record_ref_in(
-                                index_key.clone(),
+                            let sortable_key = SortableIndexKey::new_from_payload_in(
+                                index_key,
                                 index_info,
                                 self.db.allocator(),
                             )?;
@@ -1743,7 +1743,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                     panic!("BTreeKey::IndexKey requires Index cursor type");
                 };
                 let record = key.get_record().expect("index key has a record");
-                let sortable_key = Arc::new(SortableIndexKey::new_from_record_ref_in(
+                let sortable_key = Arc::new(SortableIndexKey::new_from_payload_in(
                     record,
                     index_info.clone(),
                     self.db.allocator(),

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -170,14 +170,9 @@ fn current_pos_matches_seek_key(
     seek_key: &SeekKey<'_>,
     mv_cursor_type: &MvccCursorType,
 ) -> Result<bool> {
-    Ok(match current_row_id {
-        RowKey::Int(current) => {
-            matches!(seek_key, SeekKey::TableRowId(target) if current == target)
-        }
-        RowKey::Record(current) => {
-            let Some(target) = seek_key.index_record() else {
-                return Ok(false);
-            };
+    Ok(match (current_row_id, seek_key) {
+        (RowKey::Int(current), SeekKey::TableRowId(target)) => *current == *target,
+        (RowKey::Record(current), SeekKey::IndexKey(target)) => {
             let MvccCursorType::Index(index_info) = mv_cursor_type else {
                 return Ok(false);
             };
@@ -189,6 +184,7 @@ fn current_pos_matches_seek_key(
                 .collect();
             compare_immutable(target.get_values()?, current.key.get_values()?, &key_info).is_eq()
         }
+        _ => false,
     })
 }
 
@@ -1605,8 +1601,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                                 };
                             }
                         }
-                        SeekKey::IndexKey(_) => {
-                            let index_key = seek_key.index_record().expect("index key");
+                        SeekKey::IndexKey(index_key) => {
                             let index_info = {
                                 let MvccCursorType::Index(index_info) = &self.mv_cursor_type else {
                                     panic!("SeekKey::IndexKey requires Index cursor type");
@@ -1684,8 +1679,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                             // Check if the winner matches the seek key
                             let found = match &seek_key {
                                 SeekKey::TableRowId(row_id) => winner_key == RowKey::Int(*row_id),
-                                SeekKey::IndexKey(_) => {
-                                    let index_key = seek_key.index_record().expect("index key");
+                                SeekKey::IndexKey(index_key) => {
                                     let RowKey::Record(found_key) = &winner_key else {
                                         panic!("Found rowid is not a record");
                                     };
@@ -1738,11 +1732,10 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     fn insert(&mut self, key: &BTreeKey) -> Result<IOResult<()>> {
         let row_id = match key {
             BTreeKey::TableRowId((rowid, _)) => RowID::new(self.table_id, RowKey::Int(*rowid)),
-            BTreeKey::IndexKey(_) => {
+            BTreeKey::IndexKey(record) => {
                 let MvccCursorType::Index(index_info) = &self.mv_cursor_type else {
                     panic!("BTreeKey::IndexKey requires Index cursor type");
                 };
-                let record = key.get_record().expect("index key has a record");
                 let sortable_key = Arc::new(SortableIndexKey::new_from_payload_in(
                     record,
                     index_info.clone(),
@@ -1773,13 +1766,10 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 )
             }
             MvccCursorType::Index(_) => {
-                let record = match key {
-                    BTreeKey::IndexKey(_) => key.get_record().expect("index key has a record"),
-                    BTreeKey::TableRowId(_) => {
-                        return Err(LimboError::InternalError(
-                            "Index cursor requires an IndexKey".to_string(),
-                        ));
-                    }
+                let BTreeKey::IndexKey(record) = key else {
+                    return Err(LimboError::InternalError(
+                        "Index cursor requires an IndexKey".to_string(),
+                    ));
                 };
                 Ok(Row::new_index_row(row_id, record.column_count()))
             }

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -3313,7 +3313,12 @@ mod tests {
             2,
         )
         .unwrap();
-        let sortable_key = SortableIndexKey::new_from_record(key_record, index_info);
+        let sortable_key = SortableIndexKey::new_from_record_ref_in(
+            ImmutableRecordRef::from_bin_record(key_record.get_payload()),
+            index_info,
+            TursoAllocator,
+        )
+        .unwrap();
         let key_arc = Arc::new(sortable_key.clone());
         let row = Row::new_index_row(
             RowID::new(index_id, RowKey::Record(Arc::new(sortable_key))),

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -3313,12 +3313,8 @@ mod tests {
             2,
         )
         .unwrap();
-        let sortable_key = SortableIndexKey::new_from_record_ref_in(
-            ImmutableRecordRef::from_bin_record(key_record.get_payload()),
-            index_info,
-            TursoAllocator,
-        )
-        .unwrap();
+        let sortable_key =
+            SortableIndexKey::new_from_payload_in(&key_record, index_info, TursoAllocator).unwrap();
         let key_arc = Arc::new(sortable_key.clone());
         let row = Row::new_index_row(
             RowID::new(index_id, RowKey::Record(Arc::new(sortable_key))),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -183,22 +183,15 @@ pub struct SortableIndexKey {
 }
 
 impl SortableIndexKey {
-    pub fn new_from_record_ref_in<A: ConcurrentAllocator>(
-        key: ImmutableRecordRef<'_>,
-        metadata: Arc<IndexInfo>,
-        alloc: A,
-    ) -> Result<Self, TryReserveError> {
-        Self::new_from_payload_in(key.get_payload(), metadata, alloc)
-    }
-
-    fn new_from_payload_in<A: ConcurrentAllocator>(
-        payload: &[u8],
+    pub fn new_from_payload_in<A: ConcurrentAllocator>(
+        payload: impl AsRef<[u8]>,
         metadata: Arc<IndexInfo>,
         alloc: A,
     ) -> Result<Self, TryReserveError> {
         Ok(Self {
             key: ImmutableRecordRef::from_shared_record(crate::alloc::try_arc_slice_from_slice_in(
-                payload, alloc,
+                payload.as_ref(),
+                alloc,
             )?),
             metadata,
         })

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -177,27 +177,29 @@ impl std::fmt::Display for MVTableId {
 #[derive(Debug, Clone)]
 pub struct SortableIndexKey {
     /// The key as bytes.
-    pub key: ImmutableRecord,
+    pub key: ImmutableRecordRef<'static>,
     /// Index metadata containing sort orders and collations
     pub metadata: Arc<IndexInfo>,
 }
 
 impl SortableIndexKey {
-    pub fn new_from_bytes(key_bytes: crate::ValueBlob, metadata: Arc<IndexInfo>) -> Self {
-        Self {
-            key: ImmutableRecord::from_bin_record(key_bytes),
-            metadata,
-        }
+    pub fn new_from_record_ref_in<A: ConcurrentAllocator>(
+        key: ImmutableRecordRef<'_>,
+        metadata: Arc<IndexInfo>,
+        alloc: A,
+    ) -> Result<Self, TryReserveError> {
+        Self::new_from_payload_in(key.get_payload(), metadata, alloc)
     }
 
-    pub fn new_from_record(key: ImmutableRecord, metadata: Arc<IndexInfo>) -> Self {
-        Self { key, metadata }
-    }
-
-    pub fn new_from_values(values: Vec<ValueRef>, metadata: Arc<IndexInfo>) -> Result<Self> {
-        let len = values.len();
+    fn new_from_payload_in<A: ConcurrentAllocator>(
+        payload: &[u8],
+        metadata: Arc<IndexInfo>,
+        alloc: A,
+    ) -> Result<Self, TryReserveError> {
         Ok(Self {
-            key: ImmutableRecord::from_values(values, len)?,
+            key: ImmutableRecordRef::from_shared_record(crate::alloc::try_arc_slice_from_slice_in(
+                payload, alloc,
+            )?),
             metadata,
         })
     }
@@ -277,7 +279,7 @@ impl SortableIndexKey {
 
 impl PartialEq for SortableIndexKey {
     fn eq(&self, other: &Self) -> bool {
-        if self.key == other.key {
+        if self.key.get_payload() == other.key.get_payload() {
             return true;
         }
 
@@ -388,7 +390,7 @@ impl Row {
     pub fn payload(&self) -> &[u8] {
         match self.id.row_id {
             RowKey::Int(_) => self.data.as_deref().expect("table rows should have data"),
-            RowKey::Record(ref sortable_key) => sortable_key.key.as_blob(),
+            RowKey::Record(ref sortable_key) => sortable_key.key.get_payload(),
         }
     }
 }
@@ -3402,7 +3404,7 @@ impl StateTransition for WriteRowStateMachine {
                 // Position the cursor by seeking to the row position
                 let seek_key = match &self.row.id.row_id {
                     RowKey::Int(row_id) => SeekKey::TableRowId(*row_id),
-                    RowKey::Record(record) => SeekKey::IndexKey(&record.key),
+                    RowKey::Record(record) => SeekKey::IndexKey(record.key.reborrow()),
                 };
 
                 match self
@@ -3448,7 +3450,7 @@ impl StateTransition for WriteRowStateMachine {
                 // Insert the record into the B-tree
                 let key = match &self.row.id.row_id {
                     RowKey::Int(row_id) => BTreeKey::new_table_rowid(*row_id, self.record.as_ref()),
-                    RowKey::Record(record) => BTreeKey::new_index_key(&record.key),
+                    RowKey::Record(record) => BTreeKey::new_index_key(record.key.reborrow()),
                 };
 
                 match self
@@ -3509,7 +3511,7 @@ impl StateTransition for DeleteRowStateMachine {
             DeleteRowState::Seek => {
                 let seek_key = match &self.rowid.row_id {
                     RowKey::Int(row_id) => SeekKey::TableRowId(*row_id),
-                    RowKey::Record(record) => SeekKey::IndexKey(&record.key),
+                    RowKey::Record(record) => SeekKey::IndexKey(record.key.reborrow()),
                 };
 
                 match self
@@ -7773,7 +7775,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         // Row lives only in the B-tree: record a B-tree-resident tombstone so the collection
         // (btree_resident => exists_in_db_file) materializes the physical delete.
         let version_id = self.get_version_id();
-        let row = Row::new_table_row(rowid, &[], num_cols).expect("empty tombstone row");
+        let row = Row::new_table_row_in(rowid, &[], num_cols, self.alloc.clone())
+            .expect("empty tombstone row");
         let _ = self.insert_version_raw(
             &mut versions,
             RowVersion {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -280,15 +280,11 @@ fn index_key_payload_allocation_uses_passed_allocator() {
     );
 
     alloc.fail_allocations(true);
-    let result = SortableIndexKey::new_from_record_ref_in(
-        record_ref.clone(),
-        index_info.clone(),
-        alloc.clone(),
-    );
+    let result = SortableIndexKey::new_from_payload_in(&record, index_info.clone(), alloc.clone());
     assert!(matches!(result, Err(crate::alloc::TryReserveError)));
 
     alloc.fail_allocations(false);
-    let key = SortableIndexKey::new_from_record_ref_in(record_ref, index_info, alloc).unwrap();
+    let key = SortableIndexKey::new_from_payload_in(record_ref, index_info, alloc).unwrap();
     assert_eq!(key.key.get_payload(), record.get_payload());
 }
 
@@ -6736,12 +6732,8 @@ fn test_index_finger_no_spurious_dep_on_stepped_over_key() {
     let idx_key = |v: i64| {
         let rec = crate::types::ImmutableRecord::from_values(&[Value::from_i64(v)], 1).unwrap();
         std::sync::Arc::new(
-            SortableIndexKey::new_from_record_ref_in(
-                ImmutableRecordRef::from_bin_record(rec.get_payload()),
-                info.clone(),
-                crate::alloc::TursoAllocator,
-            )
-            .unwrap(),
+            SortableIndexKey::new_from_payload_in(&rec, info.clone(), crate::alloc::TursoAllocator)
+                .unwrap(),
         )
     };
 
@@ -8746,12 +8738,9 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
         2,
     )
     .unwrap();
-    let row_key = SortableIndexKey::new_from_record_ref_in(
-        ImmutableRecordRef::from_bin_record(record.get_payload()),
-        index_info,
-        crate::alloc::TursoAllocator,
-    )
-    .unwrap();
+    let row_key =
+        SortableIndexKey::new_from_payload_in(&record, index_info, crate::alloc::TursoAllocator)
+            .unwrap();
     let row = Row::new_index_row(
         RowID::new(MVTableId::new(-42), RowKey::Record(Arc::new(row_key))),
         index.columns.len(),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -259,6 +259,61 @@ fn row_payload_allocation_uses_passed_allocator() {
     assert_eq!(row.payload(), &[1, 2, 3]);
 }
 
+#[cfg(nightly)]
+#[test]
+fn index_key_payload_allocation_uses_passed_allocator() {
+    let alloc = FailOnDemandAlloc::default();
+    let record = ImmutableRecord::from_values(&[Value::from_i64(42)], 1).unwrap();
+    let record_ref = ImmutableRecordRef::from_bin_record(record.get_payload());
+    let index_info = Arc::new(
+        IndexInfo::new(
+            [crate::types::KeyInfo {
+                sort_order: turso_parser::ast::SortOrder::Asc,
+                collation: crate::translate::collate::CollationSeq::Binary,
+                nulls_order: None,
+            }],
+            false,
+            1,
+            false,
+        )
+        .unwrap(),
+    );
+
+    alloc.fail_allocations(true);
+    let result = SortableIndexKey::new_from_record_ref_in(
+        record_ref.clone(),
+        index_info.clone(),
+        alloc.clone(),
+    );
+    assert!(matches!(result, Err(crate::alloc::TryReserveError)));
+
+    alloc.fail_allocations(false);
+    let key = SortableIndexKey::new_from_record_ref_in(record_ref, index_info, alloc).unwrap();
+    assert_eq!(key.key.get_payload(), record.get_payload());
+}
+
+#[cfg(nightly)]
+#[test]
+#[should_panic(expected = "empty tombstone row")]
+fn seqcompact_tombstone_payload_uses_store_allocator() {
+    let alloc = FailOnDemandAlloc::default();
+    let store = MvStore::new_in(
+        MvccClock::new(),
+        test_mvcc_storage("mv-store-seqcompact-allocator.db-log"),
+        alloc.clone(),
+        false,
+    )
+    .unwrap();
+    let row_id = RowID::new(MVTableId::from(-2), RowKey::Int(1));
+    let versions = store
+        .get_or_create_table_row_versions(row_id.clone())
+        .unwrap();
+    versions.write().try_reserve(1).unwrap();
+
+    alloc.fail_allocations(true);
+    store.seqcompact_commit_delete(row_id, 1, 10);
+}
+
 #[test]
 fn mv_store_insert_allocation_failure_leaves_tx_state_untouched() {
     let alloc = FailOnDemandAlloc::default();
@@ -6680,7 +6735,14 @@ fn test_index_finger_no_spurious_dep_on_stepped_over_key() {
     );
     let idx_key = |v: i64| {
         let rec = crate::types::ImmutableRecord::from_values(&[Value::from_i64(v)], 1).unwrap();
-        std::sync::Arc::new(SortableIndexKey::new_from_record(rec, info.clone()))
+        std::sync::Arc::new(
+            SortableIndexKey::new_from_record_ref_in(
+                ImmutableRecordRef::from_bin_record(rec.get_payload()),
+                info.clone(),
+                crate::alloc::TursoAllocator,
+            )
+            .unwrap(),
+        )
     };
 
     // Reader started after the writer's prepared end_ts → speculatively
@@ -8628,7 +8690,7 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
         let seek_result = run_pager_until_done(
             || {
                 cursor.write().seek(
-                    crate::types::SeekKey::IndexKey(&record),
+                    crate::types::SeekKey::IndexKey(record.as_record_ref()),
                     crate::types::SeekOp::GE { eq_only: true },
                 )
             },
@@ -8639,7 +8701,11 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
             run_pager_until_done(|| cursor.write().next(), pager.as_ref()).unwrap();
         }
         run_pager_until_done(
-            || cursor.write().insert(&BTreeKey::new_index_key(&record)),
+            || {
+                cursor
+                    .write()
+                    .insert(&BTreeKey::new_index_key(record.as_record_ref()))
+            },
             pager.as_ref(),
         )
         .unwrap();
@@ -8654,7 +8720,7 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
         let seek_result = run_pager_until_done(
             || {
                 cursor.write().seek(
-                    crate::types::SeekKey::IndexKey(&record),
+                    crate::types::SeekKey::IndexKey(record.as_record_ref()),
                     crate::types::SeekOp::GE { eq_only: true },
                 )
             },
@@ -8680,7 +8746,12 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
         2,
     )
     .unwrap();
-    let row_key = SortableIndexKey::new_from_record(record, index_info);
+    let row_key = SortableIndexKey::new_from_record_ref_in(
+        ImmutableRecordRef::from_bin_record(record.get_payload()),
+        index_info,
+        crate::alloc::TursoAllocator,
+    )
+    .unwrap();
     let row = Row::new_index_row(
         RowID::new(MVTableId::new(-42), RowKey::Record(Arc::new(row_key))),
         index.columns.len(),

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -3556,10 +3556,12 @@ impl StreamingLogicalLogReader {
                 commit_ts,
                 btree_resident,
             } => {
-                let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
+                let key_record = crate::types::ImmutableRecordRef::from_bin_record(&payload);
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Upsert)?;
-                let key = Arc::new(SortableIndexKey::new_from_record(key_record, index_info));
+                let key = Arc::new(SortableIndexKey::new_from_record_ref_in(
+                    key_record, index_info, alloc,
+                )?);
                 let rowid = RowID::new(table_id, RowKey::Record(key));
                 let row = Row::new_index_row(rowid.clone(), column_count);
                 Ok(StreamingResult::UpsertIndexRow {
@@ -3575,10 +3577,12 @@ impl StreamingLogicalLogReader {
                 commit_ts,
                 btree_resident,
             } => {
-                let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
+                let key_record = crate::types::ImmutableRecordRef::from_bin_record(&payload);
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Delete)?;
-                let key = Arc::new(SortableIndexKey::new_from_record(key_record, index_info));
+                let key = Arc::new(SortableIndexKey::new_from_record_ref_in(
+                    key_record, index_info, alloc,
+                )?);
                 let rowid = RowID::new(table_id, RowKey::Record(key));
                 let row = Row::new_index_row(rowid.clone(), column_count);
                 Ok(StreamingResult::DeleteIndexRow {
@@ -4792,7 +4796,12 @@ mod tests {
                 2,
             )
             .unwrap();
-            let sortable_key = SortableIndexKey::new_from_record(key_record, index_info.clone());
+            let sortable_key = SortableIndexKey::new_from_record_ref_in(
+                ImmutableRecordRef::from_bin_record(key_record.get_payload()),
+                index_info.clone(),
+                crate::alloc::TursoAllocator,
+            )
+            .unwrap();
             let index_rowid = RowID::new(index_id, RowKey::Record(Arc::new(sortable_key)));
 
             // Use read_from_table_or_index to read the index row
@@ -6309,7 +6318,12 @@ mod tests {
             2,
         )
         .unwrap();
-        let sortable_key = SortableIndexKey::new_from_record(key_record, test_index_info());
+        let sortable_key = SortableIndexKey::new_from_record_ref_in(
+            ImmutableRecordRef::from_bin_record(key_record.get_payload()),
+            test_index_info(),
+            crate::alloc::TursoAllocator,
+        )
+        .unwrap();
         let row_id = RowID::new(table_id, RowKey::Record(Arc::new(sortable_key)));
         let row = Row::new_index_row(row_id, 2);
         crate::mvcc::database::RowVersion {
@@ -6381,10 +6395,12 @@ mod tests {
         commit_ts: u64,
         is_delete: bool,
     ) -> crate::mvcc::database::RowVersion {
-        let sortable_key = SortableIndexKey::new_from_bytes(
-            crate::types::value_blob_from_slice(&payload_bytes).expect(crate::alloc::ALLOC_ERR_MSG),
+        let sortable_key = SortableIndexKey::new_from_record_ref_in(
+            ImmutableRecordRef::from_bin_record(&payload_bytes),
             test_index_info(),
-        );
+            crate::alloc::TursoAllocator,
+        )
+        .unwrap();
         let row_id = RowID::new(table_id, RowKey::Record(Arc::new(sortable_key)));
         let row = Row::new_index_row(row_id, 2);
         crate::mvcc::database::RowVersion {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -3559,7 +3559,7 @@ impl StreamingLogicalLogReader {
                 let key_record = crate::types::ImmutableRecordRef::from_bin_record(&payload);
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Upsert)?;
-                let key = Arc::new(SortableIndexKey::new_from_record_ref_in(
+                let key = Arc::new(SortableIndexKey::new_from_payload_in(
                     key_record, index_info, alloc,
                 )?);
                 let rowid = RowID::new(table_id, RowKey::Record(key));
@@ -3580,7 +3580,7 @@ impl StreamingLogicalLogReader {
                 let key_record = crate::types::ImmutableRecordRef::from_bin_record(&payload);
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Delete)?;
-                let key = Arc::new(SortableIndexKey::new_from_record_ref_in(
+                let key = Arc::new(SortableIndexKey::new_from_payload_in(
                     key_record, index_info, alloc,
                 )?);
                 let rowid = RowID::new(table_id, RowKey::Record(key));
@@ -4796,8 +4796,8 @@ mod tests {
                 2,
             )
             .unwrap();
-            let sortable_key = SortableIndexKey::new_from_record_ref_in(
-                ImmutableRecordRef::from_bin_record(key_record.get_payload()),
+            let sortable_key = SortableIndexKey::new_from_payload_in(
+                &key_record,
                 index_info.clone(),
                 crate::alloc::TursoAllocator,
             )
@@ -6318,8 +6318,8 @@ mod tests {
             2,
         )
         .unwrap();
-        let sortable_key = SortableIndexKey::new_from_record_ref_in(
-            ImmutableRecordRef::from_bin_record(key_record.get_payload()),
+        let sortable_key = SortableIndexKey::new_from_payload_in(
+            &key_record,
             test_index_info(),
             crate::alloc::TursoAllocator,
         )
@@ -6395,8 +6395,8 @@ mod tests {
         commit_ts: u64,
         is_delete: bool,
     ) -> crate::mvcc::database::RowVersion {
-        let sortable_key = SortableIndexKey::new_from_record_ref_in(
-            ImmutableRecordRef::from_bin_record(&payload_bytes),
+        let sortable_key = SortableIndexKey::new_from_payload_in(
+            &payload_bytes,
             test_index_info(),
             crate::alloc::TursoAllocator,
         )

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -49,8 +49,8 @@ use crate::{
     numeric::Numeric,
     return_corrupt, return_if_io,
     types::{
-        compare_immutable_iter, AsValueRef, IOResult, ImmutableRecord, SeekKey, SeekOp, Value,
-        ValueRef,
+        compare_immutable_iter, AsValueRef, IOResult, ImmutableRecord, ImmutableRecordRef, SeekKey,
+        SeekOp, Value, ValueRef,
     },
     LimboError, Result,
 };
@@ -411,26 +411,28 @@ impl std::ops::Deref for PinGuard {
 #[derive(Clone, Debug)]
 pub enum BTreeKey<'a> {
     TableRowId((i64, Option<&'a ImmutableRecord>)),
-    IndexKey(&'a ImmutableRecord),
+    IndexKey(ImmutableRecordRef<'a>),
 }
 
-impl BTreeKey<'_> {
+impl<'a> BTreeKey<'a> {
     /// Create a new table rowid key from a rowid and an optional immutable record.
     /// The record is optional because it may not be available when the key is created.
-    pub fn new_table_rowid(rowid: i64, record: Option<&ImmutableRecord>) -> BTreeKey<'_> {
+    pub fn new_table_rowid(rowid: i64, record: Option<&'a ImmutableRecord>) -> Self {
         BTreeKey::TableRowId((rowid, record))
     }
 
     /// Create a new index key from an immutable record.
-    pub fn new_index_key(record: &ImmutableRecord) -> BTreeKey<'_> {
+    pub fn new_index_key(record: ImmutableRecordRef<'a>) -> Self {
         BTreeKey::IndexKey(record)
     }
 
     /// Get the record, if present. Index will always be present,
-    pub fn get_record(&self) -> Option<&'_ ImmutableRecord> {
+    pub fn get_record(&self) -> Option<ImmutableRecordRef<'_>> {
         match self {
-            BTreeKey::TableRowId((_, record)) => *record,
-            BTreeKey::IndexKey(record) => Some(record),
+            BTreeKey::TableRowId((_, record)) => {
+                record.map(|record| ImmutableRecordRef::from_bin_record(record.get_payload()))
+            }
+            BTreeKey::IndexKey(record) => Some(record.reborrow()),
         }
     }
 
@@ -446,7 +448,9 @@ impl BTreeKey<'_> {
     fn to_rowid(&self) -> i64 {
         match self {
             BTreeKey::TableRowId((rowid, _)) => *rowid,
-            BTreeKey::IndexKey(_) => panic!("BTreeKey::to_rowid called on IndexKey"),
+            BTreeKey::IndexKey(_) => {
+                panic!("BTreeKey::to_rowid called on IndexKey")
+            }
         }
     }
 }
@@ -532,7 +536,7 @@ pub enum CursorContextKey {
 
     /// If we are in an index tree we can then reuse this field to save
     /// our cursor information
-    IndexKeyRowId(ImmutableRecord),
+    IndexKeyRowId(ImmutableRecordRef<'static>),
 }
 
 #[derive(Debug)]
@@ -543,18 +547,18 @@ pub struct CursorContext {
 
 impl CursorContext {
     fn seek_eq_only(key: &BTreeKey<'_>) -> Self {
-        Self {
-            key: key.into(),
-            seek_op: SeekOp::GE { eq_only: true },
-        }
-    }
-}
-
-impl From<&BTreeKey<'_>> for CursorContextKey {
-    fn from(key: &BTreeKey<'_>) -> Self {
-        match key {
+        let key = match key {
             BTreeKey::TableRowId((rowid, _)) => CursorContextKey::TableRowId(*rowid),
-            BTreeKey::IndexKey(record) => CursorContextKey::IndexKeyRowId((*record).clone()),
+            BTreeKey::IndexKey(record) => {
+                let payload = crate::types::value_blob_from_slice(record.get_payload())
+                    .expect(crate::alloc::ALLOC_ERR_MSG);
+                let owned = ImmutableRecord::from_bin_record(payload);
+                CursorContextKey::IndexKeyRowId(ImmutableRecordRef::from_owned_record(owned))
+            }
+        };
+        Self {
+            key,
+            seek_op: SeekOp::GE { eq_only: true },
         }
     }
 }
@@ -1605,12 +1609,10 @@ impl BTreeCursor {
     /// or e.g. find the first record greater than the seek key in a range query (e.g. SELECT * FROM table WHERE col > 10).
     /// We don't include the rowid in the comparison and that's why the last value from the record is not included.
     fn do_seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>> {
-        let ret = return_if_io!(match key {
-            SeekKey::TableRowId(rowid) => {
-                self.tablebtree_seek(rowid, op)
-            }
-            SeekKey::IndexKey(index_key) => {
-                self.indexbtree_seek(index_key, op)
+        let ret = return_if_io!(match &key {
+            SeekKey::TableRowId(rowid) => self.tablebtree_seek(*rowid, op),
+            SeekKey::IndexKey(_) => {
+                self.indexbtree_seek(key.index_record().expect("index key"), op)
             }
         });
         self.valid_state = CursorValidState::Valid;
@@ -1924,7 +1926,7 @@ impl BTreeCursor {
     #[cfg_attr(debug_assertions, instrument(skip(self, index_key), level = Level::DEBUG))]
     fn indexbtree_move_to(
         &mut self,
-        index_key: &ImmutableRecord,
+        index_key: &ImmutableRecordRef<'_>,
         cmp: SeekOp,
     ) -> Result<IOResult<()>> {
         let key_values = index_key.get_values()?;
@@ -2424,7 +2426,7 @@ impl BTreeCursor {
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     fn indexbtree_seek(
         &mut self,
-        key: &ImmutableRecord,
+        key: &ImmutableRecordRef<'_>,
         seek_op: SeekOp,
     ) -> Result<IOResult<SeekResult>> {
         let key_values = key.get_values()?;
@@ -2743,9 +2745,11 @@ impl BTreeCursor {
                     }
                 }
                 MoveToState::MoveToPage => {
-                    let ret = match key {
-                        SeekKey::TableRowId(rowid_key) => self.tablebtree_move_to(rowid_key, cmp),
-                        SeekKey::IndexKey(index_key) => self.indexbtree_move_to(index_key, cmp),
+                    let ret = match &key {
+                        SeekKey::TableRowId(rowid_key) => self.tablebtree_move_to(*rowid_key, cmp),
+                        SeekKey::IndexKey(_) => {
+                            self.indexbtree_move_to(key.index_record().expect("index key"), cmp)
+                        }
                     };
                     return_if_io!(ret);
                     self.move_to_state = MoveToState::Start;
@@ -2868,7 +2872,7 @@ impl BTreeCursor {
                         bkey.maybe_rowid(),
                         new_payload,
                         *cell_idx,
-                        record,
+                        &record,
                         usable_space,
                         self.pager.clone(),
                         fill_cell_payload_state,
@@ -2919,7 +2923,7 @@ impl BTreeCursor {
                     let mut state = state.take().expect("state should be present");
                     let cell_idx = *cell_idx;
                     if let IOResult::IO(io) =
-                        self.overwrite_cell(&page, cell_idx, record, &mut state)?
+                        self.overwrite_cell(&page, cell_idx, &record, &mut state)?
                     {
                         let CursorState::Write(write_state) = &mut self.state else {
                             panic!("expected write state");
@@ -5842,7 +5846,7 @@ impl BTreeCursor {
         &mut self,
         page: &PageRef,
         cell_idx: usize,
-        record: &ImmutableRecord,
+        record: &ImmutableRecordRef<'_>,
         state: &mut OverwriteCellState,
     ) -> Result<IOResult<()>> {
         loop {
@@ -6077,7 +6081,7 @@ impl BTreeCursor {
         let ctx = self.context.take().unwrap();
         let seek_key = match ctx.key {
             CursorContextKey::TableRowId(rowid) => SeekKey::TableRowId(rowid),
-            CursorContextKey::IndexKeyRowId(ref record) => SeekKey::IndexKey(record),
+            CursorContextKey::IndexKeyRowId(ref record) => SeekKey::IndexKey(record.clone()),
         };
         let res = self.seek(seek_key, ctx.seek_op)?;
         match res {
@@ -6515,7 +6519,9 @@ impl CursorTrait for BTreeCursor {
                             None => unreachable!("there should've been a record"),
                         };
                         CursorContext {
-                            key: CursorContextKey::IndexKeyRowId(record),
+                            key: CursorContextKey::IndexKeyRowId(
+                                ImmutableRecordRef::from_owned_record(record),
+                            ),
                             seek_op: SeekOp::GE { eq_only: true },
                         }
                     } else {
@@ -7216,7 +7222,7 @@ impl CursorTrait for BTreeCursor {
             owned
         };
         self.save_context(CursorContext {
-            key: CursorContextKey::IndexKeyRowId(cloned),
+            key: CursorContextKey::IndexKeyRowId(ImmutableRecordRef::from_owned_record(cloned)),
             seek_op: SeekOp::GE { eq_only: true },
         });
         Ok(IOResult::Done(SavePositionResult::Saved))
@@ -9556,7 +9562,7 @@ fn fill_cell_payload(
     int_key: Option<i64>,
     cell_payload: &mut Vec<u8>,
     cell_idx: usize,
-    record: &ImmutableRecord,
+    record: &impl AsRef<[u8]>,
     usable_space: usize,
     pager: Arc<Pager>,
     fill_cell_payload_state: &mut FillCellPayloadState,
@@ -9564,7 +9570,7 @@ fn fill_cell_payload(
     let overflow_page_pointer_size = 4;
     let overflow_page_data_size = usable_space - overflow_page_pointer_size;
     let result = loop {
-        let record_buf = record.get_payload();
+        let record_buf = record.as_ref();
         match fill_cell_payload_state {
             FillCellPayloadState::Start => {
                 let page_contents = page.get_contents();
@@ -10868,14 +10874,14 @@ mod tests {
                 run_until_done(
                     || {
                         let record = ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
-                        let key = SeekKey::IndexKey(&record);
+                        let key = SeekKey::IndexKey(record.as_record_ref());
                         cursor.seek(key, SeekOp::GE { eq_only: true })
                     },
                     pager.deref(),
                 )
                 .unwrap();
                 run_until_done(
-                    || cursor.insert(&BTreeKey::new_index_key(&value)),
+                    || cursor.insert(&BTreeKey::new_index_key(value.as_record_ref())),
                     pager.deref(),
                 )
                 .unwrap();
@@ -10899,7 +10905,9 @@ mod tests {
                             .collect::<Vec<_>>();
                         cursor.seek(
                             SeekKey::IndexKey(
-                                &ImmutableRecord::from_registers(&regs, regs.len()).unwrap(),
+                                ImmutableRecord::from_registers(&regs, regs.len())
+                                    .unwrap()
+                                    .as_record_ref(),
                             ),
                             SeekOp::GE { eq_only: true },
                         )
@@ -11061,7 +11069,7 @@ mod tests {
                         || {
                             let record =
                                 ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
-                            let key = SeekKey::IndexKey(&record);
+                            let key = SeekKey::IndexKey(record.as_record_ref());
                             cursor.seek(key, SeekOp::GE { eq_only: true })
                         },
                         pager.deref(),
@@ -11071,7 +11079,7 @@ mod tests {
                         run_until_done(|| cursor.next(), pager.deref()).unwrap();
                     }
                     run_until_done(
-                        || cursor.insert(&BTreeKey::new_index_key(&value)),
+                        || cursor.insert(&BTreeKey::new_index_key(value.as_record_ref())),
                         pager.deref(),
                     )
                     .unwrap();
@@ -11093,8 +11101,10 @@ mod tests {
                         // Seek to the key to delete
                         let seek_result = run_until_done(
                             || {
-                                cursor
-                                    .seek(SeekKey::IndexKey(&record), SeekOp::GE { eq_only: true })
+                                cursor.seek(
+                                    SeekKey::IndexKey(record.as_record_ref()),
+                                    SeekOp::GE { eq_only: true },
+                                )
                             },
                             pager.deref(),
                         )
@@ -11152,7 +11162,9 @@ mod tests {
                     )];
                     cursor.seek(
                         SeekKey::IndexKey(
-                            &ImmutableRecord::from_registers(&regs, regs.len()).unwrap(),
+                            ImmutableRecord::from_registers(&regs, regs.len())
+                                .unwrap()
+                                .as_record_ref(),
                         ),
                         SeekOp::GE { eq_only: true },
                     )

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -429,9 +429,7 @@ impl<'a> BTreeKey<'a> {
     /// Get the record, if present. Index will always be present,
     pub fn get_record(&self) -> Option<ImmutableRecordRef<'_>> {
         match self {
-            BTreeKey::TableRowId((_, record)) => {
-                record.map(|record| ImmutableRecordRef::from_bin_record(record.get_payload()))
-            }
+            BTreeKey::TableRowId((_, record)) => record.map(|record| record.as_record_ref()),
             BTreeKey::IndexKey(record) => Some(record.reborrow()),
         }
     }
@@ -1611,8 +1609,8 @@ impl BTreeCursor {
     fn do_seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>> {
         let ret = return_if_io!(match &key {
             SeekKey::TableRowId(rowid) => self.tablebtree_seek(*rowid, op),
-            SeekKey::IndexKey(_) => {
-                self.indexbtree_seek(key.index_record().expect("index key"), op)
+            SeekKey::IndexKey(index_key) => {
+                self.indexbtree_seek(index_key, op)
             }
         });
         self.valid_state = CursorValidState::Valid;
@@ -2747,9 +2745,7 @@ impl BTreeCursor {
                 MoveToState::MoveToPage => {
                     let ret = match &key {
                         SeekKey::TableRowId(rowid_key) => self.tablebtree_move_to(*rowid_key, cmp),
-                        SeekKey::IndexKey(_) => {
-                            self.indexbtree_move_to(key.index_record().expect("index key"), cmp)
-                        }
+                        SeekKey::IndexKey(index_key) => self.indexbtree_move_to(index_key, cmp),
                     };
                     return_if_io!(ret);
                     self.move_to_state = MoveToState::Start;
@@ -6081,7 +6077,7 @@ impl BTreeCursor {
         let ctx = self.context.take().unwrap();
         let seek_key = match ctx.key {
             CursorContextKey::TableRowId(rowid) => SeekKey::TableRowId(rowid),
-            CursorContextKey::IndexKeyRowId(ref record) => SeekKey::IndexKey(record.clone()),
+            CursorContextKey::IndexKeyRowId(ref record) => SeekKey::IndexKey(record.reborrow()),
         };
         let res = self.seek(seek_key, ctx.seek_op)?;
         match res {

--- a/core/types.rs
+++ b/core/types.rs
@@ -1136,6 +1136,26 @@ mod immutable_record {
         }
     }
 
+    impl PartialEq for ImmutableRecordRef<'_> {
+        fn eq(&self, other: &Self) -> bool {
+            self.get_payload() == other.get_payload()
+        }
+    }
+
+    impl Eq for ImmutableRecordRef<'_> {}
+
+    impl AsRef<[u8]> for ImmutableRecordRef<'_> {
+        fn as_ref(&self) -> &[u8] {
+            self.get_payload()
+        }
+    }
+
+    impl AsRef<[u8]> for ImmutableRecord {
+        fn as_ref(&self) -> &[u8] {
+            self.get_payload()
+        }
+    }
+
     struct AppendWriter<'a> {
         buf: &'a mut ValueBlob,
         pos: usize,
@@ -1469,6 +1489,16 @@ mod immutable_record {
         }
 
         #[inline]
+        pub fn contains_null(&self) -> Result<bool> {
+            contains_null(self.get_payload())
+        }
+
+        #[inline]
+        pub fn last_value(&self) -> Option<Result<ValueRef<'_>>> {
+            last_value(self.get_payload())
+        }
+
+        #[inline]
         pub fn get_value_opt(&self, idx: usize) -> Option<ValueRef<'_>> {
             value_opt(self.get_payload(), idx)
         }
@@ -1677,6 +1707,12 @@ mod immutable_record {
         #[inline]
         pub fn is_invalidated(&self) -> bool {
             self.get_payload().is_empty()
+        }
+
+        pub fn reborrow(&self) -> ImmutableRecordRef<'_> {
+            ImmutableRecordRef {
+                payload: ImmutableRecordRefPayload::Borrowed(self.get_payload()),
+            }
         }
     }
 }
@@ -3358,7 +3394,16 @@ impl SeekOp {
 #[derive(Clone, PartialEq, Debug)]
 pub enum SeekKey<'a> {
     TableRowId(i64),
-    IndexKey(&'a ImmutableRecord),
+    IndexKey(ImmutableRecordRef<'a>),
+}
+
+impl<'a> SeekKey<'a> {
+    pub fn index_record(&self) -> Option<&ImmutableRecordRef<'a>> {
+        match self {
+            Self::TableRowId(_) => None,
+            Self::IndexKey(record) => Some(record),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5667,7 +5667,7 @@ pub fn seek_internal(
                                 };
                                 (cursor, record)
                             };
-                            match cursor.seek(SeekKey::IndexKey(record), *op)? {
+                            match cursor.seek(SeekKey::IndexKey(record.as_record_ref()), *op)? {
                                 IOResult::Done(seek_result) => seek_result,
                                 IOResult::IO(io) => return Ok(SeekInternalResult::IO(io)),
                             }
@@ -10284,7 +10284,9 @@ pub fn op_insert(
                         };
                         return_if_io!(cursor.insert(&BTreeKey::new_table_rowid(key, Some(&record))));
                     } else {
-                        return_if_io!(cursor.insert(&BTreeKey::new_index_key(&record)));
+                        return_if_io!(
+                            cursor.insert(&BTreeKey::new_index_key(record.as_record_ref()))
+                        );
                     }
                     state.record_rows_written(1);
                 }
@@ -10819,7 +10821,9 @@ pub fn op_idx_insert(
             {
                 let cursor = get_cursor!(state, cursor_id);
                 let cursor = cursor.as_btree_mut();
-                return_if_io!(cursor.insert(&BTreeKey::new_index_key(record_to_insert)));
+                return_if_io!(
+                    cursor.insert(&BTreeKey::new_index_key(record_to_insert.as_record_ref()))
+                );
             }
             if flags.has(IdxInsertFlags::NCHANGE) {
                 state.record_rows_written(1);


### PR DESCRIPTION
## Summary

- store MVCC index keys as shared `ImmutableRecordRef` values backed by the MVStore allocator
- pass shared record references through read-only seek and B-tree key paths without rebuilding an owned `ValueBlob`
- allocate sequence-compaction tombstone row payloads through the MVStore allocator without changing the existing unit-returning API

## Root cause

`SortableIndexKey` owned an `ImmutableRecord`, whose blob payload uses the default `TursoAllocator` on allocator-enabled nightly builds. That bypassed the `DynAllocator` configured for the MVStore skiplist. The sequence-compaction tombstone path similarly called the default table-row constructor instead of its allocator-aware variant.

## Impact

Long-lived records stored by MVStore now participate in the configured allocator's accounting and allocation-failure behavior. Mutable record construction and append behavior remain unchanged; only stable, read-only snapshots stored by MVStore use the shared reference representation.


