### PR TITLE
fix(serverless-js): batch() rows expose positional access like execute()

### DIFF
--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -419,14 +419,6 @@ export class Session {
     return row;
   }
 
-  createObjectRow(values: any[], columns: string[]): any {
-    const row: any = {};
-    columns.forEach((column, index) => {
-      row[column] = values[index];
-    });
-    return row;
-  }
-
   /**
    * Execute multiple SQL statements in a batch.
    *
@@ -585,7 +577,7 @@ export class Session {
             const decodedRow = entry.row.map(value => decodeValue(value, safeIntegers));
             const row = raw
               ? decodedRow
-              : this.createObjectRow(decodedRow, results[currentResultIdx].columns);
+              : this.createRowObject(decodedRow, results[currentResultIdx].columns);
             results[currentResultIdx].rows.push(row);
           }
           break;

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -171,7 +171,12 @@ test.serial("Database.batch() [SELECT rows expose Statement.all() object shape]"
   t.is(rs.rows.length, 1);
 
   const row = rs.rows[0];
-  t.false(Array.isArray(row));
+  // batch() rows must expose the same dual access as execute()/Statement.all()
+  // rows: both positional (row[0]) and named (row.name). This is the contract
+  // the embedded driver honours, and serverless must match it.
+  t.is(row[0], 1);
+  t.is(row[1], "Alice");
+  t.is(row[2], "alice@example.org");
   t.is(row.id, 1);
   t.is(row.name, "Alice");
   t.is(row.email, "alice@example.org");


### PR DESCRIPTION
## What

The serverless JavaScript driver's `batch()` shaped result rows differently from its own `execute()` and from the embedded `@tursodatabase/database` driver, silently breaking positional access.

For `SELECT 10 AS a, 20 AS b` (default, no `raw`):

| source | `Array.isArray(row)` | `row[0]` | `row.a` |
|---|---|---|---|
| embedded `execute()` | false | 10 ✅ | 10 ✅ |
| embedded `batch()`   | false | 10 ✅ | 10 ✅ |
| serverless `execute()` | true | 10 ✅ | 10 ✅ |
| **serverless `batch()`** (before) | false | **undefined ❌** | 10 ✅ |

`execute()` shapes rows with `createRowObject` (an array with named properties → both `row[0]` and `row.name` work), but `batch()` used `createObjectRow` (a plain object → named access only). Any code reading batch results positionally got `undefined`.

## Fix

Shape `batch()` non-raw rows with `createRowObject`, matching `execute()`. `raw` mode still returns bare arrays. `createObjectRow` had no other callers and is removed. `execute()` is untouched.

After the fix, serverless `batch()` rows support both positional and named access, consistent with serverless `execute()` and with the embedded driver.

## Test

Strengthens the existing provider-parameterized conformance test `Database.batch() [SELECT rows expose Statement.all() object shape]` in `testing/conformance/javascript/`. It previously asserted `t.false(Array.isArray(row))` — an implementation detail that conflicts with the fix and that serverless `execute()` rows already violate. It now asserts the actual cross-provider contract: dual access (positional `row[0]` **and** named `row.name`). Passes on both `PROVIDER=turso` (embedded) and `PROVIDER=serverless`.

## Note / out of scope

This makes serverless `batch()` match serverless `execute()` and the embedded driver's **access patterns**. It does not close a separate, pre-existing difference: serverless rows are true `Array`s (`Array.isArray === true`) while the embedded driver's rows are non-array objects (both still support `[0]` + named). That broader shape difference affects `execute()` too and is left as a follow-up design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
