### PR TITLE
bindings/go: Validate missing direct query parameters

### DIFF
--- a/bindings/go/driver_db.go
+++ b/bindings/go/driver_db.go
@@ -246,7 +246,7 @@ func (c *tursoDbConnection) ExecContext(ctx context.Context, query string, args 
 		offset += tail
 
 		// Bind only for the first statement
-		if first && len(args) > 0 {
+		if first {
 			if err := bindArgs(stmt, args); err != nil {
 				_ = turso_statement_finalize(stmt)
 				turso_statement_deinit(stmt)
@@ -291,12 +291,10 @@ func (c *tursoDbConnection) QueryContext(ctx context.Context, query string, args
 	if err != nil {
 		return nil, err
 	}
-	if len(args) > 0 {
-		if err := bindArgs(stmt, args); err != nil {
-			_ = turso_statement_finalize(stmt)
-			turso_statement_deinit(stmt)
-			return nil, err
-		}
+	if err := bindArgs(stmt, args); err != nil {
+		_ = turso_statement_finalize(stmt)
+		turso_statement_deinit(stmt)
+		return nil, err
 	}
 	// Return rows wrapper; do not step yet, leave cursor before first row
 	return &tursoDbRows{
@@ -737,21 +735,9 @@ func (c *tursoDbConnection) executeFully(ctx context.Context, stmt TursoStatemen
 // bindArgs binds ordered and named values to a statement.
 // Named values are resolved via turso_statement_parameter_name, otherwise ordinal positions are used (1-based).
 func bindArgs(stmt TursoStatement, args []driver.NamedValue) error {
-	// Validate number of inputs if no named args present
-	if len(args) > 0 {
-		hasNamed := false
-		for _, nv := range args {
-			if nv.Name != "" {
-				hasNamed = true
-				break
-			}
-		}
-		if !hasNamed {
-			paramCount := int(turso_statement_parameters_count(stmt))
-			if paramCount >= 0 && len(args) != paramCount {
-				return fmt.Errorf("turso: got %d args, want %d", len(args), paramCount)
-			}
-		}
+	paramCount := int(turso_statement_parameters_count(stmt))
+	if paramCount >= 0 && len(args) != paramCount {
+		return fmt.Errorf("turso: got %d args, want %d", len(args), paramCount)
 	}
 
 	// Build bare-name → position map from statement metadata.
@@ -760,7 +746,6 @@ func bindArgs(stmt TursoStatement, args []driver.NamedValue) error {
 	// the full name (e.g. ":a", "@a", "$a"). We strip the prefix from
 	// the statement's parameter names to build the lookup table.
 	var nameMap map[string]int
-	paramCount := int(turso_statement_parameters_count(stmt))
 	if paramCount > 0 {
 		nameMap = make(map[string]int, paramCount)
 		for i := 1; i <= paramCount; i++ {

--- a/bindings/go/driver_db_test.go
+++ b/bindings/go/driver_db_test.go
@@ -350,6 +350,42 @@ func TestStatementError(t *testing.T) {
 	fmt.Println("Statement error test passed")
 }
 
+func TestQueryMissingParameterReturnsError(t *testing.T) {
+	newConn := openMem(t)
+	sql := "CREATE TABLE pair (k INTEGER NOT NULL, v INTEGER NOT NULL, UNIQUE(k, v));"
+	_, err := newConn.Exec(sql)
+	if err != nil {
+		t.Fatalf("Error creating table: %v", err)
+	}
+	sql = "INSERT OR IGNORE INTO pair(k, v) VALUES(1, 2);"
+	_, err = newConn.Exec(sql)
+	if err != nil {
+		t.Fatalf("Error inserting data: %v", err)
+	}
+	sql = "SELECT v FROM pair WHERE k=?;"
+	rows, err := newConn.Query(sql)
+	if rows != nil {
+		_ = rows.Close()
+	}
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+}
+
+func TestExecMissingParameterReturnsError(t *testing.T) {
+	newConn := openMem(t)
+	sql := "CREATE TABLE pair (k INTEGER, v INTEGER);"
+	_, err := newConn.Exec(sql)
+	if err != nil {
+		t.Fatalf("Error creating table: %v", err)
+	}
+	sql = "INSERT INTO pair(k, v) VALUES(?, ?);"
+	_, err = newConn.Exec(sql)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+}
+
 func TestDriverRowsErrorMessages(t *testing.T) {
 	db := openMem(t)
 	_, err := db.Exec("CREATE TABLE test (id INTEGER, name TEXT)")


### PR DESCRIPTION
Fixes #7862

## Description

Fixes Go binding parameter validation for direct `Query` and `Exec` calls.

Previously, direct calls such as:

 ```go
 db.Query("SELECT v FROM pair WHERE k=?")
```
could skip argument-count validation when no parameters were supplied. This change makes the driver validate the prepared statement parameter count before binding.

## Testing
- Adds regression coverage for missing parameters in both direct Query and Exec.

## Motivation and context

Missing parameters should return an error instead of executing with unbound placeholders.
