### PR TITLE
core/incremental: keep compound IS NULL predicates on the native filter path

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -1926,8 +1926,18 @@ impl DbspCompiler {
             // These simple cases don't need projection
             LogicalExpr::Column(_) | LogicalExpr::Literal(_) => false,
 
+            // `<col> IS [NOT] NULL` is handled natively by `compile_filter_predicate`
+            // as `FilterPredicate::IsNull`/`IsNotNull`. Routing it through the
+            // projection-rewrite path is wrong: that path only carries a single
+            // complex sub-expression as a temp column and then rewrites *both*
+            // sides of an AND/OR to reference that one temp column — silently
+            // dropping every other null-check predicate in a compound WHERE.
+            LogicalExpr::IsNull { expr, .. } if matches!(expr.as_ref(), LogicalExpr::Column(_)) => {
+                false
+            }
+
             // Default: assume we need projection for safety
-            // This includes: Between, InList, Like, IsNull, Cast, ScalarFunction, Case,
+            // This includes: Between, InList, Like, Cast, ScalarFunction, Case,
             // InSubquery, Exists, ScalarSubquery, and any future expression types
             _ => true,
         }

--- a/testing/sqltests/tests/ivm-compound-null-filter.sqltest
+++ b/testing/sqltests/tests/ivm-compound-null-filter.sqltest
@@ -1,0 +1,70 @@
+@database :memory:
+@skip-file-if mvcc "materialized views not supported in MVCC mode"
+@requires materialized_views "requires materialized view support"
+
+test ivm-null-where-compound-and-incremental {
+    CREATE TABLE n (id INTEGER PRIMARY KEY, a TEXT, b TEXT);
+
+    CREATE MATERIALIZED VIEW mv_n AS
+    SELECT a, b FROM n WHERE a IS NOT NULL AND b IS NOT NULL;
+
+    INSERT INTO n (a, b) VALUES ('x', NULL);
+    INSERT INTO n (a, b) VALUES (NULL, 'y');
+    INSERT INTO n (a, b) VALUES ('x', 'y');
+    INSERT INTO n (a, b) VALUES (NULL, NULL);
+
+    SELECT a, b FROM mv_n ORDER BY a, b;
+}
+expect {
+    x|y
+}
+
+test ivm-null-where-compound-mixed-incremental {
+    CREATE TABLE nh (id INTEGER PRIMARY KEY AUTOINCREMENT, region TEXT NOT NULL, block_id TEXT, ts INTEGER NOT NULL, closed_at TEXT);
+
+    CREATE MATERIALIZED VIEW focus_roots AS
+    SELECT region, block_id AS root_id, ts AS added_ts, id AS history_id
+    FROM nh
+    WHERE closed_at IS NULL AND block_id IS NOT NULL;
+
+    INSERT INTO nh (region, block_id, ts) VALUES ('main', NULL, 1000);
+    INSERT INTO nh (region, block_id, ts) VALUES ('main', 'block:a', 1001);
+    INSERT INTO nh (region, block_id, ts) VALUES ('main', 'block:b', 1002);
+
+    SELECT region, root_id FROM focus_roots ORDER BY history_id;
+}
+expect {
+    main|block:a
+    main|block:b
+}
+
+test ivm-null-where-compound-update-to-null {
+    CREATE TABLE u (id INTEGER PRIMARY KEY, a TEXT, b TEXT);
+
+    CREATE MATERIALIZED VIEW mv_u AS
+    SELECT a, b FROM u WHERE a IS NOT NULL AND b IS NOT NULL;
+
+    INSERT INTO u (id, a, b) VALUES (1, 'x', 'y');
+
+    UPDATE u SET b = NULL WHERE id = 1;
+
+    SELECT a, b FROM mv_u ORDER BY a, b;
+}
+expect {
+}
+
+test ivm-null-where-compound-and-from-scratch-parens {
+    CREATE TABLE p (id INTEGER PRIMARY KEY, a TEXT, b TEXT);
+    INSERT INTO p (a, b) VALUES ('x', NULL);
+    INSERT INTO p (a, b) VALUES (NULL, 'y');
+    INSERT INTO p (a, b) VALUES ('x', 'y');
+    INSERT INTO p (a, b) VALUES (NULL, NULL);
+
+    CREATE MATERIALIZED VIEW mv_p AS
+    SELECT a, b FROM p WHERE (a IS NOT NULL) AND (b IS NOT NULL);
+
+    SELECT a, b FROM mv_p ORDER BY a, b;
+}
+expect {
+    x|y
+}


### PR DESCRIPTION
## Why

In a materialized view, `WHERE a IS NOT NULL AND b IS NOT NULL` silently dropped the second predicate on the incremental path. `predicate_needs_projection` routed every `IsNull` expression through the projection-rewrite path, which carries only one complex sub-expression as a temp column and then rewrites *both* sides of an AND/OR to reference that single temp column — collapsing both checks onto column `a`. This marks `<col> IS [NOT] NULL` as not needing projection, so it compiles to the native `FilterPredicate::IsNull`/`IsNotNull` and composes correctly under `And`.

## Changes

- `compiler.rs`: `<col> IS [NOT] NULL` bypasses the projection rewrite.
- `.sqltest` regression coverage (compound NULL checks on insert / update / from-scratch / parenthesized — all red without the fix).

AI usage: drafted with Claude Code, reviewed and verified by a human.