### PR TITLE
postgres: add sqltest pg backend and conformance corpus

### DIFF
--- a/.github/workflows/sqltest.yml
+++ b/.github/workflows/sqltest.yml
@@ -28,6 +28,8 @@ jobs:
         run: make -C sqlite/conformance build-runner
       - name: Check test syntax
         run: make -C sqlite/conformance check
+      - name: Check pg test syntax
+        run: make -C postgres/conformance check
 
   sqltest-run-cli:
     name: Run SQL tests (CLI backend)
@@ -97,6 +99,22 @@ jobs:
       - name: Run tests (MVCC)
         working-directory: sqlite/conformance
         run: make run-js MVCC=1
+
+  sqltest-run-pg:
+    name: Run SQL tests (pg backend)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: useblacksmith/rust-cache@v3
+        with:
+          prefix-key: "v1-rust"
+      - name: Build tursopg
+        run: make -C postgres/conformance build-tursopg
+      - name: Build test runner
+        run: make -C postgres/conformance build-runner
+      - name: Run tests
+        run: make -C postgres/conformance run
 
   sqltest-sqlite:
     name: Run SQL tests (SQLite)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Default: add coverage to the narrowest existing test harness that can express th
 - `sqlite/conformance/sqlite-sqltests/` - preferred for SQL conformance coverage. These tests run the same scenario against both Turso and SQLite, so use them first for parser, planner, executor, and SQL semantics work that fits the `.sqltest` DSL.
 - `tests/integration/` - primary fallback when the behavior cannot be expressed cleanly in `.sqltest`. Put API-level regressions, multi-connection orchestration, storage assertions, injected failures, timeout behavior, and other Rust-driven scenarios here.
 - `sqlite/conformance/upstream/` - imported upstream SQLite golden tests. Do not modify these for Turso behavior changes; use them as fixed compatibility coverage, and only touch them for intentional upstream sync or harness maintenance.
+- `postgres/conformance/pg-sqltests/` - `.sqltest` coverage for the PostgreSQL frontend, run via `make -C postgres/conformance run` (spawns a tursopg server per test and drives it over the wire protocol). Only assert behavior real PostgreSQL also exhibits, so the corpus stays valid for differential runs.
 - `testing/cli_tests/` - CLI-focused Python coverage for shell behavior and end-to-end command workflows.
 - `tests/fuzz/` - minimized fuzz regressions and targeted edge cases that are easier to keep as Rust tests.
 - `testing/simulator/` and `testing/concurrent-simulator/` - deterministic concurrency, scheduling, and failure-injection coverage for state-machine and I/O correctness.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6182,6 +6182,7 @@ dependencies = [
  "tokio",
  "turso",
  "turso_parser",
+ "turso_pg_client",
 ]
 
 [[package]]
@@ -7344,6 +7345,13 @@ dependencies = [
  "turso_ext",
  "turso_parser",
  "turso_pg_parser",
+]
+
+[[package]]
+name = "turso_pg_client"
+version = "0.8.0-pre.1"
+dependencies = [
+ "thiserror 2.0.16",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "tests",
     "sqlite/parser",
     "postgres/cli",
+    "postgres/client",
     "postgres/frontend",
     "postgres/parser",
     "postgres/regress",
@@ -111,6 +112,7 @@ turso_ext = { path = "extensions/core", version = "0.8.0-pre.1" }
 turso_macros = { path = "macros", version = "0.8.0-pre.1" }
 turso_parser = { path = "sqlite/parser", version = "0.8.0-pre.1" }
 turso_pg = { path = "postgres/frontend", version = "0.8.0-pre.1" }
+turso_pg_client = { path = "postgres/client", version = "0.8.0-pre.1" }
 turso_pg_parser = { path = "postgres/parser", version = "0.8.0-pre.1" }
 turso_pg_server = { path = "postgres/server", version = "0.8.0-pre.1" }
 sql_generation = { path = "sql_generation" }

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ test-sqltest-cli:
 	@make -C sqlite/conformance run-cli
 .PHONY: test-sqltest-cli
 
+test-sqltest-pg:
+	@make -C postgres/conformance run
+.PHONY: test-sqltest-pg
+
 test-extensions: build uv-sync-test
 	RUST_LOG=$(RUST_LOG) uv run --project limbo_test test-extensions
 .PHONY: test-extensions

--- a/postgres/client/Cargo.toml
+++ b/postgres/client/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "turso_pg_client"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Minimal PostgreSQL wire-protocol client for Turso test tooling"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/postgres/client/lib.rs
+++ b/postgres/client/lib.rs
@@ -1,0 +1,470 @@
+// Copyright 2023-2026 the Turso authors. All rights reserved. MIT license.
+
+//! Minimal synchronous PostgreSQL wire-protocol client.
+//!
+//! This crate exists for Turso's test tooling: the sqltest runner's `pg`
+//! backend and the upstream regression-test runner both drive `tursopg`
+//! (or a real PostgreSQL server) over the simple query protocol. It speaks
+//! protocol 3.0 over TCP, handles the startup handshake with optional
+//! cleartext password authentication, and decodes the backend messages the
+//! simple query protocol produces. Values are returned in the text format
+//! the server sent them in; no type conversion is attempted.
+//!
+//! The API has two levels: [`PgConn::read_message`] returns raw
+//! `(tag, body)` frames for callers that need full control over rendering
+//! (the regression runner reproduces psql transcripts byte-for-byte), and
+//! [`PgConn::read_event`] / [`PgConn::simple_query`] decode the frames for
+//! callers that just want rows and errors.
+
+use std::collections::HashMap;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+/// Errors produced by the client.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
+    #[error("connection rejected: {0}")]
+    Rejected(String),
+
+    #[error("invalid DSN: {0}")]
+    Dsn(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error and notice fields keyed by their single-byte field code
+/// (`'S'` severity, `'M'` message, `'P'` position, ...).
+pub type ErrorFields = HashMap<u8, String>;
+
+/// Returns the human-readable message of an error response, if present.
+pub fn error_message(fields: &ErrorFields) -> &str {
+    fields.get(&b'M').map(String::as_str).unwrap_or("unknown")
+}
+
+/// One column of a `RowDescription` message.
+#[derive(Debug, Clone)]
+pub struct Column {
+    pub name: String,
+    pub type_oid: u32,
+}
+
+/// A decoded backend message.
+#[derive(Debug)]
+pub enum BackendEvent {
+    RowDescription(Vec<Column>),
+    DataRow(Vec<Option<String>>),
+    CommandComplete(String),
+    EmptyQueryResponse,
+    ErrorResponse(ErrorFields),
+    NoticeResponse(ErrorFields),
+    /// Transaction status byte: `'I'` idle, `'T'` in transaction, `'E'` failed.
+    ReadyForQuery(u8),
+    /// A message this client does not interpret (ParameterStatus,
+    /// BackendKeyData, notifications, ...), by tag.
+    Other(u8),
+}
+
+/// Connection parameters, typically parsed from a DSN.
+#[derive(Debug, Clone)]
+pub struct ConnParams {
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub password: Option<String>,
+    pub database: String,
+}
+
+impl ConnParams {
+    /// Parses a `postgres://[user[:password]@]host[:port][/database]` DSN.
+    pub fn parse(dsn: &str) -> Result<ConnParams> {
+        let rest = dsn
+            .strip_prefix("postgres://")
+            .or_else(|| dsn.strip_prefix("postgresql://"))
+            .ok_or_else(|| Error::Dsn(format!("DSN must start with postgres://, got {dsn}")))?;
+        let (authority, database) = match rest.split_once('/') {
+            Some((a, db)) => (a, db.split('?').next().unwrap_or(db)),
+            None => (rest, "postgres"),
+        };
+        let (userinfo, hostport) = match authority.rsplit_once('@') {
+            Some((u, h)) => (Some(u), h),
+            None => (None, authority),
+        };
+        let (user, password) = match userinfo {
+            Some(u) => match u.split_once(':') {
+                Some((user, pass)) => (user.to_string(), Some(pass.to_string())),
+                None => (u.to_string(), None),
+            },
+            None => (
+                std::env::var("USER").unwrap_or_else(|_| "postgres".to_string()),
+                None,
+            ),
+        };
+        let (host, port) = match hostport.rsplit_once(':') {
+            Some((h, p)) => (
+                h.to_string(),
+                p.parse()
+                    .map_err(|_| Error::Dsn(format!("bad port in DSN: {p}")))?,
+            ),
+            None => (hostport.to_string(), 5432),
+        };
+        Ok(ConnParams {
+            host,
+            port,
+            user,
+            password,
+            database: database.to_string(),
+        })
+    }
+}
+
+/// A connection to a PostgreSQL-protocol server.
+pub struct PgConn {
+    reader: BufReader<TcpStream>,
+    writer: BufWriter<TcpStream>,
+}
+
+impl PgConn {
+    /// Connects and performs the startup handshake. `extra_startup` entries
+    /// are sent as additional startup parameters after `user` and `database`
+    /// (e.g. `application_name`, `datestyle`, or `options`).
+    pub fn connect(params: &ConnParams, extra_startup: &[(&str, &str)]) -> Result<PgConn> {
+        let stream = TcpStream::connect((params.host.as_str(), params.port))?;
+        let reader = BufReader::new(stream.try_clone()?);
+        let writer = BufWriter::new(stream);
+        let mut conn = PgConn { reader, writer };
+
+        let mut startup = Vec::new();
+        startup.extend_from_slice(&196608u32.to_be_bytes()); // protocol 3.0
+        let base: &[(&str, &str)] = &[
+            ("user", params.user.as_str()),
+            ("database", params.database.as_str()),
+        ];
+        for (k, v) in base.iter().chain(extra_startup) {
+            startup.extend_from_slice(k.as_bytes());
+            startup.push(0);
+            startup.extend_from_slice(v.as_bytes());
+            startup.push(0);
+        }
+        startup.push(0);
+        conn.writer
+            .write_all(&((startup.len() as u32 + 4).to_be_bytes()))?;
+        conn.writer.write_all(&startup)?;
+        conn.writer.flush()?;
+
+        loop {
+            let (tag, body) = conn.read_message()?;
+            match tag {
+                b'R' => {
+                    let mut r = Reader::new(&body);
+                    match r.u32()? {
+                        0 => {} // AuthenticationOk
+                        3 => {
+                            // Cleartext password.
+                            let password = params.password.as_deref().ok_or_else(|| {
+                                Error::Rejected(
+                                    "server requested a password but none was given".to_string(),
+                                )
+                            })?;
+                            let mut msg = Vec::from(password.as_bytes());
+                            msg.push(0);
+                            conn.write_message(b'p', &msg)?;
+                        }
+                        method => {
+                            return Err(Error::Protocol(format!(
+                                "unsupported authentication method {method}"
+                            )));
+                        }
+                    }
+                }
+                b'S' | b'K' | b'N' => {} // ParameterStatus, BackendKeyData, notices
+                b'Z' => return Ok(conn),
+                b'E' => {
+                    let fields = parse_error_fields(&body)?;
+                    return Err(Error::Rejected(error_message(&fields).to_string()));
+                }
+                other => {
+                    return Err(Error::Protocol(format!(
+                        "unexpected message {:?} during startup",
+                        other as char
+                    )));
+                }
+            }
+        }
+    }
+
+    /// Sets a read timeout on the underlying socket. Blocking reads past the
+    /// deadline fail with an I/O error, after which the connection's protocol
+    /// state is indeterminate and it should be discarded.
+    pub fn set_read_timeout(&self, timeout: Option<Duration>) -> Result<()> {
+        self.reader.get_ref().set_read_timeout(timeout)?;
+        Ok(())
+    }
+
+    /// Sends one simple-query message. The string may contain multiple
+    /// semicolon-separated statements; the server executes them in order.
+    pub fn send_query(&mut self, sql: &str) -> Result<()> {
+        let mut body = Vec::from(sql.as_bytes());
+        body.push(0);
+        self.write_message(b'Q', &body)
+    }
+
+    /// Reads one raw backend message frame.
+    pub fn read_message(&mut self) -> Result<(u8, Vec<u8>)> {
+        let mut header = [0u8; 5];
+        self.reader.read_exact(&mut header).map_err(|e| {
+            Error::Protocol(format!(
+                "reading message header (server closed the connection?): {e}"
+            ))
+        })?;
+        let len = u32::from_be_bytes([header[1], header[2], header[3], header[4]]) as usize;
+        if len < 4 {
+            return Err(Error::Protocol(format!("invalid message length {len}")));
+        }
+        let mut body = vec![0u8; len - 4];
+        self.reader
+            .read_exact(&mut body)
+            .map_err(|e| Error::Protocol(format!("reading message body: {e}")))?;
+        Ok((header[0], body))
+    }
+
+    /// Reads and decodes one backend message.
+    pub fn read_event(&mut self) -> Result<BackendEvent> {
+        let (tag, body) = self.read_message()?;
+        Ok(match tag {
+            b'T' => BackendEvent::RowDescription(parse_row_description(&body)?),
+            b'D' => BackendEvent::DataRow(parse_data_row(&body)?),
+            b'C' => {
+                let mut r = Reader::new(&body);
+                BackendEvent::CommandComplete(r.cstring()?)
+            }
+            b'I' => BackendEvent::EmptyQueryResponse,
+            b'E' => BackendEvent::ErrorResponse(parse_error_fields(&body)?),
+            b'N' => BackendEvent::NoticeResponse(parse_error_fields(&body)?),
+            b'Z' => {
+                let mut r = Reader::new(&body);
+                BackendEvent::ReadyForQuery(r.u8()?)
+            }
+            other => BackendEvent::Other(other),
+        })
+    }
+
+    /// Sends `sql` as one simple query and collects every event up to and
+    /// including `ReadyForQuery`.
+    pub fn simple_query(&mut self, sql: &str) -> Result<Vec<BackendEvent>> {
+        self.send_query(sql)?;
+        let mut events = Vec::new();
+        loop {
+            let event = self.read_event()?;
+            let done = matches!(event, BackendEvent::ReadyForQuery(_));
+            events.push(event);
+            if done {
+                return Ok(events);
+            }
+        }
+    }
+
+    fn write_message(&mut self, tag: u8, body: &[u8]) -> Result<()> {
+        self.writer.write_all(&[tag])?;
+        self.writer
+            .write_all(&((body.len() as u32 + 4).to_be_bytes()))?;
+        self.writer.write_all(body)?;
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+/// Parses a `RowDescription` message body.
+pub fn parse_row_description(body: &[u8]) -> Result<Vec<Column>> {
+    let mut r = Reader::new(body);
+    let nfields = r.u16()? as usize;
+    let mut columns = Vec::with_capacity(nfields);
+    for _ in 0..nfields {
+        let name = r.cstring()?;
+        r.skip(4 + 2)?; // table oid, attnum
+        let type_oid = r.u32()?;
+        r.skip(2 + 4 + 2)?; // typlen, typmod, format
+        columns.push(Column { name, type_oid });
+    }
+    Ok(columns)
+}
+
+/// Parses a `DataRow` message body. `None` is SQL NULL; values are returned
+/// as the text the server sent.
+pub fn parse_data_row(body: &[u8]) -> Result<Vec<Option<String>>> {
+    let mut r = Reader::new(body);
+    let ncols = r.u16()? as usize;
+    let mut row = Vec::with_capacity(ncols);
+    for _ in 0..ncols {
+        let len = r.i32()?;
+        if len < 0 {
+            row.push(None);
+        } else {
+            let bytes = r.bytes(len as usize)?;
+            row.push(Some(String::from_utf8_lossy(bytes).into_owned()));
+        }
+    }
+    Ok(row)
+}
+
+/// Parses an `ErrorResponse` or `NoticeResponse` message body.
+pub fn parse_error_fields(body: &[u8]) -> Result<ErrorFields> {
+    let mut r = Reader::new(body);
+    let mut fields = HashMap::new();
+    loop {
+        let code = r.u8()?;
+        if code == 0 {
+            return Ok(fields);
+        }
+        fields.insert(code, r.cstring()?);
+    }
+}
+
+/// Cursor over a message body.
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Reader<'a> {
+        Reader { buf, pos: 0 }
+    }
+
+    fn bytes(&mut self, n: usize) -> Result<&'a [u8]> {
+        let end = self.pos.checked_add(n).filter(|&e| e <= self.buf.len());
+        let end = end.ok_or_else(|| Error::Protocol("truncated message".to_string()))?;
+        let s = &self.buf[self.pos..end];
+        self.pos = end;
+        Ok(s)
+    }
+
+    fn skip(&mut self, n: usize) -> Result<()> {
+        self.bytes(n).map(|_| ())
+    }
+
+    fn u8(&mut self) -> Result<u8> {
+        Ok(self.bytes(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16> {
+        Ok(u16::from_be_bytes(self.bytes(2)?.try_into().unwrap()))
+    }
+
+    fn u32(&mut self) -> Result<u32> {
+        Ok(u32::from_be_bytes(self.bytes(4)?.try_into().unwrap()))
+    }
+
+    fn i32(&mut self) -> Result<i32> {
+        Ok(i32::from_be_bytes(self.bytes(4)?.try_into().unwrap()))
+    }
+
+    fn cstring(&mut self) -> Result<String> {
+        let start = self.pos;
+        let nul = self.buf[start..]
+            .iter()
+            .position(|&b| b == 0)
+            .ok_or_else(|| Error::Protocol("unterminated string in message".to_string()))?;
+        let s = String::from_utf8_lossy(&self.buf[start..start + nul]).into_owned();
+        self.pos = start + nul + 1;
+        Ok(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_dsn_full() {
+        let p = ConnParams::parse("postgres://alice:secret@db.example.com:5433/mydb").unwrap();
+        assert_eq!(p.host, "db.example.com");
+        assert_eq!(p.port, 5433);
+        assert_eq!(p.user, "alice");
+        assert_eq!(p.password.as_deref(), Some("secret"));
+        assert_eq!(p.database, "mydb");
+    }
+
+    #[test]
+    fn parse_dsn_minimal() {
+        let p = ConnParams::parse("postgres://localhost").unwrap();
+        assert_eq!(p.host, "localhost");
+        assert_eq!(p.port, 5432);
+        assert_eq!(p.database, "postgres");
+        assert_eq!(p.password, None);
+    }
+
+    #[test]
+    fn parse_dsn_query_string_ignored() {
+        let p = ConnParams::parse("postgresql://h/db?sslmode=disable").unwrap();
+        assert_eq!(p.host, "h");
+        assert_eq!(p.database, "db");
+    }
+
+    #[test]
+    fn parse_dsn_rejects_other_schemes() {
+        assert!(ConnParams::parse("mysql://localhost").is_err());
+    }
+
+    #[test]
+    fn parse_row_description_body() {
+        // Two columns: "id" (int4, oid 23) and "name" (text, oid 25).
+        let mut body = Vec::new();
+        body.extend_from_slice(&2u16.to_be_bytes());
+        for (name, oid) in [("id", 23u32), ("name", 25u32)] {
+            body.extend_from_slice(name.as_bytes());
+            body.push(0);
+            body.extend_from_slice(&0u32.to_be_bytes()); // table oid
+            body.extend_from_slice(&0u16.to_be_bytes()); // attnum
+            body.extend_from_slice(&oid.to_be_bytes());
+            body.extend_from_slice(&0u16.to_be_bytes()); // typlen
+            body.extend_from_slice(&0u32.to_be_bytes()); // typmod
+            body.extend_from_slice(&0u16.to_be_bytes()); // format
+        }
+        let cols = parse_row_description(&body).unwrap();
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols[0].name, "id");
+        assert_eq!(cols[0].type_oid, 23);
+        assert_eq!(cols[1].name, "name");
+        assert_eq!(cols[1].type_oid, 25);
+    }
+
+    #[test]
+    fn parse_data_row_with_null() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&2u16.to_be_bytes());
+        body.extend_from_slice(&2i32.to_be_bytes());
+        body.extend_from_slice(b"42");
+        body.extend_from_slice(&(-1i32).to_be_bytes());
+        let row = parse_data_row(&body).unwrap();
+        assert_eq!(row, vec![Some("42".to_string()), None]);
+    }
+
+    #[test]
+    fn parse_data_row_truncated() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&1u16.to_be_bytes());
+        body.extend_from_slice(&10i32.to_be_bytes());
+        body.extend_from_slice(b"ab");
+        assert!(parse_data_row(&body).is_err());
+    }
+
+    #[test]
+    fn parse_error_fields_body() {
+        let mut body = Vec::new();
+        body.push(b'S');
+        body.extend_from_slice(b"ERROR\0");
+        body.push(b'M');
+        body.extend_from_slice(b"relation \"t\" does not exist\0");
+        body.push(0);
+        let fields = parse_error_fields(&body).unwrap();
+        assert_eq!(fields[&b'S'], "ERROR");
+        assert_eq!(error_message(&fields), "relation \"t\" does not exist");
+    }
+}

--- a/postgres/conformance/Makefile
+++ b/postgres/conformance/Makefile
@@ -1,0 +1,61 @@
+# Turso PostgreSQL conformance test Makefile
+#
+# The .sqltest corpora live here; the sqltest runner crate lives in
+# testing/sqltest. The pg backend spawns a tursopg server per database
+# instance and drives it over the PostgreSQL wire protocol.
+
+# Paths
+ROOT_DIR := $(shell cd ../.. && pwd)
+RUNNER_DIR := $(ROOT_DIR)/testing/sqltest
+
+# Use release mode in CI, debug mode locally
+ifdef CI
+    CARGO_PROFILE := --release
+    TARGET_DIR := release
+else
+    CARGO_PROFILE :=
+    TARGET_DIR := debug
+endif
+
+# Honor a CARGO_TARGET_DIR override; default to the workspace target dir.
+TARGET_ROOT := $(or $(CARGO_TARGET_DIR),$(ROOT_DIR)/target)
+TURSOPG := $(TARGET_ROOT)/$(TARGET_DIR)/tursopg
+SQLTEST := cargo run --manifest-path $(RUNNER_DIR)/Cargo.toml --bin sqltest $(CARGO_PROFILE)
+
+# Test corpora (relative to this directory)
+PG_TESTS := pg-sqltests
+
+.PHONY: all build build-tursopg build-runner check run test run-one clean
+
+# Build everything
+all: build
+
+# Build both tursopg and the sqltest runner
+build: build-tursopg build-runner
+
+# Build the tursopg server binary
+build-tursopg:
+	cd $(ROOT_DIR) && cargo build $(CARGO_PROFILE) --package tursopg
+
+# Build the sqltest runner
+build-runner:
+	cargo build --manifest-path $(RUNNER_DIR)/Cargo.toml $(CARGO_PROFILE)
+
+# Check syntax of all test files
+check: build-runner
+	$(SQLTEST) check $(PG_TESTS)
+
+# Run all tests against a spawned tursopg server
+run: build
+	$(SQLTEST) run $(PG_TESTS) --timeout 600 --backend pg --binary $(TURSOPG)
+
+# Alias for run
+test: run
+
+# Run a single test file: make run-one FILE=pg-sqltests/select.sqltest
+run-one: build
+	$(SQLTEST) run $(FILE) --backend pg --binary $(TURSOPG)
+
+# Clean build artifacts
+clean:
+	cargo clean --manifest-path $(RUNNER_DIR)/Cargo.toml

--- a/postgres/conformance/pg-sqltests/errors.sqltest
+++ b/postgres/conformance/pg-sqltests/errors.sqltest
@@ -1,0 +1,29 @@
+# Error reporting through the PostgreSQL frontend. Expectations deliberately
+# avoid matching exact message text: turso-pg and real PostgreSQL word their
+# errors differently, and this corpus should stay valid for differential runs.
+
+@database :memory:
+
+test error-missing-table {
+    SELECT * FROM missing;
+}
+expect error {}
+
+test error-missing-column {
+    CREATE TABLE t (a int);
+    SELECT nonexistent FROM t;
+}
+expect error {}
+
+test error-syntax {
+    SELEC 1;
+}
+expect error {}
+
+test error-aborts-rest-of-batch {
+    CREATE TABLE t (a int);
+    INSERT INTO t VALUES (1);
+    SELECT * FROM missing;
+    INSERT INTO t VALUES (2);
+}
+expect error {}

--- a/postgres/conformance/pg-sqltests/select.sqltest
+++ b/postgres/conformance/pg-sqltests/select.sqltest
@@ -1,0 +1,89 @@
+# Scalar expression evaluation through the PostgreSQL frontend.
+#
+# Coverage here asserts behavior that real PostgreSQL also exhibits, so the
+# corpus stays valid for future differential runs against a stock server.
+
+@database :memory:
+
+test select-integer-literal {
+    SELECT 42;
+}
+expect {
+    42
+}
+
+test select-arithmetic {
+    SELECT 1 + 2 * 3;
+}
+expect {
+    7
+}
+
+test select-float-literal {
+    SELECT 3.14;
+}
+expect {
+    3.14
+}
+
+test select-text-literal {
+    SELECT 'hello';
+}
+expect {
+    hello
+}
+
+test select-concat-operator {
+    SELECT 'foo' || 'bar';
+}
+expect {
+    foobar
+}
+
+test select-multiple-columns {
+    SELECT 1, 'two', 3.5;
+}
+expect {
+    1|two|3.5
+}
+
+test select-null-renders-empty {
+    SELECT NULL;
+}
+expect {
+}
+
+test select-coalesce {
+    SELECT coalesce(NULL, NULL, 'fallback');
+}
+expect {
+    fallback
+}
+
+test select-cast-int-to-text {
+    SELECT 1::text || '!';
+}
+expect {
+    1!
+}
+
+test select-case-expression {
+    SELECT CASE WHEN 1 < 2 THEN 'lt' ELSE 'ge' END;
+}
+expect {
+    lt
+}
+
+test select-string-functions {
+    SELECT upper('abc'), lower('DEF'), length('four');
+}
+expect {
+    ABC|def|4
+}
+
+test select-abs {
+    SELECT abs(-7);
+}
+expect {
+    7
+}

--- a/postgres/conformance/pg-sqltests/table.sqltest
+++ b/postgres/conformance/pg-sqltests/table.sqltest
@@ -1,0 +1,96 @@
+# Table DDL and DML through the PostgreSQL frontend: PostgreSQL type names,
+# multi-row inserts, updates, deletes, aggregates, and grouping.
+
+@database :memory:
+
+setup users {
+    CREATE TABLE users (id serial, name varchar(50), age int, active boolean);
+    INSERT INTO users (id, name, age, active) VALUES
+        (1, 'alice', 30, true),
+        (2, 'bob', 25, false),
+        (3, 'carol', 35, true);
+}
+
+@setup users
+test table-select-all {
+    SELECT id, name, age FROM users ORDER BY id;
+}
+expect {
+    1|alice|30
+    2|bob|25
+    3|carol|35
+}
+
+@setup users
+test table-where-boolean-column {
+    SELECT name FROM users WHERE active ORDER BY name;
+}
+expect {
+    alice
+    carol
+}
+
+@setup users
+test table-update {
+    UPDATE users SET age = age + 1 WHERE name = 'bob';
+    SELECT age FROM users WHERE name = 'bob';
+}
+expect {
+    26
+}
+
+@setup users
+test table-delete {
+    DELETE FROM users WHERE age > 34;
+    SELECT count(*) FROM users;
+}
+expect {
+    2
+}
+
+@setup users
+test table-aggregates {
+    SELECT count(*), min(age), max(age) FROM users;
+}
+expect {
+    3|25|35
+}
+
+@setup users
+test table-group-by-having {
+    SELECT active, count(*) FROM users GROUP BY active HAVING count(*) >= 2 ORDER BY active;
+}
+expect {
+    t|2
+}
+
+@setup users
+test table-order-by-limit {
+    SELECT name FROM users ORDER BY age DESC LIMIT 2;
+}
+expect {
+    carol
+    alice
+}
+
+test table-insert-null {
+    CREATE TABLE t (a int, b text);
+    INSERT INTO t VALUES (1, NULL);
+    SELECT a, b FROM t;
+}
+expect {
+    1|
+}
+
+test table-join {
+    CREATE TABLE dept (id int, name text);
+    CREATE TABLE emp (id int, dept_id int, name text);
+    INSERT INTO dept VALUES (1, 'eng'), (2, 'ops');
+    INSERT INTO emp VALUES (1, 1, 'alice'), (2, 1, 'bob'), (3, 2, 'carol');
+    SELECT d.name, e.name FROM emp e JOIN dept d ON e.dept_id = d.id ORDER BY e.id;
+}
+expect {
+    eng|alice
+    eng|bob
+    ops|carol
+}

--- a/postgres/conformance/pg-sqltests/transaction.sqltest
+++ b/postgres/conformance/pg-sqltests/transaction.sqltest
@@ -1,0 +1,41 @@
+# Transaction control through the PostgreSQL frontend.
+
+@database :memory:
+
+setup counter {
+    CREATE TABLE counter (n int);
+    INSERT INTO counter VALUES (0);
+}
+
+@setup counter
+test txn-commit-persists {
+    BEGIN;
+    UPDATE counter SET n = 1;
+    COMMIT;
+    SELECT n FROM counter;
+}
+expect {
+    1
+}
+
+@setup counter
+test txn-rollback-discards {
+    BEGIN;
+    UPDATE counter SET n = 1;
+    ROLLBACK;
+    SELECT n FROM counter;
+}
+expect {
+    0
+}
+
+@setup counter
+test txn-rollback-insert {
+    BEGIN;
+    INSERT INTO counter VALUES (99);
+    ROLLBACK;
+    SELECT count(*) FROM counter;
+}
+expect {
+    1
+}

--- a/testing/sqltest/Cargo.toml
+++ b/testing/sqltest/Cargo.toml
@@ -61,5 +61,9 @@ turso = { workspace = true, features = ["test_helper"] }
 # Turso SQL parser (for splitting multi-statement SQL)
 turso_parser = { workspace = true }
 
+# PostgreSQL wire-protocol client (for the pg backend, which drives a
+# spawned tursopg server over TCP)
+turso_pg_client = { workspace = true }
+
 [dev-dependencies]
 pretty_assertions = "1"

--- a/testing/sqltest/src/backends/mod.rs
+++ b/testing/sqltest/src/backends/mod.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod js;
+pub mod pg;
 pub mod rust;
 
 use crate::parser::ast::{Backend, Capability, DatabaseConfig, DatabaseLocation};

--- a/testing/sqltest/src/backends/pg.rs
+++ b/testing/sqltest/src/backends/pg.rs
@@ -1,0 +1,256 @@
+use super::{BackendError, DatabaseFileHandle, DatabaseInstance, QueryResult, SqlBackend};
+use crate::backends::DefaultDatabaseResolver;
+use crate::parser::ast::{Backend, Capability, DatabaseConfig, DatabaseLocation};
+use async_trait::async_trait;
+use std::collections::HashSet;
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tempfile::NamedTempFile;
+use turso_pg_client::{BackendEvent, ConnParams, PgConn, error_message};
+
+/// How long to wait for a spawned tursopg server to accept connections.
+const SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// PostgreSQL wire-protocol backend. Each database instance spawns its own
+/// `tursopg --server` on an ephemeral port and drives it over one connection
+/// using the simple query protocol — the same path any PostgreSQL client
+/// exercises, so results reflect the server's own value encoding rather than
+/// a rendering this runner would have to reimplement.
+pub struct PgBackend {
+    /// Path to the tursopg binary
+    binary_path: PathBuf,
+    /// Timeout for query execution
+    timeout: Duration,
+    /// Resolver for default database paths
+    default_db_resolver: Option<Arc<dyn DefaultDatabaseResolver>>,
+}
+
+impl PgBackend {
+    /// Create a new pg backend with the given tursopg binary path
+    pub fn new(binary_path: impl Into<PathBuf>) -> Self {
+        Self {
+            binary_path: binary_path.into(),
+            timeout: Duration::from_secs(30),
+            default_db_resolver: None,
+        }
+    }
+
+    /// Set the timeout for query execution
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Set the default database resolver
+    pub fn with_default_db_resolver(mut self, resolver: Arc<dyn DefaultDatabaseResolver>) -> Self {
+        self.default_db_resolver = Some(resolver);
+        self
+    }
+}
+
+#[async_trait]
+impl SqlBackend for PgBackend {
+    fn name(&self) -> &str {
+        "pg"
+    }
+
+    fn backend_type(&self) -> Backend {
+        Backend::Pg
+    }
+
+    fn capabilities(&self) -> HashSet<Capability> {
+        // The pg frontend's feature surface is distinct from the sqlite
+        // capabilities tests can require; grow this set as pg coverage
+        // starts needing capability gating.
+        HashSet::new()
+    }
+
+    async fn create_database(
+        &self,
+        config: &DatabaseConfig,
+    ) -> Result<Box<dyn DatabaseInstance>, BackendError> {
+        let (db_path, temp_file) = match &config.location {
+            DatabaseLocation::Memory => (":memory:".to_string(), None),
+            DatabaseLocation::TempFile => {
+                let temp = NamedTempFile::new()
+                    .map_err(|e| BackendError::CreateDatabase(e.to_string()))?;
+                let path = temp.path().to_string_lossy().to_string();
+                (path, Some(temp))
+            }
+            DatabaseLocation::Path(path) => (path.to_string_lossy().to_string(), None),
+            DatabaseLocation::Default | DatabaseLocation::DefaultNoRowidAlias => {
+                let resolved = self
+                    .default_db_resolver
+                    .as_ref()
+                    .and_then(|r| r.resolve(&config.location))
+                    .ok_or_else(|| {
+                        BackendError::CreateDatabase(
+                            "default database not generated - no resolver configured".to_string(),
+                        )
+                    })?;
+                (resolved.to_string_lossy().to_string(), None)
+            }
+        };
+
+        // Reserve an ephemeral port, then hand it to the server. The port
+        // could in principle be claimed between the drop and the spawn, in
+        // which case the server fails to bind and the readiness loop below
+        // reports the exit.
+        let port = TcpListener::bind("127.0.0.1:0")
+            .and_then(|l| l.local_addr())
+            .map_err(|e| BackendError::CreateDatabase(format!("allocating port: {e}")))?
+            .port();
+
+        let mut cmd = tokio::process::Command::new(&self.binary_path);
+        cmd.arg(&db_path)
+            .arg("--server")
+            .arg(format!("127.0.0.1:{port}"))
+            .arg("-q");
+        if config.readonly {
+            cmd.arg("--readonly");
+        }
+        cmd.stdin(std::process::Stdio::null());
+        cmd.stdout(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::piped());
+        cmd.kill_on_drop(true);
+        let mut child = cmd.spawn().map_err(|e| {
+            BackendError::CreateDatabase(format!(
+                "failed to spawn {}: {e}",
+                self.binary_path.display()
+            ))
+        })?;
+
+        let params = ConnParams {
+            host: "127.0.0.1".to_string(),
+            port,
+            user: "sqltest".to_string(),
+            password: None,
+            database: "main".to_string(),
+        };
+
+        // Wait for the server to accept the startup handshake.
+        let deadline = Instant::now() + SERVER_STARTUP_TIMEOUT;
+        let conn = loop {
+            match connect(&params).await {
+                Ok(conn) => break conn,
+                Err(e) => {
+                    if let Some(status) = child.try_wait().ok().flatten() {
+                        let stderr = read_stderr(&mut child).await;
+                        return Err(BackendError::CreateDatabase(format!(
+                            "tursopg exited with {status} before accepting connections: {stderr}"
+                        )));
+                    }
+                    if Instant::now() >= deadline {
+                        return Err(BackendError::CreateDatabase(format!(
+                            "tursopg did not accept connections within {SERVER_STARTUP_TIMEOUT:?}: {e}"
+                        )));
+                    }
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+            }
+        };
+        conn.set_read_timeout(Some(self.timeout))
+            .map_err(|e| BackendError::CreateDatabase(e.to_string()))?;
+
+        Ok(Box::new(PgDatabaseInstance {
+            child,
+            conn: Some(conn),
+            timeout: self.timeout,
+            _temp_file: temp_file,
+        }))
+    }
+}
+
+async fn connect(params: &ConnParams) -> Result<PgConn, turso_pg_client::Error> {
+    let params = params.clone();
+    tokio::task::spawn_blocking(move || {
+        PgConn::connect(&params, &[("application_name", "sqltest")])
+    })
+    .await
+    .expect("connect task panicked")
+}
+
+async fn read_stderr(child: &mut tokio::process::Child) -> String {
+    use tokio::io::AsyncReadExt;
+    let mut buf = String::new();
+    if let Some(mut stderr) = child.stderr.take() {
+        let _ = stderr.read_to_string(&mut buf).await;
+    }
+    buf.trim().to_string()
+}
+
+/// A database instance backed by a dedicated tursopg server process.
+pub struct PgDatabaseInstance {
+    child: tokio::process::Child,
+    /// The single connection to the server. Taken while a query runs on the
+    /// blocking pool and put back afterwards; left empty after a timeout,
+    /// since the wire state is indeterminate mid-protocol.
+    conn: Option<PgConn>,
+    timeout: Duration,
+    /// Keep temp file alive - it's deleted when this is dropped
+    _temp_file: Option<NamedTempFile>,
+}
+
+#[async_trait]
+impl DatabaseInstance for PgDatabaseInstance {
+    async fn execute(&mut self, sql: &str) -> Result<QueryResult, BackendError> {
+        let mut conn = self
+            .conn
+            .take()
+            .ok_or_else(|| BackendError::Execute("connection lost by earlier timeout".into()))?;
+        let sql = sql.to_string();
+        let (conn, events) = tokio::task::spawn_blocking(move || {
+            let events = conn.simple_query(&sql);
+            (conn, events)
+        })
+        .await
+        .expect("query task panicked");
+
+        let events = match events {
+            Ok(events) => {
+                self.conn = Some(conn);
+                events
+            }
+            Err(turso_pg_client::Error::Io(e))
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                return Err(BackendError::Timeout(self.timeout));
+            }
+            Err(e) => return Err(BackendError::Execute(e.to_string())),
+        };
+
+        // The simple query protocol runs statements in order and aborts the
+        // rest of the string after an error, so the first ErrorResponse is
+        // the query's outcome. NULL renders as an empty string, matching the
+        // list-mode convention the comparison layer expects.
+        let mut rows = Vec::new();
+        for event in events {
+            match event {
+                BackendEvent::DataRow(row) => rows.push(
+                    row.into_iter()
+                        .map(|v| v.unwrap_or_default())
+                        .collect::<Vec<String>>(),
+                ),
+                BackendEvent::ErrorResponse(fields) => {
+                    return Ok(QueryResult::error(error_message(&fields).to_string()));
+                }
+                _ => {}
+            }
+        }
+        Ok(QueryResult::success(rows))
+    }
+
+    async fn close(mut self: Box<Self>) -> Result<DatabaseFileHandle, BackendError> {
+        self.conn.take();
+        let _ = self.child.kill().await;
+        match self._temp_file {
+            Some(tf) => Ok(DatabaseFileHandle::temp(tf)),
+            None => Ok(DatabaseFileHandle::none()),
+        }
+    }
+}

--- a/testing/sqltest/src/main.rs
+++ b/testing/sqltest/src/main.rs
@@ -4,9 +4,9 @@ use owo_colors::OwoColorize;
 use sqltest::{
     DatabaseLocation, DefaultDatabases, Format, GeneratorConfig, INTEGRITY_FIXTURE_RELATIVE_PATHS,
     OutputFormat, ParseError, RunnerConfig, SnapshotUpdateMode, TestRunner,
-    backends::cli::CliBackend, backends::js::JsBackend, backends::rust::RustBackend, create_output,
-    find_all_pending_snapshots, generate_database, generate_integrity_fixture, load_test_files,
-    summarize, tcl_converter,
+    backends::cli::CliBackend, backends::js::JsBackend, backends::pg::PgBackend,
+    backends::rust::RustBackend, create_output, find_all_pending_snapshots, generate_database,
+    generate_integrity_fixture, load_test_files, summarize, tcl_converter,
 };
 use std::process::ExitCode;
 use std::rc::Rc;
@@ -33,7 +33,8 @@ enum Commands {
         #[arg(required = true)]
         paths: Vec<PathBuf>,
 
-        /// Backend to use: "rust" (native), "cli" (subprocess), or "js" (JavaScript bindings)
+        /// Backend to use: "rust" (native), "cli" (subprocess), "js" (JavaScript
+        /// bindings), or "pg" (tursopg server over the PostgreSQL wire protocol)
         #[arg(long, default_value = "rust")]
         backend: String,
 
@@ -422,8 +423,28 @@ async fn run_tests(
                 })
                 .await
         }
+        "pg" => {
+            // --binary defaults to tursodb for the cli backend; for pg the
+            // server binary is tursopg, so rewrite an untouched default.
+            let binary = if binary == PathBuf::from("tursodb") {
+                PathBuf::from("tursopg")
+            } else {
+                binary
+            };
+            let mut backend = PgBackend::new(&binary).with_timeout(Duration::from_secs(timeout));
+            if let Some(resolver) = resolver {
+                backend = backend.with_default_db_resolver(resolver);
+            }
+            let runner = TestRunner::new(backend).with_config(config);
+            runner
+                .run_loaded_tests(loaded, |result| {
+                    output.write_test(result);
+                    output.flush();
+                })
+                .await
+        }
         other => {
-            eprintln!("Error: unknown backend '{other}'. Use 'rust', 'cli', or 'js'");
+            eprintln!("Error: unknown backend '{other}'. Use 'rust', 'cli', 'js', or 'pg'");
             return ExitCode::from(2);
         }
     };

--- a/testing/sqltest/src/parser/ast.rs
+++ b/testing/sqltest/src/parser/ast.rs
@@ -13,11 +13,13 @@ pub enum Backend {
     Cli,
     /// JavaScript bindings backend
     Js,
+    /// PostgreSQL wire-protocol backend (tursopg server)
+    Pg,
 }
 
 impl Backend {
     /// All known backend variants
-    pub const ALL: &'static [Backend] = &[Backend::Rust, Backend::Cli, Backend::Js];
+    pub const ALL: &'static [Backend] = &[Backend::Rust, Backend::Cli, Backend::Js, Backend::Pg];
 }
 
 impl Display for Backend {
@@ -26,6 +28,7 @@ impl Display for Backend {
             Backend::Rust => write!(f, "rust"),
             Backend::Cli => write!(f, "cli"),
             Backend::Js => write!(f, "js"),
+            Backend::Pg => write!(f, "pg"),
         }
     }
 }
@@ -38,8 +41,9 @@ impl FromStr for Backend {
             "rust" => Ok(Backend::Rust),
             "cli" => Ok(Backend::Cli),
             "js" => Ok(Backend::Js),
+            "pg" => Ok(Backend::Pg),
             _ => Err(format!(
-                "unknown backend '{s}', valid backends are: rust, cli, js"
+                "unknown backend '{s}', valid backends are: rust, cli, js, pg"
             )),
         }
     }


### PR DESCRIPTION
Give the PostgreSQL frontend the same hand-written .sqltest coverage the
sqlite dialect has under sqlite/conformance. The upstream regression
harness (pg-regress branch) replays pristine psql transcripts; this
corpus instead asserts structural expectations through the sqltest DSL,
and only encodes behavior real PostgreSQL also exhibits so the corpus
stays valid for future differential runs against a stock server.

The new turso_pg_client crate is a minimal synchronous wire-protocol
client (startup handshake, simple query, row/error decoding) shared
between test tools; the upstream regression runner can adopt it when it
lands. Because the client speaks TCP to a spawned tursopg binary, the
sqltest runner gains no dependency on the pg frontend crates.

The pg backend spawns one tursopg server per database instance on an
ephemeral port and drives it over a single connection, so results
reflect the server's own wire encoding (e.g. boolean columns as t/f)
rather than a rendering the runner would have to reimplement. Whole
test blocks are sent as one simple-query message, which keeps
sqlite-dialect statement splitting out of the pg path. Wire I/O runs on
the blocking pool; a connection is discarded after a timeout since its
protocol state is indeterminate mid-stream.

The postgres/conformance Makefile honors CARGO_TARGET_DIR when locating
the tursopg binary. CI runs the corpus in a new sqltest-run-pg job and
syntax-checks it in sqltest-check.

Tests: make -C postgres/conformance run (28 tests), cargo test -p
turso_pg_client -p sqltest, make -C sqlite/conformance check

