### PR TITLE
fix(simulator): Fix ShortRead panic on large tables and Windows locks

### DIFF
--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -265,6 +265,9 @@ impl File for WindowsFile {
 
         if result == FALSE {
             let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(158) { // ERROR_NOT_LOCKED
+                return Ok(());
+            }
             return Err(LimboError::LockingError(format!(
                 "Failed to release file lock: {err}"
             )));

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2276,6 +2276,8 @@ impl Pager {
             cache.truncate(db_size as usize)?;
         }
 
+        self.max_page_count.store(db_size, Ordering::SeqCst);
+
         // No WAL position: the transaction never upgraded to a write
         // transaction, so there are no frames to rewind.
         if let (Some(wal), Some(wal_pos)) = (&self.wal, savepoint.wal_pos) {

--- a/testing/simulator/runner/memory/io.rs
+++ b/testing/simulator/runner/memory/io.rs
@@ -117,7 +117,11 @@ impl Operation {
             OperationType::Truncate { completion, len } => {
                 let file = files.get(fd.as_str()).unwrap();
                 let mut file_buf = file.buffer.borrow_mut();
-                file_buf.truncate(len);
+                if len > file_buf.len() {
+                    file_buf.resize(len, 0);
+                } else {
+                    file_buf.truncate(len);
+                }
                 completion.complete(0);
             }
         }


### PR DESCRIPTION
### Description

This PR fixes the `ShortRead` panics and Windows file lock issues that occur when running the `limbo_sim` test suite with very large tables (e.g. `configs/custom/wide-tables.json5`).

The cascading failures observed in the simulator are caused by three separate bugs which have been addressed here:

1. **`os error 158` on Windows:** The simulator consistently panicked on Windows teardown because `unlock_file` tried to release an already unlocked file segment. I patched `core/io/windows.rs` to ignore the `ERROR_NOT_LOCKED` (158) code.
2. **Pager `max_page_count` Bug:** During MVCC transaction rollbacks, `rollback_to_snapshot` inside `core/storage/pager.rs` failed to restore `self.max_page_count` from the `SavepointSnapshot`. This created holes in the page allocations and caused the database to think it was larger than it actually was. I've updated the rollback logic to correctly reset `max_page_count`.
3. **`MemorySimIO` Truncate Bug:** The `ShortRead` panic itself was caused by a simulator backend bug. When a WAL checkpoint tried to grow the database via `ptruncate`, `testing/simulator/runner/memory/io.rs` used `Vec::truncate()`, which only shrinks vectors. The read operations would then fail (EOF/0 bytes) because the file hadn't properly grown. The `Truncate` operation now correctly uses `resize(len, 0)` to pad the file with zeroes.

