### PR TITLE
ci: switch x64 windows jobs to blacksmith runners

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -94,12 +94,12 @@ jobs:
           artifact-name: native-iossimulator-arm64
           ios-deployment-target: "12.2"
 
-        - os: windows-2025
+        - os: blacksmith-4vcpu-windows-2025
           make-target: build-rust-windows64
           target: x86_64-pc-windows-msvc
           artifact-name: native-win-x64
 
-        - os: windows-2025
+        - os: blacksmith-4vcpu-windows-2025
           make-target: build-rust-windowsarm64
           target: aarch64-pc-windows-msvc
           artifact-name: native-win-arm64
@@ -451,7 +451,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: windows-2025
+        - os: blacksmith-4vcpu-windows-2025
           rid: win-x64
           executable: NativeAotSample.exe
 

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -31,6 +31,9 @@ concurrency:
 
 env:
   working-directory: bindings/dotnet
+  # Blacksmith Windows images ship VS Build Tools without LLVM, so the aegis
+  # crate's clang-cl preference fails; force the MSVC compiler instead.
+  CC_x86_64_pc_windows_msvc: cl.exe
 
 jobs:
   # Build native libraries for each platform/architecture
@@ -99,7 +102,9 @@ jobs:
           target: x86_64-pc-windows-msvc
           artifact-name: native-win-x64
 
-        - os: blacksmith-4vcpu-windows-2025
+        # Stays on GitHub-hosted: Blacksmith Windows images lack the MSVC ARM64
+        # cross tools (Microsoft.VisualStudio.Component.VC.Tools.ARM64).
+        - os: windows-2025
           make-target: build-rust-windowsarm64
           target: aarch64-pc-windows-msvc
           artifact-name: native-win-arm64

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
         os:
           - blacksmith-4vcpu-ubuntu-2404
           - blacksmith-6vcpu-macos-latest
-          - windows-latest
+          - blacksmith-4vcpu-windows-2025
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,9 @@ env:
   GH_TOKEN: ${{ secrets.TURSO_GO_PLATFORM_LIBS_TOKEN }}
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: 10
+  # Blacksmith Windows images ship VS Build Tools without LLVM, so the aegis
+  # crate's clang-cl preference fails; force the MSVC compiler instead.
+  CC_x86_64_pc_windows_msvc: cl.exe
 
 jobs:
   test:

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -33,11 +33,11 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: windows-latest
+          - host: blacksmith-4vcpu-windows-2025
             target: x86_64-pc-windows-msvc
             artifact: db-bindings-x86_64-pc-windows-msvc
             build: yarn workspace @tursodatabase/database napi-build --target x86_64-pc-windows-msvc
-          - host: windows-latest
+          - host: blacksmith-4vcpu-windows-2025
             target: x86_64-pc-windows-msvc
             artifact: sync-bindings-x86_64-pc-windows-msvc
             build: yarn workspace @tursodatabase/sync napi-build --target x86_64-pc-windows-msvc
@@ -212,7 +212,7 @@ jobs:
       matrix:
         node:
           - "20"
-    runs-on: windows-latest
+    runs-on: blacksmith-4vcpu-windows-2025
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
@@ -337,7 +337,7 @@ jobs:
       matrix:
         node:
           - "20"
-    runs-on: windows-latest
+    runs-on: blacksmith-4vcpu-windows-2025
     steps:
       - uses: actions/checkout@v4
       - name: Setup node

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -17,6 +17,9 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: 10
+  # Blacksmith Windows images ship VS Build Tools without LLVM, so the aegis
+  # crate's clang-cl preference fails; force the MSVC compiler instead.
+  CC_x86_64_pc_windows_msvc: cl.exe
 
 defaults:
   run:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,6 +20,9 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: "true"
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: 10
+  # Blacksmith Windows images ship VS Build Tools without LLVM, so the aegis
+  # crate's clang-cl preference fails; force the MSVC compiler instead.
+  CC_x86_64_pc_windows_msvc: cl.exe
 
 jobs:
   configure-strategy:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,7 +40,7 @@ jobs:
         os:
           - blacksmith-4vcpu-ubuntu-2404
           - blacksmith-6vcpu-macos-latest
-          - windows-latest
+          - blacksmith-4vcpu-windows-2025
         python-version: ${{ fromJson(needs.configure-strategy.outputs.python-versions) }}
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,6 +88,13 @@ jobs:
       - name: Install cargo-llvm-cov
         if: runner.os == 'Linux'
         uses: taiki-e/install-action@cargo-llvm-cov
+      # Blacksmith Windows images ship no LLVM; the all-features build pulls in
+      # pg_query, whose bindgen needs libclang.dll.
+      - name: Install LLVM (libclang for bindgen)
+        if: runner.os == 'Windows'
+        run: |
+          choco install llvm -y --no-progress
+          echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" >> $env:GITHUB_ENV
       - name: Set up Python 3.10
         uses: useblacksmith/setup-python@v6
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: 10
+  # Blacksmith Windows images ship VS Build Tools without LLVM, so the aegis
+  # crate's clang-cl preference fails; force the MSVC compiler instead.
+  CC_x86_64_pc_windows_msvc: cl.exe
 
 jobs:
   license-check:
@@ -146,7 +149,9 @@ jobs:
         timeout-minutes: 5
 
   build-windows-arm64-cli:
-    runs-on: blacksmith-4vcpu-windows-2025
+    # Stays on GitHub-hosted: Blacksmith Windows images lack the MSVC ARM64
+    # cross tools (Microsoft.VisualStudio.Component.VC.Tools.ARM64).
+    runs-on: windows-2025
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,14 +56,14 @@ jobs:
           fi
 
   build-native:
-    timeout-minutes: ${{ matrix.os == 'windows-latest' && 120 || 30 }}
+    timeout-minutes: ${{ matrix.os == 'blacksmith-8vcpu-windows-2025' && 120 || 30 }}
     strategy:
       matrix:
         os:
           [
             blacksmith-4vcpu-ubuntu-2404,
             blacksmith-6vcpu-macos-latest,
-            windows-latest,
+            blacksmith-8vcpu-windows-2025,
           ]
 
     runs-on: ${{ matrix.os }}
@@ -146,7 +146,7 @@ jobs:
         timeout-minutes: 5
 
   build-windows-arm64-cli:
-    runs-on: windows-2025
+    runs-on: blacksmith-4vcpu-windows-2025
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -450,7 +450,7 @@ jobs:
           ' _
 
   concurrent-simulator-windows:
-    runs-on: windows-latest
+    runs-on: blacksmith-4vcpu-windows-2025
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Move all x64 Windows CI jobs from GitHub-hosted runners to Blacksmith Windows Server 2025 runners (public beta), matching the Linux and macOS jobs that already run on Blacksmith. The heavy full-workspace build-native job gets 8 vCPUs; everything else gets the 4 vCPU equivalent of GitHub's standard runners.

Left on GitHub-hosted: the windows-11-arm dotnet test job (Blacksmith has no ARM Windows runners) and release.yml (release builds do Azure code signing and only run on tags, so switch it once CI proves out the Blacksmith toolchain).

Blacksmith images ship VS Build Tools 2022 instead of full Visual Studio; the ARM64 MSVC cross-compile jobs (build-windows-arm64-cli and dotnet build-rust-windowsarm64) will fail loudly on the first push if the VC.Tools.ARM64 component is missing from the image.