### PR TITLE
core/incremental: exclude NULL operands from IVM filter comparisons

### DIFF
--- a/core/incremental/filter_operator.rs
+++ b/core/incremental/filter_operator.rs
@@ -79,27 +79,29 @@ impl FilterOperator {
             FilterPredicate::None => true,
             FilterPredicate::Equals { column_idx, value } => {
                 let v = &values[*column_idx];
-                v == value
+                // SQL: NULL = X → NULL → false in WHERE
+                !matches!(v, Value::Null) && v == value
             }
             FilterPredicate::NotEquals { column_idx, value } => {
                 let v = &values[*column_idx];
-                v != value
+                // SQL: NULL != X → NULL → false in WHERE
+                !matches!(v, Value::Null) && v != value
             }
             FilterPredicate::GreaterThan { column_idx, value } => {
                 let v = &values[*column_idx];
-                v.cmp(value) == Ordering::Greater
+                !matches!(v, Value::Null) && v.cmp(value) == Ordering::Greater
             }
             FilterPredicate::GreaterThanOrEqual { column_idx, value } => {
                 let v = &values[*column_idx];
-                v.cmp(value) != Ordering::Less
+                !matches!(v, Value::Null) && v.cmp(value) != Ordering::Less
             }
             FilterPredicate::LessThan { column_idx, value } => {
                 let v = &values[*column_idx];
-                v.cmp(value) == Ordering::Less
+                !matches!(v, Value::Null) && v.cmp(value) == Ordering::Less
             }
             FilterPredicate::LessThanOrEqual { column_idx, value } => {
                 let v = &values[*column_idx];
-                v.cmp(value) != Ordering::Greater
+                !matches!(v, Value::Null) && v.cmp(value) != Ordering::Greater
             }
             FilterPredicate::And(left, right) => {
                 // Temporarily create sub-filters to evaluate
@@ -119,7 +121,7 @@ impl FilterOperator {
             } => {
                 let left = &values[*left_idx];
                 let right = &values[*right_idx];
-                left == right
+                !matches!(left, Value::Null) && !matches!(right, Value::Null) && left == right
             }
             FilterPredicate::ColumnNotEquals {
                 left_idx,
@@ -127,7 +129,7 @@ impl FilterOperator {
             } => {
                 let left = &values[*left_idx];
                 let right = &values[*right_idx];
-                left != right
+                !matches!(left, Value::Null) && !matches!(right, Value::Null) && left != right
             }
             FilterPredicate::ColumnGreaterThan {
                 left_idx,
@@ -135,7 +137,9 @@ impl FilterOperator {
             } => {
                 let left = &values[*left_idx];
                 let right = &values[*right_idx];
-                left.cmp(right) == Ordering::Greater
+                !matches!(left, Value::Null)
+                    && !matches!(right, Value::Null)
+                    && left.cmp(right) == Ordering::Greater
             }
             FilterPredicate::ColumnGreaterThanOrEqual {
                 left_idx,
@@ -143,7 +147,9 @@ impl FilterOperator {
             } => {
                 let left = &values[*left_idx];
                 let right = &values[*right_idx];
-                left.cmp(right) != Ordering::Less
+                !matches!(left, Value::Null)
+                    && !matches!(right, Value::Null)
+                    && left.cmp(right) != Ordering::Less
             }
             FilterPredicate::ColumnLessThan {
                 left_idx,
@@ -151,7 +157,9 @@ impl FilterOperator {
             } => {
                 let left = &values[*left_idx];
                 let right = &values[*right_idx];
-                left.cmp(right) == Ordering::Less
+                !matches!(left, Value::Null)
+                    && !matches!(right, Value::Null)
+                    && left.cmp(right) == Ordering::Less
             }
             FilterPredicate::ColumnLessThanOrEqual {
                 left_idx,
@@ -159,7 +167,9 @@ impl FilterOperator {
             } => {
                 let left = &values[*left_idx];
                 let right = &values[*right_idx];
-                left.cmp(right) != Ordering::Greater
+                !matches!(left, Value::Null)
+                    && !matches!(right, Value::Null)
+                    && left.cmp(right) != Ordering::Greater
             }
             FilterPredicate::IsNull { column_idx } => {
                 matches!(values[*column_idx], Value::Null)

--- a/testing/sqltests/tests/ivm-null-where-filter.sqltest
+++ b/testing/sqltests/tests/ivm-null-where-filter.sqltest
@@ -1,0 +1,71 @@
+@database :memory:
+@skip-file-if mvcc "materialized views not supported in MVCC mode"
+@requires materialized_views "requires materialized view support"
+
+test ivm-null-where-neq-string {
+    CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT);
+    INSERT INTO items VALUES ('a', 'Alice');
+    INSERT INTO items VALUES ('b', 'Bob');
+    INSERT INTO items VALUES ('c', NULL);
+    INSERT INTO items VALUES ('d', NULL);
+    INSERT INTO items VALUES ('e', '');
+
+    CREATE MATERIALIZED VIEW named AS SELECT id, name FROM items WHERE name != '';
+
+    SELECT id, name FROM named ORDER BY id;
+}
+expect {
+    a|Alice
+    b|Bob
+}
+
+test ivm-null-where-lt-string {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t VALUES (1, 'apple');
+    INSERT INTO t VALUES (2, NULL);
+    INSERT INTO t VALUES (3, 'banana');
+    INSERT INTO t VALUES (4, NULL);
+    INSERT INTO t VALUES (5, 'cherry');
+
+    CREATE MATERIALIZED VIEW mv_lt AS SELECT id, val FROM t WHERE val < 'cherry';
+
+    SELECT id, val FROM mv_lt ORDER BY id;
+}
+expect {
+    1|apple
+    3|banana
+}
+
+test ivm-null-where-neq-incremental {
+    CREATE TABLE data (id INTEGER PRIMARY KEY, status TEXT);
+
+    CREATE MATERIALIZED VIEW active AS SELECT id, status FROM data WHERE status != 'deleted';
+
+    INSERT INTO data VALUES (1, 'active');
+    INSERT INTO data VALUES (2, NULL);
+    INSERT INTO data VALUES (3, 'pending');
+    INSERT INTO data VALUES (4, NULL);
+
+    SELECT id, status FROM active ORDER BY id;
+}
+expect {
+    1|active
+    3|pending
+}
+
+test ivm-null-where-neq-after-update {
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, val TEXT);
+
+    CREATE MATERIALIZED VIEW mv2 AS SELECT id, val FROM t2 WHERE val != '';
+
+    INSERT INTO t2 VALUES (1, 'hello');
+    INSERT INTO t2 VALUES (2, NULL);
+    INSERT INTO t2 VALUES (3, 'world');
+
+    UPDATE t2 SET val = NULL WHERE id = 1;
+
+    SELECT id, val FROM mv2 ORDER BY id;
+}
+expect {
+    3|world
+}


### PR DESCRIPTION
## Why

`FilterOperator::evaluate_predicate` used Rust's `PartialEq`/`Ord` directly for WHERE evaluation, so a comparison against NULL (e.g. `NULL != ''`) returned true and NULL-valued rows were wrongly admitted into materialized views. SQL three-valued logic requires NULL comparisons in WHERE to yield false. This guards every comparison predicate against NULL operands.

The bug only surfaces on the incremental maintenance path (the from-scratch populate path already filtered NULLs), so the regression test covers both initial-populate and incremental INSERT/UPDATE cases.

## Changes

- `filter_operator.rs`: NULL operands make each comparison predicate (`=`, `!=`, `<`, `<=`, `>`, `>=`, and their column-vs-column forms) evaluate to false.
- `.sqltest` regression coverage (2 of 4 cases red without the fix).

AI usage: drafted with Claude Code, reviewed and verified by a human.