### PR TITLE
core/windows: fix WAL lock coordination

### DIFF
--- a/cli/config/terminal.rs
+++ b/cli/config/terminal.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TerminalTheme {
+    #[cfg_attr(target_os = "windows", allow(dead_code))]
     Light,
+    #[cfg_attr(target_os = "windows", allow(dead_code))]
     Dark,
     Unknown, // No colors - can't detect or unsupported platform
 }
@@ -222,7 +224,7 @@ impl TerminalDetector {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -30,6 +30,7 @@ cfg_block! {
     }
 
     #[cfg(all(target_os = "windows", not(miri)))] {
+        mod windows_lock;
         mod windows;
         #[cfg(feature = "fs")]
         pub use windows::WindowsIO;
@@ -233,6 +234,39 @@ pub trait File: Send + Sync {
         Err(crate::LimboError::InternalError(
             "shared WAL coordination byte locking is not supported for this file".into(),
         ))
+    }
+
+    /// Probe whether the caller could hold an exclusive lock without leaving
+    /// any lock state changed on return.
+    fn shared_wal_probe_exclusive_byte(
+        &self,
+        offset: u64,
+        kind: SharedWalLockKind,
+    ) -> Result<bool> {
+        let locked = self.shared_wal_try_lock_byte(offset, true, kind)?;
+        if locked {
+            self.shared_wal_unlock_byte(offset, kind)?;
+        }
+        Ok(locked)
+    }
+
+    /// Probe whether the caller's existing shared lock can become exclusive,
+    /// restoring that shared lock before returning.
+    fn shared_wal_probe_exclusive_while_shared_byte(
+        &self,
+        offset: u64,
+        kind: SharedWalLockKind,
+    ) -> Result<bool> {
+        self.shared_wal_unlock_byte(offset, kind)?;
+        let probe = match self.shared_wal_probe_exclusive_byte(offset, kind) {
+            Ok(probe) => probe,
+            Err(err) => {
+                self.shared_wal_lock_byte(offset, false, kind)?;
+                return Err(err);
+            }
+        };
+        self.shared_wal_lock_byte(offset, false, kind)?;
+        Ok(probe)
     }
 
     fn shared_wal_unlock_byte(&self, _offset: u64, _kind: SharedWalLockKind) -> Result<()> {

--- a/core/io/win_iocp.rs
+++ b/core/io/win_iocp.rs
@@ -43,12 +43,18 @@ use crate::io::common;
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::{Clock, Completion, CompletionError, File, LimboError, OpenFlags, Result, IO};
+use super::windows_lock::{
+    acquire_process_file_lock, release_shared_wal_locks_on_drop, shared_wal_lock_byte,
+    shared_wal_probe_exclusive_byte, shared_wal_try_lock_byte, shared_wal_unlock_byte,
+    ProcessFileLockGuard, SharedWalLockState,
+};
 
 use smallvec::SmallVec;
 use std::collections::{HashMap, VecDeque};
 use std::error::Error;
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
+use std::path::PathBuf;
 use std::ptr::NonNull;
 use windows_sys::core::BOOL;
 use windows_sys::Win32::System::Diagnostics::Debug::{
@@ -337,9 +343,27 @@ impl IO for WindowsIOCP {
                 return Err(io_error(io::Error::last_os_error(), "open"));
             };
 
+            let process_lock = if ENABLE_LOCK_ON_OPEN
+                && !open_flags.intersects(OpenFlags::ReadOnly | OpenFlags::NoLock)
+                && std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
+            {
+                match acquire_process_file_lock(file_path) {
+                    Ok(guard) => Some(guard),
+                    Err(err) => {
+                        CloseHandle(file_handle);
+                        return Err(err);
+                    }
+                }
+            } else {
+                None
+            };
+
             let windows_file = Arc::new(WindowsFile {
                 file_handle,
                 parent_io: self.instance.clone(),
+                path: PathBuf::from(file_path),
+                _process_lock: process_lock,
+                shared_wal_locks: Mutex::new(SharedWalLockState::default()),
             });
 
             // Bind file to IOCP
@@ -351,13 +375,6 @@ impl IO for WindowsIOCP {
                     "associate file with iocp",
                 ));
             };
-
-            if ENABLE_LOCK_ON_OPEN
-                && !open_flags.intersects(OpenFlags::ReadOnly | OpenFlags::NoLock)
-                && std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
-            {
-                windows_file.lock_file(true)?;
-            }
 
             Ok(windows_file)
         }
@@ -677,6 +694,9 @@ impl Drop for InnerWindowsIOCP {
 pub struct WindowsFile {
     file_handle: HANDLE,
     parent_io: Arc<InnerWindowsIOCP>,
+    path: PathBuf,
+    _process_lock: Option<ProcessFileLockGuard>,
+    shared_wal_locks: Mutex<SharedWalLockState>,
 }
 
 impl WindowsFile {
@@ -1004,14 +1024,7 @@ impl File for WindowsFile {
         exclusive: bool,
         _kind: SharedWalLockKind,
     ) -> Result<()> {
-        match self.lock_range(offset, 1, exclusive, false) {
-            Ok(true) => Ok(()),
-            Ok(false) => Err(LimboError::LockingError(
-                "Failed locking shared WAL coordination file. File is locked by another process"
-                    .into(),
-            )),
-            Err(err) => Err(err),
-        }
+        shared_wal_lock_byte(&self.path, &self.shared_wal_locks, offset, exclusive)
     }
 
     fn shared_wal_try_lock_byte(
@@ -1020,11 +1033,27 @@ impl File for WindowsFile {
         exclusive: bool,
         _kind: SharedWalLockKind,
     ) -> Result<bool> {
-        self.lock_range(offset, 1, exclusive, true)
+        shared_wal_try_lock_byte(&self.path, &self.shared_wal_locks, offset, exclusive)
+    }
+
+    fn shared_wal_probe_exclusive_byte(
+        &self,
+        offset: u64,
+        _kind: SharedWalLockKind,
+    ) -> Result<bool> {
+        shared_wal_probe_exclusive_byte(&self.path, offset)
+    }
+
+    fn shared_wal_probe_exclusive_while_shared_byte(
+        &self,
+        offset: u64,
+        _kind: SharedWalLockKind,
+    ) -> Result<bool> {
+        shared_wal_probe_exclusive_byte(&self.path, offset)
     }
 
     fn shared_wal_unlock_byte(&self, offset: u64, _kind: SharedWalLockKind) -> Result<()> {
-        self.unlock_range(offset, 1)
+        shared_wal_unlock_byte(&self.path, &self.shared_wal_locks, offset)
     }
 
     fn shared_wal_set_len(&self, len: u64) -> Result<()> {
@@ -1129,10 +1158,7 @@ impl File for WindowsFile {
 impl Drop for WindowsFile {
     fn drop(&mut self) {
         trace!("dropping handle {:08X}", self.file_handle.addr());
-
-        if ENABLE_LOCK_ON_OPEN {
-            let _ = self.unlock_file();
-        }
+        release_shared_wal_locks_on_drop(&self.path, &self.shared_wal_locks);
 
         unsafe {
             CancelIoEx(self.file_handle, ptr::null());
@@ -1146,7 +1172,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::{
-        io::{win_iocp::get_generic_limboerror_from_os_err, TempFile},
+        io::{common, win_iocp::get_generic_limboerror_from_os_err, OpenFlags, TempFile},
         Buffer, Completion, IO,
     };
 
@@ -1219,5 +1245,25 @@ mod tests {
         drop(file.pwrite(0, buffer, comp).unwrap());
         drop(iocp);
         drop(file);
+    }
+
+    #[test]
+    fn test_duplicate_opens_share_process_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("same.db");
+        let path = path.to_str().unwrap();
+        let io = WindowsIOCP::new().unwrap();
+
+        let first = io.open_file(path, OpenFlags::Create, false).unwrap();
+        let second = io.open_file(path, OpenFlags::Create, false).unwrap();
+        drop(first);
+        drop(second);
+
+        io.open_file(path, OpenFlags::Create, false).unwrap();
+    }
+
+    #[test]
+    fn test_multiple_processes_cannot_open_file() {
+        common::tests::test_multiple_processes_cannot_open_file(WindowsIOCP::new);
     }
 }

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -2,14 +2,12 @@ use crate::error::io_error;
 use crate::io::clock::{DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::io::common;
 use crate::io::FileSyncType;
-use crate::sync::{Arc, Mutex};
+use super::windows_lock::{acquire_process_file_lock, ProcessFileLockGuard};
+use crate::sync::Arc;
 use crate::{Clock, Completion, CompletionError, File, LimboError, OpenFlags, Result, IO};
 use std::cell::Cell;
-use std::collections::HashMap;
 use std::io::ErrorKind;
-use std::path::PathBuf;
 use std::ptr;
-use std::sync::OnceLock;
 #[cfg(feature = "fs")]
 use tracing::debug;
 use tracing::{instrument, trace, Level};
@@ -117,134 +115,6 @@ fn overlapped_at(pos: u64) -> OVERLAPPED {
 fn last_os_error(context: &'static str) -> LimboError {
     let err = std::io::Error::last_os_error();
     io_error(err, context)
-}
-
-/// Process-wide cross-process advisory lock for a single path.
-///
-/// `LockFileEx` is per-handle on Windows: two handles in the same process — even
-/// to the same file — race against each other instead of sharing a lock the way
-/// POSIX `fcntl` locks do per-process. Acquiring an exclusive byte-range lock on
-/// every `open_file` therefore breaks legitimate same-process patterns (multiple
-/// connections, busy-timeout retries, parallel readers).
-///
-/// To match Unix semantics — one OS lock per (process, path) — we hold a single
-/// dedicated lock handle in a process-global registry, ref-counted across all
-/// `WindowsFile`s for the same canonical path. The first opener acquires the
-/// `LockFileEx`; subsequent in-process openers just bump the refcount. Once the
-/// last opener drops its guard, the dedicated handle is closed and the OS lock
-/// is released, freeing the path for other processes.
-///
-/// The lock targets a single sentinel byte at an offset far beyond any
-/// realistic database size: `LockFileEx` blocks `ReadFile`/`WriteFile` on
-/// locked regions across *all* handles (including ones in our own process), so
-/// locking the data region itself would deadlock our own writes. The sentinel
-/// byte is never read or written by the engine, only locked.
-const PROCESS_LOCK_OFFSET: u64 = 0x4000_0000_0000_0000;
-
-struct ProcessFileLockEntry {
-    handle: HANDLE,
-    refcount: usize,
-}
-
-// HANDLE is a raw pointer; the registry mutex serializes all access to it.
-unsafe impl Send for ProcessFileLockEntry {}
-
-type ProcessFileLockRegistry = Mutex<HashMap<PathBuf, ProcessFileLockEntry>>;
-
-fn process_file_lock_registry() -> &'static ProcessFileLockRegistry {
-    static REGISTRY: OnceLock<ProcessFileLockRegistry> = OnceLock::new();
-    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-struct ProcessFileLockGuard {
-    key: PathBuf,
-}
-
-impl Drop for ProcessFileLockGuard {
-    fn drop(&mut self) {
-        let mut registry = process_file_lock_registry().lock();
-        let Some(entry) = registry.get_mut(&self.key) else {
-            return;
-        };
-        entry.refcount -= 1;
-        if entry.refcount > 0 {
-            return;
-        }
-        // Release the OS lock and close the handle while still holding the
-        // registry mutex. A concurrent acquirer for the same path is blocked
-        // on the mutex; once we drop it the entry is gone and they'll open a
-        // fresh dedicated handle. Releasing inside the critical section
-        // ensures the previous `LockFileEx` is fully unwound before any new
-        // `LockFileEx` is attempted, otherwise the new attempt would race
-        // and fail with `ERROR_LOCK_VIOLATION`.
-        let handle = registry.remove(&self.key).expect("entry just observed").handle;
-        unsafe {
-            let mut overlapped = overlapped_at(PROCESS_LOCK_OFFSET);
-            UnlockFileEx(handle, 0, 1, 0, &mut overlapped);
-            CloseHandle(handle);
-        }
-    }
-}
-
-fn acquire_process_file_lock(path: &str) -> Result<ProcessFileLockGuard> {
-    // Canonicalize so that different path strings resolving to the same file
-    // (e.g. relative vs. absolute) share a single registry entry. Fall back
-    // to the raw path if canonicalize fails for any reason; collisions across
-    // distinct paths only matter if the same caller mixes spellings, and the
-    // OS lock still provides correctness in that case.
-    let key = std::fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path));
-    let mut registry = process_file_lock_registry().lock();
-    if let Some(entry) = registry.get_mut(&key) {
-        entry.refcount += 1;
-        return Ok(ProcessFileLockGuard { key });
-    }
-
-    // First opener for this path in this process. Open a dedicated handle whose
-    // sole purpose is to hold the byte-range lock. Its lifetime is tied to the
-    // registry entry, decoupled from any individual `WindowsFile`.
-    let wide_path: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
-    let handle = unsafe {
-        CreateFileW(
-            wide_path.as_ptr(),
-            GENERIC_READ | GENERIC_WRITE,
-            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            ptr::null(),
-            OPEN_EXISTING,
-            FILE_ATTRIBUTE_NORMAL,
-            ptr::null_mut(),
-        )
-    };
-    if handle == INVALID_HANDLE_VALUE {
-        return Err(last_os_error("open lock handle"));
-    }
-
-    let mut overlapped = overlapped_at(PROCESS_LOCK_OFFSET);
-    let ok = unsafe {
-        LockFileEx(
-            handle,
-            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
-            0,
-            1,
-            0,
-            &mut overlapped,
-        )
-    };
-    if ok == FALSE {
-        let err = std::io::Error::last_os_error();
-        unsafe {
-            CloseHandle(handle);
-        }
-        let message = match err.kind() {
-            ErrorKind::WouldBlock => {
-                "Failed locking file. File is locked by another process".to_string()
-            }
-            _ => format!("Failed locking file, {err}"),
-        };
-        return Err(LimboError::LockingError(message));
-    }
-
-    registry.insert(key.clone(), ProcessFileLockEntry { handle, refcount: 1 });
-    Ok(ProcessFileLockGuard { key })
 }
 
 pub struct WindowsIO {}

--- a/core/io/windows_lock.rs
+++ b/core/io/windows_lock.rs
@@ -1,0 +1,481 @@
+use crate::sync::Mutex;
+use crate::{LimboError, Result};
+use std::collections::HashMap;
+use std::os::windows::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use windows_sys::Win32::Foundation::{
+    CloseHandle, GetLastError, ERROR_LOCK_VIOLATION, ERROR_NOT_LOCKED, FALSE, GENERIC_READ,
+    GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE, TRUE,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, LockFileEx, UnlockFileEx, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE,
+    FILE_SHARE_READ, FILE_SHARE_WRITE, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+    OPEN_EXISTING,
+};
+use windows_sys::Win32::System::IO::{OVERLAPPED, OVERLAPPED_0, OVERLAPPED_0_0};
+
+/// Keep the open-time database lock outside the useful range of every Turso
+/// file. Locking the data range itself makes Windows reject I/O through sibling
+/// handles in this process.
+const PROCESS_LOCK_OFFSET: u64 = 0x4000_0000_0000_0000;
+
+fn canonical_path(path: &str) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path))
+}
+
+fn overlapped_at(offset: u64) -> OVERLAPPED {
+    OVERLAPPED {
+        Internal: 0,
+        InternalHigh: 0,
+        Anonymous: OVERLAPPED_0 {
+            Anonymous: OVERLAPPED_0_0 {
+                Offset: offset as u32,
+                OffsetHigh: (offset >> 32) as u32,
+            },
+        },
+        hEvent: std::ptr::null_mut(),
+    }
+}
+
+fn open_lock_handle(path: &Path) -> Result<HANDLE> {
+    let path: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(LimboError::LockingError(format!(
+            "Failed opening lock handle: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(handle)
+}
+
+fn lock_range(handle: HANDLE, offset: u64, exclusive: bool, fail_immediately: bool) -> Result<bool> {
+    let flags = (if exclusive {
+        LOCKFILE_EXCLUSIVE_LOCK
+    } else {
+        0
+    }) | if fail_immediately {
+        LOCKFILE_FAIL_IMMEDIATELY
+    } else {
+        0
+    };
+    let mut overlapped = overlapped_at(offset);
+    let result = unsafe { LockFileEx(handle, flags, 0, 1, 0, &mut overlapped) };
+    if result == TRUE {
+        return Ok(true);
+    }
+    if unsafe { GetLastError() } == ERROR_LOCK_VIOLATION {
+        return Ok(false);
+    }
+    Err(LimboError::LockingError(format!(
+        "Failed acquiring Windows file lock: {}",
+        std::io::Error::last_os_error()
+    )))
+}
+
+fn unlock_range(handle: HANDLE, offset: u64) -> Result<()> {
+    let mut overlapped = overlapped_at(offset);
+    let result = unsafe { UnlockFileEx(handle, 0, 1, 0, &mut overlapped) };
+    if result == TRUE || unsafe { GetLastError() } == ERROR_NOT_LOCKED {
+        return Ok(());
+    }
+    Err(LimboError::LockingError(format!(
+        "Failed releasing Windows file lock: {}",
+        std::io::Error::last_os_error()
+    )))
+}
+
+struct ProcessFileLockEntry {
+    handle: HANDLE,
+    refcount: usize,
+}
+
+unsafe impl Send for ProcessFileLockEntry {}
+
+type ProcessFileLockRegistry = Mutex<HashMap<PathBuf, ProcessFileLockEntry>>;
+
+fn process_file_lock_registry() -> &'static ProcessFileLockRegistry {
+    static REGISTRY: OnceLock<ProcessFileLockRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// A reference to this process's single open-time lock for one database file.
+pub(crate) struct ProcessFileLockGuard {
+    key: PathBuf,
+}
+
+impl Drop for ProcessFileLockGuard {
+    fn drop(&mut self) {
+        let mut registry = process_file_lock_registry().lock();
+        let Some(entry) = registry.get_mut(&self.key) else {
+            tracing::error!(
+                path = %self.key.display(),
+                "Windows process lock registry entry missing during release"
+            );
+            return;
+        };
+        if entry.refcount == 0 {
+            tracing::error!(
+                path = %self.key.display(),
+                "Windows process lock registry reference count underflow"
+            );
+            return;
+        }
+        entry.refcount -= 1;
+        if entry.refcount != 0 {
+            return;
+        }
+
+        let handle = registry
+            .remove(&self.key)
+            .expect("process lock entry disappeared while releasing")
+            .handle;
+        if let Err(err) = unlock_range(handle, PROCESS_LOCK_OFFSET) {
+            tracing::error!(path = %self.key.display(), ?err, "failed releasing Windows process lock");
+        }
+        if unsafe { CloseHandle(handle) } == FALSE {
+            tracing::error!(
+                path = %self.key.display(),
+                error = %std::io::Error::last_os_error(),
+                "failed closing Windows process lock handle"
+            );
+        }
+    }
+}
+
+/// Acquire the per-process open-time lock for `path`.
+///
+/// Windows byte-range locks are per-handle, so all same-process opens share a
+/// single dedicated handle. The lock lives beyond the data range and therefore
+/// does not interfere with normal database I/O.
+pub(crate) fn acquire_process_file_lock(path: &str) -> Result<ProcessFileLockGuard> {
+    let key = canonical_path(path);
+    let mut registry = process_file_lock_registry().lock();
+    if let Some(entry) = registry.get_mut(&key) {
+        entry.refcount += 1;
+        return Ok(ProcessFileLockGuard { key });
+    }
+
+    let handle = open_lock_handle(&key)?;
+    match lock_range(handle, PROCESS_LOCK_OFFSET, true, true)? {
+        true => {
+            registry.insert(key.clone(), ProcessFileLockEntry { handle, refcount: 1 });
+            Ok(ProcessFileLockGuard { key })
+        }
+        false => {
+            unsafe {
+                CloseHandle(handle);
+            }
+            Err(LimboError::LockingError(
+                "Failed locking file. File is locked by another process".into(),
+            ))
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct SharedWalLockState {
+    held: HashMap<u64, HeldSharedWalLock>,
+}
+
+#[derive(Default)]
+struct HeldSharedWalLock {
+    shared: usize,
+    exclusive: usize,
+}
+
+enum SharedWalGlobalLock {
+    Shared { holders: usize },
+    Exclusive,
+}
+
+struct SharedWalFileLockEntry {
+    handle: HANDLE,
+    locks: HashMap<u64, SharedWalGlobalLock>,
+}
+
+unsafe impl Send for SharedWalFileLockEntry {}
+
+type SharedWalLockRegistry = Mutex<HashMap<PathBuf, SharedWalFileLockEntry>>;
+
+fn shared_wal_lock_registry() -> &'static SharedWalLockRegistry {
+    static REGISTRY: OnceLock<SharedWalLockRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn close_shared_wal_entry(
+    registry: &mut HashMap<PathBuf, SharedWalFileLockEntry>,
+    key: &Path,
+) {
+    let Some(entry) = registry.remove(key) else {
+        return;
+    };
+    debug_assert!(entry.locks.is_empty());
+    if unsafe { CloseHandle(entry.handle) } == FALSE {
+        tracing::error!(
+            path = %key.display(),
+            error = %std::io::Error::last_os_error(),
+            "failed closing shared WAL lock handle"
+        );
+    }
+}
+
+fn lock_shared_wal_byte(
+    path: &Path,
+    state: &Mutex<SharedWalLockState>,
+    offset: u64,
+    exclusive: bool,
+    fail_immediately: bool,
+) -> Result<bool> {
+    let key = canonical_path(path.to_str().ok_or_else(|| {
+        LimboError::InternalError("shared WAL coordination path is not valid UTF-8".into())
+    })?);
+    let mut local = state.lock();
+    let mut registry = shared_wal_lock_registry().lock();
+    let entry = match registry.entry(key.clone()) {
+        std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            let handle = open_lock_handle(&key)?;
+            entry.insert(SharedWalFileLockEntry {
+                handle,
+                locks: HashMap::new(),
+            })
+        }
+    };
+
+    match entry.locks.get_mut(&offset) {
+        Some(SharedWalGlobalLock::Shared { holders }) if !exclusive => {
+            *holders += 1;
+            local.held.entry(offset).or_default().shared += 1;
+            Ok(true)
+        }
+        Some(_) => Ok(false),
+        None => match lock_range(entry.handle, offset, exclusive, fail_immediately)? {
+            true => {
+                entry.locks.insert(
+                    offset,
+                    if exclusive {
+                        SharedWalGlobalLock::Exclusive
+                    } else {
+                        SharedWalGlobalLock::Shared { holders: 1 }
+                    },
+                );
+                let local_lock = local.held.entry(offset).or_default();
+                if exclusive {
+                    local_lock.exclusive += 1;
+                } else {
+                    local_lock.shared += 1;
+                }
+                Ok(true)
+            }
+            false => {
+                if entry.locks.is_empty() {
+                    close_shared_wal_entry(&mut registry, &key);
+                }
+                Ok(false)
+            }
+        },
+    }
+}
+
+fn release_shared_wal_lock(
+    path: &Path,
+    offset: u64,
+    shared: usize,
+    exclusive: usize,
+) -> Result<()> {
+    debug_assert!(shared == 0 || exclusive == 0);
+    let key = canonical_path(path.to_str().ok_or_else(|| {
+        LimboError::InternalError("shared WAL coordination path is not valid UTF-8".into())
+    })?);
+    let mut registry = shared_wal_lock_registry().lock();
+    let entry = registry.get_mut(&key).ok_or_else(|| {
+        LimboError::LockingError("shared WAL lock registry entry is missing".into())
+    })?;
+
+    let remove_lock = match entry.locks.get_mut(&offset) {
+        Some(SharedWalGlobalLock::Shared { holders }) if shared != 0 => {
+            if *holders < shared {
+                return Err(LimboError::LockingError(
+                    "shared WAL shared lock reference count underflow".into(),
+                ));
+            }
+            *holders -= shared;
+            *holders == 0
+        }
+        Some(SharedWalGlobalLock::Exclusive) if exclusive != 0 => true,
+        _ => {
+            return Err(LimboError::LockingError(
+                "shared WAL lock released with a mismatched mode".into(),
+            ))
+        }
+    };
+
+    if remove_lock {
+        if let Err(err) = unlock_range(entry.handle, offset) {
+            if let Some(SharedWalGlobalLock::Shared { holders }) = entry.locks.get_mut(&offset) {
+                *holders += shared;
+            }
+            return Err(err);
+        }
+        entry.locks.remove(&offset);
+    }
+    if entry.locks.is_empty() {
+        close_shared_wal_entry(&mut registry, &key);
+    }
+    Ok(())
+}
+
+pub(crate) fn shared_wal_lock_byte(
+    path: &Path,
+    state: &Mutex<SharedWalLockState>,
+    offset: u64,
+    exclusive: bool,
+) -> Result<()> {
+    if lock_shared_wal_byte(path, state, offset, exclusive, false)? {
+        Ok(())
+    } else {
+        Err(LimboError::LockingError(
+            "Failed locking shared WAL coordination file. File is locked by another process".into(),
+        ))
+    }
+}
+
+pub(crate) fn shared_wal_try_lock_byte(
+    path: &Path,
+    state: &Mutex<SharedWalLockState>,
+    offset: u64,
+    exclusive: bool,
+) -> Result<bool> {
+    lock_shared_wal_byte(path, state, offset, exclusive, true)
+}
+
+pub(crate) fn shared_wal_unlock_byte(
+    path: &Path,
+    state: &Mutex<SharedWalLockState>,
+    offset: u64,
+) -> Result<()> {
+    let (shared, exclusive) = {
+        let local = state.lock();
+        let held = local.held.get(&offset).ok_or_else(|| {
+            LimboError::LockingError("shared WAL lock released without an acquisition".into())
+        })?;
+        if held.exclusive != 0 {
+            (0, 1)
+        } else if held.shared != 0 {
+            (1, 0)
+        } else {
+            unreachable!("empty shared WAL lock state was retained");
+        }
+    };
+
+    release_shared_wal_lock(path, offset, shared, exclusive)?;
+
+    let mut local = state.lock();
+    let held = local
+        .held
+        .get_mut(&offset)
+        .expect("shared WAL local lock disappeared while releasing");
+    if exclusive != 0 {
+        held.exclusive -= 1;
+    } else {
+        held.shared -= 1;
+    }
+    if held.shared == 0 && held.exclusive == 0 {
+        local.held.remove(&offset);
+    }
+    Ok(())
+}
+
+/// Probe whether no other process holds `offset` without changing this
+/// process's aggregate shared-lock state.
+pub(crate) fn shared_wal_probe_exclusive_byte(path: &Path, offset: u64) -> Result<bool> {
+    let key = canonical_path(path.to_str().ok_or_else(|| {
+        LimboError::InternalError("shared WAL coordination path is not valid UTF-8".into())
+    })?);
+    let mut registry = shared_wal_lock_registry().lock();
+    let entry = match registry.entry(key.clone()) {
+        std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            let handle = open_lock_handle(&key)?;
+            entry.insert(SharedWalFileLockEntry {
+                handle,
+                locks: HashMap::new(),
+            })
+        }
+    };
+
+    let had_shared_lock = matches!(
+        entry.locks.get(&offset),
+        Some(SharedWalGlobalLock::Shared { .. })
+    );
+    if matches!(
+        entry.locks.get(&offset),
+        Some(SharedWalGlobalLock::Exclusive)
+    ) {
+        return Ok(false);
+    }
+
+    if had_shared_lock {
+        unlock_range(entry.handle, offset)?;
+    }
+
+    let probe = match lock_range(entry.handle, offset, true, true) {
+        Ok(probe) => probe,
+        Err(err) => {
+            if had_shared_lock {
+                if !lock_range(entry.handle, offset, false, false)? {
+                    return Err(LimboError::LockingError(
+                        "Failed restoring shared WAL lifetime lock after exclusive probe".into(),
+                    ));
+                }
+            } else if entry.locks.is_empty() {
+                close_shared_wal_entry(&mut registry, &key);
+            }
+            return Err(err);
+        }
+    };
+    if probe {
+        unlock_range(entry.handle, offset)?;
+    }
+
+    if had_shared_lock && !lock_range(entry.handle, offset, false, false)? {
+        return Err(LimboError::LockingError(
+            "Failed restoring shared WAL lifetime lock after exclusive probe".into(),
+        ));
+    }
+
+    if entry.locks.is_empty() {
+        close_shared_wal_entry(&mut registry, &key);
+    }
+    Ok(probe)
+}
+
+pub(crate) fn release_shared_wal_locks_on_drop(path: &Path, state: &Mutex<SharedWalLockState>) {
+    let held = std::mem::take(&mut state.lock().held);
+    for (offset, held) in held {
+        if let Err(err) = release_shared_wal_lock(path, offset, held.shared, held.exclusive) {
+            tracing::error!(
+                path = %path.display(),
+                offset,
+                ?err,
+                "failed releasing shared WAL lock while dropping Windows file"
+            );
+        }
+    }
+}

--- a/core/io/windows_lock.rs
+++ b/core/io/windows_lock.rs
@@ -443,39 +443,73 @@ pub(crate) fn shared_wal_probe_exclusive_byte(path: &Path, offset: u64) -> Resul
         return Ok(false);
     }
 
+    // Use a disposable handle for the exclusive probe. If releasing that
+    // exclusive lock fails, closing the handle still guarantees it cannot
+    // survive past the probe and block restoration of the shared lock.
+    let probe_handle = open_lock_handle(&key)?;
     if had_shared_lock {
-        unlock_range(entry.handle, offset)?;
-    }
-
-    let probe = match lock_range(entry.handle, offset, true, true) {
-        Ok(probe) => probe,
-        Err(err) => {
-            if had_shared_lock {
-                if !lock_range(entry.handle, offset, false, false)? {
-                    return Err(LimboError::LockingError(
-                        "Failed restoring shared WAL lifetime lock after exclusive probe".into(),
-                    ));
-                }
-            } else if entry.locks.is_empty() {
-                close_shared_wal_entry(&mut registry, &key);
+        if let Err(err) = unlock_range(entry.handle, offset) {
+            if unsafe { CloseHandle(probe_handle) } == FALSE {
+                tracing::error!(
+                    path = %key.display(),
+                    error = %std::io::Error::last_os_error(),
+                    "failed closing shared WAL exclusive probe handle"
+                );
             }
             return Err(err);
         }
-    };
-    if probe {
-        unlock_range(entry.handle, offset)?;
     }
 
-    if had_shared_lock && !lock_range(entry.handle, offset, false, false)? {
-        return Err(LimboError::LockingError(
-            "Failed restoring shared WAL lifetime lock after exclusive probe".into(),
-        ));
+    let probe = match lock_range(probe_handle, offset, true, true) {
+        Ok(true) => {
+            let result = unlock_range(probe_handle, offset).map(|()| true);
+            if unsafe { CloseHandle(probe_handle) } == FALSE {
+                tracing::error!(
+                    path = %key.display(),
+                    error = %std::io::Error::last_os_error(),
+                    "failed closing shared WAL exclusive probe handle"
+                );
+            }
+            result
+        }
+        Ok(false) => {
+            if unsafe { CloseHandle(probe_handle) } == FALSE {
+                tracing::error!(
+                    path = %key.display(),
+                    error = %std::io::Error::last_os_error(),
+                    "failed closing shared WAL exclusive probe handle"
+                );
+            }
+            Ok(false)
+        }
+        Err(err) => {
+            if unsafe { CloseHandle(probe_handle) } == FALSE {
+                tracing::error!(
+                    path = %key.display(),
+                    error = %std::io::Error::last_os_error(),
+                    "failed closing shared WAL exclusive probe handle"
+                );
+            }
+            Err(err)
+        }
+    };
+
+    if had_shared_lock {
+        match lock_range(entry.handle, offset, false, false) {
+            Ok(true) => {}
+            Ok(false) => {
+                panic!("shared WAL lifetime lock restoration was blocked after exclusive probe")
+            }
+            Err(err) => {
+                panic!("shared WAL lifetime lock restoration failed after exclusive probe: {err}")
+            }
+        }
     }
 
     if entry.locks.is_empty() {
         close_shared_wal_entry(&mut registry, &key);
     }
-    Ok(probe)
+    probe
 }
 
 pub(crate) fn release_shared_wal_locks_on_drop(path: &Path, state: &Mutex<SharedWalLockState>) {

--- a/core/io/windows_lock.rs
+++ b/core/io/windows_lock.rs
@@ -172,12 +172,18 @@ pub(crate) fn acquire_process_file_lock(path: &str) -> Result<ProcessFileLockGua
     }
 
     let handle = open_lock_handle(&key)?;
-    match lock_range(handle, PROCESS_LOCK_OFFSET, true, true)? {
-        true => {
+    match lock_range(handle, PROCESS_LOCK_OFFSET, true, true) {
+        Err(err) => {
+            unsafe {
+                CloseHandle(handle);
+            }
+            Err(err)
+        }
+        Ok(true) => {
             registry.insert(key.clone(), ProcessFileLockEntry { handle, refcount: 1 });
             Ok(ProcessFileLockGuard { key })
         }
-        false => {
+        Ok(false) => {
             unsafe {
                 CloseHandle(handle);
             }
@@ -265,8 +271,14 @@ fn lock_shared_wal_byte(
             Ok(true)
         }
         Some(_) => Ok(false),
-        None => match lock_range(entry.handle, offset, exclusive, fail_immediately)? {
-            true => {
+        None => match lock_range(entry.handle, offset, exclusive, fail_immediately) {
+            Err(err) => {
+                if entry.locks.is_empty() {
+                    close_shared_wal_entry(&mut registry, &key);
+                }
+                Err(err)
+            }
+            Ok(true) => {
                 entry.locks.insert(
                     offset,
                     if exclusive {
@@ -283,7 +295,7 @@ fn lock_shared_wal_byte(
                 }
                 Ok(true)
             }
-            false => {
+            Ok(false) => {
                 if entry.locks.is_empty() {
                     close_shared_wal_entry(&mut registry, &key);
                 }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -6504,7 +6504,9 @@ mod ptrmap_tests {
 #[cfg(all(test, feature = "fs", host_shared_wal))]
 mod checkpoint_phase_tests {
     use super::*;
-    use crate::io::{PlatformIO, IO};
+    #[cfg(not(all(target_os = "windows", feature = "experimental_win_iocp")))]
+    use crate::io::PlatformIO;
+    use crate::io::IO;
     use crate::storage::sqlite3_ondisk::DatabaseHeader;
     use crate::storage::wal::CheckpointMode;
     use crate::sync::atomic::Ordering;

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -798,13 +798,6 @@ impl MappedSharedWalCoordination {
         }
     }
 
-    fn reacquire_shared_lifetime_lock(
-        file: &Arc<dyn File>,
-        lock_kind: SharedWalLockKind,
-    ) -> Result<()> {
-        file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)
-    }
-
     /// Register this mapping in `PROCESS_LOCAL_COORDINATION_OPENS`.
     ///
     /// Returns shared Arcs for locks and ownership state so that multiple
@@ -1060,10 +1053,9 @@ impl MappedSharedWalCoordination {
         base_len: usize,
     ) -> Result<SharedWalCoordinationOpenMode> {
         let metadata_len_before_probe = file.size()? as usize;
-        match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
+        match file.shared_wal_probe_exclusive_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)? {
             true => {
-                file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
-                Self::reacquire_shared_lifetime_lock(file, lock_kind)?;
+                file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
                 let metadata_len_after_probe = file.size()? as usize;
                 if metadata_len_before_probe < base_len && metadata_len_after_probe >= base_len {
                     Ok(SharedWalCoordinationOpenMode::MultiProcess)
@@ -1072,7 +1064,7 @@ impl MappedSharedWalCoordination {
                 }
             }
             false => {
-                Self::reacquire_shared_lifetime_lock(file, lock_kind)?;
+                file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
                 Ok(SharedWalCoordinationOpenMode::MultiProcess)
             }
         }
@@ -1084,21 +1076,12 @@ impl MappedSharedWalCoordination {
     /// Close-time shutdown checkpointing uses this to approximate SQLite's
     /// "last connection cleans up shared state" behavior.
     pub(crate) fn is_last_process_mapping(&self) -> bool {
-        if !matches!(
-            self.file.shared_wal_try_lock_byte(
+        self.file
+            .shared_wal_probe_exclusive_while_shared_byte(
                 PROCESS_LIFETIME_LOCK_OFFSET,
-                true,
                 self.lock_kind(),
-            ),
-            Ok(true)
-        ) {
-            return false;
-        }
-        let _ = self
-            .file
-            .shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, self.lock_kind());
-        let _ = Self::reacquire_shared_lifetime_lock(&self.file, self.lock_kind());
-        true
+            )
+            .unwrap_or(false)
     }
 
     /// Best-effort cleanup for locks held by this mapping.
@@ -3349,10 +3332,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "lifetime-lock probe assumes shared lifetime lock; Windows uses process-scoped locks"
-    )]
     fn mapped_shared_wal_coordination_last_process_probe_reacquires_shared_lifetime_lock() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("coordination.tshm");

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -6050,10 +6050,6 @@ pub mod test {
     }
 
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "shutdown checkpoint does not truncate the WAL file to zero on Windows"
-    )]
     fn test_shutdown_checkpoint_truncates_after_restart() {
         let (db, path) = get_database();
         let mut walpath = path.clone().into_os_string().into_string().unwrap();
@@ -7085,10 +7081,6 @@ pub mod test {
 
     #[cfg(host_shared_wal)]
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "Windows file locks are mandatory; opening the same WAL twice in one process clashes"
-    )]
     fn test_shm_coordination_uses_shared_authority() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test.db-wal");
@@ -7319,10 +7311,6 @@ pub mod test {
 
     #[cfg(host_shared_wal)]
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "Windows file locks are mandatory; opening the same WAL twice in one process clashes"
-    )]
     fn test_shm_coordination_shared_index_grows_past_old_fixed_limit() {
         const OLD_FIXED_LIMIT: u64 = 65_536;
 
@@ -8285,10 +8273,6 @@ pub mod test {
 
     #[cfg(host_shared_wal)]
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "Windows file locks are mandatory; opening the same WAL twice in one process clashes"
-    )]
     fn test_shm_coordination_secondary_disk_scan_does_not_reseed_authority_while_writer_active() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test.db-wal");
@@ -8362,10 +8346,6 @@ pub mod test {
 
     #[cfg(host_shared_wal)]
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "Windows file locks are mandatory; opening the same WAL twice in one process clashes"
-    )]
     fn test_shm_coordination_disk_scan_matching_authority_keeps_frame_index() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test.db-wal");
@@ -8440,10 +8420,6 @@ pub mod test {
 
     #[cfg(host_shared_wal)]
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "Windows file locks are mandatory; opening the same WAL twice in one process clashes"
-    )]
     fn test_shm_coordination_disk_scan_matching_snapshot_rebuilds_stale_frame_index() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test.db-wal");
@@ -8571,10 +8547,6 @@ pub mod test {
 
     #[cfg(host_shared_wal)]
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "Windows file locks are mandatory; opening the same WAL twice in one process clashes"
-    )]
     fn test_shm_coordination_empty_disk_scan_does_not_clobber_positive_authority() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test.db-wal");
@@ -8756,10 +8728,6 @@ pub mod test {
 
     #[cfg(host_shared_wal)]
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "Windows file locks are mandatory; opening the same WAL twice in one process clashes"
-    )]
     fn test_shm_prepare_wal_header_does_not_clobber_zero_frame_authority_snapshot() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test.db-wal");

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -57,7 +57,7 @@ use crate::{
 pub fn multiprocess_platform_io() -> anyhow::Result<Arc<dyn IO>> {
     #[cfg(target_os = "windows")]
     {
-        return Ok(Arc::new(WindowsIOCP::new()?));
+        Ok(Arc::new(WindowsIOCP::new()?))
     }
 
     #[cfg(unix)]

--- a/testing/sqltests/src/main.rs
+++ b/testing/sqltests/src/main.rs
@@ -26,6 +26,7 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+#[expect(clippy::large_enum_variant)]
 enum Commands {
     /// Run tests
     Run {


### PR DESCRIPTION
## Summary

Fixes Windows-specific WAL lock coordination by replacing per-handle locking with process-aware dedicated lock handles. This preserves cross-process exclusion without making same-process database and shared-WAL operations conflict.

### Fixes #6812 — shutdown checkpoint leaves the WAL non-empty

**Problem:** The last-process check could not reliably determine that a Windows process was the final shared-WAL mapping holder. Shutdown therefore skipped its truncate checkpoint, leaving the WAL file non-empty.

**Fix:** The lifetime-lock probe now uses a disposable handle and restores the aggregate shared lifetime lock transactionally before returning. The last process can safely identify itself and run the shutdown truncate checkpoint.

### Fixes #6813 — last process cannot reacquire its shared lifetime lock

**Problem:** `LockFileEx` is handle-scoped. The previous exclusive probe released a shared lock from one handle and attempted to reacquire it through another, which could leave the process without its lifetime lock.

**Fix:** Shared-WAL coordination is now represented by a process-level, reference-counted byte-lock registry with one dedicated handle per coordination path. The probe preserves the registry's shared ownership and fails closed if restoration cannot be guaranteed.

### Fixes #6814 — same-process shared-WAL opens conflict

**Problem:** IOCP locked the entire file on every open. Multiple legitimate handles in one process then conflicted, producing `ERROR_LOCK_VIOLATION` and requiring seven shared-WAL tests to be disabled on Windows.

**Fix:** IOCP now shares the standard Windows process-open lock registry, using a sentinel byte outside database/WAL data ranges. Shared-WAL byte locks are aggregated per process rather than acquired independently per handle. This permits same-process opens while retaining rejection of another process.

## Additional changes

- Re-enabled the Windows regressions for all three issues.
- Added IOCP coverage for duplicate same-process opens and cross-process open rejection.
- Made strict workspace Clippy warning-free across the Windows platform paths.

## Validation

- Targeted Windows shutdown-checkpoint, lifetime-lock, shared-WAL, IOCP, and standard Windows IO tests.
- `cargo fmt --check` (workspace and `fuzz`).
- `cargo clippy --workspace --all-features --all-targets --locked --exclude memory-benchmark -- --deny=warnings`.

Fixes #6812
Fixes #6813
Fixes #6814