### PR TITLE
tests: replace iteration-capped nextval retry spin with stall deadline

### DIFF
--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -1899,6 +1899,69 @@ mod tests {
         Ok(())
     }
 
+    /// Run `SELECT nextval(...)` until it succeeds, retrying on transient
+    /// contention errors: `Busy` always, `WriteWriteConflict` only when
+    /// `allow_ww_conflict` is set (MVCC allocators legitimately race on the
+    /// watermark row; in WAL mode a WW conflict would be a bug and panics).
+    ///
+    /// Gives up on a wall-clock stall, not an iteration count. The number of
+    /// retries a waiter burns before winning the WAL single-writer lock (or
+    /// the MVCC watermark race) scales with commit fsync latency times queue
+    /// depth, so an iteration cap measures disk speed rather than forward
+    /// progress — a 10k cap tripped spuriously on slow CI disks (issue
+    /// #7738). A thread that makes no progress for the full deadline while
+    /// the whole workload should drain in well under a minute is a genuine
+    /// livelock. Backoff: stay hot for the first attempts to keep exercising
+    /// the contended path, then sleep so a long fsync-bound queue is not
+    /// spun on at full CPU.
+    fn nextval_with_retry(
+        conn: &Arc<turso_core::Connection>,
+        sql: &str,
+        allow_ww_conflict: bool,
+    ) -> i64 {
+        use std::time::{Duration, Instant};
+        const STALL_DEADLINE: Duration = Duration::from_secs(120);
+        let start = Instant::now();
+        let mut tries = 0usize;
+        loop {
+            tries += 1;
+            if start.elapsed() > STALL_DEADLINE {
+                panic!(
+                    "nextval made no progress for {STALL_DEADLINE:?} \
+                     ({tries} attempts) — livelock or leaked write lock"
+                );
+            }
+            let transient = |e: &turso_core::LimboError| {
+                matches!(e, turso_core::LimboError::Busy)
+                    || (allow_ww_conflict
+                        && matches!(e, turso_core::LimboError::WriteWriteConflict))
+            };
+            let backoff = || {
+                if tries < 100 {
+                    std::thread::yield_now();
+                } else {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+            };
+            match conn.prepare(sql) {
+                Ok(mut stmt) => {
+                    let mut got: Option<i64> = None;
+                    let r = stmt.run_with_row_callback(|row| {
+                        got = Some(row.get::<i64>(0).unwrap());
+                        Ok(())
+                    });
+                    match r {
+                        Ok(()) => return got.expect("nextval row"),
+                        Err(ref e) if transient(e) => backoff(),
+                        Err(e) => panic!("nextval failed: {e:?}"),
+                    }
+                }
+                Err(ref e) if transient(e) => backoff(),
+                Err(e) => panic!("prepare failed: {e:?}"),
+            }
+        }
+    }
+
     /// Stress: N threads, each pulling M values from the same sequence in WAL
     /// mode. Every value must be unique — duplicates would mean two threads
     /// observed the same disk watermark and computed the same next value
@@ -1932,32 +1995,7 @@ mod tests {
                     let conn = db.connect_limbo();
                     let mut mine = Vec::with_capacity(PER_THREAD);
                     for _ in 0..PER_THREAD {
-                        let mut tries = 0usize;
-                        loop {
-                            tries += 1;
-                            if tries > 10_000 {
-                                panic!("nextval gave up after 10k Busy retries");
-                            }
-                            match conn.prepare("SELECT nextval('s')") {
-                                Ok(mut stmt) => {
-                                    let mut got: Option<i64> = None;
-                                    let r = stmt.run_with_row_callback(|row| {
-                                        got = Some(row.get::<i64>(0).unwrap());
-                                        Ok(())
-                                    });
-                                    match r {
-                                        Ok(()) => {
-                                            mine.push(got.expect("nextval row"));
-                                            break;
-                                        }
-                                        Err(turso_core::LimboError::Busy) => continue,
-                                        Err(e) => panic!("nextval failed: {e:?}"),
-                                    }
-                                }
-                                Err(turso_core::LimboError::Busy) => continue,
-                                Err(e) => panic!("prepare failed: {e:?}"),
-                            }
-                        }
+                        mine.push(nextval_with_retry(&conn, "SELECT nextval('s')", false));
                     }
                     collected.lock().unwrap().extend(mine);
                 })
@@ -2033,35 +2071,7 @@ mod tests {
                     let conn = db.connect_limbo();
                     let mut mine = Vec::with_capacity(PER_THREAD);
                     for _ in 0..PER_THREAD {
-                        let mut tries = 0usize;
-                        loop {
-                            tries += 1;
-                            if tries > 10_000 {
-                                panic!("nextval gave up after 10k retries");
-                            }
-                            match conn.prepare("SELECT nextval('s')") {
-                                Ok(mut stmt) => {
-                                    let mut got: Option<i64> = None;
-                                    let r = stmt.run_with_row_callback(|row| {
-                                        got = Some(row.get::<i64>(0).unwrap());
-                                        Ok(())
-                                    });
-                                    match r {
-                                        Ok(()) => {
-                                            mine.push(got.expect("nextval row"));
-                                            break;
-                                        }
-                                        Err(turso_core::LimboError::Busy)
-                                        | Err(turso_core::LimboError::WriteWriteConflict) => {
-                                            continue
-                                        }
-                                        Err(e) => panic!("nextval failed: {e:?}"),
-                                    }
-                                }
-                                Err(turso_core::LimboError::Busy) => continue,
-                                Err(e) => panic!("prepare failed: {e:?}"),
-                            }
-                        }
+                        mine.push(nextval_with_retry(&conn, "SELECT nextval('s')", true));
                     }
                     collected.lock().unwrap().extend(mine);
                 })
@@ -2144,35 +2154,7 @@ mod tests {
                     let conn = db.connect_limbo();
                     let mut mine = Vec::with_capacity(NEXTVAL_PER_THREAD);
                     for _ in 0..NEXTVAL_PER_THREAD {
-                        let mut tries = 0usize;
-                        loop {
-                            tries += 1;
-                            if tries > 10_000 {
-                                panic!("nextval gave up after 10k retries");
-                            }
-                            match conn.prepare("SELECT nextval('s')") {
-                                Ok(mut stmt) => {
-                                    let mut got: Option<i64> = None;
-                                    let r = stmt.run_with_row_callback(|row| {
-                                        got = Some(row.get::<i64>(0).unwrap());
-                                        Ok(())
-                                    });
-                                    match r {
-                                        Ok(()) => {
-                                            mine.push(got.expect("nextval row"));
-                                            break;
-                                        }
-                                        Err(turso_core::LimboError::Busy)
-                                        | Err(turso_core::LimboError::WriteWriteConflict) => {
-                                            continue
-                                        }
-                                        Err(e) => panic!("nextval failed: {e:?}"),
-                                    }
-                                }
-                                Err(turso_core::LimboError::Busy) => continue,
-                                Err(e) => panic!("prepare failed: {e:?}"),
-                            }
-                        }
+                        mine.push(nextval_with_retry(&conn, "SELECT nextval('s')", true));
                     }
                     nextvals.lock().unwrap().extend(mine);
                 })


### PR DESCRIPTION
The nextval stress tests gave up after a fixed 10k retry iterations in
a zero-backoff spin loop. Retries-until-success scale with commit fsync
latency times writer queue depth, so the cap measured disk speed, not
forward progress: with 50ms fsync latency threads routinely reach 5-8k
consecutive retries on a healthy system, and past ~80ms they cross 10k
and panic. Slow contended disks on CI runners, coverage instrumentation,
and the same stress test running concurrently from both the core_tester
and integration_tests binaries pushed past that threshold, failing
otherwise-green PR runs.

Replace the three duplicated spin loops with a nextval_with_retry helper
that gives up only after a 120s wall-clock stall (a genuine livelock or
leaked write lock signal, ~3x the worst-case queue drain at 200ms/fsync)
and backs off: hot yield_now() for the first 100 attempts to keep
exercising the contended path, then 1ms sleeps. The WAL variant still
treats WriteWriteConflict as a hard failure; only the MVCC variants
tolerate it.

Tests: reproduced the CI panic on all three tests via strace fsync fault
injection (delay_exit=80ms, 4 CPUs) before the change; after it they
pass at 80ms and even 200ms injected latency, and all 31 common::tests
pass unchanged at normal speed.

Fixes #7738
