### PR TITLE
core/mvcc: return if truncate did truncate or not

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1431,12 +1431,20 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     fn truncate_logical_log(&self) -> Result<Completion> {
+        use crate::mvcc::persistent_storage::LogicalLogTruncateOutcome;
         let boundary = if self.mode.should_restart_log() {
             u64::MAX
         } else {
             self.durable_txid_max_new
         };
-        self.mvstore.storage.truncate(boundary)
+        let (c, outcome) = self.mvstore.storage.truncate(boundary)?;
+        if self.mode.should_restart_log() {
+            turso_assert!(
+                matches!(outcome, LogicalLogTruncateOutcome::Truncated),
+                "TRUNCATE checkpoint must clear the logical log"
+            );
+        }
+        Ok(c)
     }
 
     /// Perform a TRUNCATE checkpoint on the WAL

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -17834,7 +17834,13 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         fn update_header(&self) -> Result<Completion> {
             self.inner.update_header()
         }
-        fn truncate(&self, checkpointed_through_ts: u64) -> Result<Completion> {
+        fn truncate(
+            &self,
+            checkpointed_through_ts: u64,
+        ) -> Result<(
+            Completion,
+            crate::mvcc::persistent_storage::LogicalLogTruncateOutcome,
+        )> {
             self.inner.truncate(checkpointed_through_ts)
         }
         fn reset_to_fresh_header(&self) -> Result<Completion> {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1012,14 +1012,19 @@ impl LogicalLog {
 
     /// Truncate when `max_appended_commit_ts <= boundary`; passive uses `durable_txid_max_new`,
     /// truncate mode uses `u64::MAX` (always empty after checkpoint).
-    pub fn truncate(&mut self, checkpointed_through_ts: u64) -> Result<Completion> {
+    pub fn truncate(
+        &mut self,
+        checkpointed_through_ts: u64,
+    ) -> Result<(Completion, super::LogicalLogTruncateOutcome)> {
+        use super::LogicalLogTruncateOutcome;
         if self.max_appended_commit_ts > checkpointed_through_ts {
             // Uncheckpointed frames remain — skip truncation.
             let c = Completion::new_trunc(|_| {});
             c.complete(0);
-            return Ok(c);
+            return Ok((c, LogicalLogTruncateOutcome::Retained));
         }
-        self.truncate_to_zero()
+        let c = self.truncate_to_zero()?;
+        Ok((c, LogicalLogTruncateOutcome::Truncated))
     }
 
     /// Reset the log to a header-only file and return one completion for the
@@ -6107,7 +6112,11 @@ mod tests {
         // Truncate to 0 (simulates checkpoint truncation); header with new salt
         // will be written together with the next frame. u64::MAX boundary => all
         // frames are considered checkpointed, so it truncates unconditionally.
-        let c = log.truncate(u64::MAX).unwrap();
+        let (c, outcome) = log.truncate(u64::MAX).unwrap();
+        assert_eq!(
+            outcome,
+            crate::mvcc::persistent_storage::LogicalLogTruncateOutcome::Truncated
+        );
         io.wait_for_completion(c).unwrap();
 
         let salt_after = log.header.as_ref().unwrap().salt;
@@ -6139,6 +6148,33 @@ mod tests {
             io.block(|| reader.parse_next_transaction()),
             Ok(ParseResult::Eof)
         ));
+    }
+
+    /// Passive truncate must report Retained (and leave salt/offset alone) when commits
+    /// remain above the checkpoint boundary.
+    #[test]
+    fn test_truncate_retained_when_uncheckpointed_frames_remain() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file("truncate-retained.db-log", crate::OpenFlags::Create, false)
+            .unwrap();
+        let mut log = LogicalLog::new(file, io.clone(), None);
+
+        append_single_table_op_tx(&mut log, &io, (-2).into(), 1, 10, false, false, "a");
+        append_single_table_op_tx(&mut log, &io, (-2).into(), 2, 20, false, false, "b");
+        let salt_before = log.header.as_ref().unwrap().salt;
+        let offset_before = log.offset;
+
+        // Boundary below max_appended_commit_ts (20) => retain the live tail.
+        let (c, outcome) = log.truncate(10).unwrap();
+        assert_eq!(
+            outcome,
+            crate::mvcc::persistent_storage::LogicalLogTruncateOutcome::Retained
+        );
+        io.wait_for_completion(c).unwrap();
+        assert_eq!(log.header.as_ref().unwrap().salt, salt_before);
+        assert_eq!(log.offset, offset_before);
     }
 
     /// What this test checks: Corrupting frame 1 in a multi-frame log invalidates frame 2 even

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -15,6 +15,12 @@ use crate::mvcc::persistent_storage::logical_log::{
 };
 use crate::{CheckpointResult, Completion, File, LimboError, Result};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogicalLogTruncateOutcome {
+    Truncated,
+    Retained,
+}
+
 pub trait DurableStorage: Send + Sync + Debug {
     /// Append one row-version op to `log_record`'s payload buffer, in the
     /// on-disk wire format used by the logical log. Updates `op_count`.
@@ -69,7 +75,13 @@ pub trait DurableStorage: Send + Sync + Debug {
     /// Truncate the logical log, discarding frames at or below
     /// `checkpointed_through_ts` (the checkpoint's published boundary). Frames
     /// above the boundary (uncheckpointed concurrent commits) are preserved.
-    fn truncate(&self, checkpointed_through_ts: u64) -> Result<Completion>;
+    ///
+    /// Returns whether the log was actually truncated ([`LogicalLogTruncateOutcome::Truncated`])
+    /// or left intact ([`LogicalLogTruncateOutcome::Retained`]).
+    fn truncate(
+        &self,
+        checkpointed_through_ts: u64,
+    ) -> Result<(Completion, LogicalLogTruncateOutcome)>;
 
     /// Reset the logical log to a fresh header-only file.
     ///
@@ -196,16 +208,19 @@ impl DurableStorage for Storage {
         self.logical_log.write().update_header()
     }
 
-    fn truncate(&self, checkpointed_through_ts: u64) -> Result<Completion> {
+    fn truncate(
+        &self,
+        checkpointed_through_ts: u64,
+    ) -> Result<(Completion, LogicalLogTruncateOutcome)> {
         let mut log = self.logical_log.write();
-        let c = log.truncate(checkpointed_through_ts)?;
+        let (c, outcome) = log.truncate(checkpointed_through_ts)?;
         // Shadow the log's actual offset: 0 if it truncated, unchanged if it
         // skipped (uncheckpointed frames remain), so should_checkpoint() stays
         // accurate.
         let new_offset = log.offset;
         drop(log);
         self.shadow_offset_store(new_offset);
-        Ok(c)
+        Ok((c, outcome))
     }
 
     fn reset_to_fresh_header(&self) -> Result<Completion> {

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -86,7 +86,13 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
         self.inner.update_header()
     }
 
-    fn truncate(&self, checkpointed_through_ts: u64) -> turso_core::Result<turso_core::Completion> {
+    fn truncate(
+        &self,
+        checkpointed_through_ts: u64,
+    ) -> turso_core::Result<(
+        turso_core::Completion,
+        turso_core::mvcc::persistent_storage::LogicalLogTruncateOutcome,
+    )> {
         self.inner.truncate(checkpointed_through_ts)
     }
 

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1498,9 +1498,15 @@ fn test_mvcc_index_scan_does_not_return_row_deleted_mid_scan(
 
 fn open_file_conn(path: &str) -> Arc<turso_core::Connection> {
     let io = Arc::new(turso_core::PlatformIO::new().unwrap());
-    let db =
-        Database::open_file_with_flags(io, path, OpenFlags::default(), DatabaseOpts::new(), None)
-            .unwrap();
+    let db = Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
     db.connect().unwrap()
 }
 


### PR DESCRIPTION
## Description

Let logical log's truncate return `LogicalLogTruncateOutcome` in order to understand if we've `Truncated` or `Retained` the logical log.

