### PR TITLE
tests: reduce iteration counts in slow mvcc stress tests

### DIFF
--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1738,7 +1738,7 @@ async fn test_snapshot_isolation_violation() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_ghost_commits() {
-    for iteration in 0..500 {
+    for iteration in 0..100 {
         if iteration % 100 == 0 {
             eprintln!("test_ghost_commits: Iteration {iteration}");
         }

--- a/tests/integration/fuzz_transaction/mod.rs
+++ b/tests/integration/fuzz_transaction/mod.rs
@@ -570,7 +570,7 @@ struct DmlGenOptions {
 impl Default for FuzzOptions {
     fn default() -> Self {
         Self {
-            num_iterations: 50,
+            num_iterations: 10,
             operations_per_connection: 30,
             reopen_probability: 0.1,
             max_num_connections: 8,


### PR DESCRIPTION
## Problem

The `build-native (windows-latest)` job keeps hitting the 30-minute `Test (nextest)` step timeout on slower runners (e.g. [run 29479910601](https://github.com/tursodatabase/turso/actions/runs/29479910601/job/87561068583)). Two tests dominate the tail on Windows:

| Test | Windows | Linux (w/ coverage) | macOS |
|---|---|---|---|
| `fuzz_transaction::test_multiple_connections_fuzz_mvcc` | ~18 min | ~6 min | ~2.2 min |
| `test_ghost_commits` (rust bindings) | ~10 min | ~1.4 min | ~38 s |

Both are fsync/file-churn heavy (thousands of db reopen cycles and checkpoint truncates), which is the worst case for Windows CI disks. Green Windows runs were already finishing the step at ~25.5/30 minutes, so any runner variance tips it over.

## Change

Cut iteration counts uniformly across platforms (no per-OS special-casing):

- `test_multiple_connections_fuzz_mvcc` / `test_multiple_connections_fuzz_non_mvcc`: 50 → 10 iterations (still 10 × 1000 ops × 2 connections = 20k ops per run for the mvcc variant)
- `test_ghost_commits`: 500 → 100 iterations (still 100 × 8 workers × 100 ops = 80k racing inserts per run)

Fuzz seeds are time-based (`rng_from_time_or_env`), so coverage accumulates across CI runs and any failure prints its seed for reproduction.

Expected effect: Windows `Test (nextest)` step drops from ~25 min to roughly 17–18 min, restoring headroom under the 30-minute timeout.
