### PR TITLE
core/mvcc: allocate portable logical logs with TursoAllocator

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2378,7 +2378,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
 
         // Move the assembled log record out and transition to
         // BeginCommitLogicalLog (or directly to CommitEnd if there is nothing
-        // to log).
+        // to log). An error after this swap is terminal for the commit attempt:
+        // callers drop the state machine, whose unfinished-commit cleanup rolls
+        // the transaction back, so this emptied BuildLogRecord state is never
+        // resumed.
         let mut log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
         self.populate_portable_changes(mvcc_store, &mut log_record)?;
         tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -504,7 +504,7 @@ pub struct LogRecord {
     /// Recovery ignores this field. Raw-log consumers use it to resolve the
     /// recovery ops' MVCC table ids and read transaction-level metadata.
     #[cfg(feature = "conn_raw_api")]
-    pub portable_changes: Vec<u8>,
+    pub portable_changes: crate::alloc::Vec<u8>,
     /// True when the committing connection requested portable logical-change
     /// frames, even if this transaction has no client-visible metadata.
     #[cfg(feature = "conn_raw_api")]
@@ -529,7 +529,7 @@ impl LogRecord {
             op_count: 0,
             has_header: false,
             #[cfg(feature = "conn_raw_api")]
-            portable_changes: Vec::new(),
+            portable_changes: crate::alloc::vec![],
             #[cfg(feature = "conn_raw_api")]
             portable_changes_enabled: false,
             #[cfg(feature = "conn_raw_api")]
@@ -2427,7 +2427,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 .collect();
             metadata.sort_by(|a, b| a.0.cmp(&b.0));
             for (key, value) in metadata {
-                builder.add_metadata(&key, &value);
+                builder.add_metadata(&key, &value)?;
             }
 
             // The recovery payload is the single durable operation stream.
@@ -2594,7 +2594,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 let added = builder.add_object_map(PortableObjectMapEntry {
                     mv_table_id: i64::from(*table_id),
                     name: &table_ref.name,
-                });
+                })?;
                 turso_assert!(
                     added,
                     "portable object map unexpectedly rejected a user object"
@@ -2612,7 +2612,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 }
             }
 
-            log_record.portable_changes = builder.finish();
+            log_record.portable_changes = builder.finish()?;
             log_record.portable_changes_required = has_portable_schema_changes;
             Ok(())
         }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2378,10 +2378,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
 
         // Move the assembled log record out and transition to
         // BeginCommitLogicalLog (or directly to CommitEnd if there is nothing
-        // to log). An error after this swap is terminal for the commit attempt:
-        // callers drop the state machine, whose unfinished-commit cleanup rolls
-        // the transaction back, so this emptied BuildLogRecord state is never
-        // resumed.
+        // to log).
         let mut log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
         self.populate_portable_changes(mvcc_store, &mut log_record)?;
         tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2426,8 +2426,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 .into_iter()
                 .collect();
             metadata.sort_by(|a, b| a.0.cmp(&b.0));
-            for (key, value) in metadata {
-                builder.add_metadata(&key, &value)?;
+            for (key, value) in &metadata {
+                builder.add_metadata(key, value)?;
             }
 
             // The recovery payload is the single durable operation stream.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -15116,12 +15116,14 @@ fn decoded_object_maps(txns: &[DecodedPortableTxn]) -> Vec<&DecodedObjectMap> {
 #[test]
 fn test_mvcc_portable_changes_encoder_matches_metadata_wire_golden() {
     let mut builder = PortableLogicalBuilder::new();
-    builder.add_metadata("client", "client-a");
-    builder.add_object_map(PortableObjectMapEntry {
-        mv_table_id: -5,
-        name: "items",
-    });
-    let encoded = builder.finish();
+    builder.add_metadata("client", "client-a").unwrap();
+    builder
+        .add_object_map(PortableObjectMapEntry {
+            mv_table_id: -5,
+            name: "items",
+        })
+        .unwrap();
+    let encoded = builder.finish().unwrap();
 
     assert_eq!(
         encoded,

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -254,10 +254,13 @@ use crate::File;
 
 mod serializer;
 use serializer::EncryptedPayload;
-pub(crate) use serializer::LogSerializer;
 #[cfg(feature = "conn_raw_api")]
 use serializer::{
     extension_record_len, ExtensionRecord, PortableChangePayload, PortableEndOffsetCtx,
+};
+pub(crate) use serializer::{
+    log_write, LogBufferWrite, LogChunkStream, LogSerializer, ProtoKey, ProtoSint64, ProtoVarint,
+    PROTO_WIRE_LENGTH_DELIMITED, PROTO_WIRE_VARINT,
 };
 
 /// Logical log size in bytes at which a committing transaction will trigger a checkpoint.
@@ -7115,7 +7118,7 @@ mod tests {
             None,
         );
         portable_tx.portable_changes_enabled = true;
-        portable_tx.portable_changes = vec![0x1a, 0x00];
+        portable_tx.portable_changes = crate::alloc::vec![0x1a, 0x00];
 
         let c = log
             .upgrade_header_for_log_tx(&portable_tx)
@@ -7169,7 +7172,7 @@ mod tests {
         let c = log.log_tx(empty_sync_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let encoded_empty_logical_op = vec![0x1a, 0x00];
+        let encoded_empty_logical_op = crate::alloc::vec![0x1a, 0x00];
         let mut sync_tx = crate::mvcc::database::LogRecord::for_test(
             20,
             &[make_test_row_version((-2).into(), 2, "visible", 20)],
@@ -7219,7 +7222,7 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let portable_metadata = vec![0x1a, 0x00];
+        let portable_metadata = crate::alloc::vec![0x1a, 0x00];
         let mut tx = crate::mvcc::database::LogRecord::for_test(
             20,
             &[make_test_row_version((-2).into(), 2, "visible", 20)],

--- a/core/mvcc/persistent_storage/logical_log/serializer.rs
+++ b/core/mvcc/persistent_storage/logical_log/serializer.rs
@@ -6,7 +6,7 @@ use super::*;
 /// serializer reserve for the complete stream once, then bulk-copy each slice.
 /// Flattening the same chain to `Iterator<Item = u8>` loses those slice
 /// boundaries and makes `Vec::extend` copy the payload one byte at a time.
-pub(super) trait LogChunkStream: Sized {
+pub(crate) trait LogChunkStream: Sized {
     fn encoded_len(&self) -> Option<usize>;
 
     fn copy_to(self, writer: &mut LogChunkWriter) -> Result<()>;
@@ -17,7 +17,7 @@ pub(super) trait LogChunkStream: Sized {
     }
 }
 
-pub(super) struct ChainedLogChunks<L, R> {
+pub(crate) struct ChainedLogChunks<L, R> {
     left: L,
     right: R,
 }
@@ -84,11 +84,11 @@ impl LogChunkStream for BorrowedLogChunk<'_> {
     }
 }
 
-pub(super) trait LogBufferWrite {
+pub(crate) trait LogBufferWrite {
     fn into_chunks(self) -> impl LogChunkStream;
 }
 
-pub(super) struct LogChunkWriter {
+pub(crate) struct LogChunkWriter {
     output: *mut u8,
     capacity: usize,
     written: usize,
@@ -116,40 +116,52 @@ impl LogChunkWriter {
     }
 }
 
-trait LogBufferExt {
+pub(crate) trait LogBufferExt: std::ops::DerefMut<Target = [u8]> {
     fn try_extend_chunks(&mut self, chunks: impl LogChunkStream) -> Result<()>;
 }
 
-impl LogBufferExt for Vec<u8> {
-    #[inline(always)]
-    fn try_extend_chunks(&mut self, chunks: impl LogChunkStream) -> Result<()> {
-        let encoded_len = chunks.encoded_len().ok_or_else(log_buffer_len_overflow)?;
-        let new_len = self
-            .len()
-            .checked_add(encoded_len)
-            .ok_or_else(log_buffer_len_overflow)?;
-        self.try_reserve(encoded_len)?;
+macro_rules! impl_try_extend_chunks {
+    () => {
+        #[inline(always)]
+        fn try_extend_chunks(&mut self, chunks: impl LogChunkStream) -> Result<()> {
+            let encoded_len = chunks.encoded_len().ok_or_else(log_buffer_len_overflow)?;
+            let new_len = self
+                .len()
+                .checked_add(encoded_len)
+                .ok_or_else(log_buffer_len_overflow)?;
+            self.try_reserve(encoded_len)?;
 
-        let original_len = self.len();
-        // SAFETY: `try_reserve` above guarantees space for `encoded_len`
-        // additional bytes, so the first spare byte is within the allocation.
-        let output = unsafe { self.as_mut_ptr().add(original_len) };
-        let mut writer = LogChunkWriter {
-            output,
-            capacity: encoded_len,
-            written: 0,
-        };
-        chunks.copy_to(&mut writer)?;
-        if writer.written != encoded_len {
-            return Err(log_buffer_len_mismatch());
+            let original_len = self.len();
+            // SAFETY: `try_reserve` above guarantees space for `encoded_len`
+            // additional bytes, so the first spare byte is within the allocation.
+            let output = unsafe { self.as_mut_ptr().add(original_len) };
+            let mut writer = LogChunkWriter {
+                output,
+                capacity: encoded_len,
+                written: 0,
+            };
+            chunks.copy_to(&mut writer)?;
+            if writer.written != encoded_len {
+                return Err(log_buffer_len_mismatch());
+            }
+            // SAFETY: every byte between the old and new lengths was initialized by
+            // the checked chunk copies above.
+            unsafe {
+                self.set_len(new_len);
+            }
+            Ok(())
         }
-        // SAFETY: every byte between the old and new lengths was initialized by
-        // the checked chunk copies above.
-        unsafe {
-            self.set_len(new_len);
-        }
-        Ok(())
-    }
+    };
+}
+
+#[cfg(not(nightly))]
+impl LogBufferExt for std::vec::Vec<u8> {
+    impl_try_extend_chunks!();
+}
+
+#[cfg(nightly)]
+impl<A: crate::alloc::ApiAllocator> LogBufferExt for std::vec::Vec<u8, A> {
+    impl_try_extend_chunks!();
 }
 
 macro_rules! log_write {
@@ -168,26 +180,32 @@ macro_rules! log_write {
             log_write!($serializer, [$first $(, $rest)*])
         }
     }};
-    ($serializer:expr, [$first:expr $(, $rest:expr)* $(,)?]) => {{
+    ($serializer:expr, [$value:expr $(,)?]) => {{
+        use $crate::mvcc::persistent_storage::logical_log::LogBufferWrite;
+        $serializer.write(LogBufferWrite::into_chunks($value))
+    }};
+    ($serializer:expr, [$first:expr, $($rest:expr),+ $(,)?]) => {{
+        use $crate::mvcc::persistent_storage::logical_log::{LogBufferWrite, LogChunkStream};
         $serializer.write(
             LogBufferWrite::into_chunks($first)
-                $(.chain(LogBufferWrite::into_chunks($rest)))*
+                $(.chain(LogBufferWrite::into_chunks($rest)))+
         )
     }};
 }
+pub(crate) use log_write;
 
-pub(crate) struct LogSerializer<'a> {
-    buffer: &'a mut Vec<u8>,
+pub(crate) struct LogSerializer<'a, B: ?Sized = Vec<u8>> {
+    buffer: &'a mut B,
 }
 
-impl<'a> LogSerializer<'a> {
+impl<'a, B: LogBufferExt + ?Sized> LogSerializer<'a, B> {
     #[inline(always)]
-    pub(crate) fn new(buffer: &'a mut Vec<u8>) -> Self {
+    pub(crate) fn new(buffer: &'a mut B) -> Self {
         Self { buffer }
     }
 
     #[inline(always)]
-    fn write(&mut self, chunks: impl LogChunkStream) -> Result<()> {
+    pub(crate) fn write(&mut self, chunks: impl LogChunkStream) -> Result<()> {
         self.buffer.try_extend_chunks(chunks)
     }
 
@@ -363,46 +381,9 @@ impl<'a> LogSerializer<'a> {
     pub(crate) fn serialize_tx_trailer(&mut self, crc: u32) -> Result<()> {
         log_write!(self, [crc.to_le_bytes(), END_MAGIC.to_le_bytes()])
     }
+}
 
-    pub(crate) fn encode_delete_portable_extension(
-        identity_record: Option<&[u8]>,
-        pk_record: Option<&[u8]>,
-        rowid: Option<i64>,
-    ) -> Result<Vec<u8>> {
-        let mut extension = Vec::new();
-        let mut serializer = LogSerializer::new(&mut extension);
-        if let Some(identity_record) = identity_record.filter(|record| !record.is_empty()) {
-            log_write!(
-                serializer,
-                [
-                    ProtoKey::new(
-                        OP_EXT_FIELD_DELETE_IDENTITY_RECORD,
-                        PROTO_WIRE_LENGTH_DELIMITED
-                    ),
-                    ProtoVarint(identity_record.len() as u64),
-                    identity_record,
-                ]
-            )?;
-        }
-        if let Some(pk_record) = pk_record.filter(|record| !record.is_empty()) {
-            log_write!(
-                serializer,
-                [
-                    ProtoKey::new(OP_EXT_FIELD_DELETE_PK_RECORD, PROTO_WIRE_LENGTH_DELIMITED),
-                    ProtoVarint(pk_record.len() as u64),
-                    pk_record,
-                ]
-            )?;
-        }
-        if let Some(rowid) = rowid {
-            log_write!(
-                serializer,
-                [ProtoSint64::new(OP_EXT_FIELD_DELETE_ROWID, rowid)]
-            )?;
-        }
-        Ok(extension)
-    }
-
+impl LogSerializer<'_, Vec<u8>> {
     pub(crate) fn encrypt_payload_in_place(&mut self, payload: EncryptedPayload<'_>) -> Result<()> {
         let tag_size = payload.enc_ctx.tag_size();
         let nonce_size = payload.enc_ctx.nonce_size();
@@ -487,6 +468,45 @@ impl<'a> LogSerializer<'a> {
         );
         Ok(())
     }
+
+    pub(crate) fn encode_delete_portable_extension(
+        identity_record: Option<&[u8]>,
+        pk_record: Option<&[u8]>,
+        rowid: Option<i64>,
+    ) -> Result<Vec<u8>> {
+        let mut extension = Vec::new();
+        let mut serializer = LogSerializer::new(&mut extension);
+        if let Some(identity_record) = identity_record.filter(|record| !record.is_empty()) {
+            log_write!(
+                serializer,
+                [
+                    ProtoKey::new(
+                        OP_EXT_FIELD_DELETE_IDENTITY_RECORD,
+                        PROTO_WIRE_LENGTH_DELIMITED
+                    ),
+                    ProtoVarint(identity_record.len() as u64),
+                    identity_record,
+                ]
+            )?;
+        }
+        if let Some(pk_record) = pk_record.filter(|record| !record.is_empty()) {
+            log_write!(
+                serializer,
+                [
+                    ProtoKey::new(OP_EXT_FIELD_DELETE_PK_RECORD, PROTO_WIRE_LENGTH_DELIMITED),
+                    ProtoVarint(pk_record.len() as u64),
+                    pk_record,
+                ]
+            )?;
+        }
+        if let Some(rowid) = rowid {
+            log_write!(
+                serializer,
+                [ProtoSint64::new(OP_EXT_FIELD_DELETE_ROWID, rowid)]
+            )?;
+        }
+        Ok(extension)
+    }
 }
 
 struct SqliteVarint(u64);
@@ -500,7 +520,7 @@ impl LogBufferWrite for SqliteVarint {
     }
 }
 
-struct ProtoVarint(u64);
+pub(crate) struct ProtoVarint(pub(crate) u64);
 
 impl LogBufferWrite for ProtoVarint {
     #[inline(always)]
@@ -521,16 +541,16 @@ impl LogBufferWrite for ProtoVarint {
     }
 }
 
-const PROTO_WIRE_VARINT: u64 = 0;
-const PROTO_WIRE_LENGTH_DELIMITED: u64 = 2;
+pub(crate) const PROTO_WIRE_VARINT: u64 = 0;
+pub(crate) const PROTO_WIRE_LENGTH_DELIMITED: u64 = 2;
 
-struct ProtoKey {
+pub(crate) struct ProtoKey {
     field: u64,
     wire_type: u64,
 }
 
 impl ProtoKey {
-    fn new(field: u64, wire_type: u64) -> Self {
+    pub(crate) fn new(field: u64, wire_type: u64) -> Self {
         Self { field, wire_type }
     }
 }
@@ -541,13 +561,13 @@ impl LogBufferWrite for ProtoKey {
     }
 }
 
-struct ProtoSint64 {
+pub(crate) struct ProtoSint64 {
     field: u64,
     value: i64,
 }
 
 impl ProtoSint64 {
-    fn new(field: u64, value: i64) -> Self {
+    pub(crate) fn new(field: u64, value: i64) -> Self {
         Self { field, value }
     }
 

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -1,3 +1,8 @@
+use crate::alloc::{TursoVecExt, Vec};
+use crate::mvcc::persistent_storage::logical_log::{
+    log_write, LogSerializer, ProtoKey, ProtoSint64, ProtoVarint, PROTO_WIRE_LENGTH_DELIMITED,
+    PROTO_WIRE_VARINT,
+};
 use crate::types::{ImmutableRecordRef, ValueRef};
 use crate::{LimboError, Numeric, Result};
 use std::collections::{HashMap, HashSet};
@@ -17,42 +22,6 @@ const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
 const TURSO_SYNC_PREFIX: &str = "turso_sync_";
 const TURSO_CDC_TABLE_NAME: &str = "turso_cdc";
 const TURSO_CDC_VERSION_TABLE_NAME: &str = "turso_cdc_version";
-
-// Minimal protobuf-style encoder for core-owned portable MVCC logical changes.
-// Keeping this local avoids making turso_core depend on the sync engine or
-// server proto crate. Raw-log consumers can decode this envelope into their own
-// replay representation.
-fn write_proto_varint(mut value: u64, out: &mut Vec<u8>) {
-    while value >= 0x80 {
-        out.push((value as u8) | 0x80);
-        value >>= 7;
-    }
-    out.push(value as u8);
-}
-
-fn write_proto_key(field: u64, wire_type: u64, out: &mut Vec<u8>) {
-    write_proto_varint((field << 3) | wire_type, out);
-}
-
-fn write_proto_uint64(field: u64, value: u64, out: &mut Vec<u8>) {
-    write_proto_key(field, 0, out);
-    write_proto_varint(value, out);
-}
-
-fn write_proto_sint64(field: u64, value: i64, out: &mut Vec<u8>) {
-    let zigzag = ((value << 1) ^ (value >> 63)) as u64;
-    write_proto_uint64(field, zigzag, out);
-}
-
-fn write_proto_bytes(field: u64, value: &[u8], out: &mut Vec<u8>) {
-    write_proto_key(field, 2, out);
-    write_proto_varint(value.len() as u64, out);
-    out.extend_from_slice(value);
-}
-
-fn write_proto_string(field: u64, value: &str, out: &mut Vec<u8>) {
-    write_proto_bytes(field, value.as_bytes(), out);
-}
 
 pub(crate) fn is_portable_logical_name(name: &str) -> bool {
     !name.starts_with(SQLITE_INTERNAL_PREFIX)
@@ -121,13 +90,24 @@ pub(crate) fn is_portable_schema_row(row: &PortableSchemaRow) -> bool {
             || row.row_type.eq_ignore_ascii_case("view"))
 }
 
-#[derive(Default)]
 pub(crate) struct PortableLogicalBuilder {
     strings: Vec<String>,
     string_refs: HashMap<String, u64>,
     object_maps: Vec<Vec<u8>>,
     object_map_ids: HashSet<i64>,
     metadata: Vec<Vec<u8>>,
+}
+
+impl Default for PortableLogicalBuilder {
+    fn default() -> Self {
+        Self {
+            strings: crate::alloc::vec![],
+            string_refs: HashMap::default(),
+            object_maps: crate::alloc::vec![],
+            object_map_ids: HashSet::default(),
+            metadata: crate::alloc::vec![],
+        }
+    }
 }
 
 pub(crate) struct PortableObjectMapEntry<'a> {
@@ -140,53 +120,87 @@ impl PortableLogicalBuilder {
         Self::default()
     }
 
-    fn intern_string(&mut self, value: &str) -> u64 {
+    fn intern_string(&mut self, value: &str) -> Result<u64> {
         if let Some(idx) = self.string_refs.get(value) {
-            return *idx;
+            return Ok(*idx);
         }
         let idx = self.strings.len() as u64;
-        self.strings.push(value.to_string());
+        self.strings.try_push(value.to_string())?;
         self.string_refs.insert(value.to_string(), idx);
-        idx
+        Ok(idx)
     }
 
-    pub(crate) fn add_object_map(&mut self, entry: PortableObjectMapEntry<'_>) -> bool {
+    pub(crate) fn add_object_map(&mut self, entry: PortableObjectMapEntry<'_>) -> Result<bool> {
         if !is_portable_logical_name(entry.name) || !self.object_map_ids.insert(entry.mv_table_id) {
-            return false;
+            return Ok(false);
         }
-        let name_ref = self.intern_string(entry.name);
+        let name_ref = self.intern_string(entry.name)?;
 
-        let mut object = Vec::new();
-        write_proto_sint64(OBJECT_FIELD_MV_TABLE_ID, entry.mv_table_id, &mut object);
-        write_proto_uint64(OBJECT_FIELD_NAME_REF, name_ref, &mut object);
-        self.object_maps.push(object);
-        true
+        let mut object = crate::alloc::vec![];
+        let mut serializer = LogSerializer::new(&mut object);
+        log_write!(
+            serializer,
+            [
+                ProtoSint64::new(OBJECT_FIELD_MV_TABLE_ID, entry.mv_table_id),
+                ProtoKey::new(OBJECT_FIELD_NAME_REF, PROTO_WIRE_VARINT),
+                ProtoVarint(name_ref),
+            ]
+        )?;
+        self.object_maps.try_push(object)?;
+        Ok(true)
     }
 
-    pub(crate) fn add_metadata(&mut self, key: &str, value: &str) {
-        let key_ref = self.intern_string(key);
-        let value_ref = self.intern_string(value);
-        let mut meta = Vec::new();
-        write_proto_uint64(META_FIELD_KEY_REF, key_ref, &mut meta);
-        write_proto_uint64(META_FIELD_VALUE_REF, value_ref, &mut meta);
-        self.metadata.push(meta);
+    pub(crate) fn add_metadata(&mut self, key: &str, value: &str) -> Result<()> {
+        let key_ref = self.intern_string(key)?;
+        let value_ref = self.intern_string(value)?;
+        let mut meta = crate::alloc::vec![];
+        let mut serializer = LogSerializer::new(&mut meta);
+        log_write!(
+            serializer,
+            [
+                ProtoKey::new(META_FIELD_KEY_REF, PROTO_WIRE_VARINT),
+                ProtoVarint(key_ref),
+                ProtoKey::new(META_FIELD_VALUE_REF, PROTO_WIRE_VARINT),
+                ProtoVarint(value_ref),
+            ]
+        )?;
+        self.metadata.try_push(meta)?;
+        Ok(())
     }
 
-    pub(crate) fn finish(self) -> Vec<u8> {
-        let mut txn_fields = Vec::new();
+    pub(crate) fn finish(self) -> Result<Vec<u8>> {
+        let mut txn_fields = crate::alloc::vec![];
+        let mut serializer = LogSerializer::new(&mut txn_fields);
         for value in &self.strings {
-            write_proto_string(TX_FIELD_STRING_TABLE, value, &mut txn_fields);
+            log_write!(
+                serializer,
+                [
+                    ProtoKey::new(TX_FIELD_STRING_TABLE, PROTO_WIRE_LENGTH_DELIMITED),
+                    ProtoVarint(value.len() as u64),
+                    value.as_bytes(),
+                ]
+            )?;
         }
         for object_map in self.object_maps {
-            write_proto_key(TX_FIELD_OBJECT_MAP, 2, &mut txn_fields);
-            write_proto_varint(object_map.len() as u64, &mut txn_fields);
-            txn_fields.extend_from_slice(&object_map);
+            log_write!(
+                serializer,
+                [
+                    ProtoKey::new(TX_FIELD_OBJECT_MAP, PROTO_WIRE_LENGTH_DELIMITED),
+                    ProtoVarint(object_map.len() as u64),
+                    object_map.as_slice(),
+                ]
+            )?;
         }
         for meta in self.metadata {
-            write_proto_key(TX_FIELD_META, 2, &mut txn_fields);
-            write_proto_varint(meta.len() as u64, &mut txn_fields);
-            txn_fields.extend_from_slice(&meta);
+            log_write!(
+                serializer,
+                [
+                    ProtoKey::new(TX_FIELD_META, PROTO_WIRE_LENGTH_DELIMITED),
+                    ProtoVarint(meta.len() as u64),
+                    meta.as_slice(),
+                ]
+            )?;
         }
-        txn_fields
+        Ok(txn_fields)
     }
 }

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -131,9 +131,11 @@ impl<'a> PortableLogicalBuilder<'a> {
     }
 
     pub(crate) fn add_object_map(&mut self, entry: PortableObjectMapEntry<'a>) -> Result<bool> {
-        if !is_portable_logical_name(entry.name) || !self.object_map_ids.insert(entry.mv_table_id) {
+        if !is_portable_logical_name(entry.name) || self.object_map_ids.contains(&entry.mv_table_id)
+        {
             return Ok(false);
         }
+        let mv_table_id = entry.mv_table_id;
         let name_ref = self.intern_string(entry.name)?;
 
         let mut object = crate::alloc::vec![];
@@ -147,6 +149,10 @@ impl<'a> PortableLogicalBuilder<'a> {
             ]
         )?;
         self.object_maps.try_push(object)?;
+        assert!(
+            self.object_map_ids.insert(mv_table_id),
+            "portable object map id changed while building its payload"
+        );
         Ok(true)
     }
 

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -90,15 +90,15 @@ pub(crate) fn is_portable_schema_row(row: &PortableSchemaRow) -> bool {
             || row.row_type.eq_ignore_ascii_case("view"))
 }
 
-pub(crate) struct PortableLogicalBuilder {
-    strings: Vec<String>,
-    string_refs: HashMap<String, u64>,
+pub(crate) struct PortableLogicalBuilder<'a> {
+    strings: Vec<&'a str>,
+    string_refs: HashMap<&'a str, u64>,
     object_maps: Vec<Vec<u8>>,
     object_map_ids: HashSet<i64>,
     metadata: Vec<Vec<u8>>,
 }
 
-impl Default for PortableLogicalBuilder {
+impl Default for PortableLogicalBuilder<'_> {
     fn default() -> Self {
         Self {
             strings: crate::alloc::vec![],
@@ -115,22 +115,22 @@ pub(crate) struct PortableObjectMapEntry<'a> {
     pub(crate) name: &'a str,
 }
 
-impl PortableLogicalBuilder {
+impl<'a> PortableLogicalBuilder<'a> {
     pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    fn intern_string(&mut self, value: &str) -> Result<u64> {
+    fn intern_string(&mut self, value: &'a str) -> Result<u64> {
         if let Some(idx) = self.string_refs.get(value) {
             return Ok(*idx);
         }
         let idx = self.strings.len() as u64;
-        self.strings.try_push(value.to_string())?;
-        self.string_refs.insert(value.to_string(), idx);
+        self.strings.try_push(value)?;
+        self.string_refs.insert(value, idx);
         Ok(idx)
     }
 
-    pub(crate) fn add_object_map(&mut self, entry: PortableObjectMapEntry<'_>) -> Result<bool> {
+    pub(crate) fn add_object_map(&mut self, entry: PortableObjectMapEntry<'a>) -> Result<bool> {
         if !is_portable_logical_name(entry.name) || !self.object_map_ids.insert(entry.mv_table_id) {
             return Ok(false);
         }
@@ -150,7 +150,7 @@ impl PortableLogicalBuilder {
         Ok(true)
     }
 
-    pub(crate) fn add_metadata(&mut self, key: &str, value: &str) -> Result<()> {
+    pub(crate) fn add_metadata(&mut self, key: &'a str, value: &'a str) -> Result<()> {
         let key_ref = self.intern_string(key)?;
         let value_ref = self.intern_string(value)?;
         let mut meta = crate::alloc::vec![];


### PR DESCRIPTION
## Description

- allocate portable MVCC logical-change vectors through `TursoAllocator`
- make the logical-log chunk serializer work with allocator-backed vectors
- encode portable protobuf messages through `log_write!` so each message reserves once
- borrow string-table entries from their existing metadata and schema-name owners
- make object-map insertion failure-atomic

## Context

Portable logical-change construction used global `Vec` allocations and duplicated every unique string into both the string table and its lookup map. This routes byte-vector allocations through the configured Turso allocator while retaining the existing wire format and removes the redundant owned-string copies.