### PR TITLE
perf(vdbe): decode pseudo-cursor columns in place and skip Column op-state

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -617,6 +617,71 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
 }
 
 #[turso_macros::codspeed_criterion_benchmark]
+fn bench_execute_group_by(criterion: &mut Criterion) {
+    // https://github.com/tursodatabase/turso/issues/174
+    // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
+    let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
+
+    // Low-cardinality GROUP BY over an unindexed column: the sort is NOT elided,
+    // so this exercises the full sorter path (SorterInsert / SorterSort /
+    // SorterData) and reads every grouped row's columns back through the pseudo
+    // cursor -- the code path the other execute benchmarks (point scans, indexed
+    // COUNT) never touch. `state` is unindexed and `age`/`last_name` feed the
+    // aggregates, so all three aggregate arguments come from the sorter output.
+    const QUERY: &str =
+        "SELECT state, COUNT(*), MAX(last_name), SUM(age) FROM users GROUP BY state";
+
+    #[allow(clippy::arc_with_non_send_sync)]
+    let io = Arc::new(PlatformIO::new().unwrap());
+    let db =
+        Database::open_file(io, "../testing/system/testing.db", Arc::new(SqliteDialect)).unwrap();
+    let limbo_conn = db.connect().unwrap();
+
+    let mut group = criterion.benchmark_group(
+        "Execute `SELECT state, COUNT(*), MAX(last_name), SUM(age) GROUP BY state`",
+    );
+
+    group.bench_function("limbo_execute_group_by", |b| {
+        let mut stmt = limbo_conn.prepare(QUERY).unwrap();
+        b.iter(|| {
+            loop {
+                match stmt.step().unwrap() {
+                    turso_core::StepResult::Row => {
+                        black_box(stmt.row());
+                    }
+                    turso_core::StepResult::IO | turso_core::StepResult::Yield => {
+                        db.io.step().unwrap();
+                    }
+                    turso_core::StepResult::Done => {
+                        break;
+                    }
+                    turso_core::StepResult::Interrupt | turso_core::StepResult::Busy => {
+                        unreachable!();
+                    }
+                }
+            }
+            stmt.reset().unwrap();
+        });
+    });
+
+    if enable_rusqlite {
+        let sqlite_conn = rusqlite_open();
+
+        group.bench_function("sqlite_execute_group_by", |b| {
+            let mut stmt = sqlite_conn.prepare(QUERY).unwrap();
+            b.iter(|| {
+                let mut rows = stmt.raw_query();
+                while let Some(row) = rows.next().unwrap() {
+                    black_box(row);
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_insert_rows(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
@@ -1191,14 +1256,14 @@ fn bench_insert_randomblob(criterion: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
+    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_execute_group_by, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
 }
 
 #[cfg(feature = "codspeed")]
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
+    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_execute_group_by, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
 }
 
 criterion_main!(benches);

--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -1,4 +1,4 @@
-use crate::{types::ImmutableRecord, Result, Value};
+use crate::types::ImmutableRecord;
 
 pub struct PseudoCursor {
     current: Option<ImmutableRecord>,
@@ -20,14 +20,5 @@ impl PseudoCursor {
     #[inline]
     pub fn insert(&mut self, record: ImmutableRecord) {
         self.current = Some(record);
-    }
-
-    #[inline]
-    pub fn get_value(&self, column: usize) -> Result<Value> {
-        if let Some(record) = self.current.as_ref() {
-            Ok(record.get_value(column)?.to_owned()?)
-        } else {
-            Ok(Value::Null)
-        }
     }
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1774,6 +1774,17 @@ pub fn op_column(
         },
         insn
     );
+    // Fast path: no deferred seek pending and no suspended state machine. The
+    // column fetch either completes or yields IO with nothing persisted, so the
+    // op-state slot (enum write + drop on clear) is bypassed entirely. On IO
+    // resume the slot is still idle and this path re-executes.
+    if state.active_op_state.is_idle() && state.deferred_seeks[*cursor_id].is_none() {
+        let result = op_column_fetch(program, state, *cursor_id, *column, *dest, default)?;
+        if matches!(result, InsnFunctionStepResult::Step) {
+            state.pc += 1;
+        }
+        return Ok(result);
+    }
     'outer: loop {
         match *state.active_op_state.column() {
             OpColumnState::Start => {
@@ -1833,140 +1844,162 @@ pub fn op_column(
                 *state.active_op_state.column() = OpColumnState::GetColumn;
             }
             OpColumnState::GetColumn => {
-                let (active_cursor_id, active_column) = (*cursor_id, *column);
-                // First check if this is a MaterializedViewCursor
-                {
-                    let cursor = state.get_cursor(active_cursor_id);
-                    if let Cursor::MaterializedView(mv_cursor) = cursor {
-                        // Handle materialized view column access
-                        let value = return_if_io!(mv_cursor.column(active_column));
-                        state.registers[*dest].set_value(value);
-                        break 'outer;
-                    }
-                    // Fall back to normal handling
+                let result = op_column_fetch(program, state, *cursor_id, *column, *dest, default)?;
+                if !matches!(result, InsnFunctionStepResult::Step) {
+                    // IO yield: the slot stays at GetColumn so the resume
+                    // re-enters this arm.
+                    return Ok(result);
                 }
-
-                let (_, cursor_type) = program
-                    .cursor_ref
-                    .get(active_cursor_id)
-                    .expect("cursor_id should exist in cursor_ref");
-                match cursor_type {
-                    CursorType::BTreeTable(_)
-                    | CursorType::BTreeIndex(_)
-                    | CursorType::MaterializedView(_, _) => {
-                        {
-                            let cursor_ref = must_be_btree_cursor!(
-                                active_cursor_id,
-                                program.cursor_ref,
-                                state,
-                                "Column"
-                            );
-                            let cursor = cursor_ref.as_btree_mut();
-
-                            if cursor.get_null_flag() {
-                                tracing::trace!("op_column(null_flag)");
-                                state.registers[*dest].set_null();
-                                break 'outer;
-                            }
-
-                            let record_result = return_if_io!(cursor.record());
-                            let Some(record) = record_result else {
-                                // Cursor is not positioned on a valid row (e.g., empty table).
-                                // Return NULL, not the column's default value.
-                                // DEFAULT handling below is for when record exists
-                                // but has fewer columns than expected.
-                                state.registers[*dest].set_null();
-                                break 'outer;
-                            };
-
-                            let mut payload_iterator = record.iter()?;
-
-                            // Parse the header for serial types incrementally until we have the target column
-                            // Use nth_into_register to write directly to the register without
-                            // creating intermediate ValueRef allocations
-
-                            match payload_iterator
-                                .nth_into_register(*column, &mut state.registers[*dest])
-                            {
-                                Some(result) => {
-                                    result?;
-                                    break 'outer;
-                                }
-                                None => {
-                                    branches::mark_unlikely();
-                                    // record has fewer columns than expected
-                                }
-                            };
-
-                            //break;
-                        };
-
-                        // DEFAULT handling
-                        let Some(ref default) = default else {
-                            state.registers[*dest].set_null();
-                            break;
-                        };
-                        match (default, &mut state.registers[*dest]) {
-                            (
-                                Value::Text(new_text),
-                                Register::Value(Value::Text(existing_text)),
-                            ) => {
-                                existing_text.do_extend(new_text)?;
-                            }
-                            (
-                                Value::Blob(new_blob),
-                                Register::Value(Value::Blob(existing_blob)),
-                            ) => {
-                                existing_blob.do_extend(new_blob)?;
-                            }
-                            _ => {
-                                state.registers[*dest].set_value(default.clone());
-                            }
-                        }
-                        break;
-                    }
-                    CursorType::Sorter => {
-                        let record = {
-                            let cursor = state.get_cursor(*cursor_id);
-                            let cursor = cursor.as_sorter_mut();
-                            cursor.record().cloned()
-                        };
-                        if let Some(record) = record {
-                            state.registers[*dest].set_value(match record.get_value_opt(*column) {
-                                Some(val) => val.to_owned()?,
-                                None => default.clone().unwrap_or(Value::Null),
-                            });
-                        } else {
-                            state.registers[*dest].set_null();
-                        }
-                    }
-                    CursorType::Pseudo(_) => {
-                        let value = {
-                            let cursor = state.get_cursor(*cursor_id);
-                            let cursor = cursor.as_pseudo_mut();
-                            cursor.get_value(*column)?
-                        };
-                        state.registers[*dest].set_value(value);
-                    }
-                    CursorType::IndexMethod(..) => {
-                        let cursor = state.cursors[*cursor_id]
-                            .as_mut()
-                            .expect("cursor should exist");
-                        let cursor = cursor.as_index_method_mut();
-                        let value = return_if_io!(cursor.query_column(*column));
-                        state.registers[*dest].set_value(value);
-                    }
-                    CursorType::VirtualTable(_) => {
-                        panic!("Insn:Column on virtual table cursor, use Insn:VColumn instead");
-                    }
-                }
-                break;
+                break 'outer;
             }
         }
     }
 
     state.active_op_state.clear();
     state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
+/// Fetches one column of the cursor's current row into a register. Returns
+/// `Step` on completion; any IO is propagated without persisting state, so
+/// callers can safely re-invoke after the completion finishes.
+fn op_column_fetch(
+    program: &Program,
+    state: &mut ProgramState,
+    cursor_id: usize,
+    column: usize,
+    dest: usize,
+    default: &Option<Value>,
+) -> Result<InsnFunctionStepResult> {
+    // First check if this is a MaterializedViewCursor
+    {
+        let cursor = state.get_cursor(cursor_id);
+        if let Cursor::MaterializedView(mv_cursor) = cursor {
+            // Handle materialized view column access
+            let value = return_if_io!(mv_cursor.column(column));
+            state.registers[dest].set_value(value);
+            return Ok(InsnFunctionStepResult::Step);
+        }
+        // Fall back to normal handling
+    }
+
+    let (_, cursor_type) = program
+        .cursor_ref
+        .get(cursor_id)
+        .expect("cursor_id should exist in cursor_ref");
+    match cursor_type {
+        CursorType::BTreeTable(_)
+        | CursorType::BTreeIndex(_)
+        | CursorType::MaterializedView(_, _) => {
+            {
+                let cursor_ref =
+                    must_be_btree_cursor!(cursor_id, program.cursor_ref, state, "Column");
+                let cursor = cursor_ref.as_btree_mut();
+
+                if cursor.get_null_flag() {
+                    tracing::trace!("op_column(null_flag)");
+                    state.registers[dest].set_null();
+                    return Ok(InsnFunctionStepResult::Step);
+                }
+
+                let record_result = return_if_io!(cursor.record());
+                let Some(record) = record_result else {
+                    // Cursor is not positioned on a valid row (e.g., empty table).
+                    // Return NULL, not the column's default value.
+                    // DEFAULT handling below is for when record exists
+                    // but has fewer columns than expected.
+                    state.registers[dest].set_null();
+                    return Ok(InsnFunctionStepResult::Step);
+                };
+
+                let mut payload_iterator = record.iter()?;
+
+                // Parse the header for serial types incrementally until we have the target column
+                // Use nth_into_register to write directly to the register without
+                // creating intermediate ValueRef allocations
+
+                match payload_iterator.nth_into_register(column, &mut state.registers[dest]) {
+                    Some(result) => {
+                        result?;
+                        return Ok(InsnFunctionStepResult::Step);
+                    }
+                    None => {
+                        branches::mark_unlikely();
+                        // record has fewer columns than expected
+                    }
+                };
+            };
+
+            // DEFAULT handling
+            let Some(ref default) = default else {
+                state.registers[dest].set_null();
+                return Ok(InsnFunctionStepResult::Step);
+            };
+            match (default, &mut state.registers[dest]) {
+                (Value::Text(new_text), Register::Value(Value::Text(existing_text))) => {
+                    existing_text.do_extend(new_text)?;
+                }
+                (Value::Blob(new_blob), Register::Value(Value::Blob(existing_blob))) => {
+                    existing_blob.do_extend(new_blob)?;
+                }
+                _ => {
+                    state.registers[dest].set_value(default.clone());
+                }
+            }
+        }
+        CursorType::Sorter => {
+            let record = {
+                let cursor = state.get_cursor(cursor_id);
+                let cursor = cursor.as_sorter_mut();
+                cursor.record().cloned()
+            };
+            if let Some(record) = record {
+                state.registers[dest].set_value(match record.get_value_opt(column) {
+                    Some(val) => val.to_owned()?,
+                    None => default.clone().unwrap_or(Value::Null),
+                });
+            } else {
+                state.registers[dest].set_null();
+            }
+        }
+        CursorType::Pseudo(_) => {
+            let cursor = crate::get_cursor!(state, cursor_id);
+            let cursor = cursor.as_pseudo_mut();
+            match cursor.record() {
+                Some(record) => {
+                    // Decode straight into the register; going through an owned
+                    // Value would allocate for every TEXT/BLOB column on every row.
+                    let mut payload_iterator = record.iter()?;
+                    match payload_iterator.nth_into_register(column, &mut state.registers[dest]) {
+                        Some(result) => result?,
+                        // A pseudo cursor is opened with num_fields matching the
+                        // record built for it, so every emitted Column index is in
+                        // range. NULL on a missing column matches the b-tree arm.
+                        None => {
+                            turso_debug_assert!(
+                                false,
+                                "pseudo-cursor column out of range for record",
+                                { "column": column }
+                            );
+                            state.registers[dest].set_null();
+                        }
+                    }
+                }
+                None => state.registers[dest].set_null(),
+            }
+        }
+        CursorType::IndexMethod(..) => {
+            let cursor = state.cursors[cursor_id]
+                .as_mut()
+                .expect("cursor should exist");
+            let cursor = cursor.as_index_method_mut();
+            let value = return_if_io!(cursor.query_column(column));
+            state.registers[dest].set_value(value);
+        }
+        CursorType::VirtualTable(_) => {
+            panic!("Insn:Column on virtual table cursor, use Insn:VColumn instead");
+        }
+    }
     Ok(InsnFunctionStepResult::Step)
 }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -533,6 +533,12 @@ impl ActiveOpStateSlot {
         self.state = ActiveOpState::None;
     }
 
+    /// True when no multi-step opcode is suspended. Hot opcodes use this to
+    /// bypass the slot entirely on their non-yielding fast path.
+    fn is_idle(&self) -> bool {
+        matches!(self.state, ActiveOpState::None)
+    }
+
     fn cleanup_journal_mode_checkpoint(&mut self) -> Result<()> {
         match &mut self.state {
             ActiveOpState::JournalMode(state) => state.cleanup_checkpoint(),


### PR DESCRIPTION
## What

Speeds up `op_column`, the VDBE opcode that reads one column of a cursor's
current row into a register. Two independent per-row costs on read paths:

1. **Pseudo-cursor decode in place.** The pseudo-cursor arm (how GROUP BY /
   ORDER BY read their rows off the sorter) materialized each column as an
   owned `Value` via `get_value(...).to_owned()`, heap-allocating for every
   TEXT/BLOB column of every sorted row. It now decodes straight into the
   destination register with `nth_into_register` — the same idiom the b-tree
   arm already uses. `PseudoCursor::get_value` (now dead) is removed.

2. **Column op-state bypass.** `op_column` routed every call through the
   `ActiveOpState` slot state machine (`Start` → `GetColumn` → clear) that
   only exists to support the deferred-seek (index → table rowid) path. The
   fetch body is extracted into `op_column_fetch`; when the slot is idle and
   no deferred seek is pending, the opcode calls it directly and touches no op
   state. The slow path (deferred seek, or resuming a suspended state machine
   after IO) is unchanged and also routes through `op_column_fetch`. An IO
   yield happens before any register write, so re-execution on resume is
   idempotent. This half helps every Column op, b-tree reads included.

## Measured

Criterion baseline compare, same quiet window, `p < 0.05`:

| benchmark | query | change |
|---|---|---|
| `benchmark.rs` / select_rows/50 | `SELECT * FROM users LIMIT 50` | −11.9% |
| `benchmark.rs` / select_rows/100 | `SELECT * FROM users LIMIT 100` | −11.7% |
| `benchmark.rs` / **group_by** (added here) | `... COUNT/MAX/SUM ... GROUP BY state` | 5.70 → 4.80 ms, **−15.7%** |
| `count_benchmark.rs` / count_text_col | `SELECT COUNT(g) FROM t` | ~−12% |
| `count_benchmark.rs` / count_groupby | `SELECT g, COUNT(*) ... GROUP BY g` | −3.0% |

The gain scales with the number of Column opcodes executed per row.

## Benchmark added

Nothing in-tree exercised a GROUP BY whose sort is *not* elided by an index —
i.e. the sorter path that reads grouped rows back through a pseudo cursor.
The first commit adds `bench_execute_group_by` to `core/benches/benchmark.rs`
(`SELECT state, COUNT(*), MAX(last_name), SUM(age) FROM users GROUP BY state`,
`state` unindexed), following the existing execute-benchmark pattern
(in-process step loop + rusqlite comparison arm, CodSpeed-tracked). It is a
separate parent commit so the fix's effect on that path is measurable across
the two revisions.

## Tests

`cargo test -p turso_core`, sqltests — all green. `cargo fmt`/`clippy` clean.
An out-of-range pseudo-cursor column (unreachable in well-formed bytecode, the
cursor's `num_fields` always matches the record) is guarded with
`turso_debug_assert!` and returns NULL, matching the b-tree arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
