### PR TITLE
ci: enable Rust backtraces in the Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,8 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: 10
+  # Capture stack traces when a test panics so CI failure reports are actionable.
+  RUST_BACKTRACE: 1
   # Blacksmith Windows images ship VS Build Tools without LLVM, so the aegis
   # crate's clang-cl preference fails; force the MSVC compiler instead.
   CC_x86_64_pc_windows_msvc: cl.exe


### PR DESCRIPTION
Test panics in this workflow currently print only the panic message with
"run with RUST_BACKTRACE=1 to display a backtrace" (e.g. the nextval
stress-test failures in run 29718418429), leaving no stack trace to
debug from. Set RUST_BACKTRACE=1 at the workflow level so every job's
test runs capture backtraces on panic.
