### PR TITLE
core/incremental: re-seek index cursor after I/O yield in IVM WriteRow

### DIFF
--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -288,3 +288,239 @@ impl WriteRow {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::incremental::operator::{create_dbsp_state_index, DbspStateCursors};
+    use crate::storage::btree::{BTreeCursor, CursorTrait};
+    use crate::storage::pager::CreateBTreeFlags;
+    use crate::sync::Arc;
+    use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult};
+    use crate::util::IOExt;
+    use crate::{Database, MemoryIO, SqliteDialect, IO};
+
+    fn create_test_pager() -> (Arc<crate::Pager>, i64, i64) {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io.clone(), ":memory:", Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        let pager = conn.pager.load().clone();
+        let _ = pager.io.block(|| pager.allocate_page1());
+
+        let table_root = pager
+            .io
+            .block(|| pager.btree_create(&CreateBTreeFlags::new_table()))
+            .unwrap() as i64;
+        let index_root = pager
+            .io
+            .block(|| pager.btree_create(&CreateBTreeFlags::new_index()))
+            .unwrap() as i64;
+
+        (pager, table_root, index_root)
+    }
+
+    /// Verify that every table row has a matching index entry by scanning the
+    /// table and seeking each row's key in the index. Returns the number of
+    /// verified rows.
+    fn verify_index_integrity(pager: &Arc<crate::Pager>, cursors: &mut DbspStateCursors) -> usize {
+        pager.io.block(|| cursors.table_cursor.rewind()).unwrap();
+        let mut count = 0;
+
+        loop {
+            if cursors.table_cursor.is_empty() {
+                break;
+            }
+
+            let record = loop {
+                match cursors.table_cursor.record().unwrap() {
+                    IOResult::Done(r) => break r,
+                    IOResult::IO(io) => io.wait(&*pager.io).unwrap(),
+                }
+            };
+            let record = record.unwrap().to_owned();
+            let values = record.get_values_owned().unwrap();
+
+            let rowid = loop {
+                match cursors.table_cursor.rowid().unwrap() {
+                    IOResult::Done(r) => break r.unwrap(),
+                    IOResult::IO(io) => io.wait(&*pager.io).unwrap(),
+                }
+            };
+
+            // Build the index key: first 3 columns (operator_id, zset_id, element_id)
+            let index_key: Vec<Value> = values[..3].to_vec();
+            let index_record = ImmutableRecord::from_values(&index_key, index_key.len()).unwrap();
+
+            let seek_result = pager
+                .io
+                .block(|| {
+                    cursors.index_cursor.seek(
+                        SeekKey::IndexKey(index_record.as_record_ref()),
+                        SeekOp::GE { eq_only: true },
+                    )
+                })
+                .unwrap();
+
+            assert!(
+                matches!(seek_result, SeekResult::Found),
+                "Index entry not found for table rowid={rowid}, key={index_key:?}"
+            );
+
+            // Verify the index entry points to the correct rowid
+            let index_rowid = pager
+                .io
+                .block(|| cursors.index_cursor.rowid())
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                index_rowid, rowid,
+                "Index rowid mismatch: expected {rowid}, got {index_rowid}"
+            );
+
+            count += 1;
+            pager.io.block(|| cursors.table_cursor.next()).unwrap();
+        }
+        count
+    }
+
+    /// Resuming WriteRow at InsertIndex must write the new row's index entry at
+    /// the correct position even when the index cursor was left elsewhere. After
+    /// the table insert in InsertNew, an I/O yield can let other operations move
+    /// the index cursor, so InsertIndex must re-seek before inserting. The test
+    /// inserts the table row, deliberately moves the index cursor to a wrong key,
+    /// then resumes at InsertIndex and checks the new entry and all existing
+    /// entries are intact.
+    #[test]
+    fn test_write_row_stale_index_cursor_after_simulated_io_yield() {
+        let (pager, table_root, index_root) = create_test_pager();
+        let table_cursor = BTreeCursor::new_table(pager.clone(), table_root, 5);
+        let index_def = create_dbsp_state_index(index_root);
+        let index_cursor =
+            BTreeCursor::new_index(pager.clone(), index_root, &index_def, 4).unwrap();
+        let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
+
+        let op_id = 1i64;
+        let zset_id = 1i64;
+
+        // Insert some entries normally to populate the B-tree
+        for i in 1..=10 {
+            let mut wr = WriteRow::new();
+            let ik = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+            ];
+            let rv = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+                Value::Null,
+            ];
+            pager
+                .io
+                .block(|| wr.write_row(&mut cursors, ik.clone(), rv.clone(), 1))
+                .unwrap();
+        }
+
+        // Insert element_id=20's table row directly (what InsertNew does).
+        let new_elem_id = 20i64;
+        let rowid = 11i64; // next rowid after 10 entries
+
+        pager
+            .io
+            .block(|| {
+                cursors
+                    .table_cursor
+                    .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: false })
+            })
+            .unwrap();
+        let complete_record = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(new_elem_id),
+            Value::Null,
+            Value::from_i64(1), // weight=1
+        ];
+        let immutable_record =
+            ImmutableRecord::from_values(&complete_record, complete_record.len()).unwrap();
+        let btree_key = BTreeKey::new_table_rowid(rowid, Some(&immutable_record));
+        pager
+            .io
+            .block(|| cursors.table_cursor.insert(&btree_key))
+            .unwrap();
+
+        // Move the index cursor to element_id=1, a wrong position for inserting
+        // element_id=20, standing in for the reposition an I/O yield could cause.
+        let wrong_key = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(1i64),
+        ];
+        let wrong_record = ImmutableRecord::from_values(&wrong_key, wrong_key.len()).unwrap();
+        pager
+            .io
+            .block(|| {
+                cursors.index_cursor.seek(
+                    SeekKey::IndexKey(wrong_record.as_record_ref()),
+                    SeekOp::GE { eq_only: false },
+                )
+            })
+            .unwrap();
+
+        // Resume at InsertIndex, the state after InsertNew's table insert.
+        let index_key = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(new_elem_id),
+        ];
+        let record_values = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(new_elem_id),
+            Value::Null,
+        ];
+        let mut wr = WriteRow::InsertIndex { rowid };
+        pager
+            .io
+            .block(|| wr.write_row(&mut cursors, index_key.clone(), record_values.clone(), 1))
+            .unwrap();
+
+        // The index entry for element_id=20 must exist and point to the new rowid.
+        let search_key = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(new_elem_id),
+        ];
+        let search_record = ImmutableRecord::from_values(&search_key, search_key.len()).unwrap();
+        let seek_result = pager
+            .io
+            .block(|| {
+                cursors.index_cursor.seek(
+                    SeekKey::IndexKey(search_record.as_record_ref()),
+                    SeekOp::GE { eq_only: true },
+                )
+            })
+            .unwrap();
+        assert!(
+            matches!(seek_result, SeekResult::Found),
+            "Index entry not found for element_id={new_elem_id} after simulated I/O yield"
+        );
+        let found_rowid = pager
+            .io
+            .block(|| cursors.index_cursor.rowid())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            found_rowid, rowid,
+            "Index entry for element_id={new_elem_id} points to wrong rowid: expected {rowid}, got {found_rowid}"
+        );
+
+        // All entries must remain intact (a wrong cursor position could have
+        // corrupted an existing entry).
+        let count = verify_index_integrity(&pager, &mut cursors);
+        assert_eq!(
+            count, 11,
+            "Expected 11 rows (10 original + 1 new), found {count}"
+        );
+    }
+}

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -80,6 +80,7 @@ pub enum WriteRow {
     },
     InsertIndex {
         rowid: i64,
+        needs_seek: bool,
     },
     UpdateExisting {
         rowid: i64,
@@ -244,11 +245,28 @@ impl WriteRow {
                         ImmutableRecord::from_values(&complete_record, complete_record.len())?;
                     let btree_key = BTreeKey::new_table_rowid(rowid_val, Some(&immutable_record));
 
-                    // Transition to InsertIndex state after table insertion
-                    *self = WriteRow::InsertIndex { rowid: rowid_val };
+                    // Stay in InsertNew until the table insert completes so an I/O
+                    // yield re-runs it, then advance to InsertIndex.
                     return_if_io!(cursors.table_cursor.insert(&btree_key));
+                    *self = WriteRow::InsertIndex {
+                        rowid: rowid_val,
+                        needs_seek: true,
+                    };
                 }
-                WriteRow::InsertIndex { rowid } => {
+                WriteRow::InsertIndex { rowid, needs_seek } if *needs_seek => {
+                    // Re-seek the index cursor before inserting: its position is not
+                    // preserved across the I/O yield in the table insert above.
+                    let mut index_values = index_key.clone();
+                    index_values.push(Value::from_i64(*rowid));
+                    let index_record =
+                        ImmutableRecord::from_values(&index_values, index_values.len())?;
+                    return_if_io!(cursors.index_cursor.seek(
+                        SeekKey::IndexKey(index_record.as_record_ref()),
+                        SeekOp::GE { eq_only: false }
+                    ));
+                    *needs_seek = false;
+                }
+                WriteRow::InsertIndex { rowid, .. } => {
                     // For has_rowid indexes, we need to append the rowid to the index key
                     // Use the function parameter index_key directly
                     let mut index_values = index_key.clone();
@@ -259,9 +277,8 @@ impl WriteRow {
                         ImmutableRecord::from_values(&index_values, index_values.len())?;
                     let index_btree_key = BTreeKey::new_index_key(index_record.as_record_ref());
 
-                    // Mark as Done before index insert to avoid retry on I/O
-                    *self = WriteRow::Done;
                     return_if_io!(cursors.index_cursor.insert(&index_btree_key));
+                    *self = WriteRow::Done;
                 }
                 WriteRow::UpdateExisting {
                     rowid,
@@ -386,10 +403,10 @@ mod tests {
     /// Resuming WriteRow at InsertIndex must write the new row's index entry at
     /// the correct position even when the index cursor was left elsewhere. After
     /// the table insert in InsertNew, an I/O yield can let other operations move
-    /// the index cursor, so InsertIndex must re-seek before inserting. The test
-    /// inserts the table row, deliberately moves the index cursor to a wrong key,
-    /// then resumes at InsertIndex and checks the new entry and all existing
-    /// entries are intact.
+    /// the index cursor, so the `needs_seek` step re-seeks before inserting. The
+    /// test inserts the table row, deliberately moves the index cursor to a wrong
+    /// key, then resumes at InsertIndex with `needs_seek: true` and checks the new
+    /// entry and all existing entries are intact.
     #[test]
     fn test_write_row_stale_index_cursor_after_simulated_io_yield() {
         let (pager, table_root, index_root) = create_test_pager();
@@ -479,7 +496,10 @@ mod tests {
             Value::from_i64(new_elem_id),
             Value::Null,
         ];
-        let mut wr = WriteRow::InsertIndex { rowid };
+        let mut wr = WriteRow::InsertIndex {
+            rowid,
+            needs_seek: true,
+        };
         pager
             .io
             .block(|| wr.write_row(&mut cursors, index_key.clone(), record_values.clone(), 1))


### PR DESCRIPTION
## Why

In the IVM `WriteRow` persistence state machine, the DBSP state-index cursor keeps
the position from an earlier seek. When the table insert in `InsertNew` yields on
I/O and the machine resumes at `InsertIndex`, the index entry is written at the
stale cursor position, corrupting the state index.

## Fix

`core/incremental/persistence.rs`:

- `InsertIndex` gains a `needs_seek` flag; the seek sub-state re-seeks the index
  cursor before inserting, so the write lands at the correct position after an
  I/O yield.
- `InsertNew` stays in-state until the table insert completes (so an I/O yield
  re-runs it) and only then advances to `InsertIndex { needs_seek: true }`.
- The index insert now marks `Done` *after* the insert completes rather than
  before, so an I/O yield during the insert resumes correctly.

## Commits

1. **test** (`core/incremental: add test exposing stale index cursor in IVM WriteRow`)
   — adds `test_write_row_stale_index_cursor_after_simulated_io_yield`, which
   inserts the table row, deliberately moves the index cursor to a wrong key
   (standing in for the reposition an I/O yield can cause), and asserts the row's
   index entry is written at the right position. Fails without the fix.
2. **fix** (`core/incremental: re-seek index cursor before InsertIndex in IVM WriteRow`)
   — the `needs_seek` re-seek. Test passes.

AI usage: drafted with Claude Code, reviewed and verified by a human.
