### PR TITLE
core: match SQLite's logFunc bit-for-bit in log, log2, log10

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -17,11 +17,14 @@ mod cmath {
     pub fn log(x: f64) -> f64 {
         x.ln()
     }
+    // Use log10/log2 directly rather than log(x, base): the latter computes
+    // ln(x)/ln(base), which can be 1 ulp off from the dedicated functions
+    // SQLite calls, and e.g. mod() amplifies that into visible divergence.
     pub fn log10(x: f64) -> f64 {
-        x.log(10.)
+        x.log10()
     }
     pub fn log2(x: f64) -> f64 {
-        x.log(2.)
+        x.log2()
     }
     pub fn pow(x: f64, y: f64) -> f64 {
         x.powf(y)
@@ -1134,36 +1137,36 @@ impl Value {
         }
     }
 
+    /// Mirrors SQLite's logFunc: log(X) calls log10 directly, and log(B,X)
+    /// always computes log(X)/log(B). Special-casing base 2 or 10 to call
+    /// their dedicated logarithm functions looks more accurate but shifts
+    /// the result by 1 ulp relative to SQLite's ratio.
+    #[allow(unused_unsafe)]
     pub fn exec_math_log(&self, base: Option<&Value>) -> Value {
         let Some(f) = Numeric::from_value_strict(self).map(|v| v.to_f64()) else {
             return Value::Null;
         };
 
-        let base = match base.map(|value| Numeric::from_value_strict(value).map(|v| v.to_f64())) {
-            Some(Some(f)) => f,
-            Some(None) => return Value::Null,
-            None => 10.0,
-        };
-
-        if f <= 0.0 || base <= 0.0 || base == 1.0 {
+        if f <= 0.0 {
             return Value::Null;
         }
 
-        if base == 2.0 {
-            return Value::from_f64(libm::log2(f));
-        } else if base == 10.0 {
-            return Value::from_f64(libm::log10(f));
+        let base = match base.map(|value| Numeric::from_value_strict(value).map(|v| v.to_f64())) {
+            Some(Some(base)) => base,
+            Some(None) => return Value::Null,
+            None => return Value::from_f64(unsafe { cmath::log10(f) }),
         };
 
-        let log_x = libm::log(f);
-        let log_base = libm::log(base);
+        if base <= 0.0 {
+            return Value::Null;
+        }
 
+        let log_base = unsafe { cmath::log(base) };
         if log_base <= 0.0 {
             return Value::Null;
         }
 
-        let result = log_x / log_base;
-        Value::from_f64(result)
+        Value::from_f64(unsafe { cmath::log(f) } / log_base)
     }
 
     pub fn exec_add(&self, rhs: &Value) -> Value {

--- a/sqlite/conformance/sqlite-sqltests/math/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/math/memory.sqltest
@@ -3029,3 +3029,57 @@ test is-nonnull-divide-by-zero {
 expect {
 }
 
+
+# Full-precision compatibility with SQLite's logFunc: log10/log2/one-arg log
+# must call the dedicated C functions (computing ln(x)/ln(base) instead is
+# 1 ulp off), and two-arg log(B,X) must compute ln(X)/ln(B) with no
+# special-casing of bases 2 and 10 (the dedicated functions are 1 ulp off
+# from the ratio SQLite computes). The results are compared against exact
+# literals so the 0/1 output is identical across backends regardless of
+# float formatting.
+
+test log10-full-precision {
+    SELECT log10(2.0) = 0.3010299956639812
+}
+expect {
+    1
+}
+
+test log2-full-precision {
+    SELECT log2(3.0) = 1.584962500721156
+}
+expect {
+    1
+}
+
+test log-one-arg-full-precision {
+    SELECT log(5.0) = 0.6989700043360189
+}
+expect {
+    1
+}
+
+test log-two-arg-is-ln-ratio {
+    SELECT log(2.0, 3.0) = ln(3.0) / ln(2.0)
+}
+expect {
+    1
+}
+
+test log-two-arg-no-base2-special-case {
+    SELECT log(2.0, 3.0) = 1.5849625007211563
+}
+expect {
+    1
+}
+
+# Regression for a fuzzer-found divergence: mod() with a huge dividend
+# (cosh of ~26.9) amplifies a 1-ulp error in the log10 modulus by the
+# quotient (~8e11) into a visible difference.
+test mod-huge-dividend-log10-modulus {
+    SELECT mod(cosh(-2.0 - (0.5) * (-2.0 / 2.0 + (0.5) - degrees(1.0))), log10(2.0))
+         = mod(cosh(-2.0 - (0.5) * (-2.0 / 2.0 + (0.5) - degrees(1.0))), 0.3010299956639812)
+}
+expect {
+    1
+}

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -4174,6 +4174,32 @@ mod fuzz_tests {
         }
     }
 
+    /// Minimized regressions from math_expression_fuzz_run. Results must match
+    /// SQLite bit-for-bit: log10/log2 must call the dedicated functions rather
+    /// than computing ln(x)/ln(base) (1 ulp apart), and two-arg log(B,X) must
+    /// compute log(X)/log(B) exactly like SQLite's logFunc instead of
+    /// special-casing bases 2 and 10. mod() with a huge dividend amplifies any
+    /// 1-ulp difference in the modulus far beyond fuzzer tolerance.
+    #[turso_macros::test(mvcc)]
+    pub fn math_ex(db: TempDatabase) {
+        let _ = env_logger::try_init();
+        let limbo_conn = db.connect_limbo();
+        let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+        for query in [
+            "SELECT log10(2.0)",
+            "SELECT log2(3.0)",
+            "SELECT log(5.0)",
+            "SELECT log(2.0, 3.0)",
+            "SELECT log(10.0, 7.0)",
+            "SELECT log(0.5, 3.0)",
+            "SELECT log(1.0, 3.0)",
+            "SELECT mod(cosh(-2.0 - (0.5) * (-2.0 / 2.0 + (0.5) - degrees(1.0))), log10(2.0))",
+        ] {
+            helpers::assert_differential(&limbo_conn, &sqlite_conn, query, "");
+        }
+    }
+
     #[turso_macros::test(mvcc)]
     pub fn math_expression_fuzz_run(db: TempDatabase) {
         let (mut rng, seed) = helpers::init_fuzz_test("math_expression_fuzz_run");


### PR DESCRIPTION
The math_expression_fuzz_run differential test failed on mod(cosh(...), log10(2.0)): log10 was computed as ln(x)/ln(10), which is 1 ulp below the correctly-rounded value SQLite gets from calling the dedicated C log10, and mod with a huge dividend (cosh(26.9) ~ 2.4e11) amplifies that single ulp by the quotient into a visible 4.4e-5 divergence.

Call the dedicated log10/log2 functions in the production cmath shims, and rework exec_math_log to mirror SQLite's logFunc exactly: the one-argument form calls log10 directly and the two-argument form always computes ln(X)/ln(B). The previous special-casing of bases 2 and 10 looked more accurate but diverged from SQLite's ratio by 1 ulp, and the libm crate (a third math library besides cmath and Rust std) is dropped from this path for the same reason.

Tests: math_ex in tests/fuzz/mod.rs (exact differential against rusqlite, including the minimized fuzzer query) and full-precision log compatibility cases in testing/sqltests/tests/math/memory.sqltest, verified against both the rust backend and a real sqlite3 binary.