### PR TITLE
core: implement dense_rank() window function

### DIFF
--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -258,6 +258,12 @@ pub fn resolve_builtin_function(name: &str, arg_count: usize) -> crate::Result<O
             }
             Ok(Some(Func::Window(WindowFunc::Rank)))
         }
+        "dense_rank" => {
+            if arg_count != 0 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::DenseRank)))
+        }
         "timediff" => {
             if arg_count != 2 {
                 crate::bail_parse_error!("wrong number of arguments to function {}()", name)

--- a/core/function.rs
+++ b/core/function.rs
@@ -518,7 +518,7 @@ impl WindowFunc {
     /// drifts ahead of the resolver and users get "no such function" when
     /// they try to call them.
     pub fn is_implemented(&self) -> bool {
-        matches!(self, Self::RowNumber | Self::Rank)
+        matches!(self, Self::RowNumber | Self::Rank | Self::DenseRank)
     }
 
     /// The hardcoded frame this built-in evaluates over, overriding any

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6813,6 +6813,37 @@ fn op_window_step(
                 *rank = rows_seen;
             }
         }
+        // dense_rank() — mirrors SQLite's CallCount-based dense_rankStepFunc.
+        //
+        // State (payload):
+        //   [0] = current dense_rank value (never cleared; persists across
+        //         peer groups in a partition and resets at partition boundary
+        //         via the Null on acc_reg).
+        //   [1] = "pending bump" flag.
+        //
+        // Step sets the flag every source row (no-op past the first row of a
+        // peer group since the flag is already 1). AggValue, called once per
+        // peer-group flush, sees the flag set, bumps payload[0] by one, then
+        // clears the flag. Subsequent source rows within the same peer group
+        // re-set the flag, but no AggValue runs between them, so the bump
+        // happens exactly once per peer group — yielding no gaps.
+        WindowFunc::DenseRank => {
+            if let Register::Value(Value::Null) = state.registers[acc_reg] {
+                state.registers[acc_reg] =
+                    Register::Aggregate(AggContext::Builtin(crate::alloc::try_vec![
+                        Value::from_i64(0),
+                        Value::from_i64(0),
+                    ]?));
+            }
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                unreachable!("dense_rank accumulator must be a Builtin payload");
+            };
+            let Value::Numeric(Numeric::Integer(pending)) = &mut payload[1] else {
+                unreachable!("dense_rank pending flag must be Integer");
+            };
+            *pending = 1;
+        }
         other => {
             return Err(LimboError::InternalError(format!(
                 "window function {other} reached runtime dispatch but has no handler"
@@ -6850,6 +6881,32 @@ fn op_window_value(
                 )));
             };
             std::mem::replace(&mut payload[0], Value::from_i64(0))
+        }
+        WindowFunc::DenseRank => {
+            // If the pending-bump flag is set, increment the dense_rank value
+            // and clear the flag, then return the (possibly bumped) value.
+            // Mirrors SQLite's dense_rankValueFunc.
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                return Err(LimboError::InternalError(format!(
+                    "dense_rank accumulator in unexpected register state: {:?}",
+                    state.registers[acc_reg]
+                )));
+            };
+            let Value::Numeric(Numeric::Integer(pending)) = &mut payload[1] else {
+                unreachable!("dense_rank pending flag must be Integer");
+            };
+            let should_bump = *pending != 0;
+            if should_bump {
+                *pending = 0;
+            }
+            let Value::Numeric(Numeric::Integer(value_slot)) = &mut payload[0] else {
+                unreachable!("dense_rank current value must be Integer");
+            };
+            if should_bump {
+                *value_slot += 1;
+            }
+            Value::from_i64(*value_slot)
         }
         other => {
             return Err(LimboError::InternalError(format!(

--- a/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
@@ -291,11 +291,18 @@ expect {
     rank|w|0
 }
 
+test pragma-function-list-window-dense-rank {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'dense_rank';
+}
+expect {
+    dense_rank|w|0
+}
+
 @skip-if sqlite "sqlite implements these window functions; we don't yet, so they must not be advertised in pragma_function_list"
 test pragma-function-list-omits-unimplemented-window-functions {
     SELECT COUNT(*) FROM pragma_function_list
     WHERE name IN (
-        'dense_rank','percent_rank','cume_dist','ntile',
+        'percent_rank','cume_dist','ntile',
         'lag','lead','first_value','last_value','nth_value'
     );
 }

--- a/sqlite/conformance/sqlite-sqltests/window/dense_rank.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/dense_rank.sqltest
@@ -1,0 +1,456 @@
+@database :memory:
+
+setup dr_base {
+    CREATE TABLE dr_items(id INTEGER PRIMARY KEY, g TEXT, v INTEGER);
+    INSERT INTO dr_items VALUES
+        (1, 'a', 10),
+        (2, 'a', 10),
+        (3, 'a', 20),
+        (4, 'b', 5),
+        (5, 'b', 5),
+        (6, 'b', 5),
+        (7, 'c', 100);
+}
+
+# dense_rank gives no gaps after a peer group: peers share the rank, the
+# next group is just +1 (vs rank which jumps by the group size).
+@setup dr_base
+test dense-rank-basic-with-peers {
+    SELECT id, v, dense_rank() OVER (ORDER BY v) FROM dr_items ORDER BY id;
+}
+expect {
+    1|10|2
+    2|10|2
+    3|20|3
+    4|5|1
+    5|5|1
+    6|5|1
+    7|100|4
+}
+
+@setup dr_base
+test dense-rank-partition-by-group {
+    SELECT id, g, v, dense_rank() OVER (PARTITION BY g ORDER BY v) FROM dr_items ORDER BY id;
+}
+expect {
+    1|a|10|1
+    2|a|10|1
+    3|a|20|2
+    4|b|5|1
+    5|b|5|1
+    6|b|5|1
+    7|c|100|1
+}
+
+@setup dr_base
+test dense-rank-no-order-by {
+    SELECT id, dense_rank() OVER (PARTITION BY g) FROM dr_items ORDER BY id;
+}
+expect {
+    1|1
+    2|1
+    3|1
+    4|1
+    5|1
+    6|1
+    7|1
+}
+
+setup dr_nulls {
+    CREATE TABLE dr_n(v INTEGER);
+    INSERT INTO dr_n VALUES (NULL), (NULL), (1), (2), (2);
+}
+
+@setup dr_nulls
+test dense-rank-null-values-share-rank {
+    SELECT v, dense_rank() OVER (ORDER BY v) FROM dr_n ORDER BY v;
+}
+expect {
+    |1
+    |1
+    1|2
+    2|3
+    2|3
+}
+
+setup dr_empty {
+    CREATE TABLE dr_e(v INTEGER);
+}
+
+@setup dr_empty
+test dense-rank-empty-input {
+    SELECT v, dense_rank() OVER (ORDER BY v) FROM dr_e;
+}
+expect {
+}
+
+@setup dr_base
+test dense-rank-alongside-rank-and-row-number {
+    SELECT id, v,
+           rank() OVER (ORDER BY v),
+           dense_rank() OVER (ORDER BY v),
+           row_number() OVER (ORDER BY v)
+    FROM dr_items ORDER BY id;
+}
+expect {
+    1|10|4|2|4
+    2|10|4|2|5
+    3|20|6|3|6
+    4|5|1|1|1
+    5|5|1|1|2
+    6|5|1|1|3
+    7|100|7|4|7
+}
+
+setup dr_multikey {
+    CREATE TABLE dr_mk(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+    INSERT INTO dr_mk VALUES
+        (1, 1, 1),
+        (2, 1, 1),
+        (3, 1, 2),
+        (4, 2, 1);
+}
+
+@setup dr_multikey
+test dense-rank-multi-column-order-by {
+    SELECT id, a, b, dense_rank() OVER (ORDER BY a, b) FROM dr_mk ORDER BY id;
+}
+expect {
+    1|1|1|1
+    2|1|1|1
+    3|1|2|2
+    4|2|1|3
+}
+
+@setup dr_multikey
+test dense-rank-order-by-desc {
+    SELECT id, a, dense_rank() OVER (ORDER BY a DESC) FROM dr_mk ORDER BY id;
+}
+expect {
+    1|1|2
+    2|1|2
+    3|1|2
+    4|2|1
+}
+
+setup dr_collate {
+    CREATE TABLE dr_c(v TEXT COLLATE NOCASE);
+    INSERT INTO dr_c VALUES ('Apple'), ('apple'), ('Banana'), ('banana');
+}
+
+@setup dr_collate
+test dense-rank-collate-nocase-peers {
+    SELECT v, dense_rank() OVER (ORDER BY v) FROM dr_c ORDER BY v;
+}
+expect {
+    Apple|1
+    apple|1
+    Banana|2
+    banana|2
+}
+
+setup dr_partition_repeated {
+    CREATE TABLE dr_pr(g TEXT, v INTEGER);
+    INSERT INTO dr_pr VALUES
+        ('a', 1), ('a', 1), ('a', 2),
+        ('b', 1), ('b', 2), ('b', 2), ('b', 3);
+}
+
+# Values reappear across partitions; dense_rank must reset to 1 at each
+# partition boundary regardless of what came before.
+@setup dr_partition_repeated
+test dense-rank-resets-across-partitions {
+    SELECT g, v, dense_rank() OVER (PARTITION BY g ORDER BY v) FROM dr_pr;
+}
+expect {
+    a|1|1
+    a|1|1
+    a|2|2
+    b|1|1
+    b|2|2
+    b|2|2
+    b|3|3
+}
+
+# ---------------------------------------------------------------------------
+# Adversarial peer-detection cases: peers are decided by the ORDER BY
+# comparison, so every quirk of SQLite value comparison must carry over.
+# ---------------------------------------------------------------------------
+
+setup dr_cross_type {
+    CREATE TABLE num (x, y);
+    INSERT INTO num VALUES
+        (1,'int'), (1.0,'real'), ('1','text'), (0.0,'zero'),
+        (-0.0,'negzero'), (2,'two');
+}
+
+# Cross-type comparison: 1 and 1.0 are peers (numeric comparison), the TEXT
+# '1' is not (type ordering puts text after all numerics). -0.0 == 0.0.
+@setup dr_cross_type
+test dense-rank-cross-type-numeric-peers {
+    SELECT y, dense_rank() OVER (ORDER BY x) FROM num;
+}
+expect {
+    zero|1
+    negzero|1
+    int|2
+    real|2
+    two|3
+    text|4
+}
+
+# A constant or NULL ORDER BY key makes every row a peer: one group, rank 1.
+@setup dr_cross_type
+test dense-rank-constant-and-null-order-key {
+    SELECT dense_rank() OVER (ORDER BY 'k'), dense_rank() OVER (ORDER BY NULL) FROM num;
+}
+expect {
+    1|1
+    1|1
+    1|1
+    1|1
+    1|1
+    1|1
+}
+
+setup dr_float_precision {
+    CREATE TABLE fl (x REAL, i);
+    INSERT INTO fl VALUES (0.1+0.2, 1), (0.3, 2), (0.30000000000000004, 3);
+}
+
+# 0.1+0.2 != 0.3 in doubles: the literal 0.30000000000000004 is the peer of
+# the computed sum, 0.3 is alone. Peer detection must not round.
+@setup dr_float_precision
+test dense-rank-float-precision-not-peers {
+    SELECT i, dense_rank() OVER (ORDER BY x) FROM fl;
+}
+expect {
+    2|1
+    1|2
+    3|2
+}
+
+setup dr_int_affinity {
+    CREATE TABLE aff (n INTEGER);
+    INSERT INTO aff VALUES (1), (1.0), ('1'), (2);
+}
+
+# INTEGER affinity coerces 1.0 and '1' to integer 1 at insert, so all three
+# are peers by the time the window sees them.
+@setup dr_int_affinity
+test dense-rank-integer-affinity-coercion-peers {
+    SELECT n, typeof(n), dense_rank() OVER (ORDER BY n) FROM aff;
+}
+expect {
+    1|integer|1
+    1|integer|1
+    1|integer|1
+    2|integer|2
+}
+
+setup dr_infinities {
+    CREATE TABLE inf (x, y);
+    INSERT INTO inf VALUES
+        (9e999,'inf'), (-9e999,'ninf'), (1e308,'big'), (0,'zero'), (9e999,'inf2');
+}
+
+# Infinities order below/above all finite values and +Inf is a peer of +Inf.
+@setup dr_infinities
+test dense-rank-infinities {
+    SELECT y, dense_rank() OVER (ORDER BY x) FROM inf;
+}
+expect {
+    ninf|1
+    zero|2
+    big|3
+    inf|4
+    inf2|4
+}
+
+setup dr_type_ordering {
+    CREATE TABLE mixed (x, y);
+    INSERT INTO mixed VALUES
+        (NULL,'null'), (1,'int'), ('a','text'), (X'00','blob'),
+        ('','empty'), (X'','emptyblob');
+}
+
+# SQLite type ordering: NULL < numeric < text < blob. The empty string and
+# the empty blob sit first within their own type classes and are peers of
+# nothing.
+@setup dr_type_ordering
+test dense-rank-storage-class-ordering {
+    SELECT y, dense_rank() OVER (ORDER BY x) FROM mixed;
+}
+expect {
+    null|1
+    int|2
+    empty|3
+    text|4
+    emptyblob|5
+    blob|6
+}
+
+setup dr_unicode {
+    CREATE TABLE uni (x, y);
+    INSERT INTO uni VALUES ('a',1), ('A',2), ('ä',3), ('Ä',4), ('b',5);
+}
+
+# NOCASE folds ASCII only: 'a'/'A' compare equal but 'ä'/'Ä' don't, and both
+# umlauts sort after 'b' (multi-byte UTF-8). The second key makes the output
+# order deterministic.
+@setup dr_unicode
+test dense-rank-nocase-folds-ascii-only {
+    SELECT y, dense_rank() OVER (ORDER BY x COLLATE NOCASE, y) FROM uni;
+}
+expect {
+    1|1
+    2|2
+    5|3
+    4|4
+    3|5
+}
+
+setup dr_column_collation {
+    CREATE TABLE nc (x TEXT COLLATE NOCASE, y);
+    INSERT INTO nc VALUES ('a',1), ('A',2), ('b',3);
+}
+
+# The window ORDER BY inherits the column's declared collation, so 'a'/'A'
+# are peers unless an explicit COLLATE BINARY overrides it.
+@setup dr_column_collation
+test dense-rank-column-declared-collation {
+    SELECT y, dense_rank() OVER (ORDER BY x),
+           dense_rank() OVER (ORDER BY x COLLATE BINARY) FROM nc;
+}
+expect {
+    2|1|1
+    1|1|2
+    3|2|3
+}
+
+# ---------------------------------------------------------------------------
+# dense_rank in larger query shapes.
+# ---------------------------------------------------------------------------
+
+setup dr_comp {
+    CREATE TABLE comp (x);
+    INSERT INTO comp VALUES (3), (1), (1), (2);
+}
+
+# dense_rank over the output of another window query: the inner subquery's
+# ranks become the outer window's ORDER BY keys.
+@setup dr_comp
+test dense-rank-over-dense-rank {
+    SELECT dense_rank() OVER (ORDER BY dr DESC)
+    FROM (SELECT dense_rank() OVER (ORDER BY x) dr FROM comp);
+}
+expect {
+    1
+    2
+    3
+    3
+}
+
+# A window function is legal in the outer ORDER BY clause.
+@setup dr_comp
+test dense-rank-in-outer-order-by {
+    SELECT x FROM comp ORDER BY dense_rank() OVER (ORDER BY x DESC), x;
+}
+expect {
+    3
+    2
+    1
+    1
+}
+
+@setup dr_comp
+test dense-rank-inside-expressions {
+    SELECT dense_rank() OVER (ORDER BY x) * 100 + 5,
+           CASE dense_rank() OVER (ORDER BY x) WHEN 1 THEN 'first' ELSE 'rest' END
+    FROM comp;
+}
+expect {
+    105|first
+    105|first
+    205|rest
+    305|rest
+}
+
+@setup dr_comp
+test dense-rank-union-all-branches {
+    SELECT dense_rank() OVER (ORDER BY x) FROM comp
+    UNION ALL
+    SELECT dense_rank() OVER (ORDER BY x DESC) FROM comp;
+}
+expect {
+    1
+    1
+    2
+    3
+    1
+    2
+    3
+    3
+}
+
+setup dr_multikey_mixed {
+    CREATE TABLE mk (a, b);
+    INSERT INTO mk VALUES (1,1), (1,1), (1,2), (2,1), (2,1);
+}
+
+# Mixed ASC/DESC directions across the ORDER BY keys: peers require equality
+# on every key regardless of direction.
+@setup dr_multikey_mixed
+test dense-rank-multikey-mixed-directions {
+    SELECT a, b, dense_rank() OVER (ORDER BY a DESC, b ASC) FROM mk;
+}
+expect {
+    2|1|1
+    2|1|1
+    1|1|2
+    1|1|2
+    1|2|3
+}
+
+# Volume: 10 partitions x 100 rows with 7 interleaved peer groups each.
+# The aggregate checksum pins the whole rank assignment without a
+# thousand-line expect block.
+test dense-rank-partitioned-volume-checksum {
+    SELECT sum(dr), count(DISTINCT dr)
+    FROM (SELECT dense_rank() OVER (PARTITION BY value % 10 ORDER BY value % 7) dr
+          FROM generate_series(1, 1000));
+}
+expect {
+    4003|7
+}
+
+# ---------------------------------------------------------------------------
+# Contexts where dense_rank must be rejected.
+# ---------------------------------------------------------------------------
+
+@setup dr_comp
+test dense-rank-rejected-in-where {
+    SELECT x FROM comp WHERE dense_rank() OVER (ORDER BY x) = 1;
+}
+expect error {
+}
+
+@setup dr_comp
+test dense-rank-rejected-in-group-by {
+    SELECT count(*) FROM comp GROUP BY dense_rank() OVER (ORDER BY x);
+}
+expect error {
+}
+
+@setup dr_comp
+test dense-rank-rejected-inside-aggregate {
+    SELECT sum(dense_rank() OVER (ORDER BY x)) FROM comp;
+}
+expect error {
+}
+
+test dense-rank-rejected-in-check-constraint {
+    CREATE TABLE bad (a, b CHECK (dense_rank() OVER () > 0));
+}
+expect error {
+}

--- a/sqlite/conformance/sqlite-sqltests/window/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/memory.sqltest
@@ -448,15 +448,18 @@ setup named_window_rank_data {
 }
 
 @setup named_window_rank_data
-@skip-if sqlite "TODO: dense_rank() is not yet implemented."
 test named-window-rank-dense-rank {
     SELECT a, rank() OVER w1, dense_rank() OVER w1
     FROM t_nw_rank
     WINDOW w1 AS (ORDER BY b)
     ORDER BY a;
 }
-expect error {
-    no such function: dense_rank
+expect {
+    1|1|1
+    2|1|1
+    3|3|2
+    4|3|2
+    5|5|3
 }
 
 setup named_window_ntile_data {


### PR DESCRIPTION
dense_rank() shares a value across rows in a peer group like rank() does, but advances by exactly 1 between groups instead of by the group's size — so [a,a,b,c,c] ordered ascending becomes [1,1,2,3,3].

Wire 'dense_rank' name resolution to WindowFunc::DenseRank and add step/value arms in op_window_step / op_window_value. The state machine mirrors SQLite's CallCount-based dense_rankStepFunc / dense_rankValueFunc: 

- payload[0] is the current dense_rank value (persists across peer groups in a partition; resets at partition boundary via the acc_reg Null)
- payload[1] is a pending-bump flag.

Step sets the flag every source row (idempotent within a peer group). AggValue, called once per peer-group flush, sees the flag set, bumps payload[0] by one, and clears the flag.
