### PR TITLE
perf(vdbe): add ReopenIdx opcode to reuse btree cursors in subqueries (re-land)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -193,6 +193,10 @@ name = "count_benchmark"
 harness = false
 
 [[bench]]
+name = "correlated_subquery_benchmark"
+harness = false
+
+[[bench]]
 name = "mvcc_benchmark"
 harness = false
 

--- a/core/benches/correlated_subquery_benchmark.rs
+++ b/core/benches/correlated_subquery_benchmark.rs
@@ -1,0 +1,117 @@
+//! Microbenchmark: a GROUP BY whose projection runs a correlated scalar subquery
+//! per outer row -- a "latest related row" index lookup (ORDER BY id DESC LIMIT 1)
+//! over a full scan of the outer table -- at a couple of row counts, vs SQLite.
+//!
+//! Run: cargo bench -p turso_core --bench correlated_subquery_benchmark
+//!      (set DISABLE_RUSQLITE_BENCHMARK=1 to skip the SQLite comparison)
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion,
+};
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use std::sync::Arc;
+use tempfile::TempDir;
+use turso_core::{Database, PlatformIO, SqliteDialect, StepResult};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+const SCALES: [usize; 2] = [50_000, 200_000];
+
+const QUERY: &str = "SELECT o.grp, \
+     COALESCE((SELECT i.val FROM inner_t i \
+               WHERE i.k = o.k ORDER BY i.id DESC LIMIT 1), 'none') AS latest, \
+     COUNT(*) FROM outer_t o GROUP BY o.grp, latest";
+
+fn seed_db(n: usize) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("bench.db");
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE outer_t(id INTEGER PRIMARY KEY, k INTEGER NOT NULL, grp TEXT);
+         CREATE TABLE inner_t(id INTEGER PRIMARY KEY, k INTEGER NOT NULL, val TEXT);",
+    )
+    .unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+    {
+        let mut ins_o = tx
+            .prepare("INSERT INTO outer_t VALUES (?1, ?2, ?3)")
+            .unwrap();
+        let mut ins_i = tx
+            .prepare("INSERT INTO inner_t VALUES (?1, ?2, ?3)")
+            .unwrap();
+        for i in 1..=n as i64 {
+            ins_o
+                .execute((i, i, if i % 3 == 0 { "a" } else { "b" }))
+                .unwrap();
+            ins_i
+                .execute((i, i, if i % 2 == 0 { "x" } else { "y" }))
+                .unwrap();
+        }
+    }
+    tx.commit().unwrap();
+    conn.execute_batch("CREATE INDEX idx_inner_k ON inner_t(k);")
+        .unwrap();
+    dir
+}
+
+fn drain_turso(db: &Database, stmt: &mut turso_core::Statement) {
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                black_box(stmt.row());
+            }
+            StepResult::IO | StepResult::Yield => {
+                db.io.step().unwrap();
+            }
+            StepResult::Done => break,
+            StepResult::Interrupt | StepResult::Busy => unreachable!(),
+        }
+    }
+    stmt.reset().unwrap();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_correlated(criterion: &mut Criterion) {
+    let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
+    let mut group = criterion.benchmark_group("correlated_subquery");
+    group.sample_size(10);
+
+    for &n in SCALES.iter() {
+        let dir = seed_db(n);
+        let path = dir.path().join("bench.db");
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        group.bench_with_input(BenchmarkId::new("turso", n), &n, |b, _| {
+            let mut stmt = conn.prepare(QUERY).unwrap();
+            b.iter(|| drain_turso(&db, &mut stmt));
+        });
+
+        if enable_rusqlite {
+            let sconn = rusqlite::Connection::open(&path).unwrap();
+            sconn
+                .pragma_update(None, "locking_mode", "EXCLUSIVE")
+                .unwrap();
+            group.bench_with_input(BenchmarkId::new("sqlite", n), &n, |b, _| {
+                let mut stmt = sconn.prepare(QUERY).unwrap();
+                b.iter(|| {
+                    let mut rows = stmt.raw_query();
+                    while let Some(row) = rows.next().unwrap() {
+                        black_box(row);
+                    }
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_correlated);
+criterion_main!(benches);

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -310,11 +310,11 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
         });
 
         if !config.use_materialized_keys {
-            planner.program.emit_insn(Insn::OpenRead {
-                cursor_id: planner.hash_build_cursor_id,
-                root_page: btree.root_page,
-                db: build_table.database_id,
-            });
+            planner.program.emit_open_read(
+                planner.hash_build_cursor_id,
+                btree.root_page,
+                build_table.database_id,
+            );
         }
 
         planner.program.emit_insn(Insn::Rewind {
@@ -618,11 +618,8 @@ impl<'a, 'plan> HashProbeSetupEmitter<'a, 'plan> {
                 CursorKey::table(build_table.internal_id),
                 CursorType::BTreeTable(btree.clone()),
             );
-            self.program.emit_insn(Insn::OpenRead {
-                cursor_id,
-                root_page: btree.root_page,
-                db: build_table.database_id,
-            });
+            self.program
+                .emit_open_read(cursor_id, btree.root_page, build_table.database_id);
             cursor_id
         };
 

--- a/core/translate/main_loop/init.rs
+++ b/core/translate/main_loop/init.rs
@@ -167,18 +167,14 @@ impl InitLoop {
                     (OperationMode::SELECT, Table::BTree(btree)) => {
                         let root_page = btree.root_page;
                         if let Some(cursor_id) = table_cursor_id {
-                            program.emit_insn(Insn::OpenRead {
-                                cursor_id,
-                                root_page,
-                                db: table.database_id,
-                            });
+                            program.emit_open_read(cursor_id, root_page, table.database_id);
                         }
                         if let Some(index_cursor_id) = index_cursor_id {
-                            program.emit_insn(Insn::OpenRead {
-                                cursor_id: index_cursor_id,
-                                root_page: index.as_ref().unwrap().root_page,
-                                db: table.database_id,
-                            });
+                            program.emit_open_read(
+                                index_cursor_id,
+                                index.as_ref().unwrap().root_page,
+                                table.database_id,
+                            );
                         }
                     }
                     (OperationMode::DELETE, Table::BTree(btree)) => {
@@ -291,11 +287,11 @@ impl InitLoop {
                     match mode {
                         OperationMode::SELECT => {
                             if let Some(table_cursor_id) = table_cursor_id {
-                                program.emit_insn(Insn::OpenRead {
-                                    cursor_id: table_cursor_id,
-                                    root_page: table.table.get_root_page()?,
-                                    db: table.database_id,
-                                });
+                                program.emit_open_read(
+                                    table_cursor_id,
+                                    table.table.get_root_page()?,
+                                    table.database_id,
+                                );
                             }
                         }
                         OperationMode::DELETE | OperationMode::UPDATE { .. } => {
@@ -357,13 +353,13 @@ impl InitLoop {
                         if !index.ephemeral {
                             match mode {
                                 OperationMode::SELECT => {
-                                    program.emit_insn(Insn::OpenRead {
-                                        cursor_id: index_cursor_id.expect(
+                                    program.emit_open_read(
+                                        index_cursor_id.expect(
                                             "index cursor is always opened in Seek with index",
                                         ),
-                                        root_page: index.root_page,
-                                        db: table.database_id,
-                                    });
+                                        index.root_page,
+                                        table.database_id,
+                                    );
                                 }
                                 OperationMode::UPDATE { .. } | OperationMode::DELETE => {
                                     program.emit_insn(Insn::OpenWrite {
@@ -387,18 +383,18 @@ impl InitLoop {
                 Operation::IndexMethodQuery(_) => match mode {
                     OperationMode::SELECT => {
                         if let Some(table_cursor_id) = table_cursor_id {
-                            program.emit_insn(Insn::OpenRead {
-                                cursor_id: table_cursor_id,
-                                root_page: table.table.get_root_page()?,
-                                db: table.database_id,
-                            });
+                            program.emit_open_read(
+                                table_cursor_id,
+                                table.table.get_root_page()?,
+                                table.database_id,
+                            );
                         }
                         let index_cursor_id = index_cursor_id.unwrap();
-                        program.emit_insn(Insn::OpenRead {
-                            cursor_id: index_cursor_id,
-                            root_page: table.op.index().unwrap().root_page,
-                            db: table.database_id,
-                        });
+                        program.emit_open_read(
+                            index_cursor_id,
+                            table.op.index().unwrap().root_page,
+                            table.database_id,
+                        );
                     }
                     OperationMode::DELETE => {
                         if let Some(table_cursor_id) = table_cursor_id {
@@ -462,11 +458,11 @@ impl InitLoop {
                                 let Table::BTree(btree) = &table.table else {
                                     panic!("Expected hash join probe table to be a BTree table");
                                 };
-                                program.emit_insn(Insn::OpenRead {
-                                    cursor_id: table_cursor_id,
-                                    root_page: btree.root_page,
-                                    db: table.database_id,
-                                });
+                                program.emit_open_read(
+                                    table_cursor_id,
+                                    btree.root_page,
+                                    table.database_id,
+                                );
                             }
                         }
                         _ => unreachable!("Hash joins should only occur in SELECT operations"),
@@ -480,11 +476,11 @@ impl InitLoop {
                             };
                             // Open the table cursor
                             if let Some(table_cursor_id) = table_cursor_id {
-                                program.emit_insn(Insn::OpenRead {
-                                    cursor_id: table_cursor_id,
-                                    root_page: btree.root_page,
-                                    db: table.database_id,
-                                });
+                                program.emit_open_read(
+                                    table_cursor_id,
+                                    btree.root_page,
+                                    table.database_id,
+                                );
                             }
                             // Open cursors for each index branch
                             for branch in &multi_idx_op.branches {
@@ -493,11 +489,11 @@ impl InitLoop {
                                         Some(CursorKey::index(table.internal_id, index.clone())),
                                         index,
                                     )?;
-                                    program.emit_insn(Insn::OpenRead {
-                                        cursor_id: branch_cursor_id,
-                                        root_page: index.root_page,
-                                        db: table.database_id,
-                                    });
+                                    program.emit_open_read(
+                                        branch_cursor_id,
+                                        index.root_page,
+                                        table.database_id,
+                                    );
                                 }
                             }
                         }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -40,7 +40,7 @@ impl TableRefIdCounter {
 }
 
 use super::{
-    affinity::Affinity, BranchOffset, CursorID, Insn, InsnReference, PrepareContext,
+    affinity::Affinity, BranchOffset, CursorID, Insn, InsnReference, PageIdx, PrepareContext,
     PreparedProgram, Program,
 };
 use crate::translate::plan::BitSet;
@@ -1035,6 +1035,25 @@ impl ProgramBuilder {
             self.emitted_function_call = true;
         }
         self.insns.push((insn, self.insns.len()));
+    }
+
+    /// Emit an OpenRead, or ReopenIdx when inside a nested subquery. A correlated
+    /// subquery's cursor opens re-execute once per outer row, so they reuse the cursor
+    /// already open on the same root page instead of rebuilding it each iteration.
+    pub fn emit_open_read(&mut self, cursor_id: CursorID, root_page: PageIdx, db: usize) {
+        if self.is_nested() {
+            self.emit_insn(Insn::ReopenIdx {
+                cursor_id,
+                root_page,
+                db,
+            });
+        } else {
+            self.emit_insn(Insn::OpenRead {
+                cursor_id,
+                root_page,
+                db,
+            });
+        }
     }
 
     /// Emit an instruction that should not start or extend a constant span on its own.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -49,8 +49,8 @@ use crate::vdbe::vacuum::VacuumInPlaceOpContext;
 use crate::vdbe::value::ComparisonOp;
 use crate::vdbe::ValueIteratorExt;
 use crate::vdbe::{
-    registers_to_ref_values, DeferredSeekState, EndStatement, OpHashBuildState, OpHashProbeState,
-    StepResult, TxnCleanup, VacuumOpState,
+    registers_to_ref_values, CursorID, DeferredSeekState, EndStatement, OpHashBuildState,
+    OpHashProbeState, PageIdx, StepResult, TxnCleanup, VacuumOpState,
 };
 use crate::vector::{
     vector1bit, vector32, vector32_sparse, vector64, vector8, vector_concat, vector_distance_cos,
@@ -1159,7 +1159,65 @@ pub fn op_open_read(
         },
         insn
     );
+    open_read_cursor(program, state, cursor_id, root_page, db)
+}
 
+/// Works like OpenRead, except it is a no-op if the cursor slot already holds a btree
+/// cursor on the same root page: the cursor is reused, and a subsequent Seek/Rewind
+/// repositions it. Emitted instead of OpenRead inside subqueries, which re-execute once
+/// per outer row when correlated: rebuilding the BTreeCursor every iteration (allocation,
+/// pager registration, dropping the previous cursor) dominated runtime there.
+/// Mirrors SQLite's OP_ReopenIdx.
+pub fn op_reopen_idx(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(
+        ReopenIdx {
+            cursor_id,
+            root_page,
+            db,
+        },
+        insn
+    );
+    let can_reuse_cursor = matches!(
+        state.cursors.get(*cursor_id),
+        Some(Some(Cursor::BTree(btree_cursor))) if btree_cursor.root_page() == *root_page
+    );
+    if can_reuse_cursor {
+        // Mirrors SQLite's `assert(pCur->iDb==pOp->p3)`. The reuse condition above only
+        // compares root_page, but root pages are unique only *within* a database file:
+        // two ATTACHed databases can each hold a btree at the same root page. A cursor
+        // slot is bound to a single table reference (hence a single database) by codegen,
+        // so this never fires today — the assert is a guard rail against a future change
+        // that lets a cursor_id be reopened against a different database, which would
+        // otherwise silently reuse a cursor pointing at the wrong database's btree.
+        #[cfg(debug_assertions)]
+        if let Some(Some(Cursor::BTree(btree_cursor))) = state.cursors.get(*cursor_id) {
+            let expected_pager = program
+                .get_pager_from_database_index(db)
+                .expect("pager should exist for db");
+            debug_assert!(
+                Arc::ptr_eq(&btree_cursor.get_pager(), &expected_pager),
+                "ReopenIdx reused a cursor bound to a different database (cursor {cursor_id}, db {db})"
+            );
+        }
+        invalidate_deferred_seeks_for_cursor(state, *cursor_id);
+        state.pc += 1;
+        return Ok(InsnFunctionStepResult::Step);
+    }
+    open_read_cursor(program, state, cursor_id, root_page, db)
+}
+
+fn open_read_cursor(
+    program: &Program,
+    state: &mut ProgramState,
+    cursor_id: &CursorID,
+    root_page: &PageIdx,
+    db: &usize,
+) -> Result<InsnFunctionStepResult> {
     invalidate_deferred_seeks_for_cursor(state, *cursor_id);
 
     let pager = program.get_pager_from_database_index(db)?;
@@ -1192,6 +1250,7 @@ pub fn op_open_read(
         );
     }
     let cursors = &mut state.cursors;
+
     let num_columns = match cursor_type {
         CursorType::BTreeTable(table_rc) => table_rc.columns().len(),
         CursorType::BTreeIndex(index_arc) => index_arc.columns.len(),

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -414,6 +414,39 @@ pub fn insn_to_row(
                     )
                 },
             ),
+            Insn::ReopenIdx {
+                cursor_id,
+                root_page,
+                db,
+            } => (
+                "ReopenIdx",
+                *cursor_id as i64,
+                *root_page,
+                *db as i64,
+                Value::build_text(program.cursor_ref[*cursor_id]
+                            .1.get_explain_description()),
+                0,
+                {
+                    let cursor_type =
+                        program.cursor_ref[*cursor_id]
+                            .0
+                            .as_ref()
+                            .map_or("", |cursor_key| {
+                                if cursor_key.index.is_some() {
+                                    "index"
+                                } else {
+                                    "table"
+                                }
+                            });
+                    format!(
+                        "{}={}, root={}, iDb={}",
+                        cursor_type,
+                        get_table_or_index_name(*cursor_id),
+                        root_page,
+                        db
+                    )
+                },
+            ),
             Insn::VOpen { cursor_id } => (
                 "VOpen",
                 *cursor_id as i64,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -497,6 +497,19 @@ pub enum Insn {
         db: usize,
     },
 
+    /// Works like OpenRead, except it becomes a no-op if the cursor slot already holds a
+    /// btree cursor on the same root page: the cursor is reused instead of rebuilt, and a
+    /// subsequent Seek/Rewind repositions it. Emitted instead of OpenRead inside subqueries,
+    /// which re-execute once per outer row when correlated — rebuilding the cursor on every
+    /// iteration (allocation + pager registration + dropping the previous cursor) dominates
+    /// runtime there. Mirrors SQLite's OP_ReopenIdx, which SQLite emits only for the
+    /// OR-optimization's shared index cursors; we also emit it for table cursors.
+    ReopenIdx {
+        cursor_id: CursorID,
+        root_page: PageIdx,
+        db: usize,
+    },
+
     /// Open a cursor for a virtual table.
     VOpen {
         cursor_id: CursorID,
@@ -2046,6 +2059,7 @@ impl InsnVariants {
             InsnVariants::If => execute::op_if,
             InsnVariants::IfNot => execute::op_if_not,
             InsnVariants::OpenRead => execute::op_open_read,
+            InsnVariants::ReopenIdx => execute::op_reopen_idx,
             InsnVariants::VOpen => execute::op_vopen,
             InsnVariants::VCreate => execute::op_vcreate,
             InsnVariants::VFilter => execute::op_vfilter,

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
@@ -35,8 +35,8 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
    3          Integer          0   6   0                       0  r[6]=0; clear group by abort flag
    4          Null             0   7   0                       0  r[7]=NULL; initialize group by comparison registers to NULL
    5          Gosub           13  34   0                       0  ; go to clear accumulator subroutine
-   6          OpenRead         0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
-   7          OpenRead         1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
+   6          ReopenIdx        0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
+   7          ReopenIdx        1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
    8          Rewind           1  23   0                       0  Rewind index idx_sales_category
    9            DeferredSeek   1   0   0                       0
   10            Column         1   0  11                       0  r[11]=idx_sales_category.category

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-three-table.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-three-table.snap
@@ -28,10 +28,10 @@ BYTECODE
 addr  opcode              p1  p2  p3  p4                                          p5  comment
    0  Init                 0  95   0                                               0  Start at 95
    1  OpenEphemeral        0   1   0                                               0  cursor=0 is_table=true
-   2  OpenRead             1   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
-   3  OpenRead             2   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
+   2  ReopenIdx            1   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
+   3  ReopenIdx            2   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
    4  Once                14   0   0                                               0  goto 14
-   5  OpenRead             3   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
+   5  ReopenIdx            3   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
    6  Rewind               3  13   0                                               0  Rewind table h_items
    7    Column             3   1   8                                               0  r[8]=h_items.order_name
    8    Affinity           8   1   0                                               0  r[8..9] = A

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
@@ -28,7 +28,7 @@ addr  opcode            p1  p2  p3  p4            p5  comment
    4  Null               0   1   0                 0  r[1]=NULL
    5  Once              15   0   0                 0  goto 15
    6  OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
-   7  OpenRead           4   3   0  k(4,B,B,B,B)   0  table=users, root=3, iDb=0
+   7  ReopenIdx          4   3   0  k(4,B,B,B,B)   0  table=users, root=3, iDb=0
    8  Rewind             4  15   0                 0  Rewind table users
    9    Column           4   3   4  active         0  r[4]=users.status
   10    Ne               4   5  14  Binary         0  if r[4]!=r[5] goto 14
@@ -36,7 +36,7 @@ addr  opcode            p1  p2  p3  p4            p5  comment
   12    MakeRecord       2   1   6                 0  r[6]=mkrec(r[2..2]); for ephemeral_index_where_sub_t2
   13    IdxInsert        0   6   0                 8  key=r[6]
   14  Next               4   9   0                 0
-  15  OpenRead           3  12   0  k(2,B)         0  index=idx_orders_user_id, root=12, iDb=0
+  15  ReopenIdx          3  12   0  k(2,B)         0  index=idx_orders_user_id, root=12, iDb=0
   16  NullRow            0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
   17  Rewind             0  27   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t2)
   18    Column           0   0   8                 0  r[8]=ephemeral(ephemeral_index_where_sub_t2).id

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-select.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-select.snap
@@ -21,7 +21,7 @@ BYTECODE
 addr  opcode            p1  p2  p3  p4                         p5  comment
    0  Init               0  42   0                              0  Start at 42
    1  InitCoroutine      2  15   2                              0
-   2  OpenRead           0   5   0  k(6,B,B,B,B,B,B)            0  table=orders, root=5, iDb=0
+   2  ReopenIdx          0   5   0  k(6,B,B,B,B,B,B)            0  table=orders, root=5, iDb=0
    3  Rewind             0  14   0                              0  Rewind table orders
    4    Column           0   5   9                              0  r[9]=orders.created_at
    5    Ge               9  10  13  Binary                      0  if r[9]>=r[10] goto 13

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__update-where-self-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__update-where-self-subquery.snap
@@ -25,11 +25,11 @@ BYTECODE
 addr  opcode           p1  p2  p3  p4                 p5  comment
    0    Init            0  36   0                      0  Start at 36
    1    OpenEphemeral   0   1   0                      0  cursor=0 is_table=true
-   2    OpenRead        1   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+   2    ReopenIdx       1   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
    3    Rewind          1  19   0                      0  Rewind table products
    4      BeginSubrtn   3   0   0                      0  r[3]=NULL
    5      Integer       0   1   0                      0  r[1]=0
-   6      OpenRead      2   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+   6      ReopenIdx     2   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
    7      RowId         1   6   0                      0  r[6]=products.rowid
    8      Subtract      6   7   5                      0  r[5]=r[6]-r[7]
    9      SeekRowid     2   5  13                      0  if (r[5]!=cursor 2 for table products.rowid) goto 13

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__update-where-unrelated-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__update-where-unrelated-subquery.snap
@@ -25,11 +25,11 @@ BYTECODE
 addr  opcode           p1  p2  p3  p4                 p5  comment
    0    Init            0  33   0                      0  Start at 33
    1    OpenEphemeral   0   1   0                      0  cursor=0 is_table=true
-   2    OpenRead        1   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+   2    ReopenIdx       1   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
    3    Rewind          1  16   0                      0  Rewind table products
    4      BeginSubrtn   3   0   0                      0  r[3]=NULL
    5      Integer       0   1   0                      0  r[1]=0
-   6      OpenRead      2   3   0  k(4,B,B,B,B)        0  table=users, root=3, iDb=0
+   6      ReopenIdx     2   3   0  k(4,B,B,B,B)        0  table=users, root=3, iDb=0
    7      RowId         1   5   0                      0  r[5]=products.rowid
    8      SeekRowid     2   5  10                      0  if (r[5]!=cursor 2 for table users.rowid) goto 10
    9      Integer       1   1   0                      0  r[1]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__subquery-with-union.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__subquery-with-union.snap
@@ -29,14 +29,14 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    0  Init            0  33   0                   0  Start at 33
    1  InitCoroutine   1  24   2                   0
    2  OpenEphemeral   0   0   0                   0  cursor=0 is_table=false
-   3  OpenRead        1   2   0  k(4,B,B,B,B)     0  table=current_employees, root=2, iDb=0
+   3  ReopenIdx       1   2   0  k(4,B,B,B,B)     0  table=current_employees, root=2, iDb=0
    4  Rewind          1  10   0                   0  Rewind table current_employees
    5    Column        1   1   2                   0  r[2]=current_employees.name
    6    Column        1   2   3                   0  r[3]=current_employees.department
    7    MakeRecord    2   2   4                   0  r[4]=mkrec(r[2..3]); for compound_dedupe
    8    IdxInsert     0   4   0                   8  key=r[4]
    9  Next            1   5   0                   0
-  10  OpenRead        2   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
+  10  ReopenIdx       2   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
   11  Rewind          2  17   0                   0  Rewind table former_employees
   12    Column        2   1   2                   0  r[2]=former_employees.name
   13    Column        2   2   3                   0  r[3]=former_employees.department

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-subquery-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-subquery-aggregation.snap
@@ -37,19 +37,19 @@ BYTECODE
 addr  opcode                  p1  p2  p3  p4              p5  comment
    0          Init             0  71   0                   0  Start at 71
    1          InitCoroutine    1  21   2                   0
-   2          OpenRead         0   2   0  k(4,B,B,B,B)     0  table=current_employees, root=2, iDb=0
+   2          ReopenIdx        0   2   0  k(4,B,B,B,B)     0  table=current_employees, root=2, iDb=0
    3          Rewind           0   8   0                   0  Rewind table current_employees
    4            Column         0   1   2                   0  r[2]=current_employees.name
    5            Column         0   2   3                   0  r[3]=current_employees.department
    6            Yield          1   0   0                   0
    7          Next             0   4   0                   0
-   8          OpenRead         1   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
+   8          ReopenIdx        1   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
    9          Rewind           1  14   0                   0  Rewind table former_employees
   10            Column         1   1   2                   0  r[2]=former_employees.name
   11            Column         1   2   3                   0  r[3]=former_employees.department
   12            Yield          1   0   0                   0
   13          Next             1  10   0                   0
-  14          OpenRead         2   4   0  k(4,B,B,B,B)     0  table=contractors, root=4, iDb=0
+  14          ReopenIdx        2   4   0  k(4,B,B,B,B)     0  table=contractors, root=4, iDb=0
   15          Rewind           2  20   0                   0  Rewind table contractors
   16            Column         2   1   2                   0  r[2]=contractors.name
   17            Column         2   2   3                   0  r[3]=contractors.department

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
@@ -32,7 +32,7 @@ addr  opcode           p1  p2  p3  p4            p5  comment
    5      Null          0   7   0                 0  r[7]=NULL
    6      Integer       1   8   0                 0  r[8]=1; LIMIT counter
    7      IfNot         8  14   0                 0  if !r[8] goto 14
-   8      OpenRead      1  10   0  k(2,B)         0  index=idx_order_items_order, root=10, iDb=0
+   8      ReopenIdx     1  10   0  k(2,B)         0  index=idx_order_items_order, root=10, iDb=0
    9      RowId         0   9   0                 0  r[9]=orders.rowid
   10      SeekGE        1  14   9                 0  key=[9..9]
   11        IdxGT       1  14   9                 0  key=[9..9]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
@@ -31,7 +31,7 @@ addr  opcode              p1  p2  p3  p4              p5  comment
    5      Null             0   8   0                   0  r[8]=NULL
    6      Integer          1   9   0                   0  r[9]=1; LIMIT counter
    7      IfNot            9  17   0                   0  if !r[9] goto 17
-   8      OpenRead         1   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+   8      ReopenIdx        1   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
    9      Rewind           1  17   0                   0  Rewind table employees
   10        Column         1   3  11                   0  r[11]=employees.department
   11        Column         0   3  12                   0  r[12]=employees.department

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
@@ -31,8 +31,8 @@ addr  opcode              p1  p2  p3  p4              p5  comment
    5      Null             0   7   0                   0  r[7]=NULL
    6      Integer          1   8   0                   0  r[8]=1; LIMIT counter
    7      IfNot            8  20   0                   0  if !r[8] goto 20
-   8      OpenRead         1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   9      OpenRead         2   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+   8      ReopenIdx        1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   9      ReopenIdx        2   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
   10      Column           0   2   9                   0  r[9]=products.category_id
   11      IsNull           9  20   0                   0  if (r[9]==NULL) goto 20
   12      Affinity         9   1   0                   0  r[9..10] = C

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -41,8 +41,8 @@ addr  opcode                            p1   p2   p3  p4              p5  commen
    6                    Integer          0    8    0                   0  r[8]=0; clear group by abort flag
    7                    Null             0    9    0                   0  r[9]=NULL; initialize group by comparison registers to NULL
    8                    Gosub           15   38    0                   0  ; go to clear accumulator subroutine
-   9                    OpenRead         0    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  10                    OpenRead         1    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+   9                    ReopenIdx        0    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  10                    ReopenIdx        1    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
   11                    Rewind           1   27    0                   0  Rewind index idx_products_category
   12                      DeferredSeek   1    0    0                   0
   13                      Column         1    0   13                   0  r[13]=idx_products_category.category_id

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -49,7 +49,7 @@ addr  opcode              p1  p2  p3  p4            p5  comment
    2  Once                23   0   0                 0  goto 23
    3  OpenEphemeral        0   0   0                 0  cursor=0 is_table=false
    4  InitCoroutine        2  17   5                 0
-   5  OpenRead             1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   5  ReopenIdx            1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
    6  Rewind               1  16   0                 0  Rewind table orders
    7    Column             1   3   7                 0  r[7]=orders.total_amount
    8    RealAffinity       7   0   0                 0
@@ -67,7 +67,7 @@ addr  opcode              p1  p2  p3  p4            p5  comment
   20    MakeRecord         9   1  10                 0  r[10]=mkrec(r[9..9]); for ephemeral_index_where_sub_t4
   21    IdxInsert          0  10   0                 8  key=r[10]
   22  Goto                 0  18   0                 0
-  23  OpenRead             2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  23  ReopenIdx            2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
   24  NullRow              0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
   25  Rewind               0  33   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t4)
   26    Column             0   0  13                 0  r[13]=ephemeral(ephemeral_index_where_sub_t4).customer_id

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
@@ -46,8 +46,8 @@ addr  opcode                                       p1   p2   p3  p4            p
    6                              Integer           0    9    0                 0  r[9]=0; clear group by abort flag
    7                              Null              0   10    0                 0  r[10]=NULL; initialize group by comparison registers to NULL
    8                              Gosub            16   38    0                 0  ; go to clear accumulator subroutine
-   9                              OpenRead          0    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  10                              OpenRead          1    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   9                              ReopenIdx         0    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  10                              ReopenIdx         1    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
   11                              Rewind            1   27    0                 0  Rewind index idx_orders_customer
   12                                DeferredSeek    1    0    0                 0
   13                                Column          1    0   14                 0  r[14]=idx_orders_customer.customer_id
@@ -99,8 +99,8 @@ addr  opcode                                       p1   p2   p3  p4            p
   59                    Integer                     0   27    0                 0  r[27]=0; clear group by abort flag
   60                    Null                        0   28    0                 0  r[28]=NULL; initialize group by comparison registers to NULL
   61                    Gosub                      34   91    0                 0  ; go to clear accumulator subroutine
-  62                    OpenRead                    2    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  63                    OpenRead                    3    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+  62                    ReopenIdx                   2    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  63                    ReopenIdx                   3    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
   64                    Rewind                      3   80    0                 0  Rewind index idx_orders_customer
   65                      DeferredSeek              3    2    0                 0
   66                      Column                    3    0   32                 0  r[32]=idx_orders_customer.customer_id

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referencing-previous.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referencing-previous.snap
@@ -58,8 +58,8 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
    5          Integer            0   9   0                   0  r[9]=0; clear group by abort flag
    6          Null               0  10   0                   0  r[10]=NULL; initialize group by comparison registers to NULL
    7          Gosub             18  43   0                   0  ; go to clear accumulator subroutine
-   8          OpenRead           0   5   0  k(5,B,B,B,B,B)   0  table=order_items, root=5, iDb=0
-   9          OpenRead           1  11   0  k(2,B)           0  index=idx_order_items_product, root=11, iDb=0
+   8          ReopenIdx          0   5   0  k(5,B,B,B,B,B)   0  table=order_items, root=5, iDb=0
+   9          ReopenIdx          1  11   0  k(2,B)           0  index=idx_order_items_product, root=11, iDb=0
   10          Rewind             1  30   0                   0  Rewind index idx_order_items_product
   11            DeferredSeek     1   0   0                   0
   12            Column           1   0  15                   0  r[15]=idx_order_items_product.product_id
@@ -107,7 +107,7 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   54    Yield                    2   0   0                   0
   55  Goto                       0  48   0                   0
   56  EndCoroutine               2   0   0                   0
-  57  OpenRead                   2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  57  ReopenIdx                  2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
   58  InitCoroutine              2   0   3                   0
   59    Yield                    2  68   0                   0
   60    Copy                    21  31   0                   0  r[31]=r[21]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
@@ -42,7 +42,7 @@ addr  opcode                      p1  p2  p3  p4              p5  comment
    8              Integer          0  12   0                   0  r[12]=0; clear group by abort flag
    9              Null             0  13   0                   0  r[13]=NULL; initialize group by comparison registers to NULL
   10              Gosub           19  49   0                   0  ; go to clear accumulator subroutine
-  11              OpenRead         4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+  11              ReopenIdx        4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
   12              Rewind           4  19   0                   0  Rewind table employees
   13                Column         4   3  17                   0  r[17]=employees.department
   14                Column         4   4  18                   0  r[18]=employees.salary

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
@@ -39,7 +39,7 @@ addr  opcode           p1  p2  p3  p4          p5  comment
   17      Null          0  13   0               0  r[13]=NULL
   18      Integer       1  14   0               0  r[14]=1; LIMIT counter
   19      IfNot        14  24   0               0  if !r[14] goto 24
-  20      OpenRead      2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
+  20      ReopenIdx     2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
   21      Rewind        2  24   0               0  Rewind table t
   22        AggStep     0  15  13  count        0  accum=r[13] step(r[15])
   23      Next          2  22   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
@@ -35,8 +35,8 @@ addr  opcode                   p1  p2  p3  p4            p5  comment
    3          Integer           0   7   0                 0  r[7]=0; clear group by abort flag
    4          Null              0   8   0                 0  r[8]=NULL; initialize group by comparison registers to NULL
    5          Gosub            15  38   0                 0  ; go to clear accumulator subroutine
-   6          OpenRead          0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   7          OpenRead          1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   6          ReopenIdx         0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   7          ReopenIdx         1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
    8          Rewind            1  25   0                 0  Rewind index idx_orders_customer
    9            DeferredSeek    1   0   0                 0
   10            Column          1   0  13                 0  r[13]=idx_orders_customer.customer_id

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
@@ -38,8 +38,8 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
    4          Integer            0   8   0                 0  r[8]=0; clear group by abort flag
    5          Null               0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
    6          Gosub             15  36   0                 0  ; go to clear accumulator subroutine
-   7          OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   8          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   7          ReopenIdx          1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   8          ReopenIdx          2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
    9          Rewind             2  25   0                 0  Rewind index idx_orders_customer
   10            DeferredSeek     2   1   0                 0
   11            Column           2   0  13                 0  r[13]=idx_orders_customer.customer_id

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__exists-multiple-conditions.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__exists-multiple-conditions.snap
@@ -35,9 +35,9 @@ addr  opcode              p1  p2  p3  p4              p5  comment
    4      Integer          0   1   0                   0  r[1]=0
    5      Integer          1   7   0                   0  r[7]=1; LIMIT counter
    6      IfNot            7  21   0                   0  if !r[7] goto 21
-   7      OpenRead         1   5   0  k(5,B,B,B,B,B)   0  table=order_items, root=5, iDb=0
-   8      OpenRead         2  11   0  k(2,B)           0  index=idx_order_items_product, root=11, iDb=0
-   9      OpenRead         3   4   0  k(4,B,B,B,B)     0  table=orders, root=4, iDb=0
+   7      ReopenIdx        1   5   0  k(5,B,B,B,B,B)   0  table=order_items, root=5, iDb=0
+   8      ReopenIdx        2  11   0  k(2,B)           0  index=idx_order_items_product, root=11, iDb=0
+   9      ReopenIdx        3   4   0  k(4,B,B,B,B)     0  table=orders, root=4, iDb=0
   10      RowId            0   8   0                   0  r[8]=products.rowid
   11      SeekGE           2  21   8                   0  key=[8..8]
   12        IdxGT          2  21   8                   0  key=[8..8]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -58,8 +58,8 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   31        Null                 0  16   0                 0  r[16]=NULL
   32        Integer              1  17   0                 0  r[17]=1; LIMIT counter
   33        IfNot               17  45   0                 0  if !r[17] goto 45
-  34        OpenRead             2   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
-  35        OpenRead             3   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+  34        ReopenIdx            2   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+  35        ReopenIdx            3   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
   36        Copy                 8  18   0                 0  r[18]=r[8]
   37        IsNull              18  45   0                 0  if (r[18]==NULL) goto 45
   38        SeekGE               3  45  18                 0  key=[18..18]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -60,8 +60,8 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   32        Null                 0  17   0                   0  r[17]=NULL
   33        Integer              1  18   0                   0  r[18]=1; LIMIT counter
   34        IfNot               18  46   0                   0  if !r[18] goto 46
-  35        OpenRead             3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-  36        OpenRead             4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
+  35        ReopenIdx            3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
+  36        ReopenIdx            4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
   37        Copy                 9  19   0                   0  r[19]=r[9]
   38        IsNull              19  46   0                   0  if (r[19]==NULL) goto 46
   39        SeekGE               4  46  19                   0  key=[19..19]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
@@ -32,8 +32,8 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
    4          Integer            0   4   0                 0  r[4]=0; clear group by abort flag
    5          Null               0   5   0                 0  r[5]=NULL; initialize group by comparison registers to NULL
    6          Gosub             11  39   0                 0  ; go to clear accumulator subroutine
-   7          OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   8          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   7          ReopenIdx          1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   8          ReopenIdx          2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
    9          Rewind             2  25   0                 0  Rewind index idx_orders_customer
   10            DeferredSeek     2   1   0                 0
   11            Column           2   0   9                 0  r[9]=idx_orders_customer.customer_id

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
@@ -29,7 +29,7 @@ addr  opcode           p1  p2  p3  p4            p5  comment
    5      Null          0   6   0                 0  r[6]=NULL
    6      Integer       1   7   0                 0  r[7]=1; LIMIT counter
    7      IfNot         7  14   0                 0  if !r[7] goto 14
-   8      OpenRead      1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   8      ReopenIdx     1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
    9      RowId         0   8   0                 0  r[8]=customers.rowid
   10      SeekGE        1  14   8                 0  key=[8..8]
   11        IdxGT       1  14   8                 0  key=[8..8]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
@@ -29,7 +29,7 @@ addr  opcode             p1  p2  p3  p4              p5  comment
    4    Null              0   4   0                   0  r[4]=NULL
    5    Integer           1   5   0                   0  r[5]=1; LIMIT counter
    6    IfNot             5  14   0                   0  if !r[5] goto 14
-   7    OpenRead          0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   7    ReopenIdx         0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
    8    Rewind            0  14   0                   0  Rewind table products
    9      Column          0   3   6                   0  r[6]=products.price
   10      RealAffinity    6   0   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-simple-count.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-simple-count.snap
@@ -23,7 +23,7 @@ addr  opcode         p1  p2  p3  p4            p5  comment
    4    Null          0   4   0                 0  r[4]=NULL
    5    Integer       1   5   0                 0  r[5]=1; LIMIT counter
    6    IfNot         5  12   0                 0  if !r[5] goto 12
-   7    OpenRead      0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   7    ReopenIdx     0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
    8    Count         0   6   0                 0
    9    Close         0   0   0                 0
   10    Copy          6   3   0                 0  r[3]=r[6]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
@@ -35,7 +35,7 @@ addr  opcode             p1  p2  p3  p4              p5  comment
    1  InitCoroutine       1  29   2                   0
    2  Once               12   0   0                   0  goto 12
    3  OpenEphemeral       0   0   0                   0  cursor=0 is_table=false
-   4  OpenRead            1   3   0  k(3,B,B,B)       0  table=categories, root=3, iDb=0
+   4  ReopenIdx           1   3   0  k(3,B,B,B)       0  table=categories, root=3, iDb=0
    5  Rewind              1  12   0                   0  Rewind table categories
    6    Column            1   2   3                   0  r[3]=categories.parent_id
    7    NotNull           3  11   0                   0  r[3]!=NULL -> goto 11
@@ -43,8 +43,8 @@ addr  opcode             p1  p2  p3  p4              p5  comment
    9    MakeRecord        2   1   4                   0  r[4]=mkrec(r[2..2]); for ephemeral_index_where_sub_t2
   10    IdxInsert         0   4   0                   8  key=r[4]
   11  Next                1   6   0                   0
-  12  OpenRead            2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  13  OpenRead            3   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  12  ReopenIdx           2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  13  ReopenIdx           3   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
   14  NullRow             0   0   0                   0  Set cursor 0 to a (pseudo) NULL row
   15  Rewind              0  28   0                   0  Rewind  ephemeral(ephemeral_index_where_sub_t2)
   16    Column            0   0   8                   0  r[8]=ephemeral(ephemeral_index_where_sub_t2).id

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__update-returning-target-selfread.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__update-returning-target-selfread.snap
@@ -44,7 +44,7 @@ addr  opcode           p1  p2  p3  p4          p5  comment
   21      Null          0  16   0               0  r[16]=NULL
   22      Integer       1  17   0               0  r[17]=1; LIMIT counter
   23      IfNot        17  30   0               0  if !r[17] goto 30
-  24      OpenRead      2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
+  24      ReopenIdx     2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
   25      Rewind        2  30   0               0  Rewind table t
   26        Column      2   2  19               0  r[19]=t.val
   27        Lt         19  20  29  Binary       0  if r[19]<r[20] goto 29

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
@@ -94,9 +94,9 @@ addr  opcode                    p1  p2  p3  p4                  p5  comment
   43        Null                 0  24   0                       0  r[24]=NULL
   44        Integer              1  25   0                       0  r[25]=1; LIMIT counter
   45        IfNot               25  62   0                       0  if !r[25] goto 62
-  46        OpenRead             5   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
-  47        OpenRead             6   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
-  48        OpenRead             7   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
+  46        ReopenIdx            5   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
+  47        ReopenIdx            6   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
+  48        ReopenIdx            7   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
   49        Rewind               5  62   0                       0  Rewind table partsupp
   50          Column             5   1  26                       0  r[26]=partsupp.PS_SUPPKEY
   51          SeekRowid          6  26  61                       0  if (r[26]!=cursor 6 for table supplier.rowid) goto 61

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q13-customer-distribution.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q13-customer-distribution.snap
@@ -48,11 +48,11 @@ addr  opcode                                p1   p2   p3  p4                    
    4                    Integer              0    6    0                                               0  r[6]=0; clear group by abort flag
    5                    Null                 0    7    0                                               0  r[7]=NULL; initialize group by comparison registers to NULL
    6                    Gosub               13   92    0                                               0  ; go to clear accumulator subroutine
-   7                    OpenRead             2    8    0  k(8,B,B,B,B,B,B,B,B)                         0  table=customer, root=8, iDb=0
-   8                    OpenRead             3    9    0  k(9,B,B,B,B,B,B,B,B,B)                       0  table=orders, root=9, iDb=0
+   7                    ReopenIdx            2    8    0  k(8,B,B,B,B,B,B,B,B)                         0  table=customer, root=8, iDb=0
+   8                    ReopenIdx            3    9    0  k(9,B,B,B,B,B,B,B,B,B)                       0  table=orders, root=9, iDb=0
    9                    Integer              0   14    0                                               0  r[14]=0
   10                    Once                19    0    0                                               0  goto 19
-  11                    OpenRead             4    8    0  k(8,B,B,B,B,B,B,B,B)                         0  table=customer, root=8, iDb=0
+  11                    ReopenIdx            4    8    0  k(8,B,B,B,B,B,B,B,B)                         0  table=customer, root=8, iDb=0
   12                    Rewind               4   18    0                                               0  Rewind table customer
   13                      RowId              4   15    0                                               0  r[15]=customer.rowid
   14                      Affinity          15    1    0                                               0  r[15..16] = C

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
@@ -50,7 +50,7 @@ addr  opcode           p1  p2  p3  p4                                     p5  co
   13      Null          0  13   0                                          0  r[13]=NULL
   14      Integer       1  14   0                                          0  r[14]=1; LIMIT counter
   15      IfNot        14  24   0                                          0  if !r[14] goto 24
-  16      OpenRead      2  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+  16      ReopenIdx     2  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
   17      Rewind        2  24   0                                          0  Rewind table lineitem
   18        Column      2   1  16                                          0  r[16]=lineitem.L_PARTKEY
   19        RowId       1  17   0                                          0  r[17]=part.rowid

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
@@ -30,8 +30,8 @@ addr  opcode              p1   p2  p3  p4                     p5  comment
    0      Init             0  100   0                          0  Start at 100
    1      InitCoroutine    1   63   2                          0
    2      InitCoroutine    2   14   3                          0
-   3      OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   4      OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   3      ReopenIdx        0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   4      ReopenIdx        1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
    5      Rewind           1   13   0                          0  Rewind index idx_employees_department
    6        DeferredSeek   1    0   0                          0
    7        Column         1    0   3                          0  r[3]=idx_employees_department.department

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
@@ -42,9 +42,9 @@ addr  opcode                   p1   p2   p3  p4                     p5  comment
    2          InitCoroutine     2  132    3                          0
    3          InitCoroutine     3   75    4                          0
    4          InitCoroutine     4   21    5                          0
-   5          OpenRead          0    2    0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   6          OpenRead          1    3    0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
-   7          OpenRead          2    8    0  k(2,B)                  0  index=idx_sales_region, root=8, iDb=0
+   5          ReopenIdx         0    2    0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   6          ReopenIdx         1    3    0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
+   7          ReopenIdx         2    8    0  k(2,B)                  0  index=idx_sales_region, root=8, iDb=0
    8          Rewind            2   20    0                          0  Rewind index idx_sales_region
    9            DeferredSeek    2    1    0                          0
   10            Column          1    1   11                          0  r[11]=sales.emp_id

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
@@ -27,8 +27,8 @@ addr  opcode              p1  p2  p3  p4                     p5  comment
    0      Init             0  90   0                          0  Start at 90
    1      InitCoroutine    1  50   2                          0
    2      InitCoroutine    2  14   3                          0
-   3      OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   4      OpenRead         1   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   3      ReopenIdx        0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   4      ReopenIdx        1   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
    5      Rewind           1  13   0                          0  Rewind index idx_employees_department
    6        DeferredSeek   1   0   0                          0
    7        Column         1   0   3                          0  r[3]=idx_employees_department.department

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
@@ -24,8 +24,8 @@ BYTECODE
 addr  opcode            p1  p2  p3  p4                     p5  comment
    0    Init             0  48   0                          0  Start at 48
    1    InitCoroutine    1  13   2                          0
-   2    OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   3    OpenRead         1   5   0  k(2,B)                  0  index=idx_employees_salary, root=5, iDb=0
+   2    ReopenIdx        0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   3    ReopenIdx        1   5   0  k(2,B)                  0  index=idx_employees_salary, root=5, iDb=0
    4    Last             1  12   0                          0
    5      DeferredSeek   1   0   0                          0
    6      Column         1   0   2                          0  r[2]=idx_employees_salary.salary

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
@@ -33,7 +33,7 @@ addr  opcode              p1   p2  p3  p4                     p5  comment
    1      InitCoroutine    1   77   2                          0
    2      InitCoroutine    2   23   3                          0
    3      SorterOpen       0    2   0  k(2,B,B)                0  cursor=0
-   4      OpenRead         1    3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
+   4      ReopenIdx        1    3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
    5      Rewind           1   13   0                          0  Rewind table sales
    6        Column         1    1   8                          0  r[8]=sales.emp_id
    7        Column         1    2   9                          0  r[9]=sales.sale_date

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
@@ -27,7 +27,7 @@ addr  opcode            p1  p2  p3  p4                     p5  comment
    0    Init             0  62   0                          0  Start at 62
    1    InitCoroutine    1  24   2                          0
    2    SorterOpen       0   2   0  k(2,B,-B)               0  cursor=0
-   3    OpenRead         1   3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
+   3    ReopenIdx        1   3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
    4    Rewind           1  13   0                          0  Rewind table sales
    5      Column         1   2   8                          0  r[8]=sales.sale_date
    6      Column         1   3   9                          0  r[9]=sales.amount

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
@@ -30,8 +30,8 @@ addr  opcode                    p1  p2  p3  p4                     p5  comment
    4            Integer          0   8   0                          0  r[8]=0; clear group by abort flag
    5            Null             0   9   0                          0  r[9]=NULL; initialize group by comparison registers to NULL
    6            Gosub           16  39   0                          0  ; go to clear accumulator subroutine
-   7            OpenRead         1   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   8            OpenRead         2   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   7            ReopenIdx        1   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   8            ReopenIdx        2   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
    9            Rewind           2  25   0                          0  Rewind index idx_employees_department
   10              DeferredSeek   2   1   0                          0
   11              Column         2   0  14                          0  r[14]=idx_employees_department.department

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
@@ -39,8 +39,8 @@ addr  opcode              p1   p2  p3  p4                     p5  comment
    1      InitCoroutine    1   77   2                          0
    2      InitCoroutine    2   51   3                          0
    3      InitCoroutine    3   15   4                          0
-   4      OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   5      OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   4      ReopenIdx        0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   5      ReopenIdx        1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
    6      Rewind           1   14   0                          0  Rewind index idx_employees_department
    7        DeferredSeek   1    0   0                          0
    8        Column         1    0   4                          0  r[4]=idx_employees_department.department


### PR DESCRIPTION
Re-lands the OpenRead cursor-reuse optimization from #7716 (merged as `36e634f1c`, reverted in `5c91523ff`), reworked as a dedicated **ReopenIdx opcode** following @Pavan-Nambi's review: SQLite does not reuse cursors inside `OP_OpenRead` — it has a separate `OP_ReopenIdx` that no-ops when the cursor on P1 is already open on the same root page, and falls through to `OP_OpenRead` otherwise. This PR mirrors that structure instead of adding a runtime fast path to every OpenRead execution.

## Why it was reverted, and why it's safe now

1. **Latent btree bug (now fixed).** Cursor reuse made a pre-existing staleness bug user-visible: shape caches (rightmost page id, memoized count) were only invalidated on a cursor's *own* balancing, so peer writes through another cursor left them stale. Fixed independently in **#7721** (`84020b875`), which invalidates those caches on peer writes. The `openread-cursor-reuse-stale-cache` sqltests (5) cover this and pass.
2. **CodSpeed duplicate benchmark name (now fixed).** The benchmark now uses `#[turso_macros::codspeed_criterion_benchmark]`, so stable and nightly shards get distinct names.

## What

`op_open_read` unconditionally allocates a fresh `BTreeCursor` (plus an `Arc<IndexInfo>` for indexes), registers it with the pager, and drops the previously-open cursor on **every** execution. For a correlated scalar subquery the subquery's OpenRead runs once per outer row, so that rebuild dominated runtime.

- **New `ReopenIdx` opcode** — same operands as OpenRead; if the cursor slot already holds a btree cursor on the same root page it is reused (a subsequent `Seek`/`Rewind` repositions it), otherwise it falls through to the shared OpenRead path.
- **Emission** — the translator emits `ReopenIdx` instead of `OpenRead` for main-loop cursor opens inside nested subquery compilation contexts (`ProgramBuilder::is_nested`), via a new `ProgramBuilder::emit_open_read` helper. Top-level scans keep plain `OpenRead`, semantics identical to SQLite's.
- **Deliberate divergence, stated for the record:** SQLite emits `OP_ReopenIdx` only for the OR-optimization's shared index cursors, and rebuilds the cursor on every correlated-subquery invocation — cheap there, since cursor memory is carved out of preallocated statement space. Our rebuild is expensive, so we emit it for table and index cursors in subqueries.

## Benchmark

`core/benches/correlated_subquery_benchmark.rs` (criterion, in-process): a correlated scalar subquery probing an index once per outer row, vs SQLite.

```
cargo bench -p turso_core --bench correlated_subquery_benchmark
```

Vs no reuse at all: **660 ms → 554 ms on 200k rows (−16%, p<0.01)**; −21% on a separate 50k run. Vs the previous in-OpenRead fast-path version of this PR, the opcode is another **~3% faster** (in-run turso/sqlite ratio 3.84→3.69 at 50k, 3.58→3.49 at 200k): the reuse check now runs before the per-execution pager and mv-store lookups instead of after them.

## Testing

- `cargo test -p turso_core --lib`: 2177 passed; `integration_tests`: 983 passed
- sqltests: 9950 + 1438 passed. 39 EXPLAIN snapshots regenerated — the diff is exclusively `OpenRead` → `ReopenIdx` lines in subquery/CTE/window plans
- `openread-cursor-reuse-stale-cache`: 5 passed
- clippy clean

Supersedes the reverted #7716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)