### PR TITLE
translate: use covering indexes for column-free scans

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2666,11 +2666,14 @@ impl JoinedTable {
         let Table::BTree(btree) = &self.table else {
             return false;
         };
-        if self.col_used_mask.is_empty() {
-            return false;
-        }
         if index.index_method.is_some() {
             return false;
+        }
+        if self.col_used_mask.is_empty() {
+            // With no referenced columns, a complete index can provide the row-producing
+            // scan without opening the table. Partial-index completeness depends on the
+            // query predicate, so keep this path conservative.
+            return index.where_clause.is_none();
         }
 
         if self.expression_index_usages.is_empty() {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -28,7 +28,7 @@ use crate::vdbe::builder::CursorType;
 use crate::vdbe::insn::{
     to_u16, {CmpInsFlags, Cookie, InsertFlags, Insn, RegisterOrLiteral},
 };
-use crate::{bail_parse_error, CaptureDataChangesExt, Result};
+use crate::{bail_parse_error, turso_assert, turso_assert_eq, CaptureDataChangesExt, Result};
 use crate::{Connection, MAIN_DB_ID};
 
 use turso_ext::VTabKind;
@@ -2323,7 +2323,22 @@ pub fn translate_drop_table(
         .get_table(crate::translate::pragma::TURSO_CDC_VERSION_TABLE_NAME)
         .and_then(|t| t.btree())
     {
+        let version_index_name = format!(
+            "{PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX}{}_1",
+            crate::translate::pragma::TURSO_CDC_VERSION_TABLE_NAME
+        );
+        let version_index = resolver
+            .schema()
+            .get_index(
+                crate::translate::pragma::TURSO_CDC_VERSION_TABLE_NAME,
+                &version_index_name,
+            )
+            .cloned();
         let ver_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(version_table.clone()));
+        let ver_index_cursor_id = version_index
+            .as_ref()
+            .map(|index| program.alloc_cursor_index(None, index))
+            .transpose()?;
         let ver_table_name_reg = program.alloc_register();
         let dropped_name_reg =
             program.emit_string8_new_reg(normalize_ident(tbl_name.name.as_str()));
@@ -2334,6 +2349,13 @@ pub fn translate_drop_table(
             root_page: version_table.root_page.into(),
             db: crate::MAIN_DB_ID,
         });
+        if let (Some(index), Some(cursor_id)) = (&version_index, ver_index_cursor_id) {
+            program.emit_insn(Insn::OpenWrite {
+                cursor_id,
+                root_page: index.root_page.into(),
+                db: crate::MAIN_DB_ID,
+            });
+        }
 
         let end_ver_loop_label = program.allocate_label();
         let ver_loop_start_label = program.allocate_label();
@@ -2355,6 +2377,30 @@ pub fn translate_drop_table(
             flags: CmpInsFlags::default(),
             collation: None,
         });
+
+        if let (Some(index), Some(cursor_id)) = (&version_index, ver_index_cursor_id) {
+            turso_assert_eq!(index.columns.len(), 1);
+            turso_assert!(index.has_rowid);
+            turso_assert!(index.where_clause.is_none());
+            turso_assert!(index.columns[0].expr.is_none());
+
+            let index_key_reg = program.alloc_registers(2);
+            program.emit_column_or_rowid(
+                ver_cursor_id,
+                index.columns[0].pos_in_table,
+                index_key_reg,
+            );
+            program.emit_insn(Insn::RowId {
+                cursor_id: ver_cursor_id,
+                dest: index_key_reg + 1,
+            });
+            program.emit_insn(Insn::IdxDelete {
+                start_reg: index_key_reg,
+                num_regs: 2,
+                cursor_id,
+                raise_error_if_no_matching_entry: true,
+            });
+        }
 
         program.emit_insn(Insn::Delete {
             cursor_id: ver_cursor_id,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1787,9 +1787,12 @@ impl ProgramBuilder {
         self.table_references.contains_table(table)
     }
 
-    /// Returns true if the cursor is a BTreeTable cursor.
+    /// Returns true if the cursor is backed by a table or index B-tree.
     pub fn cursor_is_btree(&self, cursor_id: CursorID) -> bool {
-        matches!(self.cursor_ref[cursor_id].1, CursorType::BTreeTable(_))
+        matches!(
+            self.cursor_ref[cursor_id].1,
+            CursorType::BTreeTable(_) | CursorType::BTreeIndex(_)
+        )
     }
 
     /// Returns the BTreeTable for the given cursor, if it is a BTreeTable cursor.

--- a/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
@@ -26,3 +26,86 @@ expect {
     4
     6
 }
+
+test simple-count-index-correctness {
+    CREATE TABLE indexed_count(
+        id INTEGER PRIMARY KEY,
+        value TEXT,
+        payload_1 TEXT,
+        payload_2 TEXT
+    );
+    CREATE INDEX indexed_count_value_idx ON indexed_count(value);
+    CREATE INDEX indexed_count_partial_idx
+        ON indexed_count(value)
+        WHERE value IS NOT NULL;
+
+    -- A full index contains NULL keys and stops containing deleted rows.
+    INSERT INTO indexed_count VALUES
+        (1, 'one', 'a', 'b'),
+        (2, NULL, 'c', 'd'),
+        (3, 'three', 'e', 'f'),
+        (4, 'four', 'g', 'h');
+    DELETE FROM indexed_count WHERE id = 3;
+
+    SELECT count(*) FROM indexed_count;
+    SELECT count(*) FROM indexed_count INDEXED BY indexed_count_value_idx;
+    -- An unusable partial index must not omit the NULL row.
+    SELECT count(*) FROM indexed_count INDEXED BY indexed_count_partial_idx;
+}
+expect {
+    3
+    3
+    3
+}
+
+@skip-if mvcc "Expression indexes are not supported with MVCC"
+test simple-count-expression-index-correctness {
+    CREATE TABLE expression_indexed_count(value, payload_1, payload_2);
+    CREATE INDEX expression_indexed_count_idx
+        ON expression_indexed_count(length(value));
+    INSERT INTO expression_indexed_count VALUES
+        ('one', 'a', 'b'),
+        (NULL, 'c', 'd'),
+        ('three', 'e', 'f');
+    DELETE FROM expression_indexed_count WHERE value = 'three';
+
+    SELECT count(*) FROM expression_indexed_count;
+    SELECT count(*) FROM expression_indexed_count
+        INDEXED BY expression_indexed_count_idx;
+}
+expect {
+    2
+    2
+}
+
+test simple-count-empty-index {
+    CREATE TABLE empty_indexed_count(value, payload_1, payload_2);
+    CREATE INDEX empty_indexed_count_idx ON empty_indexed_count(value);
+    SELECT count(*) FROM empty_indexed_count;
+}
+expect {
+    0
+}
+
+test column-free-and-autoindex-correctness {
+    CREATE TABLE automatic_index_count(
+        email TEXT UNIQUE,
+        payload_1 TEXT,
+        payload_2 TEXT
+    );
+    INSERT INTO automatic_index_count VALUES
+        ('one@example.com', 'a', 'b'),
+        (NULL, 'c', 'd'),
+        ('three@example.com', 'e', 'f'),
+        (NULL, 'g', 'h');
+    DELETE FROM automatic_index_count WHERE email = 'three@example.com';
+
+    SELECT count(*) FROM automatic_index_count;
+    SELECT 1 FROM automatic_index_count;
+}
+expect {
+    3
+    1
+    1
+    1
+}

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/aggregation.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/aggregation.sqltest
@@ -232,6 +232,90 @@ snapshot simple-count-star {
     SELECT count(*) FROM t1;
 }
 
+setup indexed_count_table {
+    CREATE TABLE indexed_count(
+        id INTEGER PRIMARY KEY,
+        narrow_col TEXT,
+        wide_col_1 TEXT,
+        wide_col_2 TEXT,
+        wide_col_3 TEXT
+    );
+    CREATE INDEX indexed_count_wide_idx
+        ON indexed_count(narrow_col, wide_col_1, wide_col_2);
+    CREATE INDEX indexed_count_narrow_idx
+        ON indexed_count(narrow_col);
+    CREATE INDEX indexed_count_partial_idx
+        ON indexed_count(wide_col_3)
+        WHERE wide_col_3 IS NOT NULL;
+}
+
+@setup indexed_count_table
+snapshot simple-count-narrowest-index {
+    SELECT count(*) FROM indexed_count;
+}
+
+@setup indexed_count_table
+snapshot simple-count-indexed-by {
+    SELECT count(*) FROM indexed_count INDEXED BY indexed_count_wide_idx;
+}
+
+@setup indexed_count_table
+snapshot simple-count-not-indexed {
+    SELECT count(*) FROM indexed_count NOT INDEXED;
+}
+
+# Complete indexes can provide row-producing scans even when no columns are referenced.
+@setup indexed_count_table
+snapshot column-free-scan-covering-index {
+    SELECT 1 FROM indexed_count;
+}
+
+setup automatic_index_count_table {
+    CREATE TABLE automatic_index_count(
+        email TEXT UNIQUE,
+        payload_1 TEXT,
+        payload_2 TEXT
+    );
+}
+
+@setup automatic_index_count_table
+snapshot simple-count-autoindex {
+    SELECT count(*) FROM automatic_index_count;
+}
+
+setup expression_indexed_count_table {
+    CREATE TABLE expression_indexed_count(
+        id INTEGER PRIMARY KEY,
+        value TEXT,
+        payload_1 TEXT,
+        payload_2 TEXT
+    );
+    CREATE INDEX expression_indexed_count_idx
+        ON expression_indexed_count(length(value));
+}
+
+@setup expression_indexed_count_table
+snapshot simple-count-expression-index {
+    SELECT count(*) FROM expression_indexed_count;
+}
+
+setup partial_only_count_table {
+    CREATE TABLE partial_only_count(
+        id INTEGER PRIMARY KEY,
+        value TEXT,
+        payload_1 TEXT,
+        payload_2 TEXT
+    );
+    CREATE INDEX partial_only_count_idx
+        ON partial_only_count(value)
+        WHERE value IS NOT NULL;
+}
+
+@setup partial_only_count_table
+snapshot simple-count-excludes-partial-index {
+    SELECT count(*) FROM partial_only_count;
+}
+
 setup partial_index_count_table {
     CREATE TABLE t2(
         id INTEGER PRIMARY KEY,

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__column-free-scan-covering-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__column-free-scan-covering-index.snap
@@ -1,0 +1,25 @@
+---
+source: aggregation.sqltest
+expression: SELECT 1 FROM indexed_count;
+info:
+  statement_type: SELECT
+  tables:
+  - indexed_count
+  setup_blocks:
+  - indexed_count_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN indexed_count USING COVERING INDEX indexed_count_narrow_idx
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0   6   0           0  Start at 6
+   1  OpenRead      0   4   0  k(2,B)   0  index=indexed_count_narrow_idx, root=4, iDb=0
+   2  Rewind        0   5   0           0  Rewind index indexed_count_narrow_idx
+   3    ResultRow   1   1   0           0  output=r[1]
+   4  Next          0   3   0           0
+   5  Halt          0   0   0           0
+   6  Transaction   0   1   4           0  iDb=0 tx_mode=Read
+   7  Integer       1   1   0           0  r[1]=1
+   8  Goto          0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-autoindex.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-autoindex.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) FROM automatic_index_count;
+info:
+  statement_type: SELECT
+  tables:
+  - automatic_index_count
+  setup_blocks:
+  - automatic_index_count_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN automatic_index_count USING COVERING INDEX sqlite_autoindex_automatic_index_count_1
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0   8   0           0  Start at 8
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   3   0  k(2,B)   0  index=sqlite_autoindex_automatic_index_count_1, root=3, iDb=0
+   3  Count         0   3   0           0
+   4  Close         0   0   0           0
+   5  Copy          3   1   0           0  r[1]=r[3]
+   6  ResultRow     1   1   0           0  output=r[1]
+   7  Halt          0   0   0           0
+   8  Transaction   0   1   1           0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-excludes-partial-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-excludes-partial-index.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) FROM partial_only_count;
+info:
+  statement_type: SELECT
+  tables:
+  - partial_only_count
+  setup_blocks:
+  - partial_only_count_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN partial_only_count
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4            p5  comment
+   0  Init          0   8   0                 0  Start at 8
+   1  Null          0   2   0                 0  r[2]=NULL
+   2  OpenRead      0   2   0  k(4,B,B,B,B)   0  table=partial_only_count, root=2, iDb=0
+   3  Count         0   3   0                 0
+   4  Close         0   0   0                 0
+   5  Copy          3   1   0                 0  r[1]=r[3]
+   6  ResultRow     1   1   0                 0  output=r[1]
+   7  Halt          0   0   0                 0
+   8  Transaction   0   1   2                 0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-expression-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-expression-index.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) FROM expression_indexed_count;
+info:
+  statement_type: SELECT
+  tables:
+  - expression_indexed_count
+  setup_blocks:
+  - expression_indexed_count_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN expression_indexed_count USING COVERING INDEX expression_indexed_count_idx
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0   8   0           0  Start at 8
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   3   0  k(2,B)   0  index=expression_indexed_count_idx, root=3, iDb=0
+   3  Count         0   3   0           0
+   4  Close         0   0   0           0
+   5  Copy          3   1   0           0  r[1]=r[3]
+   6  ResultRow     1   1   0           0  output=r[1]
+   7  Halt          0   0   0           0
+   8  Transaction   0   1   2           0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-indexed-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-indexed-by.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) FROM indexed_count INDEXED BY indexed_count_wide_idx;
+info:
+  statement_type: SELECT
+  tables:
+  - indexed_count
+  setup_blocks:
+  - indexed_count_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN indexed_count USING COVERING INDEX indexed_count_wide_idx
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4          p5  comment
+   0  Init          0   8   0               0  Start at 8
+   1  Null          0   2   0               0  r[2]=NULL
+   2  OpenRead      0   3   0  k(4,B,B,B)   0  index=indexed_count_wide_idx, root=3, iDb=0
+   3  Count         0   3   0               0
+   4  Close         0   0   0               0
+   5  Copy          3   1   0               0  r[1]=r[3]
+   6  ResultRow     1   1   0               0  output=r[1]
+   7  Halt          0   0   0               0
+   8  Transaction   0   1   4               0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-narrowest-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-narrowest-index.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) FROM indexed_count;
+info:
+  statement_type: SELECT
+  tables:
+  - indexed_count
+  setup_blocks:
+  - indexed_count_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN indexed_count USING COVERING INDEX indexed_count_narrow_idx
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0   8   0           0  Start at 8
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   4   0  k(2,B)   0  index=indexed_count_narrow_idx, root=4, iDb=0
+   3  Count         0   3   0           0
+   4  Close         0   0   0           0
+   5  Copy          3   1   0           0  r[1]=r[3]
+   6  ResultRow     1   1   0           0  output=r[1]
+   7  Halt          0   0   0           0
+   8  Transaction   0   1   4           0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-not-indexed.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-not-indexed.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) FROM indexed_count NOT INDEXED;
+info:
+  statement_type: SELECT
+  tables:
+  - indexed_count
+  setup_blocks:
+  - indexed_count_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN indexed_count
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4              p5  comment
+   0  Init          0   8   0                   0  Start at 8
+   1  Null          0   2   0                   0  r[2]=NULL
+   2  OpenRead      0   2   0  k(5,B,B,B,B,B)   0  table=indexed_count, root=2, iDb=0
+   3  Count         0   3   0                   0
+   4  Close         0   0   0                   0
+   5  Copy          3   1   0                   0  r[1]=r[3]
+   6  ResultRow     1   1   0                   0  output=r[1]
+   7  Halt          0   0   0                   0
+   8  Transaction   0   1   4                   0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-simple-count.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-simple-count.snap
@@ -11,26 +11,26 @@ info:
 ---
 QUERY PLAN
 |--SCALAR SUBQUERY 1
-|  `--SCAN orders
+|  `--SCAN orders USING COVERING INDEX idx_orders_customer
 `--SCAN CONSTANT ROW
 
 BYTECODE
-addr  opcode         p1  p2  p3  p4            p5  comment
-   0    Init          0  16   0                 0  Start at 16
-   1    Once         13   0   0                 0  goto 13
-   2    BeginSubrtn   2   0   0                 0  r[2]=NULL
-   3    Null          0   1   0                 0  r[1]=NULL
-   4    Null          0   4   0                 0  r[4]=NULL
-   5    Integer       1   5   0                 0  r[5]=1; LIMIT counter
-   6    IfNot         5  12   0                 0  if !r[5] goto 12
-   7    OpenRead      0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   8    Count         0   6   0                 0
-   9    Close         0   0   0                 0
-  10    Copy          6   3   0                 0  r[3]=r[6]
-  11    Copy          3   1   0                 0  r[1]=r[3]
-  12  Return          2   0   1                 0
-  13  Copy            1   7   0                 0  r[7]=r[1]
-  14  ResultRow       7   1   0                 0  output=r[7]
-  15  Halt            0   0   0                 0
-  16  Transaction     0   1  11                 0  iDb=0 tx_mode=Read
-  17  Goto            0   1   0                 0
+addr  opcode         p1  p2  p3  p4      p5  comment
+   0    Init          0  16   0           0  Start at 16
+   1    Once         13   0   0           0  goto 13
+   2    BeginSubrtn   2   0   0           0  r[2]=NULL
+   3    Null          0   1   0           0  r[1]=NULL
+   4    Null          0   4   0           0  r[4]=NULL
+   5    Integer       1   5   0           0  r[5]=1; LIMIT counter
+   6    IfNot         5  12   0           0  if !r[5] goto 12
+   7    OpenRead      0   9   0  k(2,B)   0  index=idx_orders_customer, root=9, iDb=0
+   8    Count         0   6   0           0
+   9    Close         0   0   0           0
+  10    Copy          6   3   0           0  r[3]=r[6]
+  11    Copy          3   1   0           0  r[1]=r[3]
+  12  Return          2   0   1           0
+  13  Copy            1   7   0           0  r[7]=r[1]
+  14  ResultRow       7   1   0           0  output=r[7]
+  15  Halt            0   0   0           0
+  16  Transaction     0   1  11           0  iDb=0 tx_mode=Read
+  17  Goto            0   1   0           0

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -1555,6 +1555,14 @@ fn test_cdc_drop_table_cleans_up_version(db: TempDatabase) {
     // Version entry should be cleaned up
     let rows = limbo_exec_rows(&conn, "SELECT COUNT(*) FROM turso_cdc_version");
     assert_eq!(rows, vec![vec![Value::Integer(0)]]);
+
+    // The cleanup must remove the primary-key index entry as well as the table row.
+    let rows = limbo_exec_rows(
+        &conn,
+        "SELECT COUNT(*) FROM turso_cdc_version \
+         INDEXED BY sqlite_autoindex_turso_cdc_version_1",
+    );
+    assert_eq!(rows, vec![vec![Value::Integer(0)]]);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description

Allow column-free scans to treat complete, non-custom B-tree indexes as covering. This lets COUNT(*) and other column-free scans use a lower-cost index candidate instead of always scanning the table B-tree.

Keep partial indexes excluded, allow the Count opcode to operate on an index-backed B-tree cursor, and keep the turso_cdc_version primary-key index synchronized when DROP cleanup removes its table row.

## Motivation and context

COUNT(*) does not reference any table columns, so its column-used mask is empty. The covering-index check previously rejected every index in that case, even though a complete index contains one entry for every table row.

Allowing the index path also exposed a stale automatic primary-key index entry in the specialized CDC DROP cleanup. That cleanup now follows the normal deletion invariant by removing the index entry before deleting the table row, so table and index scans observe the same rows.

Partial indexes remain ineligible because they may omit rows. Custom index methods remain excluded because they do not provide the ordinary B-tree row-count semantics required by this path.

## Testing

- cargo +1.88 fmt --all -- --check
- cargo +1.88 clippy --workspace --all-features --all-targets --locked --exclude memory-benchmark -- --deny=warnings
- cargo +1.88 test -p turso_core --all-features
- CDC integration tests, including a forced automatic-index count after DROP cleanup
- Simple-count plan and result coverage for complete, partial, automatic, expression, forced, and narrow indexes
- Full release Rust SQL conformance suite with snapshot verification

## Description of AI Usage

This PR was developed with assistance from Codex. Codex was used to investigate the planner and Count opcode paths, implement the focused change, add regression tests, diagnose CI failures, and review the final diff. I reviewed the implementation and validated the behavior against SQLite.