### PR TITLE
core/vdbe: resolve aggregate argument collation at translation time

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -177,21 +177,20 @@ pub fn emit_ungrouped_aggregation<'a>(
     Ok(())
 }
 
-pub(crate) fn emit_collseq_if_needed(
-    program: &mut ProgramBuilder,
+/// Resolves the collation a comparison-based aggregate uses for its argument
+/// (explicit COLLATE clause, then the column's table-defined collation, then
+/// BINARY). The result is stored on the AggStep instruction itself.
+pub(crate) fn agg_arg_collation(
     referenced_tables: &TableReferences,
     expr: &ast::Expr,
     resolver: &Resolver,
-) {
+) -> CollationSeq {
     // Check if this is a column expression with explicit COLLATE clause
     if let ast::Expr::Collate(_, collation_name) = expr {
         if let Ok(collation) = resolver.resolve_collation(collation_name.as_str()) {
-            program.emit_insn(Insn::CollSeq {
-                reg: None,
-                collation,
-            });
+            return collation;
         }
-        return;
+        return CollationSeq::Binary;
     }
 
     // If no explicit collation, check if this is a column with table-defined collation
@@ -199,22 +198,13 @@ pub(crate) fn emit_collseq_if_needed(
         if let Some((_, table_ref)) = referenced_tables.find_table_by_internal_id(*table) {
             if let Some(table_column) = table_ref.get_column_at(*column) {
                 if let Some(c) = table_column.collation_opt() {
-                    program.emit_insn(Insn::CollSeq {
-                        reg: None,
-                        collation: c,
-                    });
-                    return;
+                    return c;
                 }
             }
         }
     }
 
-    // Always emit a CollSeq to reset to BINARY default, preventing collation
-    // from a previous aggregate leaking into this one.
-    program.emit_insn(Insn::CollSeq {
-        reg: None,
-        collation: CollationSeq::Binary,
-    });
+    CollationSeq::Binary
 }
 
 /// Emits the bytecode for handling duplicates in a distinct aggregate.
@@ -366,6 +356,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::Avg),
                 comparator: None,
+                collation: None,
             });
             target_register
         }
@@ -379,6 +370,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::Count0),
                 comparator: None,
+                collation: None,
             });
             target_register
         }
@@ -394,6 +386,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::Count),
                 comparator: None,
+                collation: None,
             });
             target_register
         }
@@ -419,6 +412,7 @@ pub fn translate_aggregation_step(
                 delimiter: delimiter_reg,
                 func: AccumulatorFunc::Agg(AggFunc::GroupConcat),
                 comparator: None,
+                collation: None,
             });
 
             target_register
@@ -430,7 +424,7 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             let expr = &agg_arg_source.arg_at(0);
-            emit_collseq_if_needed(program, referenced_tables, expr, resolver);
+            let arg_collation = agg_arg_collation(referenced_tables, expr, resolver);
             let comparator =
                 super::order_by::custom_type_comparator(expr, referenced_tables, resolver.schema());
             program.emit_insn(Insn::AggStep {
@@ -439,6 +433,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::Max),
                 comparator,
+                collation: Some(arg_collation),
             });
             target_register
         }
@@ -449,7 +444,7 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             let expr = &agg_arg_source.arg_at(0);
-            emit_collseq_if_needed(program, referenced_tables, expr, resolver);
+            let arg_collation = agg_arg_collation(referenced_tables, expr, resolver);
             let comparator =
                 super::order_by::custom_type_comparator(expr, referenced_tables, resolver.schema());
             program.emit_insn(Insn::AggStep {
@@ -458,6 +453,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::Min),
                 comparator,
+                collation: Some(arg_collation),
             });
             target_register
         }
@@ -476,6 +472,7 @@ pub fn translate_aggregation_step(
                 delimiter: value_reg,
                 func: AccumulatorFunc::Agg(AggFunc::JsonGroupObject),
                 comparator: None,
+                collation: None,
             });
             target_register
         }
@@ -492,6 +489,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::JsonGroupArray),
                 comparator: None,
+                collation: None,
             });
             target_register
         }
@@ -510,6 +508,7 @@ pub fn translate_aggregation_step(
                 delimiter: delimiter_reg,
                 func: AccumulatorFunc::Agg(AggFunc::StringAgg),
                 comparator: None,
+                collation: None,
             });
 
             target_register
@@ -526,6 +525,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::Sum),
                 comparator: None,
+                collation: None,
             });
             target_register
         }
@@ -541,6 +541,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::Total),
                 comparator: None,
+                collation: None,
             });
             target_register
         }
@@ -557,6 +558,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::ArrayAgg),
                 comparator: None,
+                collation: None,
             });
             target_register
         }
@@ -568,13 +570,14 @@ pub fn translate_aggregation_step(
             let value_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             // Activate the value's collation so finalize can sort text correctly.
             let expr = &agg_arg_source.arg_at(0);
-            emit_collseq_if_needed(program, referenced_tables, expr, resolver);
+            let arg_collation = agg_arg_collation(referenced_tables, expr, resolver);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: value_reg,
                 delimiter: 0,
                 func: AccumulatorFunc::Agg(AggFunc::Mode),
                 comparator: None,
+                collation: Some(arg_collation),
             });
             target_register
         }
@@ -590,13 +593,14 @@ pub fn translate_aggregation_step(
             let fraction_reg =
                 fraction_reg.expect("percentile fraction register must be set by InitLoop::emit");
             let expr = &agg_arg_source.arg_at(0);
-            emit_collseq_if_needed(program, referenced_tables, expr, resolver);
+            let arg_collation = agg_arg_collation(referenced_tables, expr, resolver);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: value_reg,
                 delimiter: fraction_reg,
                 func: AccumulatorFunc::Agg(func.clone()),
                 comparator: None,
+                collation: Some(arg_collation),
             });
             target_register
         }
@@ -636,6 +640,7 @@ pub fn translate_aggregation_step(
                     func.clone()
                 })),
                 comparator: None,
+                collation: None,
             });
             target_register
         }

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -1,6 +1,6 @@
 use crate::translate::plan::SimpleAggregate;
 use crate::translate::{
-    aggregation::emit_collseq_if_needed,
+    aggregation::agg_arg_collation,
     order_by::{custom_type_comparator, EmitOrderBy},
     window::EmitWindow,
 };
@@ -251,12 +251,8 @@ fn emit_loop_source<'a>(
                     None
                 };
 
-                emit_collseq_if_needed(
-                    program,
-                    &plan.table_references,
-                    &min_max.argument,
-                    &t_ctx.resolver,
-                );
+                let arg_collation =
+                    agg_arg_collation(&plan.table_references, &min_max.argument, &t_ctx.resolver);
                 let comparator = custom_type_comparator(
                     &min_max.argument,
                     &plan.table_references,
@@ -268,6 +264,7 @@ fn emit_loop_source<'a>(
                     delimiter: 0,
                     func: crate::function::AccumulatorFunc::Agg(min_max.func.clone()),
                     comparator,
+                    collation: Some(arg_collation),
                 });
                 program.emit_insn(Insn::Goto {
                     target_pc: loop_end,

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -1128,6 +1128,7 @@ fn emit_aggregation_step(
                     delimiter: 0,
                     func: AccumulatorFunc::Window(win_func.clone()),
                     comparator: None,
+                    collation: None,
                 });
             }
         }
@@ -1266,6 +1267,7 @@ fn emit_peer_group_flush(
                 delimiter: 0,
                 func: AccumulatorFunc::Window(win_func.clone()),
                 comparator: None,
+                collation: None,
             });
             program.emit_insn(Insn::AggValue {
                 acc_reg,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6875,6 +6875,7 @@ pub fn op_agg_step(
             delimiter,
             func,
             comparator,
+            collation,
         },
         insn
     );
@@ -6917,7 +6918,7 @@ pub fn op_agg_step(
         };
     }
 
-    let current_collation = state.current_collation.unwrap_or(CollationSeq::Binary);
+    let current_collation = collation.unwrap_or(CollationSeq::Binary);
     let comparator_factory = move || -> Result<Option<crate::vdbe::sorter::SortComparator>> {
         Ok(match comparator.as_ref() {
             Some(comparator) => Some(make_sort_comparator(comparator)?),
@@ -12754,28 +12755,6 @@ pub fn op_is_null(
     } else {
         state.pc += 1;
     }
-    Ok(InsnFunctionStepResult::Step)
-}
-
-pub fn op_coll_seq(
-    _program: &Program,
-    state: &mut ProgramState,
-    insn: &Insn,
-    _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
-    let Insn::CollSeq { reg, collation } = insn else {
-        unreachable!("unexpected Insn {:?}", insn)
-    };
-
-    // Set the current collation sequence for use by subsequent functions
-    state.current_collation = Some(*collation);
-
-    // If P1 is not zero, initialize that register to 0
-    if let Some(reg_idx) = reg {
-        state.registers[*reg_idx].set_int(0);
-    }
-
-    state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
 

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1261,6 +1261,7 @@ pub fn insn_to_row(
                 delimiter: _,
                 col,
                 comparator: _,
+                collation: _,
             } => (
                 "AggStep",
                 0,
@@ -2338,15 +2339,6 @@ pub fn insn_to_row(
                 0,
                 format!("r[{dest}]=journal_mode(db[{db}]{})",
                     new_mode.as_ref().map_or(String::new(), |m| format!(",'{m}'"))),
-            ),
-            Insn::CollSeq { reg, collation } => (
-                "CollSeq",
-                reg.unwrap_or(0) as i64,
-                0,
-                0,
-                Value::build_text(collation.to_string()),
-                0,
-                format!("collation={collation}"),
             ),
             Insn::IfNeg { reg, target_pc } => (
                 "IfNeg",

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1261,13 +1261,16 @@ pub fn insn_to_row(
                 delimiter: _,
                 col,
                 comparator: _,
-                collation: _,
+                collation,
             } => (
                 "AggStep",
                 0,
                 *col as i64,
                 *acc_reg as i64,
-                Value::build_text(func.as_str()),
+                Value::build_text(match collation {
+                    Some(collation) => format!("{}({collation})", func.as_str()),
+                    None => func.as_str().to_string(),
+                }),
                 0,
                 format!("accum=r[{}] step(r[{}])", *acc_reg, *col),
             ),

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1072,6 +1072,9 @@ pub enum Insn {
         func: AccumulatorFunc,
         /// Optional custom type comparator for MIN/MAX aggregates.
         comparator: Option<SortComparatorType>,
+        /// Collation for comparison-based aggregates (MIN/MAX), resolved at
+        /// translation time from the argument expression.
+        collation: Option<CollationSeq>,
     },
 
     AggFinal {
@@ -1534,21 +1537,6 @@ pub enum Insn {
         target_pc: BranchOffset,
     },
 
-    /// Set the collation sequence for the next function call.
-    /// P4 is a pointer to a CollationSeq. If the next call to a user function
-    /// or aggregate calls sqlite3GetFuncCollSeq(), this collation sequence will
-    /// be returned. This is used by the built-in min(), max() and nullif()
-    /// functions.
-    ///
-    /// If P1 is not zero, then it is a register that a subsequent min() or
-    /// max() aggregate will set to 1 if the current row is not the minimum or
-    /// maximum.  The P1 register is initialized to 0 by this instruction.
-    CollSeq {
-        /// Optional register to initialize to 0 (P1).
-        reg: Option<usize>,
-        /// The collation sequence to set (P4).
-        collation: CollationSeq,
-    },
     ParseSchema {
         db: usize,
         where_clause: Option<String>,
@@ -2161,7 +2149,6 @@ impl InsnVariants {
             InsnVariants::DropView => execute::op_drop_view,
             InsnVariants::Close => execute::op_close,
             InsnVariants::IsNull => execute::op_is_null,
-            InsnVariants::CollSeq => execute::op_coll_seq,
             InsnVariants::ParseSchema => execute::op_parse_schema,
             InsnVariants::PopulateMaterializedViews => execute::op_populate_materialized_views,
             InsnVariants::ShiftRight => execute::op_shift_right,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -749,8 +749,6 @@ pub struct ProgramState {
     seek_state: OpSeekState,
     /// Metrics collected for the lifetime of this prepared statement.
     pub metrics: StatementMetrics,
-    /// Current collation sequence set by OP_CollSeq instruction
-    current_collation: Option<CollationSeq>,
     op_vacuum_state: VacuumOpState,
     /// State machine for committing view deltas with I/O handling
     view_delta_state: ViewDeltaCommitState,
@@ -846,7 +844,6 @@ impl ProgramState {
             seek_state: OpSeekState::Start,
             metrics: StatementMetrics::new(),
             distinct_key_values: Vec::new(),
-            current_collation: None,
             op_vacuum_state: VacuumOpState::None,
             view_delta_state: ViewDeltaCommitState::NotStarted,
             auto_txn_cleanup: TxnCleanup::None,
@@ -956,7 +953,6 @@ impl ProgramState {
         self.once.clear();
         self.execution_state = ProgramExecutionState::Init;
         self.query_deadline = None;
-        self.current_collation = None;
         #[cfg(feature = "json")]
         self.json_cache.clear();
 
@@ -967,7 +963,6 @@ impl ProgramState {
         self.commit_state.cleanup_mvcc_checkpoint_state();
         self.active_op_state.clear();
         self.seek_state = OpSeekState::Start;
-        self.current_collation = None;
         self.commit_state = CommitState::Ready;
         // Drop any in-flight sequence inner-tx commit-state-machine. If
         // it was mid-step the inner mv_tx has already been swapped back

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
@@ -42,8 +42,8 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   15            Move          12   7   1                       0  r[7..7]=r[12..12]
   16            IfPos          6  40   0                       0  r[6]>0 -> r[6]-=0, goto 40; check abort flag
   17            Gosub         15  37   0                       0  ; goto clear accumulator subroutine
-  18            AggStep        0  13   9  min                  0  accum=r[9] step(r[13])
-  19            AggStep        0  14  10  max                  0  accum=r[10] step(r[14])
+  18            AggStep        0  13   9  min(Binary)          0  accum=r[9] step(r[13])
+  19            AggStep        0  14  10  max(Binary)          0  accum=r[10] step(r[14])
   20            If             5  22   0                       0  if r[5] goto 22; don't emit group columns if continuing existing group
   21            Column         1   0   8                       0  r[8]=idx_sales_category.category
   22            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
@@ -24,48 +24,46 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                  p5  comment
-   0          Init             0  43   0                       0  Start at 43
+   0          Init             0  41   0                       0  Start at 41
    1          Null             0   9  10                       0  r[9..10]=NULL
    2          Integer          0   6   0                       0  r[6]=0; clear group by abort flag
    3          Null             0   7   0                       0  r[7]=NULL; initialize group by comparison registers to NULL
-   4          Gosub           15  39   0                       0  ; go to clear accumulator subroutine
+   4          Gosub           15  37   0                       0  ; go to clear accumulator subroutine
    5          OpenRead         0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
    6          OpenRead         1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
-   7          Rewind           1  26   0                       0  Rewind index idx_sales_category
+   7          Rewind           1  24   0                       0  Rewind index idx_sales_category
    8            DeferredSeek   1   0   0                       0
    9            Column         1   0  12                       0  r[12]=idx_sales_category.category
   10            Column         0   4  13                       0  r[13]=sales.amount
   11            Column         0   4  14                       0  r[14]=sales.amount
   12            Compare        7  12   1  k(1, Binary)         0  r[7..7]==r[12..12]
   13            Jump          14  18  14                       0  ; start new group if comparison is not equal
-  14            Gosub          4  30   0                       0  ; check if ended group had data, and output if so
+  14            Gosub          4  28   0                       0  ; check if ended group had data, and output if so
   15            Move          12   7   1                       0  r[7..7]=r[12..12]
-  16            IfPos          6  42   0                       0  r[6]>0 -> r[6]-=0, goto 42; check abort flag
-  17            Gosub         15  39   0                       0  ; goto clear accumulator subroutine
-  18            CollSeq        0   0   0  Binary               0  collation=Binary
-  19            AggStep        0  13   9  min                  0  accum=r[9] step(r[13])
-  20            CollSeq        0   0   0  Binary               0  collation=Binary
-  21            AggStep        0  14  10  max                  0  accum=r[10] step(r[14])
-  22            If             5  24   0                       0  if r[5] goto 24; don't emit group columns if continuing existing group
-  23            Column         1   0   8                       0  r[8]=idx_sales_category.category
-  24            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
-  25          Next             1   8   0                       0
-  26          Gosub            4  30   0                       0  ; emit row for final group
-  27          Goto             0  42   0                       0  ; group by finished
-  28          Integer          1   6   0                       0  r[6]=1
-  29        Return             4   0   0                       0
-  30        IfPos              5  32   0                       0  r[5]>0 -> r[5]-=0, goto 32; output group by row subroutine start
-  31      Return               4   0   0                       0
-  32      AggFinal             0   9   0  min                  0  accum=r[9]
-  33      AggFinal             0  10   0  max                  0  accum=r[10]
-  34      Copy                 8   1   0                       0  r[1]=r[8]
-  35      Copy                 9   2   0                       0  r[2]=r[9]
-  36      Copy                10   3   0                       0  r[3]=r[10]
-  37      ResultRow            1   3   0                       0  output=r[1..3]
-  38    Return                 4   0   0                       0
-  39    Null                   0   8  10                       0  r[8..10]=NULL; clear accumulator subroutine start
-  40    Integer                0   5   0                       0  r[5]=0
-  41  Return                  15   0   0                       0
-  42  Halt                     0   0   0                       0
-  43  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
-  44  Goto                     0   1   0                       0
+  16            IfPos          6  40   0                       0  r[6]>0 -> r[6]-=0, goto 40; check abort flag
+  17            Gosub         15  37   0                       0  ; goto clear accumulator subroutine
+  18            AggStep        0  13   9  min                  0  accum=r[9] step(r[13])
+  19            AggStep        0  14  10  max                  0  accum=r[10] step(r[14])
+  20            If             5  22   0                       0  if r[5] goto 22; don't emit group columns if continuing existing group
+  21            Column         1   0   8                       0  r[8]=idx_sales_category.category
+  22            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
+  23          Next             1   8   0                       0
+  24          Gosub            4  28   0                       0  ; emit row for final group
+  25          Goto             0  40   0                       0  ; group by finished
+  26          Integer          1   6   0                       0  r[6]=1
+  27        Return             4   0   0                       0
+  28        IfPos              5  30   0                       0  r[5]>0 -> r[5]-=0, goto 30; output group by row subroutine start
+  29      Return               4   0   0                       0
+  30      AggFinal             0   9   0  min                  0  accum=r[9]
+  31      AggFinal             0  10   0  max                  0  accum=r[10]
+  32      Copy                 8   1   0                       0  r[1]=r[8]
+  33      Copy                 9   2   0                       0  r[2]=r[9]
+  34      Copy                10   3   0                       0  r[3]=r[10]
+  35      ResultRow            1   3   0                       0  output=r[1..3]
+  36    Return                 4   0   0                       0
+  37    Null                   0   8  10                       0  r[8..10]=NULL; clear accumulator subroutine start
+  38    Integer                0   5   0                       0  r[5]=0
+  39  Return                  15   0   0                       0
+  40  Halt                     0   0   0                       0
+  41  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
+  42  Goto                     0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
@@ -19,22 +19,20 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4      p5  comment
-   0  Init          0  17   0           0  Start at 17
+   0  Init          0  15   0           0  Start at 15
    1  Null          0   3   4           0  r[3..4]=NULL
    2  OpenRead      0   3   0  k(2,B)   0  index=idx_sales_amount, root=3, iDb=0
-   3  Rewind        0  11   0           0  Rewind index idx_sales_amount
+   3  Rewind        0   9   0           0  Rewind index idx_sales_amount
    4    Column      0   0   5           0  r[5]=idx_sales_amount.amount
-   5    CollSeq     0   0   0  Binary   0  collation=Binary
-   6    AggStep     0   5   3  min      0  accum=r[3] step(r[5])
-   7    Column      0   0   6           0  r[6]=idx_sales_amount.amount
-   8    CollSeq     0   0   0  Binary   0  collation=Binary
-   9    AggStep     0   6   4  max      0  accum=r[4] step(r[6])
-  10  Next          0   4   0           0
-  11  AggFinal      0   3   0  min      0  accum=r[3]
-  12  AggFinal      0   4   0  max      0  accum=r[4]
-  13  Copy          3   1   0           0  r[1]=r[3]
-  14  Copy          4   2   0           0  r[2]=r[4]
-  15  ResultRow     1   2   0           0  output=r[1..2]
-  16  Halt          0   0   0           0
-  17  Transaction   0   1   8           0  iDb=0 tx_mode=Read
-  18  Goto          0   1   0           0
+   5    AggStep     0   5   3  min      0  accum=r[3] step(r[5])
+   6    Column      0   0   6           0  r[6]=idx_sales_amount.amount
+   7    AggStep     0   6   4  max      0  accum=r[4] step(r[6])
+   8  Next          0   4   0           0
+   9  AggFinal      0   3   0  min      0  accum=r[3]
+  10  AggFinal      0   4   0  max      0  accum=r[4]
+  11  Copy          3   1   0           0  r[1]=r[3]
+  12  Copy          4   2   0           0  r[2]=r[4]
+  13  ResultRow     1   2   0           0  output=r[1..2]
+  14  Halt          0   0   0           0
+  15  Transaction   0   1   8           0  iDb=0 tx_mode=Read
+  16  Goto          0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
@@ -18,21 +18,21 @@ QUERY PLAN
 `--SCAN sales USING COVERING INDEX idx_sales_amount
 
 BYTECODE
-addr  opcode       p1  p2  p3  p4      p5  comment
-   0  Init          0  15   0           0  Start at 15
-   1  Null          0   3   4           0  r[3..4]=NULL
-   2  OpenRead      0   3   0  k(2,B)   0  index=idx_sales_amount, root=3, iDb=0
-   3  Rewind        0   9   0           0  Rewind index idx_sales_amount
-   4    Column      0   0   5           0  r[5]=idx_sales_amount.amount
-   5    AggStep     0   5   3  min      0  accum=r[3] step(r[5])
-   6    Column      0   0   6           0  r[6]=idx_sales_amount.amount
-   7    AggStep     0   6   4  max      0  accum=r[4] step(r[6])
-   8  Next          0   4   0           0
-   9  AggFinal      0   3   0  min      0  accum=r[3]
-  10  AggFinal      0   4   0  max      0  accum=r[4]
-  11  Copy          3   1   0           0  r[1]=r[3]
-  12  Copy          4   2   0           0  r[2]=r[4]
-  13  ResultRow     1   2   0           0  output=r[1..2]
-  14  Halt          0   0   0           0
-  15  Transaction   0   1   8           0  iDb=0 tx_mode=Read
-  16  Goto          0   1   0           0
+addr  opcode       p1  p2  p3  p4           p5  comment
+   0  Init          0  15   0                0  Start at 15
+   1  Null          0   3   4                0  r[3..4]=NULL
+   2  OpenRead      0   3   0  k(2,B)        0  index=idx_sales_amount, root=3, iDb=0
+   3  Rewind        0   9   0                0  Rewind index idx_sales_amount
+   4    Column      0   0   5                0  r[5]=idx_sales_amount.amount
+   5    AggStep     0   5   3  min(Binary)   0  accum=r[3] step(r[5])
+   6    Column      0   0   6                0  r[6]=idx_sales_amount.amount
+   7    AggStep     0   6   4  max(Binary)   0  accum=r[4] step(r[6])
+   8  Next          0   4   0                0
+   9  AggFinal      0   3   0  min           0  accum=r[3]
+  10  AggFinal      0   4   0  max           0  accum=r[4]
+  11  Copy          3   1   0                0  r[1]=r[3]
+  12  Copy          4   2   0                0  r[2]=r[4]
+  13  ResultRow     1   2   0                0  output=r[1..2]
+  14  Halt          0   0   0                0
+  15  Transaction   0   1   8                0  iDb=0 tx_mode=Read
+  16  Goto          0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
@@ -73,9 +73,9 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   41    Copy                   3  20   0                       0  r[20]=r[3]
   42    AggStep                0  20  17  avg                  0  accum=r[17] step(r[20])
   43    Copy                   3  21   0                       0  r[21]=r[3]
-  44    AggStep                0  21  18  max                  0  accum=r[18] step(r[21])
+  44    AggStep                0  21  18  max(Binary)          0  accum=r[18] step(r[21])
   45    Copy                   3  22   0                       0  r[22]=r[3]
-  46    AggStep                0  22  19  min                  0  accum=r[19] step(r[22])
+  46    AggStep                0  22  19  min(Binary)          0  accum=r[19] step(r[22])
   47  Goto                     0  40   0                       0
   48  AggFinal                 0  17   0  avg                  0  accum=r[17]
   49  AggFinal                 0  18   0  max                  0  accum=r[18]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
@@ -29,7 +29,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                  p5  comment
-   0          Init             0  58   0                       0  Start at 58
+   0          Init             0  56   0                       0  Start at 56
    1          InitCoroutine    1  38   2                       0
    2          Null             0   9   0                       0  r[9]=NULL
    3          Integer          0   6   0                       0  r[6]=0; clear group by abort flag
@@ -69,23 +69,21 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   37  EndCoroutine             1   0   0                       0
   38  Null                     0  17  19                       0  r[17..19]=NULL
   39  InitCoroutine            1   0   2                       0
-  40    Yield                  1  50   0                       0
+  40    Yield                  1  48   0                       0
   41    Copy                   3  20   0                       0  r[20]=r[3]
   42    AggStep                0  20  17  avg                  0  accum=r[17] step(r[20])
   43    Copy                   3  21   0                       0  r[21]=r[3]
-  44    CollSeq                0   0   0  Binary               0  collation=Binary
-  45    AggStep                0  21  18  max                  0  accum=r[18] step(r[21])
-  46    Copy                   3  22   0                       0  r[22]=r[3]
-  47    CollSeq                0   0   0  Binary               0  collation=Binary
-  48    AggStep                0  22  19  min                  0  accum=r[19] step(r[22])
-  49  Goto                     0  40   0                       0
-  50  AggFinal                 0  17   0  avg                  0  accum=r[17]
-  51  AggFinal                 0  18   0  max                  0  accum=r[18]
-  52  AggFinal                 0  19   0  min                  0  accum=r[19]
-  53  Copy                    17  14   0                       0  r[14]=r[17]
-  54  Copy                    18  15   0                       0  r[15]=r[18]
-  55  Copy                    19  16   0                       0  r[16]=r[19]
-  56  ResultRow               14   3   0                       0  output=r[14..16]
-  57  Halt                     0   0   0                       0
-  58  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
-  59  Goto                     0   1   0                       0
+  44    AggStep                0  21  18  max                  0  accum=r[18] step(r[21])
+  45    Copy                   3  22   0                       0  r[22]=r[3]
+  46    AggStep                0  22  19  min                  0  accum=r[19] step(r[22])
+  47  Goto                     0  40   0                       0
+  48  AggFinal                 0  17   0  avg                  0  accum=r[17]
+  49  AggFinal                 0  18   0  max                  0  accum=r[18]
+  50  AggFinal                 0  19   0  min                  0  accum=r[19]
+  51  Copy                    17  14   0                       0  r[14]=r[17]
+  52  Copy                    18  15   0                       0  r[15]=r[18]
+  53  Copy                    19  16   0                       0  r[16]=r[19]
+  54  ResultRow               14   3   0                       0  output=r[14..16]
+  55  Halt                     0   0   0                       0
+  56  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
+  57  Goto                     0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
@@ -33,9 +33,9 @@ addr  opcode       p1  p2  p3  p4                  p5  comment
    7    Column      0   4  15                       0  r[15]=sales.amount
    8    AggStep     0  15   9  avg                  0  accum=r[9] step(r[15])
    9    Column      0   4  16                       0  r[16]=sales.amount
-  10    AggStep     0  16  10  min                  0  accum=r[10] step(r[16])
+  10    AggStep     0  16  10  min(Binary)          0  accum=r[10] step(r[16])
   11    Column      0   4  17                       0  r[17]=sales.amount
-  12    AggStep     0  17  11  max                  0  accum=r[11] step(r[17])
+  12    AggStep     0  17  11  max(Binary)          0  accum=r[11] step(r[17])
   13    Column      0   5  18                       0  r[18]=sales.quantity
   14    AggStep     0  18  12  sum                  0  accum=r[12] step(r[18])
   15  Next          0   4   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
@@ -23,38 +23,36 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4                  p5  comment
-   0  Init          0  32   0                       0  Start at 32
+   0  Init          0  30   0                       0  Start at 30
    1  Null          0   7  12                       0  r[7..12]=NULL
    2  OpenRead      0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
-   3  Rewind        0  18   0                       0  Rewind table sales
+   3  Rewind        0  16   0                       0  Rewind table sales
    4    AggStep     0  13   7  count                0  accum=r[7] step(r[13])
    5    Column      0   4  14                       0  r[14]=sales.amount
    6    AggStep     0  14   8  sum                  0  accum=r[8] step(r[14])
    7    Column      0   4  15                       0  r[15]=sales.amount
    8    AggStep     0  15   9  avg                  0  accum=r[9] step(r[15])
    9    Column      0   4  16                       0  r[16]=sales.amount
-  10    CollSeq     0   0   0  Binary               0  collation=Binary
-  11    AggStep     0  16  10  min                  0  accum=r[10] step(r[16])
-  12    Column      0   4  17                       0  r[17]=sales.amount
-  13    CollSeq     0   0   0  Binary               0  collation=Binary
-  14    AggStep     0  17  11  max                  0  accum=r[11] step(r[17])
-  15    Column      0   5  18                       0  r[18]=sales.quantity
-  16    AggStep     0  18  12  sum                  0  accum=r[12] step(r[18])
-  17  Next          0   4   0                       0
-  18  AggFinal      0   7   0  count                0  accum=r[7]
-  19  AggFinal      0   8   0  sum                  0  accum=r[8]
-  20  AggFinal      0   9   0  avg                  0  accum=r[9]
-  21  AggFinal      0  10   0  min                  0  accum=r[10]
-  22  AggFinal      0  11   0  max                  0  accum=r[11]
-  23  AggFinal      0  12   0  sum                  0  accum=r[12]
-  24  Copy          7   1   0                       0  r[1]=r[7]
-  25  Copy          8   2   0                       0  r[2]=r[8]
-  26  Copy          9   3   0                       0  r[3]=r[9]
-  27  Copy         10   4   0                       0  r[4]=r[10]
-  28  Copy         11   5   0                       0  r[5]=r[11]
-  29  Copy         12   6   0                       0  r[6]=r[12]
-  30  ResultRow     1   6   0                       0  output=r[1..6]
-  31  Halt          0   0   0                       0
-  32  Transaction   0   1   8                       0  iDb=0 tx_mode=Read
-  33  Integer       1  13   0                       0  r[13]=1
-  34  Goto          0   1   0                       0
+  10    AggStep     0  16  10  min                  0  accum=r[10] step(r[16])
+  11    Column      0   4  17                       0  r[17]=sales.amount
+  12    AggStep     0  17  11  max                  0  accum=r[11] step(r[17])
+  13    Column      0   5  18                       0  r[18]=sales.quantity
+  14    AggStep     0  18  12  sum                  0  accum=r[12] step(r[18])
+  15  Next          0   4   0                       0
+  16  AggFinal      0   7   0  count                0  accum=r[7]
+  17  AggFinal      0   8   0  sum                  0  accum=r[8]
+  18  AggFinal      0   9   0  avg                  0  accum=r[9]
+  19  AggFinal      0  10   0  min                  0  accum=r[10]
+  20  AggFinal      0  11   0  max                  0  accum=r[11]
+  21  AggFinal      0  12   0  sum                  0  accum=r[12]
+  22  Copy          7   1   0                       0  r[1]=r[7]
+  23  Copy          8   2   0                       0  r[2]=r[8]
+  24  Copy          9   3   0                       0  r[3]=r[9]
+  25  Copy         10   4   0                       0  r[4]=r[10]
+  26  Copy         11   5   0                       0  r[5]=r[11]
+  27  Copy         12   6   0                       0  r[6]=r[12]
+  28  ResultRow     1   6   0                       0  output=r[1..6]
+  29  Halt          0   0   0                       0
+  30  Transaction   0   1   8                       0  iDb=0 tx_mode=Read
+  31  Integer       1  13   0                       0  r[13]=1
+  32  Goto          0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__max-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__max-after-analyze.snap
@@ -20,7 +20,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    3  Rewind           0   8   0                     0  Rewind table products
    4    Column         0   4   3                     0  r[3]=products.price
    5    RealAffinity   3   0   0                     0
-   6    AggStep        0   3   2  max                0  accum=r[2] step(r[3])
+   6    AggStep        0   3   2  max(Binary)        0  accum=r[2] step(r[3])
    7  Next             0   4   0                     0
    8  AggFinal         0   2   0  max                0  accum=r[2]
    9  Copy             2   1   0                     0  r[1]=r[2]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__max-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__max-after-analyze.snap
@@ -14,18 +14,17 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4                p5  comment
-   0  Init             0  13   0                     0  Start at 13
+   0  Init             0  12   0                     0  Start at 12
    1  Null             0   2   0                     0  r[2]=NULL
    2  OpenRead         0   2   0  k(6,B,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   3  Rewind           0   9   0                     0  Rewind table products
+   3  Rewind           0   8   0                     0  Rewind table products
    4    Column         0   4   3                     0  r[3]=products.price
    5    RealAffinity   3   0   0                     0
-   6    CollSeq        0   0   0  Binary             0  collation=Binary
-   7    AggStep        0   3   2  max                0  accum=r[2] step(r[3])
-   8  Next             0   4   0                     0
-   9  AggFinal         0   2   0  max                0  accum=r[2]
-  10  Copy             2   1   0                     0  r[1]=r[2]
-  11  ResultRow        1   1   0                     0  output=r[1]
-  12  Halt             0   0   0                     0
-  13  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
-  14  Goto             0   1   0                     0
+   6    AggStep        0   3   2  max                0  accum=r[2] step(r[3])
+   7  Next             0   4   0                     0
+   8  AggFinal         0   2   0  max                0  accum=r[2]
+   9  Copy             2   1   0                     0  r[1]=r[2]
+  10  ResultRow        1   1   0                     0  output=r[1]
+  11  Halt             0   0   0                     0
+  12  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
+  13  Goto             0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__min-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__min-after-analyze.snap
@@ -20,7 +20,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    3  Rewind           0   8   0                     0  Rewind table products
    4    Column         0   4   3                     0  r[3]=products.price
    5    RealAffinity   3   0   0                     0
-   6    AggStep        0   3   2  min                0  accum=r[2] step(r[3])
+   6    AggStep        0   3   2  min(Binary)        0  accum=r[2] step(r[3])
    7  Next             0   4   0                     0
    8  AggFinal         0   2   0  min                0  accum=r[2]
    9  Copy             2   1   0                     0  r[1]=r[2]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__min-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__min-after-analyze.snap
@@ -14,18 +14,17 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4                p5  comment
-   0  Init             0  13   0                     0  Start at 13
+   0  Init             0  12   0                     0  Start at 12
    1  Null             0   2   0                     0  r[2]=NULL
    2  OpenRead         0   2   0  k(6,B,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   3  Rewind           0   9   0                     0  Rewind table products
+   3  Rewind           0   8   0                     0  Rewind table products
    4    Column         0   4   3                     0  r[3]=products.price
    5    RealAffinity   3   0   0                     0
-   6    CollSeq        0   0   0  Binary             0  collation=Binary
-   7    AggStep        0   3   2  min                0  accum=r[2] step(r[3])
-   8  Next             0   4   0                     0
-   9  AggFinal         0   2   0  min                0  accum=r[2]
-  10  Copy             2   1   0                     0  r[1]=r[2]
-  11  ResultRow        1   1   0                     0  output=r[1]
-  12  Halt             0   0   0                     0
-  13  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
-  14  Goto             0   1   0                     0
+   6    AggStep        0   3   2  min                0  accum=r[2] step(r[3])
+   7  Next             0   4   0                     0
+   8  AggFinal         0   2   0  min                0  accum=r[2]
+   9  Copy             2   1   0                     0  r[1]=r[2]
+  10  ResultRow        1   1   0                     0  output=r[1]
+  11  Halt             0   0   0                     0
+  12  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
+  13  Goto             0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-correlated-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-correlated-max-materialized-cte-bytecode.snap
@@ -28,7 +28,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode             p1  p2  p3  p4      p5  comment
-   0    Init              0  38   0           0  Start at 38
+   0    Init              0  37   0           0  Start at 37
    1    OpenEphemeral     0   1   0           0  cursor=0 is_table=true
    2    OpenRead          1   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
    3    Rewind            1  10   0           0  Rewind index idx_products_price
@@ -38,34 +38,33 @@ addr  opcode             p1  p2  p3  p4      p5  comment
    7      NewRowid        0   5   0           0  r[5]=rowid
    8      Insert          0   4   5           4  intkey=r[5] data=r[4]
    9    Next              1   4   0           0
-  10    Rewind            0  37   0           0  Rewind  ephemeral()
+  10    Rewind            0  36   0           0  Rewind  ephemeral()
   11      Column          0   0   2           0  r[2]=ephemeral().price
   12      Copy            2   8   0           0  r[8]=r[2]
-  13      Ge              8   9  36  Binary   0  if r[8]>=r[9] goto 36
+  13      Ge              8   9  35  Binary   0  if r[8]>=r[9] goto 35
   14      BeginSubrtn    10   0   0           0  r[10]=NULL
   15      Null            0   1   0           0  r[1]=NULL
   16      OpenDup         2   0   0           0  new_cursor=2, original_cursor=0
   17      Null            0  13   0           0  r[13]=NULL
   18      Integer         1  14   0           0  r[14]=1; LIMIT counter
-  19      IfNot          14  30   0           0  if !r[14] goto 30
-  20      Last            2  30   0           0
+  19      IfNot          14  29   0           0  if !r[14] goto 29
+  20      Last            2  29   0           0
   21        Column        2   0  11           0  r[11]=ephemeral().price
   22        Copy         11  16   0           0  r[16]=r[11]
   23        Copy          2  17   0           0  r[17]=r[2]
-  24        Ge           16  17  29  Binary   0  if r[16]>=r[17] goto 29
+  24        Ge           16  17  28  Binary   0  if r[16]>=r[17] goto 28
   25        Copy         11  18   0           0  r[18]=r[11]
-  26        CollSeq       0   0   0  Binary   0  collation=Binary
-  27        AggStep       0  18  13  max      0  accum=r[13] step(r[18])
-  28        Goto          0  30   0           0
-  29      Prev            2  21   0           0
-  30      AggFinal        0  13   0  max      0  accum=r[13]
-  31      Copy           13  12   0           0  r[12]=r[13]
-  32      Copy           12   1   0           0  r[1]=r[12]
-  33    Return           10   0   1           0
-  34    Copy              1   6   0           0  r[6]=r[1]
-  35    ResultRow         6   1   0           0  output=r[6]
-  36  Next                0  11   0           0
-  37  Halt                0   0   0           0
-  38  Transaction         0   1  14           0  iDb=0 tx_mode=Read
-  39  Integer           100   9   0           0  r[9]=100
-  40  Goto                0   1   0           0
+  26        AggStep       0  18  13  max      0  accum=r[13] step(r[18])
+  27        Goto          0  29   0           0
+  28      Prev            2  21   0           0
+  29      AggFinal        0  13   0  max      0  accum=r[13]
+  30      Copy           13  12   0           0  r[12]=r[13]
+  31      Copy           12   1   0           0  r[1]=r[12]
+  32    Return           10   0   1           0
+  33    Copy              1   6   0           0  r[6]=r[1]
+  34    ResultRow         6   1   0           0  output=r[6]
+  35  Next                0  11   0           0
+  36  Halt                0   0   0           0
+  37  Transaction         0   1  14           0  iDb=0 tx_mode=Read
+  38  Integer           100   9   0           0  r[9]=100
+  39  Goto                0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-correlated-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-correlated-max-materialized-cte-bytecode.snap
@@ -27,44 +27,44 @@ QUERY PLAN
    `--SCAN prices AS p2
 
 BYTECODE
-addr  opcode             p1  p2  p3  p4      p5  comment
-   0    Init              0  37   0           0  Start at 37
-   1    OpenEphemeral     0   1   0           0  cursor=0 is_table=true
-   2    OpenRead          1   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
-   3    Rewind            1  10   0           0  Rewind index idx_products_price
-   4      Column          1   0   3           0  r[3]=idx_products_price.price
-   5      RealAffinity    3   0   0           0
-   6      MakeRecord      3   1   4           0  r[4]=mkrec(r[3..3]); for
-   7      NewRowid        0   5   0           0  r[5]=rowid
-   8      Insert          0   4   5           4  intkey=r[5] data=r[4]
-   9    Next              1   4   0           0
-  10    Rewind            0  36   0           0  Rewind  ephemeral()
-  11      Column          0   0   2           0  r[2]=ephemeral().price
-  12      Copy            2   8   0           0  r[8]=r[2]
-  13      Ge              8   9  35  Binary   0  if r[8]>=r[9] goto 35
-  14      BeginSubrtn    10   0   0           0  r[10]=NULL
-  15      Null            0   1   0           0  r[1]=NULL
-  16      OpenDup         2   0   0           0  new_cursor=2, original_cursor=0
-  17      Null            0  13   0           0  r[13]=NULL
-  18      Integer         1  14   0           0  r[14]=1; LIMIT counter
-  19      IfNot          14  29   0           0  if !r[14] goto 29
-  20      Last            2  29   0           0
-  21        Column        2   0  11           0  r[11]=ephemeral().price
-  22        Copy         11  16   0           0  r[16]=r[11]
-  23        Copy          2  17   0           0  r[17]=r[2]
-  24        Ge           16  17  28  Binary   0  if r[16]>=r[17] goto 28
-  25        Copy         11  18   0           0  r[18]=r[11]
-  26        AggStep       0  18  13  max      0  accum=r[13] step(r[18])
-  27        Goto          0  29   0           0
-  28      Prev            2  21   0           0
-  29      AggFinal        0  13   0  max      0  accum=r[13]
-  30      Copy           13  12   0           0  r[12]=r[13]
-  31      Copy           12   1   0           0  r[1]=r[12]
-  32    Return           10   0   1           0
-  33    Copy              1   6   0           0  r[6]=r[1]
-  34    ResultRow         6   1   0           0  output=r[6]
-  35  Next                0  11   0           0
-  36  Halt                0   0   0           0
-  37  Transaction         0   1  14           0  iDb=0 tx_mode=Read
-  38  Integer           100   9   0           0  r[9]=100
-  39  Goto                0   1   0           0
+addr  opcode             p1  p2  p3  p4           p5  comment
+   0    Init              0  37   0                0  Start at 37
+   1    OpenEphemeral     0   1   0                0  cursor=0 is_table=true
+   2    OpenRead          1   5   0  k(2,B)        0  index=idx_products_price, root=5, iDb=0
+   3    Rewind            1  10   0                0  Rewind index idx_products_price
+   4      Column          1   0   3                0  r[3]=idx_products_price.price
+   5      RealAffinity    3   0   0                0
+   6      MakeRecord      3   1   4                0  r[4]=mkrec(r[3..3]); for
+   7      NewRowid        0   5   0                0  r[5]=rowid
+   8      Insert          0   4   5                4  intkey=r[5] data=r[4]
+   9    Next              1   4   0                0
+  10    Rewind            0  36   0                0  Rewind  ephemeral()
+  11      Column          0   0   2                0  r[2]=ephemeral().price
+  12      Copy            2   8   0                0  r[8]=r[2]
+  13      Ge              8   9  35  Binary        0  if r[8]>=r[9] goto 35
+  14      BeginSubrtn    10   0   0                0  r[10]=NULL
+  15      Null            0   1   0                0  r[1]=NULL
+  16      OpenDup         2   0   0                0  new_cursor=2, original_cursor=0
+  17      Null            0  13   0                0  r[13]=NULL
+  18      Integer         1  14   0                0  r[14]=1; LIMIT counter
+  19      IfNot          14  29   0                0  if !r[14] goto 29
+  20      Last            2  29   0                0
+  21        Column        2   0  11                0  r[11]=ephemeral().price
+  22        Copy         11  16   0                0  r[16]=r[11]
+  23        Copy          2  17   0                0  r[17]=r[2]
+  24        Ge           16  17  28  Binary        0  if r[16]>=r[17] goto 28
+  25        Copy         11  18   0                0  r[18]=r[11]
+  26        AggStep       0  18  13  max(Binary)   0  accum=r[13] step(r[18])
+  27        Goto          0  29   0                0
+  28      Prev            2  21   0                0
+  29      AggFinal        0  13   0  max           0  accum=r[13]
+  30      Copy           13  12   0                0  r[12]=r[13]
+  31      Copy           12   1   0                0  r[1]=r[12]
+  32    Return           10   0   1                0
+  33    Copy              1   6   0                0  r[6]=r[1]
+  34    ResultRow         6   1   0                0  output=r[6]
+  35  Next                0  11   0                0
+  36  Halt                0   0   0                0
+  37  Transaction         0   1  14                0  iDb=0 tx_mode=Read
+  38  Integer           100   9   0                0  r[9]=100
+  39  Goto                0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-bytecode.snap
@@ -13,19 +13,19 @@ QUERY PLAN
 `--SCAN products USING COVERING INDEX idx_products_price
 
 BYTECODE
-addr  opcode          p1  p2  p3  p4      p5  comment
-   0  Init             0  13   0           0  Start at 13
-   1  Null             0   2   0           0  r[2]=NULL
-   2  OpenRead         0   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
-   3  Last             0   9   0           0
-   4    Column         0   0   3           0  r[3]=idx_products_price.price
-   5    RealAffinity   3   0   0           0
-   6    AggStep        0   3   2  max      0  accum=r[2] step(r[3])
-   7    Goto           0   9   0           0
-   8  Prev             0   4   0           0
-   9  AggFinal         0   2   0  max      0  accum=r[2]
-  10  Copy             2   1   0           0  r[1]=r[2]
-  11  ResultRow        1   1   0           0  output=r[1]
-  12  Halt             0   0   0           0
-  13  Transaction      0   1  14           0  iDb=0 tx_mode=Read
-  14  Goto             0   1   0           0
+addr  opcode          p1  p2  p3  p4           p5  comment
+   0  Init             0  13   0                0  Start at 13
+   1  Null             0   2   0                0  r[2]=NULL
+   2  OpenRead         0   5   0  k(2,B)        0  index=idx_products_price, root=5, iDb=0
+   3  Last             0   9   0                0
+   4    Column         0   0   3                0  r[3]=idx_products_price.price
+   5    RealAffinity   3   0   0                0
+   6    AggStep        0   3   2  max(Binary)   0  accum=r[2] step(r[3])
+   7    Goto           0   9   0                0
+   8  Prev             0   4   0                0
+   9  AggFinal         0   2   0  max           0  accum=r[2]
+  10  Copy             2   1   0                0  r[1]=r[2]
+  11  ResultRow        1   1   0                0  output=r[1]
+  12  Halt             0   0   0                0
+  13  Transaction      0   1  14                0  iDb=0 tx_mode=Read
+  14  Goto             0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-bytecode.snap
@@ -14,19 +14,18 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4      p5  comment
-   0  Init             0  14   0           0  Start at 14
+   0  Init             0  13   0           0  Start at 13
    1  Null             0   2   0           0  r[2]=NULL
    2  OpenRead         0   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
-   3  Last             0  10   0           0
+   3  Last             0   9   0           0
    4    Column         0   0   3           0  r[3]=idx_products_price.price
    5    RealAffinity   3   0   0           0
-   6    CollSeq        0   0   0  Binary   0  collation=Binary
-   7    AggStep        0   3   2  max      0  accum=r[2] step(r[3])
-   8    Goto           0  10   0           0
-   9  Prev             0   4   0           0
-  10  AggFinal         0   2   0  max      0  accum=r[2]
-  11  Copy             2   1   0           0  r[1]=r[2]
-  12  ResultRow        1   1   0           0  output=r[1]
-  13  Halt             0   0   0           0
-  14  Transaction      0   1  14           0  iDb=0 tx_mode=Read
-  15  Goto             0   1   0           0
+   6    AggStep        0   3   2  max      0  accum=r[2] step(r[3])
+   7    Goto           0   9   0           0
+   8  Prev             0   4   0           0
+   9  AggFinal         0   2   0  max      0  accum=r[2]
+  10  Copy             2   1   0           0  r[1]=r[2]
+  11  ResultRow        1   1   0           0  output=r[1]
+  12  Halt             0   0   0           0
+  13  Transaction      0   1  14           0  iDb=0 tx_mode=Read
+  14  Goto             0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-bytecode.snap
@@ -20,7 +20,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4      p5  comment
-   0  Init              0  24   0           0  Start at 24
+   0  Init              0  23   0           0  Start at 23
    1  OpenEphemeral     0   1   0           0  cursor=0 is_table=true
    2  OpenRead          1   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
    3  Rewind            1  10   0           0  Rewind index idx_products_price
@@ -31,19 +31,18 @@ addr  opcode           p1  p2  p3  p4      p5  comment
    8    Insert          0   3   4           4  intkey=r[4] data=r[3]
    9  Next              1   4   0           0
   10  Null              0   6   0           0  r[6]=NULL
-  11  Last              0  20   0           0
+  11  Last              0  19   0           0
   12    Column          0   0   1           0  r[1]=ephemeral().price
   13    Copy            1   8   0           0  r[8]=r[1]
-  14    Ge              8   9  19  Binary   0  if r[8]>=r[9] goto 19
+  14    Ge              8   9  18  Binary   0  if r[8]>=r[9] goto 18
   15    Copy            1  10   0           0  r[10]=r[1]
-  16    CollSeq         0   0   0  Binary   0  collation=Binary
-  17    AggStep         0  10   6  max      0  accum=r[6] step(r[10])
-  18    Goto            0  20   0           0
-  19  Prev              0  12   0           0
-  20  AggFinal          0   6   0  max      0  accum=r[6]
-  21  Copy              6   5   0           0  r[5]=r[6]
-  22  ResultRow         5   1   0           0  output=r[5]
-  23  Halt              0   0   0           0
-  24  Transaction       0   1  14           0  iDb=0 tx_mode=Read
-  25  Integer         100   9   0           0  r[9]=100
-  26  Goto              0   1   0           0
+  16    AggStep         0  10   6  max      0  accum=r[6] step(r[10])
+  17    Goto            0  19   0           0
+  18  Prev              0  12   0           0
+  19  AggFinal          0   6   0  max      0  accum=r[6]
+  20  Copy              6   5   0           0  r[5]=r[6]
+  21  ResultRow         5   1   0           0  output=r[5]
+  22  Halt              0   0   0           0
+  23  Transaction       0   1  14           0  iDb=0 tx_mode=Read
+  24  Integer         100   9   0           0  r[9]=100
+  25  Goto              0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-bytecode.snap
@@ -19,30 +19,30 @@ QUERY PLAN
 `--SCAN prices
 
 BYTECODE
-addr  opcode           p1  p2  p3  p4      p5  comment
-   0  Init              0  23   0           0  Start at 23
-   1  OpenEphemeral     0   1   0           0  cursor=0 is_table=true
-   2  OpenRead          1   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
-   3  Rewind            1  10   0           0  Rewind index idx_products_price
-   4    Column          1   0   2           0  r[2]=idx_products_price.price
-   5    RealAffinity    2   0   0           0
-   6    MakeRecord      2   1   3           0  r[3]=mkrec(r[2..2]); for
-   7    NewRowid        0   4   0           0  r[4]=rowid
-   8    Insert          0   3   4           4  intkey=r[4] data=r[3]
-   9  Next              1   4   0           0
-  10  Null              0   6   0           0  r[6]=NULL
-  11  Last              0  19   0           0
-  12    Column          0   0   1           0  r[1]=ephemeral().price
-  13    Copy            1   8   0           0  r[8]=r[1]
-  14    Ge              8   9  18  Binary   0  if r[8]>=r[9] goto 18
-  15    Copy            1  10   0           0  r[10]=r[1]
-  16    AggStep         0  10   6  max      0  accum=r[6] step(r[10])
-  17    Goto            0  19   0           0
-  18  Prev              0  12   0           0
-  19  AggFinal          0   6   0  max      0  accum=r[6]
-  20  Copy              6   5   0           0  r[5]=r[6]
-  21  ResultRow         5   1   0           0  output=r[5]
-  22  Halt              0   0   0           0
-  23  Transaction       0   1  14           0  iDb=0 tx_mode=Read
-  24  Integer         100   9   0           0  r[9]=100
-  25  Goto              0   1   0           0
+addr  opcode           p1  p2  p3  p4           p5  comment
+   0  Init              0  23   0                0  Start at 23
+   1  OpenEphemeral     0   1   0                0  cursor=0 is_table=true
+   2  OpenRead          1   5   0  k(2,B)        0  index=idx_products_price, root=5, iDb=0
+   3  Rewind            1  10   0                0  Rewind index idx_products_price
+   4    Column          1   0   2                0  r[2]=idx_products_price.price
+   5    RealAffinity    2   0   0                0
+   6    MakeRecord      2   1   3                0  r[3]=mkrec(r[2..2]); for
+   7    NewRowid        0   4   0                0  r[4]=rowid
+   8    Insert          0   3   4                4  intkey=r[4] data=r[3]
+   9  Next              1   4   0                0
+  10  Null              0   6   0                0  r[6]=NULL
+  11  Last              0  19   0                0
+  12    Column          0   0   1                0  r[1]=ephemeral().price
+  13    Copy            1   8   0                0  r[8]=r[1]
+  14    Ge              8   9  18  Binary        0  if r[8]>=r[9] goto 18
+  15    Copy            1  10   0                0  r[10]=r[1]
+  16    AggStep         0  10   6  max(Binary)   0  accum=r[6] step(r[10])
+  17    Goto            0  19   0                0
+  18  Prev              0  12   0                0
+  19  AggFinal          0   6   0  max           0  accum=r[6]
+  20  Copy              6   5   0                0  r[5]=r[6]
+  21  ResultRow         5   1   0                0  output=r[5]
+  22  Halt              0   0   0                0
+  23  Transaction       0   1  14                0  iDb=0 tx_mode=Read
+  24  Integer         100   9   0                0  r[9]=100
+  25  Goto              0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-no-where-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-no-where-bytecode.snap
@@ -20,7 +20,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4      p5  comment
-   0  Init             0  22   0           0  Start at 22
+   0  Init             0  21   0           0  Start at 21
    1  OpenEphemeral    0   1   0           0  cursor=0 is_table=true
    2  OpenRead         1   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
    3  Rewind           1  10   0           0  Rewind index idx_products_price
@@ -31,16 +31,15 @@ addr  opcode          p1  p2  p3  p4      p5  comment
    8    Insert         0   3   4           4  intkey=r[4] data=r[3]
    9  Next             1   4   0           0
   10  Null             0   6   0           0  r[6]=NULL
-  11  Last             0  18   0           0
+  11  Last             0  17   0           0
   12    Column         0   0   1           0  r[1]=ephemeral().price
   13    Copy           1   7   0           0  r[7]=r[1]
-  14    CollSeq        0   0   0  Binary   0  collation=Binary
-  15    AggStep        0   7   6  max      0  accum=r[6] step(r[7])
-  16    Goto           0  18   0           0
-  17  Prev             0  12   0           0
-  18  AggFinal         0   6   0  max      0  accum=r[6]
-  19  Copy             6   5   0           0  r[5]=r[6]
-  20  ResultRow        5   1   0           0  output=r[5]
-  21  Halt             0   0   0           0
-  22  Transaction      0   1  14           0  iDb=0 tx_mode=Read
-  23  Goto             0   1   0           0
+  14    AggStep        0   7   6  max      0  accum=r[6] step(r[7])
+  15    Goto           0  17   0           0
+  16  Prev             0  12   0           0
+  17  AggFinal         0   6   0  max      0  accum=r[6]
+  18  Copy             6   5   0           0  r[5]=r[6]
+  19  ResultRow        5   1   0           0  output=r[5]
+  20  Halt             0   0   0           0
+  21  Transaction      0   1  14           0  iDb=0 tx_mode=Read
+  22  Goto             0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-no-where-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-no-where-bytecode.snap
@@ -19,27 +19,27 @@ QUERY PLAN
 `--SCAN prices
 
 BYTECODE
-addr  opcode          p1  p2  p3  p4      p5  comment
-   0  Init             0  21   0           0  Start at 21
-   1  OpenEphemeral    0   1   0           0  cursor=0 is_table=true
-   2  OpenRead         1   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
-   3  Rewind           1  10   0           0  Rewind index idx_products_price
-   4    Column         1   0   2           0  r[2]=idx_products_price.price
-   5    RealAffinity   2   0   0           0
-   6    MakeRecord     2   1   3           0  r[3]=mkrec(r[2..2]); for
-   7    NewRowid       0   4   0           0  r[4]=rowid
-   8    Insert         0   3   4           4  intkey=r[4] data=r[3]
-   9  Next             1   4   0           0
-  10  Null             0   6   0           0  r[6]=NULL
-  11  Last             0  17   0           0
-  12    Column         0   0   1           0  r[1]=ephemeral().price
-  13    Copy           1   7   0           0  r[7]=r[1]
-  14    AggStep        0   7   6  max      0  accum=r[6] step(r[7])
-  15    Goto           0  17   0           0
-  16  Prev             0  12   0           0
-  17  AggFinal         0   6   0  max      0  accum=r[6]
-  18  Copy             6   5   0           0  r[5]=r[6]
-  19  ResultRow        5   1   0           0  output=r[5]
-  20  Halt             0   0   0           0
-  21  Transaction      0   1  14           0  iDb=0 tx_mode=Read
-  22  Goto             0   1   0           0
+addr  opcode          p1  p2  p3  p4           p5  comment
+   0  Init             0  21   0                0  Start at 21
+   1  OpenEphemeral    0   1   0                0  cursor=0 is_table=true
+   2  OpenRead         1   5   0  k(2,B)        0  index=idx_products_price, root=5, iDb=0
+   3  Rewind           1  10   0                0  Rewind index idx_products_price
+   4    Column         1   0   2                0  r[2]=idx_products_price.price
+   5    RealAffinity   2   0   0                0
+   6    MakeRecord     2   1   3                0  r[3]=mkrec(r[2..2]); for
+   7    NewRowid       0   4   0                0  r[4]=rowid
+   8    Insert         0   3   4                4  intkey=r[4] data=r[3]
+   9  Next             1   4   0                0
+  10  Null             0   6   0                0  r[6]=NULL
+  11  Last             0  17   0                0
+  12    Column         0   0   1                0  r[1]=ephemeral().price
+  13    Copy           1   7   0                0  r[7]=r[1]
+  14    AggStep        0   7   6  max(Binary)   0  accum=r[6] step(r[7])
+  15    Goto           0  17   0                0
+  16  Prev             0  12   0                0
+  17  AggFinal         0   6   0  max           0  accum=r[6]
+  18  Copy             6   5   0                0  r[5]=r[6]
+  19  ResultRow        5   1   0                0  output=r[5]
+  20  Halt             0   0   0                0
+  21  Transaction      0   1  14                0  iDb=0 tx_mode=Read
+  22  Goto             0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-min-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-min-bytecode.snap
@@ -13,20 +13,20 @@ QUERY PLAN
 `--SCAN products USING COVERING INDEX idx_products_price
 
 BYTECODE
-addr  opcode          p1  p2  p3  p4      p5  comment
-   0  Init             0  14   0           0  Start at 14
-   1  Null             0   2   0           0  r[2]=NULL
-   2  OpenRead         0   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
-   3  Rewind           0  10   0           0  Rewind index idx_products_price
-   4    Column         0   0   3           0  r[3]=idx_products_price.price
-   5    RealAffinity   3   0   0           0
-   6    IsNull         3   9   0           0  if (r[3]==NULL) goto 9
-   7    AggStep        0   3   2  min      0  accum=r[2] step(r[3])
-   8    Goto           0  10   0           0
-   9  Next             0   4   0           0
-  10  AggFinal         0   2   0  min      0  accum=r[2]
-  11  Copy             2   1   0           0  r[1]=r[2]
-  12  ResultRow        1   1   0           0  output=r[1]
-  13  Halt             0   0   0           0
-  14  Transaction      0   1  14           0  iDb=0 tx_mode=Read
-  15  Goto             0   1   0           0
+addr  opcode          p1  p2  p3  p4           p5  comment
+   0  Init             0  14   0                0  Start at 14
+   1  Null             0   2   0                0  r[2]=NULL
+   2  OpenRead         0   5   0  k(2,B)        0  index=idx_products_price, root=5, iDb=0
+   3  Rewind           0  10   0                0  Rewind index idx_products_price
+   4    Column         0   0   3                0  r[3]=idx_products_price.price
+   5    RealAffinity   3   0   0                0
+   6    IsNull         3   9   0                0  if (r[3]==NULL) goto 9
+   7    AggStep        0   3   2  min(Binary)   0  accum=r[2] step(r[3])
+   8    Goto           0  10   0                0
+   9  Next             0   4   0                0
+  10  AggFinal         0   2   0  min           0  accum=r[2]
+  11  Copy             2   1   0                0  r[1]=r[2]
+  12  ResultRow        1   1   0                0  output=r[1]
+  13  Halt             0   0   0                0
+  14  Transaction      0   1  14                0  iDb=0 tx_mode=Read
+  15  Goto             0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-min-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-min-bytecode.snap
@@ -14,20 +14,19 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4      p5  comment
-   0  Init             0  15   0           0  Start at 15
+   0  Init             0  14   0           0  Start at 14
    1  Null             0   2   0           0  r[2]=NULL
    2  OpenRead         0   5   0  k(2,B)   0  index=idx_products_price, root=5, iDb=0
-   3  Rewind           0  11   0           0  Rewind index idx_products_price
+   3  Rewind           0  10   0           0  Rewind index idx_products_price
    4    Column         0   0   3           0  r[3]=idx_products_price.price
    5    RealAffinity   3   0   0           0
-   6    IsNull         3  10   0           0  if (r[3]==NULL) goto 10
-   7    CollSeq        0   0   0  Binary   0  collation=Binary
-   8    AggStep        0   3   2  min      0  accum=r[2] step(r[3])
-   9    Goto           0  11   0           0
-  10  Next             0   4   0           0
-  11  AggFinal         0   2   0  min      0  accum=r[2]
-  12  Copy             2   1   0           0  r[1]=r[2]
-  13  ResultRow        1   1   0           0  output=r[1]
-  14  Halt             0   0   0           0
-  15  Transaction      0   1  14           0  iDb=0 tx_mode=Read
-  16  Goto             0   1   0           0
+   6    IsNull         3   9   0           0  if (r[3]==NULL) goto 9
+   7    AggStep        0   3   2  min      0  accum=r[2] step(r[3])
+   8    Goto           0  10   0           0
+   9  Next             0   4   0           0
+  10  AggFinal         0   2   0  min      0  accum=r[2]
+  11  Copy             2   1   0           0  r[1]=r[2]
+  12  ResultRow        1   1   0           0  output=r[1]
+  13  Halt             0   0   0           0
+  14  Transaction      0   1  14           0  iDb=0 tx_mode=Read
+  15  Goto             0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__max-with-equality-prefix-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__max-with-equality-prefix-bytecode.snap
@@ -13,20 +13,20 @@ QUERY PLAN
 `--SEARCH measurements USING INDEX idx_measurements_category_value (category=?)
 
 BYTECODE
-addr  opcode       p1  p2  p3  p4        p5  comment
-   0  Init          0  14   0             0  Start at 14
-   1  Null          0   2   0             0  r[2]=NULL
-   2  OpenRead      0   3   0  k(3,B,B)   0  index=idx_measurements_category_value, root=3, iDb=0
-   3  String8       0   3   0  a          0  r[3]='a'
-   4  SeekLE        0  10   3             0  key=[3..3]
-   5    IdxLT       0  10   3             0  key=[3..3]
-   6    Column      0   1   4             0  r[4]=idx_measurements_category_value.value
-   7    AggStep     0   4   2  max        0  accum=r[2] step(r[4])
-   8    Goto        0  10   0             0
-   9  Prev          0   5   0             0
-  10  AggFinal      0   2   0  max        0  accum=r[2]
-  11  Copy          2   1   0             0  r[1]=r[2]
-  12  ResultRow     1   1   0             0  output=r[1]
-  13  Halt          0   0   0             0
-  14  Transaction   0   1   2             0  iDb=0 tx_mode=Read
-  15  Goto          0   1   0             0
+addr  opcode       p1  p2  p3  p4           p5  comment
+   0  Init          0  14   0                0  Start at 14
+   1  Null          0   2   0                0  r[2]=NULL
+   2  OpenRead      0   3   0  k(3,B,B)      0  index=idx_measurements_category_value, root=3, iDb=0
+   3  String8       0   3   0  a             0  r[3]='a'
+   4  SeekLE        0  10   3                0  key=[3..3]
+   5    IdxLT       0  10   3                0  key=[3..3]
+   6    Column      0   1   4                0  r[4]=idx_measurements_category_value.value
+   7    AggStep     0   4   2  max(Binary)   0  accum=r[2] step(r[4])
+   8    Goto        0  10   0                0
+   9  Prev          0   5   0                0
+  10  AggFinal      0   2   0  max           0  accum=r[2]
+  11  Copy          2   1   0                0  r[1]=r[2]
+  12  ResultRow     1   1   0                0  output=r[1]
+  13  Halt          0   0   0                0
+  14  Transaction   0   1   2                0  iDb=0 tx_mode=Read
+  15  Goto          0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__max-with-equality-prefix-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__max-with-equality-prefix-bytecode.snap
@@ -14,20 +14,19 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4        p5  comment
-   0  Init          0  15   0             0  Start at 15
+   0  Init          0  14   0             0  Start at 14
    1  Null          0   2   0             0  r[2]=NULL
    2  OpenRead      0   3   0  k(3,B,B)   0  index=idx_measurements_category_value, root=3, iDb=0
    3  String8       0   3   0  a          0  r[3]='a'
-   4  SeekLE        0  11   3             0  key=[3..3]
-   5    IdxLT       0  11   3             0  key=[3..3]
+   4  SeekLE        0  10   3             0  key=[3..3]
+   5    IdxLT       0  10   3             0  key=[3..3]
    6    Column      0   1   4             0  r[4]=idx_measurements_category_value.value
-   7    CollSeq     0   0   0  Binary     0  collation=Binary
-   8    AggStep     0   4   2  max        0  accum=r[2] step(r[4])
-   9    Goto        0  11   0             0
-  10  Prev          0   5   0             0
-  11  AggFinal      0   2   0  max        0  accum=r[2]
-  12  Copy          2   1   0             0  r[1]=r[2]
-  13  ResultRow     1   1   0             0  output=r[1]
-  14  Halt          0   0   0             0
-  15  Transaction   0   1   2             0  iDb=0 tx_mode=Read
-  16  Goto          0   1   0             0
+   7    AggStep     0   4   2  max        0  accum=r[2] step(r[4])
+   8    Goto        0  10   0             0
+   9  Prev          0   5   0             0
+  10  AggFinal      0   2   0  max        0  accum=r[2]
+  11  Copy          2   1   0             0  r[1]=r[2]
+  12  ResultRow     1   1   0             0  output=r[1]
+  13  Halt          0   0   0             0
+  14  Transaction   0   1   2             0  iDb=0 tx_mode=Read
+  15  Goto          0   1   0             0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
@@ -27,56 +27,56 @@ QUERY PLAN
    `--SEARCH p2 USING INDEX ephemeral_subquery_t7 (price<?)
 
 BYTECODE
-addr  opcode               p1  p2  p3  p4      p5  comment
-   0    Init                0  49   0           0  Start at 49
-   1    OpenEphemeral       0   1   0           0  cursor=0 is_table=true
-   2    OpenRead            1   2   0  k(2,B)   0  table=products, root=2, iDb=0
-   3    Rewind              1  10   0           0  Rewind table products
-   4      Column            1   0   3           0  r[3]=products.price
-   5      RealAffinity      3   0   0           0
-   6      MakeRecord        3   1   4           0  r[4]=mkrec(r[3..3]); for
-   7      NewRowid          0   5   0           0  r[5]=rowid
-   8      Insert            0   4   5           4  intkey=r[5] data=r[4]
-   9    Next                1   4   0           0
-  10    Rewind              0  48   0           0  Rewind  ephemeral()
-  11      Column            0   0   2           0  r[2]=ephemeral().price
-  12      Copy              2   8   0           0  r[8]=r[2]
-  13      Ge                8   9  47  Binary   0  if r[8]>=r[9] goto 47
-  14      BeginSubrtn      10   0   0           0  r[10]=NULL
-  15      Null              0   1   0           0  r[1]=NULL
-  16      OpenDup           2   0   0           0  new_cursor=2, original_cursor=0
-  17      Null              0  13   0           0  r[13]=NULL
-  18      Integer           1  14   0           0  r[14]=1; LIMIT counter
-  19      IfNot            14  41   0           0  if !r[14] goto 41
-  20      Once             28   0   0           0  goto 28
-  21      OpenAutoindex     3   0   0           0  cursor=3
-  22      Rewind            2  23   0           0  Rewind  ephemeral()
-  23        Column          2   0  15           0  r[15]=ephemeral().price
-  24        RowId           2  16   0           0  r[16]=ephemeral().rowid
-  25        MakeRecord     15   2  17           0  r[17]=mkrec(r[15..16]); for ephemeral_subquery_t7
-  26        IdxInsert       3  17  15           0  key=r[17]
-  27      Next              2  23   0           0
-  28      Copy              2  18   0           0  r[18]=r[2]
-  29      IsNull           18  41   0           0  if (r[18]==NULL) goto 41
-  30      Affinity         18   1   0           0  r[18..19] = C
-  31      SeekLT            3  41  18           0  key=[18..18]
-  32        Null            0  18   0           0  r[18]=NULL
-  33        IdxLE           3  41  18           0  key=[18..18]
-  34        DeferredSeek    3   2   0           0
-  35        Column          2   0  11           0  r[11]=ephemeral().price
-  36        Column          3   0  19           0  r[19]=ephemeral(ephemeral_subquery_t7).price
-  37        RealAffinity   19   0   0           0
-  38        AggStep         0  19  13  max      0  accum=r[13] step(r[19])
-  39        Goto            0  41   0           0
-  40      Prev              3  32   0           0
-  41      AggFinal          0  13   0  max      0  accum=r[13]
-  42      Copy             13  12   0           0  r[12]=r[13]
-  43      Copy             12   1   0           0  r[1]=r[12]
-  44    Return             10   0   1           0
-  45    Copy                1   6   0           0  r[6]=r[1]
-  46    ResultRow           6   1   0           0  output=r[6]
-  47  Next                  0  11   0           0
-  48  Halt                  0   0   0           0
-  49  Transaction           0   1   1           0  iDb=0 tx_mode=Read
-  50  Integer             100   9   0           0  r[9]=100
-  51  Goto                  0   1   0           0
+addr  opcode               p1  p2  p3  p4           p5  comment
+   0    Init                0  49   0                0  Start at 49
+   1    OpenEphemeral       0   1   0                0  cursor=0 is_table=true
+   2    OpenRead            1   2   0  k(2,B)        0  table=products, root=2, iDb=0
+   3    Rewind              1  10   0                0  Rewind table products
+   4      Column            1   0   3                0  r[3]=products.price
+   5      RealAffinity      3   0   0                0
+   6      MakeRecord        3   1   4                0  r[4]=mkrec(r[3..3]); for
+   7      NewRowid          0   5   0                0  r[5]=rowid
+   8      Insert            0   4   5                4  intkey=r[5] data=r[4]
+   9    Next                1   4   0                0
+  10    Rewind              0  48   0                0  Rewind  ephemeral()
+  11      Column            0   0   2                0  r[2]=ephemeral().price
+  12      Copy              2   8   0                0  r[8]=r[2]
+  13      Ge                8   9  47  Binary        0  if r[8]>=r[9] goto 47
+  14      BeginSubrtn      10   0   0                0  r[10]=NULL
+  15      Null              0   1   0                0  r[1]=NULL
+  16      OpenDup           2   0   0                0  new_cursor=2, original_cursor=0
+  17      Null              0  13   0                0  r[13]=NULL
+  18      Integer           1  14   0                0  r[14]=1; LIMIT counter
+  19      IfNot            14  41   0                0  if !r[14] goto 41
+  20      Once             28   0   0                0  goto 28
+  21      OpenAutoindex     3   0   0                0  cursor=3
+  22      Rewind            2  23   0                0  Rewind  ephemeral()
+  23        Column          2   0  15                0  r[15]=ephemeral().price
+  24        RowId           2  16   0                0  r[16]=ephemeral().rowid
+  25        MakeRecord     15   2  17                0  r[17]=mkrec(r[15..16]); for ephemeral_subquery_t7
+  26        IdxInsert       3  17  15                0  key=r[17]
+  27      Next              2  23   0                0
+  28      Copy              2  18   0                0  r[18]=r[2]
+  29      IsNull           18  41   0                0  if (r[18]==NULL) goto 41
+  30      Affinity         18   1   0                0  r[18..19] = C
+  31      SeekLT            3  41  18                0  key=[18..18]
+  32        Null            0  18   0                0  r[18]=NULL
+  33        IdxLE           3  41  18                0  key=[18..18]
+  34        DeferredSeek    3   2   0                0
+  35        Column          2   0  11                0  r[11]=ephemeral().price
+  36        Column          3   0  19                0  r[19]=ephemeral(ephemeral_subquery_t7).price
+  37        RealAffinity   19   0   0                0
+  38        AggStep         0  19  13  max(Binary)   0  accum=r[13] step(r[19])
+  39        Goto            0  41   0                0
+  40      Prev              3  32   0                0
+  41      AggFinal          0  13   0  max           0  accum=r[13]
+  42      Copy             13  12   0                0  r[12]=r[13]
+  43      Copy             12   1   0                0  r[1]=r[12]
+  44    Return             10   0   1                0
+  45    Copy                1   6   0                0  r[6]=r[1]
+  46    ResultRow           6   1   0                0  output=r[6]
+  47  Next                  0  11   0                0
+  48  Halt                  0   0   0                0
+  49  Transaction           0   1   1                0  iDb=0 tx_mode=Read
+  50  Integer             100   9   0                0  r[9]=100
+  51  Goto                  0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
@@ -28,7 +28,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode               p1  p2  p3  p4      p5  comment
-   0    Init                0  50   0           0  Start at 50
+   0    Init                0  49   0           0  Start at 49
    1    OpenEphemeral       0   1   0           0  cursor=0 is_table=true
    2    OpenRead            1   2   0  k(2,B)   0  table=products, root=2, iDb=0
    3    Rewind              1  10   0           0  Rewind table products
@@ -38,16 +38,16 @@ addr  opcode               p1  p2  p3  p4      p5  comment
    7      NewRowid          0   5   0           0  r[5]=rowid
    8      Insert            0   4   5           4  intkey=r[5] data=r[4]
    9    Next                1   4   0           0
-  10    Rewind              0  49   0           0  Rewind  ephemeral()
+  10    Rewind              0  48   0           0  Rewind  ephemeral()
   11      Column            0   0   2           0  r[2]=ephemeral().price
   12      Copy              2   8   0           0  r[8]=r[2]
-  13      Ge                8   9  48  Binary   0  if r[8]>=r[9] goto 48
+  13      Ge                8   9  47  Binary   0  if r[8]>=r[9] goto 47
   14      BeginSubrtn      10   0   0           0  r[10]=NULL
   15      Null              0   1   0           0  r[1]=NULL
   16      OpenDup           2   0   0           0  new_cursor=2, original_cursor=0
   17      Null              0  13   0           0  r[13]=NULL
   18      Integer           1  14   0           0  r[14]=1; LIMIT counter
-  19      IfNot            14  42   0           0  if !r[14] goto 42
+  19      IfNot            14  41   0           0  if !r[14] goto 41
   20      Once             28   0   0           0  goto 28
   21      OpenAutoindex     3   0   0           0  cursor=3
   22      Rewind            2  23   0           0  Rewind  ephemeral()
@@ -57,27 +57,26 @@ addr  opcode               p1  p2  p3  p4      p5  comment
   26        IdxInsert       3  17  15           0  key=r[17]
   27      Next              2  23   0           0
   28      Copy              2  18   0           0  r[18]=r[2]
-  29      IsNull           18  42   0           0  if (r[18]==NULL) goto 42
+  29      IsNull           18  41   0           0  if (r[18]==NULL) goto 41
   30      Affinity         18   1   0           0  r[18..19] = C
-  31      SeekLT            3  42  18           0  key=[18..18]
+  31      SeekLT            3  41  18           0  key=[18..18]
   32        Null            0  18   0           0  r[18]=NULL
-  33        IdxLE           3  42  18           0  key=[18..18]
+  33        IdxLE           3  41  18           0  key=[18..18]
   34        DeferredSeek    3   2   0           0
   35        Column          2   0  11           0  r[11]=ephemeral().price
   36        Column          3   0  19           0  r[19]=ephemeral(ephemeral_subquery_t7).price
   37        RealAffinity   19   0   0           0
-  38        CollSeq         0   0   0  Binary   0  collation=Binary
-  39        AggStep         0  19  13  max      0  accum=r[13] step(r[19])
-  40        Goto            0  42   0           0
-  41      Prev              3  32   0           0
-  42      AggFinal          0  13   0  max      0  accum=r[13]
-  43      Copy             13  12   0           0  r[12]=r[13]
-  44      Copy             12   1   0           0  r[1]=r[12]
-  45    Return             10   0   1           0
-  46    Copy                1   6   0           0  r[6]=r[1]
-  47    ResultRow           6   1   0           0  output=r[6]
-  48  Next                  0  11   0           0
-  49  Halt                  0   0   0           0
-  50  Transaction           0   1   1           0  iDb=0 tx_mode=Read
-  51  Integer             100   9   0           0  r[9]=100
-  52  Goto                  0   1   0           0
+  38        AggStep         0  19  13  max      0  accum=r[13] step(r[19])
+  39        Goto            0  41   0           0
+  40      Prev              3  32   0           0
+  41      AggFinal          0  13   0  max      0  accum=r[13]
+  42      Copy             13  12   0           0  r[12]=r[13]
+  43      Copy             12   1   0           0  r[1]=r[12]
+  44    Return             10   0   1           0
+  45    Copy                1   6   0           0  r[6]=r[1]
+  46    ResultRow           6   1   0           0  output=r[6]
+  47  Next                  0  11   0           0
+  48  Halt                  0   0   0           0
+  49  Transaction           0   1   1           0  iDb=0 tx_mode=Read
+  50  Integer             100   9   0           0  r[9]=100
+  51  Goto                  0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-materialized-cte-max-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-materialized-cte-max-bytecode.snap
@@ -20,7 +20,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4      p5  comment
-   0  Init             0  21   0           0  Start at 21
+   0  Init             0  20   0           0  Start at 20
    1  OpenEphemeral    0   1   0           0  cursor=0 is_table=true
    2  OpenRead         1   2   0  k(2,B)   0  table=products, root=2, iDb=0
    3  Rewind           1  10   0           0  Rewind table products
@@ -31,15 +31,14 @@ addr  opcode          p1  p2  p3  p4      p5  comment
    8    Insert         0   3   4           4  intkey=r[4] data=r[3]
    9  Next             1   4   0           0
   10  Null             0   6   0           0  r[6]=NULL
-  11  Rewind           0  17   0           0  Rewind  ephemeral()
+  11  Rewind           0  16   0           0  Rewind  ephemeral()
   12    Column         0   0   1           0  r[1]=ephemeral().price
   13    Copy           1   7   0           0  r[7]=r[1]
-  14    CollSeq        0   0   0  Binary   0  collation=Binary
-  15    AggStep        0   7   6  max      0  accum=r[6] step(r[7])
-  16  Next             0  12   0           0
-  17  AggFinal         0   6   0  max      0  accum=r[6]
-  18  Copy             6   5   0           0  r[5]=r[6]
-  19  ResultRow        5   1   0           0  output=r[5]
-  20  Halt             0   0   0           0
-  21  Transaction      0   1   1           0  iDb=0 tx_mode=Read
-  22  Goto             0   1   0           0
+  14    AggStep        0   7   6  max      0  accum=r[6] step(r[7])
+  15  Next             0  12   0           0
+  16  AggFinal         0   6   0  max      0  accum=r[6]
+  17  Copy             6   5   0           0  r[5]=r[6]
+  18  ResultRow        5   1   0           0  output=r[5]
+  19  Halt             0   0   0           0
+  20  Transaction      0   1   1           0  iDb=0 tx_mode=Read
+  21  Goto             0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-materialized-cte-max-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-materialized-cte-max-bytecode.snap
@@ -19,26 +19,26 @@ QUERY PLAN
 `--SCAN prices
 
 BYTECODE
-addr  opcode          p1  p2  p3  p4      p5  comment
-   0  Init             0  20   0           0  Start at 20
-   1  OpenEphemeral    0   1   0           0  cursor=0 is_table=true
-   2  OpenRead         1   2   0  k(2,B)   0  table=products, root=2, iDb=0
-   3  Rewind           1  10   0           0  Rewind table products
-   4    Column         1   0   2           0  r[2]=products.price
-   5    RealAffinity   2   0   0           0
-   6    MakeRecord     2   1   3           0  r[3]=mkrec(r[2..2]); for
-   7    NewRowid       0   4   0           0  r[4]=rowid
-   8    Insert         0   3   4           4  intkey=r[4] data=r[3]
-   9  Next             1   4   0           0
-  10  Null             0   6   0           0  r[6]=NULL
-  11  Rewind           0  16   0           0  Rewind  ephemeral()
-  12    Column         0   0   1           0  r[1]=ephemeral().price
-  13    Copy           1   7   0           0  r[7]=r[1]
-  14    AggStep        0   7   6  max      0  accum=r[6] step(r[7])
-  15  Next             0  12   0           0
-  16  AggFinal         0   6   0  max      0  accum=r[6]
-  17  Copy             6   5   0           0  r[5]=r[6]
-  18  ResultRow        5   1   0           0  output=r[5]
-  19  Halt             0   0   0           0
-  20  Transaction      0   1   1           0  iDb=0 tx_mode=Read
-  21  Goto             0   1   0           0
+addr  opcode          p1  p2  p3  p4           p5  comment
+   0  Init             0  20   0                0  Start at 20
+   1  OpenEphemeral    0   1   0                0  cursor=0 is_table=true
+   2  OpenRead         1   2   0  k(2,B)        0  table=products, root=2, iDb=0
+   3  Rewind           1  10   0                0  Rewind table products
+   4    Column         1   0   2                0  r[2]=products.price
+   5    RealAffinity   2   0   0                0
+   6    MakeRecord     2   1   3                0  r[3]=mkrec(r[2..2]); for
+   7    NewRowid       0   4   0                0  r[4]=rowid
+   8    Insert         0   3   4                4  intkey=r[4] data=r[3]
+   9  Next             1   4   0                0
+  10  Null             0   6   0                0  r[6]=NULL
+  11  Rewind           0  16   0                0  Rewind  ephemeral()
+  12    Column         0   0   1                0  r[1]=ephemeral().price
+  13    Copy           1   7   0                0  r[7]=r[1]
+  14    AggStep        0   7   6  max(Binary)   0  accum=r[6] step(r[7])
+  15  Next             0  12   0                0
+  16  AggFinal         0   6   0  max           0  accum=r[6]
+  17  Copy             6   5   0                0  r[5]=r[6]
+  18  ResultRow        5   1   0                0  output=r[5]
+  19  Halt             0   0   0                0
+  20  Transaction      0   1   1                0  iDb=0 tx_mode=Read
+  21  Goto             0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -80,7 +80,7 @@ addr  opcode                            p1   p2   p3  p4              p5  commen
   45            InitCoroutine            3    0    5                   0
   46              Yield                  3   50    0                   0
   47              Copy                   5   19    0                   0  r[19]=r[5]
-  48              AggStep                0   19   17  max              0  accum=r[17] step(r[19])
+  48              AggStep                0   19   17  max(Binary)      0  accum=r[17] step(r[19])
   49            Goto                     0   46    0                   0
   50            AggFinal                 0   17    0  max              0  accum=r[17]
   51            Copy                    17   16    0                   0  r[16]=r[17]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -32,8 +32,8 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                            p1   p2   p3  p4              p5  comment
-   0                    Init             0  118    0                   0  Start at 118
-   1                    Once            55    0    0                   0  goto 55
+   0                    Init             0  117    0                   0  Start at 117
+   1                    Once            54    0    0                   0  goto 54
    2                    BeginSubrtn      2    0    0                   0  r[2]=NULL
    3                    Null             0    1    0                   0  r[1]=NULL
    4                    InitCoroutine    3   42    5                   0
@@ -76,80 +76,79 @@ addr  opcode                            p1   p2   p3  p4              p5  commen
   41            EndCoroutine             3    0    0                   0
   42            Null                     0   17    0                   0  r[17]=NULL
   43            Integer                  1   18    0                   0  r[18]=1; LIMIT counter
-  44            IfNot                   18   51    0                   0  if !r[18] goto 51
+  44            IfNot                   18   50    0                   0  if !r[18] goto 50
   45            InitCoroutine            3    0    5                   0
-  46              Yield                  3   51    0                   0
+  46              Yield                  3   50    0                   0
   47              Copy                   5   19    0                   0  r[19]=r[5]
-  48              CollSeq                0    0    0  Binary           0  collation=Binary
-  49              AggStep                0   19   17  max              0  accum=r[17] step(r[19])
-  50            Goto                     0   46    0                   0
-  51            AggFinal                 0   17    0  max              0  accum=r[17]
-  52            Copy                    17   16    0                   0  r[16]=r[17]
-  53            Copy                    16    1    0                   0  r[1]=r[16]
-  54          Return                     2    0    1                   0
-  55          OpenEphemeral              2    1    0                   0  cursor=2 is_table=true
-  56          Null                       0   29    0                   0  r[29]=NULL
-  57          Integer                    0   26    0                   0  r[26]=0; clear group by abort flag
-  58          Null                       0   27    0                   0  r[27]=NULL; initialize group by comparison registers to NULL
-  59          Gosub                     33   91    0                   0  ; go to clear accumulator subroutine
-  60          OpenRead                   3    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  61          OpenRead                   4    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  62          Rewind                     4   78    0                   0  Rewind index idx_products_category
-  63            DeferredSeek             4    3    0                   0
-  64            Column                   4    0   31                   0  r[31]=idx_products_category.category_id
-  65            Column                   3    3   32                   0  r[32]=products.price
-  66            RealAffinity            32    0    0                   0
-  67            Compare                 27   31    1  k(1, Binary)     0  r[27..27]==r[31..31]
-  68            Jump                    69   73   69                   0  ; start new group if comparison is not equal
-  69            Gosub                   24   82    0                   0  ; check if ended group had data, and output if so
-  70            Move                    31   27    1                   0  r[27..27]=r[31..31]
-  71            IfPos                   26   94    0                   0  r[26]>0 -> r[26]-=0, goto 94; check abort flag
-  72            Gosub                   33   91    0                   0  ; goto clear accumulator subroutine
-  73            AggStep                  0   32   29  avg              0  accum=r[29] step(r[32])
-  74            If                      25   76    0                   0  if r[25] goto 76; don't emit group columns if continuing existing group
-  75            Column                   4    0   28                   0  r[28]=idx_products_category.category_id
-  76            Integer                  1   25    0                   0  r[25]=1; indicate data in accumulator
-  77          Next                       4   63    0                   0
-  78          Gosub                     24   82    0                   0  ; emit row for final group
-  79          Goto                       0   94    0                   0  ; group by finished
-  80          Integer                    1   26    0                   0  r[26]=1
-  81        Return                      24    0    0                   0
-  82        IfPos                       25   84    0                   0  r[25]>0 -> r[25]-=0, goto 84; output group by row subroutine start
-  83      Return                        24    0    0                   0
-  84      AggFinal                       0   29    0  avg              0  accum=r[29]
-  85      Copy                          28   22    0                   0  r[22]=r[28]
-  86      Copy                          29   23    0                   0  r[23]=r[29]
-  87      MakeRecord                    22    2   34                   0  r[34]=mkrec(r[22..23]); for
-  88      NewRowid                       2   35    0                   0  r[35]=rowid
-  89      Insert                         2   34   35                   4  intkey=r[35] data=r[34]
-  90    Return                          24    0    0                   0
-  91    Null                             0   28   29                   0  r[28..29]=NULL; clear accumulator subroutine start
-  92    Integer                          0   25    0                   0  r[25]=0
-  93  Return                            33    0    0                   0
-  94  OpenRead                           5    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  95  OpenRead                           6    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  96  Rewind                             2  117    0                   0  Rewind  ephemeral()
-  97    Column                           2    0   20                   0  r[20]=ephemeral().category_id
-  98    Column                           2    1   21                   0  r[21]=ephemeral().avg_price
-  99    Copy                            20   39    0                   0  r[39]=r[20]
- 100    IsNull                          39  116    0                   0  if (r[39]==NULL) goto 116
- 101    Affinity                        39    1    0                   0  r[39..40] = C
- 102    SeekGE                           6  116   39                   0  key=[39..39]
- 103      IdxGT                          6  116   39                   0  key=[39..39]
- 104      DeferredSeek                   6    5    0                   0
- 105      Column                         5    3   41                   0  r[41]=products.price
- 106      RealAffinity                  41    0    0                   0
- 107      Copy                           1   43    0                   0  r[43]=r[1]
- 108      Multiply                      43   44   42                   0  r[42]=r[43]*r[44]
- 109      Le                            41   42  115  Binary           0  if r[41]<=r[42] goto 115
- 110      Column                         5    1   36                   0  r[36]=products.name
- 111      Column                         5    3   37                   0  r[37]=products.price
- 112      RealAffinity                  37    0    0                   0
- 113      Copy                          21   38    0                   0  r[38]=r[21]
- 114      ResultRow                     36    3    0                   0  output=r[36..38]
- 115    Next                             6  103    0                   0
- 116  Next                               2   97    0                   0
- 117  Halt                               0    0    0                   0
- 118  Transaction                        0    1   11                   0  iDb=0 tx_mode=Read
- 119  Real                               0   44    0  0.8              0  r[44]=0.8
- 120  Goto                               0    1    0                   0
+  48              AggStep                0   19   17  max              0  accum=r[17] step(r[19])
+  49            Goto                     0   46    0                   0
+  50            AggFinal                 0   17    0  max              0  accum=r[17]
+  51            Copy                    17   16    0                   0  r[16]=r[17]
+  52            Copy                    16    1    0                   0  r[1]=r[16]
+  53          Return                     2    0    1                   0
+  54          OpenEphemeral              2    1    0                   0  cursor=2 is_table=true
+  55          Null                       0   29    0                   0  r[29]=NULL
+  56          Integer                    0   26    0                   0  r[26]=0; clear group by abort flag
+  57          Null                       0   27    0                   0  r[27]=NULL; initialize group by comparison registers to NULL
+  58          Gosub                     33   90    0                   0  ; go to clear accumulator subroutine
+  59          OpenRead                   3    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  60          OpenRead                   4    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  61          Rewind                     4   77    0                   0  Rewind index idx_products_category
+  62            DeferredSeek             4    3    0                   0
+  63            Column                   4    0   31                   0  r[31]=idx_products_category.category_id
+  64            Column                   3    3   32                   0  r[32]=products.price
+  65            RealAffinity            32    0    0                   0
+  66            Compare                 27   31    1  k(1, Binary)     0  r[27..27]==r[31..31]
+  67            Jump                    68   72   68                   0  ; start new group if comparison is not equal
+  68            Gosub                   24   81    0                   0  ; check if ended group had data, and output if so
+  69            Move                    31   27    1                   0  r[27..27]=r[31..31]
+  70            IfPos                   26   93    0                   0  r[26]>0 -> r[26]-=0, goto 93; check abort flag
+  71            Gosub                   33   90    0                   0  ; goto clear accumulator subroutine
+  72            AggStep                  0   32   29  avg              0  accum=r[29] step(r[32])
+  73            If                      25   75    0                   0  if r[25] goto 75; don't emit group columns if continuing existing group
+  74            Column                   4    0   28                   0  r[28]=idx_products_category.category_id
+  75            Integer                  1   25    0                   0  r[25]=1; indicate data in accumulator
+  76          Next                       4   62    0                   0
+  77          Gosub                     24   81    0                   0  ; emit row for final group
+  78          Goto                       0   93    0                   0  ; group by finished
+  79          Integer                    1   26    0                   0  r[26]=1
+  80        Return                      24    0    0                   0
+  81        IfPos                       25   83    0                   0  r[25]>0 -> r[25]-=0, goto 83; output group by row subroutine start
+  82      Return                        24    0    0                   0
+  83      AggFinal                       0   29    0  avg              0  accum=r[29]
+  84      Copy                          28   22    0                   0  r[22]=r[28]
+  85      Copy                          29   23    0                   0  r[23]=r[29]
+  86      MakeRecord                    22    2   34                   0  r[34]=mkrec(r[22..23]); for
+  87      NewRowid                       2   35    0                   0  r[35]=rowid
+  88      Insert                         2   34   35                   4  intkey=r[35] data=r[34]
+  89    Return                          24    0    0                   0
+  90    Null                             0   28   29                   0  r[28..29]=NULL; clear accumulator subroutine start
+  91    Integer                          0   25    0                   0  r[25]=0
+  92  Return                            33    0    0                   0
+  93  OpenRead                           5    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  94  OpenRead                           6    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  95  Rewind                             2  116    0                   0  Rewind  ephemeral()
+  96    Column                           2    0   20                   0  r[20]=ephemeral().category_id
+  97    Column                           2    1   21                   0  r[21]=ephemeral().avg_price
+  98    Copy                            20   39    0                   0  r[39]=r[20]
+  99    IsNull                          39  115    0                   0  if (r[39]==NULL) goto 115
+ 100    Affinity                        39    1    0                   0  r[39..40] = C
+ 101    SeekGE                           6  115   39                   0  key=[39..39]
+ 102      IdxGT                          6  115   39                   0  key=[39..39]
+ 103      DeferredSeek                   6    5    0                   0
+ 104      Column                         5    3   41                   0  r[41]=products.price
+ 105      RealAffinity                  41    0    0                   0
+ 106      Copy                           1   43    0                   0  r[43]=r[1]
+ 107      Multiply                      43   44   42                   0  r[42]=r[43]*r[44]
+ 108      Le                            41   42  114  Binary           0  if r[41]<=r[42] goto 114
+ 109      Column                         5    1   36                   0  r[36]=products.name
+ 110      Column                         5    3   37                   0  r[37]=products.price
+ 111      RealAffinity                  37    0    0                   0
+ 112      Copy                          21   38    0                   0  r[38]=r[21]
+ 113      ResultRow                     36    3    0                   0  output=r[36..38]
+ 114    Next                             6  102    0                   0
+ 115  Next                               2   96    0                   0
+ 116  Halt                               0    0    0                   0
+ 117  Transaction                        0    1   11                   0  iDb=0 tx_mode=Read
+ 118  Real                               0   44    0  0.8              0  r[44]=0.8
+ 119  Goto                               0    1    0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -24,11 +24,11 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4            p5  comment
-   0            Init             0  59   0                 0  Start at 59
+   0            Init             0  58   0                 0  Start at 58
    1            Null             0   9   0                 0  r[9]=NULL
    2            Integer          0   6   0                 0  r[6]=0; clear group by abort flag
    3            Null             0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
-   4            Gosub           13  55   0                 0  ; go to clear accumulator subroutine
+   4            Gosub           13  54   0                 0  ; go to clear accumulator subroutine
    5            OpenRead         0   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
    6            OpenRead         1   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
    7            Rewind           1  22   0                 0  Rewind index idx_grouped_values_grp
@@ -39,15 +39,15 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   12              Jump          13  17  13                 0  ; start new group if comparison is not equal
   13              Gosub          4  26   0                 0  ; check if ended group had data, and output if so
   14              Move          11   7   1                 0  r[7..7]=r[11..11]
-  15              IfPos          6  58   0                 0  r[6]>0 -> r[6]-=0, goto 58; check abort flag
-  16              Gosub         13  55   0                 0  ; goto clear accumulator subroutine
+  15              IfPos          6  57   0                 0  r[6]>0 -> r[6]-=0, goto 57; check abort flag
+  16              Gosub         13  54   0                 0  ; goto clear accumulator subroutine
   17              AggStep        0  12   9  sum            0  accum=r[9] step(r[12])
   18              If             5  20   0                 0  if r[5] goto 20; don't emit group columns if continuing existing group
   19              Column         1   0   8                 0  r[8]=idx_grouped_values_grp.grp
   20              Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
   21            Next             1   8   0                 0
   22            Gosub            4  26   0                 0  ; emit row for final group
-  23            Goto             0  58   0                 0  ; group by finished
+  23            Goto             0  57   0                 0  ; group by finished
   24            Integer          1   6   0                 0  r[6]=1
   25          Return             4   0   0                 0
   26          IfPos              5  28   0                 0  r[5]>0 -> r[5]-=0, goto 28; output group by row subroutine start
@@ -57,31 +57,30 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   30        Null                 0   1   0                 0  r[1]=NULL
   31        Null                 0  16   0                 0  r[16]=NULL
   32        Integer              1  17   0                 0  r[17]=1; LIMIT counter
-  33        IfNot               17  45   0                 0  if !r[17] goto 45
+  33        IfNot               17  44   0                 0  if !r[17] goto 44
   34        OpenRead             2   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
   35        OpenRead             3   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
   36        Copy                 8  18   0                 0  r[18]=r[8]
-  37        IsNull              18  45   0                 0  if (r[18]==NULL) goto 45
-  38        SeekGE               3  45  18                 0  key=[18..18]
-  39          IdxGT              3  45  18                 0  key=[18..18]
+  37        IsNull              18  44   0                 0  if (r[18]==NULL) goto 44
+  38        SeekGE               3  44  18                 0  key=[18..18]
+  39          IdxGT              3  44  18                 0  key=[18..18]
   40          DeferredSeek       3   2   0                 0
   41          Column             2   1  19                 0  r[19]=grouped_values.val
-  42          CollSeq            0   0   0  Binary         0  collation=Binary
-  43          AggStep            0  19  16  max            0  accum=r[16] step(r[19])
-  44        Next                 3  39   0                 0
-  45        AggFinal             0  16   0  max            0  accum=r[16]
-  46        Copy                16  15   0                 0  r[15]=r[16]
-  47        Copy                15   1   0                 0  r[1]=r[15]
-  48      Return                14   0   1                 0
-  49      Copy                   1  20   0                 0  r[20]=r[1]
-  50      IsNull                20  27   0                 0  if (r[20]==NULL) goto 27
-  51      Copy                   8   2   0                 0  r[2]=r[8]
-  52      Copy                   9   3   0                 0  r[3]=r[9]
-  53      ResultRow              2   2   0                 0  output=r[2..3]
-  54    Return                   4   0   0                 0
-  55    Null                     0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
-  56    Integer                  0   5   0                 0  r[5]=0
-  57  Return                    13   0   0                 0
-  58  Halt                       0   0   0                 0
-  59  Transaction                0   1   2                 0  iDb=0 tx_mode=Read
-  60  Goto                       0   1   0                 0
+  42          AggStep            0  19  16  max            0  accum=r[16] step(r[19])
+  43        Next                 3  39   0                 0
+  44        AggFinal             0  16   0  max            0  accum=r[16]
+  45        Copy                16  15   0                 0  r[15]=r[16]
+  46        Copy                15   1   0                 0  r[1]=r[15]
+  47      Return                14   0   1                 0
+  48      Copy                   1  20   0                 0  r[20]=r[1]
+  49      IsNull                20  27   0                 0  if (r[20]==NULL) goto 27
+  50      Copy                   8   2   0                 0  r[2]=r[8]
+  51      Copy                   9   3   0                 0  r[3]=r[9]
+  52      ResultRow              2   2   0                 0  output=r[2..3]
+  53    Return                   4   0   0                 0
+  54    Null                     0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
+  55    Integer                  0   5   0                 0  r[5]=0
+  56  Return                    13   0   0                 0
+  57  Halt                       0   0   0                 0
+  58  Transaction                0   1   2                 0  iDb=0 tx_mode=Read
+  59  Goto                       0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -66,7 +66,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   39          IdxGT              3  44  18                 0  key=[18..18]
   40          DeferredSeek       3   2   0                 0
   41          Column             2   1  19                 0  r[19]=grouped_values.val
-  42          AggStep            0  19  16  max            0  accum=r[16] step(r[19])
+  42          AggStep            0  19  16  max(Binary)    0  accum=r[16] step(r[19])
   43        Next                 3  39   0                 0
   44        AggFinal             0  16   0  max            0  accum=r[16]
   45        Copy                16  15   0                 0  r[15]=r[16]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -25,12 +25,12 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4              p5  comment
-   0            Init             0  68   0                   0  Start at 68
+   0            Init             0  67   0                   0  Start at 67
    1            SorterOpen       0   2   0  k(2,-B,Binary)   0  cursor=0
    2            Null             0  10   0                   0  r[10]=NULL
    3            Integer          0   7   0                   0  r[7]=0; clear group by abort flag
    4            Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
-   5            Gosub           14  57   0                   0  ; go to clear accumulator subroutine
+   5            Gosub           14  56   0                   0  ; go to clear accumulator subroutine
    6            OpenRead         1   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
    7            OpenRead         2   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
    8            Rewind           2  23   0                   0  Rewind index idx_grouped_values_grp
@@ -41,15 +41,15 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   13              Jump          14  18  14                   0  ; start new group if comparison is not equal
   14              Gosub          5  27   0                   0  ; check if ended group had data, and output if so
   15              Move          12   8   1                   0  r[8..8]=r[12..12]
-  16              IfPos          7  60   0                   0  r[7]>0 -> r[7]-=0, goto 60; check abort flag
-  17              Gosub         14  57   0                   0  ; goto clear accumulator subroutine
+  16              IfPos          7  59   0                   0  r[7]>0 -> r[7]-=0, goto 59; check abort flag
+  17              Gosub         14  56   0                   0  ; goto clear accumulator subroutine
   18              AggStep        0  13  10  sum              0  accum=r[10] step(r[13])
   19              If             6  21   0                   0  if r[6] goto 21; don't emit group columns if continuing existing group
   20              Column         2   0   9                   0  r[9]=idx_grouped_values_grp.grp
   21              Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
   22            Next             2   9   0                   0
   23            Gosub            5  27   0                   0  ; emit row for final group
-  24            Goto             0  60   0                   0  ; group by finished
+  24            Goto             0  59   0                   0  ; group by finished
   25            Integer          1   7   0                   0  r[7]=1
   26          Return             5   0   0                   0
   27          IfPos              6  29   0                   0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
@@ -59,39 +59,38 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   31        Null                 0   1   0                   0  r[1]=NULL
   32        Null                 0  17   0                   0  r[17]=NULL
   33        Integer              1  18   0                   0  r[18]=1; LIMIT counter
-  34        IfNot               18  46   0                   0  if !r[18] goto 46
+  34        IfNot               18  45   0                   0  if !r[18] goto 45
   35        OpenRead             3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
   36        OpenRead             4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
   37        Copy                 9  19   0                   0  r[19]=r[9]
-  38        IsNull              19  46   0                   0  if (r[19]==NULL) goto 46
-  39        SeekGE               4  46  19                   0  key=[19..19]
-  40          IdxGT              4  46  19                   0  key=[19..19]
+  38        IsNull              19  45   0                   0  if (r[19]==NULL) goto 45
+  39        SeekGE               4  45  19                   0  key=[19..19]
+  40          IdxGT              4  45  19                   0  key=[19..19]
   41          DeferredSeek       4   3   0                   0
   42          Column             3   1  20                   0  r[20]=grouped_values.val
-  43          CollSeq            0   0   0  Binary           0  collation=Binary
-  44          AggStep            0  20  17  max              0  accum=r[17] step(r[20])
-  45        Next                 4  40   0                   0
-  46        AggFinal             0  17   0  max              0  accum=r[17]
-  47        Copy                17  16   0                   0  r[16]=r[17]
-  48        Copy                16   1   0                   0  r[1]=r[16]
-  49      Return                15   0   1                   0
-  50      Copy                   1  21   0                   0  r[21]=r[1]
-  51      Sequence               0  22   0                   0
-  52      Copy                   9  23   0                   0  r[23]=r[9]
-  53      Copy                  10  24   0                   0  r[24]=r[10]
-  54      MakeRecord            21   4   4                   0  r[4]=mkrec(r[21..24])
-  55      SorterInsert           0   4   0  0                0  key=r[4]
-  56    Return                   5   0   0                   0
-  57    Null                     0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
-  58    Integer                  0   6   0                   0  r[6]=0
-  59  Return                    14   0   0                   0
-  60  OpenPseudo                 5   4   4                   0  4 columns in r[4]
-  61  SorterSort                 0  67   0                   0
-  62    SorterData               0   4   5                   0  r[4]=data
-  63    Column                   5   2   2                   0  r[2]=pseudo.column 2
-  64    Column                   5   3   3                   0  r[3]=pseudo.column 3
-  65    ResultRow                2   2   0                   0  output=r[2..3]
-  66  SorterNext                 0  62   0                   0
-  67  Halt                       0   0   0                   0
-  68  Transaction                0   1   2                   0  iDb=0 tx_mode=Read
-  69  Goto                       0   1   0                   0
+  43          AggStep            0  20  17  max              0  accum=r[17] step(r[20])
+  44        Next                 4  40   0                   0
+  45        AggFinal             0  17   0  max              0  accum=r[17]
+  46        Copy                17  16   0                   0  r[16]=r[17]
+  47        Copy                16   1   0                   0  r[1]=r[16]
+  48      Return                15   0   1                   0
+  49      Copy                   1  21   0                   0  r[21]=r[1]
+  50      Sequence               0  22   0                   0
+  51      Copy                   9  23   0                   0  r[23]=r[9]
+  52      Copy                  10  24   0                   0  r[24]=r[10]
+  53      MakeRecord            21   4   4                   0  r[4]=mkrec(r[21..24])
+  54      SorterInsert           0   4   0  0                0  key=r[4]
+  55    Return                   5   0   0                   0
+  56    Null                     0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
+  57    Integer                  0   6   0                   0  r[6]=0
+  58  Return                    14   0   0                   0
+  59  OpenPseudo                 5   4   4                   0  4 columns in r[4]
+  60  SorterSort                 0  66   0                   0
+  61    SorterData               0   4   5                   0  r[4]=data
+  62    Column                   5   2   2                   0  r[2]=pseudo.column 2
+  63    Column                   5   3   3                   0  r[3]=pseudo.column 3
+  64    ResultRow                2   2   0                   0  output=r[2..3]
+  65  SorterNext                 0  61   0                   0
+  66  Halt                       0   0   0                   0
+  67  Transaction                0   1   2                   0  iDb=0 tx_mode=Read
+  68  Goto                       0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -68,7 +68,7 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   40          IdxGT              4  45  19                   0  key=[19..19]
   41          DeferredSeek       4   3   0                   0
   42          Column             3   1  20                   0  r[20]=grouped_values.val
-  43          AggStep            0  20  17  max              0  accum=r[17] step(r[20])
+  43          AggStep            0  20  17  max(Binary)      0  accum=r[17] step(r[20])
   44        Next                 4  40   0                   0
   45        AggFinal             0  17   0  max              0  accum=r[17]
   46        Copy                17  16   0                   0  r[16]=r[17]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
@@ -33,7 +33,7 @@ addr  opcode             p1  p2  p3  p4              p5  comment
    8    Rewind            0  13   0                   0  Rewind table products
    9      Column          0   3   6                   0  r[6]=products.price
   10      RealAffinity    6   0   0                   0
-  11      AggStep         0   6   4  max              0  accum=r[4] step(r[6])
+  11      AggStep         0   6   4  max(Binary)      0  accum=r[4] step(r[6])
   12    Next              0   9   0                   0
   13    AggFinal          0   4   0  max              0  accum=r[4]
   14    Copy              4   3   0                   0  r[3]=r[4]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
@@ -22,36 +22,35 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode             p1  p2  p3  p4              p5  comment
-   0    Init              0  30   0                   0  Start at 30
-   1    Once             18   0   0                   0  goto 18
+   0    Init              0  29   0                   0  Start at 29
+   1    Once             17   0   0                   0  goto 17
    2    BeginSubrtn       2   0   0                   0  r[2]=NULL
    3    Null              0   1   0                   0  r[1]=NULL
    4    Null              0   4   0                   0  r[4]=NULL
    5    Integer           1   5   0                   0  r[5]=1; LIMIT counter
-   6    IfNot             5  14   0                   0  if !r[5] goto 14
+   6    IfNot             5  13   0                   0  if !r[5] goto 13
    7    OpenRead          0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   8    Rewind            0  14   0                   0  Rewind table products
+   8    Rewind            0  13   0                   0  Rewind table products
    9      Column          0   3   6                   0  r[6]=products.price
   10      RealAffinity    6   0   0                   0
-  11      CollSeq         0   0   0  Binary           0  collation=Binary
-  12      AggStep         0   6   4  max              0  accum=r[4] step(r[6])
-  13    Next              0   9   0                   0
-  14    AggFinal          0   4   0  max              0  accum=r[4]
-  15    Copy              4   3   0                   0  r[3]=r[4]
-  16    Copy              3   1   0                   0  r[1]=r[3]
-  17  Return              2   0   1                   0
-  18  OpenRead            1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  19  Rewind              1  29   0                   0  Rewind table products
-  20    Column            1   3  11                   0  r[11]=products.price
-  21    RealAffinity     11   0   0                   0
-  22    Le               11  12  28  Binary           0  if r[11]<=r[12] goto 28
-  23    Column            1   1   7                   0  r[7]=products.name
-  24    Column            1   3   8                   0  r[8]=products.price
-  25    RealAffinity      8   0   0                   0
-  26    Copy              1   9   0                   0  r[9]=r[1]
-  27    ResultRow         7   3   0                   0  output=r[7..9]
-  28  Next                1  20   0                   0
-  29  Halt                0   0   0                   0
-  30  Transaction         0   1  11                   0  iDb=0 tx_mode=Read
-  31  Integer           100  12   0                   0  r[12]=100
-  32  Goto                0   1   0                   0
+  11      AggStep         0   6   4  max              0  accum=r[4] step(r[6])
+  12    Next              0   9   0                   0
+  13    AggFinal          0   4   0  max              0  accum=r[4]
+  14    Copy              4   3   0                   0  r[3]=r[4]
+  15    Copy              3   1   0                   0  r[1]=r[3]
+  16  Return              2   0   1                   0
+  17  OpenRead            1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  18  Rewind              1  28   0                   0  Rewind table products
+  19    Column            1   3  11                   0  r[11]=products.price
+  20    RealAffinity     11   0   0                   0
+  21    Le               11  12  27  Binary           0  if r[11]<=r[12] goto 27
+  22    Column            1   1   7                   0  r[7]=products.name
+  23    Column            1   3   8                   0  r[8]=products.price
+  24    RealAffinity      8   0   0                   0
+  25    Copy              1   9   0                   0  r[9]=r[1]
+  26    ResultRow         7   3   0                   0  output=r[7..9]
+  27  Next                1  19   0                   0
+  28  Halt                0   0   0                   0
+  29  Transaction         0   1  11                   0  iDb=0 tx_mode=Read
+  30  Integer           100  12   0                   0  r[12]=100
+  31  Goto                0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
@@ -26,108 +26,106 @@ QUERY PLAN
       `--SCAN employees USING INDEX idx_employees_department
 
 BYTECODE
-addr  opcode              p1   p2  p3  p4                     p5  comment
-   0      Init             0  100   0                          0  Start at 100
-   1      InitCoroutine    1   63   2                          0
-   2      InitCoroutine    2   14   3                          0
-   3      OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   4      OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
-   5      Rewind           1   13   0                          0  Rewind index idx_employees_department
-   6        DeferredSeek   1    0   0                          0
-   7        Column         1    0   3                          0  r[3]=idx_employees_department.department
-   8        IdxRowId       1    4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
-   9        Column         0    1   5                          0  r[5]=employees.name
-  10        Column         0    3   6                          0  r[6]=employees.salary
-  11        Yield          2    0   0                          0
-  12      Next             1    6   0                          0
-  13      EndCoroutine     2    0   0                          0
-  14      OpenEphemeral    2    1   0                          0  cursor=2 is_table=true
-  15      OpenDup          3    2   0                          0  new_cursor=3, original_cursor=2
-  16      Null             0   27   0                          0  r[27]=NULL
-  17      Null             0   28   0                          0  r[28]=NULL
-  18      InitCoroutine    2    0   3                          0
-  19        Yield          2   40   0                          0
-  20        Compare        3   28   1  k(1, Binary)            0  r[3..3]==r[28..28]; compare partition keys to detect new partition
-  21        Jump          22   25  22                          0
-  22        Gosub         29   41   0                          0  ; detected new partition
-  23        Null           0   27   0                          0  r[27]=NULL
-  24        Copy           3   28   0                          0  r[28]=r[3]
-  25        NotNull       27   27   0                          0  r[27]!=NULL -> goto 27
-  26        Null           0   15  18                          0  r[15..18]=NULL; reset accumulator registers
-  27        MakeRecord     3    4  30                          0  r[30]=mkrec(r[3..6])
-  28        NewRowid       3   27   0                          0  r[27]=rowid
-  29        Insert         3   30  27  buffer_table_window_1   0  intkey=r[27] data=r[30]
-  30        AggStep        0   31  15  count                   0  accum=r[15] step(r[31])
-  31        Copy           6   32   0                          0  r[32]=r[6]
-  32        CollSeq        0    0   0  Binary                  0  collation=Binary
-  33        AggStep        0   32  16  min                     0  accum=r[16] step(r[32])
-  34        Copy           6   33   0                          0  r[33]=r[6]
-  35        CollSeq        0    0   0  Binary                  0  collation=Binary
-  36        AggStep        0   33  17  max                     0  accum=r[17] step(r[33])
-  37        Copy           6   34   0                          0  r[34]=r[6]
-  38        AggStep        0   34  18  avg                     0  accum=r[18] step(r[34])
-  39      Goto             0   19   0                          0
-  40      Null             0   29   0                          0  r[29]=NULL; return remaining buffered rows
-  41      Rewind           2   60   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  42      AggValue         0   15  19  count                   0  accum=r[15] dest=r[19]
-  43      AggValue         0   16  20  min                     0  accum=r[16] dest=r[20]
-  44      AggValue         0   17  21  max                     0  accum=r[17] dest=r[21]
-  45      AggValue         0   18  22  avg                     0  accum=r[18] dest=r[22]
-  46        Column         2    1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
-  47        Column         2    2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
-  48        Column         2    0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
-  49        Column         2    3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
-  50        Copy          23    7   0                          0  r[7]=r[23]
-  51        Copy          24    8   0                          0  r[8]=r[24]
-  52        Copy          25    9   0                          0  r[9]=r[25]
-  53        Copy          26   10   0                          0  r[10]=r[26]
-  54        Copy          19   11   0                          0  r[11]=r[19]
-  55        Copy          20   12   0                          0  r[12]=r[20]
-  56        Copy          21   13   0                          0  r[13]=r[21]
-  57        Copy          22   14   0                          0  r[14]=r[22]
-  58        Yield          1    0   0                          0
-  59      Next             2   46   0                          0
-  60      ResetSorter      2    0   0                          0  cursor=2
-  61    Return            29    0   1                          0
-  62    EndCoroutine       1    0   0                          0
-  63    OpenEphemeral      4    1   0                          0  cursor=4 is_table=true
-  64    OpenDup            5    4   0                          0  new_cursor=5, original_cursor=4
-  65    Null               0   54   0                          0  r[54]=NULL
-  66    InitCoroutine      1    0   2                          0
-  67      Yield            1   75   0                          0
-  68      NotNull         54   70   0                          0  r[54]!=NULL -> goto 70
-  69      Null             0   44  44                          0  r[44..44]=NULL; reset accumulator registers
-  70      MakeRecord       7    8  56                          0  r[56]=mkrec(r[7..14])
-  71      NewRowid         5   54   0                          0  r[54]=rowid
-  72      Insert           5   56  54  buffer_table_window_0   0  intkey=r[54] data=r[56]
-  73      AggStep          0   57  44  count                   0  accum=r[44] step(r[57])
-  74    Goto               0   67   0                          0
-  75    Null               0   55   0                          0  r[55]=NULL; return remaining buffered rows
-  76    Rewind             4   97   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  77    AggValue           0   44  45  count                   0  accum=r[44] dest=r[45]
-  78      Column           4    0  46                          0  r[46]=ephemeral(buffer_table_window_0).emp_id
-  79      Column           4    1  47                          0  r[47]=ephemeral(buffer_table_window_0).name
-  80      Column           4    2  48                          0  r[48]=ephemeral(buffer_table_window_0).department
-  81      Column           4    3  49                          0  r[49]=ephemeral(buffer_table_window_0).salary
-  82      Column           4    4  50                          0  r[50]=ephemeral(buffer_table_window_0).column 4
-  83      Column           4    5  51                          0  r[51]=ephemeral(buffer_table_window_0).column 5
-  84      Column           4    6  52                          0  r[52]=ephemeral(buffer_table_window_0).column 6
-  85      Column           4    7  53                          0  r[53]=ephemeral(buffer_table_window_0).column 7
-  86      Copy            46   35   0                          0  r[35]=r[46]
-  87      Copy            47   36   0                          0  r[36]=r[47]
-  88      Copy            48   37   0                          0  r[37]=r[48]
-  89      Copy            49   38   0                          0  r[38]=r[49]
-  90      Copy            45   39   0                          0  r[39]=r[45]
-  91      Copy            50   40   0                          0  r[40]=r[50]
-  92      Copy            51   41   0                          0  r[41]=r[51]
-  93      Copy            52   42   0                          0  r[42]=r[52]
-  94      Copy            53   43   0                          0  r[43]=r[53]
-  95      ResultRow       35    9   0                          0  output=r[35..43]
-  96    Next               4   78   0                          0
-  97    ResetSorter        4    0   0                          0  cursor=4
-  98  Return              55    0   1                          0
-  99  Halt                 0    0   0                          0
- 100  Transaction          0    1   7                          0  iDb=0 tx_mode=Read
- 101  Integer              1   31   0                          0  r[31]=1
- 102  Integer              1   57   0                          0  r[57]=1
- 103  Goto                 0    1   0                          0
+addr  opcode              p1  p2  p3  p4                     p5  comment
+   0      Init             0  98   0                          0  Start at 98
+   1      InitCoroutine    1  61   2                          0
+   2      InitCoroutine    2  14   3                          0
+   3      OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   4      OpenRead         1   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   5      Rewind           1  13   0                          0  Rewind index idx_employees_department
+   6        DeferredSeek   1   0   0                          0
+   7        Column         1   0   3                          0  r[3]=idx_employees_department.department
+   8        IdxRowId       1   4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
+   9        Column         0   1   5                          0  r[5]=employees.name
+  10        Column         0   3   6                          0  r[6]=employees.salary
+  11        Yield          2   0   0                          0
+  12      Next             1   6   0                          0
+  13      EndCoroutine     2   0   0                          0
+  14      OpenEphemeral    2   1   0                          0  cursor=2 is_table=true
+  15      OpenDup          3   2   0                          0  new_cursor=3, original_cursor=2
+  16      Null             0  27   0                          0  r[27]=NULL
+  17      Null             0  28   0                          0  r[28]=NULL
+  18      InitCoroutine    2   0   3                          0
+  19        Yield          2  38   0                          0
+  20        Compare        3  28   1  k(1, Binary)            0  r[3..3]==r[28..28]; compare partition keys to detect new partition
+  21        Jump          22  25  22                          0
+  22        Gosub         29  39   0                          0  ; detected new partition
+  23        Null           0  27   0                          0  r[27]=NULL
+  24        Copy           3  28   0                          0  r[28]=r[3]
+  25        NotNull       27  27   0                          0  r[27]!=NULL -> goto 27
+  26        Null           0  15  18                          0  r[15..18]=NULL; reset accumulator registers
+  27        MakeRecord     3   4  30                          0  r[30]=mkrec(r[3..6])
+  28        NewRowid       3  27   0                          0  r[27]=rowid
+  29        Insert         3  30  27  buffer_table_window_1   0  intkey=r[27] data=r[30]
+  30        AggStep        0  31  15  count                   0  accum=r[15] step(r[31])
+  31        Copy           6  32   0                          0  r[32]=r[6]
+  32        AggStep        0  32  16  min                     0  accum=r[16] step(r[32])
+  33        Copy           6  33   0                          0  r[33]=r[6]
+  34        AggStep        0  33  17  max                     0  accum=r[17] step(r[33])
+  35        Copy           6  34   0                          0  r[34]=r[6]
+  36        AggStep        0  34  18  avg                     0  accum=r[18] step(r[34])
+  37      Goto             0  19   0                          0
+  38      Null             0  29   0                          0  r[29]=NULL; return remaining buffered rows
+  39      Rewind           2  58   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  40      AggValue         0  15  19  count                   0  accum=r[15] dest=r[19]
+  41      AggValue         0  16  20  min                     0  accum=r[16] dest=r[20]
+  42      AggValue         0  17  21  max                     0  accum=r[17] dest=r[21]
+  43      AggValue         0  18  22  avg                     0  accum=r[18] dest=r[22]
+  44        Column         2   1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
+  45        Column         2   2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
+  46        Column         2   0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
+  47        Column         2   3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
+  48        Copy          23   7   0                          0  r[7]=r[23]
+  49        Copy          24   8   0                          0  r[8]=r[24]
+  50        Copy          25   9   0                          0  r[9]=r[25]
+  51        Copy          26  10   0                          0  r[10]=r[26]
+  52        Copy          19  11   0                          0  r[11]=r[19]
+  53        Copy          20  12   0                          0  r[12]=r[20]
+  54        Copy          21  13   0                          0  r[13]=r[21]
+  55        Copy          22  14   0                          0  r[14]=r[22]
+  56        Yield          1   0   0                          0
+  57      Next             2  44   0                          0
+  58      ResetSorter      2   0   0                          0  cursor=2
+  59    Return            29   0   1                          0
+  60    EndCoroutine       1   0   0                          0
+  61    OpenEphemeral      4   1   0                          0  cursor=4 is_table=true
+  62    OpenDup            5   4   0                          0  new_cursor=5, original_cursor=4
+  63    Null               0  54   0                          0  r[54]=NULL
+  64    InitCoroutine      1   0   2                          0
+  65      Yield            1  73   0                          0
+  66      NotNull         54  68   0                          0  r[54]!=NULL -> goto 68
+  67      Null             0  44  44                          0  r[44..44]=NULL; reset accumulator registers
+  68      MakeRecord       7   8  56                          0  r[56]=mkrec(r[7..14])
+  69      NewRowid         5  54   0                          0  r[54]=rowid
+  70      Insert           5  56  54  buffer_table_window_0   0  intkey=r[54] data=r[56]
+  71      AggStep          0  57  44  count                   0  accum=r[44] step(r[57])
+  72    Goto               0  65   0                          0
+  73    Null               0  55   0                          0  r[55]=NULL; return remaining buffered rows
+  74    Rewind             4  95   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  75    AggValue           0  44  45  count                   0  accum=r[44] dest=r[45]
+  76      Column           4   0  46                          0  r[46]=ephemeral(buffer_table_window_0).emp_id
+  77      Column           4   1  47                          0  r[47]=ephemeral(buffer_table_window_0).name
+  78      Column           4   2  48                          0  r[48]=ephemeral(buffer_table_window_0).department
+  79      Column           4   3  49                          0  r[49]=ephemeral(buffer_table_window_0).salary
+  80      Column           4   4  50                          0  r[50]=ephemeral(buffer_table_window_0).column 4
+  81      Column           4   5  51                          0  r[51]=ephemeral(buffer_table_window_0).column 5
+  82      Column           4   6  52                          0  r[52]=ephemeral(buffer_table_window_0).column 6
+  83      Column           4   7  53                          0  r[53]=ephemeral(buffer_table_window_0).column 7
+  84      Copy            46  35   0                          0  r[35]=r[46]
+  85      Copy            47  36   0                          0  r[36]=r[47]
+  86      Copy            48  37   0                          0  r[37]=r[48]
+  87      Copy            49  38   0                          0  r[38]=r[49]
+  88      Copy            45  39   0                          0  r[39]=r[45]
+  89      Copy            50  40   0                          0  r[40]=r[50]
+  90      Copy            51  41   0                          0  r[41]=r[51]
+  91      Copy            52  42   0                          0  r[42]=r[52]
+  92      Copy            53  43   0                          0  r[43]=r[53]
+  93      ResultRow       35   9   0                          0  output=r[35..43]
+  94    Next               4  76   0                          0
+  95    ResetSorter        4   0   0                          0  cursor=4
+  96  Return              55   0   1                          0
+  97  Halt                 0   0   0                          0
+  98  Transaction          0   1   7                          0  iDb=0 tx_mode=Read
+  99  Integer              1  31   0                          0  r[31]=1
+ 100  Integer              1  57   0                          0  r[57]=1
+ 101  Goto                 0   1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
@@ -59,9 +59,9 @@ addr  opcode              p1  p2  p3  p4                     p5  comment
   29        Insert         3  30  27  buffer_table_window_1   0  intkey=r[27] data=r[30]
   30        AggStep        0  31  15  count                   0  accum=r[15] step(r[31])
   31        Copy           6  32   0                          0  r[32]=r[6]
-  32        AggStep        0  32  16  min                     0  accum=r[16] step(r[32])
+  32        AggStep        0  32  16  min(Binary)             0  accum=r[16] step(r[32])
   33        Copy           6  33   0                          0  r[33]=r[6]
-  34        AggStep        0  33  17  max                     0  accum=r[17] step(r[33])
+  34        AggStep        0  33  17  max(Binary)             0  accum=r[17] step(r[33])
   35        Copy           6  34   0                          0  r[34]=r[6]
   36        AggStep        0  34  18  avg                     0  accum=r[18] step(r[34])
   37      Goto             0  19   0                          0


### PR DESCRIPTION
Comparison-based aggregates (MIN/MAX/mode/percentile) received their collation from a `CollSeq` instruction executed before each `AggStep`: it wrote mutable interpreter state that the following `AggStep` read. The collation is a static property of the argument expression, so it now lives on the `AggStep` instruction itself. The `CollSeq` opcode and the interpreter's `current_collation` state are deleted outright: nothing emits or reads them anymore.

## Why this is safe

The collation was already fixed at translation time. `CollSeq` carried a compile-time constant and was always emitted immediately before the `AggStep` that consumed it, and its state write had exactly one reader in the engine (`AggStep`). Scalar min/max/nullif, window accumulators, and extension aggregates all use separate mechanisms. SQLite keeps its per-row `OP_CollSeq` only because its C function ABI has no collation parameter, so the value must be smuggled through an adjacent instruction; our aggregates are native interpreter code that takes the collation directly.

## Benchmarks

`bench_execute_group_by` (`core/benches/benchmark.rs`), which executes `SELECT state, COUNT(*), MAX(last_name), SUM(age) FROM users GROUP BY state`, improves by **3.4%** [-6.8%, -1.0%] (p = 0.01, criterion, 100 samples vs the parent commit): one fewer instruction per aggregated row.

## Tests

`cargo test`, sqltests (collate suites cover NOCASE/RTRIM aggregate arguments); bytecode snapshots regenerated. `cargo fmt` and `cargo clippy --workspace --all-features --all-targets -- --deny=warnings` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
