### PR TITLE
core: drop cfg_aliases build dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6671,7 +6671,6 @@ dependencies = [
  "branches",
  "bumpalo",
  "bytemuck",
- "cfg_aliases",
  "cfg_block",
  "chrono",
  "codspeed-criterion-compat",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -153,9 +153,6 @@ aegis = { version = "0.9.8", features = ["pure-rust"] }
 [target.'cfg(not(any(target_os = "android", target_os = "macos")))'.dependencies]
 aegis = { version = "0.9.8" }
 
-[build-dependencies]
-cfg_aliases = "0.2.1"
-
 [target.'cfg(not(target_family = "windows"))'.dev-dependencies]
 pprof = { version = "0.14.0", features = ["criterion", "flamegraph"] }
 

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,12 +1,22 @@
-use cfg_aliases::cfg_aliases;
 use std::path::PathBuf;
 use std::process::Command;
 use std::{env, fs};
 
 fn main() {
-    cfg_aliases! {
-        injected_yields: { any(feature = "test_helper", feature = "simulator") },
-        host_shared_wal: { all(any(unix, target_os = "windows"), target_pointer_width = "64") },
+    // cfg(injected_yields): any(feature = "test_helper", feature = "simulator")
+    println!("cargo::rustc-check-cfg=cfg(injected_yields)");
+    if env::var_os("CARGO_FEATURE_TEST_HELPER").is_some()
+        || env::var_os("CARGO_FEATURE_SIMULATOR").is_some()
+    {
+        println!("cargo::rustc-cfg=injected_yields");
+    }
+
+    // cfg(host_shared_wal): all(any(unix, target_os = "windows"), target_pointer_width = "64")
+    println!("cargo::rustc-check-cfg=cfg(host_shared_wal)");
+    let unix_or_windows = env::var_os("CARGO_CFG_UNIX").is_some()
+        || env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows");
+    if unix_or_windows && env::var("CARGO_CFG_TARGET_POINTER_WIDTH").as_deref() == Ok("64") {
+        println!("cargo::rustc-cfg=host_shared_wal");
     }
 
     // Ensure Cargo reruns when this script or the reproducibility seed changes.


### PR DESCRIPTION
Recent Rust nightlies promote the semicolon_in_expressions_from_macros
future-compat lint to deny-by-default, and the cfg_aliases! macro in
core/build.rs trips it, breaking the nightly fuzz CI build. No fixed
cfg_aliases release exists, so emit the two cfg aliases directly from
the build script via cargo::rustc-cfg instructions, which is what the
macro expanded to anyway.
