### PR TITLE
Agentic instructions

### DIFF
--- a/docs/agent-guides/code-quality.md
+++ b/docs/agent-guides/code-quality.md
@@ -22,6 +22,7 @@ Production database. Correctness paramount. Crash > corrupt.
 - Prefer enums over strings/sentinels
 - Minimize heap allocations
 - Write CPU-friendly code (microsecond = long time)
+- Don't make identifier visibility any broader than it needs to be.
 
 ### Avoid `unwrap()`
 
@@ -70,16 +71,7 @@ Use if-statements only when both branches are expected paths.
 
 ## Comments
 
-**Do:**
-- Document WHY, not what
-- Document functions, structs, enums, variants
-- Focus on why something is necessary
-- Preserve explanatory comments when refactoring
-
-**Don't:**
-- Comments that repeat code
-- References to AI conversations ("This test should trigger the bug")
-- Temporal markers ("added", "existing code", "Phase 1")
+- Do not add comments. Instead, focus on making your code expressive.
 
 ## Avoid Over-Engineering
 

--- a/docs/agent-guides/pr-workflow.md
+++ b/docs/agent-guides/pr-workflow.md
@@ -15,8 +15,10 @@ Learn `git rebase -i` for clean history.
 ## PR Guidelines
 
 - Keep PRs focused and small
+- Make your fixes surgical, try to minimize the diffs when you can.
 - Run relevant tests before submitting
 - Each commit tells part of the story
+- Do not include test plans in PR descriptions
 
 ## CI Environment Notes
 

--- a/docs/agent-guides/testing.md
+++ b/docs/agent-guides/testing.md
@@ -69,6 +69,9 @@ fn test_something() {
 - Prefer in-memory DBs: `:memory:` (sqltest) or `{:memory:}` (TCL)
 - Don't invent new test formats. Follow existing patterns
 - Write tests first when possible
+- If tasked with identifying a reproducer for a bug, strongly prefer using only user-facing APIs. Manipulating DB internals to artificially trigger a condition, or asserting internal state, is a bad reproducer.
+- A reproducer must serve as a regression test once the bug is fixed.
+
 
 ## Test Database Schema
 


### PR DESCRIPTION
I imported some instructions from my local `AGENTS.md`.

---

## No more comments

I've instructed the agent to not add any comments. Here is my rationale:

I find that most of them are either redundant, arcane, unintelligible, or irrelevant (for example when they refer to the old implementation). For example, here are two code comments from recent PRs that left me dumbfounded, and would likely confuse any future readers:

> Nodes that translate_expr's Binary arm routes to dedicated paths terminate the spine and are translated as opaque operands below

and

> the larger values place the abort throughout the backfill, including inside the band of pages the post-rollback updates changed

If something in the code is unclear, my experience is that humans are still the best judges of clarity and can either (1) ask the LLM to write more expressive code, or (2) add concise comments themselves (proving that they have read and understood the code, and are able to exercise critical judgement on it). 

If we find that this doesn't work for us, we can easily revert it.