### PR TITLE
core: implement first_value() and last_value() window functions

### DIFF
--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -264,6 +264,18 @@ pub fn resolve_builtin_function(name: &str, arg_count: usize) -> crate::Result<O
             }
             Ok(Some(Func::Window(WindowFunc::DenseRank)))
         }
+        "first_value" => {
+            if arg_count != 1 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::FirstValue)))
+        }
+        "last_value" => {
+            if arg_count != 1 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::LastValue)))
+        }
         "timediff" => {
             if arg_count != 2 {
                 crate::bail_parse_error!("wrong number of arguments to function {}()", name)

--- a/core/function.rs
+++ b/core/function.rs
@@ -518,7 +518,10 @@ impl WindowFunc {
     /// drifts ahead of the resolver and users get "no such function" when
     /// they try to call them.
     pub fn is_implemented(&self) -> bool {
-        matches!(self, Self::RowNumber | Self::Rank | Self::DenseRank)
+        matches!(
+            self,
+            Self::RowNumber | Self::Rank | Self::DenseRank | Self::FirstValue | Self::LastValue
+        )
     }
 
     /// The hardcoded frame this built-in evaluates over, overriding any
@@ -584,8 +587,8 @@ impl WindowFunc {
     ///   before the loop over buffered rows, reading the accumulator into a
     ///   result register. The loop then writes that one register's contents
     ///   into the output for every buffered row in the group.
-    /// * false (row_number, ntile, lag, lead, first/last/nth_value): nothing
-    ///   is emitted in `emit_aggregation_step`. Both `AggStep` and `AggValue`
+    /// * false (row_number, ntile, lag, lead, nth_value): nothing is
+    ///   emitted in `emit_aggregation_step`. Both `AggStep` and `AggValue`
     ///   are emitted inside the per-row loop in `emit_peer_group_flush`,
     ///   so they run once per buffered row and produce a distinct value for
     ///   each output row.
@@ -612,19 +615,25 @@ impl WindowFunc {
     ///
     /// Functions returning true: `rank`, `dense_rank`, `percent_rank`,
     /// `cume_dist` — their value is determined entirely by where the peer
-    /// group sits in the partition's ordering.
+    /// group sits in the partition's ordering — plus `first_value` and
+    /// `last_value`, whose default frame (`RANGE UNBOUNDED PRECEDING TO
+    /// CURRENT ROW`) ends at the current peer group, so every row in the
+    /// group sees the same frame contents.
     /// Functions returning false: `row_number`, `ntile`, `lag`, `lead`,
-    /// `first_value`, `last_value`, `nth_value` — all depend on a row's
-    /// position within the partition/frame, not just its peer group.
+    /// `nth_value` — all depend on a row's position within the
+    /// partition/frame, not just its peer group.
     pub fn one_value_per_peer_group(&self) -> bool {
         match self {
-            Self::Rank | Self::DenseRank | Self::PercentRank | Self::CumeDist => true,
+            Self::Rank
+            | Self::DenseRank
+            | Self::PercentRank
+            | Self::CumeDist
+            | Self::FirstValue
+            | Self::LastValue => true,
             Self::RowNumber
             | Self::Ntile
             | Self::Lag
             | Self::Lead
-            | Self::FirstValue
-            | Self::LastValue
             | Self::NthValue
             | Self::External(_) => false,
         }

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -1116,15 +1116,30 @@ fn emit_aggregation_step(
                 }
             }
             AccumulatorFunc::Window(win_func) => {
-                // Rank-family functions take no arguments. Emit `AggStep`
-                // here, inside the input-scan loop, so the function's
-                // internal counter and peer-detection state advance once for
-                // every row read from the subquery. `AggValue` is NOT emitted
-                // here — the accumulator is read later, once per peer-group
-                // flush, in `emit_peer_group_flush`.
+                // Emit `AggStep` here, inside the input-scan loop, so the
+                // function's internal state advances once for every row read
+                // from the subquery. `AggValue` is NOT emitted here — the
+                // accumulator is read later, once per peer-group flush, in
+                // `emit_peer_group_flush`. Rank-family functions take no
+                // arguments; first_value/last_value take one, evaluated into
+                // a register so the runtime step can capture it.
+                let arg_reg = match func.current_expr() {
+                    Expr::FunctionCall { args, .. } if !args.is_empty() => {
+                        let reg = program.alloc_register();
+                        translate_expr(
+                            program,
+                            Some(&plan.table_references),
+                            &args[0],
+                            reg,
+                            resolver,
+                        )?;
+                        reg
+                    }
+                    _ => 0,
+                };
                 program.emit_insn(Insn::AggStep {
                     acc_reg: reg_acc_start,
-                    col: 0,
+                    col: arg_reg,
                     delimiter: 0,
                     func: AccumulatorFunc::Window(win_func.clone()),
                     comparator: None,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6756,6 +6756,7 @@ fn ordered_set_percentile_disc(values: &[Value], fraction: f64, collation: Colla
 fn op_window_step(
     state: &mut ProgramState,
     acc_reg: usize,
+    arg_reg: usize,
     func: &WindowFunc,
 ) -> Result<InsnFunctionStepResult> {
     match func {
@@ -6844,6 +6845,67 @@ fn op_window_step(
             };
             *pending = 1;
         }
+        // first_value(expr) — captures the argument value of the first row
+        // of the partition once, then never updates. Under our default
+        // RANGE UNBOUNDED PRECEDING TO CURRENT ROW frame this corresponds
+        // to "value at frame start = partition start" (matches SQLite's
+        // first_valueStepFunc behavior on the same frame).
+        //
+        // State: payload[0] = captured value, payload[1] = captured flag
+        // (Integer 0 = not yet captured, 1 = captured). The flag lets us
+        // distinguish "no captures yet" from "captured a NULL".
+        WindowFunc::FirstValue => {
+            if let Register::Value(Value::Null) = state.registers[acc_reg] {
+                state.registers[acc_reg] =
+                    Register::Aggregate(AggContext::Builtin(crate::alloc::try_vec![
+                        Value::Null,
+                        Value::from_i64(0),
+                    ]?));
+            }
+            // Most steps past the first per partition are no-ops; check the
+            // capture flag with an immutable borrow first so we don't clone
+            // the arg (potentially a Text/Blob allocation) on every row.
+            let already_captured = {
+                let Register::Aggregate(AggContext::Builtin(payload)) = &state.registers[acc_reg]
+                else {
+                    unreachable!("first_value accumulator must be a Builtin payload");
+                };
+                let Value::Numeric(Numeric::Integer(captured)) = &payload[1] else {
+                    unreachable!("first_value capture flag must be Integer");
+                };
+                *captured != 0
+            };
+            if !already_captured {
+                let arg_value = state.registers[arg_reg].get_value().clone();
+                let Register::Aggregate(AggContext::Builtin(payload)) =
+                    &mut state.registers[acc_reg]
+                else {
+                    unreachable!("first_value accumulator must be a Builtin payload");
+                };
+                payload[0] = arg_value;
+                let Value::Numeric(Numeric::Integer(captured)) = &mut payload[1] else {
+                    unreachable!("first_value capture flag must be Integer");
+                };
+                *captured = 1;
+            }
+        }
+        // last_value(expr) — captures the argument value of every source row,
+        // so payload[0] always holds the value of the most recently stepped
+        // row. With our default RANGE frame, AggValue is called once per
+        // peer-group flush, so the captured value at that moment is the value
+        // of the last row of the just-finished peer group.
+        WindowFunc::LastValue => {
+            if let Register::Value(Value::Null) = state.registers[acc_reg] {
+                state.registers[acc_reg] =
+                    Register::Aggregate(AggContext::Builtin(crate::alloc::try_vec![Value::Null]?));
+            }
+            let arg_value = state.registers[arg_reg].get_value().clone();
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                unreachable!("last_value accumulator must be a Builtin payload");
+            };
+            payload[0] = arg_value;
+        }
         other => {
             return Err(LimboError::InternalError(format!(
                 "window function {other} reached runtime dispatch but has no handler"
@@ -6908,6 +6970,32 @@ fn op_window_value(
             }
             Value::from_i64(*value_slot)
         }
+        WindowFunc::FirstValue => {
+            // first_value captures payload[0] once per partition; every
+            // peer-group flush in the partition reads the same slot, so
+            // we have to clone instead of taking ownership.
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                return Err(LimboError::InternalError(format!(
+                    "first_value accumulator in unexpected register state: {:?}",
+                    state.registers[acc_reg]
+                )));
+            };
+            payload[0].clone()
+        }
+        WindowFunc::LastValue => {
+            // last_value's slot is overwritten by the next AggStep anyway,
+            // so we can take ownership here and save a clone per peer-group
+            // flush (notable for Text / Blob args).
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                return Err(LimboError::InternalError(format!(
+                    "last_value accumulator in unexpected register state: {:?}",
+                    state.registers[acc_reg]
+                )));
+            };
+            std::mem::replace(&mut payload[0], Value::Null)
+        }
         other => {
             return Err(LimboError::InternalError(format!(
                 "window function {other} reached runtime dispatch but has no handler"
@@ -6937,7 +7025,7 @@ pub fn op_agg_step(
     );
 
     if let AccumulatorFunc::Window(win_func) = func {
-        return op_window_step(state, *acc_reg, win_func);
+        return op_window_step(state, *acc_reg, *col, win_func);
     }
     let func = func.expect_agg();
 

--- a/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
@@ -298,12 +298,26 @@ expect {
     dense_rank|w|0
 }
 
+test pragma-function-list-window-first-value {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'first_value';
+}
+expect {
+    first_value|w|1
+}
+
+test pragma-function-list-window-last-value {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'last_value';
+}
+expect {
+    last_value|w|1
+}
+
 @skip-if sqlite "sqlite implements these window functions; we don't yet, so they must not be advertised in pragma_function_list"
 test pragma-function-list-omits-unimplemented-window-functions {
     SELECT COUNT(*) FROM pragma_function_list
     WHERE name IN (
         'percent_rank','cume_dist','ntile',
-        'lag','lead','first_value','last_value','nth_value'
+        'lag','lead','nth_value'
     );
 }
 expect {

--- a/sqlite/conformance/sqlite-sqltests/window/first_last_value.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/first_last_value.sqltest
@@ -1,0 +1,456 @@
+@database :memory:
+
+setup fv_lv_base {
+    CREATE TABLE fv_lv(id INTEGER PRIMARY KEY, g TEXT, v INTEGER);
+    INSERT INTO fv_lv VALUES
+        (1, 'a', 10),
+        (2, 'a', 20),
+        (3, 'a', 30),
+        (4, 'b', 5),
+        (5, 'b', 15),
+        (6, 'b', 15);
+}
+
+# first_value reads the first row of the frame; under the default
+# RANGE UNBOUNDED PRECEDING TO CURRENT ROW frame that's the first row of
+# the partition. last_value reads the last row of the frame; under the
+# same frame that's the last row of the current peer group.
+@setup fv_lv_base
+test first-value-last-value-partition-order {
+    SELECT id, g, v,
+           first_value(v) OVER (PARTITION BY g ORDER BY v),
+           last_value(v) OVER (PARTITION BY g ORDER BY v)
+    FROM fv_lv ORDER BY id;
+}
+expect {
+    1|a|10|10|10
+    2|a|20|10|20
+    3|a|30|10|30
+    4|b|5|5|5
+    5|b|15|5|15
+    6|b|15|5|15
+}
+
+setup fv_lv_peers {
+    CREATE TABLE fv_p(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO fv_p VALUES (1, 1), (2, 2), (3, 2), (4, 3), (5, 3), (6, 3);
+}
+
+# Rows in the same peer group share last_value: they all see the same
+# "end of frame" because the frame ends at the last peer of the current
+# row under RANGE.
+@setup fv_lv_peers
+test first-last-value-shared-within-peer-group {
+    SELECT id, v,
+           first_value(v) OVER (ORDER BY v),
+           last_value(v) OVER (ORDER BY v)
+    FROM fv_p ORDER BY id;
+}
+expect {
+    1|1|1|1
+    2|2|1|2
+    3|2|1|2
+    4|3|1|3
+    5|3|1|3
+    6|3|1|3
+}
+
+setup fv_nulls {
+    CREATE TABLE fv_n(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO fv_n VALUES (1, NULL), (2, 5), (3, 10);
+}
+
+# A NULL first value is preserved (the capture flag distinguishes
+# "no row stepped yet" from "the captured value was NULL").
+@setup fv_nulls
+test first-value-null-is-preserved {
+    SELECT id, v, first_value(v) OVER (ORDER BY v) FROM fv_n ORDER BY id;
+}
+expect {
+    1||
+    2|5|
+    3|10|
+}
+
+setup fv_lv_empty {
+    CREATE TABLE fv_e(v INTEGER);
+}
+
+@setup fv_lv_empty
+test first-value-last-value-empty-input {
+    SELECT first_value(v) OVER (ORDER BY v), last_value(v) OVER (ORDER BY v) FROM fv_e;
+}
+expect {
+}
+
+setup fv_lv_text {
+    CREATE TABLE fv_t(v TEXT);
+    INSERT INTO fv_t VALUES ('apple'), ('banana'), ('cherry');
+}
+
+@setup fv_lv_text
+test first-last-value-text-args {
+    SELECT v, first_value(v) OVER (ORDER BY v), last_value(v) OVER (ORDER BY v) FROM fv_t ORDER BY v;
+}
+expect {
+    apple|apple|apple
+    banana|apple|banana
+    cherry|apple|cherry
+}
+
+@setup fv_lv_base
+test first-value-expression-argument {
+    SELECT id, v, first_value(v * 10) OVER (ORDER BY v) FROM fv_lv ORDER BY id;
+}
+expect {
+    1|10|50
+    2|20|50
+    3|30|50
+    4|5|50
+    5|15|50
+    6|15|50
+}
+
+@setup fv_lv_base
+test first-value-different-from-last-value-column {
+    SELECT id, g, v,
+           first_value(g) OVER (ORDER BY v),
+           last_value(v) OVER (ORDER BY v)
+    FROM fv_lv ORDER BY id;
+}
+expect {
+    1|a|10|b|10
+    2|a|20|b|20
+    3|a|30|b|30
+    4|b|5|b|5
+    5|b|15|b|15
+    6|b|15|b|15
+}
+
+@setup fv_lv_base
+test first-last-value-alongside-rank-and-row-number {
+    SELECT id, g, v,
+           rank() OVER (PARTITION BY g ORDER BY v),
+           first_value(v) OVER (PARTITION BY g ORDER BY v),
+           last_value(v) OVER (PARTITION BY g ORDER BY v),
+           row_number() OVER (PARTITION BY g ORDER BY v)
+    FROM fv_lv ORDER BY id;
+}
+expect {
+    1|a|10|1|10|10|1
+    2|a|20|2|10|20|2
+    3|a|30|3|10|30|3
+    4|b|5|1|5|5|1
+    5|b|15|2|5|15|2
+    6|b|15|2|5|15|3
+}
+
+setup fv_lv_no_order {
+    CREATE TABLE fv_no(g TEXT, v INTEGER);
+    INSERT INTO fv_no VALUES ('a', 1), ('a', 2), ('a', 3), ('b', 10), ('b', 20);
+}
+
+# With no ORDER BY, the frame covers the entire partition; first and
+# last_value both read across the whole partition.
+@setup fv_lv_no_order
+test first-last-value-no-order-by {
+    SELECT g, v,
+           first_value(v) OVER (PARTITION BY g),
+           last_value(v) OVER (PARTITION BY g)
+    FROM fv_no;
+}
+expect {
+    a|1|1|3
+    a|2|1|3
+    a|3|1|3
+    b|10|10|20
+    b|20|10|20
+}
+
+@setup fv_lv_base
+test first-last-value-named-window-shared {
+    SELECT id, first_value(v) OVER w, last_value(v) OVER w
+    FROM fv_lv WINDOW w AS (ORDER BY v) ORDER BY id;
+}
+expect {
+    1|5|10
+    2|5|20
+    3|5|30
+    4|5|5
+    5|5|15
+    6|5|15
+}
+
+# ---------------------------------------------------------------------------
+# Adversarial value-fidelity cases: the captured value must round-trip every
+# storage class untouched.
+# ---------------------------------------------------------------------------
+
+setup fvlv_types {
+    CREATE TABLE ty (x, y);
+    INSERT INTO ty VALUES (1,NULL), (2,'b'), (3,X'ff00'), (4,7.5), (5,42);
+}
+
+# first_value latches the partition-leading NULL for every row; last_value's
+# type tracks the current peer group's row.
+@setup fvlv_types
+test first-last-value-typeof-preservation {
+    SELECT typeof(first_value(y) OVER (ORDER BY x)),
+           typeof(last_value(y) OVER (ORDER BY x)) FROM ty;
+}
+expect {
+    null|null
+    null|text
+    null|blob
+    null|real
+    null|integer
+}
+
+# DESC flips which end each function reads; hex() keeps the blob printable.
+@setup fvlv_types
+test first-last-value-desc-hex-roundtrip {
+    SELECT hex(first_value(y) OVER (ORDER BY x DESC)),
+           hex(last_value(y) OVER (ORDER BY x DESC)) FROM ty;
+}
+expect {
+    3432|3432
+    3432|372E35
+    3432|FF00
+    3432|62
+    3432|
+}
+
+setup fvlv_empties {
+    CREATE TABLE es (x, y);
+    INSERT INTO es VALUES (1,''), (2,NULL), (3,X'');
+}
+
+# Empty string, NULL, and empty blob are three different captured values;
+# none may collapse into another.
+@setup fvlv_empties
+test first-last-value-empty-string-vs-null-vs-empty-blob {
+    SELECT typeof(first_value(y) OVER (ORDER BY x)),
+           length(first_value(y) OVER (ORDER BY x)),
+           typeof(last_value(y) OVER (ORDER BY x)) FROM es;
+}
+expect {
+    text|0|text
+    text|0|null
+    text|0|blob
+}
+
+setup fvlv_null_keys {
+    CREATE TABLE nk (x, y);
+    INSERT INTO nk VALUES (NULL,'n1'), (1,'a'), (NULL,'n2'), (2,'b');
+}
+
+# NULL ordering keys are peers of each other; NULLS LAST moves the group to
+# the end, so last_value inside it reads the group's final row for both.
+@setup fvlv_null_keys
+test first-last-value-null-keys-nulls-last {
+    SELECT y, first_value(y) OVER (ORDER BY x NULLS LAST),
+           last_value(y) OVER (ORDER BY x NULLS LAST) FROM nk;
+}
+expect {
+    a|a|a
+    b|a|b
+    n1|a|n2
+    n2|a|n2
+}
+
+setup fvlv_column_collation {
+    CREATE TABLE nc (x TEXT COLLATE NOCASE, y);
+    INSERT INTO nc VALUES ('a',1), ('A',2), ('b',3);
+}
+
+# The window ORDER BY inherits the column's declared NOCASE collation, so
+# 'a' and 'A' are peers (the second key keeps output deterministic).
+@setup fvlv_column_collation
+test first-last-value-column-declared-collation {
+    SELECT y, first_value(y) OVER (ORDER BY x, y),
+           last_value(y) OVER (ORDER BY x, y) FROM nc;
+}
+expect {
+    1|1|1
+    2|1|2
+    3|1|3
+}
+
+# ---------------------------------------------------------------------------
+# Argument-shape cases.
+# ---------------------------------------------------------------------------
+
+setup fvlv_comp {
+    CREATE TABLE co (x);
+    INSERT INTO co VALUES (3), (1), (1), (2);
+}
+
+@setup fvlv_comp
+test first-last-value-case-expression-argument {
+    SELECT first_value(CASE WHEN x > 1 THEN x*10 ELSE -x END) OVER (ORDER BY x DESC),
+           last_value(CASE WHEN x > 1 THEN x*10 ELSE -x END) OVER (ORDER BY x) FROM co;
+}
+expect {
+    30|30
+    30|20
+    30|-1
+    30|-1
+}
+
+# The argument can be the partition/order key itself.
+@setup fvlv_comp
+test first-last-value-arg-is-key {
+    SELECT first_value(x) OVER (PARTITION BY x ORDER BY x),
+           last_value(x) OVER (PARTITION BY x) FROM co;
+}
+expect {
+    1|1
+    1|1
+    2|2
+    3|3
+}
+
+# Window over aggregates: the functions see one row per group, and their
+# argument is the group's aggregate.
+setup fvlv_groupby {
+    CREATE TABLE ga (k, x);
+    INSERT INTO ga VALUES ('a',1), ('a',2), ('b',30), ('c',5);
+}
+
+@setup fvlv_groupby
+test first-last-value-over-group-by-aggregates {
+    SELECT k, first_value(sum(x)) OVER (ORDER BY k),
+           last_value(sum(x)) OVER (ORDER BY k),
+           last_value(count(*)) OVER (ORDER BY sum(x) DESC)
+    FROM ga GROUP BY k;
+}
+expect {
+    a|3|3|2
+    b|3|30|1
+    c|3|5|1
+}
+
+# ---------------------------------------------------------------------------
+# Larger query shapes.
+# ---------------------------------------------------------------------------
+
+setup fvlv_two_windows {
+    CREATE TABLE tw (p, x);
+    INSERT INTO tw VALUES (1,10), (1,20), (2,30), (2,40);
+}
+
+# The same function pair over opposite orderings of the same partition: four
+# window layers in one SELECT.
+@setup fvlv_two_windows
+test first-last-value-opposite-direction-windows {
+    SELECT p, x,
+           first_value(x) OVER (PARTITION BY p ORDER BY x),
+           first_value(x) OVER (PARTITION BY p ORDER BY x DESC),
+           last_value(x) OVER (PARTITION BY p ORDER BY x),
+           last_value(x) OVER (PARTITION BY p ORDER BY x DESC)
+    FROM tw;
+}
+expect {
+    1|10|10|20|10|10
+    1|20|10|20|20|20
+    2|30|30|40|30|30
+    2|40|30|40|40|40
+}
+
+# first/last_value over another window query's output.
+@setup fvlv_comp
+test first-last-value-over-row-number {
+    SELECT first_value(rn) OVER (ORDER BY rn DESC),
+           last_value(rn) OVER (ORDER BY rn DESC)
+    FROM (SELECT row_number() OVER (ORDER BY x) rn FROM co);
+}
+expect {
+    4|4
+    4|3
+    4|2
+    4|1
+}
+
+@setup fvlv_comp
+test first-last-value-union-all-branches {
+    SELECT first_value(x) OVER (ORDER BY x) FROM co
+    UNION ALL
+    SELECT last_value(x) OVER (ORDER BY x) FROM co;
+}
+expect {
+    1
+    1
+    1
+    1
+    1
+    1
+    2
+    3
+}
+
+@setup fvlv_comp
+test first-last-value-insert-into-select {
+    CREATE TABLE dst (a, b, c);
+    INSERT INTO dst SELECT x, first_value(x) OVER (ORDER BY x DESC),
+                           last_value(x) OVER (ORDER BY x DESC) FROM co;
+    SELECT * FROM dst ORDER BY a, c;
+}
+expect {
+    1|3|1
+    1|3|1
+    2|3|2
+    3|3|3
+}
+
+test first-last-value-generate-series-source {
+    SELECT first_value(value) OVER (ORDER BY value % 3, value),
+           last_value(value) OVER (ORDER BY value % 3, value)
+    FROM generate_series(1, 7);
+}
+expect {
+    3|3
+    3|6
+    3|1
+    3|4
+    3|7
+    3|2
+    3|5
+}
+
+# Volume with fat values: 50 rows of ~500-byte strings; the length checksums
+# pin every captured value without a huge expect block.
+test first-last-value-fat-values-checksum {
+    SELECT sum(length(fv)), sum(length(lv))
+    FROM (SELECT first_value(y) OVER (ORDER BY x) fv,
+                 last_value(y) OVER (ORDER BY x) lv
+          FROM (SELECT value x, printf('%.*c', 500, 'q') || value y
+                FROM generate_series(1, 50)));
+}
+expect {
+    25050|25091
+}
+
+# ---------------------------------------------------------------------------
+# Contexts where first_value / last_value must be rejected.
+# ---------------------------------------------------------------------------
+
+@setup fvlv_comp
+test first-value-rejected-inside-aggregate {
+    SELECT sum(first_value(x) OVER (ORDER BY x)) FROM co;
+}
+expect error {
+}
+
+@setup fvlv_comp
+test first-value-rejected-nested-window {
+    SELECT first_value(row_number() OVER (ORDER BY x)) OVER (ORDER BY x) FROM co;
+}
+expect error {
+}
+
+@setup fvlv_comp
+test last-value-rejected-in-having {
+    SELECT count(*) FROM co GROUP BY x HAVING last_value(x) OVER (ORDER BY x) > 0;
+}
+expect error {
+}


### PR DESCRIPTION
Both fit the existing per-source-row step + per-peer-group AggValue emit pattern; the runtime difference is what each does at step time.

  first_value(expr) — captures the arg of the first row of the
  partition and keeps it. Under our default RANGE UNBOUNDED PRECEDING
  TO CURRENT ROW frame this corresponds to 'value at frame start =
  partition start'. Payload [Value, captured_flag] — the flag lets us
  distinguish 'no capture yet' from 'captured a NULL'. After the first
  capture, every subsequent step is a no-op flag check, so the arg is
  cloned only on the first row of each partition.

  last_value(expr) — captures the arg of every row, so payload[0]
  always holds the most recent. AggValue at peer-group flush returns
  that value (= last row of the just-finished peer group). AggValue
  takes ownership via mem::replace since the next step overwrites the
  slot anyway, saving a Text/Blob clone per flush.

Wire 'first_value' / 'last_value' name resolution (arity 1), extend WindowFunc::one_value_per_peer_group to include them (their default frame ends at the current peer group, so every row in the group sees the same frame contents), and plumb the function's single arg through op_window_step (previously 0-ary only).