### PR TITLE
core: implement PRAGMA foreign_key_check

### DIFF
--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -186,6 +186,14 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["foreign_keys"],
         ),
+        ForeignKeyCheck => Pragma::new(
+            PragmaFlags::NeedSchema
+                | PragmaFlags::ReadOnly
+                | PragmaFlags::Result0
+                | PragmaFlags::Result1
+                | PragmaFlags::SchemaOpt,
+            &["table", "rowid", "parent", "fkid"],
+        ),
         ForeignKeyList => Pragma::new(
             PragmaFlags::NeedSchema | PragmaFlags::Result1 | PragmaFlags::SchemaOpt,
             &[

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -274,7 +274,7 @@ pub fn open_read_table(program: &mut ProgramBuilder, tbl: &Arc<BTreeTable>, db: 
 /// Copy `len` registers starting at `src_start` to a fresh block and apply index affinities.
 /// Returns the destination start register.
 #[inline]
-fn copy_with_affinity(
+pub(super) fn copy_with_affinity(
     program: &mut ProgramBuilder,
     src_start: usize,
     len: usize,
@@ -429,7 +429,7 @@ where
     Ok(())
 }
 
-fn emit_skip_if_any_null(
+pub(super) fn emit_skip_if_any_null(
     program: &mut ProgramBuilder,
     reg_start: usize,
     nregs: usize,

--- a/core/translate/foreign_key_check.rs
+++ b/core/translate/foreign_key_check.rs
@@ -1,0 +1,163 @@
+//! VDBE bytecode generation for `PRAGMA foreign_key_check`.
+
+use super::fkeys::{
+    copy_with_affinity, emit_skip_if_any_null, index_probe, open_read_index, open_read_table,
+};
+use crate::{
+    schema::{BTreeTable, ResolvedFkRef, Schema},
+    vdbe::{builder::ProgramBuilder, insn::Insn},
+    Result,
+};
+
+/// Translate `PRAGMA foreign_key_check` and its single-table form
+/// `PRAGMA foreign_key_check(table-name)`.
+///
+/// For every table with foreign keys (or just `table_name`, when given), scans
+/// every row and emits one result row — `(table, rowid, parent, fkid)` — for
+/// each child row whose foreign key value has no matching row in the
+/// referenced parent table. Rows with a NULL foreign key column are not
+/// checked, matching SQLite's behavior of treating NULL as "no reference".
+///
+/// `fkid` is numbered the same way `PRAGMA foreign_key_list` numbers its `id`
+/// column (reverse declaration order), so the two pragmas agree on which
+/// constraint a row refers to.
+pub fn translate_foreign_key_check(
+    schema: &Schema,
+    program: &mut ProgramBuilder,
+    database_id: usize,
+    table_name: Option<&str>,
+    base_reg: usize,
+) -> Result<()> {
+    let tables: Vec<_> = match table_name {
+        Some(name) => schema.get_btree_table(name).into_iter().collect(),
+        None => schema.tables.values().filter_map(|t| t.btree()).collect(),
+    };
+
+    for child_tbl in &tables {
+        let mut fks = schema.resolved_fks_for_child(&child_tbl.name)?;
+        if fks.is_empty() {
+            continue;
+        }
+        fks.sort_by_key(|r| std::cmp::Reverse(r.fk.decl_order));
+
+        let ccur = open_read_table(program, child_tbl, database_id);
+        let table_done = program.allocate_label();
+        program.emit_insn(Insn::Rewind {
+            cursor_id: ccur,
+            pc_if_empty: table_done,
+        });
+
+        let loop_top = program.allocate_label();
+        program.preassign_label_to_next_insn(loop_top);
+
+        let rowid_reg = program.alloc_register();
+        program.emit_insn(Insn::RowId {
+            cursor_id: ccur,
+            dest: rowid_reg,
+        });
+
+        for (fkid, fk_ref) in fks.iter().enumerate() {
+            emit_fk_row_check(
+                program,
+                schema,
+                database_id,
+                child_tbl,
+                fk_ref,
+                fkid,
+                ccur,
+                rowid_reg,
+                base_reg,
+            )?;
+        }
+
+        program.emit_insn(Insn::Next {
+            cursor_id: ccur,
+            pc_if_next: loop_top,
+        });
+        program.preassign_label_to_next_insn(table_done);
+        program.emit_insn(Insn::Close { cursor_id: ccur });
+    }
+
+    Ok(())
+}
+
+/// Check a single foreign key constraint against the row currently under the
+/// child cursor, emitting a `(table, rowid, parent, fkid)` result row if the
+/// referenced parent key is missing.
+#[allow(clippy::too_many_arguments)]
+fn emit_fk_row_check(
+    program: &mut ProgramBuilder,
+    schema: &Schema,
+    database_id: usize,
+    child_tbl: &BTreeTable,
+    fk_ref: &ResolvedFkRef,
+    fkid: usize,
+    child_cursor_id: usize,
+    rowid_reg: usize,
+    base_reg: usize,
+) -> Result<()> {
+    let ncols = fk_ref.child_pos.len();
+    let key_start = program.alloc_registers(ncols);
+    for (i, &pos) in fk_ref.child_pos.iter().enumerate() {
+        program.emit_column_or_rowid(child_cursor_id, pos, key_start + i);
+    }
+
+    let skip_fk = program.allocate_label();
+    emit_skip_if_any_null(program, key_start, ncols, skip_fk);
+
+    let emit_violation = |p: &mut ProgramBuilder| -> Result<()> {
+        p.emit_string8(child_tbl.name.clone(), base_reg);
+        p.emit_insn(Insn::Copy {
+            src_reg: rowid_reg,
+            dst_reg: base_reg + 1,
+            extra_amount: 0,
+        });
+        p.emit_string8(fk_ref.fk.parent_table.clone(), base_reg + 2);
+        p.emit_int(fkid as i64, base_reg + 3);
+        p.emit_result_row(base_reg, 4);
+        Ok(())
+    };
+
+    if fk_ref.parent_uses_rowid {
+        let parent_tbl = schema
+            .get_btree_table(&fk_ref.fk.parent_table)
+            .expect("resolved_fks_for_child guarantees the parent table exists");
+        let pcur = open_read_table(program, &parent_tbl, database_id);
+
+        let missing = program.allocate_label();
+        program.emit_insn(Insn::MustBeInt {
+            reg: key_start,
+            target_pc: Some(missing),
+        });
+        program.emit_insn(Insn::NotExists {
+            cursor: pcur,
+            rowid_reg: key_start,
+            target_pc: missing,
+        });
+
+        let found = program.allocate_label();
+        program.emit_insn(Insn::Close { cursor_id: pcur });
+        program.emit_insn(Insn::Goto { target_pc: found });
+
+        program.preassign_label_to_next_insn(missing);
+        program.emit_insn(Insn::Close { cursor_id: pcur });
+        emit_violation(program)?;
+
+        program.preassign_label_to_next_insn(found);
+    } else {
+        let idx = fk_ref
+            .parent_unique_index
+            .as_ref()
+            .expect("resolved_fks_for_child guarantees a unique index for non-rowid parents");
+        let parent_tbl = schema
+            .get_btree_table(&fk_ref.fk.parent_table)
+            .expect("resolved_fks_for_child guarantees the parent table exists");
+
+        let icur = open_read_index(program, idx, database_id);
+        let probe = copy_with_affinity(program, key_start, ncols, idx, &parent_tbl);
+        index_probe(program, icur, probe, ncols, |_p| Ok(()), emit_violation)?;
+    }
+
+    program.preassign_label_to_next_insn(skip_fk);
+    Ok(())
+}

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod emitter;
 pub(crate) mod expr;
 pub(crate) mod expression_index;
 pub(crate) mod fkeys;
+pub(crate) mod foreign_key_check;
 pub(crate) mod group_by;
 pub(crate) mod index;
 pub(crate) mod insert;

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -9,6 +9,7 @@ use turso_macros::{match_ignore_ascii_case, turso_debug_assert};
 use turso_parser::ast::PragmaName;
 use turso_parser::ast::{self, Expr, Literal};
 
+use super::foreign_key_check::translate_foreign_key_check;
 use super::integrity_check::{
     translate_integrity_check, translate_quick_check, MAX_INTEGRITY_CHECK_ERRORS,
 };
@@ -249,6 +250,7 @@ pub fn translate_pragma(
             PragmaName::IndexInfo
             | PragmaName::IndexXinfo
             | PragmaName::IndexList
+            | PragmaName::ForeignKeyCheck
             | PragmaName::ForeignKeyList
             | PragmaName::TableList
             | PragmaName::TableInfo
@@ -610,6 +612,7 @@ fn update_pragma(
         PragmaName::IndexInfo => unreachable!("index_info cannot be set"),
         PragmaName::IndexXinfo => unreachable!("index_xinfo cannot be set"),
         PragmaName::IndexList => unreachable!("index_list cannot be set"),
+        PragmaName::ForeignKeyCheck => unreachable!("foreign_key_check cannot be set"),
         PragmaName::ForeignKeyList => unreachable!("foreign_key_list cannot be set"),
         PragmaName::TableList => unreachable!("table_list cannot be set"),
         PragmaName::QueryOnly => query_pragma(
@@ -1181,6 +1184,29 @@ fn query_pragma(
                 program.add_pragma_result_column(col_name.to_string());
             }
             Ok(TransactionMode::None)
+        }
+        PragmaName::ForeignKeyCheck => {
+            let table_name = match value {
+                Some(ast::Expr::Name(ref name)) => Some(name.as_str()),
+                _ => None,
+            };
+
+            // Scans actual row data, so (like integrity_check) it must see this
+            // connection's just-committed schema rather than a possibly-stale
+            // MVCC tx-snapshot.
+            let main_schema = (database_id == 0 && connection.mvcc_enabled())
+                .then(|| connection.db.schema.lock().clone());
+            let schema = main_schema.as_deref().unwrap_or(schema);
+
+            let base_reg = register;
+            program.alloc_registers(3);
+            translate_foreign_key_check(schema, program, database_id, table_name, base_reg)?;
+
+            let pragma_meta = pragma_for(&pragma);
+            for col_name in pragma_meta.columns.iter() {
+                program.add_pragma_result_column(col_name.to_string());
+            }
+            Ok(TransactionMode::Read)
         }
         PragmaName::ForeignKeyList => {
             let table_name = match value {

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1792,6 +1792,8 @@ pub enum PragmaName {
     FreelistCount,
     /// Enable or disable foreign key constraint enforcement
     ForeignKeys,
+    /// Checks the database, or a single table, for foreign key constraint violations
+    ForeignKeyCheck,
     /// Returns information about foreign keys declared by a table
     ForeignKeyList,
     /// Deprecated: control whether column names include table name prefix

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -573,3 +573,171 @@ fn test_pragma_vtab_query_with_limit_then_write(db: TempDatabase) {
         "insert after LIMITed pragma vtab query must be committed"
     );
 }
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_foreign_key_check_clean_database_returns_no_rows(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE parent(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))",
+    )
+    .unwrap();
+    conn.execute("INSERT INTO parent VALUES (1), (2)").unwrap();
+    conn.execute("INSERT INTO child VALUES (10, 1), (11, NULL)")
+        .unwrap();
+
+    let rows = limbo_exec_rows(&conn, "PRAGMA foreign_key_check");
+    assert_eq!(
+        rows,
+        Vec::<Vec<RValue>>::new(),
+        "no violations and a NULL fk column must not be reported"
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_foreign_key_check_detects_rowid_violation(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE parent(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))",
+    )
+    .unwrap();
+    conn.execute("INSERT INTO parent VALUES (1)").unwrap();
+    conn.execute("PRAGMA foreign_keys=OFF").unwrap();
+    conn.execute("INSERT INTO child VALUES (10, 1), (11, 99)")
+        .unwrap();
+    conn.execute("PRAGMA foreign_keys=ON").unwrap();
+
+    let rows = limbo_exec_rows(&conn, "PRAGMA foreign_key_check");
+    assert_eq!(
+        rows,
+        vec![vec![
+            RValue::Text("child".to_string()),
+            RValue::Integer(11),
+            RValue::Text("parent".to_string()),
+            RValue::Integer(0),
+        ]]
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_foreign_key_check_single_table_form(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE parent(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE child_a(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))",
+    )
+    .unwrap();
+    conn.execute(
+        "CREATE TABLE child_b(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))",
+    )
+    .unwrap();
+    conn.execute("PRAGMA foreign_keys=OFF").unwrap();
+    conn.execute("INSERT INTO child_a VALUES (1, 99)").unwrap();
+    conn.execute("INSERT INTO child_b VALUES (1, 99)").unwrap();
+    conn.execute("PRAGMA foreign_keys=ON").unwrap();
+
+    let rows = limbo_exec_rows(&conn, "PRAGMA foreign_key_check(child_a)");
+    assert_eq!(
+        rows,
+        vec![vec![
+            RValue::Text("child_a".to_string()),
+            RValue::Integer(1),
+            RValue::Text("parent".to_string()),
+            RValue::Integer(0),
+        ]],
+        "single-table form must not report violations from other tables"
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_foreign_key_check_unique_index_parent(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE parent(code TEXT UNIQUE)")
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE child(id INTEGER PRIMARY KEY, parent_code TEXT REFERENCES parent(code))",
+    )
+    .unwrap();
+    conn.execute("INSERT INTO parent VALUES ('a')").unwrap();
+    conn.execute("PRAGMA foreign_keys=OFF").unwrap();
+    conn.execute("INSERT INTO child VALUES (1, 'a'), (2, 'missing')")
+        .unwrap();
+    conn.execute("PRAGMA foreign_keys=ON").unwrap();
+
+    let rows = limbo_exec_rows(&conn, "PRAGMA foreign_key_check");
+    assert_eq!(
+        rows,
+        vec![vec![
+            RValue::Text("child".to_string()),
+            RValue::Integer(2),
+            RValue::Text("parent".to_string()),
+            RValue::Integer(0),
+        ]]
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_foreign_key_check_composite_key(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE parent(a INTEGER, b INTEGER, UNIQUE(a, b))")
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE child(id INTEGER PRIMARY KEY, pa INTEGER, pb INTEGER, \
+         FOREIGN KEY(pa, pb) REFERENCES parent(a, b))",
+    )
+    .unwrap();
+    conn.execute("INSERT INTO parent VALUES (1, 2)").unwrap();
+    conn.execute("PRAGMA foreign_keys=OFF").unwrap();
+    // (1, NULL): one column NULL means the whole key is not checked.
+    // (1, 3): fully non-NULL but no matching parent row -> violation.
+    conn.execute("INSERT INTO child VALUES (1, 1, 2), (2, 1, NULL), (3, 1, 3)")
+        .unwrap();
+    conn.execute("PRAGMA foreign_keys=ON").unwrap();
+
+    let rows = limbo_exec_rows(&conn, "PRAGMA foreign_key_check");
+    assert_eq!(
+        rows,
+        vec![vec![
+            RValue::Text("child".to_string()),
+            RValue::Integer(3),
+            RValue::Text("parent".to_string()),
+            RValue::Integer(0),
+        ]]
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_foreign_key_check_fkid_matches_foreign_key_list(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE parent_a(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute("CREATE TABLE parent_b(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE child(id INTEGER PRIMARY KEY, a_id INTEGER REFERENCES parent_a(id), \
+         b_id INTEGER REFERENCES parent_b(id))",
+    )
+    .unwrap();
+    conn.execute("PRAGMA foreign_keys=OFF").unwrap();
+    conn.execute("INSERT INTO child VALUES (1, 99, 1)").unwrap();
+    conn.execute("INSERT INTO parent_b VALUES (1)").unwrap();
+    conn.execute("PRAGMA foreign_keys=ON").unwrap();
+
+    let list_rows = limbo_exec_rows(&conn, "PRAGMA foreign_key_list(child)");
+    let expected_fkid = list_rows
+        .iter()
+        .find(|row| row[2] == RValue::Text("parent_a".to_string()))
+        .map(|row| row[0].clone())
+        .expect("foreign_key_list must report the parent_a constraint");
+
+    let check_rows = limbo_exec_rows(&conn, "PRAGMA foreign_key_check(child)");
+    assert_eq!(check_rows.len(), 1);
+    assert_eq!(
+        check_rows[0][3], expected_fkid,
+        "foreign_key_check's fkid must match foreign_key_list's id for the same constraint"
+    );
+}


### PR DESCRIPTION
## Problem

`PRAGMA foreign_key_check` and its single-table form `PRAGMA foreign_key_check(table-name)` are listed as unimplemented in COMPAT.md. Currently the PRAGMA is silently accepted and always returns zero rows, even when real foreign key violations exist in the database — it behaves identically to a completely unrecognized PRAGMA name.

### Reproducer

```sql
CREATE TABLE parent(id INTEGER PRIMARY KEY);
CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));
INSERT INTO parent VALUES (1);
PRAGMA foreign_keys=OFF;
INSERT INTO child VALUES (10, 1), (11, 99); -- row 11 has a dangling parent_id
PRAGMA foreign_keys=ON;
PRAGMA foreign_key_check;
```

sqlite3:
```
child|11|parent|0
```

turso (before this PR): no rows.

## Fix

Adds `PRAGMA foreign_key_check` (and the single-table form). For every table with foreign keys, it scans the table's rows and, for each foreign key column set that is non-NULL, probes the referenced parent table (by rowid or by the parent's UNIQUE index, matching how FK enforcement already does this for INSERT/UPDATE/DELETE in `core/translate/fkeys.rs`). Rows with no matching parent are reported as `(table, rowid, parent, fkid)`, matching SQLite's column layout. `fkid` uses the same reverse-declaration-order numbering as `PRAGMA foreign_key_list`'s `id` column, so the two pragmas agree on which constraint a row refers to.

Implementation lives in a new `core/translate/foreign_key_check.rs`, following the same "scan every row, emit a result row per violation" shape as `PRAGMA integrity_check`, and reuses the existing index/table-scan helpers from `fkeys.rs` rather than duplicating them.

## Testing

Added `tests/integration/pragma.rs` coverage (verified against real `sqlite3` output for each case):
- clean database → no rows
- a single-column rowid-parent violation
- the single-table argument form only reporting that table's violations
- a UNIQUE-index-backed (non-rowid) parent key violation
- a composite (multi-column) foreign key, including a NULL-column row being correctly skipped
- `fkid` numbering agreeing with `PRAGMA foreign_key_list`'s `id` for the same constraint, when a table has more than one FK

All new tests pass in both plain and MVCC mode. `cargo fmt` and `cargo clippy` are clean.