### PR TITLE
ci: pin nightly toolchains to nightly-2025-12-17

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -127,7 +127,12 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        # Pinned so upstream nightly regressions can't break this job
+        # independently of our changes; bump deliberately when needed.
+        # Keep in sync with nightly-cfg.yml.
+        toolchain: nightly-2025-12-17
     - name: Setup mold linker
       uses: rui314/setup-mold@v1
     - uses: Swatinem/rust-cache@v2
@@ -137,4 +142,4 @@ jobs:
     - name: Install cargo-fuzz
       run: cargo install cargo-fuzz@0.13.0
     - name: Run scalar_func fuzzer
-      run: cargo +nightly fuzz run scalar_func -- -max_total_time=300
+      run: cargo +nightly-2025-12-17 fuzz run scalar_func -- -max_total_time=300

--- a/.github/workflows/stack-sizes.yml
+++ b/.github/workflows/stack-sizes.yml
@@ -42,7 +42,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          # Pinned so upstream nightly regressions can't break this job
+          # independently of our changes; bump deliberately when needed.
+          # Keep in sync with nightly-cfg.yml.
+          toolchain: nightly-2025-12-17
 
       - name: Setup mold linker
         uses: "./.github/shared/setup-mold"
@@ -99,7 +104,7 @@ jobs:
         run: |
           set -euo pipefail
           RUSTFLAGS="-Zemit-stack-sizes -Cforce-frame-pointers=yes" \
-            cargo +nightly build \
+            cargo +nightly-2025-12-17 build \
             --release \
             --locked \
             -p turso_cli \


### PR DESCRIPTION
The fuzz and stack-sizes workflows installed bleeding-edge nightly via
dtolnay/rust-toolchain@nightly and invoked cargo +nightly, so any
upstream nightly change could break main CI with no change on our side.
This happened when semicolon_in_expressions_from_macros became
deny-by-default and broke the fuzz workflow.

Pin both to nightly-2025-12-17, matching the pins already used in
nightly-cfg.yml, rust.yml, and codspeed.yml, so nightly bumps are a
deliberate, reviewable change instead of a background breakage.
