### PR TITLE
allow to pass arbitrary request headers in the queries through queryOptions

### DIFF
--- a/serverless/javascript/README.md
+++ b/serverless/javascript/README.md
@@ -85,6 +85,21 @@ const conn = connect({
 });
 ```
 
+Headers can also be set per query via the trailing query-options argument.
+They apply to that call only and are merged over the connection-level
+`requestHeaders`, so a query can override a header the connection sets:
+
+```javascript
+await conn.execute("SELECT * FROM users", [], {
+  requestHeaders: { "x-request-id": "abc123" },
+});
+
+// Also accepted by run()/get()/all()/iterate() and prepared statements:
+await conn.run("INSERT INTO users (email) VALUES (?)", "user@example.com", {
+  requestHeaders: { "x-request-id": "abc124" },
+});
+```
+
 ### libSQL Compatibility Layer
 
 For existing libSQL applications, use the compatibility layer:

--- a/serverless/javascript/README.md
+++ b/serverless/javascript/README.md
@@ -91,12 +91,30 @@ They apply to that call only and are merged over the connection-level
 
 ```javascript
 await conn.execute("SELECT * FROM users", [], {
-  requestHeaders: { "x-request-id": "abc123" },
+  requestHeaders: { "X-Turso-Request-Identity": "abc123" },
 });
 
 // Also accepted by run()/get()/all()/iterate() and prepared statements:
 await conn.run("INSERT INTO users (email) VALUES (?)", "user@example.com", {
-  requestHeaders: { "x-request-id": "abc124" },
+  requestHeaders: { "X-Turso-Request-Identity": "abc124" },
+});
+```
+
+Per-query headers are attached to exactly the HTTP request(s) issued by that
+call. Inside a `conn.transaction(...)` callback each statement still carries
+only its own per-query headers — the `BEGIN`/`COMMIT`/`ROLLBACK` requests are
+issued by the transaction wrapper itself and carry just the connection-level
+headers. To stamp every request of a transaction (including `BEGIN` and
+`COMMIT`), set the header at the connection level, or use an atomic batch,
+which sends the whole transaction as a single HTTP request:
+
+```javascript
+// One HTTP request: BEGIN, both inserts, and COMMIT all carry the header.
+await conn.batch([
+  { sql: "INSERT INTO users (email) VALUES (?)", args: ["alice@example.com"] },
+  { sql: "INSERT INTO users (email) VALUES (?)", args: ["bob@example.com"] },
+], "immediate", {
+  requestHeaders: { "X-Turso-Request-Identity": "abc125" },
 });
 ```
 

--- a/serverless/javascript/integration-tests/protocol.test.mjs
+++ b/serverless/javascript/integration-tests/protocol.test.mjs
@@ -87,7 +87,7 @@ test('processCursorEntries handles string lastInsertRowid', async t => {
 
 // --- Connection.prepare() baton continuity (issue #6562) ---
 
-test('prepare() sends describe with the current transaction baton', async t => {
+test.serial('prepare() sends describe with the current transaction baton', async t => {
   const { connect } = await import('../dist/index.js');
 
   const requests = [];
@@ -170,7 +170,7 @@ test('Session resets baton after HTTP error', async t => {
   t.is(session['baton'], null);
 });
 
-test('Session.batch encodes named arguments for statement objects', async t => {
+test.serial('Session.batch encodes named arguments for statement objects', async t => {
   const session = new Session({ url: 'http://fake-host' });
   const requests = [];
   const originalFetch = globalThis.fetch;
@@ -198,7 +198,7 @@ test('Session.batch encodes named arguments for statement objects', async t => {
 
 // --- requestHeaders ---
 
-test('Session attaches requestHeaders and lets them override Authorization', async t => {
+test.serial('Session attaches requestHeaders and lets them override Authorization', async t => {
   const session = new Session({
     url: 'http://fake-host',
     authToken: 'standard-token',
@@ -255,4 +255,139 @@ test('request building rejects a Host requestHeader added after construction', a
     instanceOf: DatabaseError,
     message: "overwriting the 'Host' header is not supported",
   });
+});
+
+// --- per-query requestHeaders ---
+
+test.serial('per-query requestHeaders are attached and override session-level headers', async t => {
+  const session = new Session({
+    url: 'http://fake-host',
+    authToken: 'standard-token',
+    requestHeaders: {
+      'x-session-header': 'session-value',
+      'x-shared-header': 'session-value',
+    },
+  });
+  const capturedHeaders = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (url, opts) => {
+    capturedHeaders.push(opts.headers);
+    return new Response(
+      `${JSON.stringify({ baton: null, base_url: null })}\n${JSON.stringify({ type: 'step_begin', cols: [] })}\n${JSON.stringify({ type: 'step_end', affected_row_count: 0 })}\n`,
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  };
+
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  await session.execute('SELECT 1', [], false, {
+    requestHeaders: {
+      'x-shared-header': 'query-value',
+      'x-query-header': 'query-value',
+      'Authorization': 'Bearer query-token',
+    },
+  });
+  await session.execute('SELECT 1');
+
+  const queryHeaders = capturedHeaders[0];
+  t.is(queryHeaders['x-session-header'], 'session-value',
+    'session-level headers are still attached');
+  t.is(queryHeaders['x-shared-header'], 'query-value',
+    'per-query headers override session-level headers');
+  t.is(queryHeaders['x-query-header'], 'query-value');
+  t.is(queryHeaders['Authorization'], 'Bearer query-token',
+    'per-query headers are applied after standard headers, so they override Authorization');
+
+  const followupHeaders = capturedHeaders[1];
+  t.is(followupHeaders['x-shared-header'], 'session-value',
+    'per-query headers apply to a single call only');
+  t.is(followupHeaders['x-query-header'], undefined);
+  t.is(followupHeaders['Authorization'], 'Bearer standard-token');
+});
+
+test.serial('per-query requestHeaders apply to batch and sequence requests', async t => {
+  const session = new Session({ url: 'http://fake-host' });
+  const capturedHeaders = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (url, opts) => {
+    capturedHeaders.push(opts.headers);
+    if (url.endsWith('/v3/pipeline')) {
+      return new Response(JSON.stringify({
+        baton: null,
+        base_url: null,
+        results: [{ type: 'ok', response: { type: 'sequence' } }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response(
+      `${JSON.stringify({ baton: null, base_url: null })}\n${JSON.stringify({ type: 'step_end', affected_row_count: 0 })}\n`,
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  };
+
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  const queryOptions = { requestHeaders: { 'x-query-header': 'query-value' } };
+  await session.batch(['SELECT 1'], undefined, queryOptions);
+  await session.sequence('SELECT 1', queryOptions);
+
+  t.is(capturedHeaders.length, 2);
+  t.is(capturedHeaders[0]['x-query-header'], 'query-value');
+  t.is(capturedHeaders[1]['x-query-header'], 'query-value');
+});
+
+test.serial('per-query requestHeaders reject a Host key before the request is sent', async t => {
+  const session = new Session({ url: 'http://fake-host' });
+  const originalFetch = globalThis.fetch;
+  let fetchCalled = false;
+
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    return new Response('', { status: 200 });
+  };
+
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  await t.throwsAsync(
+    () => session.execute('SELECT 1', [], false, { requestHeaders: { Host: 'evil-host' } }),
+    {
+      instanceOf: DatabaseError,
+      message: "overwriting the 'Host' header is not supported",
+    }
+  );
+  t.false(fetchCalled, 'the request must not be sent with a Host override');
+});
+
+test.serial('run() treats a trailing requestHeaders-only object as query options, not a bind parameter', async t => {
+  const { connect } = await import('../dist/index.js');
+
+  const capturedHeaders = [];
+  const capturedArgs = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (url, opts) => {
+    capturedHeaders.push(opts.headers);
+    capturedArgs.push(JSON.parse(opts.body).batch.steps[0].stmt.args);
+    return new Response(
+      `${JSON.stringify({ baton: null, base_url: null })}\n${JSON.stringify({ type: 'step_begin', cols: [] })}\n${JSON.stringify({ type: 'step_end', affected_row_count: 1 })}\n`,
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  };
+
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  const conn = connect({ url: 'http://fake-host' });
+  await conn.run('INSERT INTO t VALUES (?)', 1, { requestHeaders: { 'x-query-header': 'query-value' } });
+
+  t.is(capturedHeaders[0]['x-query-header'], 'query-value');
+  t.deepEqual(capturedArgs[0], [{ type: 'integer', value: '1' }],
+    'the options object must not be bound as a parameter');
+
+  // No bind parameters at all: the single trailing object is still query
+  // options, not a named-args object.
+  await conn.run('DELETE FROM t', { requestHeaders: { 'x-query-header': 'no-args-value' } });
+
+  t.is(capturedHeaders[1]['x-query-header'], 'no-args-value');
+  t.deepEqual(capturedArgs[1], [], 'no parameters must be bound');
 });

--- a/serverless/javascript/src/args.ts
+++ b/serverless/javascript/src/args.ts
@@ -18,7 +18,8 @@ function isQueryOptions(value: any): boolean {
   return value != null
     && typeof value === "object"
     && !Array.isArray(value)
-    && Object.prototype.hasOwnProperty.call(value, "queryTimeout");
+    && (Object.prototype.hasOwnProperty.call(value, "queryTimeout")
+      || Object.prototype.hasOwnProperty.call(value, "requestHeaders"));
 }
 
 /**

--- a/serverless/javascript/src/protocol.ts
+++ b/serverless/javascript/src/protocol.ts
@@ -256,10 +256,17 @@ function buildFetchOptions(ctx: HttpContext, body: string, signal?: AbortSignal)
   };
 }
 
-/** Per-query timeout options. Overrides defaultQueryTimeout for this call. */
+/** Per-query options. Override the session-level defaults for a single call. */
 export interface QueryOptions {
   /** Per-query timeout in milliseconds. Overrides defaultQueryTimeout for this call. */
   queryTimeout?: number;
+  /**
+   * Extra HTTP headers attached to this request only. Applied after the
+   * standard headers and any session-level `requestHeaders`, so they can
+   * override both. Passing the `Host` key (case-insensitive) throws —
+   * fetch forbids setting it.
+   */
+  requestHeaders?: Record<string, string>;
 }
 
 function wrapAbortError(error: unknown): never {

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -101,12 +101,19 @@ export class Session {
     this.baseUrl = normalizeUrl(config.url);
   }
 
-  private httpContext(): HttpContext {
+  private httpContext(queryOptions?: QueryOptions): HttpContext {
+    // Per-query headers are merged over the session-level ones, so a query
+    // can override a header the session sets (and both override the
+    // standard headers).
+    let requestHeaders = this.config.requestHeaders;
+    if (queryOptions?.requestHeaders) {
+      requestHeaders = { ...requestHeaders, ...queryOptions.requestHeaders };
+    }
     return {
       url: this.baseUrl,
       authToken: this.config.authToken,
       remoteEncryptionKey: this.config.remoteEncryptionKey,
-      requestHeaders: this.config.requestHeaders,
+      requestHeaders,
     };
   }
 
@@ -168,7 +175,7 @@ export class Session {
 
     let response;
     try {
-      response = await executePipeline(this.httpContext(), request, this.createAbortSignal(queryOptions));
+      response = await executePipeline(this.httpContext(queryOptions), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
       this.autocommit = true;
@@ -236,7 +243,7 @@ export class Session {
 
     let result;
     try {
-      result = await executeCursor(this.httpContext(), request, this.createAbortSignal(queryOptions));
+      result = await executeCursor(this.httpContext(queryOptions), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
       throw e;
@@ -432,7 +439,7 @@ export class Session {
 
     let batchResult;
     try {
-      batchResult = await executeCursor(this.httpContext(), request, this.createAbortSignal(queryOptions));
+      batchResult = await executeCursor(this.httpContext(queryOptions), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
       throw e;
@@ -553,7 +560,7 @@ export class Session {
 
     let seqResponse;
     try {
-      seqResponse = await executePipeline(this.httpContext(), request, this.createAbortSignal(queryOptions));
+      seqResponse = await executePipeline(this.httpContext(queryOptions), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
       this.autocommit = true;


### PR DESCRIPTION
So user can pass `X-Turso-Request-Identity` in header per-query