### PR TITLE
bindings/rust: add Builder::experimental_autovacuum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7113,6 +7113,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "reqwest",
+ "rusqlite",
  "serde_json",
  "tempfile",
  "thiserror 2.0.16",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -58,6 +58,7 @@ name = "concurrent_writes"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+rusqlite = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 rand.workspace = true
 rand_chacha = { workspace = true }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -146,6 +146,7 @@ pub struct Builder {
     enable_index_method: bool,
     enable_materialized_views: bool,
     enable_vacuum: bool,
+    enable_autovacuum: bool,
     enable_generated_columns: bool,
     enable_multiprocess_wal: bool,
     enable_without_rowid: bool,
@@ -166,6 +167,7 @@ impl Builder {
             enable_index_method: false,
             enable_materialized_views: false,
             enable_vacuum: false,
+            enable_autovacuum: false,
             enable_generated_columns: false,
             enable_multiprocess_wal: false,
             enable_without_rowid: false,
@@ -226,6 +228,11 @@ impl Builder {
         self
     }
 
+    pub fn experimental_autovacuum(mut self, enabled: bool) -> Self {
+        self.enable_autovacuum = enabled;
+        self
+    }
+
     pub fn experimental_multiprocess_wal(mut self, enabled: bool) -> Self {
         self.enable_multiprocess_wal = enabled;
         self
@@ -271,6 +278,9 @@ impl Builder {
         }
         if self.enable_vacuum {
             features.push("vacuum");
+        }
+        if self.enable_autovacuum {
+            features.push("autovacuum");
         }
         if self.enable_generated_columns {
             features.push("generated_columns");
@@ -863,6 +873,61 @@ mod tests {
             wal_size as f64 / 1024.0
         );
         assert!(wal_size > 0, "WAL file should exist and be non-empty");
+
+        Ok(())
+    }
+    /// Proves `Builder::experimental_autovacuum` reaches
+    /// `turso_core::DatabaseOpts::with_autovacuum`: a database with
+    /// autovacuum persisted in its header is forced read-only when opened
+    /// without the flag, and writable when opened with it. Mirrors the
+    /// engine-level `test_autovacuum_readonly_behavior` in
+    /// `tests/integration/storage/autovacuum.rs`, using `rusqlite` the same
+    /// way that test does to write the on-disk auto_vacuum header field
+    /// directly, independent of the engine's own `PRAGMA auto_vacuum`
+    /// support.
+    #[tokio::test]
+    async fn test_experimental_autovacuum_gates_readonly() -> Result<()> {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.pragma_update(None, "auto_vacuum", "FULL").unwrap();
+            conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", [])
+                .unwrap();
+            conn.execute("INSERT INTO t (v) VALUES ('seed')", [])
+                .unwrap();
+        }
+
+        // Open WITHOUT the flag: the engine must force read-only mode, so a
+        // write fails.
+        {
+            let db = Builder::new_local(db_path_str).build().await?;
+            let conn = db.connect()?;
+            let result = conn
+                .execute("INSERT INTO t (v) VALUES ('should_fail');", ())
+                .await;
+            assert!(
+                matches!(result, Err(Error::Readonly(_))),
+                "expected a Readonly error on a forced-readonly autovacuum database, got: {result:?}"
+            );
+        }
+
+        // Open WITH the flag: the database must be writable.
+        {
+            let db = Builder::new_local(db_path_str)
+                .experimental_autovacuum(true)
+                .build()
+                .await?;
+            let conn = db.connect()?;
+            conn.execute("INSERT INTO t (v) VALUES ('should_succeed');", ())
+                .await?;
+
+            let mut rows = conn.query("SELECT count(*) FROM t;", ()).await?;
+            let row = rows.next().await?.unwrap();
+            assert_eq!(row.get_value(0)?, Value::Integer(2));
+        }
 
         Ok(())
     }

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -120,6 +120,7 @@ pub struct Builder {
     enable_index_method: bool,
     enable_materialized_views: bool,
     enable_vacuum: bool,
+    enable_autovacuum: bool,
     enable_generated_columns: bool,
     enable_multiprocess_wal: bool,
     enable_without_rowid: bool,
@@ -144,6 +145,7 @@ impl Builder {
             enable_index_method: false,
             enable_materialized_views: false,
             enable_vacuum: false,
+            enable_autovacuum: false,
             enable_generated_columns: false,
             enable_multiprocess_wal: false,
             enable_without_rowid: false,
@@ -186,6 +188,13 @@ impl Builder {
     /// Mirrors the local [`crate::Builder::experimental_vacuum`].
     pub fn experimental_vacuum(mut self, enable: bool) -> Self {
         self.enable_vacuum = enable;
+        self
+    }
+
+    /// Enable the experimental `autovacuum` engine feature for the synced
+    /// database. Mirrors the local [`crate::Builder::experimental_autovacuum`].
+    pub fn experimental_autovacuum(mut self, enable: bool) -> Self {
+        self.enable_autovacuum = enable;
         self
     }
 
@@ -322,6 +331,9 @@ impl Builder {
         }
         if self.enable_vacuum {
             features.push("vacuum");
+        }
+        if self.enable_autovacuum {
+            features.push("autovacuum");
         }
         if self.enable_generated_columns {
             features.push("generated_columns");
@@ -979,12 +991,13 @@ mod tests {
                 .experimental_index_method(true)
                 .experimental_materialized_views(true)
                 .experimental_vacuum(true)
+                .experimental_autovacuum(true)
                 .experimental_generated_columns(true)
                 .experimental_multiprocess_wal(true)
                 .experimental_without_rowid(true)
                 .experimental_features_string()
                 .as_deref(),
-            Some("attach,custom_types,index_method,views,vacuum,generated_columns,multiprocess_wal,without_rowid")
+            Some("attach,custom_types,index_method,views,vacuum,autovacuum,generated_columns,multiprocess_wal,without_rowid")
         );
     }
 


### PR DESCRIPTION
The engine already implements autovacuum end to end (`DatabaseOpts::with_autovacuum`), the experimental-features parser accepts the `"autovacuum"` token (`sdk-kit/src/rsapi.rs`), and the CLI (`--experimental-autovacuum`) and JS binding expose the flag — but neither the local nor the sync Rust `Builder` has a method for it. As a result, Rust binding users cannot open an autovacuum-enabled database read-write: the engine's open gate forces such databases read-only unless the flag is set, and there is no public way to set it.

This adds `experimental_autovacuum(bool)` to both Builders, mirroring `experimental_vacuum` in shape and placement, and emits the token in the experimental-features string. Additive only; default off; no behavior change for existing callers.

Tests:
- New `test_experimental_autovacuum_gates_readonly` in `bindings/rust/src/lib.rs`: a database with autovacuum persisted in its header (fixture written via `rusqlite`, the same way `tests/integration/storage/autovacuum.rs` does) is forced read-only when opened without the flag and writable with it. `rusqlite` added as a dev-dependency (already a workspace dependency).
- `experimental_features_string_composition` in `sync.rs` extended to cover the new token.

`cargo fmt` clean; `cargo test -p turso --lib` and the sync composition test pass. (`cargo clippy --all-features` fails on current `main` in `turso_core` with an unfulfilled `expect` lint on my toolchain — pre-existing, unrelated to this change.)