### PR TITLE
core/mvcc: use dynamic allocator for logical-log buffers

### DIFF
--- a/core/alloc/collections/boxed.rs
+++ b/core/alloc/collections/boxed.rs
@@ -1,6 +1,11 @@
 use super::{TryClone, TursoBoxExt, TursoFromIterator, TursoNewExt, TursoTryNewExt};
 use crate::alloc::{AllocError, Box, TryReserveError};
 
+#[cfg(not(nightly))]
+pub type DynBoxedSlice<T> = std::boxed::Box<[T]>;
+#[cfg(nightly)]
+pub type DynBoxedSlice<T> = std::boxed::Box<[T], crate::alloc::DynAllocator>;
+
 fn boxed<T>(value: T) -> Box<T> {
     Box::new(value)
 }

--- a/core/alloc/collections/mod.rs
+++ b/core/alloc/collections/mod.rs
@@ -12,6 +12,7 @@ mod traits;
 mod vec;
 mod vec_deque;
 
+pub use boxed::DynBoxedSlice;
 pub(crate) use traits::impl_try_clone_via_clone;
 #[cfg(nightly)]
 pub use traits::TursoFromIteratorIn;
@@ -20,3 +21,4 @@ pub use traits::{
     TursoHashSetExt, TursoIteratorExt, TursoNewExt, TursoSliceExt, TursoTryNewExt,
     TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt, TursoVecInExt,
 };
+pub use vec::DynVec;

--- a/core/alloc/collections/vec/mod.rs
+++ b/core/alloc/collections/vec/mod.rs
@@ -2,6 +2,11 @@
 mod nightly;
 
 #[cfg(not(nightly))]
+pub type DynVec<T> = std::vec::Vec<T>;
+#[cfg(nightly)]
+pub type DynVec<T> = std::vec::Vec<T, crate::alloc::DynAllocator>;
+
+#[cfg(not(nightly))]
 use super::{
     TryClone, TursoAllocExt, TursoFromIterator, TursoSliceExt, TursoTryWithCapacityExt,
     TursoVecExt, TursoVecInExt,

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -27,9 +27,10 @@ pub(crate) use collections::impl_try_clone_via_clone;
 #[cfg(nightly)]
 pub use collections::TursoFromIteratorIn;
 pub use collections::{
-    TryClone, TursoAllocExt, TursoBinaryHeapExt, TursoBoxExt, TursoFromIterator, TursoHashMapExt,
-    TursoHashSetExt, TursoIteratorExt, TursoNewExt, TursoSliceExt, TursoTryNewExt,
-    TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt, TursoVecInExt,
+    DynBoxedSlice, DynVec, TryClone, TursoAllocExt, TursoBinaryHeapExt, TursoBoxExt,
+    TursoFromIterator, TursoHashMapExt, TursoHashSetExt, TursoIteratorExt, TursoNewExt,
+    TursoSliceExt, TursoTryNewExt, TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt,
+    TursoVecInExt,
 };
 
 pub const ALLOC_ERR_MSG: &str = "fallible allocations";
@@ -181,6 +182,24 @@ macro_rules! __turso_alloc_try_vec {
             <$crate::alloc::Vec<_> as $crate::alloc::TursoAllocExt>::new(),
         )
     };
+    ($element:expr; $count:expr; $alloc:expr) => {{
+        (|| {
+            let count = $count;
+            let alloc = $alloc;
+            #[cfg(not(nightly))]
+            let mut values =
+                <$crate::alloc::Vec<_> as $crate::alloc::TursoVecInExt<_, _>>::try_with_capacity_in(
+                    count, alloc,
+                )?;
+            #[cfg(nightly)]
+            let mut values = <$crate::alloc::Vec<_, _> as $crate::alloc::TursoVecInExt<
+                _,
+                _,
+            >>::try_with_capacity_in(count, alloc)?;
+            values.resize(count, $element);
+            Ok::<_, $crate::alloc::TryReserveError>(values)
+        })()
+    }};
     ($element:expr; $count:expr) => {{
         (|| {
             let count = $count;

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -53,6 +53,7 @@ impl Iterator for UnderreportedLowerBound {
 
 struct CountingAlloc {
     allocations: StdArc<AtomicUsize>,
+    deallocations: StdArc<AtomicUsize>,
 }
 
 unsafe impl ApiAllocator for CountingAlloc {
@@ -62,6 +63,7 @@ unsafe impl ApiAllocator for CountingAlloc {
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        self.deallocations.fetch_add(1, Ordering::Relaxed);
         unsafe {
             <Global as ApiAllocator>::deallocate(&Global, ptr, layout);
         }
@@ -71,8 +73,10 @@ unsafe impl ApiAllocator for CountingAlloc {
 #[test]
 fn dyn_allocator_delegates_skiplist_allocations() {
     let allocations = StdArc::new(AtomicUsize::new(0));
+    let deallocations = StdArc::new(AtomicUsize::new(0));
     let alloc = DynAllocator::new(CountingAlloc {
         allocations: allocations.clone(),
+        deallocations,
     });
     let map: crate::skiplist::SkipMap<i32, i32, _, DynAllocator> =
         crate::skiplist::SkipMap::new_in(alloc);
@@ -85,8 +89,10 @@ fn dyn_allocator_delegates_skiplist_allocations() {
 #[test]
 fn database_open_with_allocator_uses_allocator_for_mvstore_skiplist() {
     let allocations = StdArc::new(AtomicUsize::new(0));
+    let deallocations = StdArc::new(AtomicUsize::new(0));
     let alloc = DynAllocator::new(CountingAlloc {
         allocations: allocations.clone(),
+        deallocations,
     });
     let io = StdArc::new(crate::MemoryIO::new());
     let file = crate::IO::open_file(
@@ -112,6 +118,27 @@ fn database_open_with_allocator_uses_allocator_for_mvstore_skiplist() {
 
     assert!(db.get_mv_store().is_some());
     assert!(allocations.load(Ordering::Relaxed) > 0);
+}
+
+#[cfg(nightly)]
+#[test]
+fn logical_log_shared_buffer_retains_dyn_allocator() {
+    let allocations = StdArc::new(AtomicUsize::new(0));
+    let deallocations = StdArc::new(AtomicUsize::new(0));
+    let alloc = DynAllocator::new(CountingAlloc {
+        allocations: allocations.clone(),
+        deallocations: deallocations.clone(),
+    });
+    let record = crate::mvcc::database::LogRecord::new(1, alloc).unwrap();
+    let data: DynBoxedSlice<u8> = record.buf.into_boxed_slice();
+    let shared = crate::io::SharedBufferData::new(crate::sync::Arc::new(data));
+    let returned = shared.clone();
+
+    assert!(allocations.load(Ordering::Relaxed) > 0);
+    drop(shared);
+    assert_eq!(deallocations.load(Ordering::Relaxed), 0);
+    drop(returned);
+    assert!(deallocations.load(Ordering::Relaxed) > 0);
 }
 
 #[test]
@@ -162,6 +189,13 @@ fn vec_push_within_capacity_returns_value_when_full() {
 
     assert_eq!(values.push_within_capacity(1), Err(1));
     assert!(values.is_empty());
+}
+
+#[test]
+fn try_vec_with_allocator_builds_requested_values() {
+    let values: DynVec<_> = try_vec![7; 3; DynAllocator::default()].unwrap();
+
+    assert_eq!(values.as_slice(), &[7, 7, 7]);
 }
 
 #[test]

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -1,3 +1,4 @@
+use crate::alloc::DynBoxedSlice;
 use crate::storage::buffer_pool::ArenaBuffer;
 use crate::storage::sqlite3_ondisk::WAL_FRAME_HEADER_SIZE;
 use crate::sync::Arc;
@@ -561,18 +562,18 @@ pub type BufferData = Pin<Box<[u8]>>;
 
 #[derive(Clone)]
 pub enum SharedBufferData {
-    Full(Arc<Box<[u8]>>),
+    Full(Arc<DynBoxedSlice<u8>>),
     View(SharedBufferView),
 }
 
 #[derive(Clone)]
 pub struct SharedBufferView {
-    data: Arc<Box<[u8]>>,
+    data: Arc<DynBoxedSlice<u8>>,
     start: usize,
 }
 
 impl SharedBufferView {
-    fn new(data: Arc<Box<[u8]>>, start: usize) -> Self {
+    fn new(data: Arc<DynBoxedSlice<u8>>, start: usize) -> Self {
         assert!(
             start <= data.len(),
             "SharedBufferData::new_view: start ({start}) > data.len() ({})",
@@ -599,11 +600,11 @@ impl SharedBufferView {
 }
 
 impl SharedBufferData {
-    pub fn new(data: Arc<Box<[u8]>>) -> Self {
+    pub fn new(data: Arc<DynBoxedSlice<u8>>) -> Self {
         Self::Full(data)
     }
 
-    pub fn new_view(data: Arc<Box<[u8]>>, start: usize) -> Self {
+    pub fn new_view(data: Arc<DynBoxedSlice<u8>>, start: usize) -> Self {
         Self::View(SharedBufferView::new(data, start))
     }
 
@@ -687,7 +688,7 @@ impl Buffer {
         Self::Heap(Pin::new(data.into_boxed_slice()))
     }
 
-    pub fn new_shared(data: Arc<Box<[u8]>>) -> Self {
+    pub fn new_shared(data: Arc<DynBoxedSlice<u8>>) -> Self {
         Self::Shared(SharedBufferData::new(data))
     }
 
@@ -809,9 +810,20 @@ crate::thread::thread_local! {
 mod buffer_tests {
     use super::*;
 
+    fn shared_bytes(bytes: &[u8]) -> Arc<DynBoxedSlice<u8>> {
+        let mut data =
+            <crate::alloc::DynVec<u8> as crate::alloc::TursoVecInExt<
+                u8,
+                crate::alloc::DynAllocator,
+            >>::try_with_capacity_in(bytes.len(), crate::alloc::DynAllocator::default())
+            .expect("failed to allocate shared buffer test data");
+        data.extend_from_slice(bytes);
+        Arc::new(data.into_boxed_slice())
+    }
+
     #[test]
     fn shared_buffer_exposes_arc_bytes() {
-        let data = Arc::new(vec![1, 2, 3, 4].into_boxed_slice());
+        let data = shared_bytes(&[1, 2, 3, 4]);
         let buffer = Buffer::new_shared(data.clone());
 
         assert_eq!(buffer.len(), 4);
@@ -823,7 +835,7 @@ mod buffer_tests {
 
     #[test]
     fn shared_buffer_view_exposes_tail_without_copying() {
-        let data = Arc::new(vec![0, 1, 2, 3, 4].into_boxed_slice());
+        let data = shared_bytes(&[0, 1, 2, 3, 4]);
         let shared = SharedBufferData::new_view(data.clone(), 2);
         let buffer = Buffer::new_shared_data(shared.clone());
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1,6 +1,6 @@
 use crate::alloc::{
-    ConcurrentAllocator, TryReserveError, TursoAllocator, TursoTryWithCapacityExt, TursoVecInExt,
-    ALLOC_ERR_MSG,
+    ConcurrentAllocator, DynAllocator, DynVec, TryReserveError, TursoAllocator,
+    TursoTryWithCapacityExt, TursoVecInExt, ALLOC_ERR_MSG,
 };
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::cursor::{static_iterator_hack, MvccIterator};
@@ -485,7 +485,7 @@ pub type TxID = u64;
 /// pre-serialized into a frame buffer that the logical-log flush path
 /// finalizes (backfills the TX header, appends the CRC trailer, optionally
 /// chunk-encrypts the payload) and writes to disk.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct LogRecord {
     pub(crate) tx_timestamp: TxID,
     /// Frame buffer that grows in place into the on-disk representation.
@@ -493,7 +493,7 @@ pub struct LogRecord {
     /// (zeros) so that op-entry appends land at the correct on-disk
     /// offset; the flush path backfills the framing prefix and appends
     /// the trailer.
-    pub buf: Vec<u8>,
+    pub buf: DynVec<u8>,
     /// Number of op entries appended to `buf`. Includes any header op.
     pub op_count: u32,
     /// True once a `DatabaseHeader` op has been appended. At most one
@@ -520,16 +520,36 @@ impl LogRecord {
         feature = "aristo-instr",
         aristo::instrument::expose_pub(as = "new_for_test")
     )]
-    pub(crate) fn new(tx_timestamp: TxID) -> Self {
-        Self {
+    pub(crate) fn new(tx_timestamp: TxID, alloc: DynAllocator) -> Result<Self> {
+        let buf: DynVec<u8> = crate::alloc::try_vec![
+            0;
+            crate::mvcc::persistent_storage::logical_log::LOG_RECORD_PREFIX_SIZE;
+            alloc
+        ]?;
+        Ok(Self {
             tx_timestamp,
             // Pre-reserve the framing prefix at the front of buf:
             //   [LOG_HDR slot (56B) | TX_HEADER slot (24B) | <ops here>]
             // The log-header slot is only filled on the very first write to
-            // a log file; otherwise it stays zero and the flush path wraps
-            // the buf with `Buffer::new_with_start(..., LOG_HDR_SIZE)` so
-            // those 56 bytes never reach disk.
-            buf: vec![0u8; crate::mvcc::persistent_storage::logical_log::LOG_RECORD_PREFIX_SIZE],
+            // a log file; otherwise it stays zero and the flush path exposes
+            // a shared view starting at `LOG_HDR_SIZE`, so those 56 bytes never
+            // reach disk.
+            buf,
+            op_count: 0,
+            has_header: false,
+            #[cfg(feature = "conn_raw_api")]
+            portable_changes: crate::alloc::vec![],
+            #[cfg(feature = "conn_raw_api")]
+            portable_changes_enabled: false,
+            #[cfg(feature = "conn_raw_api")]
+            portable_changes_required: false,
+        })
+    }
+
+    fn empty(tx_timestamp: TxID, alloc: DynAllocator) -> Self {
+        Self {
+            tx_timestamp,
+            buf: <DynVec<u8> as TursoVecInExt<u8, DynAllocator>>::new_in(alloc),
             op_count: 0,
             has_header: false,
             #[cfg(feature = "conn_raw_api")]
@@ -563,7 +583,8 @@ impl LogRecord {
         row_versions: &[RowVersion],
         header: Option<DatabaseHeader>,
     ) -> Self {
-        let mut record = Self::new(tx_timestamp);
+        let mut record = Self::new(tx_timestamp, DynAllocator::default())
+            .expect("failed to allocate logical log record in test");
         for rv in row_versions {
             record.push_row_version_for_test(rv);
         }
@@ -2383,7 +2404,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         // Move the assembled log record out and transition to
         // BeginCommitLogicalLog (or directly to CommitEnd if there is nothing
         // to log).
-        let mut log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
+        let mut log_record = std::mem::replace(
+            &mut ctx.log_record,
+            LogRecord::empty(end_ts, mvcc_store.logical_log_allocator()),
+        );
         self.populate_portable_changes(mvcc_store, &mut log_record)?;
         tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
 
@@ -3015,7 +3039,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 };
                 self.state = CommitState::BuildLogRecord(BuildLogRecordCtx {
                     end_ts,
-                    log_record: LogRecord::new(end_ts),
+                    log_record: LogRecord::new(end_ts, mvcc_store.logical_log_allocator())?,
                     cursor: 0,
                     schema_process: true,
                     pending_header,
@@ -3049,7 +3073,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                     &mut self.state,
                     CommitState::UpgradeLogicalLogHeader {
                         end_ts,
-                        log_record: LogRecord::new(end_ts),
+                        log_record: LogRecord::empty(end_ts, mvcc_store.logical_log_allocator()),
                     },
                 ) {
                     CommitState::BeginCommitLogicalLog { log_record, .. } => log_record,
@@ -3069,7 +3093,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                     &mut self.state,
                     CommitState::WriteLogicalLog {
                         end_ts,
-                        log_record: LogRecord::new(end_ts),
+                        log_record: LogRecord::empty(end_ts, mvcc_store.logical_log_allocator()),
                     },
                 ) {
                     CommitState::UpgradeLogicalLogHeader { log_record, .. } => log_record,
@@ -3940,6 +3964,9 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// Allocator backing every skiplist in this store, including lazily
     /// created per-index maps in `index_rows`.
     alloc: A,
+    /// Type-erased clone of `alloc` used by logical-log buffers that cross the
+    /// durable-storage trait-object and I/O ownership boundaries.
+    logical_log_alloc: DynAllocator,
     tx_ids: AtomicU64,
     version_id_counter: AtomicU64,
     next_rowid: AtomicU64,
@@ -4089,6 +4116,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         self.alloc.clone()
     }
 
+    fn logical_log_allocator(&self) -> DynAllocator {
+        self.logical_log_alloc.clone()
+    }
+
     fn uses_durable_mvcc_metadata(&self, connection: &Arc<Connection>) -> bool {
         !connection.db.is_in_memory_db()
     }
@@ -4143,6 +4174,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         alloc: A,
         experimental_mvcc_passive_checkpoint: bool,
     ) -> Result<Self> {
+        let logical_log_alloc = DynAllocator::new(alloc.clone());
         let table_id_to_rootpage = SkipMap::new_in(alloc.clone());
         // table id 1 / root page 1 is always sqlite_schema.
         table_id_to_rootpage.try_insert(SQLITE_SCHEMA_MVCC_TABLE_ID, RootEntry::live(Some(1)))?;
@@ -4154,6 +4186,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             txs: SkipMap::new_in(alloc.clone()),
             finalized_tx_states: SkipMap::new_in(alloc.clone()),
             alloc,
+            logical_log_alloc,
             tx_ids: AtomicU64::new(1), // let's reserve transaction 0 for special purposes
             version_id_counter: AtomicU64::new(1), // Reserve 0 for special purposes
             next_rowid: AtomicU64::new(0), // TODO: determine this from B-Tree

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -3785,7 +3785,9 @@ mod tests {
         let file = io.open_file(file_name, OpenFlags::Create, false).unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord::new(commit_ts);
+        let mut tx =
+            crate::mvcc::database::LogRecord::new(commit_ts, crate::alloc::DynAllocator::default())
+                .unwrap();
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
@@ -4636,7 +4638,9 @@ mod tests {
         let op_size = 6 + payload_len_len + payload_len;
         let frame_size = TX_HEADER_SIZE + op_size + TX_TRAILER_SIZE;
 
-        let mut tx1 = crate::mvcc::database::LogRecord::new(10);
+        let mut tx1 =
+            crate::mvcc::database::LogRecord::new(10, crate::alloc::DynAllocator::default())
+                .unwrap();
         tx1.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
             begin: crate::mvcc::database::PackedTs::pack(Some(
@@ -4650,7 +4654,9 @@ mod tests {
         let c = log.log_tx(tx1).unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut tx2 = crate::mvcc::database::LogRecord::new(20);
+        let mut tx2 =
+            crate::mvcc::database::LogRecord::new(20, crate::alloc::DynAllocator::default())
+                .unwrap();
         tx2.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 2,
             begin: crate::mvcc::database::PackedTs::pack(Some(
@@ -4960,7 +4966,9 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord::new(123);
+        let mut tx =
+            crate::mvcc::database::LogRecord::new(123, crate::alloc::DynAllocator::default())
+                .unwrap();
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
@@ -5438,7 +5446,9 @@ mod tests {
             .open_file("bitflip.db-log", crate::OpenFlags::Create, false)
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
-        let mut tx = crate::mvcc::database::LogRecord::new(300);
+        let mut tx =
+            crate::mvcc::database::LogRecord::new(300, crate::alloc::DynAllocator::default())
+                .unwrap();
         tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
             begin: crate::mvcc::database::PackedTs::pack(Some(
@@ -5510,7 +5520,11 @@ mod tests {
 
         let mut expected = Vec::new();
         for tx_i in 0..128u64 {
-            let mut tx = crate::mvcc::database::LogRecord::new(1_000 + tx_i);
+            let mut tx = crate::mvcc::database::LogRecord::new(
+                1_000 + tx_i,
+                crate::alloc::DynAllocator::default(),
+            )
+            .unwrap();
             let op_count = (rng.next_u64() % 4) as usize;
             for _ in 0..op_count {
                 let rowid = (rng.next_u64() % 64) as i64 + 1;
@@ -5568,7 +5582,11 @@ mod tests {
         // correctly when a single frame spans chunk boundaries.
         let large_commit_ts = 1_000 + 128u64;
         let large_text: String = "x".repeat(200);
-        let mut large_tx = crate::mvcc::database::LogRecord::new(large_commit_ts);
+        let mut large_tx = crate::mvcc::database::LogRecord::new(
+            large_commit_ts,
+            crate::alloc::DynAllocator::default(),
+        )
+        .unwrap();
         for rowid in 1..=30i64 {
             let row = generate_simple_string_row((-3).into(), rowid, &large_text);
             expected.push(ExpectedTableOp::Upsert {
@@ -5721,7 +5739,9 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord::new(55);
+        let mut tx =
+            crate::mvcc::database::LogRecord::new(55, crate::alloc::DynAllocator::default())
+                .unwrap();
         let mut row = generate_simple_string_row((-2).into(), 1, "foo");
         row.id.table_id = (-2).into();
         let version = crate::mvcc::database::RowVersion {
@@ -5784,7 +5804,9 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord::new(10);
+        let mut tx =
+            crate::mvcc::database::LogRecord::new(10, crate::alloc::DynAllocator::default())
+                .unwrap();
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,

--- a/core/mvcc/persistent_storage/logical_log/serializer.rs
+++ b/core/mvcc/persistent_storage/logical_log/serializer.rs
@@ -118,6 +118,7 @@ impl LogChunkWriter {
 
 pub(crate) trait LogBufferExt: std::ops::DerefMut<Target = [u8]> {
     fn try_extend_chunks(&mut self, chunks: impl LogChunkStream) -> Result<()>;
+    fn try_resize_zeroed(&mut self, new_len: usize) -> Result<()>;
 }
 
 macro_rules! impl_try_extend_chunks {
@@ -149,6 +150,16 @@ macro_rules! impl_try_extend_chunks {
             unsafe {
                 self.set_len(new_len);
             }
+            Ok(())
+        }
+
+        #[inline(always)]
+        fn try_resize_zeroed(&mut self, new_len: usize) -> Result<()> {
+            let additional = new_len.checked_sub(self.len()).ok_or_else(|| {
+                LimboError::InternalError("logical log buffer shrinks unexpectedly".to_string())
+            })?;
+            self.try_reserve(additional)?;
+            self.resize(new_len, 0);
             Ok(())
         }
     };
@@ -383,7 +394,7 @@ impl<'a, B: LogBufferExt + ?Sized> LogSerializer<'a, B> {
     }
 }
 
-impl LogSerializer<'_, Vec<u8>> {
+impl<B: LogBufferExt + ?Sized> LogSerializer<'_, B> {
     pub(crate) fn encrypt_payload_in_place(&mut self, payload: EncryptedPayload<'_>) -> Result<()> {
         let tag_size = payload.enc_ctx.tag_size();
         let nonce_size = payload.enc_ctx.nonce_size();
@@ -404,11 +415,7 @@ impl LogSerializer<'_, Vec<u8>> {
                 "encrypted payload start exceeds buffer length".to_string(),
             ));
         }
-        let additional = payload_end.checked_sub(self.buffer.len()).ok_or_else(|| {
-            LimboError::InternalError("encrypted payload shrinks unexpectedly".to_string())
-        })?;
-        self.buffer.try_reserve(additional)?;
-        self.buffer.resize(payload_end, 0);
+        self.buffer.try_resize_zeroed(payload_end)?;
 
         let chunk_count = encrypted_payload_chunk_count(payload.plaintext_size, payload.chunk_size);
         let plaintext_size = u64::try_from(payload.plaintext_size).map_err(|_| {
@@ -468,7 +475,9 @@ impl LogSerializer<'_, Vec<u8>> {
         );
         Ok(())
     }
+}
 
+impl LogSerializer<'_, Vec<u8>> {
     pub(crate) fn encode_delete_portable_extension(
         identity_record: Option<&[u8]>,
         pk_record: Option<&[u8]>,


### PR DESCRIPTION
## Description

- add `DynVec` and `DynBox` aliases in their collection modules
- make `LogRecord::new` fallible and allocate its record bytes with `DynAllocator`
- preserve that allocator when record storage moves into `SharedBufferData`
- update logical-log serialization call sites and cover allocator retention

## Context

Stacked on #7930. Review the final commit for this PR-specific change.

Logical-log record bytes cross the generic allocator boundary when they are returned as `SharedBufferData`. Using `DynAllocator` keeps the configured database allocator attached to that owned buffer without making `SharedBufferData` generic over `TursoAllocator`.
