### PR TITLE
sync/engine: temporarily use truncate checkpoint only in mvcc mode

### DIFF
--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -2756,13 +2756,35 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
     }
 
     pub async fn checkpoint<Ctx>(&self, coro: &Coro<Ctx>) -> Result<()> {
+        let main_conn = connect_untracked(&self.main_tape)?;
+        if self.meta().logical_mvcc_pull_active && main_conn.mvcc_enabled() {
+            let main_wal_state = main_conn.wal_state()?;
+            let result = main_conn.checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: Some(main_wal_state.max_frame),
+            })?;
+            tracing::info!(
+                "checkpoint(path={:?}): logical MVCC TRUNCATE checkpoint result: {:?}",
+                self.main_db_path,
+                result
+            );
+            if !result.everything_backfilled() {
+                return Err(LimboError::Busy.into());
+            }
+            self.update_meta(coro, |meta| {
+                meta.revert_since_wal_salt = None;
+                meta.revert_since_wal_watermark = 0;
+            })
+            .await?;
+            publish_schema_after_sync_checkpoint(&main_conn)?;
+            return Ok(());
+        }
+
         let (main_wal_salt, watermark) = self.checkpoint_passive(coro).await?;
 
         tracing::info!(
             "checkpoint(path={:?}): passive checkpoint is done",
             self.main_db_path
         );
-        let main_conn = connect_untracked(&self.main_tape)?;
         let revert_conn = self.open_revert_db_conn(coro).await?;
 
         let mut page = [0u8; PAGE_SIZE];

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -3815,30 +3815,14 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 use_pushed_change_hint_for_local_replay(stream_kind, raw_page_replay_on_sql_conn);
 
             // Phase 4: as now DB has all data from remote - let's read pull generation and last change id for current client
-            let (remote_pull_gen, remote_last_change_id) = if replace_base_pages {
-                tracing::info!(
-                    "apply_changes(path={}): using local acknowledged high-water mark for replace-base replay floor: pull_gen={} change_id={:?}",
-                    self.main_db_path,
-                    local_pull_gen,
-                    local_last_change_id,
-                );
-                (
-                    local_pull_gen,
-                    if no_checkpoint_replace_base {
-                        None
-                    } else {
-                        local_last_change_id
-                    },
-                )
-            } else {
+            let (remote_pull_gen, remote_last_change_id) =
                 read_last_change_id(coro, phase_conn, &self.client_unique_id)
                     .await
                     .map_err(|error| {
                         Error::DatabaseSyncEngineError(format!(
                             "failed to read last_change_id after remote apply: {error}",
                         ))
-                    })?
-            };
+                    })?;
 
             if remote_pull_gen > local_pull_gen {
                 return Err(Error::DatabaseSyncEngineError(format!(


### PR DESCRIPTION
Passive checkpoints in MVCC are still experimental.. now that they technically exist in mvcc mode we have to explicitly truncate checkpoint.

Also includes a turso core fix found by the fuzzer:

Read `turso_sync_last_change_id` from the installed remote snapshot when applying a logical MVCC replace-base response and use that acknowledgement as the local CDC replay floor.

## Problem

An MVCC replace-base response installs the server's checkpointed generation base and then performs a logical pull from that base revision to recover the uncheckpointed generation tail. The sync engine preserves the client's local CDC before replacing the database so it can restore transactions originating from that client after applying the remote state.

The checkpointed base already contains some prefix of those local changes. Its `turso_sync_last_change_id` row identifies exactly which changes from this client are represented in the installed page image.

The logical MVCC replace-base path previously ignored that row and forced the acknowledged change ID to `None`. This made the replay floor zero, causing the engine to replay historical local CDC that was already present in the base. A stale local update could consequently overwrite a newer remote update applied by the follow-up logical pull.

## Fix

For replace-base responses with logical MVCC pull enabled, read the client's acknowledgement row from the post-restore connection and use it to calculate the local replay floor. This gives the apply sequence the intended behavior:

1. Preserve local CDC.
2. Install the checkpointed remote base.
3. Apply the remote logical-log tail.
4. Replay only local changes newer than the acknowledgement contained in the base.

This complements the server behavior that advertises an MVCC replace-base page image at `{ generation, log_offset: 0, wal_fragment_no: 0 }`, allowing the follow-up pull to stream the rest of that generation.
