### PR TITLE
translate: skip CDC autocommit epilogue on constant-false DML

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1709,6 +1709,33 @@ pub fn emit_cdc_commit_insns(
     Ok(())
 }
 
+/// Jump to `skip_label` when the transaction captured no change.
+///
+/// `conn_txn_id(-1)` returns the active CDC transaction id, or -1 when nothing was captured.
+/// The opcode is an idempotent get-or-set, so `emit_cdc_commit_insns` recomputing it for the
+/// record itself sees the same value this gate tested.
+fn emit_skip_if_no_captured_change(program: &mut ProgramBuilder, skip_label: BranchOffset) {
+    let minus_one_reg = program.alloc_register();
+    program.emit_int(-1, minus_one_reg);
+    let txn_id_reg = program.alloc_register();
+    program.emit_insn(Insn::Function {
+        constant_mask: 0,
+        start_reg: minus_one_reg,
+        dest: txn_id_reg,
+        func: crate::function::FuncCtx {
+            func: Func::Scalar(crate::function::ScalarFunc::ConnTxnId),
+            arg_count: 1,
+        },
+    });
+    program.emit_insn(Insn::Eq {
+        lhs: txn_id_reg,
+        rhs: minus_one_reg,
+        target_pc: skip_label,
+        flags: crate::vdbe::insn::CmpInsFlags::default(),
+        collation: None,
+    });
+}
+
 /// Emit a CDC COMMIT record at end-of-statement when in autocommit mode (v2 only).
 /// This should be called once per statement, after the main loop, not per-row.
 pub fn emit_cdc_autocommit_commit(
@@ -1716,6 +1743,12 @@ pub fn emit_cdc_autocommit_commit(
     resolver: &Resolver,
     cdc_cursor_id: usize,
 ) -> Result<()> {
+    // Trigger and FK-action subprograms run inside an outer statement whose own
+    // epilogue emits the COMMIT record; emitting one here would insert a
+    // mid-statement COMMIT into the CDC stream.
+    if program.flags.is_subprogram() {
+        return Ok(());
+    }
     let cdc_info = program.capture_data_changes_info().as_ref();
     if cdc_info.is_some_and(|info| info.cdc_version().has_commit_record()) {
         // Check if we're in autocommit mode; if so, emit a COMMIT record.
@@ -1739,6 +1772,9 @@ pub fn emit_cdc_autocommit_commit(
             jump_if_null: true,
         });
 
+        // A never-capturing statement may never have opened the CDC cursor.
+        emit_skip_if_no_captured_change(program, skip_label);
+
         emit_cdc_commit_insns(program, resolver, cdc_cursor_id)?;
 
         program.preassign_label_to_next_insn(skip_label);
@@ -1757,41 +1793,14 @@ pub fn emit_cdc_autocommit_commit(
 /// nor clears that page, so it leaks into the next transaction and trips the "dirty pages
 /// should be empty for read txn" assertion on a later ROLLBACK
 /// (https://github.com/tursodatabase/turso/issues/7677).
-///
-/// `conn_txn_id(-1)` returns the active CDC transaction id, or -1 when nothing was captured.
-/// When it is set, the transaction already performed a write (the data-change statement
-/// established the write transaction), so inserting the commit record is safe. When it is -1
-/// the transaction made no changes and we skip the record entirely, leaving the transaction
-/// read-only.
 pub fn emit_cdc_explicit_commit_insns(
     program: &mut ProgramBuilder,
     schema: &Schema,
     resolver: &Resolver,
 ) -> Result<()> {
-    let minus_one_reg = program.alloc_register();
-    program.emit_int(-1, minus_one_reg);
-    let txn_id_reg = program.alloc_register();
-    program.emit_insn(Insn::Function {
-        constant_mask: 0,
-        start_reg: minus_one_reg,
-        dest: txn_id_reg,
-        func: crate::function::FuncCtx {
-            func: Func::Scalar(crate::function::ScalarFunc::ConnTxnId),
-            arg_count: 1,
-        },
-    });
-
-    // Skip the whole record (including the CDC OpenWrite) when no change was captured.
-    // `emit_cdc_commit_insns` recomputes `conn_txn_id(-1)` for the record itself; because the
-    // opcode is an idempotent get-or-set, the second call returns the same value we gated on.
+    // Skipping also skips the CDC OpenWrite below.
     let skip_label = program.allocate_label();
-    program.emit_insn(Insn::Eq {
-        lhs: txn_id_reg,
-        rhs: minus_one_reg,
-        target_pc: skip_label,
-        flags: crate::vdbe::insn::CmpInsFlags::default(),
-        collation: None,
-    });
+    emit_skip_if_no_captured_change(program, skip_label);
 
     // The CDC record write needs a transaction; joins the open one (keeping its mode) if any.
     program.emit_insn(Insn::Transaction {

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1633,6 +1633,33 @@ pub fn emit_cdc_commit_insns(
     Ok(())
 }
 
+/// Jump to `skip_label` when the transaction captured no change.
+///
+/// `conn_txn_id(-1)` returns the active CDC transaction id, or -1 when nothing was captured.
+/// The opcode is an idempotent get-or-set, so `emit_cdc_commit_insns` recomputing it for the
+/// record itself sees the same value this gate tested.
+fn emit_skip_if_no_captured_change(program: &mut ProgramBuilder, skip_label: BranchOffset) {
+    let minus_one_reg = program.alloc_register();
+    program.emit_int(-1, minus_one_reg);
+    let txn_id_reg = program.alloc_register();
+    program.emit_insn(Insn::Function {
+        constant_mask: 0,
+        start_reg: minus_one_reg,
+        dest: txn_id_reg,
+        func: crate::function::FuncCtx {
+            func: Func::Scalar(crate::function::ScalarFunc::ConnTxnId),
+            arg_count: 1,
+        },
+    });
+    program.emit_insn(Insn::Eq {
+        lhs: txn_id_reg,
+        rhs: minus_one_reg,
+        target_pc: skip_label,
+        flags: crate::vdbe::insn::CmpInsFlags::default(),
+        collation: None,
+    });
+}
+
 /// Emit a CDC COMMIT record at end-of-statement when in autocommit mode (v2 only).
 /// This should be called once per statement, after the main loop, not per-row.
 pub fn emit_cdc_autocommit_commit(
@@ -1640,6 +1667,12 @@ pub fn emit_cdc_autocommit_commit(
     resolver: &Resolver,
     cdc_cursor_id: usize,
 ) -> Result<()> {
+    // Trigger and FK-action subprograms run inside an outer statement whose own
+    // epilogue emits the COMMIT record; emitting one here would insert a
+    // mid-statement COMMIT into the CDC stream.
+    if program.flags.is_subprogram() {
+        return Ok(());
+    }
     let cdc_info = program.capture_data_changes_info().as_ref();
     if cdc_info.is_some_and(|info| info.cdc_version().has_commit_record()) {
         // Check if we're in autocommit mode; if so, emit a COMMIT record.
@@ -1663,6 +1696,9 @@ pub fn emit_cdc_autocommit_commit(
             jump_if_null: true,
         });
 
+        // A never-capturing statement may never have opened the CDC cursor.
+        emit_skip_if_no_captured_change(program, skip_label);
+
         emit_cdc_commit_insns(program, resolver, cdc_cursor_id)?;
 
         program.preassign_label_to_next_insn(skip_label);
@@ -1681,41 +1717,14 @@ pub fn emit_cdc_autocommit_commit(
 /// nor clears that page, so it leaks into the next transaction and trips the "dirty pages
 /// should be empty for read txn" assertion on a later ROLLBACK
 /// (https://github.com/tursodatabase/turso/issues/7677).
-///
-/// `conn_txn_id(-1)` returns the active CDC transaction id, or -1 when nothing was captured.
-/// When it is set, the transaction already performed a write (the data-change statement
-/// established the write transaction), so inserting the commit record is safe. When it is -1
-/// the transaction made no changes and we skip the record entirely, leaving the transaction
-/// read-only.
 pub fn emit_cdc_explicit_commit_insns(
     program: &mut ProgramBuilder,
     schema: &Schema,
     resolver: &Resolver,
 ) -> Result<()> {
-    let minus_one_reg = program.alloc_register();
-    program.emit_int(-1, minus_one_reg);
-    let txn_id_reg = program.alloc_register();
-    program.emit_insn(Insn::Function {
-        constant_mask: 0,
-        start_reg: minus_one_reg,
-        dest: txn_id_reg,
-        func: crate::function::FuncCtx {
-            func: Func::Scalar(crate::function::ScalarFunc::ConnTxnId),
-            arg_count: 1,
-        },
-    });
-
-    // Skip the whole record (including the CDC OpenWrite) when no change was captured.
-    // `emit_cdc_commit_insns` recomputes `conn_txn_id(-1)` for the record itself; because the
-    // opcode is an idempotent get-or-set, the second call returns the same value we gated on.
+    // Skipping also skips the CDC OpenWrite below.
     let skip_label = program.allocate_label();
-    program.emit_insn(Insn::Eq {
-        lhs: txn_id_reg,
-        rhs: minus_one_reg,
-        target_pc: skip_label,
-        flags: crate::vdbe::insn::CmpInsFlags::default(),
-        collation: None,
-    });
+    emit_skip_if_no_captured_change(program, skip_label);
 
     // A COMMIT record has no associated table, so pass `None` (no self-exclusion check).
     if let Some((cdc_cursor_id, _)) = prepare_cdc_if_necessary(program, schema, None)? {

--- a/sqlite/conformance/sqlite-sqltests/cdc-dml-constant-false.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/cdc-dml-constant-false.sqltest
@@ -1,0 +1,188 @@
+@database :memory:
+@skip-file-if mvcc "CDC is not supported in MVCC mode"
+@skip-file-if sqlite "CDC is a turso-specific feature"
+
+# WHERE 0 skips the main loop's OpenWrite for the CDC cursor; the autocommit
+# COMMIT epilogue must not use it.
+
+test cdc-delete-where-false {
+    CREATE TABLE t(id INTEGER, val TEXT);
+    INSERT INTO t VALUES (1, 'a');
+    INSERT INTO t VALUES (2, 'b');
+    PRAGMA capture_data_changes_conn('full');
+    DELETE FROM t WHERE 0;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|a
+    2|b
+}
+
+test cdc-delete-where-not-1 {
+    CREATE TABLE t2(id INTEGER);
+    INSERT INTO t2 VALUES (1);
+    PRAGMA capture_data_changes_conn('full');
+    DELETE FROM t2 WHERE NOT 1;
+    SELECT * FROM t2;
+}
+expect {
+    1
+}
+
+test cdc-delete-empty-table-where-false {
+    CREATE TABLE t3(id INTEGER);
+    PRAGMA capture_data_changes_conn('full');
+    DELETE FROM t3 WHERE 0;
+    SELECT count(*) FROM t3;
+}
+expect {
+    0
+}
+
+test cdc-update-where-false {
+    CREATE TABLE t4(id INTEGER, val TEXT);
+    INSERT INTO t4 VALUES (1, 'a');
+    INSERT INTO t4 VALUES (2, 'b');
+    PRAGMA capture_data_changes_conn('full');
+    UPDATE t4 SET val = 'x' WHERE 0;
+    SELECT * FROM t4 ORDER BY id;
+}
+expect {
+    1|a
+    2|b
+}
+
+test cdc-update-where-not-1 {
+    CREATE TABLE t5(id INTEGER, val TEXT);
+    INSERT INTO t5 VALUES (1, 'a');
+    PRAGMA capture_data_changes_conn('full');
+    UPDATE t5 SET val = 'x' WHERE NOT 1;
+    SELECT * FROM t5;
+}
+expect {
+    1|a
+}
+
+test cdc-update-empty-table-where-false {
+    CREATE TABLE t6(id INTEGER, val TEXT);
+    PRAGMA capture_data_changes_conn('full');
+    UPDATE t6 SET val = 'x' WHERE 0;
+    SELECT count(*) FROM t6;
+}
+expect {
+    0
+}
+
+# LIMIT 0 skips the loop at runtime, where the constant-false plan flag cannot see it.
+
+test cdc-delete-limit-zero {
+    CREATE TABLE t7(id INTEGER);
+    INSERT INTO t7 VALUES (1);
+    PRAGMA capture_data_changes_conn('full');
+    DELETE FROM t7 LIMIT 0;
+    SELECT count(*) FROM t7;
+}
+expect {
+    1
+}
+
+test cdc-update-limit-zero {
+    CREATE TABLE t8(id INTEGER, val TEXT);
+    INSERT INTO t8 VALUES (1, 'a');
+    PRAGMA capture_data_changes_conn('full');
+    UPDATE t8 SET val = 'x' LIMIT 0;
+    SELECT val FROM t8;
+}
+expect {
+    a
+}
+
+# A statement that captures nothing must leave turso_cdc empty - no rows, no COMMIT record.
+
+test cdc-table-empty-after-constant-false {
+    CREATE TABLE t9(id INTEGER);
+    INSERT INTO t9 VALUES (1);
+    PRAGMA capture_data_changes_conn('full');
+    DELETE FROM t9 WHERE 0;
+    DELETE FROM t9 WHERE NULL;
+    DELETE FROM t9 WHERE 1 = 2;
+    UPDATE t9 SET id = 5 WHERE 0;
+    DELETE FROM t9 LIMIT 0;
+    SELECT count(*) FROM turso_cdc;
+}
+expect {
+    0
+}
+
+test cdc-table-empty-after-no-match {
+    CREATE TABLE t10(id INTEGER);
+    INSERT INTO t10 VALUES (1);
+    PRAGMA capture_data_changes_conn('full');
+    DELETE FROM t10 WHERE id = 999;
+    UPDATE t10 SET id = 5 WHERE id = 999;
+    SELECT count(*) FROM turso_cdc;
+}
+expect {
+    0
+}
+
+# The connection must keep capturing correctly after a zero-change statement.
+
+test cdc-capture-still-works-after-constant-false {
+    CREATE TABLE t11(id INTEGER, val TEXT);
+    INSERT INTO t11 VALUES (1, 'a');
+    PRAGMA capture_data_changes_conn('full');
+    DELETE FROM t11 WHERE 0;
+    UPDATE t11 SET val = 'b' WHERE id = 1;
+    SELECT change_type, coalesce(table_name, '-') FROM turso_cdc ORDER BY change_id;
+}
+expect {
+    0|t11
+    2|-
+}
+
+# Trigger bodies must not add their own COMMIT record mid-statement.
+
+test cdc-trigger-body-single-commit {
+    CREATE TABLE src(x INTEGER);
+    CREATE TABLE dst(y INTEGER);
+    INSERT INTO dst VALUES (1);
+    CREATE TRIGGER tr AFTER INSERT ON src BEGIN DELETE FROM dst WHERE y = 1; END;
+    PRAGMA capture_data_changes_conn('full');
+    INSERT INTO src VALUES (1);
+    SELECT change_type, coalesce(table_name, '-') FROM turso_cdc ORDER BY change_id;
+}
+expect {
+    -1|dst
+    1|src
+    2|-
+}
+
+test cdc-trigger-body-constant-false {
+    CREATE TABLE src2(x INTEGER);
+    CREATE TABLE dst2(y INTEGER);
+    CREATE TRIGGER tr2 AFTER INSERT ON src2 BEGIN DELETE FROM dst2 WHERE 0; END;
+    PRAGMA capture_data_changes_conn('full');
+    INSERT INTO src2 VALUES (1);
+    SELECT change_type, coalesce(table_name, '-') FROM turso_cdc ORDER BY change_id;
+}
+expect {
+    1|src2
+    2|-
+}
+
+# FK actions, like triggers, must not emit their own COMMIT record.
+
+test cdc-fk-cascade-single-commit {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) ON DELETE CASCADE);
+    INSERT INTO p VALUES (1);
+    INSERT INTO c VALUES (10, 1);
+    PRAGMA capture_data_changes_conn('full');
+    DELETE FROM p WHERE id = 1;
+    SELECT count(*) FROM turso_cdc WHERE change_type = 2;
+}
+expect {
+    1
+}


### PR DESCRIPTION
**This PR has been rewritten.** The earlier version guarded the CDC epilogue on `contains_constant_false_condition`, which fixed one route into the bug and left the rest. Reviewers who saw the previous diff should re-read.

## The problem

With CDC enabled, DML that skips the main loop panics with `cursor id 0 is None`: the loop is where the CDC cursor's `OpenWrite` is emitted, but the autocommit epilogue emits CDC-commit bytecode regardless.

A compile-time predicate cannot cover this. Besides the constant-false plan flag, `init_limit` (`emitter/mod.rs:1826`) emits `IfNot reg_limit → main_loop_end` before `InitLoop::emit` opens the cursor, so with CDC on:

```sql
DELETE FROM t LIMIT 0;         -- panics
UPDATE t SET val = 'x' LIMIT 0; -- panics
```

The limit is a runtime value — `LIMIT ?` bound to 0 compiles identically — so no plan-time flag can catch it.

The epilogue is also wrong in two cases that never panic. A statement matching no row writes a COMMIT record with `change_txn_id = -1` into `turso_cdc`; and trigger and FK-action subprograms, which clone the CDC info (`trigger_exec.rs:583`) and compile through the same emitters, emit a second COMMIT record mid-transaction.

## The fix

Gate the record on whether the transaction captured anything — the same `conn_txn_id(-1) == -1` check `emit_cdc_explicit_commit_insns` already uses two functions down (issue #7677) — and exclude subprograms, whose outer statement writes the record.

Having captured a change implies the cursor was opened, so this is exactly the safety condition: it covers every route the loop can be skipped, present and future, and fixes the orphan and duplicate records with it. The previous compile-time guards are removed as subsumed.

**This changes observable CDC output**, in the direction the codebase's own invariant prescribes: zero-capture statements and trigger subprograms no longer emit COMMIT records.

## Test

`sqlite/conformance/sqlite-sqltests/cdc-dml-constant-false.sqltest`, 14 cases: `DELETE`/`UPDATE` × `WHERE 0` / `WHERE NOT 1` / empty table, plus `LIMIT 0`, no-match DML, trigger and FK-cascade cases, and `turso_cdc` content assertions rather than base-table-only checks.

- `d3499c4a` test only. Red on main: 3 failed, 11 errors — the panics via both routes plus the COMMIT-record semantics.
- `4d1c058d` the fix. 14/14 green.

```
make -C sqlite/conformance run-one FILE=sqlite-sqltests/cdc-dml-constant-false.sqltest
```

Also green: `cargo test -p turso_core` 2203 passed, CDC integration 43 passed, `turso_sync_engine --lib` 76 passed, `cargo fmt --check`, `clippy -p turso_core --all-features --all-targets --deny=warnings`.

## Known gap, not fixed here

FK cascade child deletes are not CDC-captured at all — only the parent delete appears. Separate pre-existing gap with a different mechanism; the cascade test here asserts one parent-delete record so it stays valid when that is fixed. Happy to file it separately.

Reproducer came from a materialized-view-heavy workload. Fix drafted with Claude Code, then adversarially reviewed by a separate model — which is what found the `LIMIT 0` route; reviewed by me at the level I can judge.

