### PR TITLE
serverless: remove Connection.execute() from the main API

### DIFF
--- a/serverless/javascript/AGENT.md
+++ b/serverless/javascript/AGENT.md
@@ -49,7 +49,7 @@ for await (const row of stmt.iterate()) { ... } // Streaming iterator
 
 #### Connection
 - **Purpose**: Database connection and session management
-- **Methods**: `prepare()`, `execute()`, `batch()`, `executeRaw()`
+- **Methods**: `prepare()`, `run()`, `get()`, `all()`, `iterate()`, `exec()`, `batch()`, `pragma()`, `transaction()`
 - **Internal**: Manages baton tokens, base URL updates, cursor streaming
 
 #### Statement  

--- a/serverless/javascript/README.md
+++ b/serverless/javascript/README.md
@@ -90,11 +90,11 @@ They apply to that call only and are merged over the connection-level
 `requestHeaders`, so a query can override a header the connection sets:
 
 ```javascript
-await conn.execute("SELECT * FROM users", [], {
+await conn.all("SELECT * FROM users", {
   requestHeaders: { "X-Turso-Request-Identity": "abc123" },
 });
 
-// Also accepted by run()/get()/all()/iterate() and prepared statements:
+// Also accepted by run()/get()/iterate() and prepared statements:
 await conn.run("INSERT INTO users (email) VALUES (?)", "user@example.com", {
   requestHeaders: { "X-Turso-Request-Identity": "abc124" },
 });

--- a/serverless/javascript/examples/cloud-encryption/index.mjs
+++ b/serverless/javascript/examples/cloud-encryption/index.mjs
@@ -43,18 +43,18 @@ await client.batch(
 console.log("\nInserted 3 secrets into encrypted database");
 
 // Query the data back
-const result = await client.execute("SELECT * FROM secrets");
+const secrets = await client.all("SELECT * FROM secrets");
 console.log("\nSecrets retrieved:");
-for (const row of result.rows) {
+for (const row of secrets) {
     console.log(`  - id=${row.id}, data="${row.data}"`);
 }
 
 // Show table info
-const tables = await client.execute(
+const tables = await client.all(
     "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
 );
 console.log("\nTables in database:");
-for (const row of tables.rows) {
+for (const row of tables) {
     console.log(`  - ${row.name}`);
 }
 

--- a/serverless/javascript/examples/remote/index.mjs
+++ b/serverless/javascript/examples/remote/index.mjs
@@ -15,9 +15,9 @@ await client.batch(
     "write",
 );
 
-// Using execute method
-const result = await client.execute("SELECT * FROM users");
-console.log("Users (execute):", result.rows);
+// Using the connection-level all method
+const users = await client.all("SELECT * FROM users");
+console.log("Users (all):", users);
 
 // Using prepare and get method
 const stmt = client.prepare("SELECT * FROM users LIMIT 1");

--- a/serverless/javascript/integration-tests/serverless.test.mjs
+++ b/serverless/javascript/integration-tests/serverless.test.mjs
@@ -6,31 +6,33 @@ const client = connect({
   authToken: process.env.TURSO_AUTH_TOKEN,
 });
 
-test.serial('execute() method creates table and inserts data', async t => {
-  await client.execute('DROP TABLE IF EXISTS test_users');
-  
-  await client.execute('CREATE TABLE test_users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)');
-  
-  const insertResult = await client.execute(
+test.serial('run() method creates table and inserts data', async t => {
+  await client.exec('DROP TABLE IF EXISTS test_users');
+
+  await client.exec('CREATE TABLE test_users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)');
+
+  const insertResult = await client.run(
     'INSERT INTO test_users (name, email) VALUES (?, ?)',
     ['John Doe', 'john@example.com']
   );
-  
-  t.is(insertResult.rowsAffected, 1);
+
+  t.is(insertResult.changes, 1);
   t.is(typeof insertResult.lastInsertRowid, 'number');
 });
 
-test.serial('execute() method queries data correctly', async t => {
-  const queryResult = await client.execute('SELECT * FROM test_users WHERE name = ?', ['John Doe']);
-  
-  t.is(queryResult.columns.length, 3);
-  t.true(queryResult.columns.includes('id'));
-  t.true(queryResult.columns.includes('name'));
-  t.true(queryResult.columns.includes('email'));
-  
-  t.is(queryResult.rows.length, 1);
-  t.is(queryResult.rows[0][1], 'John Doe');
-  t.is(queryResult.rows[0][2], 'john@example.com');
+test.serial('all() method queries data correctly', async t => {
+  const stmt = await client.prepare('SELECT * FROM test_users WHERE name = ?');
+  const columns = stmt.columns().map(col => col.name);
+
+  t.is(columns.length, 3);
+  t.true(columns.includes('id'));
+  t.true(columns.includes('name'));
+  t.true(columns.includes('email'));
+
+  const rows = await client.all('SELECT * FROM test_users WHERE name = ?', ['John Doe']);
+  t.is(rows.length, 1);
+  t.is(rows[0].name, 'John Doe');
+  t.is(rows[0].email, 'john@example.com');
 });
 
 test.serial('prepare() method creates statement', async t => {
@@ -53,8 +55,8 @@ test.serial('Statement.run()', async t => {
 
 test.serial('statement iterate() method works', async t => {
   // Ensure test data exists
-  await client.execute('CREATE TABLE IF NOT EXISTS test_users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)');
-  await client.execute('INSERT OR IGNORE INTO test_users (name, email) VALUES (?, ?)', ['John Doe', 'john@example.com']);
+  await client.exec('CREATE TABLE IF NOT EXISTS test_users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)');
+  await client.run('INSERT OR IGNORE INTO test_users (name, email) VALUES (?, ?)', ['John Doe', 'john@example.com']);
   
   const stmt = await client.prepare('SELECT * FROM test_users');
   
@@ -68,7 +70,7 @@ test.serial('statement iterate() method works', async t => {
 });
 
 test.serial('batch() method executes multiple statements', async t => {
-  await client.execute('DROP TABLE IF EXISTS test_products');
+  await client.exec('DROP TABLE IF EXISTS test_products');
   
   const batchResult = await client.batch([
     'CREATE TABLE test_products (id INTEGER PRIMARY KEY, name TEXT, price REAL)',
@@ -82,47 +84,40 @@ test.serial('batch() method executes multiple statements', async t => {
   const insertedRows = batchResult.slice(1).reduce((sum, rs) => sum + rs.rowsAffected, 0);
   t.is(insertedRows, 3);
 
-  const queryResult = await client.execute('SELECT COUNT(*) as count FROM test_products');
-  t.is(queryResult.rows[0][0], 3);
+  const countRow = await client.get('SELECT COUNT(*) as count FROM test_products');
+  t.is(countRow.count, 3);
 });
 
-test.serial('execute() method queries a single value', async t => {
-  const rs = await client.execute('SELECT 42');
-  
-  t.is(rs.columns.length, 1);
-  t.is(rs.columnTypes.length, 1);
-  t.is(rs.rows.length, 1);
-  t.is(rs.rows[0].length, 1);
-  t.is(rs.rows[0][0], 42);
+test.serial('get() method queries a single value', async t => {
+  const row = await client.get('SELECT 42 AS answer');
+
+  t.is(row.answer, 42);
+  t.is(row[0], 42);
 });
 
-test.serial('execute() method queries a single row', async t => {
-  const rs = await client.execute(
-    "SELECT 1 AS one, 'two' AS two, 0.5 AS three"
-  );
-  
-  t.deepEqual(rs.columns, ["one", "two", "three"]);
-  t.deepEqual(rs.columnTypes, ["", "", ""]);
-  t.is(rs.rows.length, 1);
+test.serial('get() method queries a single row', async t => {
+  const stmt = await client.prepare("SELECT 1 AS one, 'two' AS two, 0.5 AS three");
+  t.deepEqual(stmt.columns().map(col => col.name), ["one", "two", "three"]);
 
-  const r = rs.rows[0];
-  t.is(r.length, 3);
-  t.deepEqual(Array.from(r), [1, "two", 0.5]);
+  const rows = await client.all("SELECT 1 AS one, 'two' AS two, 0.5 AS three");
+  t.is(rows.length, 1);
+
+  const r = rows[0];
   t.deepEqual(Object.entries(r), [
-    ["0", 1],
-    ["1", "two"],
-    ["2", 0.5],
+    ["one", 1],
+    ["two", "two"],
+    ["three", 0.5],
   ]);
-  
-  // Test column name access
-  t.is(r.one, 1);
-  t.is(r.two, "two");
-  t.is(r.three, 0.5);
+
+  // Positional access is also available
+  t.is(r[0], 1);
+  t.is(r[1], "two");
+  t.is(r[2], 0.5);
 });
 
 test.serial('error handling works correctly', async t => {
   const error = await t.throwsAsync(
-    () => client.execute('SELECT * FROM nonexistent_table')
+    () => client.all('SELECT * FROM nonexistent_table')
   );
   t.regex(error.message, /SQLite error.*no such table|no such table|HTTP error/);
 });

--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -64,14 +64,14 @@ function toResultSet(result: any): any {
  * and corrupt the stream. This is the same model as SQLite itself (one execution
  * at a time per connection).
  *
- * If you call `execute()` while another is in flight, the call automatically
+ * If you call `all()` while another statement is in flight, the call automatically
  * waits for the previous one to finish — just like the native
  * `@tursodatabase/database` binding.
  *
  * ## Parallel queries
  *
  * For parallelism, create multiple connections. `connect()` is cheap — it just
- * allocates a config object. No TCP connection is opened until the first `execute()`,
+ * allocates a config object. No TCP connection is opened until the first query,
  * and the underlying `fetch()` runtime automatically pools and reuses TCP/TLS
  * connections to the same origin.
  *
@@ -82,14 +82,14 @@ function toResultSet(result: any): any {
  *
  * // Option 1: one connection per parallel query
  * const [users, orders] = await Promise.all([
- *   connect(config).execute("SELECT * FROM users WHERE active = 1"),
- *   connect(config).execute("SELECT * FROM orders WHERE status = 'pending'"),
+ *   connect(config).all("SELECT * FROM users WHERE active = 1"),
+ *   connect(config).all("SELECT * FROM orders WHERE status = 'pending'"),
  * ]);
  *
  * // Option 2: reusable pool for repeated parallel work
  * const pool = Array.from({ length: 4 }, () => connect(config));
  * const results = await Promise.all(
- *   queries.map((sql, i) => pool[i % pool.length].execute(sql))
+ *   queries.map((sql, i) => pool[i % pool.length].all(sql))
  * );
  * ```
  */
@@ -224,31 +224,6 @@ export class Connection {
 
   /**
    * Execute a SQL statement and return all results.
-   *
-   * @param sql - The SQL statement to execute
-   * @param args - Optional array of parameter values
-   * @returns Promise resolving to the complete result set
-   *
-   * @example
-   * ```typescript
-   * const result = await client.execute("SELECT * FROM users WHERE id = ?", [123]);
-   * console.log(result.rows);
-   * ```
-   */
-  async execute(sql: string, args?: any[], queryOptions?: QueryOptions): Promise<any> {
-    if (!this.isOpen) {
-      throw new TypeError("The database connection is not open");
-    }
-    await this.execLock.acquire();
-    try {
-      return await this.session.execute(sql, args || [], this.defaultSafeIntegerMode, queryOptions);
-    } finally {
-      this.execLock.release();
-    }
-  }
-
-  /**
-   * Execute a SQL statement and return all results.
    * 
    * @param sql - The SQL statement to execute
    * @returns Promise resolving to the complete result set
@@ -326,7 +301,7 @@ export class Connection {
    * // Atomic via the transaction() API for mixed workloads.
    * const txn = db.transaction(async () => {
    *   await db.batch([{ sql: "INSERT INTO users(name) VALUES (?)", args: ["Eve"] }]);
-   *   await db.execute("UPDATE counters SET n = n + 1");
+   *   await db.run("UPDATE counters SET n = n + 1");
    * });
    * await txn.immediate();
    */
@@ -482,13 +457,13 @@ export class Connection {
  *
  * // Sequential (single connection is fine)
  * const conn = connect(config);
- * const a = await conn.execute("SELECT 1");
- * const b = await conn.execute("SELECT 2");
+ * const a = await conn.all("SELECT 1");
+ * const b = await conn.all("SELECT 2");
  *
  * // Parallel (use separate connections)
  * const [x, y] = await Promise.all([
- *   connect(config).execute("SELECT 1"),
- *   connect(config).execute("SELECT 2"),
+ *   connect(config).all("SELECT 1"),
+ *   connect(config).all("SELECT 2"),
  * ]);
  * ```
  *

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -1256,7 +1256,7 @@ test.serial("Concurrent writes over same connection", async (t) => {
   t.is(rows[0][0], 22);
 });
 
-test.serial("Statement.iterate() with nested execute() on same connection does not deadlock", async (t) => {
+test.serial("Statement.iterate() with a nested query on same connection does not deadlock", async (t) => {
   if (process.env.PROVIDER !== "serverless") {
     t.pass("Skipping serverless-only deadlock reproduction");
     return;
@@ -1272,12 +1272,12 @@ test.serial("Statement.iterate() with nested execute() on same connection does n
   const run = (async () => {
     for await (const row of stmt.iterate()) {
       const id = row.id ?? row[0];
-      await db.execute("SELECT ? as echoed_id", [id]);
+      await db.all("SELECT ? as echoed_id", [id]);
     }
   })();
 
   await t.notThrowsAsync(async () => {
-    await withTimeout(run, 2000, "nested iterate/execute");
+    await withTimeout(run, 2000, "nested iterate/query");
   });
 });
 
@@ -1433,7 +1433,7 @@ test.serial("defaultQueryTimeout interrupts long-running query", async (t) => {
   });
 
   const error = await t.throwsAsync(async () => {
-    await db.execute(
+    await db.all(
       "WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM r) SELECT * FROM r;"
     );
   });
@@ -1456,9 +1456,9 @@ test.serial("defaultQueryTimeout allows short-running query", async (t) => {
     defaultQueryTimeout: 5000,
   });
 
-  const result = await db.execute("SELECT 1 AS value");
-  t.is(result.rows.length, 1);
-  t.is(result.rows[0].value, 1);
+  const rows = await db.all("SELECT 1 AS value");
+  t.is(rows.length, 1);
+  t.is(rows[0].value, 1);
 
   await db.close();
 });
@@ -1475,9 +1475,8 @@ test.serial("Per-query queryTimeout interrupts long-running query", async (t) =>
   });
 
   const error = await t.throwsAsync(async () => {
-    await db.execute(
+    await db.all(
       "WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM r) SELECT * FROM r;",
-      [],
       { queryTimeout: 100 }
     );
   });


### PR DESCRIPTION
The serverless driver's main entry point is meant to mirror the native @tursodatabase/database surface, which has no execute() — it exposes prepare/run/get/all/iterate/exec/batch/pragma/transaction. Connection.execute() was a libsql-client-ism on that surface, and it returned the raw protocol result shape rather than the {changes, lastInsertRowid} / row-array contracts the sibling methods use.

The libsql compatibility layer keeps its own execute(), which talks to Session.execute() directly and never went through Connection.execute(), so the compat surface is unaffected.

Tests: rewrote the serverless integration tests and the serverless-only conformance tests against exec/run/get/all; tsc and the package build pass. Both suites need a live TURSO_DATABASE_URL and were not run.