### PR TITLE
serverless/javascript: fix stale inTransaction after execute and batch

### DIFF
--- a/serverless/javascript/integration-tests/protocol.test.mjs
+++ b/serverless/javascript/integration-tests/protocol.test.mjs
@@ -1,7 +1,5 @@
 import test from 'ava';
-import { decodeValue, encodeValue } from '../dist/protocol.js';
-import { Session } from '../dist/session.js';
-import { DatabaseError } from '../dist/error.js';
+import { decodeValue, encodeValue, Session, DatabaseError } from '../dist/index.js';
 
 // Unit tests for serverless protocol encoding/decoding.
 // These test the serverless driver directly — no server needed.
@@ -87,7 +85,7 @@ test('processCursorEntries handles string lastInsertRowid', async t => {
 
 // --- Connection.prepare() baton continuity (issue #6562) ---
 
-test('prepare() sends describe with the current transaction baton', async t => {
+test.serial('prepare() sends describe with the current transaction baton', async t => {
   const { connect } = await import('../dist/index.js');
 
   const requests = [];
@@ -155,7 +153,7 @@ test('prepare() sends describe with the current transaction baton', async t => {
 
 // --- Session baton reset on error ---
 
-test('Session resets baton after HTTP error', async t => {
+test.serial('Session resets baton after HTTP error', async t => {
   const session = new Session({ url: 'http://127.0.0.1:1' });
 
   // Simulate a previous successful request that set a baton
@@ -170,7 +168,7 @@ test('Session resets baton after HTTP error', async t => {
   t.is(session['baton'], null);
 });
 
-test('Session.batch encodes named arguments for statement objects', async t => {
+test.serial('Session.batch encodes named arguments for statement objects', async t => {
   const session = new Session({ url: 'http://fake-host' });
   const requests = [];
   const originalFetch = globalThis.fetch;
@@ -194,11 +192,14 @@ test('Session.batch encodes named arguments for statement objects', async t => {
     { name: 'name', value: { type: 'text', value: 'alice' } },
     { name: 'age', value: { type: 'integer', value: '30' } },
   ]);
+  // The trailing step is the is_autocommit transaction-state probe.
+  const probeStep = requests[0].batch.steps.at(-1);
+  t.deepEqual(probeStep.condition, { type: 'is_autocommit' });
 });
 
 // --- requestHeaders ---
 
-test('Session attaches requestHeaders and lets them override Authorization', async t => {
+test.serial('Session attaches requestHeaders and lets them override Authorization', async t => {
   const session = new Session({
     url: 'http://fake-host',
     authToken: 'standard-token',
@@ -213,7 +214,7 @@ test('Session attaches requestHeaders and lets them override Authorization', asy
   globalThis.fetch = async (url, opts) => {
     capturedHeaders.push(opts.headers);
     return new Response(
-      `${JSON.stringify({ baton: null, base_url: null })}\n${JSON.stringify({ type: 'step_begin', cols: [] })}\n${JSON.stringify({ type: 'step_end', affected_row_count: 0 })}\n`,
+      `${JSON.stringify({ baton: null, base_url: null })}\n${JSON.stringify({ type: 'step_begin', step: 0, cols: [] })}\n${JSON.stringify({ type: 'step_end', affected_row_count: 0 })}\n`,
       { status: 200, headers: { 'Content-Type': 'application/json' } }
     );
   };

--- a/serverless/javascript/src/index.ts
+++ b/serverless/javascript/src/index.ts
@@ -3,4 +3,4 @@ export { Connection, connect, type Config, type BatchStatement, type BatchOption
 export { Statement } from './statement.js';
 export { Session, type SessionConfig } from './session.js';
 export { DatabaseError, TimeoutError } from './error.js';
-export { type Column, type QueryOptions, ENCRYPTION_KEY_HEADER } from './protocol.js';
+export { encodeValue, decodeValue, type Column, type QueryOptions, ENCRYPTION_KEY_HEADER } from './protocol.js';

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -198,7 +198,7 @@ export class Session {
 
   /**
    * Execute a SQL statement and return all results.
-   * 
+   *
    * @param sql - The SQL statement to execute
    * @param args - Optional array of parameter values or object with named parameters
    * @param safeIntegers - Whether to return integers as BigInt
@@ -211,8 +211,61 @@ export class Session {
   }
 
   /**
+   * A trailing batch step gated on `is_autocommit`, appended to every cursor
+   * request. The cursor endpoint cannot carry a `get_autocommit` probe, so
+   * whether this step executed tells us the connection's transaction state
+   * without an extra round trip.
+   */
+  private static autocommitProbeStep(): BatchStep {
+    return {
+      stmt: { sql: 'SELECT 1', args: [], named_args: [], want_rows: false },
+      condition: { type: 'is_autocommit' },
+    };
+  }
+
+  /**
+   * Filter the probe step's entries out of a cursor stream and update the
+   * cached transaction state from whether the probe executed. The probe is
+   * always the last step, so everything after its step_begin belongs to it.
+   *
+   * If the stream ends abnormally (fatal error entry, a probe error, or the
+   * consumer stops iterating early) the probe answer is unreliable, so the
+   * state is refreshed with a fallback pipeline request instead.
+   */
+  private async *trackAutocommit(entries: AsyncGenerator<CursorEntry>, probeIdx: number, queryOptions?: QueryOptions): AsyncGenerator<CursorEntry> {
+    let sawProbe = false;
+    let unreliable = false;
+    let completed = false;
+    try {
+      for await (const entry of entries) {
+        if (entry.type === 'step_begin' && entry.step === probeIdx) {
+          sawProbe = true;
+          continue;
+        }
+        if (sawProbe && (entry.type === 'row' || entry.type === 'step_end')) {
+          continue;
+        }
+        if (entry.type === 'error' || (entry.type === 'step_error' && entry.step === probeIdx)) {
+          unreliable = true;
+          if (entry.type === 'step_error') {
+            continue;
+          }
+        }
+        yield entry;
+      }
+      completed = true;
+    } finally {
+      if (completed && !unreliable) {
+        this.autocommit = sawProbe;
+      } else {
+        await this.refreshAutocommit(queryOptions);
+      }
+    }
+  }
+
+  /**
    * Execute a SQL statement and return the raw response and entries.
-   * 
+   *
    * @param sql - The SQL statement to execute
    * @param args - Optional array of parameter values or object with named parameters
    * @returns Promise resolving to the raw response and cursor entries
@@ -230,7 +283,7 @@ export class Session {
             named_args: encodedArgs.namedArgs,
             want_rows: true
           }
-        }]
+        }, Session.autocommitProbeStep()]
       }
     };
 
@@ -239,6 +292,7 @@ export class Session {
       result = await executeCursor(this.httpContext(), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
+      this.autocommit = true;
       throw e;
     }
 
@@ -248,7 +302,35 @@ export class Session {
       this.baseUrl = response.base_url;
     }
 
-    return { response, entries };
+    return { response, entries: this.trackAutocommit(entries, 1, queryOptions) };
+  }
+
+  /**
+   * Refresh the cached transaction state with a standalone `get_autocommit`
+   * pipeline request. Errors are not rethrown — this runs from generator
+   * cleanup where an exception would mask the original failure; a dead stream
+   * means the server rolled back, so the state resets to autocommit instead.
+   */
+  private async refreshAutocommit(queryOptions?: QueryOptions): Promise<void> {
+    const request: PipelineRequest = {
+      baton: this.baton,
+      requests: [{ type: 'get_autocommit' } as GetAutocommitRequest],
+    };
+
+    let response;
+    try {
+      response = await executePipeline(this.httpContext(), request, this.createAbortSignal(queryOptions));
+    } catch {
+      this.baton = null;
+      this.autocommit = true;
+      return;
+    }
+
+    this.baton = response.baton;
+    if (response.base_url) {
+      this.baseUrl = response.base_url;
+    }
+    this.updateAutocommit(response);
   }
 
   /**
@@ -425,9 +507,10 @@ export class Session {
       ];
     }
 
+    const probeIdx = steps.length;
     const request: CursorRequest = {
       baton: this.baton,
-      batch: { steps },
+      batch: { steps: [...steps, Session.autocommitProbeStep()] },
     };
 
     let batchResult;
@@ -435,6 +518,7 @@ export class Session {
       batchResult = await executeCursor(this.httpContext(), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
+      this.autocommit = true;
       throw e;
     }
 
@@ -473,7 +557,14 @@ export class Session {
       return undefined;
     };
 
-    for await (const entry of entries) {
+    for await (const entry of this.trackAutocommit(entries, probeIdx, queryOptions)) {
+      // Once a step has errored the whole batch will throw, so stop
+      // decoding and buffering later steps' results while draining the
+      // rest of the stream for the probe. Fatal stream errors still
+      // surface below.
+      if (deferredError !== null && entry.type !== 'error') {
+        continue;
+      }
       switch (entry.type) {
         case 'step_begin':
           currentResultIdx = stepToResultIdx(entry.step);
@@ -510,15 +601,12 @@ export class Session {
           break;
         }
         case 'step_error':
-          if (mode === undefined) {
-            throw new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
-          }
-          // Atomic batch: capture the first error from BEGIN, any user
-          // step, or COMMIT and keep draining so ROLLBACK has a chance
-          // to clean up. Errors on the synthetic ROLLBACK step are
-          // suppressed — by the time it runs the transaction has
-          // already been undone and surfacing a ROLLBACK error would
-          // mask the real cause we already captured.
+          // Capture the first error from BEGIN, any user step, or COMMIT
+          // and keep draining so the trailing probe (and, in atomic mode,
+          // ROLLBACK) is still observed. Errors on the synthetic ROLLBACK
+          // step are suppressed — by the time it runs the transaction has
+          // already been undone and surfacing a ROLLBACK error would mask
+          // the real cause we already captured.
           if (deferredError === null && entry.step !== rollbackIdx) {
             deferredError = new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
           }

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -369,38 +369,31 @@ test.serial("Database.batch() [atomic mode rolls back on failure]", async (t) =>
   t.deepEqual(rows, []);
 });
 
-test.serial("Database.batch() [atomic mode does not abort manually-opened outer transaction on BEGIN failure]", async (t) => {
-  if (process.env.PROVIDER !== "serverless") {
-    // The native binding emits BEGIN via exec() sequentially and the
-    // failure propagates immediately; this race only exists on the
-    // serverless Hrana-condition-chain path.
-    t.pass();
-    return;
-  }
+test.serial("Database.batch() [atomic mode joins a manually-opened outer transaction]", async (t) => {
   const db = t.context.db;
 
   // Manually open an outer transaction on the same stream and write a
   // row inside it.
-  await db.execute("BEGIN");
-  await db.execute("INSERT INTO users(name, email) VALUES ('Outer', 'outer@example.net')");
+  await db.exec("BEGIN");
+  await db.run("INSERT INTO users(name, email) VALUES ('Outer', 'outer@example.net')");
 
-  // An atomic batch tries to emit BEGIN IMMEDIATE while a transaction
-  // is already open, so the synthetic BEGIN step errors. The atomic
-  // batch must (a) reject so the caller knows nothing committed, and
-  // (b) skip the synthetic ROLLBACK — otherwise it would abort the
-  // outer transaction along with it.
-  await t.throwsAsync(async () => {
-    await db.batch([
-      { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Inner", "inner@example.net"] },
-    ], "immediate");
-  });
+  // A transaction is already open on this stream, so the batch's mode is
+  // ignored and its statements join the outer transaction instead of
+  // emitting a nested BEGIN — the same contract as batch() inside a
+  // transaction() callback.
+  await db.batch([
+    { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Inner", "inner@example.net"] },
+  ], "immediate");
 
-  // The outer transaction is still open and can be committed.
-  await db.execute("COMMIT");
+  t.true(db.inTransaction, "outer transaction is still open after the batch");
+
+  // Rolling back the outer transaction must undo the batch's INSERT too —
+  // that proves the batch joined it rather than committing on its own.
+  await db.exec("ROLLBACK");
 
   const names = (await db.all("SELECT name FROM users ORDER BY id")).map(r => r.name);
-  t.true(names.includes("Outer"), "outer transaction's INSERT should be visible");
-  t.false(names.includes("Inner"), "atomic batch's INSERT must not have committed");
+  t.false(names.includes("Outer"), "outer transaction's INSERT was rolled back");
+  t.false(names.includes("Inner"), "batch INSERT rolled back with the outer transaction");
 });
 
 test.serial("Database.batch() [non-insert batch does not expose lastInsertRowid]", async (t) => {
@@ -537,6 +530,43 @@ test.serial("Database.inTransaction property", async (t) => {
   t.true(db.inTransaction, "in a transaction after raw BEGIN");
   await db.exec("ROLLBACK");
   t.false(db.inTransaction, "autocommit after raw ROLLBACK");
+});
+
+test.serial("Database.inTransaction tracks raw BEGIN via run()", async (t) => {
+  const db = t.context.db;
+
+  // inTransaction must reflect the real transaction state no matter which
+  // API opened or closed the transaction, not just exec().
+  await db.run("BEGIN IMMEDIATE");
+  t.true(db.inTransaction, "in a transaction after raw BEGIN via run()");
+  await db.run("ROLLBACK");
+  t.false(db.inTransaction, "autocommit after raw ROLLBACK via run()");
+});
+
+test.serial("Database.inTransaction after failed batch() with raw BEGIN", async (t) => {
+  const db = t.context.db;
+
+  // A UNIQUE constraint failure has statement-level ABORT semantics: it
+  // aborts the failing INSERT but leaves the surrounding explicit
+  // transaction open. inTransaction must report that open transaction —
+  // cleanup code relies on it to decide whether a ROLLBACK is needed, and
+  // a stale false here leaks a server-side write transaction that starves
+  // every other writer.
+  await t.throwsAsync(async () => {
+    await db.batch([
+      "BEGIN IMMEDIATE",
+      "INSERT INTO users (id, name, email) VALUES (100, 'Carol', 'carol@example.org')",
+      "INSERT INTO users (id, name, email) VALUES (100, 'Dave', 'dave@example.org')",
+    ]);
+  });
+
+  t.true(db.inTransaction, "transaction is still open after the constraint error");
+
+  await db.exec("ROLLBACK");
+  t.false(db.inTransaction, "autocommit after ROLLBACK on the same connection");
+
+  const rows = await db.all("SELECT COUNT(*) AS n FROM users WHERE id = 100");
+  t.is(rows[0].n, 0, "ROLLBACK undid the batch's successful INSERT");
 });
 
 test.serial("Database.transaction()", async (t) => {


### PR DESCRIPTION
The driver caches the server's get_autocommit answer to back the synchronous Connection.inTransaction property, but only describe and sequence refreshed it. execute() and batch() went through the cursor endpoint, which cannot carry a get_autocommit probe, so the cached flag went stale. After a raw BEGIN IMMEDIATE batch hit a constraint error, the server-side write transaction stayed open (statement-level ABORT) while inTransaction still read false, so cleanup code skipped ROLLBACK and the leaked transaction starved every other writer until timeout.

Learn the transaction state in-band instead: every cursor batch gets a trailing SELECT 1 step gated on the is_autocommit condition. The server executes the step only when the connection is in autocommit, so its presence in the entry stream is the authoritative answer, with no extra round trip and no change to the streaming transport. A shared wrapper filters the probe's entries out of the stream and falls back to a standalone get_autocommit pipeline request when the stream ends abnormally (fatal error entry or the consumer stops iterating early), where the probe answer is unreliable.

Non-atomic batch() now defers its first step error until the stream is drained instead of throwing immediately, so the probe is still observed; the server ran the remaining unconditioned steps either way, so the observable semantics are unchanged.

With the flag accurate, an atomic batch inside a manually-opened transaction now joins it (mode ignored) instead of failing on a nested BEGIN, matching batch() inside transaction(); the conformance test pinning the old failure mode now pins the join contract.