### PR TITLE
core/vector: set C-dependent simsimd as an opt-out feature

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ name = "turso_core"
 path = "lib.rs"
 
 [features]
-default = ["fs", "uuid", "time", "json", "series", "encryption", "percentile"]
+default = ["fs", "uuid", "time", "json", "series", "encryption", "percentile", "simd"]
 tracing_release = ["tracing/release_max_level_info"]
 conn_raw_api = []
 fs = ["turso_ext/vfs"]
@@ -46,6 +46,7 @@ codspeed = ["bench"]
 optimizer_params = ["serde", "dep:serde_json"]
 stacker = ["dep:stacker"]
 percentile = []
+simd = ["dep:simsimd"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61.2", features = [
@@ -133,7 +134,7 @@ num-traits = "0.2"
 stacker = { version = "0.1", optional = true }
 
 [target.'cfg(not(any(target_family = "wasm", all(target_os = "windows", target_arch = "aarch64"))))'.dependencies]
-simsimd = "6.5.3"
+simsimd = { version = "6.5.3", optional = true }
 
 [target.'cfg(antithesis)'.dependencies]
 antithesis_sdk = { workspace = true, features = ["full"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,6 +26,7 @@ default = [
     "encryption",
     "percentile",
     "autovacuum",
+    "simd",
 ]
 tracing_release = ["tracing/release_max_level_info"]
 conn_raw_api = []
@@ -60,6 +61,7 @@ codspeed = ["bench"]
 optimizer_params = ["serde", "dep:serde_json"]
 stacker = ["dep:stacker"]
 percentile = []
+simd = ["dep:simsimd"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [
@@ -149,7 +151,7 @@ num-traits = "0.2"
 stacker = { version = "0.1", optional = true }
 
 [target.'cfg(not(any(target_family = "wasm", all(target_os = "windows", target_arch = "aarch64"))))'.dependencies]
-simsimd = "6.5.3"
+simsimd = { version = "6.5.3", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 # From fastbloom/rand

--- a/core/vector/operations/distance_cos.rs
+++ b/core/vector/operations/distance_cos.rs
@@ -2,10 +2,13 @@ use crate::{
     vector::vector_types::{Vector, VectorSparse, VectorType},
     LimboError, Result,
 };
-#[cfg(not(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-)))]
+#[cfg(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+))]
 use simsimd::SpatialSimilarity;
 
 pub fn vector_distance_cos(v1: &Vector, v2: &Vector) -> Result<f64> {
@@ -78,10 +81,13 @@ fn vector_f8_distance_cos(v1: &Vector, v2: &Vector) -> f64 {
 }
 
 #[allow(dead_code)]
-#[cfg(not(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-)))]
+#[cfg(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+))]
 fn vector_f32_distance_cos_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
     f32::cosine(v1, v2).unwrap_or(f64::NAN)
 }
@@ -102,19 +108,25 @@ fn vector_f32_distance_cos_rust(v1: &[f32], v2: &[f32]) -> f64 {
 }
 
 #[allow(dead_code)]
-#[cfg(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-))]
+#[cfg(not(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+)))]
 fn vector_f32_distance_cos_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
     vector_f32_distance_cos_rust(v1, v2)
 }
 
 #[allow(dead_code)]
-#[cfg(not(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-)))]
+#[cfg(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+))]
 fn vector_f64_distance_cos_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
     f64::cosine(v1, v2).unwrap_or(f64::NAN)
 }
@@ -135,10 +147,13 @@ fn vector_f64_distance_cos_rust(v1: &[f64], v2: &[f64]) -> f64 {
 }
 
 #[allow(dead_code)]
-#[cfg(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-))]
+#[cfg(not(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+)))]
 fn vector_f64_distance_cos_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
     vector_f64_distance_cos_rust(v1, v2)
 }

--- a/core/vector/operations/distance_cos.rs
+++ b/core/vector/operations/distance_cos.rs
@@ -101,8 +101,14 @@ fn vector_f32_distance_cos_rust(v1: &[f32], v2: &[f32]) -> f64 {
         norm1 += a * a;
         norm2 += b * b;
     }
-    if norm1 == 0.0 || norm2 == 0.0 {
+    // simsimd calls two zero vectors identical, and a zero vector maximally
+    // distant from any other vector. Match it so the fallback and the SIMD
+    // path agree.
+    if norm1 == 0.0 && norm2 == 0.0 {
         return 0.0;
+    }
+    if dot == 0.0 {
+        return 1.0;
     }
     (1.0 - dot / (norm1 * norm2).sqrt()) as f64
 }
@@ -140,8 +146,14 @@ fn vector_f64_distance_cos_rust(v1: &[f64], v2: &[f64]) -> f64 {
         norm1 += a * a;
         norm2 += b * b;
     }
-    if norm1 == 0.0 || norm2 == 0.0 {
+    // simsimd calls two zero vectors identical, and a zero vector maximally
+    // distant from any other vector. Match it so the fallback and the SIMD
+    // path agree.
+    if norm1 == 0.0 && norm2 == 0.0 {
         return 0.0;
+    }
+    if dot == 0.0 {
+        return 1.0;
     }
     1.0 - dot / (norm1 * norm2).sqrt()
 }
@@ -228,6 +240,18 @@ mod tests {
         assert!(vector_f64_distance_cos_simsimd(&[1.0, 2.0], &[1.0, 2.0]).abs() < 1e-6);
         assert!((vector_f64_distance_cos_simsimd(&[1.0, 2.0], &[-1.0, -2.0]) - 2.0).abs() < 1e-6);
         assert!((vector_f64_distance_cos_simsimd(&[1.0, 2.0], &[-2.0, 1.0]) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_vector_distance_cos_f32_rust_zero_vectors() {
+        assert_eq!(vector_f32_distance_cos_rust(&[], &[]), 0.0);
+        assert_eq!(vector_f32_distance_cos_rust(&[1.0, 2.0], &[0.0, 0.0]), 1.0);
+    }
+
+    #[test]
+    fn test_vector_distance_cos_f64_rust_zero_vectors() {
+        assert_eq!(vector_f64_distance_cos_rust(&[], &[]), 0.0);
+        assert_eq!(vector_f64_distance_cos_rust(&[1.0, 2.0], &[0.0, 0.0]), 1.0);
     }
 
     #[test]

--- a/core/vector/operations/distance_dot.rs
+++ b/core/vector/operations/distance_dot.rs
@@ -2,10 +2,13 @@ use crate::{
     vector::vector_types::{Vector, VectorSparse, VectorType},
     LimboError, Result,
 };
-#[cfg(not(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-)))]
+#[cfg(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+))]
 use simsimd::SpatialSimilarity;
 
 pub fn vector_distance_dot(v1: &Vector, v2: &Vector) -> Result<f64> {
@@ -76,10 +79,13 @@ fn vector_f8_distance_dot(v1: &Vector, v2: &Vector) -> f64 {
 }
 
 #[allow(dead_code)]
-#[cfg(not(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-)))]
+#[cfg(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+))]
 fn vector_f32_distance_dot_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
     -f32::dot(v1, v2).unwrap_or(f64::NAN)
 }
@@ -95,19 +101,25 @@ fn vector_f32_distance_dot_rust(v1: &[f32], v2: &[f32]) -> f64 {
 }
 
 #[allow(dead_code)]
-#[cfg(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-))]
+#[cfg(not(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+)))]
 fn vector_f32_distance_dot_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
     vector_f32_distance_dot_rust(v1, v2)
 }
 
 #[allow(dead_code)]
-#[cfg(not(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-)))]
+#[cfg(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+))]
 fn vector_f64_distance_dot_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
     -f64::dot(v1, v2).unwrap_or(f64::NAN)
 }
@@ -123,10 +135,13 @@ fn vector_f64_distance_dot_rust(v1: &[f64], v2: &[f64]) -> f64 {
 }
 
 #[allow(dead_code)]
-#[cfg(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-))]
+#[cfg(not(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+)))]
 fn vector_f64_distance_dot_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
     vector_f64_distance_dot_rust(v1, v2)
 }

--- a/core/vector/operations/distance_l2.rs
+++ b/core/vector/operations/distance_l2.rs
@@ -2,10 +2,13 @@ use crate::{
     vector::vector_types::{Vector, VectorSparse, VectorType},
     LimboError, Result,
 };
-#[cfg(not(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-)))]
+#[cfg(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+))]
 use simsimd::SpatialSimilarity;
 
 pub fn vector_distance_l2(v1: &Vector, v2: &Vector) -> Result<f64> {
@@ -53,10 +56,13 @@ fn vector_f8_distance_l2(v1: &Vector, v2: &Vector) -> f64 {
 }
 
 #[allow(dead_code)]
-#[cfg(not(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-)))]
+#[cfg(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+))]
 fn vector_f32_distance_l2_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
     f32::euclidean(v1, v2).unwrap_or(f64::NAN)
 }
@@ -73,19 +79,25 @@ fn vector_f32_distance_l2_rust(v1: &[f32], v2: &[f32]) -> f64 {
 }
 
 #[allow(dead_code)]
-#[cfg(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-))]
+#[cfg(not(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+)))]
 fn vector_f32_distance_l2_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
     vector_f32_distance_l2_rust(v1, v2)
 }
 
 #[allow(dead_code)]
-#[cfg(not(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-)))]
+#[cfg(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+))]
 fn vector_f64_distance_l2_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
     f64::euclidean(v1, v2).unwrap_or(f64::NAN)
 }
@@ -102,10 +114,13 @@ fn vector_f64_distance_l2_rust(v1: &[f64], v2: &[f64]) -> f64 {
 }
 
 #[allow(dead_code)]
-#[cfg(any(
-    target_family = "wasm",
-    all(target_os = "windows", target_arch = "aarch64")
-))]
+#[cfg(not(all(
+    feature = "simd",
+    not(any(
+        target_family = "wasm",
+        all(target_os = "windows", target_arch = "aarch64")
+    ))
+)))]
 fn vector_f64_distance_l2_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
     vector_f64_distance_l2_rust(v1, v2)
 }


### PR DESCRIPTION
## Description

Makes simsimd optional feature and includes it under 'default' features.

When turned off, relies on the pure-Rust fallback already available for WASM and windows-aarch64.

Fixes #7660 partly


## Motivation and context

`turso_core` could be a perfect replacement as a pure-alternative to `rusqlite`, but `turso_core` is not pure Rust by default, due to `aegis` and `simsimd` depending on C functionality. On Android, this requires a painful setup of Android NDK. `aegis` can already be used in pure Rust when `features = ["pure-rust-crypto"]` is set, but this is not possible for `simsimd`. A pure Rust implementation already exists, and WASM and windows-aarch64, but these are automatic fallbacks not available for an Android build.

Fixes #7660 partly

Additional - why `turso_core` instead of `turso`: My app has the SQLite DB on-device, only a single user, and threading (calls to Rust code) is arranged from Kotlin. Therefore, I want to keep the Rust code simple and avoid `Tokio` dependency for `async`.


## Description of AI Usage

Asked Claude code to investigate if `simsimd` could be set to optional, so I could use `turso_core` as pure Rust (I don't need Vector search for my app). It quickly discovered the mechanics were already there to set it to pure Rust, just not available behind a feature flag.