### PR TITLE
core/mvcc: stream logical log serialization

### DIFF
--- a/core/benches/logical_log_serialization.rs
+++ b/core/benches/logical_log_serialization.rs
@@ -34,6 +34,15 @@ fn cold_buffer(bencher: Bencher, payload_len: usize) {
 fn transaction_batch(bencher: Bencher, op_count: usize) {
     let row_version = table_upsert(128);
 
+    // CodSpeed instruments a single iteration, unlike Divan's wall-time runner.
+    // Prime mimalloc's size classes so segment setup is not charged to whichever
+    // batch size happens to request a fresh allocator page first.
+    let mut warm_buffer = Vec::new();
+    for _ in 0..op_count {
+        benchmark_serialize_op_entry(&mut warm_buffer, &row_version, None).unwrap();
+    }
+    black_box(warm_buffer);
+
     bencher
         .with_inputs(Vec::new)
         .bench_local_values(|mut buffer| {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -65,7 +65,7 @@ pub use checkpoint_state_machine::{
 
 #[cfg(feature = "conn_raw_api")]
 use super::persistent_storage::logical_log::{
-    encode_delete_portable_extension, parse_ops_from_plaintext, LOG_RECORD_PREFIX_SIZE,
+    parse_ops_from_plaintext, LogSerializer, LOG_RECORD_PREFIX_SIZE,
 };
 use super::persistent_storage::logical_log::{
     HeaderReadResult, IndexOpKind, ParsedOp, StreamingLogicalLogReader, StreamingResult,
@@ -572,12 +572,9 @@ impl LogRecord {
     /// Test-only: append one row-version op to the payload buffer.
     #[cfg(test)]
     pub(crate) fn push_row_version_for_test(&mut self, row_version: &RowVersion) {
-        crate::mvcc::persistent_storage::logical_log::serialize_op_entry(
-            &mut self.buf,
-            row_version,
-            None,
-        )
-        .expect("failed to serialize row version in test");
+        crate::mvcc::persistent_storage::logical_log::LogSerializer::new(&mut self.buf)
+            .serialize_op_entry(row_version, None)
+            .expect("failed to serialize row version in test");
         self.op_count += 1;
     }
 
@@ -585,7 +582,9 @@ impl LogRecord {
     #[cfg(test)]
     pub(crate) fn set_header_for_test(&mut self, header: &DatabaseHeader) {
         assert!(!self.has_header, "header op appended twice in test");
-        crate::mvcc::persistent_storage::logical_log::serialize_header_entry(&mut self.buf, header);
+        crate::mvcc::persistent_storage::logical_log::LogSerializer::new(&mut self.buf)
+            .serialize_header_entry(header)
+            .expect("failed to serialize database header in test");
         self.has_header = true;
         self.op_count += 1;
     }
@@ -706,8 +705,11 @@ fn portable_delete_op_extension_for_row_version<Clock: LogicalClock, A: Concurre
     };
 
     if row_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-        let extension =
-            encode_delete_portable_extension(Some(row_version.row.payload()), None, Some(rowid));
+        let extension = LogSerializer::encode_delete_portable_extension(
+            Some(row_version.row.payload()),
+            None,
+            Some(rowid),
+        )?;
         return Ok((!extension.is_empty()).then_some(extension));
     }
 
@@ -758,7 +760,8 @@ fn portable_delete_op_extension_for_row_version<Clock: LogicalClock, A: Concurre
     } else {
         ImmutableRecord::from_values(&pk_values, pk_values.len())?.into_payload()
     };
-    let extension = encode_delete_portable_extension(None, Some(&pk_record), Some(rowid));
+    let extension =
+        LogSerializer::encode_delete_portable_extension(None, Some(&pk_record), Some(rowid))?;
     Ok((!extension.is_empty()).then_some(extension))
 }
 

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -236,7 +236,7 @@ use crate::sync::Arc;
 use crate::sync::RwLock;
 use crate::turso_assert;
 use crate::{
-    alloc::{ConcurrentAllocator, TursoAllocator, TursoFromIterator},
+    alloc::{ConcurrentAllocator, TursoAllocator},
     io::{CompletionGroup, ReadComplete},
     io_yield_one,
     mvcc::database::{LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey},

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -236,13 +236,13 @@ use crate::sync::Arc;
 use crate::sync::RwLock;
 use crate::turso_assert;
 use crate::{
-    alloc::{ConcurrentAllocator, TursoAllocator},
+    alloc::{ConcurrentAllocator, TursoAllocator, TursoFromIterator},
     io::{CompletionGroup, ReadComplete},
     io_yield_one,
     mvcc::database::{LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey},
     return_if_io,
     storage::sqlite3_ondisk::{
-        read_varint, read_varint_partial, varint_len, write_varint_to_vec, DatabaseHeader,
+        read_varint, read_varint_partial, varint_len, write_varint, DatabaseHeader,
     },
     types::{IOCompletions, IOResult, IndexInfo},
     util::IOExt as _,
@@ -251,6 +251,14 @@ use crate::{
 
 use crate::storage::encryption::EncryptionContext;
 use crate::File;
+
+mod serializer;
+use serializer::EncryptedPayload;
+pub(crate) use serializer::LogSerializer;
+#[cfg(feature = "conn_raw_api")]
+use serializer::{
+    extension_record_len, ExtensionRecord, PortableChangePayload, PortableEndOffsetCtx,
+};
 
 /// Logical log size in bytes at which a committing transaction will trigger a checkpoint.
 /// Default to the size of 1000 SQLite WAL frames; disable by setting a negative value.
@@ -680,10 +688,10 @@ impl LogicalLog {
             }
         }
         if has_portable_changes {
-            tx.buf.splice(
-                LOG_RECORD_PREFIX_SIZE..LOG_RECORD_PREFIX_SIZE,
+            LogSerializer::new(&mut tx.buf).insert(
+                LOG_RECORD_PREFIX_SIZE,
                 [0u8; TX_EXT_HEADER_SIZE - TX_HEADER_SIZE],
-            );
+            )?;
         }
 
         let tx_header_size = if has_portable_changes {
@@ -694,14 +702,12 @@ impl LogicalLog {
         let frame_payload_start = LOG_HDR_SIZE + tx_header_size;
 
         #[cfg(feature = "conn_raw_api")]
-        let extension_block = if !has_portable_changes {
-            Vec::new()
-        } else {
+        let extension_size = if has_portable_changes {
             let encryption_overhead = self
                 .encryption_ctx
                 .as_ref()
                 .map(|enc_ctx| (enc_ctx.tag_size(), enc_ctx.nonce_size()));
-            let portable_changes = encode_portable_change_payload_with_stable_end_offset(
+            let portable_changes = PortableChangePayload::with_stable_end_offset(
                 PortableEndOffsetCtx {
                     write_offset: self.offset,
                     includes_log_header: is_first_write,
@@ -713,20 +719,21 @@ impl LogicalLog {
                 tx.tx_timestamp,
                 &tx.portable_changes,
             )?;
-            encode_extension_record(EXTENSION_TYPE_PORTABLE_CHANGES, 0, &portable_changes)?
+            let extension =
+                ExtensionRecord::new(EXTENSION_TYPE_PORTABLE_CHANGES, 0, portable_changes);
+            let extension_size =
+                u64::try_from(extension_record_len(&extension)?).map_err(|_| {
+                    LimboError::InternalError("Logical log extension size exceeds u64".to_string())
+                })?;
+            LogSerializer::new(&mut tx.buf)
+                .insert_portable_extension(frame_payload_start, extension)?;
+            extension_size
+        } else {
+            0
         };
         #[cfg(not(feature = "conn_raw_api"))]
-        let extension_block = Vec::new();
-
-        let extension_size = u64::try_from(extension_block.len()).map_err(|_| {
-            LimboError::InternalError("Logical log extension size exceeds u64".to_string())
-        })?;
-        if !extension_block.is_empty() {
-            tx.buf
-                .splice(frame_payload_start..frame_payload_start, extension_block);
-        }
+        let extension_size = 0u64;
         let plaintext_size = tx.buf.len() - frame_payload_start;
-        let plaintext_size_u64 = plaintext_size as u64;
 
         // 2. Build the on-disk payload. Unencrypted is the zero-shift fast
         // path: plaintext is already after the TX header. Extension frames are
@@ -739,59 +746,15 @@ impl LogicalLog {
                 .as_ref()
                 .expect("log header must be set before writing")
                 .salt;
-            let on_disk_payload_size = encrypted_payload_blob_size(
+            LogSerializer::new(&mut tx.buf).encrypt_payload_in_place(EncryptedPayload {
+                enc_ctx,
+                payload_start: frame_payload_start,
                 plaintext_size,
-                self.encrypted_payload_chunk_size,
-                enc_ctx.tag_size(),
-                enc_ctx.nonce_size(),
-            )?;
-            let total = frame_payload_start + on_disk_payload_size + TX_TRAILER_SIZE;
-            // Move the plaintext out (`split_off` returns the tail past the
-            // framing prefix; `tx.buf` is left with just the header prefix
-            // to grow back into with encrypted chunks).
-            let plaintext = tx.buf.split_off(frame_payload_start);
-            debug_assert_eq!(plaintext.len(), plaintext_size);
-            tx.buf.reserve(total - tx.buf.len());
-
-            let chunk_count =
-                encrypted_payload_chunk_count(plaintext_size, self.encrypted_payload_chunk_size);
-            let payload_start = tx.buf.len();
-            for (chunk_index, plaintext_chunk) in plaintext
-                .chunks(self.encrypted_payload_chunk_size)
-                .enumerate()
-            {
-                let is_last_chunk = chunk_index + 1 == chunk_count;
-                let aad = build_encrypted_chunk_aad(
-                    salt,
-                    is_last_chunk.then_some(plaintext_size_u64),
-                    op_count,
-                    commit_ts,
-                    u32::try_from(chunk_index).map_err(|_| {
-                        LimboError::InternalError(
-                            "encrypted payload chunk index exceeds u32".to_string(),
-                        )
-                    })?,
-                );
-                let (ciphertext, nonce) = enc_ctx.encrypt_chunk(plaintext_chunk, &aad)?;
-                // encrypt_chunk returns ciphertext with the auth tag appended, so its
-                // length must be exactly plaintext_len + tag_size. The read path relies
-                // on this to split each chunk back into (ciphertext+tag, nonce).
-                debug_assert_eq!(
-                    ciphertext.len(),
-                    plaintext_chunk.len() + enc_ctx.tag_size(),
-                    "encrypt_chunk output size mismatch: expected plaintext({}) + tag({}), got {}",
-                    plaintext_chunk.len(),
-                    enc_ctx.tag_size(),
-                    ciphertext.len(),
-                );
-                tx.buf.extend_from_slice(&ciphertext);
-                tx.buf.extend_from_slice(&nonce);
-            }
-            turso_assert!(
-                tx.buf.len() - payload_start == on_disk_payload_size,
-                "encrypted on-disk payload size mismatch"
-            );
-            // `plaintext` is dropped here, freeing its allocation before pwrite.
+                chunk_size: self.encrypted_payload_chunk_size,
+                salt,
+                op_count,
+                commit_ts,
+            })?;
         }
         // Unencrypted: plaintext bytes are already in place after the TX header.
 
@@ -826,8 +789,7 @@ impl LogicalLog {
         // CRC stored within its 56 bytes.
         let payload_end = tx.buf.len();
         let crc = crc32c::crc32c_append(self.running_crc, &tx.buf[tx_header_start..payload_end]);
-        tx.buf.extend_from_slice(&crc.to_le_bytes());
-        tx.buf.extend_from_slice(&END_MAGIC.to_le_bytes());
+        LogSerializer::new(&mut tx.buf).serialize_tx_trailer(crc)?;
 
         // 5. Fill the LOG_HDR slot (first-write only). Non-first-write
         // commits leave it as zeros; those bytes never reach disk because
@@ -1056,83 +1018,6 @@ impl LogicalLog {
     }
 }
 
-/// Serialize one op into `buffer`.
-/// Op layout: tag(1) | flags(1) | table_id(4, le i32) | payload_len(varint) | payload(variable)
-pub(crate) fn serialize_op_entry(
-    buffer: &mut Vec<u8>,
-    row_version: &RowVersion,
-    portable_extension: Option<&[u8]>,
-) -> Result<()> {
-    let is_delete = row_version.end().is_some();
-
-    let mut flags = 0u8;
-    if row_version.btree_resident {
-        flags |= OP_FLAG_BTREE_RESIDENT;
-    }
-    if portable_extension.is_some_and(|extension| !extension.is_empty()) {
-        flags |= OP_FLAG_PORTABLE_EXTENSION;
-    }
-
-    let table_id_i64: i64 = row_version.row.id.table_id.into();
-    turso_assert!(
-        table_id_i64 < 0,
-        "table_id_i64 should be negative, but got {table_id_i64}"
-    );
-    turso_assert!(
-        (i32::MIN as i64..=i32::MAX as i64).contains(&table_id_i64),
-        "table_id_i64 out of i32 range: {table_id_i64}"
-    );
-    let table_id_i32 = table_id_i64 as i32;
-
-    let write_header = |buf: &mut Vec<u8>, tag: u8| {
-        buf.push(tag);
-        buf.push(flags);
-        buf.extend_from_slice(&table_id_i32.to_le_bytes());
-    };
-
-    match (&row_version.row.id.row_id, is_delete) {
-        (&RowKey::Int(rowid), false) => {
-            write_header(buffer, OP_UPSERT_TABLE);
-            let record_bytes = row_version.row.payload();
-            let rowid_u64 = rowid as u64;
-            let rowid_len = varint_len(rowid_u64);
-            let payload_len = rowid_len + record_bytes.len();
-            write_varint_to_vec(payload_len as u64, buffer);
-            write_varint_to_vec(rowid_u64, buffer);
-            buffer.extend_from_slice(record_bytes);
-        }
-        (&RowKey::Int(rowid), true) => {
-            write_header(buffer, OP_DELETE_TABLE);
-            let rowid_u64 = rowid as u64;
-            let rowid_len = varint_len(rowid_u64);
-            write_varint_to_vec(rowid_len as u64, buffer);
-            write_varint_to_vec(rowid_u64, buffer);
-        }
-        (RowKey::Record(_), is_delete) => {
-            write_header(
-                buffer,
-                if is_delete {
-                    OP_DELETE_INDEX
-                } else {
-                    OP_UPSERT_INDEX
-                },
-            );
-            let key_bytes = row_version.row.payload();
-            write_varint_to_vec(key_bytes.len() as u64, buffer);
-            buffer.extend_from_slice(key_bytes);
-        }
-    }
-
-    if let Some(portable_extension) =
-        portable_extension.filter(|portable_extension| !portable_extension.is_empty())
-    {
-        write_varint_to_vec(portable_extension.len() as u64, buffer);
-        buffer.extend_from_slice(portable_extension);
-    }
-
-    Ok(())
-}
-
 /// Serializes one logical-log operation for the serialization benchmark.
 #[cfg(feature = "bench")]
 pub fn benchmark_serialize_op_entry(
@@ -1140,62 +1025,7 @@ pub fn benchmark_serialize_op_entry(
     row_version: &RowVersion,
     portable_extension: Option<&[u8]>,
 ) -> Result<()> {
-    serialize_op_entry(buffer, row_version, portable_extension)
-}
-
-pub(crate) fn serialize_header_entry(buffer: &mut Vec<u8>, header: &DatabaseHeader) {
-    // Header op uses tag-only addressing (table_id=0, flags=0) and fixed payload length.
-    buffer.push(OP_UPDATE_HEADER);
-    buffer.push(0);
-    buffer.extend_from_slice(&0i32.to_le_bytes());
-    write_varint_to_vec(DatabaseHeader::SIZE as u64, buffer);
-    buffer.extend_from_slice(bytemuck::bytes_of(header));
-}
-
-fn write_proto_varint(mut value: u64, buffer: &mut Vec<u8>) {
-    while value >= 0x80 {
-        buffer.push((value as u8) | 0x80);
-        value >>= 7;
-    }
-    buffer.push(value as u8);
-}
-
-fn write_proto_key(field: u64, wire_type: u64, buffer: &mut Vec<u8>) {
-    write_proto_varint((field << 3) | wire_type, buffer);
-}
-
-fn write_proto_sint64(field: u64, value: i64, buffer: &mut Vec<u8>) {
-    let zigzag = ((value << 1) ^ (value >> 63)) as u64;
-    write_proto_key(field, 0, buffer);
-    write_proto_varint(zigzag, buffer);
-}
-
-fn write_proto_bytes(field: u64, value: &[u8], buffer: &mut Vec<u8>) {
-    write_proto_key(field, 2, buffer);
-    write_proto_varint(value.len() as u64, buffer);
-    buffer.extend_from_slice(value);
-}
-
-pub(crate) fn encode_delete_portable_extension(
-    identity_record: Option<&[u8]>,
-    pk_record: Option<&[u8]>,
-    rowid: Option<i64>,
-) -> Vec<u8> {
-    let mut extension = Vec::new();
-    if let Some(identity_record) = identity_record.filter(|record| !record.is_empty()) {
-        write_proto_bytes(
-            OP_EXT_FIELD_DELETE_IDENTITY_RECORD,
-            identity_record,
-            &mut extension,
-        );
-    }
-    if let Some(pk_record) = pk_record.filter(|record| !record.is_empty()) {
-        write_proto_bytes(OP_EXT_FIELD_DELETE_PK_RECORD, pk_record, &mut extension);
-    }
-    if let Some(rowid) = rowid {
-        write_proto_sint64(OP_EXT_FIELD_DELETE_ROWID, rowid, &mut extension);
-    }
-    extension
+    LogSerializer::new(buffer).serialize_op_entry(row_version, portable_extension)
 }
 
 fn read_proto_varint_from_buf(bytes: &[u8], offset: &mut usize) -> Result<u64> {
@@ -1297,123 +1127,6 @@ fn decode_delete_portable_extension(extension: &[u8]) -> Result<DeletePortableEx
         }
     }
     Ok(decoded)
-}
-
-fn proto_varint_len(mut value: u64) -> usize {
-    let mut len = 1;
-    while value >= 0x80 {
-        len += 1;
-        value >>= 7;
-    }
-    len
-}
-
-fn encode_portable_change_payload(
-    end_offset: u64,
-    commit_ts: u64,
-    encoded_metadata: &[u8],
-) -> Vec<u8> {
-    let body_len =
-        2 + proto_varint_len(end_offset) + proto_varint_len(commit_ts) + encoded_metadata.len();
-    let mut out = Vec::with_capacity(proto_varint_len(body_len as u64) + body_len);
-    write_proto_varint(body_len as u64, &mut out);
-    // PortableLogicalTxn.end_offset, field 1, varint.
-    write_proto_varint(1 << 3, &mut out);
-    write_proto_varint(end_offset, &mut out);
-    // PortableLogicalTxn.commit_ts, field 2, varint.
-    write_proto_varint(2 << 3, &mut out);
-    write_proto_varint(commit_ts, &mut out);
-    out.extend_from_slice(encoded_metadata);
-    out
-}
-
-/// Wraps commit-built logical op messages in one length-delimited
-/// portable MVCC logical transaction payload and iterates until the embedded
-/// `end_offset` matches the final frame size.
-///
-/// `end_offset` is part of the raw-log replay cursor, but its varint width can
-/// change the payload length. The fixed-point loop converges after the varint
-/// width stops changing.
-struct PortableEndOffsetCtx {
-    write_offset: u64,
-    includes_log_header: bool,
-    tx_header_size: usize,
-    recovery_payload_size: usize,
-    encrypted_payload_chunk_size: usize,
-    encryption_overhead: Option<(usize, usize)>,
-}
-
-fn encode_portable_change_payload_with_stable_end_offset(
-    ctx: PortableEndOffsetCtx,
-    tx_timestamp: u64,
-    portable_changes: &[u8],
-) -> Result<Vec<u8>> {
-    let frame_end_offset = |portable_payload_len: usize| -> Result<u64> {
-        let extension_size = EXTENSION_RECORD_HEADER_SIZE
-            .checked_add(portable_payload_len)
-            .ok_or_else(|| {
-                LimboError::InternalError("portable logical extension size overflow".to_string())
-            })?;
-        let plaintext_size = ctx
-            .recovery_payload_size
-            .checked_add(extension_size)
-            .ok_or_else(|| {
-                LimboError::InternalError("portable logical plaintext size overflow".to_string())
-            })?;
-        let body_size = if let Some((tag_size, nonce_size)) = ctx.encryption_overhead {
-            encrypted_payload_blob_size(
-                plaintext_size,
-                ctx.encrypted_payload_chunk_size,
-                tag_size,
-                nonce_size,
-            )?
-        } else {
-            plaintext_size
-        };
-        let prefix_size = if ctx.includes_log_header {
-            LOG_HDR_SIZE
-        } else {
-            0
-        };
-        let frame_bytes = prefix_size
-            .checked_add(ctx.tx_header_size)
-            .and_then(|value| value.checked_add(body_size))
-            .and_then(|value| value.checked_add(TX_TRAILER_SIZE))
-            .ok_or_else(|| {
-                LimboError::InternalError("portable logical frame size overflow".to_string())
-            })?;
-        ctx.write_offset
-            .checked_add(frame_bytes as u64)
-            .ok_or_else(|| {
-                LimboError::InternalError("portable logical frame offset overflow".to_string())
-            })
-    };
-
-    let mut end_offset = frame_end_offset(0)?;
-    loop {
-        let payload = encode_portable_change_payload(end_offset, tx_timestamp, portable_changes);
-        let next_end_offset = frame_end_offset(payload.len())?;
-        if next_end_offset == end_offset {
-            return Ok(payload);
-        }
-        end_offset = next_end_offset;
-    }
-}
-
-fn encode_extension_record(
-    extension_type: u16,
-    extension_flags: u16,
-    payload: &[u8],
-) -> Result<Vec<u8>> {
-    let payload_len = u32::try_from(payload.len()).map_err(|_| {
-        LimboError::InternalError("Logical log extension record exceeds u32".to_string())
-    })?;
-    let mut record = Vec::with_capacity(EXTENSION_RECORD_HEADER_SIZE + payload.len());
-    record.extend_from_slice(&extension_type.to_le_bytes());
-    record.extend_from_slice(&extension_flags.to_le_bytes());
-    record.extend_from_slice(&payload_len.to_le_bytes());
-    record.extend_from_slice(payload);
-    Ok(record)
 }
 
 fn find_extension_payload(
@@ -3988,12 +3701,11 @@ mod tests {
 
     use super::{
         build_encrypted_chunk_aad, encrypted_chunk_blob_size, encrypted_chunk_plaintext_len,
-        encrypted_payload_blob_size, encrypted_payload_chunk_count, serialize_header_entry,
-        serialize_op_entry, HeaderReadResult, LogHeader, LogicalLog, ParseResult, ParsedOp,
-        StreamingLogicalLogReader, ENCRYPTED_CHUNK_AAD_SIZE, ENCRYPTED_PAYLOAD_CHUNK_SIZE,
-        END_MAGIC, EXT_FRAME_MAGIC, FRAME_MAGIC, LOG_HDR_CRC_START, LOG_HDR_RESERVED_START,
-        LOG_HDR_SIZE, LOG_VERSION, LOG_VERSION_V2, TX_EXT_HEADER_SIZE, TX_HEADER_SIZE,
-        TX_HEADER_SIZE_V2, TX_TRAILER_SIZE,
+        encrypted_payload_blob_size, encrypted_payload_chunk_count, HeaderReadResult, LogHeader,
+        LogSerializer, LogicalLog, ParseResult, ParsedOp, StreamingLogicalLogReader,
+        ENCRYPTED_CHUNK_AAD_SIZE, ENCRYPTED_PAYLOAD_CHUNK_SIZE, END_MAGIC, EXT_FRAME_MAGIC,
+        FRAME_MAGIC, LOG_HDR_CRC_START, LOG_HDR_RESERVED_START, LOG_HDR_SIZE, LOG_VERSION,
+        LOG_VERSION_V2, TX_EXT_HEADER_SIZE, TX_HEADER_SIZE, TX_HEADER_SIZE_V2, TX_TRAILER_SIZE,
     };
     #[cfg(feature = "conn_raw_api")]
     use super::{EXTENSION_RECORD_HEADER_SIZE, EXTENSION_TYPE_PORTABLE_CHANGES, OP_UPSERT_TABLE};
@@ -6435,7 +6147,9 @@ mod tests {
         let mut encoded = Vec::new();
         let value = "x".repeat(text_len);
         let row_version = make_test_row_version((-2).into(), rowid, &value, 100);
-        serialize_op_entry(&mut encoded, &row_version, None).unwrap();
+        LogSerializer::new(&mut encoded)
+            .serialize_op_entry(&row_version, None)
+            .unwrap();
         encoded.len()
     }
 
@@ -6792,11 +6506,17 @@ mod tests {
         chunk_size: usize,
     ) {
         let mut filler_buf = Vec::new();
-        serialize_op_entry(&mut filler_buf, short_filler, None).unwrap();
+        LogSerializer::new(&mut filler_buf)
+            .serialize_op_entry(short_filler, None)
+            .unwrap();
         let mut short_upsert_buf = Vec::new();
-        serialize_op_entry(&mut short_upsert_buf, short_upsert, None).unwrap();
+        LogSerializer::new(&mut short_upsert_buf)
+            .serialize_op_entry(short_upsert, None)
+            .unwrap();
         let mut long_upsert_buf = Vec::new();
-        serialize_op_entry(&mut long_upsert_buf, long_upsert, None).unwrap();
+        LogSerializer::new(&mut long_upsert_buf)
+            .serialize_op_entry(long_upsert, None)
+            .unwrap();
 
         turso_assert_less_than!(
             filler_buf.len(),
@@ -6846,7 +6566,9 @@ mod tests {
             false,
         );
         let mut short_upsert_buf = Vec::new();
-        serialize_op_entry(&mut short_upsert_buf, &short_upsert, None).unwrap();
+        LogSerializer::new(&mut short_upsert_buf)
+            .serialize_op_entry(&short_upsert, None)
+            .unwrap();
         turso_assert_less_than!(
             short_upsert_buf.len(),
             StreamingLogicalLogReader::MAX_SERIALIZED_OP_PREFIX_LEN,
@@ -7727,11 +7449,15 @@ mod tests {
         let expected_second_record_bytes = second.row.payload().to_vec();
 
         let mut filler_buf = Vec::new();
-        serialize_op_entry(&mut filler_buf, &filler, None).unwrap();
+        LogSerializer::new(&mut filler_buf)
+            .serialize_op_entry(&filler, None)
+            .unwrap();
         assert_eq!(filler_buf.len(), ENCRYPTED_PAYLOAD_CHUNK_SIZE - 7);
 
         let mut second_buf = Vec::new();
-        serialize_op_entry(&mut second_buf, &second, None).unwrap();
+        LogSerializer::new(&mut second_buf)
+            .serialize_op_entry(&second, None)
+            .unwrap();
         // Table ops begin with a fixed 6-byte prelude:
         // 1 byte op tag + 1 byte flags + 4 bytes table_id.
         // The payload_len varint begins immediately after that prefix.
@@ -7771,7 +7497,9 @@ mod tests {
         let mut header = DatabaseHeader::default();
         header.database_size = 123.into();
         header.schema_cookie = 456.into();
-        serialize_header_entry(&mut header_buf, &header);
+        LogSerializer::new(&mut header_buf)
+            .serialize_header_entry(&header)
+            .unwrap();
 
         let filler_payload_size = ENCRYPTED_PAYLOAD_CHUNK_SIZE - (header_buf.len() - 1);
         let filler_len = text_len_for_single_upsert_table_op_size(filler_payload_size);
@@ -7780,7 +7508,9 @@ mod tests {
         let expected_filler_record_bytes = filler.row.payload().to_vec();
 
         let mut filler_buf = Vec::new();
-        serialize_op_entry(&mut filler_buf, &filler, None).unwrap();
+        LogSerializer::new(&mut filler_buf)
+            .serialize_op_entry(&filler, None)
+            .unwrap();
         assert_eq!(filler_buf.len(), filler_payload_size);
         assert_eq!(
             filler_buf.len() + header_buf.len() - 1,

--- a/core/mvcc/persistent_storage/logical_log/serializer.rs
+++ b/core/mvcc/persistent_storage/logical_log/serializer.rs
@@ -1,0 +1,669 @@
+use super::*;
+
+/// A logical-log fragment that can be flattened into an exact byte iterator.
+///
+/// `TursoFromIterator::try_extend` uses the iterator's upper bound to reserve
+/// before mutation and specializes for the concrete iterator where possible.
+pub(super) trait LogBufferWrite {
+    fn into_bytes(self) -> impl Iterator<Item = u8>;
+}
+
+macro_rules! log_write {
+    ($serializer:expr, [$first:expr $(, $rest:expr)* $(,)?], $extension:expr) => {{
+        if let Some(extension) = $extension {
+            log_write!(
+                $serializer,
+                [
+                    $first,
+                    $($rest,)*
+                    SqliteVarint(extension.len() as u64),
+                    extension,
+                ]
+            )
+        } else {
+            log_write!($serializer, [$first $(, $rest)*])
+        }
+    }};
+    ($serializer:expr, [$first:expr $(, $rest:expr)* $(,)?]) => {{
+        $serializer.write(
+            LogBufferWrite::into_bytes($first)
+                $(.chain(LogBufferWrite::into_bytes($rest)))*
+        )
+    }};
+}
+
+pub(crate) struct LogSerializer<'a> {
+    buffer: &'a mut Vec<u8>,
+}
+
+impl<'a> LogSerializer<'a> {
+    #[inline(always)]
+    pub(crate) fn new(buffer: &'a mut Vec<u8>) -> Self {
+        Self { buffer }
+    }
+
+    #[inline(always)]
+    fn write(&mut self, bytes: impl Iterator<Item = u8>) -> Result<()> {
+        self.buffer.try_extend(bytes)?;
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub(super) fn insert<W: LogBufferWrite>(&mut self, offset: usize, value: W) -> Result<()> {
+        if offset > self.buffer.len() {
+            return Err(LimboError::InternalError(
+                "logical log serializer insert offset exceeds buffer length".to_string(),
+            ));
+        }
+
+        let bytes = value.into_bytes();
+        let encoded_len = exact_iterator_len(&bytes).ok_or_else(log_buffer_len_overflow)?;
+        let new_len = self
+            .buffer
+            .len()
+            .checked_add(encoded_len)
+            .ok_or_else(log_buffer_len_overflow)?;
+        self.buffer.try_extend(bytes)?;
+        debug_assert_eq!(
+            self.buffer.len(),
+            new_len,
+            "logical log serializer encoded length mismatch"
+        );
+        self.buffer[offset..].rotate_right(encoded_len);
+        Ok(())
+    }
+
+    pub(super) fn insert_portable_extension(
+        &mut self,
+        offset: usize,
+        record: ExtensionRecord<PortableChangePayload<'_>>,
+    ) -> Result<()> {
+        if offset > self.buffer.len() {
+            return Err(LimboError::InternalError(
+                "logical log serializer insert offset exceeds buffer length".to_string(),
+            ));
+        }
+
+        let encoded_len = extension_record_len(&record)?;
+        let payload_len = encoded_len - EXTENSION_RECORD_HEADER_SIZE;
+        let payload_len = u32::try_from(payload_len).map_err(|_| {
+            LimboError::InternalError("Logical log extension record exceeds u32".to_string())
+        })?;
+        let original_len = self.buffer.len();
+        let new_len = original_len
+            .checked_add(encoded_len)
+            .ok_or_else(log_buffer_len_overflow)?;
+
+        let ExtensionRecord {
+            extension_type,
+            extension_flags,
+            payload,
+        } = record;
+        let body_len = payload.body_len().ok_or_else(log_buffer_len_overflow)?;
+        log_write!(
+            self,
+            [
+                extension_type.to_le_bytes(),
+                extension_flags.to_le_bytes(),
+                payload_len.to_le_bytes(),
+                ProtoVarint(body_len as u64),
+                ProtoKey::new(1, PROTO_WIRE_VARINT),
+                ProtoVarint(payload.end_offset),
+                ProtoKey::new(2, PROTO_WIRE_VARINT),
+                ProtoVarint(payload.commit_ts),
+                payload.encoded_metadata,
+            ]
+        )?;
+        debug_assert_eq!(
+            self.buffer.len(),
+            new_len,
+            "logical log serializer encoded length mismatch"
+        );
+        self.buffer[offset..].rotate_right(encoded_len);
+        Ok(())
+    }
+
+    /// Serialize one operation into the wrapped buffer.
+    ///
+    /// Layout: tag(1) | flags(1) | table_id(4) | payload_len(varint) | payload.
+    #[inline(always)]
+    pub(crate) fn serialize_op_entry(
+        &mut self,
+        row_version: &RowVersion,
+        portable_extension: Option<&[u8]>,
+    ) -> Result<()> {
+        let is_delete = row_version.end().is_some();
+
+        let mut flags = 0u8;
+        if row_version.btree_resident {
+            flags |= OP_FLAG_BTREE_RESIDENT;
+        }
+        if portable_extension.is_some_and(|extension| !extension.is_empty()) {
+            flags |= OP_FLAG_PORTABLE_EXTENSION;
+        }
+
+        let table_id_i64: i64 = row_version.row.id.table_id.into();
+        turso_assert!(
+            table_id_i64 < 0,
+            "table_id_i64 should be negative, but got {table_id_i64}"
+        );
+        turso_assert!(
+            (i32::MIN as i64..=i32::MAX as i64).contains(&table_id_i64),
+            "table_id_i64 out of i32 range: {table_id_i64}"
+        );
+        let table_id = (table_id_i64 as i32).to_le_bytes();
+        let portable_extension = portable_extension.filter(|extension| !extension.is_empty());
+
+        match (&row_version.row.id.row_id, is_delete) {
+            (&RowKey::Int(rowid), false) => {
+                let record = row_version.row.payload();
+                let rowid = rowid as u64;
+                let payload_len = varint_len(rowid)
+                    .checked_add(record.len())
+                    .ok_or_else(log_buffer_len_overflow)?;
+                log_write!(
+                    self,
+                    [
+                        OP_UPSERT_TABLE,
+                        flags,
+                        table_id,
+                        SqliteVarint(payload_len as u64),
+                        SqliteVarint(rowid),
+                        record,
+                    ],
+                    portable_extension
+                )?;
+            }
+            (&RowKey::Int(rowid), true) => {
+                let rowid = rowid as u64;
+                log_write!(
+                    self,
+                    [
+                        OP_DELETE_TABLE,
+                        flags,
+                        table_id,
+                        SqliteVarint(varint_len(rowid) as u64),
+                        SqliteVarint(rowid),
+                    ],
+                    portable_extension
+                )?;
+            }
+            (RowKey::Record(_), is_delete) => {
+                let key = row_version.row.payload();
+                log_write!(
+                    self,
+                    [
+                        if is_delete {
+                            OP_DELETE_INDEX
+                        } else {
+                            OP_UPSERT_INDEX
+                        },
+                        flags,
+                        table_id,
+                        SqliteVarint(key.len() as u64),
+                        key,
+                    ],
+                    portable_extension
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub(crate) fn serialize_header_entry(&mut self, header: &DatabaseHeader) -> Result<()> {
+        // Header operations use tag-only addressing (table_id=0, flags=0).
+        log_write!(
+            self,
+            [
+                OP_UPDATE_HEADER,
+                0,
+                0i32.to_le_bytes(),
+                SqliteVarint(DatabaseHeader::SIZE as u64),
+                bytemuck::bytes_of(header),
+            ]
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn serialize_tx_trailer(&mut self, crc: u32) -> Result<()> {
+        log_write!(self, [crc.to_le_bytes(), END_MAGIC.to_le_bytes()])
+    }
+
+    pub(crate) fn encode_delete_portable_extension(
+        identity_record: Option<&[u8]>,
+        pk_record: Option<&[u8]>,
+        rowid: Option<i64>,
+    ) -> Result<Vec<u8>> {
+        let mut extension = Vec::new();
+        let mut serializer = LogSerializer::new(&mut extension);
+        if let Some(identity_record) = identity_record.filter(|record| !record.is_empty()) {
+            log_write!(
+                serializer,
+                [
+                    ProtoKey::new(
+                        OP_EXT_FIELD_DELETE_IDENTITY_RECORD,
+                        PROTO_WIRE_LENGTH_DELIMITED
+                    ),
+                    ProtoVarint(identity_record.len() as u64),
+                    identity_record,
+                ]
+            )?;
+        }
+        if let Some(pk_record) = pk_record.filter(|record| !record.is_empty()) {
+            log_write!(
+                serializer,
+                [
+                    ProtoKey::new(OP_EXT_FIELD_DELETE_PK_RECORD, PROTO_WIRE_LENGTH_DELIMITED),
+                    ProtoVarint(pk_record.len() as u64),
+                    pk_record,
+                ]
+            )?;
+        }
+        if let Some(rowid) = rowid {
+            log_write!(
+                serializer,
+                [ProtoSint64::new(OP_EXT_FIELD_DELETE_ROWID, rowid)]
+            )?;
+        }
+        Ok(extension)
+    }
+
+    pub(crate) fn encrypt_payload_in_place(&mut self, payload: EncryptedPayload<'_>) -> Result<()> {
+        let tag_size = payload.enc_ctx.tag_size();
+        let nonce_size = payload.enc_ctx.nonce_size();
+        let on_disk_size = encrypted_payload_blob_size(
+            payload.plaintext_size,
+            payload.chunk_size,
+            tag_size,
+            nonce_size,
+        )?;
+        let payload_end = payload
+            .payload_start
+            .checked_add(on_disk_size)
+            .ok_or_else(|| {
+                LimboError::InternalError("encrypted payload end offset overflow".to_string())
+            })?;
+        if payload.payload_start > self.buffer.len() {
+            return Err(LimboError::InternalError(
+                "encrypted payload start exceeds buffer length".to_string(),
+            ));
+        }
+        let additional = payload_end.checked_sub(self.buffer.len()).ok_or_else(|| {
+            LimboError::InternalError("encrypted payload shrinks unexpectedly".to_string())
+        })?;
+        self.buffer.try_reserve(additional)?;
+        self.buffer.resize(payload_end, 0);
+
+        let chunk_count = encrypted_payload_chunk_count(payload.plaintext_size, payload.chunk_size);
+        let plaintext_size = u64::try_from(payload.plaintext_size).map_err(|_| {
+            LimboError::InternalError("encrypted plaintext size exceeds u64".to_string())
+        })?;
+        let mut encrypted_tail = on_disk_size;
+
+        // Ciphertext chunks are larger than plaintext chunks. Moving and
+        // encrypting them back-to-front preserves plaintext not yet consumed.
+        for chunk_index in (0..chunk_count).rev() {
+            let plaintext_len = encrypted_chunk_plaintext_len(
+                payload.plaintext_size,
+                chunk_index,
+                payload.chunk_size,
+            )?;
+            let encrypted_len = encrypted_chunk_blob_size(plaintext_len, tag_size, nonce_size)?;
+            encrypted_tail -= encrypted_len;
+
+            let plaintext_offset = chunk_index * payload.chunk_size;
+            let plaintext_start = payload.payload_start + plaintext_offset;
+            let plaintext_end = plaintext_start + plaintext_len;
+            let ciphertext_start = payload.payload_start + encrypted_tail;
+            if ciphertext_start != plaintext_start {
+                self.buffer
+                    .copy_within(plaintext_start..plaintext_end, ciphertext_start);
+            }
+
+            let aad = build_encrypted_chunk_aad(
+                payload.salt,
+                (chunk_index + 1 == chunk_count).then_some(plaintext_size),
+                payload.op_count,
+                payload.commit_ts,
+                u32::try_from(chunk_index).map_err(|_| {
+                    LimboError::InternalError(
+                        "encrypted payload chunk index exceeds u32".to_string(),
+                    )
+                })?,
+            );
+            let tag_start = ciphertext_start + plaintext_len;
+            let nonce_start = tag_start + tag_size;
+            let chunk_end = nonce_start + nonce_size;
+            let chunk = &mut self.buffer[ciphertext_start..chunk_end];
+            let (ciphertext, tag_and_nonce) = chunk.split_at_mut(plaintext_len);
+            let (tag, nonce) = tag_and_nonce.split_at_mut(tag_size);
+            payload
+                .enc_ctx
+                .encrypt_chunk_in_place(ciphertext, &aad, tag, nonce)?;
+        }
+
+        turso_assert!(
+            encrypted_tail == 0,
+            "encrypted payload tail cursor should end at payload start"
+        );
+        turso_assert!(
+            self.buffer.len() - payload.payload_start == on_disk_size,
+            "encrypted on-disk payload size mismatch"
+        );
+        Ok(())
+    }
+}
+
+struct SqliteVarint(u64);
+
+impl LogBufferWrite for SqliteVarint {
+    #[inline(always)]
+    fn into_bytes(self) -> impl Iterator<Item = u8> {
+        let mut bytes = [0; 9];
+        let len = write_varint(&mut bytes, self.0);
+        bytes.into_iter().take(len)
+    }
+}
+
+struct ProtoVarint(u64);
+
+impl LogBufferWrite for ProtoVarint {
+    #[inline(always)]
+    fn into_bytes(self) -> impl Iterator<Item = u8> {
+        let mut value = self.0;
+        let mut bytes = [0; 10];
+        let mut len = 0;
+        loop {
+            let byte = value as u8;
+            value >>= 7;
+            bytes[len] = byte | (u8::from(value != 0) * 0x80);
+            len += 1;
+            if value == 0 {
+                break;
+            }
+        }
+        bytes.into_iter().take(len)
+    }
+}
+
+const PROTO_WIRE_VARINT: u64 = 0;
+const PROTO_WIRE_LENGTH_DELIMITED: u64 = 2;
+
+struct ProtoKey {
+    field: u64,
+    wire_type: u64,
+}
+
+impl ProtoKey {
+    fn new(field: u64, wire_type: u64) -> Self {
+        Self { field, wire_type }
+    }
+}
+
+impl LogBufferWrite for ProtoKey {
+    fn into_bytes(self) -> impl Iterator<Item = u8> {
+        ProtoVarint((self.field << 3) | self.wire_type).into_bytes()
+    }
+}
+
+struct ProtoSint64 {
+    field: u64,
+    value: i64,
+}
+
+impl ProtoSint64 {
+    fn new(field: u64, value: i64) -> Self {
+        Self { field, value }
+    }
+
+    fn zigzag(&self) -> u64 {
+        ((self.value << 1) ^ (self.value >> 63)) as u64
+    }
+}
+
+impl LogBufferWrite for ProtoSint64 {
+    fn into_bytes(self) -> impl Iterator<Item = u8> {
+        let zigzag = self.zigzag();
+        ProtoKey::new(self.field, PROTO_WIRE_VARINT)
+            .into_bytes()
+            .chain(ProtoVarint(zigzag).into_bytes())
+    }
+}
+
+impl LogBufferWrite for u8 {
+    fn into_bytes(self) -> impl Iterator<Item = u8> {
+        std::iter::once(self)
+    }
+}
+
+impl<const N: usize> LogBufferWrite for [u8; N] {
+    fn into_bytes(self) -> impl Iterator<Item = u8> {
+        self.into_iter()
+    }
+}
+
+impl LogBufferWrite for &[u8] {
+    fn into_bytes(self) -> impl Iterator<Item = u8> {
+        self.iter().copied()
+    }
+}
+
+fn exact_iterator_len(iter: &impl Iterator) -> Option<usize> {
+    let (lower, upper) = iter.size_hint();
+    (upper == Some(lower)).then_some(lower)
+}
+
+fn log_buffer_len_overflow() -> LimboError {
+    LimboError::InternalError("logical log serialization size overflow".to_string())
+}
+
+fn proto_varint_len(mut value: u64) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        len += 1;
+        value >>= 7;
+    }
+    len
+}
+
+/// Context needed to find the stable raw-log cursor encoded in a portable payload.
+pub(super) struct PortableEndOffsetCtx {
+    pub(super) write_offset: u64,
+    pub(super) includes_log_header: bool,
+    pub(super) tx_header_size: usize,
+    pub(super) recovery_payload_size: usize,
+    pub(super) encrypted_payload_chunk_size: usize,
+    pub(super) encryption_overhead: Option<(usize, usize)>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct PortableChangePayload<'a> {
+    end_offset: u64,
+    commit_ts: u64,
+    encoded_metadata: &'a [u8],
+}
+
+impl<'a> PortableChangePayload<'a> {
+    fn new(end_offset: u64, commit_ts: u64, encoded_metadata: &'a [u8]) -> Self {
+        Self {
+            end_offset,
+            commit_ts,
+            encoded_metadata,
+        }
+    }
+
+    /// Iterates until the embedded `end_offset` and the encoded frame size agree.
+    ///
+    /// The cursor itself is a varint, so crossing a varint-width boundary changes
+    /// the frame size that determines the cursor.
+    pub(super) fn with_stable_end_offset(
+        ctx: PortableEndOffsetCtx,
+        commit_ts: u64,
+        encoded_metadata: &'a [u8],
+    ) -> Result<Self> {
+        let frame_end_offset = |portable_payload_len: usize| -> Result<u64> {
+            let extension_size = EXTENSION_RECORD_HEADER_SIZE
+                .checked_add(portable_payload_len)
+                .ok_or_else(|| {
+                    LimboError::InternalError(
+                        "portable logical extension size overflow".to_string(),
+                    )
+                })?;
+            let plaintext_size = ctx
+                .recovery_payload_size
+                .checked_add(extension_size)
+                .ok_or_else(|| {
+                    LimboError::InternalError(
+                        "portable logical plaintext size overflow".to_string(),
+                    )
+                })?;
+            let body_size = if let Some((tag_size, nonce_size)) = ctx.encryption_overhead {
+                encrypted_payload_blob_size(
+                    plaintext_size,
+                    ctx.encrypted_payload_chunk_size,
+                    tag_size,
+                    nonce_size,
+                )?
+            } else {
+                plaintext_size
+            };
+            let prefix_size = if ctx.includes_log_header {
+                LOG_HDR_SIZE
+            } else {
+                0
+            };
+            let frame_size = prefix_size
+                .checked_add(ctx.tx_header_size)
+                .and_then(|size| size.checked_add(body_size))
+                .and_then(|size| size.checked_add(TX_TRAILER_SIZE))
+                .ok_or_else(|| {
+                    LimboError::InternalError("portable logical frame size overflow".to_string())
+                })?;
+            let frame_size = u64::try_from(frame_size).map_err(|_| {
+                LimboError::InternalError("portable logical frame size exceeds u64".to_string())
+            })?;
+            ctx.write_offset.checked_add(frame_size).ok_or_else(|| {
+                LimboError::InternalError("portable logical frame offset overflow".to_string())
+            })
+        };
+
+        let mut end_offset = frame_end_offset(0)?;
+        loop {
+            let payload = Self::new(end_offset, commit_ts, encoded_metadata);
+            let encoded_len = payload.encoded_len().ok_or_else(log_buffer_len_overflow)?;
+            let next_end_offset = frame_end_offset(encoded_len)?;
+            if next_end_offset == end_offset {
+                return Ok(payload);
+            }
+            end_offset = next_end_offset;
+        }
+    }
+
+    fn body_len(&self) -> Option<usize> {
+        proto_varint_len((1 << 3) | PROTO_WIRE_VARINT)
+            .checked_add(proto_varint_len(self.end_offset))?
+            .checked_add(proto_varint_len((2 << 3) | PROTO_WIRE_VARINT))?
+            .checked_add(proto_varint_len(self.commit_ts))?
+            .checked_add(self.encoded_metadata.len())
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        let body_len = self.body_len()?;
+        proto_varint_len(body_len as u64).checked_add(body_len)
+    }
+}
+
+impl LogBufferWrite for PortableChangePayload<'_> {
+    fn into_bytes(self) -> impl Iterator<Item = u8> {
+        let body_len = self
+            .body_len()
+            .expect("portable payload length was checked before writing");
+        ProtoVarint(body_len as u64)
+            .into_bytes()
+            .chain(ProtoKey::new(1, PROTO_WIRE_VARINT).into_bytes())
+            .chain(ProtoVarint(self.end_offset).into_bytes())
+            .chain(ProtoKey::new(2, PROTO_WIRE_VARINT).into_bytes())
+            .chain(ProtoVarint(self.commit_ts).into_bytes())
+            .chain(self.encoded_metadata.iter().copied())
+    }
+}
+
+pub(super) struct ExtensionRecord<P> {
+    extension_type: u16,
+    extension_flags: u16,
+    payload: P,
+}
+
+impl<P> ExtensionRecord<P> {
+    pub(super) fn new(extension_type: u16, extension_flags: u16, payload: P) -> Self {
+        Self {
+            extension_type,
+            extension_flags,
+            payload,
+        }
+    }
+}
+
+pub(super) fn extension_record_len(
+    record: &ExtensionRecord<PortableChangePayload<'_>>,
+) -> Result<usize> {
+    let payload_len = record
+        .payload
+        .encoded_len()
+        .ok_or_else(log_buffer_len_overflow)?;
+    let _ = u32::try_from(payload_len).map_err(|_| {
+        LimboError::InternalError("Logical log extension record exceeds u32".to_string())
+    })?;
+    EXTENSION_RECORD_HEADER_SIZE
+        .checked_add(payload_len)
+        .ok_or_else(log_buffer_len_overflow)
+}
+
+pub(crate) struct EncryptedPayload<'a> {
+    pub(super) enc_ctx: &'a EncryptionContext,
+    pub(super) payload_start: usize,
+    pub(super) plaintext_size: usize,
+    pub(super) chunk_size: usize,
+    pub(super) salt: u64,
+    pub(super) op_count: u32,
+    pub(super) commit_ts: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fragment_iterator_has_exact_size_hint() {
+        let bytes = PortableChangePayload::new(1, 2, &[3]).into_bytes();
+
+        assert_eq!(bytes.size_hint(), (6, Some(6)));
+        assert_eq!(bytes.collect::<Vec<_>>(), [5, 8, 1, 16, 2, 3]);
+    }
+
+    #[test]
+    fn insert_preserves_surrounding_bytes() {
+        let mut buffer = vec![1, 4];
+        LogSerializer::new(&mut buffer).insert(1, [2, 3]).unwrap();
+
+        assert_eq!(buffer, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn portable_extension_insert_preserves_wire_format() {
+        let mut buffer = vec![9, 10];
+        let payload = PortableChangePayload::new(1, 2, &[3]);
+        let record = ExtensionRecord::new(0x1234, 0x5678, payload);
+
+        LogSerializer::new(&mut buffer)
+            .insert_portable_extension(1, record)
+            .unwrap();
+
+        assert_eq!(
+            buffer,
+            [9, 0x34, 0x12, 0x78, 0x56, 6, 0, 0, 0, 5, 8, 1, 16, 2, 3, 10,]
+        );
+    }
+}

--- a/core/mvcc/persistent_storage/logical_log/serializer.rs
+++ b/core/mvcc/persistent_storage/logical_log/serializer.rs
@@ -1,11 +1,155 @@
 use super::*;
 
-/// A logical-log fragment that can be flattened into an exact byte iterator.
+/// A statically composed stream of logical-log chunks.
 ///
-/// `TursoFromIterator::try_extend` uses the iterator's upper bound to reserve
-/// before mutation and specializes for the concrete iterator where possible.
+/// Keeping inline values and borrowed slices as distinct chunks lets the
+/// serializer reserve for the complete stream once, then bulk-copy each slice.
+/// Flattening the same chain to `Iterator<Item = u8>` loses those slice
+/// boundaries and makes `Vec::extend` copy the payload one byte at a time.
+pub(super) trait LogChunkStream: Sized {
+    fn encoded_len(&self) -> Option<usize>;
+
+    fn copy_to(self, writer: &mut LogChunkWriter) -> Result<()>;
+
+    #[inline(always)]
+    fn chain<R: LogChunkStream>(self, right: R) -> ChainedLogChunks<Self, R> {
+        ChainedLogChunks { left: self, right }
+    }
+}
+
+pub(super) struct ChainedLogChunks<L, R> {
+    left: L,
+    right: R,
+}
+
+impl<L: LogChunkStream, R: LogChunkStream> LogChunkStream for ChainedLogChunks<L, R> {
+    #[inline(always)]
+    fn encoded_len(&self) -> Option<usize> {
+        self.left
+            .encoded_len()?
+            .checked_add(self.right.encoded_len()?)
+    }
+
+    #[inline(always)]
+    fn copy_to(self, writer: &mut LogChunkWriter) -> Result<()> {
+        self.left.copy_to(writer)?;
+        self.right.copy_to(writer)
+    }
+}
+
+struct InlineLogChunk<const N: usize> {
+    bytes: [u8; N],
+    len: usize,
+}
+
+impl<const N: usize> InlineLogChunk<N> {
+    #[inline(always)]
+    fn full(bytes: [u8; N]) -> Self {
+        Self { bytes, len: N }
+    }
+
+    #[inline(always)]
+    fn prefix(bytes: [u8; N], len: usize) -> Self {
+        assert!(
+            len <= N,
+            "inline logical-log chunk length exceeds its buffer"
+        );
+        Self { bytes, len }
+    }
+}
+
+impl<const N: usize> LogChunkStream for InlineLogChunk<N> {
+    #[inline(always)]
+    fn encoded_len(&self) -> Option<usize> {
+        Some(self.len)
+    }
+
+    #[inline(always)]
+    fn copy_to(self, writer: &mut LogChunkWriter) -> Result<()> {
+        writer.copy_from_slice(&self.bytes[..self.len])
+    }
+}
+
+struct BorrowedLogChunk<'a>(&'a [u8]);
+
+impl LogChunkStream for BorrowedLogChunk<'_> {
+    #[inline(always)]
+    fn encoded_len(&self) -> Option<usize> {
+        Some(self.0.len())
+    }
+
+    #[inline(always)]
+    fn copy_to(self, writer: &mut LogChunkWriter) -> Result<()> {
+        writer.copy_from_slice(self.0)
+    }
+}
+
 pub(super) trait LogBufferWrite {
-    fn into_bytes(self) -> impl Iterator<Item = u8>;
+    fn into_chunks(self) -> impl LogChunkStream;
+}
+
+pub(super) struct LogChunkWriter {
+    output: *mut u8,
+    capacity: usize,
+    written: usize,
+}
+
+impl LogChunkWriter {
+    #[inline(always)]
+    fn copy_from_slice(&mut self, bytes: &[u8]) -> Result<()> {
+        let next_written = self
+            .written
+            .checked_add(bytes.len())
+            .filter(|next| *next <= self.capacity)
+            .ok_or_else(log_buffer_len_mismatch)?;
+        // SAFETY: `next_written` proves this chunk fits in the reserved spare
+        // capacity. Chunk sources cannot overlap the mutably borrowed buffer.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                self.output.add(self.written),
+                bytes.len(),
+            );
+        }
+        self.written = next_written;
+        Ok(())
+    }
+}
+
+trait LogBufferExt {
+    fn try_extend_chunks(&mut self, chunks: impl LogChunkStream) -> Result<()>;
+}
+
+impl LogBufferExt for Vec<u8> {
+    #[inline(always)]
+    fn try_extend_chunks(&mut self, chunks: impl LogChunkStream) -> Result<()> {
+        let encoded_len = chunks.encoded_len().ok_or_else(log_buffer_len_overflow)?;
+        let new_len = self
+            .len()
+            .checked_add(encoded_len)
+            .ok_or_else(log_buffer_len_overflow)?;
+        self.try_reserve(encoded_len)?;
+
+        let original_len = self.len();
+        // SAFETY: `try_reserve` above guarantees space for `encoded_len`
+        // additional bytes, so the first spare byte is within the allocation.
+        let output = unsafe { self.as_mut_ptr().add(original_len) };
+        let mut writer = LogChunkWriter {
+            output,
+            capacity: encoded_len,
+            written: 0,
+        };
+        chunks.copy_to(&mut writer)?;
+        if writer.written != encoded_len {
+            return Err(log_buffer_len_mismatch());
+        }
+        // SAFETY: every byte between the old and new lengths was initialized by
+        // the checked chunk copies above.
+        unsafe {
+            self.set_len(new_len);
+        }
+        Ok(())
+    }
 }
 
 macro_rules! log_write {
@@ -26,8 +170,8 @@ macro_rules! log_write {
     }};
     ($serializer:expr, [$first:expr $(, $rest:expr)* $(,)?]) => {{
         $serializer.write(
-            LogBufferWrite::into_bytes($first)
-                $(.chain(LogBufferWrite::into_bytes($rest)))*
+            LogBufferWrite::into_chunks($first)
+                $(.chain(LogBufferWrite::into_chunks($rest)))*
         )
     }};
 }
@@ -43,9 +187,8 @@ impl<'a> LogSerializer<'a> {
     }
 
     #[inline(always)]
-    fn write(&mut self, bytes: impl Iterator<Item = u8>) -> Result<()> {
-        self.buffer.try_extend(bytes)?;
-        Ok(())
+    fn write(&mut self, chunks: impl LogChunkStream) -> Result<()> {
+        self.buffer.try_extend_chunks(chunks)
     }
 
     #[inline(always)]
@@ -56,19 +199,9 @@ impl<'a> LogSerializer<'a> {
             ));
         }
 
-        let bytes = value.into_bytes();
-        let encoded_len = exact_iterator_len(&bytes).ok_or_else(log_buffer_len_overflow)?;
-        let new_len = self
-            .buffer
-            .len()
-            .checked_add(encoded_len)
-            .ok_or_else(log_buffer_len_overflow)?;
-        self.buffer.try_extend(bytes)?;
-        debug_assert_eq!(
-            self.buffer.len(),
-            new_len,
-            "logical log serializer encoded length mismatch"
-        );
+        let original_len = self.buffer.len();
+        self.write(value.into_chunks())?;
+        let encoded_len = self.buffer.len() - original_len;
         self.buffer[offset..].rotate_right(encoded_len);
         Ok(())
     }
@@ -360,10 +493,10 @@ struct SqliteVarint(u64);
 
 impl LogBufferWrite for SqliteVarint {
     #[inline(always)]
-    fn into_bytes(self) -> impl Iterator<Item = u8> {
+    fn into_chunks(self) -> impl LogChunkStream {
         let mut bytes = [0; 9];
         let len = write_varint(&mut bytes, self.0);
-        bytes.into_iter().take(len)
+        InlineLogChunk::prefix(bytes, len)
     }
 }
 
@@ -371,7 +504,7 @@ struct ProtoVarint(u64);
 
 impl LogBufferWrite for ProtoVarint {
     #[inline(always)]
-    fn into_bytes(self) -> impl Iterator<Item = u8> {
+    fn into_chunks(self) -> impl LogChunkStream {
         let mut value = self.0;
         let mut bytes = [0; 10];
         let mut len = 0;
@@ -384,7 +517,7 @@ impl LogBufferWrite for ProtoVarint {
                 break;
             }
         }
-        bytes.into_iter().take(len)
+        InlineLogChunk::prefix(bytes, len)
     }
 }
 
@@ -403,8 +536,8 @@ impl ProtoKey {
 }
 
 impl LogBufferWrite for ProtoKey {
-    fn into_bytes(self) -> impl Iterator<Item = u8> {
-        ProtoVarint((self.field << 3) | self.wire_type).into_bytes()
+    fn into_chunks(self) -> impl LogChunkStream {
+        ProtoVarint((self.field << 3) | self.wire_type).into_chunks()
     }
 }
 
@@ -424,39 +557,38 @@ impl ProtoSint64 {
 }
 
 impl LogBufferWrite for ProtoSint64 {
-    fn into_bytes(self) -> impl Iterator<Item = u8> {
+    fn into_chunks(self) -> impl LogChunkStream {
         let zigzag = self.zigzag();
         ProtoKey::new(self.field, PROTO_WIRE_VARINT)
-            .into_bytes()
-            .chain(ProtoVarint(zigzag).into_bytes())
+            .into_chunks()
+            .chain(ProtoVarint(zigzag).into_chunks())
     }
 }
 
 impl LogBufferWrite for u8 {
-    fn into_bytes(self) -> impl Iterator<Item = u8> {
-        std::iter::once(self)
+    fn into_chunks(self) -> impl LogChunkStream {
+        InlineLogChunk::full([self])
     }
 }
 
 impl<const N: usize> LogBufferWrite for [u8; N] {
-    fn into_bytes(self) -> impl Iterator<Item = u8> {
-        self.into_iter()
+    fn into_chunks(self) -> impl LogChunkStream {
+        InlineLogChunk::full(self)
     }
 }
 
 impl LogBufferWrite for &[u8] {
-    fn into_bytes(self) -> impl Iterator<Item = u8> {
-        self.iter().copied()
+    fn into_chunks(self) -> impl LogChunkStream {
+        BorrowedLogChunk(self)
     }
-}
-
-fn exact_iterator_len(iter: &impl Iterator) -> Option<usize> {
-    let (lower, upper) = iter.size_hint();
-    (upper == Some(lower)).then_some(lower)
 }
 
 fn log_buffer_len_overflow() -> LimboError {
     LimboError::InternalError("logical log serialization size overflow".to_string())
+}
+
+fn log_buffer_len_mismatch() -> LimboError {
+    LimboError::InternalError("logical log serialization length mismatch".to_string())
 }
 
 fn proto_varint_len(mut value: u64) -> usize {
@@ -575,18 +707,18 @@ impl<'a> PortableChangePayload<'a> {
     }
 }
 
-impl LogBufferWrite for PortableChangePayload<'_> {
-    fn into_bytes(self) -> impl Iterator<Item = u8> {
+impl<'payload> LogBufferWrite for PortableChangePayload<'payload> {
+    fn into_chunks(self) -> impl LogChunkStream {
         let body_len = self
             .body_len()
             .expect("portable payload length was checked before writing");
         ProtoVarint(body_len as u64)
-            .into_bytes()
-            .chain(ProtoKey::new(1, PROTO_WIRE_VARINT).into_bytes())
-            .chain(ProtoVarint(self.end_offset).into_bytes())
-            .chain(ProtoKey::new(2, PROTO_WIRE_VARINT).into_bytes())
-            .chain(ProtoVarint(self.commit_ts).into_bytes())
-            .chain(self.encoded_metadata.iter().copied())
+            .into_chunks()
+            .chain(ProtoKey::new(1, PROTO_WIRE_VARINT).into_chunks())
+            .chain(ProtoVarint(self.end_offset).into_chunks())
+            .chain(ProtoKey::new(2, PROTO_WIRE_VARINT).into_chunks())
+            .chain(ProtoVarint(self.commit_ts).into_chunks())
+            .chain(LogBufferWrite::into_chunks(self.encoded_metadata))
     }
 }
 
@@ -636,11 +768,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fragment_iterator_has_exact_size_hint() {
-        let bytes = PortableChangePayload::new(1, 2, &[3]).into_bytes();
+    fn fragment_chunks_preserve_wire_format() {
+        let metadata = [3];
+        let mut bytes = Vec::new();
+        LogSerializer::new(&mut bytes)
+            .write(PortableChangePayload::new(1, 2, &metadata).into_chunks())
+            .unwrap();
 
-        assert_eq!(bytes.size_hint(), (6, Some(6)));
-        assert_eq!(bytes.collect::<Vec<_>>(), [5, 8, 1, 16, 2, 3]);
+        assert_eq!(bytes, [5, 8, 1, 16, 2, 3]);
+    }
+
+    #[test]
+    fn chunk_length_mismatch_does_not_change_buffer() {
+        struct WrongLength;
+
+        impl LogChunkStream for WrongLength {
+            fn encoded_len(&self) -> Option<usize> {
+                Some(0)
+            }
+
+            fn copy_to(self, writer: &mut LogChunkWriter) -> Result<()> {
+                writer.copy_from_slice(&[1])
+            }
+        }
+
+        let mut buffer = vec![2];
+        let result = LogSerializer::new(&mut buffer).write(WrongLength);
+
+        assert!(result.is_err());
+        assert_eq!(buffer, [2]);
     }
 
     #[test]

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -10,8 +10,7 @@ use std::fmt::Debug;
 pub mod logical_log;
 use crate::mvcc::database::{LogRecord, RowVersion};
 use crate::mvcc::persistent_storage::logical_log::{
-    serialize_header_entry, serialize_op_entry, LogicalLog, OnSerializationComplete,
-    DEFAULT_LOG_CHECKPOINT_THRESHOLD,
+    LogSerializer, LogicalLog, OnSerializationComplete, DEFAULT_LOG_CHECKPOINT_THRESHOLD,
 };
 use crate::{CheckpointResult, Completion, File, LimboError, Result};
 
@@ -150,7 +149,8 @@ impl DurableStorage for Storage {
         row_version: &RowVersion,
         portable_extension: Option<&[u8]>,
     ) -> Result<()> {
-        serialize_op_entry(&mut log_record.buf, row_version, portable_extension)?;
+        LogSerializer::new(&mut log_record.buf)
+            .serialize_op_entry(row_version, portable_extension)?;
         log_record.op_count = log_record.op_count.checked_add(1).ok_or_else(|| {
             LimboError::InternalError("logical log op_count exceeds u32".to_string())
         })?;
@@ -166,7 +166,7 @@ impl DurableStorage for Storage {
             !log_record.has_header,
             "DatabaseHeader op appended more than once to a single LogRecord"
         );
-        serialize_header_entry(&mut log_record.buf, header);
+        LogSerializer::new(&mut log_record.buf).serialize_header_entry(header)?;
         log_record.has_header = true;
         log_record.op_count = log_record.op_count.checked_add(1).ok_or_else(|| {
             LimboError::InternalError("logical log op_count exceeds u32".to_string())

--- a/core/storage/encryption.rs
+++ b/core/storage/encryption.rs
@@ -199,6 +199,39 @@ macro_rules! define_aegis_cipher {
                 Ok((result, nonce))
             }
 
+            fn encrypt_in_place(
+                &self,
+                plaintext_ciphertext: &mut [u8],
+                ad: &[u8],
+                tag_out: &mut [u8],
+                nonce_out: &mut [u8],
+            ) -> Result<()> {
+                if tag_out.len() != Self::TAG_SIZE {
+                    return Err(CipherError::InvalidTagSize { cipher: $name }.into());
+                }
+                if nonce_out.len() != $nonce_size {
+                    return Err(LimboError::InternalError(format!(
+                        "Invalid nonce size for {}: expected {}, got {}",
+                        $name,
+                        $nonce_size,
+                        nonce_out.len()
+                    )));
+                }
+                let nonce = generate_secure_nonce::<$nonce_size>();
+                let key_bytes = self.key.$key_method().ok_or_else(|| -> LimboError {
+                    CipherError::InvalidKeySize {
+                        cipher: $name,
+                        expected: $key_size,
+                    }
+                    .into()
+                })?;
+                let tag = <$cipher_type>::new(key_bytes, &nonce)
+                    .encrypt_in_place(plaintext_ciphertext, ad);
+                tag_out.copy_from_slice(&tag);
+                nonce_out.copy_from_slice(&nonce);
+                Ok(())
+            }
+
             fn decrypt(&self, ciphertext: &[u8], nonce: &[u8; $nonce_size], ad: &[u8]) -> Result<Vec<u8>> {
                 let mut out = Vec::with_capacity(ciphertext.len().saturating_sub(Self::TAG_SIZE));
                 self.decrypt_into(ciphertext, nonce, ad, &mut out)?;
@@ -275,6 +308,36 @@ macro_rules! define_aes_gcm_cipher {
                 let mut nonce_array = [0u8; 12];
                 nonce_array.copy_from_slice(&nonce);
                 Ok((ciphertext, nonce_array))
+            }
+
+            fn encrypt_in_place(
+                &self,
+                plaintext_ciphertext: &mut [u8],
+                ad: &[u8],
+                tag_out: &mut [u8],
+                nonce_out: &mut [u8],
+            ) -> Result<()> {
+                if tag_out.len() != Self::TAG_SIZE {
+                    return Err(CipherError::InvalidTagSize { cipher: $name }.into());
+                }
+                if nonce_out.len() != Self::NONCE_SIZE {
+                    return Err(LimboError::InternalError(format!(
+                        "Invalid nonce size for {}: expected {}, got {}",
+                        $name,
+                        Self::NONCE_SIZE,
+                        nonce_out.len()
+                    )));
+                }
+                let nonce = <$cipher_type>::generate_nonce(&mut OsRng);
+                let tag = self
+                    .cipher
+                    .encrypt_in_place_detached(&nonce, ad, plaintext_ciphertext)
+                    .map_err(|e| {
+                        LimboError::InternalError(format!("{} encryption failed: {e:?}", $name))
+                    })?;
+                tag_out.copy_from_slice(&tag);
+                nonce_out.copy_from_slice(&nonce);
+                Ok(())
             }
 
             fn decrypt(&self, ciphertext: &[u8], nonce: &[u8; 12], ad: &[u8]) -> Result<Vec<u8>> {
@@ -559,6 +622,16 @@ impl EncryptionContext {
 
     pub fn encrypt_chunk(&self, plaintext: &[u8], aad: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
         self.encrypt_raw_with_ad(plaintext, aad)
+    }
+
+    pub fn encrypt_chunk_in_place(
+        &self,
+        plaintext_ciphertext: &mut [u8],
+        aad: &[u8],
+        tag_out: &mut [u8],
+        nonce_out: &mut [u8],
+    ) -> Result<()> {
+        self.encrypt_raw_with_ad_in_place(plaintext_ciphertext, aad, tag_out, nonce_out)
     }
 
     pub fn decrypt_chunk(&self, ciphertext: &[u8], nonce: &[u8], aad: &[u8]) -> Result<Vec<u8>> {
@@ -882,6 +955,31 @@ impl EncryptionContext {
         }
     }
 
+    fn encrypt_raw_with_ad_in_place(
+        &self,
+        plaintext_ciphertext: &mut [u8],
+        ad: &[u8],
+        tag_out: &mut [u8],
+        nonce_out: &mut [u8],
+    ) -> Result<()> {
+        macro_rules! encrypt_cipher {
+            ($cipher:expr) => {{
+                $cipher.encrypt_in_place(plaintext_ciphertext, ad, tag_out, nonce_out)
+            }};
+        }
+
+        match &self.cipher {
+            Cipher::Aes128Gcm(cipher) => encrypt_cipher!(cipher),
+            Cipher::Aes256Gcm(cipher) => encrypt_cipher!(cipher),
+            Cipher::Aegis256(cipher) => encrypt_cipher!(cipher),
+            Cipher::Aegis256X2(cipher) => encrypt_cipher!(cipher),
+            Cipher::Aegis256X4(cipher) => encrypt_cipher!(cipher),
+            Cipher::Aegis128L(cipher) => encrypt_cipher!(cipher),
+            Cipher::Aegis128X2(cipher) => encrypt_cipher!(cipher),
+            Cipher::Aegis128X4(cipher) => encrypt_cipher!(cipher),
+        }
+    }
+
     fn decrypt_raw(&self, ciphertext: &[u8], nonce: &[u8]) -> Result<Vec<u8>> {
         const AD: &[u8] = b"";
         self.decrypt_raw_with_ad(ciphertext, nonce, AD)
@@ -1048,6 +1146,15 @@ mod tests {
                 assert_ne!(ciphertext[..plaintext.len()], plaintext[..]);
 
                 let decrypted = ctx.decrypt_raw(&ciphertext, &nonce).unwrap();
+                assert_eq!(decrypted, plaintext);
+
+                let mut in_place_ciphertext = plaintext.to_vec();
+                let mut tag = vec![0; ctx.tag_size()];
+                let mut nonce = vec![0; ctx.nonce_size()];
+                ctx.encrypt_chunk_in_place(&mut in_place_ciphertext, b"", &mut tag, &mut nonce)
+                    .unwrap();
+                in_place_ciphertext.extend_from_slice(&tag);
+                let decrypted = ctx.decrypt_raw(&in_place_ciphertext, &nonce).unwrap();
                 assert_eq!(decrypted, plaintext);
             }
         };


### PR DESCRIPTION
## Description

- introduce a dedicated `LogSerializer` for logical-log entries, transaction framing, and portable-extension records
- compose each serialized value as a static `LogChunkStream` that keeps inline fields and borrowed payload slices as separate chunks
- compute the complete encoded length, reserve once per stream, and bulk-copy chunks directly into the destination vector's spare capacity
- include an operation's optional portable-extension length and payload in the same composed write
- encode frame-level portable-change records directly into the transaction buffer
- expand and encrypt logical-log payloads in place, processing chunks back-to-front across AES-GCM and AEGIS backends
- preserve the existing logical-log wire format and recovery behavior

## Context

The previous serializer appended fields individually and built temporary buffers for portable and encrypted payloads. A flat `Iterator<Item = u8>` can expose one complete write and size hint, but it also erases borrowed-slice boundaries and makes large payloads pass through the iterator byte by byte.

The final design keeps one statically composed stream per logical entry while preserving each slice as a chunk. The writer checks the stream's encoded length, reserves once, bulk-copies every chunk, and only updates the vector length after the bytes written match the declared size.

Encrypted payloads no longer split plaintext into a temporary vector or allocate ciphertext and nonce vectors per chunk. The destination is grown to its final size first, then plaintext chunks are moved and encrypted in reverse order so unread plaintext is not overwritten.

The standalone logical-log serialization benchmark landed in #7883. This PR only adjusts its transaction-batch setup to prime mimalloc size classes before CodSpeed's single measured iteration, without warming the measured destination buffer.

