### PR TITLE
core/mvcc: benchmark logical log serialization

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -201,6 +201,11 @@ name = "mvcc_recovery_benchmark"
 harness = false
 
 [[bench]]
+name = "logical_log_serialization"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
 name = "json_benchmark"
 harness = false
 

--- a/core/benches/logical_log_serialization.rs
+++ b/core/benches/logical_log_serialization.rs
@@ -1,0 +1,64 @@
+use divan::{black_box, AllocProfiler, Bencher};
+use mimalloc::MiMalloc;
+use turso_core::mvcc::database::{MVTableId, Row, RowID, RowKey, RowVersion, TxTimestampOrID};
+use turso_core::mvcc::persistent_storage::logical_log::benchmark_serialize_op_entry;
+
+#[global_allocator]
+static ALLOC: AllocProfiler<MiMalloc> = AllocProfiler::new(MiMalloc);
+
+fn main() {
+    divan::main();
+}
+
+fn table_upsert(payload_len: usize) -> RowVersion {
+    let payload = vec![0x5a; payload_len];
+    let row =
+        Row::new_table_row(RowID::new(MVTableId::new(-1), RowKey::Int(42)), &payload, 1).unwrap();
+    RowVersion::new(1, Some(TxTimestampOrID::Timestamp(1)), None, row, false)
+}
+
+#[turso_macros::divan_bench(args = [16, 1_024, 65_536])]
+fn cold_buffer(bencher: Bencher, payload_len: usize) {
+    let row_version = table_upsert(payload_len);
+
+    bencher
+        .with_inputs(Vec::new)
+        .bench_local_values(|mut buffer| {
+            benchmark_serialize_op_entry(black_box(&mut buffer), black_box(&row_version), None)
+                .unwrap();
+            black_box(buffer)
+        });
+}
+
+#[turso_macros::divan_bench(args = [1, 16, 256])]
+fn transaction_batch(bencher: Bencher, op_count: usize) {
+    let row_version = table_upsert(128);
+
+    bencher
+        .with_inputs(Vec::new)
+        .bench_local_values(|mut buffer| {
+            for _ in 0..op_count {
+                benchmark_serialize_op_entry(black_box(&mut buffer), black_box(&row_version), None)
+                    .unwrap();
+            }
+            black_box(buffer)
+        });
+}
+
+#[turso_macros::divan_bench(args = [16, 1_024, 65_536])]
+fn portable_extension(bencher: Bencher, extension_len: usize) {
+    let row_version = table_upsert(128);
+    let extension = vec![0xa5; extension_len];
+
+    bencher
+        .with_inputs(Vec::new)
+        .bench_local_values(|mut buffer| {
+            benchmark_serialize_op_entry(
+                black_box(&mut buffer),
+                black_box(&row_version),
+                Some(black_box(&extension)),
+            )
+            .unwrap();
+            black_box(buffer)
+        });
+}

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1133,6 +1133,16 @@ pub(crate) fn serialize_op_entry(
     Ok(())
 }
 
+/// Serializes one logical-log operation for the serialization benchmark.
+#[cfg(feature = "bench")]
+pub fn benchmark_serialize_op_entry(
+    buffer: &mut Vec<u8>,
+    row_version: &RowVersion,
+    portable_extension: Option<&[u8]>,
+) -> Result<()> {
+    serialize_op_entry(buffer, row_version, portable_extension)
+}
+
 pub(crate) fn serialize_header_entry(buffer: &mut Vec<u8>, header: &DatabaseHeader) {
     // Header op uses tag-only addressing (table_id=0, flags=0) and fixed payload length.
     buffer.push(OP_UPDATE_HEADER);


### PR DESCRIPTION
## Description

- add a Divan benchmark for logical-log operation serialization
- cover cold buffers with 16 B, 1 KiB, and 64 KiB records
- cover portable extensions at the same payload sizes
- cover transaction batches of 1, 16, and 256 operations
- enable Divan allocation profiling with mimalloc
- expose the existing operation serializer through a benchmark-only shim

## Context

Logical-log serializer changes need a stable before/after workload that measures both execution time and buffer allocation growth. Keeping this benchmark in a standalone PR establishes the baseline independently of the serializer implementation.

The benchmark functions use `#[turso_macros::divan_bench]` so stable and nightly CodSpeed runs retain distinct names.

