### PR TITLE
ci: give every build-native leg a 60 minute timeout

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
           fi
 
   build-native:
-    timeout-minutes: ${{ matrix.os == 'blacksmith-8vcpu-windows-2025' && 120 || 30 }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os:


### PR DESCRIPTION
The Ubuntu leg has crept up to 20-26 minutes and now intermittently trips the 30 minute cap, cancelling otherwise-passing runs.

The 120 minute Windows branch of the conditional dated from the GitHub-hosted windows-latest runner; on blacksmith-8vcpu-windows-2025 that leg finishes in 6-8 minutes, so the split no longer buys anything. Use one flat 60 minute limit that leaves headroom on all three runners.