### PR TITLE
postgres: accept COMMENT ON as a no-op

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -48,6 +48,7 @@ Basics not enumerated by the official feature matrix.
 | ALTER TABLE | 🟡 Partial | ADD/DROP COLUMN, RENAME TABLE/COLUMN work; ALTER COLUMN TYPE translates but fails at execution; SET/DROP DEFAULT, SET/DROP NOT NULL, ADD CONSTRAINT rejected |
 | CREATE INDEX | ✅ Supported | UNIQUE, multi-column, partial (WHERE), expression indexes, IF NOT EXISTS |
 | CREATE VIEW | ✅ Supported | Column aliases supported; TEMP silently ignored |
+| COMMENT ON | 🟡 Partial | Accepted but discarded; comments are not persisted in `pg_description` |
 | CREATE SCHEMA / DROP SCHEMA | ✅ Supported | Schemas are ATTACHed databases; DROP ... CASCADE; `public` is special-cased |
 | CREATE SEQUENCE / nextval / currval / setval | ✅ Supported | START, INCREMENT, MIN/MAXVALUE, CYCLE; CACHE accepted (no-op); pg_sequences view |
 | CREATE DOMAIN | ✅ Supported | Base type + DEFAULT, NOT NULL, CHECK constraints enforced |

--- a/postgres/cli/TODO.md
+++ b/postgres/cli/TODO.md
@@ -4,7 +4,7 @@ Sorted by implementation difficulty.
 
 ## Trivial (hours, mostly wiring)
 
-1. **COMMENT ON** — parse + ignore (no-op, just don't error)
+1. ~~**COMMENT ON**~~ — DONE (accepted as a no-op; comments are not persisted)
 2. **PREPARE / EXECUTE / DEALLOCATE** — wire protocol already handles this; just need the SQL syntax to not error
 3. **GRANT/REVOKE** — parse + ignore (single-user system, just don't error)
 4. **More PG system functions** — register existing Turso functions under PG aliases (e.g. `string_agg` → `group_concat`, `regexp_replace`, etc.)

--- a/postgres/cli/tests/tursopg.rs
+++ b/postgres/cli/tests/tursopg.rs
@@ -749,6 +749,19 @@ fn refresh_materialized_view_is_noop() {
     assert!(out.contains("ok"), "REFRESH should be a no-op: {out}");
 }
 
+#[test]
+fn comment_on_is_noop() {
+    let output = run_tursopg(
+        b"CREATE TABLE docs(id INT, title TEXT);\n\
+          COMMENT ON TABLE docs IS 'documentation';\n\
+          COMMENT ON COLUMN docs.title IS NULL;\n\
+          SELECT 'ok';\n",
+    );
+    assert_eq!(output.status.code(), Some(0));
+    let out = stdout(&output);
+    assert!(out.contains("ok"), "COMMENT ON should be a no-op: {out}");
+}
+
 // ---------------------------------------------------------------------------
 // Named windows (WINDOW clause)
 // ---------------------------------------------------------------------------
@@ -1143,6 +1156,20 @@ fn wire_copy_from_returns_copy_n() {
     std::fs::remove_file(&path).ok();
     server.kill().ok();
     server.wait().ok();
+}
+
+#[test]
+fn wire_comment_on_returns_comment_tag() {
+    with_pg_client(|client| {
+        let tags = client.query_command_tags("CREATE TABLE docs(id INT)");
+        assert!(
+            tags.iter().any(|tag| tag.starts_with("CREATE")),
+            "expected CREATE tag, got: {tags:?}"
+        );
+
+        let tags = client.query_command_tags("COMMENT ON TABLE docs IS 'documentation'");
+        assert_eq!(tags, ["COMMENT"]);
+    });
 }
 
 /// Wire-protocol fixture: spin up tursopg, hand the caller a connected

--- a/postgres/frontend/session.rs
+++ b/postgres/frontend/session.rs
@@ -7,9 +7,9 @@ use crate::catalog::{self, PostgresDialect};
 use turso_core::{Connection, LimboError, Result, Statement, Value};
 use turso_parser::ast;
 use turso_pg_parser::translator::{
-    is_refresh_matview, try_extract_copy_from, try_extract_create_schema, try_extract_drop_schema,
-    try_extract_set, try_extract_show, PgCopyFromStmt, PgCreateSchemaStmt, PgDropSchemaStmt,
-    PostgreSQLTranslator,
+    is_comment_on, is_refresh_matview, try_extract_copy_from, try_extract_create_schema,
+    try_extract_drop_schema, try_extract_set, try_extract_show, PgCopyFromStmt, PgCreateSchemaStmt,
+    PgDropSchemaStmt, PostgreSQLTranslator,
 };
 
 use crate::copy::parse_copy_text_format;
@@ -244,6 +244,10 @@ fn try_prepare_special(conn: &Arc<Connection>, sql: &str) -> Result<Option<State
     }
 
     if is_refresh_matview(&parse_result) {
+        return Ok(Some(noop_statement(conn)?));
+    }
+
+    if is_comment_on(&parse_result) {
         return Ok(Some(noop_statement(conn)?));
     }
 

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -4289,6 +4289,18 @@ pub fn is_refresh_matview(parse_result: &ParseResult) -> bool {
     matches!(&nodes[0].0, NodeRef::RefreshMatViewStmt(_))
 }
 
+/// Returns true if the parse result is a COMMENT ON statement.
+/// Comments are accepted for PostgreSQL compatibility but are not persisted.
+pub fn is_comment_on(parse_result: &ParseResult) -> bool {
+    use pg_query::NodeRef;
+
+    let nodes = parse_result.protobuf.nodes();
+    if nodes.is_empty() {
+        return false;
+    }
+    matches!(&nodes[0].0, NodeRef::CommentStmt(_))
+}
+
 /// Extracted COPY FROM statement info for use by the connection layer.
 #[derive(Debug, Clone)]
 pub struct PgCopyFromStmt {

--- a/postgres/server/lib.rs
+++ b/postgres/server/lib.rs
@@ -640,6 +640,7 @@ fn is_pg_non_query(sql: &str) -> bool {
         || upper.starts_with("CREATE SCHEMA")
         || upper.starts_with("DROP SCHEMA")
         || upper.starts_with("REFRESH MATERIALIZED VIEW")
+        || upper.starts_with("COMMENT")
 }
 
 fn command_tag(query: &str, affected_rows: usize) -> Tag {
@@ -682,6 +683,8 @@ fn command_tag(query: &str, affected_rows: usize) -> Tag {
         Tag::new("SET")
     } else if upper.starts_with("COPY") {
         Tag::new("COPY").with_rows(affected_rows)
+    } else if upper.starts_with("COMMENT") {
+        Tag::new("COMMENT")
     } else {
         Tag::new("OK")
     }

--- a/postgres/tests/integration/postgres/dialect.rs
+++ b/postgres/tests/integration/postgres/dialect.rs
@@ -42,6 +42,89 @@ fn test_postgres_simple_select_literal(db: TempDatabase) {
 }
 
 #[turso_macros::test(mvcc)]
+fn test_postgres_comment_on_supported_object_forms_are_noops(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    // COMMENT ON is intentionally accepted without validating or storing the
+    // referenced object, so cover the distinct PostgreSQL grammar forms here.
+    for (object_kind, sql) in [
+        ("table", "COMMENT ON TABLE comment_docs IS 'documentation'"),
+        (
+            "column",
+            "COMMENT ON COLUMN comment_docs.title IS 'column documentation'",
+        ),
+        (
+            "constraint",
+            "COMMENT ON CONSTRAINT comment_docs_pkey ON comment_docs IS 'constraint documentation'",
+        ),
+        (
+            "database",
+            "COMMENT ON DATABASE main IS 'database documentation'",
+        ),
+        (
+            "domain",
+            "COMMENT ON DOMAIN email IS 'domain documentation'",
+        ),
+        ("type", "COMMENT ON TYPE status IS 'type documentation'"),
+        (
+            "index",
+            "COMMENT ON INDEX comment_docs_idx IS 'index documentation'",
+        ),
+        (
+            "view",
+            "COMMENT ON VIEW comment_view IS 'view documentation'",
+        ),
+        (
+            "materialized view",
+            "COMMENT ON MATERIALIZED VIEW comment_matview IS 'materialized view documentation'",
+        ),
+        (
+            "schema",
+            "COMMENT ON SCHEMA accounting IS 'schema documentation'",
+        ),
+        (
+            "sequence",
+            "COMMENT ON SEQUENCE comment_docs_id_seq IS 'sequence documentation'",
+        ),
+        (
+            "trigger",
+            "COMMENT ON TRIGGER audit_changes ON comment_docs IS 'trigger documentation'",
+        ),
+        (
+            "function",
+            "COMMENT ON FUNCTION format_comment(integer) IS 'function documentation'",
+        ),
+        (
+            "cast",
+            "COMMENT ON CAST (text AS integer) IS 'cast documentation'",
+        ),
+        (
+            "operator",
+            "COMMENT ON OPERATOR + (integer, integer) IS 'operator documentation'",
+        ),
+        (
+            "operator class",
+            "COMMENT ON OPERATOR CLASS int4_ops USING btree IS 'operator class documentation'",
+        ),
+        (
+            "policy",
+            "COMMENT ON POLICY access_policy ON comment_docs IS 'policy documentation'",
+        ),
+        (
+            "rule",
+            "COMMENT ON RULE update_rule ON comment_docs IS 'rule documentation'",
+        ),
+        (
+            "language",
+            "COMMENT ON LANGUAGE plpgsql IS 'language documentation'",
+        ),
+    ] {
+        conn.execute(sql)
+            .unwrap_or_else(|err| panic!("COMMENT ON {object_kind} should be accepted: {err}"));
+    }
+}
+
+#[turso_macros::test(mvcc)]
 fn test_postgres_arithmetic_expression(db: TempDatabase) {
     let conn = db.connect_postgres();
 


### PR DESCRIPTION
Allow PostgreSQL clients and migrations to issue COMMENT ON statements without persisting comment metadata. Return the COMMENT wire completion tag so clients do not observe the internal no-op statement.

Tests: `cargo fmt --all -- --check`; `git diff --check`

# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->

## Description

- Recognize PostgreSQL `CommentStmt` values before generic PostgreSQL-to-Turso translation.
- Handle `COMMENT ON` as a no-op and return the PostgreSQL `COMMENT` wire completion tag.
- Document that comment metadata is intentionally discarded and is not exposed through `pg_description`.

## Motivation and context

PostgreSQL clients and migration tools commonly emit `COMMENT ON` statements. libpg_query accepts this syntax, but Turso previously rejected the resulting parse-tree node as unsupported. This change preserves client and migration compatibility without introducing comment metadata storage.

No related issue.

## Description of AI Usage

This PR was developed with assistance from Codex. Codex was used to explore the PostgreSQL frontend, implement the focused compatibility change, add tests, and review the diff. 
