### PR TITLE
core/translate: report row value misused on arity mismatch

### DIFF
--- a/core/translate/expr/binary.rs
+++ b/core/translate/expr/binary.rs
@@ -14,9 +14,7 @@ pub(super) fn binary_expr_shared(
     let lhs_arity = expr_vector_size(e1)?;
     let rhs_arity = expr_vector_size(e2)?;
     if lhs_arity != rhs_arity {
-        crate::bail_parse_error!(
-            "all arguments to binary operator {op} must return the same number of values. Got: ({lhs_arity}) {op} ({rhs_arity})"
-        );
+        crate::bail_parse_error!("row value misused");
     }
 
     if lhs_arity == 1 {

--- a/core/translate/expr/vectors.rs
+++ b/core/translate/expr/vectors.rs
@@ -10,9 +10,7 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
             let evs_start = expr_vector_size(start)?;
             let evs_end = expr_vector_size(end)?;
             if evs_left != evs_start || evs_left != evs_end {
-                crate::bail_parse_error!(
-                    "all arguments to BETWEEN must return the same number of values. Got: ({evs_left}) BETWEEN ({evs_start}) AND ({evs_end})"
-                );
+                crate::bail_parse_error!("row value misused");
             }
             1
         }
@@ -20,9 +18,7 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
             let evs_left = expr_vector_size(expr)?;
             let evs_right = expr_vector_size(expr1)?;
             if evs_left != evs_right {
-                crate::bail_parse_error!(
-                    "all arguments to binary operator {operator} must return the same number of values. Got: ({evs_left}) {operator} ({evs_right})"
-                );
+                crate::bail_parse_error!("row value misused");
             }
             if evs_left > 1 && !supports_row_value_binary_comparison(operator) {
                 crate::bail_parse_error!("row value misused");
@@ -38,31 +34,23 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
             if let Some(base) = base {
                 let evs_base = expr_vector_size(base)?;
                 if evs_base != 1 {
-                    crate::bail_parse_error!(
-                        "base expression in CASE must return 1 value. Got: ({evs_base})"
-                    );
+                    crate::bail_parse_error!("row value misused");
                 }
             }
             for (when, then) in when_then_pairs {
                 let evs_when = expr_vector_size(when)?;
                 if evs_when != 1 {
-                    crate::bail_parse_error!(
-                        "when expression in CASE must return 1 value. Got: ({evs_when})"
-                    );
+                    crate::bail_parse_error!("row value misused");
                 }
                 let evs_then = expr_vector_size(then)?;
                 if evs_then != 1 {
-                    crate::bail_parse_error!(
-                        "then expression in CASE must return 1 value. Got: ({evs_then})"
-                    );
+                    crate::bail_parse_error!("row value misused");
                 }
             }
             if let Some(else_expr) = else_expr {
                 let evs_else_expr = expr_vector_size(else_expr)?;
                 if evs_else_expr != 1 {
-                    crate::bail_parse_error!(
-                        "else expression in CASE must return 1 value. Got: ({evs_else_expr})"
-                    );
+                    crate::bail_parse_error!("row value misused");
                 }
             }
             1
@@ -70,29 +58,24 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
         Expr::Cast { expr, .. } => {
             let evs_expr = expr_vector_size(expr)?;
             if evs_expr != 1 {
-                crate::bail_parse_error!("argument to CAST must return 1 value. Got: ({evs_expr})");
+                crate::bail_parse_error!("row value misused");
             }
             1
         }
         Expr::Collate(expr, _) => {
             let evs_expr = expr_vector_size(expr)?;
             if evs_expr != 1 {
-                crate::bail_parse_error!(
-                    "argument to COLLATE must return 1 value. Got: ({evs_expr})"
-                );
+                crate::bail_parse_error!("row value misused");
             }
             1
         }
         Expr::DoublyQualified(..) => 1,
         Expr::Exists(_) => 1, // EXISTS returns a single boolean value (0 or 1)
-        Expr::FunctionCall { name, args, .. } => {
-            for (pos, arg) in args.iter().enumerate() {
+        Expr::FunctionCall { args, .. } => {
+            for arg in args.iter() {
                 let evs_arg = expr_vector_size(arg)?;
                 if evs_arg != 1 {
-                    crate::bail_parse_error!(
-                        "argument {} to function call {name} must return 1 value. Got: ({evs_arg})",
-                        pos + 1
-                    );
+                    crate::bail_parse_error!("row value misused");
                 }
             }
             1
@@ -106,8 +89,14 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
             for rhs in rhs.iter() {
                 let evs_rhs = expr_vector_size(rhs)?;
                 if evs_lhs != evs_rhs {
+                    // SQLite reports "row value misused" for a scalar LHS, but a
+                    // dedicated arity error when the LHS is a row value.
+                    if evs_lhs == 1 {
+                        crate::bail_parse_error!("row value misused");
+                    }
                     crate::bail_parse_error!(
-                        "all arguments to IN list must return the same number of values, got: ({evs_lhs}) IN ({evs_rhs})"
+                        "IN(...) element has {evs_rhs} term{} - expected {evs_lhs}",
+                        if evs_rhs == 1 { "" } else { "s" }
                     );
                 }
             }
@@ -122,9 +111,7 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
         Expr::IsNull(expr) => {
             let evs_expr = expr_vector_size(expr)?;
             if evs_expr != 1 {
-                crate::bail_parse_error!(
-                    "argument to IS NULL must return 1 value. Got: ({evs_expr})"
-                );
+                crate::bail_parse_error!("row value misused");
             }
             1
         }
@@ -132,15 +119,11 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
             let evs_lhs = expr_vector_size(lhs)?;
             // MATCH allows multi-column LHS: (col1, col2) MATCH 'query'
             if evs_lhs != 1 && *op != ast::LikeOperator::Match {
-                crate::bail_parse_error!(
-                    "left operand of LIKE must return 1 value. Got: ({evs_lhs})"
-                );
+                crate::bail_parse_error!("row value misused");
             }
             let evs_rhs = expr_vector_size(rhs)?;
             if evs_rhs != 1 {
-                crate::bail_parse_error!(
-                    "right operand of LIKE must return 1 value. Got: ({evs_rhs})"
-                );
+                crate::bail_parse_error!("row value misused");
             }
             1
         }
@@ -149,9 +132,7 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
         Expr::NotNull(expr) => {
             let evs_expr = expr_vector_size(expr)?;
             if evs_expr != 1 {
-                crate::bail_parse_error!(
-                    "argument to NOT NULL must return 1 value. Got: ({evs_expr})"
-                );
+                crate::bail_parse_error!("row value misused");
             }
             1
         }
@@ -162,12 +143,10 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
         Expr::Subquery(_) => {
             crate::bail_parse_error!("Scalar subquery is not supported in this context")
         }
-        Expr::Unary(unary_operator, expr) => {
+        Expr::Unary(_, expr) => {
             let evs_expr = expr_vector_size(expr)?;
             if evs_expr != 1 {
-                crate::bail_parse_error!(
-                    "argument to unary operator {unary_operator} must return 1 value. Got: ({evs_expr})"
-                );
+                crate::bail_parse_error!("row value misused");
             }
             1
         }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -863,33 +863,27 @@ fn validate_expr_correct_column_counts(plan: &SelectPlan) -> Result<()> {
     for result_column in plan.result_columns.iter() {
         let vec_size = expr_vector_size(&result_column.expr)?;
         if vec_size != 1 {
-            crate::bail_parse_error!("result column must return 1 value, got {}", vec_size);
+            crate::bail_parse_error!("row value misused");
         }
     }
     for (expr, _, _) in plan.order_by.iter() {
         let vec_size = expr_vector_size(expr)?;
         if vec_size != 1 {
-            crate::bail_parse_error!("order by expression must return 1 value, got {}", vec_size);
+            crate::bail_parse_error!("row value misused");
         }
     }
     if let Some(group_by) = &plan.group_by {
         for expr in group_by.exprs.iter() {
             let vec_size = expr_vector_size(expr)?;
             if vec_size != 1 {
-                crate::bail_parse_error!(
-                    "group by expression must return 1 value, got {}",
-                    vec_size
-                );
+                crate::bail_parse_error!("row value misused");
             }
         }
         if let Some(having) = &group_by.having {
             for expr in having.iter() {
                 let vec_size = expr_vector_size(expr)?;
                 if vec_size != 1 {
-                    crate::bail_parse_error!(
-                        "having expression must return 1 value, got {}",
-                        vec_size
-                    );
+                    crate::bail_parse_error!("row value misused");
                 }
             }
         }
@@ -898,40 +892,34 @@ fn validate_expr_correct_column_counts(plan: &SelectPlan) -> Result<()> {
         for arg in aggregate.args.iter() {
             let vec_size = expr_vector_size(arg)?;
             if vec_size != 1 {
-                crate::bail_parse_error!(
-                    "aggregate argument must return 1 value, got {}",
-                    vec_size
-                );
+                crate::bail_parse_error!("row value misused");
             }
         }
     }
     for term in plan.where_clause.iter() {
         let vec_size = expr_vector_size(&term.expr)?;
         if vec_size != 1 {
-            crate::bail_parse_error!(
-                "where clause expression must return 1 value, got {}",
-                vec_size
-            );
+            crate::bail_parse_error!("row value misused");
         }
     }
     for expr in plan.values.iter() {
         for value in expr.iter() {
             let vec_size = expr_vector_size(value)?;
             if vec_size != 1 {
-                crate::bail_parse_error!("value must return 1 value, got {}", vec_size);
+                crate::bail_parse_error!("row value misused");
             }
         }
     }
     if let Some(limit) = &plan.limit {
         let vec_size = expr_vector_size(limit)?;
         if vec_size != 1 {
-            crate::bail_parse_error!("limit expression must return 1 value, got {}", vec_size);
+            crate::bail_parse_error!("row value misused");
         }
     }
     if let Some(offset) = &plan.offset {
         let vec_size = expr_vector_size(offset)?;
         if vec_size != 1 {
-            crate::bail_parse_error!("offset expression must return 1 value, got {}", vec_size);
+            crate::bail_parse_error!("row value misused");
         }
     }
     Ok(())

--- a/sqlite/conformance/sqlite-sqltests/row-value-arity-mismatch-error.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/row-value-arity-mismatch-error.sqltest
@@ -1,0 +1,151 @@
+@database :memory:
+
+# Regression tests for https://github.com/tursodatabase/turso/issues/7934
+#
+# When a row-value expression appears where a scalar is required, or the
+# operands of a binary operator, BETWEEN, or IN have mismatched arities,
+# SQLite reports "row value misused" (or, for IN with a row-value LHS,
+# "IN(...) element has N term(s) - expected M"). Turso used to leak the
+# internal arity counts into the error message instead, e.g.:
+#   all arguments to binary operator > must return the same number of values.
+#   Got: (1) > (2)
+
+test binary-op-row-value-arity-mismatch-error-message {
+    SELECT count(*) > ('abc', 'def');
+}
+expect error {
+    row value misused
+}
+
+test binary-op-row-value-arity-mismatch-eq-error-message {
+    SELECT 1 = (1, 2);
+}
+expect error {
+    row value misused
+}
+
+test binary-op-row-value-arity-mismatch-lhs-error-message {
+    SELECT ('a', 'b') < 3;
+}
+expect error {
+    row value misused
+}
+
+test between-row-value-arity-mismatch-error-message {
+    SELECT (1, 2) BETWEEN 1 AND 2;
+}
+expect error {
+    row value misused
+}
+
+test case-row-value-error-message {
+    SELECT CASE (1, 2) WHEN 1 THEN 1 END;
+}
+expect error {
+    row value misused
+}
+
+test cast-row-value-error-message {
+    SELECT CAST((1, 2) AS INT);
+}
+expect error {
+    row value misused
+}
+
+test collate-row-value-error-message {
+    SELECT (1, 2) COLLATE nocase;
+}
+expect error {
+    row value misused
+}
+
+test function-arg-row-value-error-message {
+    SELECT abs((1, 2));
+}
+expect error {
+    row value misused
+}
+
+test in-list-scalar-lhs-row-value-error-message {
+    SELECT 1 IN ((1, 2));
+}
+expect error {
+    row value misused
+}
+
+test in-list-vector-lhs-arity-mismatch-error-message {
+    SELECT (1, 2) IN (1, 2);
+}
+expect error {
+    IN\(\.\.\.\) element has 1 term - expected 2
+}
+
+test in-list-vector-lhs-arity-mismatch-plural-error-message {
+    SELECT (1, 2) IN ((1, 2, 3));
+}
+expect error {
+    IN\(\.\.\.\) element has 3 terms - expected 2
+}
+
+test is-null-row-value-error-message {
+    SELECT (1, 2) IS NULL;
+}
+expect error {
+    row value misused
+}
+
+test like-row-value-error-message {
+    SELECT (1, 2) LIKE 'a';
+}
+expect error {
+    row value misused
+}
+
+test unary-op-row-value-error-message {
+    SELECT -(1, 2);
+}
+expect error {
+    row value misused
+}
+
+test result-column-row-value-error-message {
+    SELECT (1, 2);
+}
+expect error {
+    row value misused
+}
+
+test where-clause-row-value-error-message {
+    SELECT 1 WHERE (1, 2);
+}
+expect error {
+    row value misused
+}
+
+test group-by-row-value-error-message {
+    SELECT 1 GROUP BY (1, 2);
+}
+expect error {
+    row value misused
+}
+
+test limit-row-value-error-message {
+    SELECT 1 LIMIT (1, 2);
+}
+expect error {
+    row value misused
+}
+
+test values-row-value-error-message {
+    VALUES((1, 2));
+}
+expect error {
+    row value misused
+}
+
+test aggregate-arg-row-value-error-message {
+    SELECT max((1, 2));
+}
+expect error {
+    row value misused
+}


### PR DESCRIPTION
When a row-value expression appeared where a scalar was required, or the
operands of a binary operator, BETWEEN, or IN list had mismatched
arities, we leaked internal arity counts into the error message, e.g.
"all arguments to binary operator > must return the same number of
values. Got: (1) > (2)". This is confusing for users and diverges from
SQLite, which reports the generic "row value misused" error for these
cases.

Replace the arity-detail messages in expr_vector_size, binary operator
translation, and select plan column-count validation with "row value
misused". For IN lists with a row-value LHS, match SQLite's dedicated
message "IN(...) element has N term(s) - expected M" instead, so every
row-value misuse path (binary ops, BETWEEN, CASE, CAST, COLLATE,
function args, IN lists, IS NULL, LIKE, unary ops, and select-plan
positions like WHERE/GROUP BY/LIMIT/VALUES) matches sqlite3 output.

Tests: sqlite/conformance/sqlite-sqltests/row-value-arity-mismatch-error.sqltest

Fixes #7934