### PR TITLE
core: add nth_value() window function

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -129,7 +129,7 @@ ongoing work to pass the full SQLite TCL test suite.
 | UPDATE                    | ✅ Yes     |                                                                                   |
 | VACUUM                    | 🚧 Partial | VACUUM INTO supported; plain in-place VACUUM is experimental                       |
 | WITH clause               | 🚧 Partial | WITH RECURSIVE not yet supported.  |
-| WINDOW functions             | 🚧 Partial | Only `row_number()` and aggregate `… OVER (…)` work. Missing: `rank`, `dense_rank`, `percent_rank`, `cume_dist`, `ntile`, `lag`, `lead`, `first_value`, `last_value`, `nth_value`. Custom frame specs (`ROWS`/`RANGE`/`GROUPS BETWEEN`, `EXCLUDE`) not yet supported. `agg(…) FILTER (…) OVER (…)` **panics**. |
+| WINDOW functions             | 🚧 Partial | Aggregate functions, `row_number`, `rank`, `dense_rank`, `first_value`, `last_value`, and `nth_value` work with the default frame. Missing: `percent_rank`, `cume_dist`, `ntile`, `lag`, and `lead`. Custom frame specs (`ROWS`/`RANGE`/`GROUPS BETWEEN`, `EXCLUDE`) are not yet supported. |
 | GENERATED                 | 🚧 Partial      | virtual columns only (no ALTER, partial affinity support). Requires `--experimental-generated-columns`. |
 | WITHOUT ROWID             | 🚧 Partial | Requires `--experimental-without-rowid`. Effectively **insert-only**: CREATE / INSERT / SELECT work (incl. composite PK), but UPDATE, DELETE, UPSERT, `INSERT OR REPLACE`, secondary UNIQUE constraints, secondary `CREATE INDEX`, `FOREIGN KEY`, CDC, and materialized views are all rejected. AUTOINCREMENT and missing PK rejection are parity with SQLite. |
 | CREATE TRIGGER ... INSTEAD OF | ❌ No  | Triggers on views are not supported. Currently errors with misleading "no such table" message. |

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -276,6 +276,12 @@ pub fn resolve_builtin_function(name: &str, arg_count: usize) -> crate::Result<O
             }
             Ok(Some(Func::Window(WindowFunc::LastValue)))
         }
+        "nth_value" => {
+            if arg_count != 2 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::NthValue)))
+        }
         "timediff" => {
             if arg_count != 2 {
                 crate::bail_parse_error!("wrong number of arguments to function {}()", name)

--- a/core/function.rs
+++ b/core/function.rs
@@ -520,7 +520,12 @@ impl WindowFunc {
     pub fn is_implemented(&self) -> bool {
         matches!(
             self,
-            Self::RowNumber | Self::Rank | Self::DenseRank | Self::FirstValue | Self::LastValue
+            Self::RowNumber
+                | Self::Rank
+                | Self::DenseRank
+                | Self::FirstValue
+                | Self::LastValue
+                | Self::NthValue
         )
     }
 
@@ -573,70 +578,25 @@ impl WindowFunc {
         }
     }
 
-    /// Whether the function produces a single value shared by every row in a
-    /// peer group (true) or a distinct value per row (false).
-    ///
-    /// This controls where `emit_aggregation_step` and
-    /// `emit_peer_group_flush` emit the function's `AggStep` and
-    /// `AggValue` opcodes:
-    ///
-    /// * true (rank-family): `AggStep` is emitted inside the input-scan loop
-    ///   in `emit_aggregation_step`, so it runs once for every row read from
-    ///   the subquery and advances the function's internal counter. `AggValue`
-    ///   is emitted once per peer-group flush in `emit_peer_group_flush`,
-    ///   before the loop over buffered rows, reading the accumulator into a
-    ///   result register. The loop then writes that one register's contents
-    ///   into the output for every buffered row in the group.
-    /// * false (row_number, ntile, lag, lead, nth_value): nothing is
-    ///   emitted in `emit_aggregation_step`. Both `AggStep` and `AggValue`
-    ///   are emitted inside the per-row loop in `emit_peer_group_flush`,
-    ///   so they run once per buffered row and produce a distinct value for
-    ///   each output row.
-    ///
-    /// Concrete example. Given `scores(name, score)`:
-    ///
-    ///   alice  100
-    ///   bob    100
-    ///   carol   90
-    ///
-    /// `rank() OVER (ORDER BY score DESC)` returns true — alice and bob are
-    /// peers on score=100 and share the same rank:
-    ///
-    ///   alice  100  1
-    ///   bob    100  1
-    ///   carol   90  3
-    ///
-    /// `row_number() OVER (ORDER BY score DESC)` returns false — every row
-    /// gets a distinct number even within the score=100 peer group:
-    ///
-    ///   alice  100  1
-    ///   bob    100  2
-    ///   carol   90  3
-    ///
-    /// Functions returning true: `rank`, `dense_rank`, `percent_rank`,
-    /// `cume_dist` — their value is determined entirely by where the peer
-    /// group sits in the partition's ordering — plus `first_value` and
-    /// `last_value`, whose default frame (`RANGE UNBOUNDED PRECEDING TO
-    /// CURRENT ROW`) ends at the current peer group, so every row in the
-    /// group sees the same frame contents.
-    /// Functions returning false: `row_number`, `ntile`, `lag`, `lead`,
-    /// `nth_value` — all depend on a row's position within the
-    /// partition/frame, not just its peer group.
-    pub fn one_value_per_peer_group(&self) -> bool {
-        match self {
-            Self::Rank
-            | Self::DenseRank
-            | Self::PercentRank
-            | Self::CumeDist
-            | Self::FirstValue
-            | Self::LastValue => true,
+    /// Returns true when the function waits for a row to be returned before
+    /// calculating that row's answer. Other functions build their answer as
+    /// input rows are read.
+    pub fn calculates_answer_when_row_is_returned(&self) -> bool {
+        matches!(
+            self,
             Self::RowNumber
-            | Self::Ntile
-            | Self::Lag
-            | Self::Lead
-            | Self::NthValue
-            | Self::External(_) => false,
-        }
+                | Self::Ntile
+                | Self::Lag
+                | Self::Lead
+                | Self::NthValue
+                | Self::External(_)
+        )
+    }
+
+    /// Returns true when rows must remain saved after they have been returned
+    /// because a later result may need to read them again.
+    pub(crate) fn needs_rows_after_returning_them(&self) -> bool {
+        matches!(self, Self::NthValue)
     }
 }
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -521,6 +521,7 @@ mod tests {
     use crate::alloc::TryClone;
     use crate::io::MemoryIO;
     use crate::schema::{BTreeTable, Table, SQLITE_SEQUENCE_TABLE_NAME};
+    use crate::vdbe::insn::Insn;
     use crate::Database;
     use crate::SqliteDialect;
 
@@ -556,6 +557,41 @@ mod tests {
         assert!(
             err.contains("no such function: regexp"),
             "expected 'no such function: regexp', got: {err}"
+        );
+    }
+
+    #[test]
+    fn nth_value_reads_from_saved_rows_without_an_accumulator() {
+        let io = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE items(value)").unwrap();
+
+        let statement = conn
+            .prepare("SELECT nth_value(value, 2) OVER (ORDER BY value) FROM items")
+            .unwrap();
+        let instructions = &statement.get_program().insns;
+
+        let missing_row_target = instructions
+            .iter()
+            .find_map(|(instruction, _)| match instruction {
+                Insn::SeekRowid { target_pc, .. } => Some(target_pc.as_offset_int() as usize),
+                _ => None,
+            })
+            .expect("nth_value must read its answer from the saved window rows");
+        assert!(
+            matches!(
+                &instructions[missing_row_target].0,
+                Insn::Halt { on_error: None, .. }
+            ),
+            "a missing saved row must stop execution instead of returning NULL"
+        );
+        assert!(
+            instructions.iter().all(|(instruction, _)| !matches!(
+                instruction,
+                Insn::AggStep { .. } | Insn::AggValue { .. }
+            )),
+            "nth_value must not keep another copy of saved values in an accumulator"
         );
     }
 

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -11,8 +11,8 @@ use crate::translate::expr::{
 };
 use crate::translate::order_by::EmitOrderBy;
 use crate::translate::plan::{
-    Aggregate, Distinctness, JoinOrderMember, JoinedTable, QueryDestination, ResultSetColumn,
-    RewrittenWindowCall, SelectPlan, TableReferences, Window, WindowFunction,
+    Aggregate, Distinctness, FrameBoundary, JoinOrderMember, JoinedTable, QueryDestination,
+    ResultSetColumn, RewrittenWindowCall, SelectPlan, TableReferences, Window, WindowFunction,
 };
 use crate::translate::planner::resolve_window_and_aggregate_functions;
 use crate::translate::result_row::emit_select_result;
@@ -21,7 +21,7 @@ use crate::types::KeyInfo;
 use crate::util::exprs_are_equivalent;
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
 use crate::vdbe::insn::{
-    to_u16, {InsertFlags, Insn},
+    to_u16, {CmpInsFlags, InsertFlags, Insn},
 };
 use crate::vdbe::{BranchOffset, CursorID};
 use crate::Connection;
@@ -29,7 +29,7 @@ use crate::Result;
 use crate::{turso_assert, turso_assert_eq};
 use std::mem;
 use turso_parser::ast::Name;
-use turso_parser::ast::{Expr, Literal, Over, SortOrder, TableInternalId};
+use turso_parser::ast::{Expr, Literal, Over, ResolveType, SortOrder, TableInternalId};
 
 const SUBQUERY_DATABASE_ID: usize = 0;
 
@@ -504,12 +504,64 @@ pub struct WindowMetadata<'a> {
     pub labels: WindowLabels,
     pub registers: WindowRegisters,
     pub cursors: WindowCursors,
+    buffer_mode: WindowBufferMode,
+    pub nth_value: Option<NthValueMetadata>,
     /// Number of input columns in the source subquery.
     pub src_column_count: usize,
     /// Maps expressions in the current query that reference subquery columns
     /// to their corresponding column indexes in the subquery’s result.
     pub expressions_referencing_subquery: Vec<(&'a Expr, usize)>,
     pub buffer_table_name: String,
+}
+
+/// Controls whether a window may discard a saved row after returning it.
+/// Keeping a whole partition is more expensive, so it is only used when a
+/// later result may need to read an earlier row again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WindowBufferMode {
+    DeleteReturnedRows,
+    KeepPartitionRows { rowid_one_register: usize },
+}
+
+impl WindowBufferMode {
+    fn for_window(window: &Window, program: &mut ProgramBuilder) -> Self {
+        let keeps_partition_rows = window.functions.iter().any(|function| {
+            matches!(
+                &function.func,
+                AccumulatorFunc::Window(window_function)
+                    if window_function.needs_rows_after_returning_them()
+            )
+        });
+        if keeps_partition_rows {
+            let rowid_one_register = program.alloc_register();
+            program.emit_insn(Insn::Integer {
+                value: 1,
+                dest: rowid_one_register,
+            });
+            Self::KeepPartitionRows { rowid_one_register }
+        } else {
+            Self::DeleteReturnedRows
+        }
+    }
+
+    fn keeps_partition_rows(self) -> bool {
+        matches!(self, Self::KeepPartitionRows { .. })
+    }
+}
+
+/// State used to find an `nth_value` result in the saved rows. Saved rows get
+/// rowids 1, 2, 3, and so on in window order within each partition. Custom
+/// frames are not supported, so every frame starts at rowid 1 and the position
+/// argument is also the rowid to read.
+#[derive(Debug)]
+pub struct NthValueMetadata {
+    /// Finds a saved row by its ordered position without moving the cursor
+    /// that returns rows.
+    pub row_by_position_cursor: CursorID,
+    /// Holds the rowid of the last row in the current window frame. The first
+    /// row of the next sort group is saved before the current group is
+    /// returned, so the lookup must not read beyond this rowid.
+    pub frame_end_rowid_register: usize,
 }
 
 #[derive(Debug)]
@@ -551,9 +603,8 @@ pub struct WindowRegisters {
     pub prev_order_by_columns_start: Option<usize>,
 }
 
-/// Cursors on the ephemeral "buffer" B-tree that holds rows of the current
-/// partition. Naming mirrors SQLite's allocation in `sqlite3WindowCodeStep`
-/// (`window.c`).
+/// Cursors that can move independently over the saved rows. Separate cursors
+/// are needed because inserting a row must not move the row being returned.
 #[derive(Debug)]
 pub struct WindowCursors {
     /// Used to `Insert` newly-buffered source rows. Position is implicit
@@ -598,7 +649,9 @@ impl EmitWindow {
         let order_by_len = window.order_by.len();
         let window_function_count = window.functions.len();
 
-        // An ephemeral table used to buffer rows for the current frame
+        // Save rows because a window result may depend on rows that arrived
+        // earlier. `nth_value` keeps every row already seen in the current
+        // partition so it can find one by its ordered position.
         let buffer_table = Arc::new(BTreeTable::new(
             0,
             // TODO: Generating the name this way may cause collisions with real tables in the
@@ -629,6 +682,32 @@ impl EmitWindow {
             original_cursor_id: cursor_csr_current,
             new_cursor_id: cursor_csr_write,
         });
+        let buffer_mode = WindowBufferMode::for_window(window, program);
+        let has_nth_value = window.functions.iter().any(|func| {
+            matches!(
+                &func.func,
+                AccumulatorFunc::Window(crate::function::WindowFunc::NthValue)
+            )
+        });
+        let nth_value = if has_nth_value {
+            turso_assert!(
+                matches!(&window.frame.start, FrameBoundary::UnboundedPreceding),
+                "nth_value row lookup requires a frame that starts at the first partition row"
+            );
+            let row_by_position_cursor =
+                program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));
+            program.emit_insn(Insn::OpenDup {
+                original_cursor_id: cursor_csr_current,
+                new_cursor_id: row_by_position_cursor,
+            });
+            let frame_end_rowid_register = program.alloc_registers_and_init_w_null(1);
+            Some(NthValueMetadata {
+                row_by_position_cursor,
+                frame_end_rowid_register,
+            })
+        } else {
+            None
+        };
 
         // Window function processing is similar to aggregation processing in how results are mapped
         // to registers. Each function expression is stored in `expr_to_reg_cache` along with its
@@ -691,6 +770,8 @@ impl EmitWindow {
                 csr_write: cursor_csr_write,
                 csr_current: cursor_csr_current,
             },
+            buffer_mode,
+            nth_value,
             src_column_count,
             expressions_referencing_subquery,
             buffer_table_name: buffer_table.name.clone(),
@@ -701,8 +782,9 @@ impl EmitWindow {
     /// Emits bytecode to process a single row of the window’s input (always a subquery).
     ///
     /// Note:
-    /// The **buffer table** mentioned below is an ephemeral B-tree that temporarily
-    /// stores rows for the current window frame.
+    /// The **buffer table** mentioned below saves rows because a window result may
+    /// depend on rows that arrived earlier. Most rows are removed after they are
+    /// returned. `nth_value` keeps them because later results may refer back to them.
     ///
     /// High-level overview:
     /// - Each row from the subquery is read, and its ORDER BY columns are loaded into
@@ -723,6 +805,8 @@ impl EmitWindow {
             labels,
             registers,
             cursors,
+            buffer_mode,
+            nth_value,
             src_column_count: input_column_count,
             buffer_table_name,
             ..
@@ -730,17 +814,52 @@ impl EmitWindow {
         let window = plan.window.as_ref().expect("missing window");
 
         emit_load_order_by_columns(program, window, registers);
-        emit_flush_buffer_if_new_partition(program, labels, registers, window, plan)?;
-        emit_reset_state_if_new_partition(program, registers, window);
-        emit_flush_buffer_if_not_peer(program, labels, registers, window, plan)?;
-        emit_insert_row_into_buffer(
+        emit_flush_buffer_if_new_partition(
             program,
+            labels,
             registers,
             cursors,
-            input_column_count,
-            buffer_table_name,
-        );
+            *buffer_mode,
+            window,
+            plan,
+        )?;
+        emit_reset_state_if_new_partition(program, registers, nth_value.as_ref(), window);
+        if let WindowBufferMode::KeepPartitionRows { rowid_one_register } = *buffer_mode {
+            // Keep the return cursor on the first row of the next sort group,
+            // as SQLite does. That row must be inserted before the completed
+            // group is returned so the cursor does not run past the table.
+            emit_insert_row_into_buffer(
+                program,
+                registers,
+                cursors,
+                input_column_count,
+                buffer_table_name,
+            );
+            emit_rewind_return_cursor_for_first_partition_row(
+                program,
+                cursors.csr_current,
+                registers.rowid,
+                rowid_one_register,
+            );
+            emit_flush_buffer_if_not_peer(program, labels, registers, window, plan)?;
+        } else {
+            emit_flush_buffer_if_not_peer(program, labels, registers, window, plan)?;
+            emit_insert_row_into_buffer(
+                program,
+                registers,
+                cursors,
+                input_column_count,
+                buffer_table_name,
+            );
+        }
         emit_aggregation_step(program, window, &t_ctx.resolver, plan, registers)?;
+        if let Some(nth_value) = nth_value {
+            program.emit_insn(Insn::Copy {
+                src_reg: registers.rowid,
+                dst_reg: nth_value.frame_end_rowid_register,
+                extra_amount: 0,
+            });
+        }
 
         Ok(())
     }
@@ -803,6 +922,8 @@ fn emit_flush_buffer_if_new_partition(
     program: &mut ProgramBuilder,
     labels: &WindowLabels,
     registers: &WindowRegisters,
+    cursors: &WindowCursors,
+    buffer_mode: WindowBufferMode,
     window: &Window,
     plan: &SelectPlan,
 ) -> Result<()> {
@@ -862,6 +983,11 @@ fn emit_flush_buffer_if_new_partition(
             target_pc: labels.flush_buffer,
             return_reg: registers.flush_buffer_return_offset,
         });
+        if buffer_mode.keeps_partition_rows() {
+            program.emit_insn(Insn::ResetSorter {
+                cursor_id: cursors.csr_current,
+            });
+        }
         // Reset rowid to signal the start of processing a new partition.
         program.emit_insn(Insn::Null {
             dest: registers.rowid,
@@ -882,6 +1008,7 @@ fn emit_flush_buffer_if_new_partition(
 fn emit_reset_state_if_new_partition(
     program: &mut ProgramBuilder,
     registers: &WindowRegisters,
+    nth_value: Option<&NthValueMetadata>,
     window: &Window,
 ) {
     let label_skip_reset_state = program.allocate_label();
@@ -913,6 +1040,12 @@ fn emit_reset_state_if_new_partition(
         dest: registers.acc_start,
         dest_end: Some(registers.acc_start + window.functions.len() - 1),
     });
+    if let Some(nth_value) = nth_value {
+        program.emit_insn(Insn::Null {
+            dest: nth_value.frame_end_rowid_register,
+            dest_end: None,
+        });
+    }
 
     program.preassign_label_to_next_insn(label_skip_reset_state);
 }
@@ -933,27 +1066,11 @@ fn emit_flush_buffer_if_not_peer(
             .expect("prev_order_by_columns_start must exist");
 
         program.add_comment(program.offset(), "compare ORDER BY columns to detect peer");
-        let mut compare_key_info = (0..window.order_by.len())
-            .map(|_| KeyInfo {
-                sort_order: SortOrder::Asc,
-                collation: CollationSeq::default(),
-                nulls_order: None,
-            })
-            .collect::<Vec<_>>();
-        for (i, c) in compare_key_info
-            .iter_mut()
-            .enumerate()
-            .take(window.order_by.len())
-        {
-            let maybe_collation =
-                get_collseq_from_expr(&window.order_by[i].0, &plan.table_references)?;
-            c.collation = maybe_collation.unwrap_or_default();
-        }
         program.emit_insn(Insn::Compare {
             start_reg_a: reg_prev_order_by_columns_start,
             start_reg_b: reg_new_order_by_columns_start,
             count: order_by_len,
-            key_info: compare_key_info,
+            key_info: window_order_by_key_info(window, plan)?,
         });
         program.emit_insn(Insn::Jump {
             target_pc_lt: label_not_peer,
@@ -977,6 +1094,20 @@ fn emit_flush_buffer_if_not_peer(
     }
 
     Ok(())
+}
+
+fn window_order_by_key_info(window: &Window, plan: &SelectPlan) -> Result<Vec<KeyInfo>> {
+    window
+        .order_by
+        .iter()
+        .map(|(expr, _, _)| {
+            Ok(KeyInfo {
+                sort_order: SortOrder::Asc,
+                collation: get_collseq_from_expr(expr, &plan.table_references)?.unwrap_or_default(),
+                nulls_order: None,
+            })
+        })
+        .collect()
 }
 
 fn emit_load_order_by_columns(
@@ -1033,6 +1164,27 @@ fn emit_insert_row_into_buffer(
     });
 }
 
+fn emit_rewind_return_cursor_for_first_partition_row(
+    program: &mut ProgramBuilder,
+    return_cursor: CursorID,
+    inserted_rowid_register: usize,
+    rowid_one_register: usize,
+) {
+    let cursor_ready = program.allocate_label();
+    program.emit_insn(Insn::Ne {
+        lhs: inserted_rowid_register,
+        rhs: rowid_one_register,
+        target_pc: cursor_ready,
+        flags: CmpInsFlags::default(),
+        collation: None,
+    });
+    program.emit_insn(Insn::Rewind {
+        cursor_id: return_cursor,
+        pc_if_empty: cursor_ready,
+    });
+    program.preassign_label_to_next_insn(cursor_ready);
+}
+
 fn emit_aggregation_step(
     program: &mut ProgramBuilder,
     window: &Window,
@@ -1040,22 +1192,19 @@ fn emit_aggregation_step(
     plan: &SelectPlan,
     registers: &WindowRegisters,
 ) -> crate::Result<()> {
-    // Only iterate over functions whose accumulator is advanced once per
-    // input row read from the subquery. Aggregate window functions always
-    // qualify; window functions qualify when they produce one value per
-    // peer group (rank-family). row_number and the positional functions
-    // are handled entirely inside the per-row loop in
-    // `emit_peer_group_flush`.
-    let accumulates_per_input_row = |func: &WindowFunction| match &func.func {
-        AccumulatorFunc::Agg(_) => true,
-        AccumulatorFunc::Window(w) => w.one_value_per_peer_group(),
-    };
-
     for (i, func) in window
         .functions
         .iter()
         .enumerate()
-        .filter(|(_, f)| accumulates_per_input_row(f))
+        .filter(|(_, func)| match &func.func {
+            // Aggregates and these window functions build their answers while
+            // input rows arrive. Functions that wait for a result row are
+            // handled later, when that row is returned.
+            AccumulatorFunc::Agg(_) => true,
+            AccumulatorFunc::Window(window_func) => {
+                !window_func.calculates_answer_when_row_is_returned()
+            }
+        })
     {
         let reg_acc_start = registers.acc_start + i;
         match &func.func {
@@ -1116,26 +1265,22 @@ fn emit_aggregation_step(
                 }
             }
             AccumulatorFunc::Window(win_func) => {
-                // Emit `AggStep` here, inside the input-scan loop, so the
-                // function's internal state advances once for every row read
-                // from the subquery. `AggValue` is NOT emitted here — the
-                // accumulator is read later, once per peer-group flush, in
-                // `emit_peer_group_flush`. Rank-family functions take no
-                // arguments; first_value/last_value take one, evaluated into
-                // a register so the runtime step can capture it.
-                let arg_reg = match func.current_expr() {
-                    Expr::FunctionCall { args, .. } if !args.is_empty() => {
-                        let reg = program.alloc_register();
-                        translate_expr(
-                            program,
-                            Some(&plan.table_references),
-                            &args[0],
-                            reg,
-                            resolver,
-                        )?;
-                        reg
-                    }
-                    _ => 0,
+                // These functions need at most their first argument while
+                // input rows arrive. Arguments that may differ for each result
+                // row are read later from that saved row.
+                let first_arg = match func.current_expr() {
+                    Expr::FunctionCall { args, .. } => args.first(),
+                    Expr::FunctionCallStar { .. } => None,
+                    _ => unreachable!("window function must be a function call"),
+                };
+                let arg_reg = if let Some(arg) = first_arg {
+                    let reg = program.alloc_register();
+                    translate_expr(program, Some(&plan.table_references), arg, reg, resolver)?;
+                    reg
+                } else {
+                    // TODO: Make `AggStep::col` optional. It currently requires a
+                    // register number, so reserved register 0 means no argument.
+                    0
                 };
                 program.emit_insn(Insn::AggStep {
                     acc_reg: reg_acc_start,
@@ -1168,41 +1313,53 @@ pub fn emit_window_results(
         labels,
         registers,
         cursors,
+        buffer_mode,
         ..
     } = t_ctx.meta_window.as_ref().expect("missing window metadata");
     let window = plan.window.as_ref().expect("missing window");
 
     let label_empty = program.allocate_label();
     let label_window_processing_end = labels.window_processing_end;
+    let label_flush_buffer = labels.flush_buffer;
     let reg_flush_buffer_return_offset = registers.flush_buffer_return_offset;
     let cursor_csr_current = cursors.csr_current;
+    let keeps_partition_rows = buffer_mode.keeps_partition_rows();
 
     // All source rows have already been processed at this point.
     // In fallthrough mode, we are not returning to a caller — we just flush
     // the buffered rows and continue execution.
     program.add_comment(program.offset(), "return remaining buffered rows");
     program.emit_insn(Insn::Null {
-        dest: registers.flush_buffer_return_offset,
+        dest: reg_flush_buffer_return_offset,
         dest_end: None,
     });
 
     // If control jumps here (labels.flush_buffer), we are in subroutine mode.
     // In that case, after flushing the buffer, execution will return to the
     // address stored in `flush_buffer_return_offset`.
-    program.preassign_label_to_next_insn(labels.flush_buffer);
+    program.preassign_label_to_next_insn(label_flush_buffer);
 
-    program.emit_insn(Insn::Rewind {
-        cursor_id: cursor_csr_current,
-        pc_if_empty: label_empty,
-    });
+    if keeps_partition_rows {
+        program.emit_insn(Insn::IsNull {
+            reg: registers.rowid,
+            target_pc: label_empty,
+        });
+    } else {
+        program.emit_insn(Insn::Rewind {
+            cursor_id: cursor_csr_current,
+            pc_if_empty: label_empty,
+        });
+    }
 
     emit_peer_group_flush(program, window, t_ctx, plan)?;
 
     program.preassign_label_to_next_insn(label_empty);
 
-    program.emit_insn(Insn::ResetSorter {
-        cursor_id: cursor_csr_current,
-    });
+    if !keeps_partition_rows {
+        program.emit_insn(Insn::ResetSorter {
+            cursor_id: cursor_csr_current,
+        });
+    }
     program.emit_insn(Insn::Return {
         return_reg: reg_flush_buffer_return_offset,
         can_fallthrough: true,
@@ -1223,23 +1380,23 @@ fn emit_peer_group_flush(
         labels,
         registers,
         cursors,
+        buffer_mode,
+        nth_value,
         expressions_referencing_subquery,
         ..
     } = t_ctx.meta_window.as_ref().expect("missing window metadata");
 
-    // For aggregate window functions and the rank-family, the accumulator
-    // has already been advanced once per source row during the input scan.
-    // Emit one `AggValue` per such function here, before entering the loop
-    // over buffered rows: this reads the accumulator into the result
-    // register exactly once per peer-group flush. The per-row loop below
-    // will copy that register's contents into the output for every buffered
-    // row in the group (RANGE UNBOUNDED PRECEDING TO CURRENT ROW semantics).
+    // Calculate shared answers before returning rows with equal sort values,
+    // so every such row reuses the same answer. `nth_value` is calculated
+    // below because its second argument is read separately from each row.
     for (i, func) in window.functions.iter().enumerate() {
-        let value_pre_loop = match &func.func {
+        let answer_is_shared = match &func.func {
             AccumulatorFunc::Agg(_) => true,
-            AccumulatorFunc::Window(w) => w.one_value_per_peer_group(),
+            AccumulatorFunc::Window(window_func) => {
+                !window_func.calculates_answer_when_row_is_returned()
+            }
         };
-        if value_pre_loop {
+        if answer_is_shared {
             program.emit_insn(Insn::AggValue {
                 acc_reg: registers.acc_start + i,
                 dest_reg: registers.acc_result_start + i,
@@ -1259,22 +1416,109 @@ fn emit_peer_group_flush(
         let reg_result = registers.result_columns_start + i;
         program.emit_column_or_rowid(cursors.csr_current, *col_idx, reg_result);
     }
-    // For row_number, ntile, lag, lead and first/last/nth_value no
-    // `AggStep` ran during the input scan. Emit `AggStep` + `AggValue` here,
-    // inside the per-row loop over buffered rows: `AggStep` advances the
-    // function's state for the current row, then `AggValue` reads the
-    // resulting value into the result register that gets written to this
-    // row's output. This is the site that gives every buffered row in a
-    // peer group a distinct value. Functions where
-    // `one_value_per_peer_group()` is true were handled above the loop and
-    // are skipped here.
+    // Calculate these answers while returning each row because rows with equal
+    // sort values may still have different answers.
     for (i, func) in window.functions.iter().enumerate() {
         if let AccumulatorFunc::Window(win_func) = &func.func {
-            if win_func.one_value_per_peer_group() {
+            if !win_func.calculates_answer_when_row_is_returned() {
                 continue;
             }
-            let acc_reg = registers.acc_start + i;
             let dest_reg = registers.acc_result_start + i;
+            if matches!(win_func, crate::function::WindowFunc::NthValue) {
+                let Expr::FunctionCall { args, .. } = func.current_expr() else {
+                    unreachable!("nth_value must be a function call");
+                };
+                let Expr::Column {
+                    column: value_column,
+                    ..
+                } = args[0].as_ref()
+                else {
+                    unreachable!("rewritten nth_value value must be a subquery column");
+                };
+                let Expr::Column {
+                    column: position_column,
+                    ..
+                } = args[1].as_ref()
+                else {
+                    unreachable!("rewritten nth_value position argument must be a subquery column");
+                };
+                let nth_value = nth_value
+                    .as_ref()
+                    .expect("nth_value requires a partition lookup cursor");
+                let position_lookup_done = program.allocate_label();
+                let missing_saved_row = program.allocate_label();
+                let invalid_position = program.allocate_label();
+                let valid_position = program.allocate_label();
+                let position_register = program.alloc_register();
+                let zero_register = program.alloc_register();
+                program.emit_insn(Insn::Null {
+                    dest: dest_reg,
+                    dest_end: None,
+                });
+                program.emit_column_or_rowid(
+                    cursors.csr_current,
+                    *position_column,
+                    position_register,
+                );
+                program.emit_insn(Insn::MustBeInt {
+                    reg: position_register,
+                    target_pc: Some(invalid_position),
+                });
+                program.emit_insn(Insn::Integer {
+                    value: 0,
+                    dest: zero_register,
+                });
+                program.emit_insn(Insn::Gt {
+                    lhs: position_register,
+                    rhs: zero_register,
+                    target_pc: valid_position,
+                    flags: CmpInsFlags::default(),
+                    collation: None,
+                });
+                program.preassign_label_to_next_insn(invalid_position);
+                program.emit_insn(Insn::Halt {
+                    err_code: crate::error::SQLITE_ERROR,
+                    description: "second argument to nth_value must be a positive integer"
+                        .to_string(),
+                    on_error: Some(ResolveType::Abort),
+                    description_reg: None,
+                });
+                program.preassign_label_to_next_insn(valid_position);
+                program.emit_insn(Insn::Gt {
+                    lhs: position_register,
+                    rhs: nth_value.frame_end_rowid_register,
+                    target_pc: position_lookup_done,
+                    flags: CmpInsFlags::default(),
+                    collation: None,
+                });
+                program.emit_insn(Insn::SeekRowid {
+                    cursor_id: nth_value.row_by_position_cursor,
+                    src_reg: position_register,
+                    target_pc: missing_saved_row,
+                });
+                program.emit_column_or_rowid(
+                    nth_value.row_by_position_cursor,
+                    *value_column,
+                    dest_reg,
+                );
+                program.emit_insn(Insn::Goto {
+                    target_pc: position_lookup_done,
+                });
+                program.preassign_label_to_next_insn(missing_saved_row);
+                program.emit_insn(Insn::Halt {
+                    err_code: crate::error::SQLITE_ERROR,
+                    description: "nth_value could not find a saved row within its frame"
+                        .to_string(),
+                    on_error: None,
+                    description_reg: None,
+                });
+                program.preassign_label_to_next_insn(position_lookup_done);
+                continue;
+            }
+
+            let acc_reg = registers.acc_start + i;
+            // TODO: Make `AggStep::col` optional. It currently requires a
+            // register number, so reserved register 0 means no argument.
             program.emit_insn(Insn::AggStep {
                 acc_reg,
                 col: 0,
@@ -1317,10 +1561,50 @@ fn emit_peer_group_flush(
         program.preassign_label_to_next_insn(distinct_ctx.label_on_conflict);
     }
 
-    program.emit_insn(Insn::Next {
-        cursor_id: cursors.csr_current,
-        pc_if_next: label_loop_start,
-    });
+    let must_stop_return_cursor_at_next_peer_group =
+        buffer_mode.keeps_partition_rows() && !window.order_by.is_empty();
+    if must_stop_return_cursor_at_next_peer_group {
+        // The first row of the next sort group was inserted before this group
+        // was returned. Stop on that row so this cursor can continue from it
+        // when the next group is ready.
+        let next_row_found = program.allocate_label();
+        let finished_returning_group = program.allocate_label();
+        program.emit_insn(Insn::Next {
+            cursor_id: cursors.csr_current,
+            pc_if_next: next_row_found,
+        });
+        program.emit_insn(Insn::Goto {
+            target_pc: finished_returning_group,
+        });
+
+        program.preassign_label_to_next_insn(next_row_found);
+        let current_order_by_start = program.alloc_registers(window.order_by.len());
+        for (i, (expr, _, _)) in window.order_by.iter().enumerate() {
+            let Expr::Column { column, .. } = expr else {
+                unreachable!("rewritten window ORDER BY term must be a subquery column");
+            };
+            program.emit_column_or_rowid(cursors.csr_current, *column, current_order_by_start + i);
+        }
+        program.emit_insn(Insn::Compare {
+            start_reg_a: registers
+                .prev_order_by_columns_start
+                .expect("window ORDER BY values must be saved"),
+            start_reg_b: current_order_by_start,
+            count: window.order_by.len(),
+            key_info: window_order_by_key_info(window, plan)?,
+        });
+        program.emit_insn(Insn::Jump {
+            target_pc_lt: finished_returning_group,
+            target_pc_eq: label_loop_start,
+            target_pc_gt: finished_returning_group,
+        });
+        program.preassign_label_to_next_insn(finished_returning_group);
+    } else {
+        program.emit_insn(Insn::Next {
+            cursor_id: cursors.csr_current,
+            pc_if_next: label_loop_start,
+        });
+    }
 
     Ok(())
 }

--- a/core/util.rs
+++ b/core/util.rs
@@ -1264,7 +1264,7 @@ pub fn checked_cast_text_to_numeric(text: &str, lossless: bool) -> std::result::
     // sqlite will parse the first N digits of a string to numeric value, then determine
     // whether _that_ value is more likely a real or integer value. e.g.
     // '-100234-2344.23e14' evaluates to -100234 instead of -100234.0
-    let original_len = text.trim().len();
+    let original_len = trim_ascii_whitespace(text).len();
     let (kind, text) = parse_numeric_str(text)?;
 
     if original_len != text.len() && lossless {
@@ -1318,7 +1318,7 @@ fn real_to_numeric_value(value: f64) -> Value {
 }
 
 fn parse_numeric_str(text: &str) -> Result<(ValueType, &str), ()> {
-    let text = text.trim();
+    let text = trim_ascii_whitespace(text);
     let bytes = text.as_bytes();
 
     if matches!(
@@ -6536,6 +6536,10 @@ pub mod tests {
         assert_eq!(
             checked_cast_text_to_numeric("\t-3.22\n", true),
             Ok(Value::from_f64(-3.22))
+        );
+        assert_eq!(
+            checked_cast_text_to_numeric("\u{00A0}123\u{00A0}", true),
+            Err(())
         );
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6753,6 +6753,8 @@ fn ordered_set_percentile_disc(values: &[Value], fraction: f64, collation: Colla
     sorted[index.min(n - 1)].clone()
 }
 
+/// Records what a window function needs from one row so its answer can be read
+/// later. Functions without arguments do not read `arg_reg`.
 fn op_window_step(
     state: &mut ProgramState,
     acc_reg: usize,
@@ -6971,13 +6973,12 @@ fn op_window_value(
             Value::from_i64(*value_slot)
         }
         WindowFunc::FirstValue => {
-            // first_value captures payload[0] once per partition; every
-            // peer-group flush in the partition reads the same slot, so
-            // we have to clone instead of taking ownership.
+            // Keep the saved value because every later row in this partition
+            // may need the same answer.
             let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
             else {
                 return Err(LimboError::InternalError(format!(
-                    "first_value accumulator in unexpected register state: {:?}",
+                    "{func} accumulator in unexpected register state: {:?}",
                     state.registers[acc_reg]
                 )));
             };
@@ -11347,9 +11348,9 @@ fn new_rowid_inner(
     }
 }
 
-fn coerce_register_to_integer(state: &mut ProgramState, reg: usize) -> Result<bool> {
+fn coerce_register_to_integer(state: &mut ProgramState, reg: usize) -> bool {
     let converted = match state.registers[reg].get_value() {
-        Value::Numeric(Numeric::Integer(_)) => return Ok(true),
+        Value::Numeric(Numeric::Integer(_)) => return true,
         Value::Numeric(Numeric::Float(f)) => cast_real_to_integer(f64::from(*f)).ok(),
         Value::Text(text) => match checked_cast_text_to_numeric(text.as_str(), true) {
             Ok(Value::Numeric(Numeric::Integer(i))) => Some(i),
@@ -11358,13 +11359,12 @@ fn coerce_register_to_integer(state: &mut ProgramState, reg: usize) -> Result<bo
         },
         _ => None,
     };
+    let Some(i) = converted else {
+        return false;
+    };
 
-    if let Some(i) = converted {
-        state.registers[reg].set_int(i);
-        Ok(true)
-    } else {
-        Ok(false)
-    }
+    state.registers[reg].set_int(i);
+    true
 }
 
 pub fn op_must_be_int(
@@ -11374,7 +11374,7 @@ pub fn op_must_be_int(
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(MustBeInt { reg, target_pc }, insn);
-    if !coerce_register_to_integer(state, *reg)? {
+    if !coerce_register_to_integer(state, *reg) {
         if let Some(target_pc) = target_pc {
             state.pc = target_pc.as_offset_int();
             return Ok(InsnFunctionStepResult::Step);

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1279,7 +1279,11 @@ pub fn insn_to_row(
                 0,
                 format!("accum=r[{}]", *register),
             ),
-            Insn::AggValue { acc_reg, dest_reg, func } => (
+            Insn::AggValue {
+                acc_reg,
+                dest_reg,
+                func,
+            } => (
                 "AggValue",
                 0,
                 *acc_reg as i64,

--- a/docs/sql-reference/functions/window.mdx
+++ b/docs/sql-reference/functions/window.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Window
 Window functions perform calculations across a set of rows that are related to the current row. Unlike aggregate functions with GROUP BY, window functions do not collapse rows into a single output row. Every input row produces a corresponding output row, with the window function result appended.
 
 <Info>
-Turso supports aggregate functions used as window functions with the default frame definition, the `row_number()` ranking function, and the `FILTER (WHERE ...)` clause. The remaining dedicated window functions (`rank`, `dense_rank`, `ntile`, `lag`, `lead`, `first_value`, `last_value`, `nth_value`) and custom frame specifications (ROWS, RANGE, or GROUPS with explicit bounds) are not yet supported.
+Turso supports aggregate functions used as window functions with the default frame definition, `row_number()`, `rank()`, `dense_rank()`, `first_value()`, `last_value()`, `nth_value()`, and the `FILTER (WHERE ...)` clause. Other dedicated window functions and custom frame specifications (ROWS, RANGE, or GROUPS with explicit bounds) are not yet supported.
 </Info>
 
 ## Syntax
@@ -276,14 +276,9 @@ The following window function features are not yet supported in Turso:
 
 | Feature | Status |
 |---------|--------|
-| `rank()` | Not supported |
-| `dense_rank()` | Not supported |
 | `ntile(N)` | Not supported |
 | `lag(expr, offset, default)` | Not supported |
 | `lead(expr, offset, default)` | Not supported |
-| `first_value(expr)` | Not supported |
-| `last_value(expr)` | Not supported |
-| `nth_value(expr, N)` | Not supported |
 | `cume_dist()` | Not supported |
 | `percent_rank()` | Not supported |
 | Custom frame: `ROWS BETWEEN ...` | Not supported |
@@ -291,7 +286,7 @@ The following window function features are not yet supported in Turso:
 | Custom frame: `GROUPS BETWEEN ...` | Not supported |
 | `EXCLUDE` clause | Not supported |
 
-`row_number()` and `FILTER (WHERE ...)` are supported — see the sections above.
+The supported functions listed above use the default frame definition.
 
 ## See Also
 

--- a/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
@@ -312,12 +312,19 @@ expect {
     last_value|w|1
 }
 
-@skip-if sqlite "sqlite implements these window functions; we don't yet, so they must not be advertised in pragma_function_list"
+test pragma-function-list-window-nth-value {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'nth_value';
+}
+expect {
+    nth_value|w|2
+}
+
+@skip-if sqlite "Turso should not list window functions that it cannot run"
 test pragma-function-list-omits-unimplemented-window-functions {
     SELECT COUNT(*) FROM pragma_function_list
     WHERE name IN (
         'percent_rank','cume_dist','ntile',
-        'lag','lead','nth_value'
+        'lag','lead'
     );
 }
 expect {

--- a/sqlite/conformance/sqlite-sqltests/window/nth_value.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/nth_value.sqltest
@@ -1,0 +1,508 @@
+@database :memory:
+
+setup nth_base {
+    CREATE TABLE nth_items(id INTEGER PRIMARY KEY, g TEXT, v INTEGER);
+    INSERT INTO nth_items VALUES
+        (1, 'a', 10),
+        (2, 'a', 20),
+        (3, 'a', 30),
+        (4, 'b', 100),
+        (5, 'b', 200);
+}
+
+# Position 1 means the first value ordered by v among rows with the same g
+# value. This should match first_value for this query.
+@setup nth_base
+test nth-value-first-row {
+    SELECT id, v, nth_value(v, 1) OVER (PARTITION BY g ORDER BY v) FROM nth_items ORDER BY id;
+}
+expect {
+    1|10|10
+    2|20|10
+    3|30|10
+    4|100|100
+    5|200|100
+}
+
+# Position 2 is not available until the second row in the window order has
+# been reached, so the first row gets NULL.
+@setup nth_base
+test nth-value-second-row {
+    SELECT id, v, nth_value(v, 2) OVER (PARTITION BY g ORDER BY v) FROM nth_items ORDER BY id;
+}
+expect {
+    1|10|
+    2|20|20
+    3|30|20
+    4|100|
+    5|200|200
+}
+
+# No partition has ten rows, so position 10 always gives NULL.
+@setup nth_base
+test nth-value-out-of-bounds {
+    SELECT id, v, nth_value(v, 10) OVER (PARTITION BY g ORDER BY v) FROM nth_items ORDER BY id;
+}
+expect {
+    1|10|
+    2|20|
+    3|30|
+    4|100|
+    5|200|
+}
+
+setup nth_nulls {
+    CREATE TABLE nth_n(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO nth_n VALUES (1, 10), (2, NULL), (3, 30);
+}
+
+# When the chosen value is NULL, later rows must keep returning NULL instead
+# of choosing a later non-NULL value.
+@setup nth_nulls
+test nth-value-captures-null {
+    SELECT id, v, nth_value(v, 2) OVER (ORDER BY id) FROM nth_n ORDER BY id;
+}
+expect {
+    1|10|
+    2||
+    3|30|
+}
+
+setup nth_peers {
+    CREATE TABLE nth_p(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO nth_p VALUES (1, 1), (2, 1), (3, 2), (4, 2), (5, 3);
+}
+
+# The position counts individual rows, including rows with equal sort values.
+# Position 3 is therefore the first row whose value is 2.
+@setup nth_peers
+test nth-value-counts-rows-not-peers {
+    SELECT id, v, nth_value(v, 3) OVER (ORDER BY v) FROM nth_p ORDER BY id;
+}
+expect {
+    1|1|
+    2|1|
+    3|2|2
+    4|2|2
+    5|3|2
+}
+
+setup nth_empty {
+    CREATE TABLE nth_e(v INTEGER);
+}
+
+@setup nth_empty
+test nth-value-empty-input {
+    SELECT nth_value(v, 1) OVER (ORDER BY v) FROM nth_e;
+}
+expect {
+}
+
+@setup nth_base
+test nth-value-expression-argument {
+    SELECT id, nth_value(v * 10, 2) OVER (ORDER BY v) FROM nth_items ORDER BY id;
+}
+expect {
+    1|
+    2|200
+    3|200
+    4|200
+    5|200
+}
+
+@setup nth_base
+test nth-value-with-first-and-last-value {
+    SELECT id, v,
+           first_value(v) OVER (ORDER BY v),
+           nth_value(v, 2) OVER (ORDER BY v),
+           nth_value(v, 3) OVER (ORDER BY v),
+           last_value(v) OVER (ORDER BY v)
+    FROM nth_items ORDER BY id;
+}
+expect {
+    1|10|10|||10
+    2|20|10|20||20
+    3|30|10|20|30|30
+    4|100|10|20|30|100
+    5|200|10|20|30|200
+}
+
+setup nth_text {
+    CREATE TABLE nth_t(v TEXT);
+    INSERT INTO nth_t VALUES ('apple'), ('banana'), ('cherry');
+}
+
+@setup nth_text
+test nth-value-text-argument {
+    SELECT v, nth_value(v, 2) OVER (ORDER BY v) FROM nth_t ORDER BY v;
+}
+expect {
+    apple|
+    banana|banana
+    cherry|banana
+}
+
+@setup nth_base
+test nth-value-float-n-converts-losslessly {
+    SELECT id, nth_value(v, 2.0) OVER (ORDER BY v) FROM nth_items ORDER BY id;
+}
+expect {
+    1|
+    2|20
+    3|20
+    4|20
+    5|20
+}
+
+# SQLite treats the text '2' as position 2, so Turso must do the same.
+@setup nth_base
+test nth-value-text-n-coerces {
+    SELECT id, nth_value(v, '2') OVER (ORDER BY v) FROM nth_items ORDER BY id;
+}
+expect {
+    1|
+    2|20
+    3|20
+    4|20
+    5|20
+}
+
+# The position must be a positive whole number. These invalid forms must all
+# return the same error as SQLite.
+@setup nth_base
+test nth-value-n-zero-errors {
+    SELECT nth_value(v, 0) OVER (ORDER BY v) FROM nth_items;
+}
+expect error {
+}
+
+@setup nth_base
+test nth-value-n-negative-errors {
+    SELECT nth_value(v, -1) OVER (ORDER BY v) FROM nth_items;
+}
+expect error {
+}
+
+@setup nth_base
+test nth-value-n-lossy-float-errors {
+    SELECT nth_value(v, 1.5) OVER (ORDER BY v) FROM nth_items;
+}
+expect error {
+}
+
+@setup nth_base
+test nth-value-n-non-numeric-text-errors {
+    SELECT nth_value(v, 'abc') OVER (ORDER BY v) FROM nth_items;
+}
+expect error {
+    second argument to nth_value must be a positive integer
+}
+
+# SQLite rejects text with anything after the number, so Turso must reject it.
+@setup nth_base
+test nth-value-n-text-prefix-errors {
+    SELECT nth_value(v, '2abc') OVER (ORDER BY v) FROM nth_items;
+}
+expect error {
+    second argument to nth_value must be a positive integer
+}
+
+@setup nth_base
+test nth-value-n-null-errors {
+    SELECT nth_value(v, NULL) OVER (ORDER BY v) FROM nth_items;
+}
+expect error {
+    second argument to nth_value must be a positive integer
+}
+
+setup nth_adversarial {
+    CREATE TABLE nth_a(id INTEGER PRIMARY KEY, g TEXT, ord INTEGER, v, n INTEGER);
+    INSERT INTO nth_a VALUES
+        (1, 'a', 1, 'raven', 1),
+        (2, 'a', 1, 'nevermore', 2),
+        (3, 'a', 2, NULL, 3),
+        (4, 'a', 2, 'telltale', 4),
+        (5, 'a', 3, 'pendulum', 99),
+        (6, 'b', NULL, x'00ff', 1),
+        (7, 'b', NULL, 3.5, 2),
+        (8, 'b', 1, -7, 3);
+}
+
+# Each result row uses its own position argument. This also checks that the
+# chosen value keeps its type and that a missing position gives NULL.
+@setup nth_adversarial
+test nth-value-varying-n-replaces-earlier-match {
+    SELECT id,
+           typeof(nth_value(v, n) OVER (PARTITION BY g ORDER BY id)),
+           quote(nth_value(v, n) OVER (PARTITION BY g ORDER BY id))
+    FROM nth_a ORDER BY id;
+}
+expect {
+    1|text|'raven'
+    2|text|'nevermore'
+    3|null|NULL
+    4|text|'telltale'
+    5|null|NULL
+    6|blob|X'00FF'
+    7|real|3.5
+    8|integer|-7
+}
+
+# Rows with equal sort values consider the same rows, but each row uses its own
+# position argument. The counts avoid relying on the order of tied rows.
+@setup nth_adversarial
+test nth-value-varying-n-across-peer-groups {
+    WITH results AS (
+        SELECT g, ord, nth_value(v, n) OVER (PARTITION BY g ORDER BY ord) AS x
+        FROM nth_a
+    )
+    SELECT g, quote(ord), count(*), count(x), count(DISTINCT x)
+    FROM results
+    GROUP BY g, ord
+    ORDER BY g, ord;
+}
+expect {
+    a|1|2|2|2
+    a|2|2|1|1
+    a|3|1|0|0
+    b|NULL|2|2|2
+    b|1|1|1|1
+}
+
+# Without ORDER BY, every row considers its whole partition. Position 2 must
+# therefore give the same answer throughout each partition.
+@setup nth_adversarial
+test nth-value-without-order-by-sees-whole-partition {
+    SELECT id, quote(nth_value(v, 2) OVER (PARTITION BY g))
+    FROM nth_a ORDER BY id;
+}
+expect {
+    1|'nevermore'
+    2|'nevermore'
+    3|'nevermore'
+    4|'nevermore'
+    5|'nevermore'
+    6|3.5
+    7|3.5
+    8|3.5
+}
+
+# The extra id ordering decides which tied row comes first. A row still gets
+# NULL until position 2 has been reached.
+@setup nth_adversarial
+test nth-value-descending-null-order-and-tiebreaker {
+    SELECT id,
+           quote(nth_value(v, 2) OVER (
+               PARTITION BY g ORDER BY ord DESC NULLS LAST, id DESC
+           ))
+    FROM nth_a ORDER BY id;
+}
+expect {
+    1|'telltale'
+    2|'telltale'
+    3|'telltale'
+    4|'telltale'
+    5|NULL
+    6|3.5
+    7|3.5
+    8|NULL
+}
+
+# Naming a window only reuses its definition, so it must not change the result.
+@setup nth_adversarial
+test nth-value-varying-n-with-named-window {
+    SELECT id, quote(nth_value(v, n) OVER gothic)
+    FROM nth_a
+    WINDOW gothic AS (PARTITION BY g ORDER BY ord, id)
+    ORDER BY id;
+}
+expect {
+    1|'raven'
+    2|'nevermore'
+    3|NULL
+    4|'telltale'
+    5|NULL
+    6|X'00FF'
+    7|3.5
+    8|-7
+}
+
+# These calls order the same rows differently. Reusing one call's lookup for
+# another would return the wrong value.
+@setup nth_adversarial
+test nth-value-multiple-window-definitions {
+    SELECT id,
+           quote(nth_value(v, n) OVER (PARTITION BY g ORDER BY ord, id)),
+           quote(nth_value(v, 2) OVER (PARTITION BY g ORDER BY ord DESC, id DESC)),
+           quote(nth_value(v, 3) OVER (PARTITION BY g ORDER BY id))
+    FROM nth_a ORDER BY id;
+}
+expect {
+    1|'raven'|'telltale'|NULL
+    2|'nevermore'|'telltale'|NULL
+    3|NULL|'telltale'|NULL
+    4|'telltale'|'telltale'|NULL
+    5|NULL|NULL|NULL
+    6|X'00FF'|3.5|NULL
+    7|3.5|3.5|NULL
+    8|-7|NULL|-7
+}
+
+# The position argument may change from one result row to the next, so every
+# returned row must check its own value.
+setup nth_late_invalid {
+    CREATE TABLE nth_li(id INTEGER PRIMARY KEY, v TEXT, n);
+    INSERT INTO nth_li VALUES (1, 'first', 1), (2, 'second', 2), (3, 'doom', 0);
+}
+
+@setup nth_late_invalid
+test nth-value-varying-n-late-invalid-errors {
+    SELECT nth_value(v, n) OVER (ORDER BY id) FROM nth_li;
+}
+expect error {
+    second argument to nth_value must be a positive integer
+}
+
+# LIMIT 2 prevents the third result from being returned, so its invalid
+# position must not cause an error.
+@setup nth_late_invalid
+test nth-value-limit-stops-before-late-invalid-n {
+    SELECT id, nth_value(v, n) OVER (ORDER BY id)
+    FROM nth_li ORDER BY id LIMIT 2;
+}
+expect {
+    1|first
+    2|second
+}
+
+# OFFSET hides the first result only after its window value is calculated, so
+# its invalid position must still cause an error.
+setup nth_offset_invalid {
+    CREATE TABLE nth_oi(id INTEGER PRIMARY KEY, v TEXT, n);
+    INSERT INTO nth_oi VALUES (1, 'doom', 0), (2, 'second', 2);
+}
+
+@setup nth_offset_invalid
+test nth-value-offset-does-not-hide-invalid-n {
+    SELECT id, nth_value(v, n) OVER (ORDER BY id)
+    FROM nth_oi ORDER BY id LIMIT 1 OFFSET 1;
+}
+expect error {
+    second argument to nth_value must be a positive integer
+}
+
+# With no input rows, there is no position argument to check.
+@setup nth_empty
+test nth-value-invalid-n-on-empty-input-does-not-error {
+    SELECT nth_value(v, 0) OVER () FROM nth_e;
+}
+expect {
+}
+
+# SQLite accepts this exactly represented whole decimal. It is beyond this
+# small partition, so the result must be NULL rather than an error.
+@setup nth_base
+test nth-value-largest-near-boundary-exact-real {
+    SELECT quote(nth_value(v, 9223372036854774784.0) OVER (ORDER BY v))
+    FROM nth_items ORDER BY v;
+}
+expect {
+    NULL
+    NULL
+    NULL
+    NULL
+    NULL
+}
+
+# The first decimal rounds to the second value shown below. Both are larger
+# than the greatest supported integer, so SQLite rejects them.
+@setup nth_base
+test nth-value-rounded-i64-max-real-errors {
+    SELECT nth_value(v, 9223372036854775807.0) OVER () FROM nth_items;
+}
+expect error {
+    second argument to nth_value must be a positive integer
+}
+
+@setup nth_base
+test nth-value-two-to-63-real-errors {
+    SELECT nth_value(v, 9223372036854775808.0) OVER () FROM nth_items;
+}
+expect error {
+    second argument to nth_value must be a positive integer
+}
+
+# SQLite accepts spaces and an exponent when the text still represents a
+# positive whole number, so Turso must do the same.
+@setup nth_base
+test nth-value-text-exponent-n-coerces {
+    SELECT id, nth_value(v, ' 2e0 ') OVER (ORDER BY v)
+    FROM nth_items ORDER BY id;
+}
+expect {
+    1|
+    2|20
+    3|20
+    4|20
+    5|20
+}
+
+# SQLite only treats ASCII whitespace around a number as numeric input.
+@setup nth_base
+test nth-value-unicode-whitespace-n-errors {
+    SELECT nth_value(v, char(160) || '1' || char(160)) OVER () FROM nth_items;
+}
+expect error {
+    second argument to nth_value must be a positive integer
+}
+
+# A blob is not a position number, even when its byte spells '2'.
+@setup nth_base
+test nth-value-blob-n-errors {
+    SELECT nth_value(v, x'32') OVER () FROM nth_items;
+}
+expect error {
+    second argument to nth_value must be a positive integer
+}
+
+# Force 512 tied rows onto disk and read a value near the end. This exercises
+# position lookup after the saved table has grown across many pages.
+setup nth_large_peer {
+    PRAGMA temp_store=FILE;
+}
+
+@setup nth_large_peer
+test nth-value-large-peer-group-uses-temp-storage {
+    WITH digit(i) AS (
+        VALUES(0), (1), (2), (3), (4), (5), (6), (7)
+    )
+    SELECT count(*), sum(length(value))
+    FROM (
+        SELECT nth_value(zeroblob(32768), 512) OVER (ORDER BY 0) AS value
+        FROM digit AS a CROSS JOIN digit AS b CROSS JOIN digit AS c
+    );
+}
+expect {
+    512|16777216
+}
+
+# Every new sort value makes the preceding row ready while all earlier rows
+# remain saved. The large values force the saved table to grow across many
+# pages. Its return cursor must stay on the next row while that table grows.
+@setup nth_large_peer
+test nth-value-return-cursor-survives-growing-buffer {
+    WITH digit(i) AS (
+        VALUES(0), (1), (2), (3), (4), (5), (6), (7)
+    )
+    SELECT count(*), sum(length(chosen))
+    FROM (
+        SELECT nth_value(zeroblob(4096), i) OVER (ORDER BY i) AS chosen
+        FROM (
+            SELECT a.i * 64 + b.i * 8 + c.i + 1 AS i
+            FROM digit AS a CROSS JOIN digit AS b CROSS JOIN digit AS c
+        )
+    );
+}
+expect {
+    512|2097152
+}


### PR DESCRIPTION
Add nth_value(value, position), which returns the value at a chosen position among the ordered rows visible to each result row.

Keep the rows in the existing temporary window table and look up the requested row as each result is produced. This avoids making a second in-memory copy of every value and allows large groups to use temporary disk storage.

Read and check the position separately for each result row, matching SQLite when positions vary, rows have equal sort values, or LIMIT stops early. Accept only positive whole numbers that fit in an integer.