### PR TITLE
core/mvcc: handle abort on inner transaction of sequence properly

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -18506,6 +18506,57 @@ fn test_nextval_no_inner_tx_retry_on_concurrent_mvcc() {
     );
 }
 
+#[test]
+fn test_sequence_write_conflict_rolls_back_outer_tx_and_rejects_commit() {
+    let db = MvccTestDbNoConn::new();
+    let setup = db.connect();
+    setup.execute("CREATE TABLE t(a INTEGER)").unwrap();
+    setup.execute("CREATE SEQUENCE s").unwrap();
+    setup.execute("INSERT INTO t VALUES (1)").unwrap();
+
+    let nextval_conn = db.connect();
+    let setval_conn = db.connect();
+
+    nextval_conn.execute("BEGIN CONCURRENT").unwrap();
+    setval_conn.execute("BEGIN CONCURRENT").unwrap();
+    nextval_conn.execute("DELETE FROM t WHERE TRUE").unwrap();
+
+    let setval_rows = get_rows(&setval_conn, "SELECT setval('s', 100, true)");
+    assert_eq!(setval_rows[0][0].as_int().unwrap(), 100);
+
+    let nextval = nextval_conn.execute("SELECT nextval('s')");
+    assert!(
+        matches!(nextval, Err(LimboError::WriteWriteConflict)),
+        "conflicting nextval must abort with WriteWriteConflict, got {nextval:?}"
+    );
+
+    setval_conn.execute("COMMIT").unwrap();
+
+    assert!(
+        nextval_conn.get_auto_commit(),
+        "write-write conflict must leave the losing connection in autocommit"
+    );
+    assert_eq!(
+        nextval_conn.get_mv_tx_id(),
+        None,
+        "write-write conflict must clear the losing connection's MVCC tx"
+    );
+
+    let commit = nextval_conn.execute("COMMIT");
+    let expected = "cannot commit - no transaction is active";
+    assert!(
+        matches!(commit, Err(LimboError::TxError(ref msg)) if msg == expected),
+        "COMMIT after conflict rollback must report no active transaction, got {commit:?}"
+    );
+
+    let rows = get_rows(&setup, "SELECT count(*) FROM t");
+    assert_eq!(
+        rows[0][0].as_int().unwrap(),
+        1,
+        "the DELETE from the rolled-back transaction must not persist"
+    );
+}
+
 /// Regression: a multi-row `INSERT INTO autoinc_table VALUES (...), (...)`
 /// inside `BEGIN CONCURRENT` whose second-row nextval exhausts the
 /// AUTOINCREMENT sequence must leave NO partial row committed — even

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1977,6 +1977,16 @@ impl Program {
         mv_store: Option<&Arc<MvStore>>,
         rollback: bool,
     ) -> Result<IOResult<()>> {
+        if !rollback {
+            turso_assert!(
+                !matches!(
+                    program_state.sequence_inner_tx_pending.as_ref(),
+                    Some(pending) if pending.saved_outer.is_some()
+                ),
+                "cannot commit while a sequence inner tx has a saved outer user tx"
+            );
+        }
+
         // Apply view deltas with I/O handling
         match self.apply_view_deltas(program_state, rollback, &pager)? {
             IOResult::IO(io) => return Ok(IOResult::IO(io)),
@@ -2610,6 +2620,13 @@ impl Program {
                     // These MVCC errors mean the current transaction cannot
                     // commit. Roll it back even if this statement opened a
                     // statement savepoint, as DDL does.
+                    if let Err(err) = self.rollback_pending_sequence_outer_tx(state) {
+                        capture_abort_error(
+                            &mut abort_error,
+                            err,
+                            "Failed to rollback saved outer transaction after sequence conflict",
+                        );
+                    }
                     self.rollback_current_txn(pager);
                     self.connection.set_changes(0);
                 }
@@ -2768,6 +2785,44 @@ impl Program {
 
     fn rollback_current_txn(&self, pager: &Arc<Pager>) {
         self.connection.rollback_current_txn_state(pager, true);
+    }
+
+    /// MVCC sequence operations run in a separate inner tx, which temporarily
+    /// replaces the connection's `mv_tx` slot. If a transaction-level conflict
+    /// happens while that swap is active, the user transaction lives only in
+    /// `saved_outer`, not in `connection.mv_tx`. Roll it back here and clear
+    /// `saved_outer` so later statement cleanup cannot restore a transaction
+    /// that has already been aborted.
+    fn rollback_pending_sequence_outer_tx(&self, state: &mut ProgramState) -> Result<()> {
+        let Some(pending) = state.sequence_inner_tx_pending.as_mut() else {
+            return Ok(());
+        };
+        let db = pending.db;
+        let (outer_tx_id, _) = pending.saved_outer.take().ok_or_else(|| {
+            LimboError::InternalError(
+                "sequence conflict rollback had pending inner transaction without saved outer \
+                 transaction"
+                    .to_string(),
+            )
+        })?;
+        let mv_store = self.connection.mv_store_for_db(db).ok_or_else(|| {
+            LimboError::InternalError(
+                "sequence inner transaction has no MV store during conflict rollback".to_string(),
+            )
+        })?;
+        let pager = self.connection.get_pager_from_database_index(&db)?;
+        if !mv_store.is_tx_rollbackable(outer_tx_id) {
+            return Err(LimboError::InternalError(format!(
+                "saved sequence outer transaction {outer_tx_id} is not rollbackable during \
+                 conflict rollback"
+            )));
+        }
+        mv_store.rollback_tx(outer_tx_id, pager, &self.connection, db);
+        // `rollback_tx` clears the connection's MVCC tx slot for this db. The caller's
+        // generic rollback then has no current tx to inspect, so it will not flip
+        // autocommit for us.
+        self.connection.auto_commit.store(true, Ordering::SeqCst);
+        Ok(())
     }
 
     pub fn is_trigger_subprogram(&self) -> bool {


### PR DESCRIPTION
## Description

fixes #7603

## Prerequisites

For the main database, MVCC keeps the current transaction in `connection.mv_tx`.

Normally this is simple:

```text
BEGIN CONCURRENT;
  connection.mv_tx = user tx

COMMIT / ROLLBACK;
  connection.mv_tx = None
```

`nextval()` is different under MVCC.

The sequence backing table update is done in a short inner transaction. So during a wrapped `nextval()`:

```text
before nextval:
  connection.mv_tx = user tx

SequenceBeginInnerTx:
  save user tx in sequence_inner_tx_pending.saved_outer
  start sequence inner tx
  connection.mv_tx = sequence inner tx

successful SequenceCommitInnerTx:
  commit sequence inner tx
  restore connection.mv_tx = saved user tx
```

So while wrapped `nextval()` is running, `connection.mv_tx` points at the sequence inner tx, not the user transaction.

## The bug

Consider this:

```sql
CREATE TABLE t(a INTEGER);
CREATE SEQUENCE s;
INSERT INTO t VALUES (1);

-- conn1
BEGIN CONCURRENT;
DELETE FROM t WHERE TRUE;

-- conn0
BEGIN CONCURRENT;
SELECT setval('s', 100, true);

-- conn1
SELECT nextval('s');
```

`conn0` changes the sequence backing table inside its own concurrent transaction.

Then `conn1` calls `nextval()`. `nextval()` starts a sequence inner tx, saves conn1's user tx in `sequence_inner_tx_pending.saved_outer`, and replaces `connection.mv_tx` with the inner tx.

The sequence write conflicts with conn0's sequence write and returns `WriteWriteConflict`.

For this error class, the user transaction is dead. `conn1` should leave the statement back in autocommit mode. A later `COMMIT` should fail with:

```text
cannot commit - no transaction is active
```

Before this patch, transaction-level rollback did not consume the saved outer tx. Generic rollback looked at the current `connection.mv_tx`, but at that moment the current tx was the seque

The real user tx was still saved here:

```text
state.sequence_inner_tx_pending.saved_outer
```

Then statement cleanup could restore that saved tx back into the connection.

Broken state:

```text
SELECT nextval('s') -> WriteWriteConflict

connection still has saved outer tx restored

COMMIT -> Ok(())
```

But the user's `DELETE` was not committed:

```sql
SELECT count(*) FROM t;
-- 1
```

The row staying alive is correct because the transaction conflicted and should roll back. The bug is that `COMMIT` returned success after the transaction was already dead.

## The fix

On `WriteWriteConflict` and `SchemaConflict`, abort now checks whether there is a pending sequence inner tx before running generic rollback.

If there is one, it takes the saved outer tx and rolls that tx back directly.

The helper also sets `auto_commit = true` after rolling back the saved outer tx. `rollback_tx()` clears the connection's MVCC tx slot for this db, so the following generic rollback has no current tx to inspect and will not flip autocommit for us.

Comes with a regression test which fails without the patch:

```text
write-write conflict must leave the losing connection in autocommit
```

## Description of AI Usage

Debugging and regression test.