### PR TITLE
sql_generation: exclude i64::MAX from shadow integer affinity conversion

### DIFF
--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -372,7 +372,7 @@ impl SimValue {
                         } else {
                             fl as i64
                         };
-                        if (int_val as f64) == fl && int_val != i64::MIN {
+                        if (int_val as f64) == fl && int_val != i64::MIN && int_val != i64::MAX {
                             return SimValue(types::Value::from_i64(int_val));
                         }
                     }


### PR DESCRIPTION
The simulator shadow model's SimValue::apply_affinity clamps a REAL to
i64::MAX before its lossless round-trip check. At exactly 2^63 the clamp
produces i64::MAX, and i64::MAX as f64 rounds back up to 2^63, so the
check passes spuriously and the shadow converts REAL 2^63 into
Integer(i64::MAX). SQLite's sqlite3VdbeIntegerAffinity and Turso core's
apply_integer_affinity both require the converted value to be strictly
between i64::MIN and i64::MAX, keeping REAL 2^63 as REAL.

The divergence made the shadow manufacture a phantom UNIQUE violation on
an INTEGER UNIQUE virtual generated column whose expression overflowed
to REAL 2^63 in one row while another row genuinely computed i64::MAX,
failing CI with "DB succeeded but shadow detected error" even though
Turso and SQLite agree the rows are distinct.

Tests: simulator seed 17556740185362989829 with the InsertHeavy CI
arguments failed before this change and now runs to completion.
