### PR TITLE
core/translate: remove duplicate clippy annotation

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -70,7 +70,6 @@ use update::translate_update;
 #[instrument(skip_all, level = Level::DEBUG)]
 #[allow(clippy::too_many_arguments)]
 #[turso_macros::trace_stack]
-#[allow(clippy::too_many_arguments)]
 pub fn translate(
     schema: &Schema,
     stmt: ast::Stmt,


### PR DESCRIPTION
Remove the duplicate `#[allow(clippy::too_many_arguments)]` attribute from the `translate` function definition.

# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description
Remove duplicate clippy annotation

## Motivation and context
I was reading the code and thought it would a good contribution to get me started.

## Description of AI Usage
Edits made manually and saved, agy cli to run the git commands with commit message review.
