### PR TITLE
bindings/c: implement sqlite3_deserialize

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -823,7 +823,7 @@ Modifiers:
 | Interface              | Status  | Comment |
 |------------------------|---------|---------|
 | sqlite3_serialize      | ❌ No      | Stub    |
-| sqlite3_deserialize    | ❌ No      | Stub    |
+| sqlite3_deserialize    | 🚧 Partial | Copy-based (image copied into a MemoryIO); `FREEONCLOSE` honored; `RESIZEABLE`/`READONLY` rejected (`SQLITE_ERROR`); only the `main` schema |
 
 ### Miscellaneous
 

--- a/bindings/c/include/sqlite3.h
+++ b/bindings/c/include/sqlite3.h
@@ -135,7 +135,10 @@ sqlite3_stmt *sqlite3_next_stmt(sqlite3 *db, sqlite3_stmt *stmt);
 
 int sqlite3_serialize(sqlite3 *_db, const char *_schema, void **_out, int *_out_bytes, unsigned int _flags);
 
-int sqlite3_deserialize(sqlite3 *_db, const char *_schema, const void *_in_, int _in_bytes, unsigned int _flags);
+#define SQLITE_DESERIALIZE_FREEONCLOSE 1 /* Call sqlite3_free() on close */
+#define SQLITE_DESERIALIZE_RESIZEABLE  2 /* Resize using sqlite3_realloc64() */
+#define SQLITE_DESERIALIZE_READONLY    4 /* Database is read-only */
+int sqlite3_deserialize(sqlite3 *db, const char *zSchema, unsigned char *pData, sqlite3_int64 szDb, sqlite3_int64 szBuf, unsigned int mFlags);
 
 int sqlite3_get_autocommit(sqlite3 *_db);
 

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -425,6 +425,11 @@ pub const SQLITE_OPEN_SHAREDCACHE: ffi::c_int = 0x00020000;
 pub const SQLITE_OPEN_PRIVATECACHE: ffi::c_int = 0x00040000;
 pub const SQLITE_OPEN_NOFOLLOW: ffi::c_int = 0x01000000;
 
+/* Flags for sqlite3_deserialize() */
+pub const SQLITE_DESERIALIZE_FREEONCLOSE: ffi::c_uint = 1;
+pub const SQLITE_DESERIALIZE_RESIZEABLE: ffi::c_uint = 2;
+pub const SQLITE_DESERIALIZE_READONLY: ffi::c_uint = 4;
+
 /// Percent-decode a URI component (e.g., `%20` -> ` `, `%2F` -> `/`).
 /// Returns None if a percent sequence is malformed or the result is not valid UTF-8.
 fn percent_decode(input: &str) -> Option<String> {
@@ -1351,15 +1356,108 @@ pub unsafe extern "C" fn sqlite3_serialize(
     stub!();
 }
 
+/// Open the database `db` on the contents of the in-memory image `p_data`.
+///
+/// Copy-based (not zero-copy): the first `sz_db` bytes are copied into a fresh
+/// in-memory IO backend, a database is opened over it (mirroring
+/// `sqlite3_open(":memory:")`), and the connection on `db` is swapped to it.
+///
+/// Flags: `SQLITE_DESERIALIZE_FREEONCLOSE` is honored (the image is copied, so
+/// the caller's buffer is freed immediately via `sqlite3_free`, including on
+/// failure, per the SQLite contract). `SQLITE_DESERIALIZE_RESIZEABLE` and
+/// `SQLITE_DESERIALIZE_READONLY` are not yet supported and are rejected with
+/// `SQLITE_ERROR` rather than silently ignored. `sz_buf` (buffer capacity, only
+/// meaningful for RESIZEABLE) is unused. Only the `main` schema is supported.
+///
+/// A zero-copy variant would implement a borrowed-buffer `DatabaseStorage` via
+/// `OpenOptions::storage` instead of copying — tracked as a follow-up.
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_deserialize(
-    _db: *mut sqlite3,
-    _schema: *const ffi::c_char,
-    _in_: *const ffi::c_void,
-    _in_bytes: ffi::c_int,
-    _flags: ffi::c_uint,
+    db: *mut sqlite3,
+    schema: *const ffi::c_char,
+    p_data: *mut ffi::c_uchar,
+    sz_db: i64,
+    _sz_buf: i64,
+    flags: ffi::c_uint,
 ) -> ffi::c_int {
-    stub!();
+    trace!("sqlite3_deserialize");
+    // Per the SQLite contract, FREEONCLOSE transfers buffer ownership to us and
+    // is honored even when deserialization fails. Since we copy, free eagerly.
+    let free_on_close = flags & SQLITE_DESERIALIZE_FREEONCLOSE != 0;
+    let maybe_free = |p: *mut ffi::c_uchar| {
+        if free_on_close && !p.is_null() {
+            unsafe { sqlite3_free(p as *mut ffi::c_void) };
+        }
+    };
+    if db.is_null() || p_data.is_null() || sz_db < 0 {
+        maybe_free(p_data);
+        return SQLITE_MISUSE;
+    }
+    // Reject flags we cannot honor rather than silently mis-serving the caller.
+    if flags & (SQLITE_DESERIALIZE_RESIZEABLE | SQLITE_DESERIALIZE_READONLY) != 0 {
+        maybe_free(p_data);
+        return SQLITE_ERROR;
+    }
+    // Only the main schema is supported; anything else would silently replace it.
+    if !schema.is_null() && CStr::from_ptr(schema).to_str() != Ok("main") {
+        maybe_free(p_data);
+        return SQLITE_ERROR;
+    }
+    let Ok(len) = usize::try_from(sz_db) else {
+        maybe_free(p_data);
+        return SQLITE_TOOBIG;
+    };
+    let db_ref: &sqlite3 = &*db;
+    let mut inner = db_ref.inner.lock().unwrap();
+    // SQLite refuses deserialize while statements are open OR a transaction is
+    // active on the connection (exec-driven BEGIN leaves no sqlite3_stmt, so the
+    // autocommit check is required in addition to the stmt list).
+    if !inner.stmt_list.is_null() || !inner.conn.get_auto_commit() {
+        maybe_free(p_data);
+        return SQLITE_BUSY;
+    }
+    // Copy the caller-provided image, then release the caller's buffer if owned.
+    let bytes = std::slice::from_raw_parts(p_data as *const u8, len).to_vec();
+    maybe_free(p_data);
+    // Fresh in-memory IO seeded with the image (MemoryIO caches files by path,
+    // so the seeded pages are visible to the subsequent Database open).
+    let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::MemoryIO::new());
+    let file = match io.open_file(":memory:", turso_core::OpenFlags::Create, false) {
+        Ok(f) => f,
+        Err(_) => return SQLITE_CANTOPEN,
+    };
+    let buf = Arc::new(turso_core::Buffer::new(bytes));
+    if file
+        .pwrite(0, buf, turso_core::Completion::new_write(|_| {}))
+        .is_err()
+    {
+        return SQLITE_IOERR;
+    }
+    match turso_core::Database::open_file_with_flags(
+        io.clone(),
+        ":memory:",
+        turso_core::OpenFlags::default(),
+        default_db_opts(),
+        None,
+        Arc::new(SqliteDialect),
+    ) {
+        Ok(new_db) => match new_db.connect() {
+            Ok(conn) => {
+                inner._io = io;
+                inner._db = new_db;
+                inner.conn = conn;
+                SQLITE_OK
+            }
+            Err(e) => {
+                trace!("sqlite3_deserialize: connect failed: {e:?}");
+                SQLITE_ERROR
+            }
+        },
+        Err(e) => {
+            trace!("sqlite3_deserialize: open failed: {e:?}");
+            SQLITE_CANTOPEN
+        }
+    }
 }
 
 #[no_mangle]
@@ -3233,6 +3331,86 @@ unsafe fn set_db_err(db: &mut sqlite3Inner, err: LimboError) -> i32 {
 mod tests {
     use super::*;
     use std::ptr;
+
+    // sqlite3_deserialize round-trips a real database image: build a populated
+    // database through the C API, read its on-disk bytes, deserialize them into
+    // a fresh :memory: connection, and query. Self-contained; fails without the
+    // implementation (the prior stub aborts).
+    #[test]
+    fn sqlite3_deserialize_roundtrips_a_populated_database() {
+        unsafe {
+            // 1. Build a populated on-disk database via the C API.
+            let tmp = std::env::temp_dir()
+                .join(format!("turso_deserialize_test_{}.db", std::process::id()));
+            let wal = std::path::PathBuf::from(format!("{}-wal", tmp.display()));
+            let shm = std::path::PathBuf::from(format!("{}-shm", tmp.display()));
+            let clean = || {
+                let _ = std::fs::remove_file(&tmp);
+                let _ = std::fs::remove_file(&wal);
+                let _ = std::fs::remove_file(&shm);
+            };
+            clean();
+            let tmp_c = std::ffi::CString::new(tmp.to_str().unwrap()).unwrap();
+            let mut wdb = ptr::null_mut();
+            assert_eq!(sqlite3_open(tmp_c.as_ptr(), &mut wdb), SQLITE_OK);
+            assert_eq!(
+                sqlite3_exec(
+                    wdb,
+                    c"CREATE TABLE t(id INTEGER, name TEXT)".as_ptr(),
+                    None,
+                    ptr::null_mut(),
+                    ptr::null_mut()
+                ),
+                SQLITE_OK
+            );
+            for i in 0..100 {
+                let sql =
+                    std::ffi::CString::new(format!("INSERT INTO t VALUES ({i}, 'n{i}')")).unwrap();
+                assert_eq!(
+                    sqlite3_exec(wdb, sql.as_ptr(), None, ptr::null_mut(), ptr::null_mut()),
+                    SQLITE_OK
+                );
+            }
+            // Flush the WAL into the main file so the raw bytes are complete.
+            assert_eq!(sqlite3_wal_checkpoint(wdb, ptr::null()), SQLITE_OK);
+            sqlite3_close(wdb);
+
+            // 2. Read the on-disk image.
+            let bytes = std::fs::read(&tmp).unwrap();
+            assert!(!bytes.is_empty(), "on-disk image is empty");
+
+            // 3. Deserialize the image into a fresh in-memory connection.
+            let mut db = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+            let rc = sqlite3_deserialize(
+                db,
+                c"main".as_ptr(),
+                bytes.as_ptr() as *mut ffi::c_uchar,
+                bytes.len() as i64,
+                bytes.len() as i64,
+                0,
+            );
+            assert_eq!(rc, SQLITE_OK, "deserialize rc={rc}");
+
+            // 4. Query the deserialized database.
+            let mut stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT count(*) FROM t".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut()
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+            assert_eq!(sqlite3_column_int64(stmt, 0), 100, "deserialized row count");
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            clean();
+        }
+    }
 
     #[test]
     fn test_sqlite3_stmt_status_rows_read_written() {

--- a/bindings/c/tests/sqlite3_tests.c
+++ b/bindings/c/tests/sqlite3_tests.c
@@ -21,6 +21,7 @@ void test_sqlite3_column_decltype();
 void test_sqlite3_next_stmt();
 void test_sqlite3_table_column_metadata();
 void test_sqlite3_insert_returning();
+void test_sqlite3_deserialize();
 
 int allocated = 0;
 
@@ -41,6 +42,7 @@ int main(void)
     test_sqlite3_next_stmt();
     test_sqlite3_table_column_metadata();
     test_sqlite3_insert_returning();
+    test_sqlite3_deserialize();
     return 0;
 }
 
@@ -791,4 +793,63 @@ void test_sqlite3_insert_returning()
     sqlite3_close(db);
 
     printf("test_sqlite3_insert_retuning test passed\n");
+}
+void test_sqlite3_deserialize()
+{
+    // Build a populated on-disk database, read its bytes, and deserialize them
+    // into a fresh in-memory connection. Runs against both real SQLite and
+    // Turso, so it verifies behavioral parity.
+    const char *path = "test_deserialize_tmp.db";
+    char wal[512], shm[512];
+    snprintf(wal, sizeof(wal), "%s-wal", path);
+    snprintf(shm, sizeof(shm), "%s-shm", path);
+    remove(path);
+    remove(wal);
+    remove(shm);
+
+    sqlite3 *wdb;
+    assert(sqlite3_open(path, &wdb) == SQLITE_OK);
+    assert(sqlite3_exec(wdb, "CREATE TABLE t(id INTEGER, name TEXT)", 0, 0, 0) ==
+           SQLITE_OK);
+    for (int i = 0; i < 100; i++) {
+        char sql[64];
+        snprintf(sql, sizeof(sql), "INSERT INTO t VALUES (%d, 'n%d')", i, i);
+        assert(sqlite3_exec(wdb, sql, 0, 0, 0) == SQLITE_OK);
+    }
+    // Flush the WAL into the main file (Turso); a no-op on a rollback journal.
+    sqlite3_wal_checkpoint(wdb, NULL);
+    sqlite3_close(wdb);
+
+    // Read the on-disk image.
+    FILE *f = fopen(path, "rb");
+    assert(f != NULL);
+    assert(fseek(f, 0, SEEK_END) == 0);
+    long sz = ftell(f);
+    assert(sz > 0);
+    assert(fseek(f, 0, SEEK_SET) == 0);
+    unsigned char *buf = (unsigned char *)malloc((size_t)sz);
+    assert(buf != NULL);
+    assert(fread(buf, 1, (size_t)sz, f) == (size_t)sz);
+    fclose(f);
+
+    // Deserialize into a fresh in-memory connection. With flags=0 the buffer is
+    // used in place by real SQLite, so it must outlive the connection: free
+    // after close.
+    sqlite3 *db;
+    assert(sqlite3_open(":memory:", &db) == SQLITE_OK);
+    assert(sqlite3_deserialize(db, "main", buf, sz, sz, 0) == SQLITE_OK);
+
+    sqlite3_stmt *stmt;
+    assert(sqlite3_prepare_v2(db, "SELECT count(*) FROM t", -1, &stmt, NULL) ==
+           SQLITE_OK);
+    assert(sqlite3_step(stmt) == SQLITE_ROW);
+    assert(sqlite3_column_int64(stmt, 0) == 100);
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+    free(buf);
+
+    remove(path);
+    remove(wal);
+    remove(shm);
+    printf("test_sqlite3_deserialize passed\n");
 }


### PR DESCRIPTION
> Draft — opening for early visibility; I'll mark it Ready after a final self-review. Happy to take edits from maintainers.

## Description

`sqlite3_deserialize` was a `todo!()` stub that aborts across the FFI boundary. This implements the copy-based path: the caller's image is copied into a fresh `MemoryIO` (which caches files by path), seeded via `File::pwrite`, a `Database` is opened over it mirroring `sqlite3_open(":memory:")`, and the connection on the handle is swapped — returning `SQLITE_BUSY` if statements are open or a transaction is active.

It adopts SQLite's exact prototype (6 args, `sqlite3_int64` sizes, `unsigned mFlags`) in both the function and the committed `sqlite3.h`, so the ABI doesn't diverge from the symbol it implements. `SQLITE_DESERIALIZE_FREEONCLOSE` is honored (the image is copied, so the buffer is freed via `sqlite3_free`, including on failure); `RESIZEABLE`/`READONLY` are rejected with `SQLITE_ERROR` rather than silently ignored; a non-`main` schema is refused. `COMPAT.md` moves the row `❌ No / Stub` → `🚧 Partial` with the remaining limits.

## Motivation and context

`sqlite3_deserialize` opens a database from an in-memory image without touching the filesystem. The stub currently aborts the process, so any caller (or a wrapper probing for the symbol) crashes. The seam already exists: `Database::open` accepts caller storage via `OpenOptions::storage` (doc-commented "for a remote page server service"), the pager talks to `DatabaseStorage` rather than a file descriptor, and `:memory:` already implements the file trait over a page map — so a buffer-backed open is idiomatic here.

This is the copy-based first step. Natural follow-ups: a zero-copy variant (a borrowed-buffer `DatabaseStorage` over `OpenOptions::storage`, avoiding the copy) and the companion `sqlite3_serialize`.

Tests:
- `bindings/c/src/lib.rs`: builds a populated database through the C API, checkpoints, reads its on-disk bytes, deserializes them into a fresh `:memory:` connection, and queries it (fails without this change).
- `bindings/c/tests/sqlite3_tests.c`: a differential test that passes against both real `-lsqlite3` and `-lturso_sqlite3`.

## Description of AI Usage

Developed with substantial help from an AI coding agent (Claude Code) as a collaborator: exploring the storage/IO abstractions to confirm the approach, drafting the implementation against the existing `sqlite3_open` path, writing the Rust and C tests, and running an adversarial self-review that caught the signature, flag-handling, and transaction-guard issues before this was opened. I directed the work, reviewed it, ran fmt/clippy/tests locally, and take responsibility for the code.