### PR TITLE
bindings/js, serverless/js: collapse duplicate column names in expanded rows

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -50,9 +50,12 @@ jobs:
       - name: Install test dependencies
         working-directory: testing/conformance/javascript
         run: npm install
-      - name: Run conformance tests
+      - name: Run conformance tests against Turso
         working-directory: testing/conformance/javascript
         run: npm run test:turso
+      - name: Run conformance tests against better-sqlite3
+        working-directory: testing/conformance/javascript
+        run: npm run test:better-sqlite3
 
   sqlite-tcl:
     name: SQLite TCL conformance tests

--- a/bindings/javascript/packages/native/compat.test.ts
+++ b/bindings/javascript/packages/native/compat.test.ts
@@ -48,18 +48,21 @@ test('exec multiple statements', async () => {
     expect(rows).toEqual([{ x: 1 }, { x: 2 }]);
 })
 
-test('expanded rows preserve positional values for duplicate column names', () => {
+test('expanded rows collapse duplicate column names like better-sqlite3', () => {
     const db = new Database(":memory:");
     db.exec("CREATE TABLE role(path TEXT); CREATE TABLE org_unit(path TEXT)");
     db.exec("INSERT INTO role VALUES ('/Employee'); INSERT INTO org_unit VALUES ('/')");
 
-    const row = db.prepare("SELECT role.path, org_unit.path FROM role JOIN org_unit").get();
+    const stmt = db.prepare("SELECT role.path, org_unit.path FROM role JOIN org_unit");
+    const row = stmt.get();
 
     expect(Object.keys(row)).toEqual(["path"]);
     expect(row.path).toBe("/");
-    expect(row[0]).toBe("/Employee");
-    expect(row[1]).toBe("/");
+    expect(row[0]).toBe(undefined);
+    expect(row[1]).toBe(undefined);
     expect(row).toEqual({ path: "/" });
+
+    expect(stmt.raw(true).get()).toEqual(["/Employee", "/"]);
 })
 
 test('readonly-db', () => {

--- a/bindings/javascript/packages/native/promise.test.ts
+++ b/bindings/javascript/packages/native/promise.test.ts
@@ -39,7 +39,7 @@ test('exec multiple statements', async () => {
     expect(rows).toEqual([{ x: 1 }, { x: 2 }]);
 })
 
-test('expanded rows preserve positional values for duplicate column names', async () => {
+test('expanded rows collapse duplicate column names like better-sqlite3', async () => {
     const db = await connect(":memory:");
     await db.exec("CREATE TABLE role(path TEXT); CREATE TABLE org_unit(path TEXT)");
     await db.exec("INSERT INTO role VALUES ('/Employee'); INSERT INTO org_unit VALUES ('/')");
@@ -48,9 +48,12 @@ test('expanded rows preserve positional values for duplicate column names', asyn
 
     expect(Object.keys(row)).toEqual(["path"]);
     expect(row.path).toBe("/");
-    expect(row[0]).toBe("/Employee");
-    expect(row[1]).toBe("/");
+    expect(row[0]).toBe(undefined);
+    expect(row[1]).toBe(undefined);
     expect(row).toEqual({ path: "/" });
+
+    const stmt = await db.prepare("SELECT role.path, org_unit.path FROM role JOIN org_unit");
+    expect(await stmt.raw(true).get()).toEqual(["/Employee", "/"]);
 })
 
 test('readonly-db', async () => {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -863,10 +863,9 @@ impl Statement {
                 to_js_value(env, value, safe_integers)?
             }
             PresentationMode::Expanded => {
-                let mut row = Object::new(env)?;
+                let row = Object::new(env)?;
                 let raw_row = row.raw();
                 let raw_env = env.raw();
-                let mut positional_properties = Vec::with_capacity(row_data.len());
                 for idx in 0..row_data.len() {
                     let value = row_data.get_value(idx);
                     let column_name = &self.column_names[idx];
@@ -879,16 +878,7 @@ impl Statement {
                             js_value.raw(),
                         )
                     })?;
-                    positional_properties.push(
-                        Property::new()
-                            .with_utf8_name(&idx.to_string())?
-                            .with_value(&js_value)
-                            .with_property_attributes(
-                                PropertyAttributes::Writable | PropertyAttributes::Configurable,
-                            ),
-                    );
                 }
-                row.define_properties(&positional_properties)?;
                 row.to_unknown()
             }
         };

--- a/serverless/javascript/src/row.ts
+++ b/serverless/javascript/src/row.ts
@@ -3,12 +3,6 @@ export function createExpandedRow(row: any[], columns: string[]): any {
 
   columns.forEach((column, index) => {
     expanded[column] = row[index];
-    Object.defineProperty(expanded, String(index), {
-      value: row[index],
-      enumerable: false,
-      writable: true,
-      configurable: true,
-    });
   });
 
   return expanded;

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -799,7 +799,7 @@ test.serial("Statement.get() [raw]", async (t) => {
   t.deepEqual(await stmt.raw().get(1), [1, "Alice", "alice@example.org"]);
 });
 
-test.serial("Database.all() preserves positional values for duplicate column names", async (t) => {
+test.serial("Database.all() collapses duplicate column names", async (t) => {
   const db = t.context.db;
 
   await db.exec("DROP TABLE IF EXISTS role; DROP TABLE IF EXISTS org_unit");
@@ -810,9 +810,12 @@ test.serial("Database.all() preserves positional values for duplicate column nam
 
   t.deepEqual(Object.keys(row), ["path"]);
   t.is(row.path, "/");
-  t.is(row[0], "/Employee");
-  t.is(row[1], "/");
+  t.is(row[0], undefined);
+  t.is(row[1], undefined);
   t.deepEqual(row, { path: "/" });
+
+  const stmt = await db.prepare("SELECT role.path, org_unit.path FROM role JOIN org_unit");
+  t.deepEqual(await stmt.raw().get(), ["/Employee", "/"]);
 });
 
 test.serial("Statement.get() values", async (t) => {

--- a/testing/conformance/javascript/__test__/sync.test.js
+++ b/testing/conformance/javascript/__test__/sync.test.js
@@ -430,20 +430,23 @@ test.serial("Statement.get() [raw]", async (t) => {
   t.deepEqual(stmt.raw().get(1), [1, "Alice", "alice@example.org"]);
 });
 
-test.serial("Statement.get() preserves positional values for duplicate column names", async (t) => {
+test.serial("Statement.get() collapses duplicate column names", async (t) => {
   const db = t.context.db;
 
   db.exec("DROP TABLE IF EXISTS role; DROP TABLE IF EXISTS org_unit");
   db.exec("CREATE TABLE role(path TEXT); CREATE TABLE org_unit(path TEXT)");
   db.exec("INSERT INTO role VALUES ('/Employee'); INSERT INTO org_unit VALUES ('/')");
 
-  const row = db.prepare("SELECT role.path, org_unit.path FROM role JOIN org_unit").get();
+  const stmt = db.prepare("SELECT role.path, org_unit.path FROM role JOIN org_unit");
+  const row = stmt.get();
 
   t.deepEqual(Object.keys(row), ["path"]);
   t.is(row.path, "/");
-  t.is(row[0], "/Employee");
-  t.is(row[1], "/");
+  t.is(row[0], undefined);
+  t.is(row[1], undefined);
   t.deepEqual(row, { path: "/" });
+
+  t.deepEqual(stmt.raw().get(), ["/Employee", "/"]);
 });
 
 test.serial("Statement.get() values", async (t) => {


### PR DESCRIPTION
Expanded rows grew hidden non-enumerable positional properties ("0",
"1", ...) in 4c0febfed ("Preserve JS row positional values") to work
around duplicate column names collapsing in object rows. That is a
Turso-only extension: neither better-sqlite3 nor libsql attaches
positional keys to expanded rows, so the conformance suite failed under
PROVIDER=better-sqlite3 and PROVIDER=libsql, and a result column
literally named "0" would collide with the synthetic property.

Remove the positional properties from the native binding's expanded row
mode and the serverless driver's createExpandedRow so expanded rows are
plain objects where duplicate names collapse, exactly like
better-sqlite3 and libsql. Positional access remains available through
raw mode, and the libsql-client compat surface keeps its genuine hybrid
rows built by Session.createRowObject.

The divergence went unnoticed because CI only ran the conformance suite
under PROVIDER=turso; the workflow now also runs it against
better-sqlite3 so drop-in incompatibilities fail in CI.

Tests: rewrote the positional-value tests to assert the collapsing
behavior plus raw-mode access, so they pass identically under the
turso, better-sqlite3, and libsql providers.
