### PR TITLE
whopper: wait for TRUNCATE checkpoint to reset WAL generation

### DIFF
--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -196,24 +196,49 @@ fn count_test_rows(whopper: &mut MultiprocessWhopper, worker_idx: usize) -> i64 
 
 #[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]
 fn truncate_checkpoint_until_stable(whopper: &mut MultiprocessWhopper, connection_idx: usize) {
-    for _ in 0..32 {
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+    const RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(10);
+
+    let started = std::time::Instant::now();
+    loop {
         let result = whopper
             .execute_sql_direct(connection_idx, "PRAGMA wal_checkpoint(TRUNCATE)")
             .expect("run TRUNCATE checkpoint");
-        match result {
-            Ok(_) => return,
+        let last_state = match result {
+            Ok(_) => {
+                let snapshot = whopper
+                    .shared_wal_snapshot_direct(connection_idx)
+                    .expect("read shared WAL snapshot after TRUNCATE checkpoint")
+                    .expect("shared WAL snapshot should exist after TRUNCATE checkpoint");
+                if snapshot.max_frame == 0 {
+                    return;
+                }
+                format!(
+                    "checkpoint returned successfully but WAL max_frame remained {}",
+                    snapshot.max_frame
+                )
+            }
             Err(
-                LimboError::Busy
+                err @ (LimboError::Busy
                 | LimboError::BusySnapshot
                 | LimboError::SchemaUpdated
                 | LimboError::SchemaConflict
                 | LimboError::TableLocked
-                | LimboError::OutOfMemory,
-            ) => continue,
+                | LimboError::OutOfMemory),
+            ) => format!("checkpoint returned {err}"),
             Err(err) => panic!("TRUNCATE checkpoint should stabilize: {err}"),
+        };
+
+        let elapsed = started.elapsed();
+        if elapsed >= TIMEOUT {
+            panic!(
+                "TRUNCATE checkpoint did not reset the WAL generation within {TIMEOUT:?}; last state: {last_state}"
+            );
         }
+
+        std::thread::yield_now();
+        std::thread::sleep(RETRY_BACKOFF.min(TIMEOUT.saturating_sub(elapsed)));
     }
-    panic!("TRUNCATE checkpoint did not stabilize after transient multiprocess errors");
 }
 
 #[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -223,8 +223,7 @@ fn truncate_checkpoint_until_stable(whopper: &mut MultiprocessWhopper, connectio
                 | LimboError::BusySnapshot
                 | LimboError::SchemaUpdated
                 | LimboError::SchemaConflict
-                | LimboError::TableLocked
-                | LimboError::OutOfMemory),
+                | LimboError::TableLocked),
             ) => format!("checkpoint returned {err}"),
             Err(err) => panic!("TRUNCATE checkpoint should stabilize: {err}"),
         };
@@ -236,7 +235,6 @@ fn truncate_checkpoint_until_stable(whopper: &mut MultiprocessWhopper, connectio
             );
         }
 
-        std::thread::yield_now();
         std::thread::sleep(RETRY_BACKOFF.min(TIMEOUT.saturating_sub(elapsed)));
     }
 }


### PR DESCRIPTION
`PRAGMA wal_checkpoint(TRUNCATE)` can return SQL success while a shared reader still keeps the current WAL generation alive. The regression helper treated that response as checkpoint completion, while known transient failures were retried 32 times without yielding. On loaded runners, those attempts can exhaust before cross-process state settles.

Make the helper wait for the actual invariant: the shared WAL snapshot must report `max_frame == 0`. Incomplete successful checkpoints and the existing known transient errors now yield and back off for 10 ms. A 10-second watchdog fails with the last observed state, and unexpected errors still fail immediately.