### PR TITLE
core: Clean up `Database::open()` variants with `OpenOptions`

### DIFF
--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -97,16 +97,12 @@ fn database_open_with_allocator_uses_allocator_for_mvstore_skiplist() {
     )
     .unwrap();
     let db_file = StdArc::new(crate::storage::database::DatabaseFile::new(file));
-    let db = crate::Database::open_with_flags_with_allocator(
+    let db = crate::Database::open(
         io,
         "open-with-allocator.db",
-        db_file,
-        crate::OpenFlags::default(),
-        crate::DatabaseOpts::new(),
-        None,
-        None,
-        alloc,
-        StdArc::new(crate::SqliteDialect),
+        crate::OpenOptions::new(StdArc::new(crate::SqliteDialect))
+            .storage(db_file)
+            .allocator(alloc),
     )
     .unwrap();
     let conn = db.connect().unwrap();

--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -410,16 +410,10 @@ mod tests {
     ) -> crate::Result<Arc<Database>> {
         let file = io.open_file(path, OpenFlags::Create, true)?;
         let db_file = Arc::new(DatabaseFile::new(file));
-        Database::open_with_flags_with_allocator(
+        Database::open(
             io.clone(),
             path,
-            db_file,
-            OpenFlags::default(),
-            DatabaseOpts::new(),
-            None,
-            None,
-            crate::alloc::DynAllocator::default(),
-            dialect,
+            crate::OpenOptions::new(dialect).storage(db_file),
         )
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -364,6 +364,11 @@ impl EncryptionOpts {
 pub struct OpenOptions {
     /// Pre-opened database storage for the file at the database path.
     storage: Option<Arc<dyn DatabaseStorage>>,
+    /// WAL file path override. Defaults to `"{path}-wal"`. Only honored by
+    /// [`Database::do_open`]/[`Database::do_open_async`]; the registry-aware
+    /// [`Database::open`]/[`Database::open_async`] reject it, because the
+    /// process-wide registry keys on the default WAL for a path.
+    wal_path: Option<String>,
     flags: OpenFlags,
     db_opts: DatabaseOpts,
     encryption: Option<EncryptionOpts>,
@@ -381,6 +386,7 @@ impl OpenOptions {
     pub fn new(dialect: Arc<dyn Dialect>) -> Self {
         Self {
             storage: None,
+            wal_path: None,
             flags: OpenFlags::default(),
             db_opts: DatabaseOpts::default(),
             encryption: None,
@@ -392,6 +398,14 @@ impl OpenOptions {
 
     pub fn storage(mut self, storage: Arc<dyn DatabaseStorage>) -> Self {
         self.storage = Some(storage);
+        self
+    }
+
+    /// Override the WAL file path (defaults to `"{path}-wal"`). Only honored
+    /// by [`Database::do_open`]/[`Database::do_open_async`]; passing it to the
+    /// registry-aware entry points is an error.
+    pub fn wal_path(mut self, wal_path: impl Into<String>) -> Self {
+        self.wal_path = Some(wal_path.into());
         self
     }
 
@@ -1186,13 +1200,24 @@ impl Database {
     ///
     /// Uses the database registry to ensure a single Database instance per
     /// file within a process; an `Opening` sentinel prevents concurrent opens
-    /// of the same path without holding the mutex across I/O yields.
+    /// of the same path without holding the mutex across I/O yields. Callers
+    /// that need a second Database instance for one file (e.g. a copied or
+    /// revert WAL) use [`Database::do_open_async`] with `OpenOptions::wal_path`;
+    /// passing `wal_path` here is an error, because the registry keys on the
+    /// default WAL path.
     pub fn open_async(
         state: &mut OpenDbAsyncState,
         io: Arc<dyn IO>,
         path: &str,
         options: &OpenOptions,
     ) -> Result<IOResult<Arc<Database>>> {
+        if options.wal_path.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "OpenOptions::wal_path is only supported by Database::do_open/do_open_async, \
+                 which skip the process-wide registry; the registry keys on the default WAL path"
+                    .to_string(),
+            ));
+        }
         let Some(storage) = options.storage.clone() else {
             return Err(LimboError::InvalidArgument(
                 "OpenOptions::storage is required for Database::open_async".to_string(),
@@ -1201,50 +1226,16 @@ impl Database {
         // Re-derive lock-mode flags from opts: multiprocess WAL must open the
         // WAL file with NoLock or the second process fails to lock `-wal`.
         // Callers may hand us default flags on every poll, so this runs each
-        // time; the rewrite is idempotent.
+        // time; the rewrite is idempotent. The raw do_open_async path does not
+        // do this — it is reserved for the registry-aware entry point.
         #[cfg(feature = "fs")]
         let flags = Self::effective_open_flags_for_path(&io, path, options.flags, options.db_opts)?;
         #[cfg(not(feature = "fs"))]
         let flags = options.flags;
-        let result = Self::open_with_flags_async_internal(
-            state,
-            io,
-            path,
-            storage,
-            flags,
-            options.db_opts,
-            options.encryption.clone(),
-            options.durable_storage.clone(),
-            options.allocator.clone(),
-            options.dialect.clone(),
-        );
-        if result.is_err() {
-            // On error, remove the Opening sentinel so other callers can proceed.
-            if let Some(registry_key) = state.registry_key.take() {
-                let mut registry = DATABASE_MANAGER.lock();
-                registry.remove(&registry_key);
-            }
-        }
-        result
-    }
 
-    #[allow(clippy::too_many_arguments)]
-    fn open_with_flags_async_internal(
-        state: &mut OpenDbAsyncState,
-        io: Arc<dyn IO>,
-        path: &str,
-        db_file: Arc<dyn DatabaseStorage>,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        allocator: alloc::DynAllocator,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<IOResult<Arc<Database>>> {
         // turso-sync-engine creates 2 databases with different names in the same IO if MemoryIO is used
         // in this case we need to bypass registry (as this is MemoryIO DB) but also preserve original distinction in names (e.g. :memory:-draft and :memory:-synced)
         // so, we bypass registry for all in memory dbs (i.e. db paths which starts with ":memory:")
-
         if matches!(state.phase, OpenDbAsyncPhase::Init) && !is_memory_like(path) {
             // Briefly lock the registry to check/reserve — never hold across I/O yields.
             let mut registry = DATABASE_MANAGER.lock();
@@ -1260,13 +1251,13 @@ impl Database {
 
                             let db_is_encrypted =
                                 !matches!(db.encryption_cipher_mode.get(), CipherMode::None);
-                            if db_is_encrypted && encryption_opts.is_none() {
+                            if db_is_encrypted && options.encryption.is_none() {
                                 return Err(LimboError::InvalidArgument(
                                     "Database is encrypted but no encryption options provided"
                                         .to_string(),
                                 ));
                             }
-                            Self::check_registry_dialect(&db, dialect.as_ref())?;
+                            Self::check_registry_dialect(&db, options.dialect.as_ref())?;
                             return Ok(IOResult::Done(db));
                         }
                         // Weak ref expired — treat as absent, fall through to insert Opening.
@@ -1290,92 +1281,51 @@ impl Database {
             // of the same path without holding the mutex across yields.
         }
 
-        // Open the database asynchronously (no registry lock held).
-        let result = Self::open_with_flags_bypass_registry_async_with_allocator(
+        // Open the database (no registry lock held; never re-consults it).
+        let result = Self::do_open_async_guarded(
             state,
             io.clone(),
             path,
             None,
-            db_file,
+            storage,
             flags,
-            opts,
-            encryption_opts,
-            durable_storage,
-            allocator,
-            dialect,
-        )?;
-
-        if let IOResult::Done(ref db) = result {
-            // Register the opened database and remove the Opening sentinel.
-            if let Some(registry_key) = state.registry_key.take() {
-                let mut registry = DATABASE_MANAGER.lock();
-                registry.insert(registry_key, RegistryEntry::Ready(Arc::downgrade(db)));
-            }
-        }
-
-        Ok(result)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn open_with_flags_bypass_registry_async_with_allocator(
-        state: &mut OpenDbAsyncState,
-        io: Arc<dyn IO>,
-        path: &str,
-        wal_path: Option<&str>,
-        db_file: Arc<dyn DatabaseStorage>,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        allocator: alloc::DynAllocator,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<IOResult<Arc<Database>>> {
-        let result = Self::open_with_flags_bypass_registry_async_internal(
-            state,
-            io,
-            path,
-            wal_path,
-            db_file,
-            flags,
-            opts,
-            encryption_opts,
-            durable_storage,
-            allocator,
-            dialect,
+            options.db_opts,
+            options.encryption.clone(),
+            options.durable_storage.clone(),
+            options.allocator.clone(),
+            options.dialect.clone(),
         );
-        if result.is_err() {
-            let _ = state.schema_guard.take();
+
+        match &result {
+            Ok(IOResult::Done(db)) => {
+                // Register the opened database and remove the Opening sentinel.
+                if let Some(registry_key) = state.registry_key.take() {
+                    let mut registry = DATABASE_MANAGER.lock();
+                    registry.insert(registry_key, RegistryEntry::Ready(Arc::downgrade(db)));
+                }
+            }
+            Err(_) => {
+                // On error, remove the Opening sentinel so other callers can proceed.
+                if let Some(registry_key) = state.registry_key.take() {
+                    let mut registry = DATABASE_MANAGER.lock();
+                    registry.remove(&registry_key);
+                }
+            }
+            Ok(IOResult::IO(_)) => {}
         }
         result
     }
 
-    /// method for tests - for all other code we must use async alternative
+    /// Synchronous [`Database::do_open_async`] that drives the IO loop.
+    ///
+    /// Test-only helper for scenarios that intentionally open a second
+    /// Database instance for one file (e.g. reading through a copied WAL);
+    /// production code uses the registry-aware [`Database::open`].
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_with_flags_bypass_registry(
-        io: Arc<dyn IO>,
-        path: &str,
-        wal_path: &str,
-        db_file: Arc<dyn DatabaseStorage>,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<Arc<Database>> {
+    pub fn do_open(io: Arc<dyn IO>, path: &str, options: OpenOptions) -> Result<Arc<Database>> {
         let mut state = OpenDbAsyncState::new();
         loop {
-            match Self::open_with_flags_bypass_registry_async(
-                &mut state,
-                io.clone(),
-                path,
-                Some(wal_path),
-                db_file.clone(),
-                flags,
-                opts,
-                encryption_opts.clone(),
-                None,
-                dialect.clone(),
-            )? {
+            match Self::do_open_async(&mut state, io.clone(), path, &options)? {
                 IOResult::Done(db) => return Ok(db),
                 IOResult::IO(io_completion) => {
                     io_completion.wait(&*io)?;
@@ -1384,11 +1334,42 @@ impl Database {
         }
     }
 
-    /// Async version of database opening that returns IOResult.
-    /// Caller must drive the IO loop and pass state between calls.
-    /// This is useful for sync engine which needs to yield on IO.
+    /// Raw open that never consults the process-wide registry, driven by the
+    /// caller's IO loop. This is the only entry point that honors
+    /// `OpenOptions::wal_path`. Prefer [`Database::open_async`] unless you
+    /// deliberately need a second Database instance for a file (e.g. the sync
+    /// engine's revert WAL).
+    pub fn do_open_async(
+        state: &mut OpenDbAsyncState,
+        io: Arc<dyn IO>,
+        path: &str,
+        options: &OpenOptions,
+    ) -> Result<IOResult<Arc<Database>>> {
+        let Some(storage) = options.storage.clone() else {
+            return Err(LimboError::InvalidArgument(
+                "OpenOptions::storage is required for Database::do_open_async".to_string(),
+            ));
+        };
+        Self::do_open_async_guarded(
+            state,
+            io,
+            path,
+            options.wal_path.as_deref(),
+            storage,
+            options.flags,
+            options.db_opts,
+            options.encryption.clone(),
+            options.durable_storage.clone(),
+            options.allocator.clone(),
+            options.dialect.clone(),
+        )
+    }
+
+    /// Run the open state machine and release the schema guard if it fails.
+    /// Never touches the registry; both the registry-aware and raw entry
+    /// points funnel through here.
     #[allow(clippy::too_many_arguments)]
-    pub fn open_with_flags_bypass_registry_async(
+    fn do_open_async_guarded(
         state: &mut OpenDbAsyncState,
         io: Arc<dyn IO>,
         path: &str,
@@ -1398,9 +1379,10 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        allocator: alloc::DynAllocator,
         dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
-        let result = Self::open_with_flags_bypass_registry_async_internal(
+        let result = Self::do_open_async_internal(
             state,
             io,
             path,
@@ -1410,19 +1392,17 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
-            alloc::DynAllocator::default(),
+            allocator,
             dialect,
         );
         if result.is_err() {
-            // schema_guard is set by the open_with_flags_bypass_registry_async_internal - so we release it in case of error
-            // registry_guard is not managed by this function - so we don't touch it here and reset in the appropriate place
             let _ = state.schema_guard.take();
         }
         result
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn open_with_flags_bypass_registry_async_internal(
+    fn do_open_async_internal(
         state: &mut OpenDbAsyncState,
         io: Arc<dyn IO>,
         path: &str,
@@ -1436,10 +1416,7 @@ impl Database {
         dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
         loop {
-            tracing::debug!(
-                "open_with_flags_bypass_registry_async: state.phase={:?}",
-                state.phase
-            );
+            tracing::debug!("do_open_async_internal: state.phase={:?}", state.phase);
             match &state.phase {
                 OpenDbAsyncPhase::Init => {
                     // Parse encryption key from encryption_opts if provided
@@ -1561,7 +1538,7 @@ impl Database {
                         .schema_guard
                         .as_mut()
                         .expect("schema_guard must be acquired in Init phase");
-                    // while we logically exclusively own schema as we hold DATABASE_MANAGER lock in the top level `open_with_flags_async_internal` function
+                    // while we logically exclusively own schema as we hold DATABASE_MANAGER lock in the top level `open_async` function
                     // at the moment we already created connection which cloned the schema internally
                     // so, we can't use get_mut here for now
                     //
@@ -1666,7 +1643,7 @@ impl Database {
                 }
 
                 OpenDbAsyncPhase::Done => {
-                    panic!("open_with_flags_bypass_registry_async called after completion");
+                    panic!("do_open_async_internal called after completion");
                 }
             }
         }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1165,25 +1165,9 @@ impl Database {
     ///
     /// Drives the IO loop internally. `OpenOptions::storage` must be set.
     pub fn open(io: Arc<dyn IO>, path: &str, options: OpenOptions) -> Result<Arc<Database>> {
-        let Some(storage) = options.storage else {
-            return Err(LimboError::InvalidArgument(
-                "OpenOptions::storage is required for Database::open".to_string(),
-            ));
-        };
         let mut state = OpenDbAsyncState::new();
         loop {
-            match Self::open_with_flags_async_with_allocator(
-                &mut state,
-                io.clone(),
-                path,
-                storage.clone(),
-                options.flags,
-                options.db_opts,
-                options.encryption.clone(),
-                options.durable_storage.clone(),
-                options.allocator.clone(),
-                options.dialect.clone(),
-            )? {
+            match Self::open_async(&mut state, io.clone(), path, &options)? {
                 IOResult::Done(db) => return Ok(db),
                 IOResult::IO(io_completion) => {
                     io_completion.wait(&*io)?;
@@ -1192,69 +1176,47 @@ impl Database {
         }
     }
 
-    /// async flow of opening the database
-    /// this is important to have open async, otherwise sync-engine will not work properly for cases when schema table span multiple pages
-    /// (so, potentially network IO is needed to load them)
+    /// IOResult-driven twin of [`Database::open`]: the caller drives the IO
+    /// loop and passes `state` between calls. `OpenOptions::storage` must be
+    /// set.
     ///
-    /// Uses the database registry to ensure single Database instance per file within a process.
-    /// Caller must drive the IO loop and pass state between calls.
-    /// An `Opening` sentinel in the registry prevents concurrent opens of the same path
-    /// without holding the mutex across I/O yields.
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_with_flags_async(
+    /// This matters for the sync engine, which must yield on IO when the
+    /// schema table spans multiple pages (potentially needing network IO to
+    /// load them).
+    ///
+    /// Uses the database registry to ensure a single Database instance per
+    /// file within a process; an `Opening` sentinel prevents concurrent opens
+    /// of the same path without holding the mutex across I/O yields.
+    pub fn open_async(
         state: &mut OpenDbAsyncState,
         io: Arc<dyn IO>,
         path: &str,
-        db_file: Arc<dyn DatabaseStorage>,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        dialect: Arc<dyn Dialect>,
+        options: &OpenOptions,
     ) -> Result<IOResult<Arc<Database>>> {
-        // Re-derive lock-mode flags from opts the same way the sync
-        // `open_file_with_flags` path does: multiprocess WAL must open the
+        let Some(storage) = options.storage.clone() else {
+            return Err(LimboError::InvalidArgument(
+                "OpenOptions::storage is required for Database::open_async".to_string(),
+            ));
+        };
+        // Re-derive lock-mode flags from opts: multiprocess WAL must open the
         // WAL file with NoLock or the second process fails to lock `-wal`.
+        // Callers may hand us default flags on every poll, so this runs each
+        // time; the rewrite is idempotent.
         #[cfg(feature = "fs")]
-        let flags = Self::effective_open_flags_for_path(&io, path, flags, opts)?;
-        Self::open_with_flags_async_with_allocator(
-            state,
-            io,
-            path,
-            db_file,
-            flags,
-            opts,
-            encryption_opts,
-            durable_storage,
-            alloc::DynAllocator::default(),
-            dialect,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_with_flags_async_with_allocator(
-        state: &mut OpenDbAsyncState,
-        io: Arc<dyn IO>,
-        path: &str,
-        db_file: Arc<dyn DatabaseStorage>,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        allocator: alloc::DynAllocator,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<IOResult<Arc<Database>>> {
+        let flags = Self::effective_open_flags_for_path(&io, path, options.flags, options.db_opts)?;
+        #[cfg(not(feature = "fs"))]
+        let flags = options.flags;
         let result = Self::open_with_flags_async_internal(
             state,
             io,
             path,
-            db_file,
+            storage,
             flags,
-            opts,
-            encryption_opts,
-            durable_storage,
-            allocator,
-            dialect,
+            options.db_opts,
+            options.encryption.clone(),
+            options.durable_storage.clone(),
+            options.allocator.clone(),
+            options.dialect.clone(),
         );
         if result.is_err() {
             // On error, remove the Opening sentinel so other callers can proceed.

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -349,6 +349,81 @@ impl EncryptionOpts {
     }
 }
 
+/// Options for opening a [`Database`].
+///
+/// Mirrors the `std::fs::OpenOptions` idiom: configure, then open.
+///
+/// ```ignore
+/// let db = Database::open(
+///     io,
+///     "app.db",
+///     OpenOptions::new(Arc::new(SqliteDialect)).flags(OpenFlags::ReadOnly),
+/// )?;
+/// ```
+#[derive(Clone)]
+pub struct OpenOptions {
+    /// Pre-opened database storage for the file at the database path.
+    storage: Option<Arc<dyn DatabaseStorage>>,
+    flags: OpenFlags,
+    db_opts: DatabaseOpts,
+    encryption: Option<EncryptionOpts>,
+    durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+    allocator: alloc::DynAllocator,
+    /// SQL dialect the database is opened with. The dialect is fixed at open
+    /// time and shared by every user of the registered instance; a registry
+    /// hit with a different dialect is an error.
+    dialect: Arc<dyn Dialect>,
+}
+
+impl OpenOptions {
+    /// The dialect has no default: it is fixed at open time and shared by
+    /// every user of the instance, so the caller must choose it explicitly.
+    pub fn new(dialect: Arc<dyn Dialect>) -> Self {
+        Self {
+            storage: None,
+            flags: OpenFlags::default(),
+            db_opts: DatabaseOpts::default(),
+            encryption: None,
+            durable_storage: None,
+            allocator: alloc::DynAllocator::default(),
+            dialect,
+        }
+    }
+
+    pub fn storage(mut self, storage: Arc<dyn DatabaseStorage>) -> Self {
+        self.storage = Some(storage);
+        self
+    }
+
+    pub fn flags(mut self, flags: OpenFlags) -> Self {
+        self.flags = flags;
+        self
+    }
+
+    pub fn db_opts(mut self, db_opts: DatabaseOpts) -> Self {
+        self.db_opts = db_opts;
+        self
+    }
+
+    pub fn encryption(mut self, encryption: impl Into<Option<EncryptionOpts>>) -> Self {
+        self.encryption = encryption.into();
+        self
+    }
+
+    pub fn durable_storage(
+        mut self,
+        durable_storage: impl Into<Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>>,
+    ) -> Self {
+        self.durable_storage = durable_storage.into();
+        self
+    }
+
+    pub fn allocator(mut self, allocator: alloc::DynAllocator) -> Self {
+        self.allocator = allocator;
+        self
+    }
+}
+
 pub type Result<T, E = LimboError> = std::result::Result<T, E>;
 
 #[derive(Debug, AtomicEnum, Clone, Copy, PartialEq, Eq)]
@@ -1074,68 +1149,40 @@ impl Database {
         //    authority appeared between the initial probe and the actual open
         Self::reject_live_multiprocess_wal_for_legacy_open(&io, path, opts)?;
         let db_file = Arc::new(DatabaseFile::new(file));
-        Self::open_with_flags_with_allocator(
+        Self::open(
             io,
             path,
-            db_file,
-            effective_flags,
-            opts,
-            encryption_opts,
-            durable_storage,
-            alloc::DynAllocator::default(),
-            dialect,
+            OpenOptions::new(dialect)
+                .storage(db_file)
+                .flags(effective_flags)
+                .db_opts(opts)
+                .encryption(encryption_opts)
+                .durable_storage(durable_storage),
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_with_flags(
-        io: Arc<dyn IO>,
-        path: &str,
-        db_file: Arc<dyn DatabaseStorage>,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<Arc<Database>> {
-        Self::open_with_flags_with_allocator(
-            io,
-            path,
-            db_file,
-            flags,
-            opts,
-            encryption_opts,
-            durable_storage,
-            alloc::DynAllocator::default(),
-            dialect,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_with_flags_with_allocator(
-        io: Arc<dyn IO>,
-        path: &str,
-        db_file: Arc<dyn DatabaseStorage>,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        allocator: alloc::DynAllocator,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<Arc<Database>> {
+    /// Open a database with the given [`OpenOptions`].
+    ///
+    /// Drives the IO loop internally. `OpenOptions::storage` must be set.
+    pub fn open(io: Arc<dyn IO>, path: &str, options: OpenOptions) -> Result<Arc<Database>> {
+        let Some(storage) = options.storage else {
+            return Err(LimboError::InvalidArgument(
+                "OpenOptions::storage is required for Database::open".to_string(),
+            ));
+        };
         let mut state = OpenDbAsyncState::new();
         loop {
             match Self::open_with_flags_async_with_allocator(
                 &mut state,
                 io.clone(),
                 path,
-                db_file.clone(),
-                flags,
-                opts,
-                encryption_opts.clone(),
-                durable_storage.clone(),
-                allocator.clone(),
-                dialect.clone(),
+                storage.clone(),
+                options.flags,
+                options.db_opts,
+                options.encryption.clone(),
+                options.durable_storage.clone(),
+                options.allocator.clone(),
+                options.dialect.clone(),
             )? {
                 IOResult::Done(db) => return Ok(db),
                 IOResult::IO(io_completion) => {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1087,24 +1087,6 @@ impl Database {
         )
     }
 
-    pub fn open(
-        io: Arc<dyn IO>,
-        path: &str,
-        db_file: Arc<dyn DatabaseStorage>,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<Arc<Database>> {
-        Self::open_with_flags(
-            io,
-            path,
-            db_file,
-            OpenFlags::default(),
-            DatabaseOpts::new(),
-            None,
-            None,
-            dialect,
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub fn open_with_flags(
         io: Arc<dyn IO>,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -974,6 +974,7 @@ impl Database {
     fn reject_live_multiprocess_wal_for_legacy_open(
         io: &Arc<dyn IO>,
         path: &str,
+        wal_path: Option<&str>,
         opts: DatabaseOpts,
     ) -> Result<()> {
         if opts.enable_multiprocess_wal
@@ -984,8 +985,13 @@ impl Database {
             return Ok(());
         }
 
-        let coordination_path =
-            storage::wal::coordination_path_for_wal_path(&format!("{path}-wal"));
+        // The coordination file is derived from the WAL path, so probe the
+        // configured WAL (not a hard-coded `{path}-wal`) or a custom-WAL open
+        // would check the wrong coordination file and miss a live authority.
+        let wal_path = wal_path
+            .map(str::to_owned)
+            .unwrap_or_else(|| format!("{path}-wal"));
+        let coordination_path = storage::wal::coordination_path_for_wal_path(&wal_path);
         let Some(authority) =
             MappedSharedWalCoordination::open_existing(io, Path::new(&coordination_path), 64)?
         else {
@@ -1009,6 +1015,7 @@ impl Database {
     fn reject_live_multiprocess_wal_for_legacy_open(
         _io: &Arc<dyn IO>,
         _path: &str,
+        _wal_path: Option<&str>,
         _opts: DatabaseOpts,
     ) -> Result<()> {
         Ok(())
@@ -1112,39 +1119,44 @@ impl Database {
         encryption_opts: Option<EncryptionOpts>,
         dialect: Arc<dyn Dialect>,
     ) -> Result<Arc<Database>> {
-        Self::open_file_with_flags_and_durable_storage(
+        Self::open(
             io,
             path,
-            flags,
-            opts,
-            encryption_opts,
-            None,
-            dialect,
+            OpenOptions::new(dialect)
+                .flags(flags)
+                .db_opts(opts)
+                .encryption(encryption_opts),
         )
     }
 
+    /// Resolve `OpenOptions::storage` for a file-backed open when the caller
+    /// did not supply pre-opened storage: optionally consult the registry, run
+    /// the legacy/multiprocess WAL probes, open the file, and fill in
+    /// `options.storage` and the effective flags in place. Returns `Some(db)`
+    /// when a registry hit short-circuits the open (only possible when
+    /// `use_registry` is set).
     #[cfg(feature = "fs")]
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_file_with_flags_and_durable_storage(
-        io: Arc<dyn IO>,
+    fn resolve_default_storage(
+        io: &Arc<dyn IO>,
         path: &str,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<Arc<Database>> {
+        options: &mut OpenOptions,
+        use_registry: bool,
+    ) -> Result<Option<Arc<Database>>> {
         // Check the registry before opening the file to avoid acquiring a file
         // lock that would conflict with an already-open Database in this process.
-        if let Some(db) = Self::lookup_in_registry(path, &encryption_opts, dialect.as_ref())? {
-            if durable_storage.is_some() && db.durable_storage.is_none() {
-                return Err(LimboError::InvalidArgument(
-                    "database already open without custom durable storage; \
-                     close the existing instance before reopening with a custom DurableStorage"
-                        .to_string(),
-                ));
+        if use_registry {
+            if let Some(db) =
+                Self::lookup_in_registry(path, &options.encryption, options.dialect.as_ref())?
+            {
+                if options.durable_storage.is_some() && db.durable_storage.is_none() {
+                    return Err(LimboError::InvalidArgument(
+                        "database already open without custom durable storage; \
+                         close the existing instance before reopening with a custom DurableStorage"
+                            .to_string(),
+                    ));
+                }
+                return Ok(Some(db));
             }
-            return Ok(db);
         }
         // Mixed legacy/multiprocess opens are incompatible, but the two modes
         // advertise themselves through different lock domains (`.tshm` vs DB
@@ -1152,33 +1164,79 @@ impl Database {
         // open to narrow the TOCTOU window:
         //
         // 1. legacy open rejects an already-live multiprocess authority
-        Self::reject_live_multiprocess_wal_for_legacy_open(&io, path, opts)?;
-        let effective_flags = Self::effective_open_flags_for_path(&io, path, flags, opts)?;
+        Self::reject_live_multiprocess_wal_for_legacy_open(
+            io,
+            path,
+            options.wal_path.as_deref(),
+            options.db_opts,
+        )?;
+        let effective_flags =
+            Self::effective_open_flags_for_path(io, path, options.flags, options.db_opts)?;
 
         // 2. multiprocess open rejects an already-live legacy DB-file lock
-        Self::reject_live_legacy_wal_for_multiprocess_open(&io, path, flags, opts)?;
+        Self::reject_live_legacy_wal_for_multiprocess_open(
+            io,
+            path,
+            options.flags,
+            options.db_opts,
+        )?;
         let file = io.open_file(path, effective_flags, true)?;
 
         // 3. legacy open re-checks after `open_file()` in case a multiprocess
         //    authority appeared between the initial probe and the actual open
-        Self::reject_live_multiprocess_wal_for_legacy_open(&io, path, opts)?;
-        let db_file = Arc::new(DatabaseFile::new(file));
-        Self::open(
+        Self::reject_live_multiprocess_wal_for_legacy_open(
             io,
             path,
-            OpenOptions::new(dialect)
-                .storage(db_file)
-                .flags(effective_flags)
-                .db_opts(opts)
-                .encryption(encryption_opts)
-                .durable_storage(durable_storage),
-        )
+            options.wal_path.as_deref(),
+            options.db_opts,
+        )?;
+        options.flags = effective_flags;
+        options.storage = Some(Arc::new(DatabaseFile::new(file)));
+        Ok(None)
+    }
+
+    #[cfg(not(feature = "fs"))]
+    fn resolve_default_storage(
+        _io: &Arc<dyn IO>,
+        _path: &str,
+        _options: &mut OpenOptions,
+        _use_registry: bool,
+    ) -> Result<Option<Arc<Database>>> {
+        Err(LimboError::InvalidArgument(
+            "OpenOptions::storage is required to open a database without the `fs` feature"
+                .to_string(),
+        ))
+    }
+
+    /// The registry-aware entry points reject a custom WAL path: the
+    /// process-wide registry keys on the default WAL, so an instance reading a
+    /// nonstandard WAL must go through [`Database::do_open`]/
+    /// [`Database::do_open_async`] instead.
+    fn reject_wal_path_for_registry_open(options: &OpenOptions) -> Result<()> {
+        if options.wal_path.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "OpenOptions::wal_path is only supported by Database::do_open/do_open_async, \
+                 which skip the process-wide registry; the registry keys on the default WAL path"
+                    .to_string(),
+            ));
+        }
+        Ok(())
     }
 
     /// Open a database with the given [`OpenOptions`].
     ///
-    /// Drives the IO loop internally. `OpenOptions::storage` must be set.
-    pub fn open(io: Arc<dyn IO>, path: &str, options: OpenOptions) -> Result<Arc<Database>> {
+    /// Drives the IO loop internally. When `OpenOptions::storage` is unset,
+    /// opens the file at `path` (consulting the process-wide registry first).
+    pub fn open(io: Arc<dyn IO>, path: &str, mut options: OpenOptions) -> Result<Arc<Database>> {
+        // Reject before resolving default storage: a registry hit there would
+        // otherwise return the cached default-WAL instance and silently ignore
+        // the custom wal_path before open_async runs its own check.
+        Self::reject_wal_path_for_registry_open(&options)?;
+        if options.storage.is_none() {
+            if let Some(db) = Self::resolve_default_storage(&io, path, &mut options, true)? {
+                return Ok(db);
+            }
+        }
         let mut state = OpenDbAsyncState::new();
         loop {
             match Self::open_async(&mut state, io.clone(), path, &options)? {
@@ -1211,13 +1269,7 @@ impl Database {
         path: &str,
         options: &OpenOptions,
     ) -> Result<IOResult<Arc<Database>>> {
-        if options.wal_path.is_some() {
-            return Err(LimboError::InvalidArgument(
-                "OpenOptions::wal_path is only supported by Database::do_open/do_open_async, \
-                 which skip the process-wide registry; the registry keys on the default WAL path"
-                    .to_string(),
-            ));
-        }
+        Self::reject_wal_path_for_registry_open(options)?;
         let Some(storage) = options.storage.clone() else {
             return Err(LimboError::InvalidArgument(
                 "OpenOptions::storage is required for Database::open_async".to_string(),
@@ -1322,7 +1374,12 @@ impl Database {
     /// Database instance for one file (e.g. reading through a copied WAL);
     /// production code uses the registry-aware [`Database::open`].
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
-    pub fn do_open(io: Arc<dyn IO>, path: &str, options: OpenOptions) -> Result<Arc<Database>> {
+    pub fn do_open(io: Arc<dyn IO>, path: &str, mut options: OpenOptions) -> Result<Arc<Database>> {
+        if options.storage.is_none() {
+            // `use_registry = false`: the raw path never consults the registry,
+            // so this only opens the file and never returns a cached Database.
+            Self::resolve_default_storage(&io, path, &mut options, false)?;
+        }
         let mut state = OpenDbAsyncState::new();
         loop {
             match Self::do_open_async(&mut state, io.clone(), path, &options)? {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -873,20 +873,17 @@ impl Database {
         Ok(db)
     }
 
+    /// Deprecated convenience shim: prefer [`Database::open`] with
+    /// [`OpenOptions`]. Equivalent to
+    /// `Database::open(io, path, OpenOptions::new(dialect))`. Kept for existing
+    /// callers; new code should not use it.
     #[cfg(feature = "fs")]
     pub fn open_file(
         io: Arc<dyn IO>,
         path: &str,
         dialect: Arc<dyn Dialect>,
     ) -> Result<Arc<Database>> {
-        Self::open_file_with_flags(
-            io,
-            path,
-            OpenFlags::default(),
-            DatabaseOpts::new(),
-            None,
-            dialect,
-        )
+        Self::open(io, path, OpenOptions::new(dialect))
     }
 
     /// Open or retrieve a shared named in-memory database.
@@ -1110,6 +1107,10 @@ impl Database {
         Ok(Some(db))
     }
 
+    /// Deprecated convenience shim: prefer [`Database::open`] with
+    /// [`OpenOptions`]. Equivalent to `Database::open(io, path,
+    /// OpenOptions::new(dialect).flags(flags).db_opts(opts).encryption(enc))`.
+    /// Kept for existing callers; new code should not use it.
     #[cfg(feature = "fs")]
     pub fn open_file_with_flags(
         io: Arc<dyn IO>,

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -31,6 +31,8 @@ const MULTIPROCESS_SHM_EXPECT_OPEN_FAILURE_CHILD_TEST: &str =
 const DEFAULT_LOCKED_DB_CHILD_TEST: &str = "multiprocess_tests::default_locked_db_child_process";
 const MULTIPROCESS_ASYNC_OPEN_CHILD_TEST: &str =
     "multiprocess_tests::multiprocess_async_open_child_process";
+const MULTIPROCESS_HOLD_OPEN_CHILD_TEST: &str =
+    "multiprocess_tests::multiprocess_hold_open_child_process";
 
 fn multiprocess_test_io() -> Arc<dyn IO> {
     #[cfg(all(target_os = "windows", feature = "experimental_win_iocp"))]
@@ -466,6 +468,100 @@ fn multiprocess_async_open_child_process() {
     let db = open_multiprocess_db_async(io, db_path.to_str().unwrap()).unwrap();
     let conn = db.connect().unwrap();
     assert_eq!(count_test_rows(&conn), 1);
+}
+
+/// Child half of `reject_live_multiprocess_probe_uses_configured_wal_path`:
+/// open the multiprocess database, hold it open (keeping the authority in
+/// multiprocess mode), signal readiness, and wait for release before exiting.
+#[test]
+fn multiprocess_hold_open_child_process() {
+    let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
+        return;
+    };
+    let ready_file = std::env::var_os("TURSO_MULTIPROCESS_READY_FILE")
+        .map(std::path::PathBuf::from)
+        .unwrap();
+    let release_file = std::env::var_os("TURSO_MULTIPROCESS_RELEASE_FILE")
+        .map(std::path::PathBuf::from)
+        .unwrap();
+
+    let io: Arc<dyn IO> = multiprocess_test_io();
+    let db = open_multiprocess_db(io, db_path.to_str().unwrap()).unwrap();
+    let last = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db.build_wal(last, db.buffer_pool.clone()).unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_open_mode_name(), Some("multiprocess"));
+
+    std::fs::write(&ready_file, b"ready").unwrap();
+    wait_for_file(&release_file);
+}
+
+/// The legacy/multiprocess probe keys the coordination file off the configured
+/// WAL path, not a hard-coded `{path}-wal`. With a live multiprocess authority
+/// held open by a child process, the probe rejects a legacy open only when it
+/// inspects the WAL path that actually backs the authority; a probe pointed at
+/// a different WAL path finds nothing. Before the fix, the probe hard-coded
+/// `{path}-wal` and so missed the authority whenever a custom WAL path was in
+/// use.
+#[test]
+fn reject_live_multiprocess_probe_uses_configured_wal_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("probe-wal-path.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let ready_file = dir.path().join("child-ready");
+    let release_file = dir.path().join("child-release");
+    let io: Arc<dyn IO> = multiprocess_test_io();
+
+    // Parent keeps the multiprocess database open so a second (child) opener
+    // flips the authority into multiprocess mode.
+    let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("create table test(id integer primary key, value text)")
+        .unwrap();
+
+    let current_exe = std::env::current_exe().unwrap();
+    let mut child = Command::new(&current_exe)
+        .arg(MULTIPROCESS_HOLD_OPEN_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .env("TURSO_MULTIPROCESS_READY_FILE", &ready_file)
+        .env("TURSO_MULTIPROCESS_RELEASE_FILE", &release_file)
+        .spawn()
+        .unwrap();
+    wait_for_file(&ready_file);
+
+    // Probing the WAL path that actually backs the authority finds it and
+    // rejects a legacy open.
+    let default_wal = format!("{db_path_str}-wal");
+    let err = Database::reject_live_multiprocess_wal_for_legacy_open(
+        &io,
+        db_path_str,
+        Some(&default_wal),
+        DatabaseOpts::new(),
+    )
+    .expect_err("legacy open over a live multiprocess authority must be rejected");
+    assert!(
+        matches!(err, LimboError::LockingError(_)),
+        "expected LockingError from the multiprocess probe, got {err:?}"
+    );
+
+    // Probing an unrelated WAL path must NOT reject: the coordination file is
+    // keyed on the WAL path, so the probe must honor its argument.
+    let other_wal = format!("{db_path_str}-other-wal");
+    Database::reject_live_multiprocess_wal_for_legacy_open(
+        &io,
+        db_path_str,
+        Some(&other_wal),
+        DatabaseOpts::new(),
+    )
+    .expect("probe over an unrelated wal path must not reject");
+
+    std::fs::write(&release_file, b"release").unwrap();
+    assert!(
+        child.wait().unwrap().success(),
+        "hold-open child should exit cleanly after release"
+    );
 }
 
 #[test]

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -137,9 +137,9 @@ fn open_multiprocess_db(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
 }
 
 /// Mimic the sdk-kit async open path: the caller pre-opens the DB file with
-/// NoLock but hands `OpenFlags::default()` to `open_with_flags_async`, so the
-/// async entrypoint itself must re-derive the multiprocess lock mode before
-/// the WAL file is opened.
+/// NoLock but hands `OpenFlags::default()` to `open_async`, so the async
+/// entrypoint itself must re-derive the multiprocess lock mode before the WAL
+/// file is opened.
 fn open_multiprocess_db_async(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
     let file = io.open_file(path, OpenFlags::default() | OpenFlags::NoLock, true)?;
     let db_file = Arc::new(DatabaseFile::new(file));

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -143,19 +143,12 @@ fn open_multiprocess_db(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
 fn open_multiprocess_db_async(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
     let file = io.open_file(path, OpenFlags::default() | OpenFlags::NoLock, true)?;
     let db_file = Arc::new(DatabaseFile::new(file));
+    let options = OpenOptions::new(Arc::new(SqliteDialect))
+        .storage(db_file)
+        .db_opts(multiprocess_wal_db_opts());
     let mut state = OpenDbAsyncState::new();
     loop {
-        match Database::open_with_flags_async(
-            &mut state,
-            io.clone(),
-            path,
-            db_file.clone(),
-            OpenFlags::default(),
-            multiprocess_wal_db_opts(),
-            None,
-            None,
-            Arc::new(SqliteDialect),
-        )? {
+        match Database::open_async(&mut state, io.clone(), path, &options)? {
             IOResult::Done(db) => return Ok(db),
             IOResult::IO(io_completion) => io_completion.wait(&*io)?,
         }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -17933,14 +17933,11 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         None,
     ));
     let busy_storage = BusyOnLogTxStorage::new(inner_storage);
-    let db = Database::open_file_with_flags_and_durable_storage(
+    let db = Database::open(
         io,
         &path_str,
-        OpenFlags::default(),
-        DatabaseOpts::new(),
-        None,
-        Some(busy_storage.clone() as Arc<dyn DurableStorage>),
-        Arc::new(SqliteDialect),
+        crate::OpenOptions::new(Arc::new(SqliteDialect))
+            .durable_storage(busy_storage.clone() as Arc<dyn DurableStorage>),
     )
     .unwrap();
 

--- a/postgres/frontend/session.rs
+++ b/postgres/frontend/session.rs
@@ -45,16 +45,13 @@ pub fn open_database_with_io(
 ) -> Result<Arc<turso_core::Database>> {
     let file = io.open_file(path, flags, true)?;
     let db_file = Arc::new(turso_core::storage::database::DatabaseFile::new(file));
-    turso_core::Database::open_with_flags_with_allocator(
+    turso_core::Database::open(
         io,
         path,
-        db_file,
-        flags,
-        opts,
-        None,
-        None,
-        turso_core::alloc::DynAllocator::default(),
-        Arc::new(PostgresDialect),
+        turso_core::OpenOptions::new(Arc::new(PostgresDialect))
+            .storage(db_file)
+            .flags(flags)
+            .db_opts(opts),
     )
 }
 

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -21,8 +21,8 @@ use tracing_subscriber::{
 };
 use turso_core::{
     storage::database::DatabaseFile, types::AsValueRef, Connection, Database, DatabaseOpts,
-    DatabaseStorage, EncryptionKey, IOResult, LimboError, OpenDbAsyncState, OpenFlags, QueryMode,
-    Statement, StepResult, IO,
+    DatabaseStorage, EncryptionKey, IOResult, LimboError, OpenDbAsyncState, OpenFlags, OpenOptions,
+    QueryMode, Statement, StepResult, IO,
 };
 
 use crate::{
@@ -791,16 +791,16 @@ impl TursoDatabase {
                     let opts = state.opts.expect("opts must be initialized in Init phase");
                     let open_flags = state.open_flags;
 
-                    match Database::open_with_flags_async(
+                    let options = OpenOptions::new(Arc::new(SqliteDialect))
+                        .storage(db_file)
+                        .flags(open_flags)
+                        .db_opts(opts)
+                        .encryption(self.config.encryption.clone());
+                    match Database::open_async(
                         &mut state.open_db_state,
                         io.clone(),
                         &self.config.path,
-                        db_file,
-                        open_flags,
-                        opts,
-                        self.config.encryption.clone(),
-                        None,
-                        Arc::new(SqliteDialect),
+                        &options,
                     )? {
                         IOResult::Done(db) => {
                             let mut inner_db = self.db.lock().unwrap();

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -2609,18 +2609,17 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         )?;
 
         // Use async database opening that yields on IO for large schemas
+        let main_db_options = turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(main_db_storage)
+            .flags(OpenFlags::Create)
+            .db_opts(opts.db_opts);
         let mut open_state = turso_core::OpenDbAsyncState::new();
         let main_db = loop {
-            match turso_core::Database::open_with_flags_async(
+            match turso_core::Database::open_async(
                 &mut open_state,
                 io.clone(),
                 main_db_path,
-                main_db_storage.clone(),
-                OpenFlags::Create,
-                opts.db_opts,
-                None,
-                None,
-                Arc::new(SqliteDialect),
+                &main_db_options,
             )? {
                 turso_core::IOResult::Done(db) => break db,
                 turso_core::IOResult::IO(io_completion) => {

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -2638,19 +2638,18 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         coro: &Coro<Ctx>,
     ) -> Result<Arc<turso_core::Connection>> {
         let db = {
+            let options = turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+                .storage(self.db_file.clone())
+                .wal_path(self.revert_db_wal_path.clone())
+                .flags(OpenFlags::Create)
+                .db_opts(self.opts.db_opts);
             let mut state = OpenDbAsyncState::new();
             loop {
-                match turso_core::Database::open_with_flags_bypass_registry_async(
+                match turso_core::Database::do_open_async(
                     &mut state,
                     self.io.clone(),
                     &self.main_db_path,
-                    Some(&self.revert_db_wal_path),
-                    self.db_file.clone(),
-                    OpenFlags::Create,
-                    self.opts.db_opts,
-                    None,
-                    None,
-                    Arc::new(SqliteDialect),
+                    &options,
                 )? {
                     turso_core::IOResult::Done(db) => break db,
                     turso_core::IOResult::IO(io_completion) => {

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -285,14 +285,14 @@ fn test_fresh_mvcc_attach_rejects_custom_durable_storage_without_attached_backen
         None,
     ));
 
-    let db = Database::open_file_with_flags_and_durable_storage(
+    let db = Database::open(
         tmp_db.io.clone(),
         db_path.to_str().unwrap(),
-        OpenFlags::default(),
-        DatabaseOpts::new().with_attach(true),
-        None,
-        Some(durable_storage),
-        Arc::new(SqliteDialect),
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .db_opts(DatabaseOpts::new().with_attach(true))
+            .durable_storage(
+                durable_storage as Arc<dyn turso_core::mvcc::persistent_storage::DurableStorage>,
+            ),
     )?;
     let conn = db.connect()?;
     conn.pragma_update("journal_mode", "'mvcc'")?;

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -166,8 +166,8 @@ fn test_sdk_close_finalizes_leaked_statements() {
     );
 }
 
-/// Database::open with OpenOptions: opening through the unified entry point
-/// works with pre-opened storage, and storage is required.
+/// Database::open with OpenOptions: works with pre-opened storage, and — when
+/// no storage is supplied — resolves the default file storage at `path`.
 #[test]
 fn test_database_open_with_options() {
     let tmp_dir = tempfile::TempDir::new().unwrap();
@@ -190,12 +190,38 @@ fn test_database_open_with_options() {
     conn.execute("CREATE TABLE t(x INTEGER)").unwrap();
     conn.execute("INSERT INTO t VALUES (1)").unwrap();
 
-    let err = Database::open(
+    // With no storage supplied, open resolves the default file storage at
+    // `path` and returns the same registered instance.
+    let db_default = Database::open(
         io,
         path,
-        turso_core::OpenOptions::new(Arc::new(SqliteDialect)),
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect)).flags(OpenFlags::Create),
     )
-    .expect_err("open without storage must fail until default storage resolution exists");
+    .unwrap();
+    assert!(
+        Arc::ptr_eq(&db, &db_default),
+        "open without storage must resolve default storage and hit the registered instance"
+    );
+}
+
+/// Database::open_async still requires storage: default-storage resolution is
+/// synchronous (registry lookup, file probes, file open) and only runs in the
+/// synchronous Database::open entry point.
+#[test]
+fn test_open_async_requires_storage() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let path = tmp_dir.path().join("async-needs-storage.db");
+    let path = path.to_str().unwrap();
+
+    let io: Arc<dyn turso_core::IO + Send> = Arc::new(turso_core::PlatformIO::new().unwrap());
+    let mut state = turso_core::OpenDbAsyncState::new();
+    let err = Database::open_async(
+        &mut state,
+        io,
+        path,
+        &turso_core::OpenOptions::new(Arc::new(SqliteDialect)),
+    )
+    .expect_err("open_async without storage must fail");
     assert!(
         matches!(err, turso_core::LimboError::InvalidArgument(ref m) if m.contains("storage")),
         "expected InvalidArgument about missing storage, got {err:?}"
@@ -216,7 +242,7 @@ fn test_open_rejects_wal_path() {
     let db_file = Arc::new(turso_core::storage::database::DatabaseFile::new(file));
 
     let err = Database::open(
-        io,
+        io.clone(),
         path,
         turso_core::OpenOptions::new(Arc::new(SqliteDialect))
             .storage(db_file)
@@ -227,6 +253,28 @@ fn test_open_rejects_wal_path() {
     assert!(
         matches!(err, turso_core::LimboError::InvalidArgument(ref m) if m.contains("wal_path")),
         "expected InvalidArgument about wal_path, got {err:?}"
+    );
+
+    // Register a canonical instance, then repeat with no pre-opened storage:
+    // the rejection must fire before default-storage resolution, so a registry
+    // hit cannot silently return the cached default-WAL instance.
+    let _registered = Database::open(
+        io.clone(),
+        path,
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect)).flags(OpenFlags::Create),
+    )
+    .unwrap();
+    let err = Database::open(
+        io,
+        path,
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .flags(OpenFlags::Create)
+            .wal_path(format!("{path}-wal-override")),
+    )
+    .expect_err("Database::open must reject a custom wal_path even with a registry hit");
+    assert!(
+        matches!(err, turso_core::LimboError::InvalidArgument(ref m) if m.contains("wal_path")),
+        "expected InvalidArgument about wal_path on the registry-hit path, got {err:?}"
     );
 }
 

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -165,3 +165,39 @@ fn test_sdk_close_finalizes_leaked_statements() {
          close() should have finalized statements and released the stale Database"
     );
 }
+
+/// Database::open with OpenOptions: opening through the unified entry point
+/// works with pre-opened storage, and storage is required.
+#[test]
+fn test_database_open_with_options() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let path = tmp_dir.path().join("opts.db");
+    let path = path.to_str().unwrap();
+
+    let io: Arc<dyn turso_core::IO + Send> = Arc::new(turso_core::PlatformIO::new().unwrap());
+
+    let file = io.open_file(path, OpenFlags::Create, false).unwrap();
+    let db_file = Arc::new(turso_core::storage::database::DatabaseFile::new(file));
+    let db = Database::open(
+        io.clone(),
+        path,
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file)
+            .flags(OpenFlags::Create),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t(x INTEGER)").unwrap();
+    conn.execute("INSERT INTO t VALUES (1)").unwrap();
+
+    let err = Database::open(
+        io,
+        path,
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect)),
+    )
+    .expect_err("open without storage must fail until default storage resolution exists");
+    assert!(
+        matches!(err, turso_core::LimboError::InvalidArgument(ref m) if m.contains("storage")),
+        "expected InvalidArgument about missing storage, got {err:?}"
+    );
+}

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -201,3 +201,85 @@ fn test_database_open_with_options() {
         "expected InvalidArgument about missing storage, got {err:?}"
     );
 }
+
+/// The registry-aware Database::open rejects a custom WAL path: the process
+/// registry keys on the default WAL, so a nonstandard WAL must go through the
+/// raw do_open path instead.
+#[test]
+fn test_open_rejects_wal_path() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let path = tmp_dir.path().join("reject-wal.db");
+    let path = path.to_str().unwrap();
+
+    let io: Arc<dyn turso_core::IO + Send> = Arc::new(turso_core::PlatformIO::new().unwrap());
+    let file = io.open_file(path, OpenFlags::Create, false).unwrap();
+    let db_file = Arc::new(turso_core::storage::database::DatabaseFile::new(file));
+
+    let err = Database::open(
+        io,
+        path,
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file)
+            .flags(OpenFlags::Create)
+            .wal_path(format!("{path}-wal-override")),
+    )
+    .expect_err("Database::open must reject a custom wal_path");
+    assert!(
+        matches!(err, turso_core::LimboError::InvalidArgument(ref m) if m.contains("wal_path")),
+        "expected InvalidArgument about wal_path, got {err:?}"
+    );
+}
+
+/// do_open skips the process-wide registry: opening the same path first
+/// through the registry-aware open and then through do_open yields two
+/// distinct Database instances, and do_open does not register itself (so a
+/// later open() does not observe the do_open instance).
+#[test]
+fn test_do_open_skips_registry() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let path = tmp_dir.path().join("do-open-distinct.db");
+    let path = path.to_str().unwrap();
+
+    let io: Arc<dyn turso_core::IO + Send> = Arc::new(turso_core::PlatformIO::new().unwrap());
+    let file = io.open_file(path, OpenFlags::Create, false).unwrap();
+    let db_file = Arc::new(turso_core::storage::database::DatabaseFile::new(file));
+
+    // Register a canonical instance via the registry-aware open.
+    let registered = Database::open(
+        io.clone(),
+        path,
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file.clone())
+            .flags(OpenFlags::Create),
+    )
+    .unwrap();
+
+    // do_open must NOT return the registered instance.
+    let detached = Database::do_open(
+        io.clone(),
+        path,
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file.clone())
+            .flags(OpenFlags::Create),
+    )
+    .unwrap();
+    assert!(
+        !Arc::ptr_eq(&registered, &detached),
+        "do_open must open a fresh Database instance, not the registered one"
+    );
+
+    // A registry-aware open still returns the originally registered instance,
+    // proving do_open did not register itself over it.
+    let registered_again = Database::open(
+        io,
+        path,
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file)
+            .flags(OpenFlags::Create),
+    )
+    .unwrap();
+    assert!(
+        Arc::ptr_eq(&registered, &registered_again),
+        "open() must still return the registered instance; do_open must not replace it"
+    );
+}

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -890,15 +890,12 @@ fn test_db_share_same_file() {
         .execute("insert into a values (2, randomblob(2 * 4096))")
         .unwrap();
 
-    let db2 = turso_core::Database::open_with_flags_bypass_registry(
+    let db2 = turso_core::Database::do_open(
         io.clone(),
         path.to_str().unwrap(),
-        &format!("{}-wal-copy", path.to_str().unwrap()),
-        db_file.clone(),
-        turso_core::OpenFlags::default(),
-        turso_core::DatabaseOpts::new(),
-        None,
-        Arc::new(SqliteDialect),
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file.clone())
+            .wal_path(format!("{}-wal-copy", path.to_str().unwrap())),
     )
     .unwrap();
     let conn2 = db2.connect().unwrap();

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -865,15 +865,12 @@ fn test_db_share_same_file() {
         .open_file(path.to_str().unwrap(), turso_core::OpenFlags::Create, false)
         .unwrap();
     let db_file = Arc::new(turso_core::storage::database::DatabaseFile::new(db_file));
-    let db1 = turso_core::Database::open_with_flags(
+    let db1 = turso_core::Database::open(
         io.clone(),
         path.to_str().unwrap(),
-        db_file.clone(),
-        turso_core::OpenFlags::Create,
-        turso_core::DatabaseOpts::new(),
-        None,
-        None,
-        Arc::new(SqliteDialect),
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file.clone())
+            .flags(turso_core::OpenFlags::Create),
     )
     .unwrap();
     let conn1 = db1.connect().unwrap();

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -26,7 +26,7 @@ fn create_mvcc_db(io: &Arc<dyn turso_core::io::IO + Send>, path: &Path) -> anyho
 
 /// A minimal DurableStorage wrapper that delegates to the built-in implementation,
 /// but records that it was used. This validates per-database injection via
-/// `Database::open_file_with_flags_and_durable_storage`.
+/// `Database::open` with `OpenOptions::durable_storage`.
 #[derive(Debug)]
 struct RecordingDurableStorage {
     inner: Arc<dyn turso_core::mvcc::persistent_storage::DurableStorage>,
@@ -172,7 +172,7 @@ fn test_mvcc_create_table_on_attached_db(tmp_db: TempDatabase) -> anyhow::Result
 }
 
 /// Injecting a custom MVCC durable storage implementation via
-/// `Database::open_file_with_flags_and_durable_storage` should work.
+/// `Database::open` with `OpenOptions::durable_storage` should work.
 /// We validate that MVCC commits route through the injected storage by recording `log_tx` calls.
 ///
 /// Note: this uses the real on-disk DurableStorage under the hood and simply wraps it.
@@ -192,14 +192,12 @@ fn test_mvcc_custom_durable_storage_injected(tmp_db: TempDatabase) -> anyhow::Re
     let recording = Arc::new(RecordingDurableStorage::new(default_storage));
 
     // Open DB with injected durable storage, then enable MVCC.
-    let db = Database::open_file_with_flags_and_durable_storage(
+    let db = Database::open(
         tmp_db.io.clone(),
         db_path.to_str().unwrap(),
-        OpenFlags::default(),
-        DatabaseOpts::new(),
-        None,
-        Some(recording.clone()),
-        Arc::new(SqliteDialect),
+        turso_core::OpenOptions::new(Arc::new(SqliteDialect)).durable_storage(
+            recording.clone() as Arc<dyn turso_core::mvcc::persistent_storage::DurableStorage>
+        ),
     )?;
     let conn = db.connect()?;
     conn.pragma_update("journal_mode", "'mvcc'")?;


### PR DESCRIPTION
The `Database` struct has lots of different `open()` variants. Let's clean them up with `OpenOptions` parameter object.