### PR TITLE
perf(core): recycle record and value buffers through the register file

### DIFF
--- a/core/alloc/allocation_site.rs
+++ b/core/alloc/allocation_site.rs
@@ -18,6 +18,10 @@ pub enum ValueBlobAllocationSite {
     JsonbCopy,
     Hash128,
     RecordDecode,
+    CloneFrom,
+    RecordBuild,
+    RecordCopy,
+    AggAccumulate,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -13,10 +13,9 @@ use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
 use crate::sync::Arc;
 use crate::translate::plan::IterationDirection;
 use crate::types::{
-    compare_immutable, IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekKey, SeekOp,
-    SeekResult, Value,
+    compare_immutable, IOCompletions, IOResult, ImmutableRecord, IndexInfo, RecordBuf, SeekKey,
+    SeekOp, SeekResult, Value,
 };
-use crate::vdbe::make_record;
 use crate::vdbe::Register;
 use crate::{return_if_io, Completion, Connection, LimboError, Pager, Result};
 use std::any::Any;
@@ -506,6 +505,9 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator 
     tx_id: u64,
     /// Reusable immutable record, used to allow better allocation strategy.
     reusable_immutable_record: Option<ImmutableRecord>,
+    /// Spent buffer recycled across [`Self::seek_unpacked`] calls so each
+    /// seek's key record reuses one allocation.
+    seek_record_buf: Option<RecordBuf>,
     btree_cursor: Box<dyn CursorTrait>,
     null_flag: bool,
     creating_new_rowid: bool,
@@ -584,6 +586,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             current_pos: CursorPosition::BeforeFirst,
             table_id,
             reusable_immutable_record: None,
+            seek_record_buf: None,
             btree_cursor,
             null_flag: false,
             creating_new_rowid: false,
@@ -1486,8 +1489,11 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         registers: &[Register],
         op: SeekOp,
     ) -> Result<IOResult<SeekResult>> {
-        let record = make_record(registers, &0, &registers.len())?;
-        self.seek(SeekKey::IndexKey(record.as_record_ref()), op)
+        let buf = self.seek_record_buf.take().unwrap_or_else(RecordBuf::alloc);
+        let record = ImmutableRecord::build_from_registers(registers, buf)?;
+        let result = self.seek(SeekKey::IndexKey(record.as_record_ref()), op);
+        self.seek_record_buf = Some(record.retire());
+        result
     }
 
     fn seek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>> {

--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -1,24 +1,19 @@
-use crate::types::ImmutableRecord;
-
+/// A pseudo cursor exposes the record stored in its content register as a
+/// one-row table, mirroring SQLite's OpenPseudo. It holds no data itself:
+/// SorterData moves each record into the content register and Column ops
+/// decode straight out of it.
 pub struct PseudoCursor {
-    current: Option<ImmutableRecord>,
-}
-
-impl Default for PseudoCursor {
-    #[inline]
-    fn default() -> Self {
-        Self { current: None }
-    }
+    content_reg: usize,
 }
 
 impl PseudoCursor {
     #[inline]
-    pub fn record(&self) -> Option<&ImmutableRecord> {
-        self.current.as_ref()
+    pub fn new(content_reg: usize) -> Self {
+        Self { content_reg }
     }
 
     #[inline]
-    pub fn insert(&mut self, record: ImmutableRecord) {
-        self.current = Some(record);
+    pub fn content_reg(&self) -> usize {
+        self.content_reg
     }
 }

--- a/core/tests/record_alloc_fault.rs
+++ b/core/tests/record_alloc_fault.rs
@@ -1,0 +1,349 @@
+//! Allocation-failure behavior of the record buffer-recycling paths.
+//!
+//! Installs a process-wide allocator backend that fails tagged allocations
+//! while armed on the current thread, then drives the fallible record and
+//! value-copy APIs through failure and recovery. Runs as its own test binary
+//! because the Turso allocator backend is process-global and set-once.
+//!
+//! Requires `--cfg nightly` (only the allocator-aware `Vec<T, TursoAllocator>`
+//! routes through the backend) and the `allocation_metric` feature (the
+//! allocation-site guards compile to nothing without it). Run with:
+//! `RUSTFLAGS="--cfg nightly" cargo +nightly test -p turso_core \
+//!     --features allocation_metric --test record_alloc_fault`
+//! The concurrent simulator soaks the same sites probabilistically in CI via
+//! `--allocation-fault-probability`.
+//!
+//! The Text arm of `Value::try_clone_from` is fallible through
+//! `String::try_reserve` but not injectable here: `String` is not
+//! allocator-parameterized, so its growth never reaches the Turso backend.
+#![cfg(all(nightly, feature = "allocation_metric"))]
+#![feature(allocator_api)]
+
+use std::cell::Cell;
+use std::ptr::NonNull;
+use std::sync::Once;
+
+use turso_core::alloc::{
+    set_allocator, AllocError, AllocationSite, ApiAllocator, Global, Layout, TursoAllocBackend,
+    ValueBlobAllocationSite,
+};
+use turso_core::types::{ImmutableRecord, RecordBuf, Value};
+
+#[derive(Clone, Copy, PartialEq)]
+enum FailMode {
+    Disarmed,
+    /// Fail every tagged allocation site.
+    AllTagged,
+    /// Fail only the record buffer-recycling sites.
+    RecyclingSites,
+    /// Fail the aggregate-accumulation site and the value-copy site
+    /// aggregates stage their arguments through.
+    AggSites,
+}
+
+thread_local! {
+    static ARMED: Cell<FailMode> = const { Cell::new(FailMode::Disarmed) };
+}
+
+fn is_recycling_site(site: AllocationSite) -> bool {
+    matches!(
+        site,
+        AllocationSite::ValueBlob(
+            ValueBlobAllocationSite::CloneFrom
+                | ValueBlobAllocationSite::RecordBuild
+                | ValueBlobAllocationSite::RecordCopy
+        )
+    )
+}
+
+struct FailTaggedWhileArmed;
+
+unsafe impl TursoAllocBackend for FailTaggedWhileArmed {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let fail = match (
+            ARMED.with(Cell::get),
+            turso_core::alloc::current_allocation_site(),
+        ) {
+            (FailMode::Disarmed, _) | (_, None) => false,
+            (_, Some(AllocationSite::NoFaultInjection)) => false,
+            (FailMode::AllTagged, Some(_)) => true,
+            (FailMode::RecyclingSites, Some(site)) => is_recycling_site(site),
+            (FailMode::AggSites, Some(site)) => matches!(
+                site,
+                AllocationSite::ValueBlob(
+                    ValueBlobAllocationSite::AggAccumulate | ValueBlobAllocationSite::CloneFrom
+                )
+            ),
+        };
+        if fail {
+            return Err(AllocError);
+        }
+        Global.allocate(layout)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe { Global.deallocate(ptr, layout) }
+    }
+}
+
+static BACKEND: FailTaggedWhileArmed = FailTaggedWhileArmed;
+static INSTALL: Once = Once::new();
+
+fn with_failing_mode<T>(mode: FailMode, f: impl FnOnce() -> T) -> T {
+    INSTALL.call_once(|| {
+        unsafe { set_allocator(&BACKEND) }.expect("no other backend installed in this process");
+    });
+    ARMED.with(|armed| armed.set(mode));
+    let result = f();
+    ARMED.with(|armed| armed.set(FailMode::Disarmed));
+    result
+}
+
+fn with_failing_allocations<T>(f: impl FnOnce() -> T) -> T {
+    with_failing_mode(FailMode::AllTagged, f)
+}
+
+fn sample_values() -> Vec<Value> {
+    vec![
+        Value::build_text(String::from(
+            "a text value long enough to require a real heap allocation",
+        )),
+        Value::Blob({
+            let mut blob = turso_core::alloc::vec![];
+            blob.extend(0u8..96);
+            blob
+        }),
+        Value::from_i64(1234567890),
+        Value::Null,
+    ]
+}
+
+#[test]
+fn record_build_fails_without_panicking_and_recovers() {
+    let values = sample_values();
+    let expected = ImmutableRecord::from_values(&values, values.len()).unwrap();
+
+    // Growth from an empty buffer must allocate; while armed it errors.
+    let err = with_failing_allocations(|| ImmutableRecord::build(&values, RecordBuf::alloc()));
+    assert!(err.is_err(), "build under allocation failure must error");
+
+    // The same call succeeds once allocations recover, byte-identical.
+    let record = ImmutableRecord::build(&values, RecordBuf::alloc()).unwrap();
+    assert_eq!(record.get_payload(), expected.get_payload());
+}
+
+#[test]
+fn record_build_into_recycled_buffer_needs_no_allocation() {
+    let values = sample_values();
+    let record = ImmutableRecord::build(&values, RecordBuf::alloc()).unwrap();
+    let expected = record.get_payload().to_vec();
+
+    // A recycled buffer with sufficient capacity allocates nothing, so the
+    // rebuild succeeds even while every tagged allocation fails.
+    let rebuilt = with_failing_allocations(|| ImmutableRecord::build(&values, record.retire()))
+        .expect("recycled-buffer build must not allocate");
+    assert_eq!(rebuilt.get_payload(), expected);
+}
+
+#[test]
+fn record_copy_payload_fails_without_panicking_and_recovers() {
+    let values = sample_values();
+    let source = ImmutableRecord::from_values(&values, values.len()).unwrap();
+
+    let err = with_failing_allocations(|| {
+        ImmutableRecord::copy_payload(source.get_payload(), RecordBuf::alloc())
+    });
+    assert!(
+        err.is_err(),
+        "copy_payload under allocation failure must error"
+    );
+
+    let copy = ImmutableRecord::copy_payload(source.get_payload(), RecordBuf::alloc()).unwrap();
+    assert_eq!(copy.get_payload(), source.get_payload());
+
+    // With a recycled buffer of sufficient capacity the copy allocates nothing.
+    let spare = ImmutableRecord::copy_payload(source.get_payload(), RecordBuf::alloc()).unwrap();
+    let recopied = with_failing_allocations(|| {
+        ImmutableRecord::copy_payload(source.get_payload(), spare.retire())
+    })
+    .expect("recycled-buffer copy must not allocate");
+    assert_eq!(recopied.get_payload(), source.get_payload());
+}
+
+#[test]
+fn value_try_clone_from_fails_without_panicking_and_stays_valid() {
+    // Blob growth past the destination's capacity errors while armed and
+    // leaves the destination valid (empty but usable).
+    let mut big = turso_core::alloc::vec![];
+    big.extend(0u8..128);
+    let src = Value::Blob(big);
+    let mut dst = Value::Blob(turso_core::alloc::vec![1, 2, 3]);
+    let err = with_failing_allocations(|| dst.try_clone_from(&src));
+    assert!(
+        err.is_err(),
+        "blob growth under allocation failure must error"
+    );
+    match &dst {
+        Value::Blob(b) => assert!(b.is_empty()),
+        other => panic!("destination changed variant: {other:?}"),
+    }
+    dst.try_clone_from(&src).unwrap();
+    assert_eq!(dst, src);
+
+    // A destination whose buffer already fits the source copies without
+    // allocating, even while armed.
+    let small = Value::Blob(turso_core::alloc::vec![9, 9]);
+    with_failing_allocations(|| dst.try_clone_from(&small))
+        .expect("in-capacity blob copy must not allocate");
+    assert_eq!(dst, small);
+
+    // Variant mismatch allocates a fresh value; that path is fallible too and
+    // leaves the destination untouched on failure.
+    let mut dst = Value::from_i64(7);
+    let err = with_failing_allocations(|| dst.try_clone_from(&src));
+    assert!(
+        err.is_err(),
+        "mismatch copy under allocation failure must error"
+    );
+    assert_eq!(dst, Value::from_i64(7));
+    dst.try_clone_from(&src).unwrap();
+    assert_eq!(dst, src);
+}
+
+mod end_to_end {
+    use super::{with_failing_mode, FailMode};
+    use std::sync::Arc;
+    use turso_core::{Database, SqliteDialect, StepResult, Value};
+
+    fn open_mem_db() -> (Arc<Database>, Arc<turso_core::Connection>) {
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io = Arc::new(turso_core::MemoryIO::new());
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        (db, conn)
+    }
+
+    fn run(
+        db: &Database,
+        conn: &Arc<turso_core::Connection>,
+        sql: &str,
+    ) -> turso_core::Result<Vec<Value>> {
+        let mut stmt = conn.prepare(sql)?;
+        let mut first_col = Vec::new();
+        loop {
+            match stmt.step()? {
+                StepResult::Row => {
+                    let row = stmt.row().expect("row available after StepResult::Row");
+                    first_col.push(row.get_value(0).clone());
+                }
+                StepResult::IO | StepResult::Yield => {
+                    db.io.step()?;
+                }
+                StepResult::Done => break,
+                StepResult::Interrupt | StepResult::Busy => {
+                    panic!("unexpected step result")
+                }
+            }
+        }
+        Ok(first_col)
+    }
+
+    /// A sorted query and an INSERT surface allocation failures in the record
+    /// buffer-recycling opcodes (MakeRecord, RowData, SorterData) as statement
+    /// errors, without panicking, and the connection stays usable.
+    #[test]
+    fn statements_error_cleanly_when_recycling_sites_fail() {
+        let (db, conn) = open_mem_db();
+        run(&db, &conn, "CREATE TABLE t (x INTEGER, y TEXT)").unwrap();
+        for i in 0..100 {
+            run(
+                &db,
+                &conn,
+                &format!("INSERT INTO t VALUES ({i}, 'row payload number {i} with some heft')"),
+            )
+            .unwrap();
+        }
+
+        let select = "SELECT y FROM t ORDER BY y DESC";
+        let insert = "INSERT INTO t VALUES (100, 'inserted under allocation failure')";
+
+        let select_err = with_failing_mode(FailMode::RecyclingSites, || run(&db, &conn, select));
+        assert!(
+            select_err.is_err(),
+            "ORDER BY under failing recycling sites must error, got {select_err:?}"
+        );
+        let insert_err = with_failing_mode(FailMode::RecyclingSites, || run(&db, &conn, insert));
+        assert!(
+            insert_err.is_err(),
+            "INSERT under failing recycling sites must error, got {insert_err:?}"
+        );
+
+        // The connection recovers: the same statements succeed afterwards and
+        // the sorted result reflects only the successful inserts.
+        run(&db, &conn, insert).unwrap();
+        let rows = run(&db, &conn, select).unwrap();
+        assert_eq!(rows.len(), 101);
+        let mut sorted = rows.clone();
+        sorted.sort_by(|a, b| b.cmp(a));
+        assert_eq!(rows, sorted, "results are ordered DESC");
+    }
+
+    /// Aggregate and window-function statements surface allocation failures
+    /// in the accumulator paths as statement errors, without panicking, and
+    /// the connection recovers.
+    ///
+    /// Only blob-backed accumulators are injectable: group_concat accumulates
+    /// into a String, which is not allocator-parameterized, so its (fallible)
+    /// growth never reaches the Turso backend — the same limitation as the
+    /// Text arm of `Value::try_clone_from`. json_group_array grows a ValueBlob
+    /// (AggAccumulate) and last_value over growing blobs recaptures through
+    /// the Blob arm of try_clone_from (CloneFrom).
+    #[test]
+    fn aggregates_error_cleanly_when_agg_sites_fail() {
+        let (db, conn) = open_mem_db();
+        run(&db, &conn, "CREATE TABLE t (x INTEGER, y TEXT, b BLOB)").unwrap();
+        for i in 0..50 {
+            run(
+                &db,
+                &conn,
+                &format!(
+                    "INSERT INTO t VALUES ({i}, 'value {i} with enough text to allocate', zeroblob(64 + {i}))"
+                ),
+            )
+            .unwrap();
+        }
+
+        let json_group = "SELECT json_group_array(y) FROM t";
+        let last_value = "SELECT last_value(b) OVER (ORDER BY x) FROM t";
+
+        for sql in [json_group, last_value] {
+            let err = with_failing_mode(FailMode::AggSites, || run(&db, &conn, sql));
+            assert!(
+                err.is_err(),
+                "{sql} under failing aggregate sites must error, got {err:?}"
+            );
+        }
+
+        // Recovery: the aggregates produce full, correct results.
+        let rows = run(&db, &conn, json_group).unwrap();
+        let expected = format!(
+            "[{}]",
+            (0..50)
+                .map(|i| format!("\"value {i} with enough text to allocate\""))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        assert_eq!(rows, vec![Value::build_text(expected)]);
+        let rows = run(&db, &conn, last_value).unwrap();
+        assert_eq!(rows.len(), 50);
+
+        // group_concat is not injectable, but its rewritten accumulator path
+        // must still produce the exact concatenation.
+        let rows = run(&db, &conn, "SELECT group_concat(y, '|') FROM t").unwrap();
+        let expected = (0..50)
+            .map(|i| format!("value {i} with enough text to allocate"))
+            .collect::<Vec<_>>()
+            .join("|");
+        assert_eq!(rows, vec![Value::build_text(expected)]);
+    }
+}

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -451,10 +451,12 @@ fn emit_refill_index(
             order_collations_nulls,
             comparators: crate::alloc::vec![],
         });
-        let content_reg = program.alloc_register();
+        // SorterData moves each sorted record into the pseudo cursor's
+        // content register; the two must name the same register.
+        let sorted_record_reg = program.alloc_register();
         program.emit_insn(Insn::OpenPseudo {
             cursor_id: pseudo_cursor_id,
-            content_reg,
+            content_reg: sorted_record_reg,
             num_fields: columns.len() + 1,
         });
 
@@ -550,8 +552,6 @@ fn emit_refill_index(
             cursor_id: sorter_cursor_id,
             pc_if_empty: sorted_loop_end,
         });
-
-        let sorted_record_reg = program.alloc_register();
 
         if idx.unique {
             let goto_label = program.allocate_label();

--- a/core/types.rs
+++ b/core/types.rs
@@ -14,7 +14,9 @@ use crate::numeric::Numeric;
 use crate::pseudo::PseudoCursor;
 use crate::schema::Index;
 use crate::storage::btree::CursorTrait;
-use crate::storage::sqlite3_ondisk::{read_integer, read_value, read_varint, write_varint};
+use crate::storage::sqlite3_ondisk::{
+    read_integer, read_value, read_varint, varint_len, write_varint,
+};
 use crate::translate::collate::CollationSeq;
 use crate::translate::plan::IterationDirection;
 use crate::vdbe::sorter::Sorter;
@@ -338,6 +340,56 @@ pub enum Value {
     Numeric(Numeric),
     Text(Text),
     Blob(#[cfg_attr(feature = "serde", serde(with = "value_blob_serde"))] ValueBlob),
+}
+
+impl Value {
+    /// Fallibly copies `source` into `self`, reusing the existing Text/Blob
+    /// allocation when the variants match, so hot per-row copies are
+    /// allocation-free once buffers have grown to the row size. On allocation
+    /// failure `self` is left valid but unspecified (an empty Text/Blob).
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::CloneFrom)]
+    pub fn try_clone_from(&mut self, source: &Self) -> std::result::Result<(), TryReserveError> {
+        match (self, source) {
+            (Self::Text(dst), Self::Text(src)) => {
+                let src_str = src.as_str();
+                match &mut dst.value {
+                    Cow::Owned(s) => {
+                        s.clear();
+                        s.try_reserve(src_str.len())?;
+                        s.push_str(src_str);
+                    }
+                    borrowed => {
+                        let mut s = String::new();
+                        s.try_reserve(src_str.len())?;
+                        s.push_str(src_str);
+                        *borrowed = Cow::Owned(s);
+                    }
+                }
+                dst.subtype = src.subtype;
+            }
+            (Self::Blob(dst), Self::Blob(src)) => {
+                dst.clear();
+                dst.try_reserve(src.len())?;
+                dst.extend_from_slice(src);
+            }
+            (dst, src) => {
+                *dst = match src {
+                    Self::Text(t) => {
+                        let mut s = String::new();
+                        s.try_reserve(t.as_str().len())?;
+                        s.push_str(t.as_str());
+                        Self::Text(Text {
+                            value: Cow::Owned(s),
+                            subtype: t.subtype,
+                        })
+                    }
+                    Self::Blob(b) => Self::from_slice(b)?,
+                    other => other.clone(),
+                };
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -807,6 +859,25 @@ pub enum AggContext {
 }
 
 impl AggContext {
+    /// Fallible clone: the builtin payload's Vec and each contained Text/Blob
+    /// go through fallible reservation. External state holds only FFI
+    /// pointers and copies without allocating.
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::CloneFrom)]
+    pub fn try_clone(&self) -> Result<Self> {
+        match self {
+            Self::Builtin(payload) => {
+                let mut values = Vec::try_with_capacity_ext(payload.len())?;
+                for value in payload {
+                    let mut copy = Value::Null;
+                    copy.try_clone_from(value)?;
+                    values.push(copy);
+                }
+                Ok(Self::Builtin(values))
+            }
+            Self::External(_) => Ok(self.clone()),
+        }
+    }
+
     pub fn compute_external(&self) -> Result<Value> {
         if let Self::External(ext_state) = self {
             let mut final_value =
@@ -1508,12 +1579,51 @@ mod immutable_record {
         }
     }
 
+    /// A spent record buffer, obtained by retiring a record ([ImmutableRecord::retire],
+    /// [Register::take_buf]). Hot-path record construction requires one, so per-row
+    /// callers either recycle a previous record's allocation or go through the single
+    /// explicit entry point, [RecordBuf::alloc]. The wrapped buffer is always empty;
+    /// only its capacity carries over.
+    #[must_use = "dropping a RecordBuf discards a reusable allocation"]
+    pub struct RecordBuf(ValueBlob);
+
+    impl RecordBuf {
+        pub fn alloc() -> Self {
+            Self(crate::alloc::vec![])
+        }
+    }
+
     impl ImmutableRecord {
         pub fn new(payload_capacity: usize) -> Result<Self> {
             let mut payload = crate::alloc::vec![];
             payload.try_reserve_exact(payload_capacity)?;
             Ok(Self {
                 payload: Value::Blob(payload),
+            })
+        }
+
+        /// Consumes the record, keeping its allocation for reuse.
+        pub fn retire(self) -> RecordBuf {
+            let mut buf = self.into_payload();
+            buf.clear();
+            RecordBuf(buf)
+        }
+
+        /// An invalidated record backed by `buf`'s allocation.
+        pub fn from_buf(buf: RecordBuf) -> Self {
+            Self {
+                payload: Value::Blob(buf.0),
+            }
+        }
+
+        /// A record holding a copy of `payload`, serialized into `buf`.
+        #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::RecordCopy)]
+        pub fn copy_payload(payload: &[u8], buf: RecordBuf) -> Result<Self> {
+            let RecordBuf(mut buf) = buf;
+            buf.try_reserve(payload.len())?;
+            buf.extend_from_slice(payload);
+            Ok(Self {
+                payload: Value::Blob(buf),
             })
         }
 
@@ -1538,42 +1648,62 @@ mod immutable_record {
             Self::from_values(registers.into_iter().map(|x| x.get_value()), len)
         }
 
+        /// Like [Self::from_registers], but serializes into `buf`; see [Self::build].
+        pub fn build_from_registers<'a, I: Iterator<Item = &'a Register> + Clone>(
+            registers: impl IntoIterator<Item = &'a Register, IntoIter = I>,
+            buf: RecordBuf,
+        ) -> Result<Self> {
+            Self::build(registers.into_iter().map(|x| x.get_value()), buf)
+        }
+
         pub fn from_values<'a>(
             values: impl IntoIterator<Item = impl AsValueRef + 'a> + Clone,
-            len: usize,
+            _len: usize,
         ) -> Result<Self> {
-            let mut serials = Vec::try_with_capacity_ext(len)?;
+            Self::build(values, RecordBuf::alloc())
+        }
+
+        /// Serializes `values` into `buf`, allocating only when the buffer's
+        /// capacity is insufficient. Per-row callers recycle the destination
+        /// register's previous record buffer, making steady-state record
+        /// construction allocation-free.
+        #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::RecordBuild)]
+        pub fn build<'a>(
+            values: impl IntoIterator<Item = impl AsValueRef + 'a> + Clone,
+            buf: RecordBuf,
+        ) -> Result<Self> {
+            let RecordBuf(mut buf) = buf;
             let mut size_header = 0;
             let mut size_values = 0;
 
             let mut serial_type_buf = [0; 9];
-            // write serial types
+            // Sizing pass: the cloneable iterator is re-walked below to write
+            // the serial types, so no scratch buffer is needed.
             for value in values.clone() {
                 let serial_type = SerialType::from(value.as_value_ref());
-                let n = write_varint(&mut serial_type_buf[0..], serial_type.into());
-                serials.push((serial_type_buf, n));
-
-                let value_size = serial_type.size();
-
-                size_header += n;
-                size_values += value_size;
+                size_header += varint_len(serial_type.into());
+                size_values += serial_type.size();
             }
 
             let header_size = Record::calc_header_size(size_header);
 
             // 1. write header size
-            let mut buf = crate::alloc::vec![];
-            buf.try_reserve_exact(header_size + size_values)?;
-            assert_eq!(buf.capacity(), header_size + size_values);
+            let total_size = header_size + size_values;
+            if buf.capacity() < total_size {
+                // Relative to the empty buffer, so a no-op when capacity suffices.
+                buf.try_reserve_exact(total_size)?;
+            }
             let n = write_varint(&mut serial_type_buf, header_size as u64);
 
-            buf.resize(buf.capacity(), 0);
+            buf.resize(total_size, 0);
             let mut writer = AppendWriter::new(&mut buf, 0);
             writer.extend_from_slice(&serial_type_buf[..n]);
 
-            // 2. Write serial
-            for (value, n) in serials {
-                writer.extend_from_slice(&value[..n]);
+            // 2. Write serial types
+            for value in values.clone() {
+                let serial_type = SerialType::from(value.as_value_ref());
+                let n = write_varint(&mut serial_type_buf[0..], serial_type.into());
+                writer.extend_from_slice(&serial_type_buf[..n]);
             }
 
             // write content
@@ -1651,6 +1781,7 @@ mod immutable_record {
         }
 
         #[inline]
+        #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::RecordCopy)]
         pub fn start_serialization(&mut self, payload: &[u8]) -> Result<()> {
             let blob = self.as_blob_mut();
             blob.try_reserve(payload.len())?;
@@ -1717,7 +1848,7 @@ mod immutable_record {
     }
 }
 
-pub use immutable_record::{ImmutableRecord, ImmutableRecordRef};
+pub use immutable_record::{ImmutableRecord, ImmutableRecordRef, RecordBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Record {
@@ -4503,5 +4634,96 @@ mod tests {
                 "column_count should be {num_values}, not {cnt}"
             );
         }
+    }
+
+    #[test]
+    fn test_value_try_clone_from_reuses_allocations() {
+        // Text into Text: an owned destination String buffer is reused.
+        let src = Value::build_text(String::from("short"));
+        let mut dst =
+            Value::build_text(String::from("a destination string with plenty of capacity"));
+        let ptr = match &dst {
+            Value::Text(t) => t.as_str().as_ptr(),
+            _ => unreachable!(),
+        };
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        match &dst {
+            Value::Text(t) => assert_eq!(t.as_str().as_ptr(), ptr),
+            _ => unreachable!(),
+        }
+
+        // A borrowed Text destination becomes owned.
+        let mut dst = Value::build_text("static text");
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+
+        // Blob into Blob: the destination Vec buffer is reused.
+        let src = Value::Blob(vec![1, 2, 3]);
+        let mut big_blob: ValueBlob = vec![];
+        big_blob.extend(0u8..32);
+        let mut dst = Value::Blob(big_blob);
+        let ptr = match &dst {
+            Value::Blob(b) => b.as_ptr(),
+            _ => unreachable!(),
+        };
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        match &dst {
+            Value::Blob(b) => assert_eq!(b.as_ptr(), ptr),
+            _ => unreachable!(),
+        }
+
+        // Mismatched variants replace the destination.
+        let src = Value::from_i64(9);
+        let mut dst = Value::build_text("text");
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        let src = Value::build_text("into an integer slot");
+        let mut dst = Value::from_i64(3);
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn test_build_reuses_retired_buffer_and_matches_from_values() {
+        let mut blob: ValueBlob = vec![];
+        blob.extend(0u8..64);
+        let big = vec![
+            Value::build_text("a longer text value that forces a real allocation"),
+            Value::Blob(blob),
+            Value::from_i64(42),
+        ];
+        let small = vec![Value::from_i64(1), Value::Null];
+
+        let expected_big = ImmutableRecord::from_values(&big, big.len()).unwrap();
+        let expected_small = ImmutableRecord::from_values(&small, small.len()).unwrap();
+
+        let record = ImmutableRecord::build(&big, RecordBuf::alloc()).unwrap();
+        assert_eq!(record.get_payload(), expected_big.get_payload());
+
+        // A retired buffer with sufficient capacity is reused without reallocating.
+        let capacity = record.as_blob().capacity();
+        let ptr = record.get_payload().as_ptr();
+        let record = ImmutableRecord::build(&small, record.retire()).unwrap();
+        assert_eq!(record.get_payload(), expected_small.get_payload());
+        assert_eq!(record.as_blob().capacity(), capacity);
+        assert_eq!(record.get_payload().as_ptr(), ptr);
+
+        // Growing past the recycled capacity still serializes correctly.
+        let record = ImmutableRecord::build(&big, expected_small.retire()).unwrap();
+        assert_eq!(record.get_payload(), expected_big.get_payload());
+    }
+
+    #[test]
+    fn test_copy_payload_reuses_buffer() {
+        let values = vec![Value::build_text("payload to copy"), Value::from_i64(7)];
+        let source = ImmutableRecord::from_values(&values, values.len()).unwrap();
+        let spare = ImmutableRecord::from_values(&values, values.len()).unwrap();
+
+        let ptr = spare.get_payload().as_ptr();
+        let copy = ImmutableRecord::copy_payload(source.get_payload(), spare.retire()).unwrap();
+        assert_eq!(copy.get_payload(), source.get_payload());
+        assert_eq!(copy.get_payload().as_ptr(), ptr);
     }
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -154,7 +154,7 @@ use crate::{
     json::jsonb_patch, json::jsonb_remove, json::jsonb_replace, json::jsonb_set, json::Conv,
 };
 
-use super::{make_record, Program, ProgramState, Register};
+use super::{Program, ProgramState, Register};
 
 #[cfg(feature = "fs")]
 use crate::connection::resolve_ext_path;
@@ -1399,9 +1399,12 @@ pub fn op_vfilter(
     let has_rows = {
         let cursor = get_cursor!(state, *cursor_id);
         let cursor = cursor.as_virtual_mut();
-        let mut args = Vec::with_capacity(*arg_count);
+        let mut args = Vec::new();
+        args.try_reserve(*arg_count)?;
         for i in 0..*arg_count {
-            args.push(state.registers[args_reg + i].get_value().clone());
+            let mut value = Value::Null;
+            value.try_clone_from(state.registers[args_reg + i].get_value())?;
+            args.push(value);
         }
         let idx_str = if let Some(idx_str) = idx_str {
             Some(state.registers[*idx_str].get_value().to_string())
@@ -1491,10 +1494,13 @@ pub fn op_vupdate(
             "VUpdate: arg_count must be at least 2 (rowid and insert_rowid)".to_string(),
         ));
     }
-    let mut argv = Vec::with_capacity(*arg_count);
+    let mut argv = Vec::new();
+    argv.try_reserve(*arg_count)?;
     for i in 0..*arg_count {
         if let Some(value) = state.registers.get(*start_reg + i) {
-            argv.push(value.get_value().clone());
+            let mut copy = Value::Null;
+            copy.try_clone_from(value.get_value())?;
+            argv.push(copy);
         } else {
             mark_unlikely();
             return Err(LimboError::InternalError(format!(
@@ -1655,14 +1661,14 @@ pub fn op_open_pseudo(
     load_insn!(
         OpenPseudo {
             cursor_id,
-            content_reg: _,
+            content_reg,
             num_fields: _,
         },
         insn
     );
     {
         let cursors = &mut state.cursors;
-        let cursor = PseudoCursor::default();
+        let cursor = PseudoCursor::new(*content_reg);
         cursors
             .get_mut(*cursor_id)
             .expect("cursor_id should be valid")
@@ -1963,14 +1969,25 @@ fn op_column_fetch(
             }
         }
         CursorType::Pseudo(_) => {
-            let cursor = crate::get_cursor!(state, cursor_id);
-            let cursor = cursor.as_pseudo_mut();
-            match cursor.record() {
-                Some(record) => {
+            let content_reg = crate::get_cursor!(state, cursor_id)
+                .as_pseudo_mut()
+                .content_reg();
+            // The record (content register) is read while decoding into the
+            // destination register, so the two must be distinct.
+            let [content, dest_reg] = state
+                .registers
+                .get_disjoint_mut([content_reg, dest])
+                .map_err(|_| {
+                    LimboError::InternalError(format!(
+                        "Column: pseudo-cursor content register {content_reg} and destination register {dest} must be distinct"
+                    ))
+                })?;
+            match content {
+                Register::Record(record) => {
                     // Decode straight into the register; going through an owned
                     // Value would allocate for every TEXT/BLOB column on every row.
                     let mut payload_iterator = record.iter()?;
-                    match payload_iterator.nth_into_register(column, &mut state.registers[dest]) {
+                    match payload_iterator.nth_into_register(column, dest_reg) {
                         Some(result) => result?,
                         // A pseudo cursor is opened with num_fields matching the
                         // record built for it, so every emitted Column index is in
@@ -1981,11 +1998,11 @@ fn op_column_fetch(
                                 "pseudo-cursor column out of range for record",
                                 { "column": column }
                             );
-                            state.registers[dest].set_null();
+                            dest_reg.set_null();
                         }
                     }
                 }
-                None => state.registers[dest].set_null(),
+                _ => dest_reg.set_null(),
             }
         }
         CursorType::IndexMethod(..) => {
@@ -2631,7 +2648,14 @@ pub fn op_reg_copy_offset(
             state.registers.len()
         )));
     }
-    state.registers[dest] = state.registers[*src].clone();
+    if dest != *src {
+        // try_clone_from reuses the destination register's allocation.
+        let [src, dst] = state
+            .registers
+            .get_disjoint_mut([*src, dest])
+            .expect("RegCopyOffset source and destination registers are distinct");
+        dst.try_clone_from(src)?;
+    }
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -2814,7 +2838,18 @@ pub fn op_make_record(
         }
     }
 
-    let record = make_record(&state.registers, &start_reg, &count)?;
+    if dest_reg >= start_reg && dest_reg < start_reg + count {
+        return Err(LimboError::InternalError(format!(
+            "MakeRecord: destination register {dest_reg} overlaps its source range {start_reg}..{}",
+            start_reg + count
+        )));
+    }
+    // Serialize into the destination register's spent record buffer: per-row
+    // paths (sorter fills, INSERT loops) become allocation-free once the
+    // buffer has grown to the row size.
+    let buf = state.registers[dest_reg].take_buf();
+    let regs = &state.registers[start_reg..start_reg + count];
+    let record = ImmutableRecord::build_from_registers(regs, buf)?;
     state.registers[dest_reg] = Register::Record(record);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -5071,6 +5106,9 @@ pub fn op_row_data(
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(RowData { cursor_id, dest }, insn);
 
+    // Copy the row into the destination register's spent record buffer: one
+    // payload copy, no allocation once the buffer has grown to the row size.
+    let buf = state.registers[*dest].take_buf();
     let record = {
         let cursor_ref = must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "RowData");
         let cursor = cursor_ref.as_btree_mut();
@@ -5081,7 +5119,7 @@ pub fn op_row_data(
             LimboError::InternalError("RowData: cursor has no record".to_string())
         })?;
 
-        record.clone()
+        ImmutableRecord::copy_payload(record.get_payload(), buf)?
     };
 
     let reg = &mut state.registers[*dest];
@@ -6229,10 +6267,11 @@ fn init_agg_payload(func: &AggFunc, payload: &mut crate::alloc::Vec<Value>) -> R
 /// - **ArrayAgg/Mode/PercentileCont/PercentileDisc**: buffer every input value by growing the
 ///   payload `Vec` (one push per row); the leading slots hold a running count and, for the
 ///   ordered-set aggregates, the collation / percentile fraction to use at finalize time.
+#[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::AggAccumulate)]
 fn update_agg_payload(
     func: &AggFunc,
-    arg: &Value,               // first argument
-    maybe_arg2: Option<Value>, // for GroupConcat/StringAgg, JsonGroupObject/JsonbGroupObject,
+    arg: &Value,                // first argument
+    maybe_arg2: Option<&Value>, // for GroupConcat/StringAgg, JsonGroupObject/JsonbGroupObject,
     payload: &mut crate::alloc::Vec<Value>,
     collation: CollationSeq,
     comparator: impl FnOnce() -> Result<Option<crate::vdbe::sorter::SortComparator>>,
@@ -6407,7 +6446,7 @@ fn update_agg_payload(
                 return Ok(());
             }
             if matches!(payload[0], Value::Null) {
-                payload[0] = arg.clone();
+                payload[0].try_clone_from(arg)?;
                 return Ok(());
             }
             use std::cmp::Ordering;
@@ -6426,22 +6465,25 @@ fn update_agg_payload(
                 _ => false,
             };
             if should_update {
-                payload[0] = arg.clone();
+                payload[0].try_clone_from(arg)?;
             }
         }
         AggFunc::GroupConcat | AggFunc::StringAgg => {
             if matches!(arg, Value::Null) {
                 return Ok(());
             }
-            let delimiter = maybe_arg2.unwrap_or_else(|| Value::build_text(","));
             let acc = &mut payload[0];
             if matches!(acc, Value::Null) {
-                // First non-null value: convert to Text
-                *acc = Value::build_text(arg.to_string());
+                // First non-null value: start an empty Text accumulator; the
+                // arg is appended below with no intermediate String.
+                *acc = Value::build_text(String::new());
             } else {
-                acc.exec_group_concat(&delimiter);
-                acc.exec_group_concat(arg);
+                match maybe_arg2 {
+                    Some(delimiter) => acc.try_group_concat_push(delimiter)?,
+                    None => acc.try_group_concat_push(&Value::build_text(","))?,
+                }
             }
+            acc.try_group_concat_push(arg)?;
         }
         AggFunc::External(_) => {
             mark_unlikely();
@@ -6459,13 +6501,14 @@ fn update_agg_payload(
                 ));
             };
             let mut key_vec = convert_dbtype_to_raw_jsonb(arg, Conv::ToString)?;
-            let mut val_vec = convert_dbtype_to_raw_jsonb(&value, Conv::NotStrict)?;
+            let mut val_vec = convert_dbtype_to_raw_jsonb(value, Conv::NotStrict)?;
             let Value::Blob(vec) = &mut payload[0] else {
                 mark_unlikely();
                 return Err(LimboError::InternalError(
                     "JsonGroupObject: payload[0] is not a blob".to_string(),
                 ));
             };
+            vec.try_reserve(usize::from(vec.is_empty()) + key_vec.len() + val_vec.len())?;
             if vec.is_empty() {
                 // bits for obj header
                 vec.push(12);
@@ -6480,7 +6523,7 @@ fn update_agg_payload(
                 LimboError::InternalError("array_agg count slot must be an integer".into())
             })? as usize;
             payload[0] = Value::from_i64((count + 1) as i64);
-            payload.push(arg.clone());
+            try_push_value_clone(payload, arg)?;
         }
         AggFunc::Mode => {
             // Record the value's collation (constant per group) for finalize-time sorting, then
@@ -6489,19 +6532,19 @@ fn update_agg_payload(
             if !matches!(arg, Value::Null) {
                 let count = payload[1].as_int().unwrap_or(0) as usize;
                 payload[1] = Value::from_i64((count + 1) as i64);
-                payload.push(arg.clone());
+                try_push_value_clone(payload, arg)?;
             }
         }
         AggFunc::PercentileCont | AggFunc::PercentileDisc => {
             payload[0] = Value::from_i64(collation.to_bits() as i64);
             // The fraction is a per-group constant; record it on every step.
             if let Some(fraction) = maybe_arg2 {
-                payload[2] = fraction;
+                payload[2].try_clone_from(fraction)?;
             }
             if !matches!(arg, Value::Null) {
                 let count = payload[1].as_int().unwrap_or(0) as usize;
                 payload[1] = Value::from_i64((count + 1) as i64);
-                payload.push(arg.clone());
+                try_push_value_clone(payload, arg)?;
             }
         }
         #[cfg(feature = "json")]
@@ -6514,12 +6557,23 @@ fn update_agg_payload(
                     "JsonGroupArray: payload[0] is not a blob".to_string(),
                 ));
             };
+            vec.try_reserve(usize::from(vec.is_empty()) + data.len())?;
             if vec.is_empty() {
                 vec.push(11); // bits for array header
             }
             vec.append(&mut data);
         }
     }
+    Ok(())
+}
+
+/// Fallibly appends a copy of `value` to `payload`, used by aggregates that
+/// buffer every input value (array_agg, mode, percentiles).
+fn try_push_value_clone(payload: &mut crate::alloc::Vec<Value>, value: &Value) -> Result<()> {
+    payload.try_reserve(1)?;
+    let mut copy = Value::Null;
+    copy.try_clone_from(value)?;
+    payload.push(copy);
     Ok(())
 }
 
@@ -6876,13 +6930,18 @@ fn op_window_step(
                 *captured != 0
             };
             if !already_captured {
-                let arg_value = state.registers[arg_reg].get_value().clone();
-                let Register::Aggregate(AggContext::Builtin(payload)) =
-                    &mut state.registers[acc_reg]
-                else {
+                let [arg_slot, acc_slot] = state
+                    .registers
+                    .get_disjoint_mut([arg_reg, acc_reg])
+                    .map_err(|_| {
+                        LimboError::InternalError(format!(
+                            "first_value: argument register {arg_reg} and accumulator register {acc_reg} must be distinct"
+                        ))
+                    })?;
+                let Register::Aggregate(AggContext::Builtin(payload)) = acc_slot else {
                     unreachable!("first_value accumulator must be a Builtin payload");
                 };
-                payload[0] = arg_value;
+                payload[0].try_clone_from(arg_slot.get_value())?;
                 let Value::Numeric(Numeric::Integer(captured)) = &mut payload[1] else {
                     unreachable!("first_value capture flag must be Integer");
                 };
@@ -6899,12 +6958,19 @@ fn op_window_step(
                 state.registers[acc_reg] =
                     Register::Aggregate(AggContext::Builtin(crate::alloc::try_vec![Value::Null]?));
             }
-            let arg_value = state.registers[arg_reg].get_value().clone();
-            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
-            else {
+            // try_clone_from reuses payload[0]'s allocation on every row.
+            let [arg_slot, acc_slot] = state
+                .registers
+                .get_disjoint_mut([arg_reg, acc_reg])
+                .map_err(|_| {
+                    LimboError::InternalError(format!(
+                        "last_value: argument register {arg_reg} and accumulator register {acc_reg} must be distinct"
+                    ))
+                })?;
+            let Register::Aggregate(AggContext::Builtin(payload)) = acc_slot else {
                 unreachable!("last_value accumulator must be a Builtin payload");
             };
-            payload[0] = arg_value;
+            payload[0].try_clone_from(arg_slot.get_value())?;
         }
         other => {
             return Err(LimboError::InternalError(format!(
@@ -7126,19 +7192,23 @@ pub fn op_agg_step(
             }
         }
         _ => {
-            // Second argument (delimiter for group_concat/json, fraction for percentiles),
-            let maybe_arg2 = match func {
-                AggFunc::GroupConcat | AggFunc::StringAgg => {
-                    Some(state.registers[*delimiter].get_value().clone())
-                }
+            // Second argument (delimiter for group_concat/json, fraction for
+            // percentiles), staged in a per-statement scratch Value so its
+            // buffer is reused across rows.
+            let uses_arg2 = match func {
+                AggFunc::GroupConcat | AggFunc::StringAgg => true,
                 #[cfg(feature = "json")]
-                AggFunc::JsonGroupObject | AggFunc::JsonbGroupObject => {
-                    Some(state.registers[*delimiter].get_value().clone())
-                }
-                AggFunc::PercentileCont | AggFunc::PercentileDisc => {
-                    Some(state.registers[*delimiter].get_value().clone())
-                }
-                _ => None,
+                AggFunc::JsonGroupObject | AggFunc::JsonbGroupObject => true,
+                AggFunc::PercentileCont | AggFunc::PercentileDisc => true,
+                _ => false,
+            };
+            let maybe_arg2 = if uses_arg2 {
+                state
+                    .agg_arg2_scratch
+                    .try_clone_from(state.registers[*delimiter].get_value())?;
+                Some(&state.agg_arg2_scratch)
+            } else {
+                None
             };
 
             let [arg_reg, acc_slot] =
@@ -7369,23 +7439,40 @@ pub fn op_sorter_data(
         },
         insn
     );
-    let record = {
+    // Column ops on the pseudo cursor read the record through its content
+    // register, so the record moved into dest_reg is only visible to them if
+    // the translator paired the two registers.
+    {
+        let content_reg = state
+            .get_cursor(*pseudo_cursor)
+            .as_pseudo_mut()
+            .content_reg();
+        if content_reg != *dest_reg {
+            return Err(LimboError::InternalError(format!(
+                "SorterData: destination register {dest_reg} must be pseudo-cursor {pseudo_cursor}'s content register {content_reg}"
+            )));
+        }
+    }
+    {
         let cursor = state.get_cursor(*cursor_id);
-        let cursor = cursor.as_sorter_mut();
-        cursor.record().cloned()
-    };
-    let record = match record {
-        Some(record) => record,
-        None => {
+        if cursor.as_sorter_mut().record().is_none() {
             state.pc += 1;
             return Ok(InsnFunctionStepResult::Step);
         }
-    };
-    state.registers[*dest_reg] = Register::Record(record.clone());
-    {
-        let pseudo_cursor = state.get_cursor(*pseudo_cursor);
-        pseudo_cursor.as_pseudo_mut().insert(record);
     }
+    // Move the record out of the sorter and into the content register with no
+    // allocation or payload copy; the register's spent buffer seeds the
+    // sorter's next row. Pseudo-cursor Column ops read the record through
+    // this register.
+    let buf = state.registers[*dest_reg].take_buf();
+    let record = {
+        let cursor = state.get_cursor(*cursor_id);
+        cursor
+            .as_sorter_mut()
+            .take_current(buf)
+            .expect("sorter record checked above")
+    };
+    state.registers[*dest_reg] = Register::Record(record);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -7998,15 +8085,14 @@ pub fn op_function(
             ScalarFunc::Cast => {
                 assert_eq!(arg_count, 2);
                 assert!(*start_reg + 1 < state.registers.len());
-                let reg_value_argument = state.registers[*start_reg].clone();
-                let Value::Text(reg_value_type) =
-                    state.registers[*start_reg + 1].get_value().clone()
-                else {
-                    unreachable!("Cast with non-text type");
+                let result = {
+                    let Value::Text(cast_type) = state.registers[*start_reg + 1].get_value() else {
+                        unreachable!("Cast with non-text type");
+                    };
+                    state.registers[*start_reg]
+                        .get_value()
+                        .exec_cast(cast_type.as_str())?
                 };
-                let result = reg_value_argument
-                    .get_value()
-                    .exec_cast(reg_value_type.as_str())?;
                 state.registers[*dest].set_value(result);
             }
             ScalarFunc::Changes => {
@@ -11753,7 +11839,16 @@ pub fn op_copy(
         insn
     );
     for i in 0..=*extra_amount {
-        state.registers[*dst_reg + i] = state.registers[*src_reg + i].clone();
+        let (src, dst) = (*src_reg + i, *dst_reg + i);
+        if src == dst {
+            continue;
+        }
+        // try_clone_from reuses the destination register's allocation.
+        let [src, dst] = state
+            .registers
+            .get_disjoint_mut([src, dst])
+            .expect("Copy source and destination registers are distinct");
+        dst.try_clone_from(src)?;
     }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -15640,11 +15735,21 @@ pub fn op_hash_distinct(
         .get_mut(&data.hash_table_id)
         .expect("hash table exists");
 
+    // Stage the key values in a per-statement scratch Vec; try_clone_from
+    // reuses each slot's allocation across rows.
     let key_values = &mut state.distinct_key_values;
-    key_values.clear();
-    for i in 0..data.num_keys {
-        let reg = &state.registers[data.key_start_reg + i];
-        key_values.push(reg.get_value().clone());
+    if key_values.len() == data.num_keys {
+        for (i, dst) in key_values.iter_mut().enumerate() {
+            dst.try_clone_from(state.registers[data.key_start_reg + i].get_value())?;
+        }
+    } else {
+        key_values.clear();
+        key_values.try_reserve(data.num_keys)?;
+        for i in 0..data.num_keys {
+            let mut value = Value::Null;
+            value.try_clone_from(state.registers[data.key_start_reg + i].get_value())?;
+            key_values.push(value);
+        }
     }
 
     let mut key_refs: SmallVec<[ValueRef; 2]> = SmallVec::with_capacity(data.num_keys);
@@ -15689,12 +15794,14 @@ fn write_hash_payload_to_registers(
     entry: &HashEntry,
     payload_dest_reg: Option<usize>,
     num_payload: usize,
-) {
+) -> Result<()> {
     if let Some(dest_reg) = payload_dest_reg {
         for (i, value) in entry.payload_values.iter().take(num_payload).enumerate() {
-            registers[dest_reg + i].set_value(value.clone());
+            // try_clone_value_from reuses the destination register's allocation.
+            registers[dest_reg + i].try_clone_value_from(value)?;
         }
     }
+    Ok(())
 }
 
 pub fn op_hash_probe(
@@ -15826,7 +15933,7 @@ pub fn op_hash_probe(
                     entry,
                     payload_dest_reg,
                     num_payload,
-                );
+                )?;
                 state.active_op_state.clear();
                 state.pc += 1;
                 Ok(InsnFunctionStepResult::Step)
@@ -15847,7 +15954,7 @@ pub fn op_hash_probe(
                     entry,
                     payload_dest_reg,
                     num_payload,
-                );
+                )?;
                 state.active_op_state.clear();
                 state.pc += 1;
                 Ok(InsnFunctionStepResult::Step)
@@ -15890,7 +15997,7 @@ pub fn op_hash_next(
                 entry,
                 *payload_dest_reg,
                 *num_payload,
-            );
+            )?;
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
@@ -16055,7 +16162,7 @@ fn advance_unmatched_scan(
         match hash_table.next_unmatched() {
             Some(entry) => {
                 registers[dest_reg].set_int(entry.rowid);
-                write_hash_payload_to_registers(registers, entry, payload_dest_reg, num_payload);
+                write_hash_payload_to_registers(registers, entry, payload_dest_reg, num_payload)?;
                 *pc += 1;
                 return Ok(InsnFunctionStepResult::Step);
             }
@@ -17780,6 +17887,55 @@ mod tests {
         };
         assert!(matches!(err, LimboError::Constraint(message) if message == "datatype mismatch"));
         assert_eq!(state.pc, 0);
+    }
+
+    #[test]
+    fn test_make_record_overlapping_dest_returns_error() {
+        let stmt = prepare_test_statement();
+
+        let mut state = ProgramState::new(3, 0);
+        for i in 0..3 {
+            state.set_register(i, Register::Value(Value::from_i64(i as i64)));
+        }
+        let insn = Insn::MakeRecord {
+            start_reg: 0,
+            count: 3,
+            dest_reg: 1,
+            index_name: None,
+            affinity_str: None,
+        };
+
+        let err = match op_make_record(stmt.get_program(), &mut state, &insn, stmt.get_pager()) {
+            Ok(_) => panic!("overlapping destination register must fail"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, LimboError::InternalError(ref m) if m.contains("overlaps its source range")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_sorter_data_unpaired_content_register_returns_error() {
+        let stmt = prepare_test_statement();
+
+        // Pseudo cursor 1 exposes register 2, but SorterData targets register 3.
+        let mut state = ProgramState::new(4, 2);
+        state.cursors[1] = Some(Cursor::new_pseudo(crate::pseudo::PseudoCursor::new(2)));
+        let insn = Insn::SorterData {
+            cursor_id: 0,
+            dest_reg: 3,
+            pseudo_cursor: 1,
+        };
+
+        let err = match op_sorter_data(stmt.get_program(), &mut state, &insn, stmt.get_pager()) {
+            Ok(_) => panic!("unpaired content register must fail"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, LimboError::InternalError(ref m) if m.contains("content register")),
+            "unexpected error: {err:?}"
+        );
     }
 
     #[test]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -73,7 +73,7 @@ use crate::sync::RwLock;
 use crate::{
     storage::pager::Pager,
     translate::plan::ResultSetColumn,
-    types::{AggContext, Cursor, ImmutableRecord, Value},
+    types::{AggContext, Cursor, ImmutableRecord, RecordBuf, Value},
     vdbe::{builder::CursorType, insn::Insn},
 };
 use crate::{
@@ -262,6 +262,61 @@ pub enum Register {
 }
 
 impl Register {
+    /// Takes the register's spent record buffer for reuse, leaving NULL.
+    /// Callers about to overwrite the register use this to recycle its
+    /// allocation instead of dropping it.
+    #[inline]
+    pub fn take_buf(&mut self) -> RecordBuf {
+        match std::mem::replace(self, Register::Value(Value::Null)) {
+            Register::Record(record) => record.retire(),
+            _ => RecordBuf::alloc(),
+        }
+    }
+
+    /// Fallibly copies `source` into this register, reusing the destination's
+    /// Value or record allocation when the variants match; see
+    /// [Value::try_clone_from].
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::CloneFrom)]
+    pub fn try_clone_from(&mut self, source: &Self) -> crate::Result<()> {
+        match (self, source) {
+            (Register::Value(dst), Register::Value(src)) => dst.try_clone_from(src)?,
+            (Register::Record(dst), Register::Record(src)) => {
+                let buf = dst.as_blob_mut();
+                buf.clear();
+                buf.try_reserve(src.get_payload().len())?;
+                buf.extend_from_slice(src.get_payload());
+            }
+            (dst, Register::Value(src)) => {
+                let mut value = Value::Null;
+                value.try_clone_from(src)?;
+                *dst = Register::Value(value);
+            }
+            (dst, Register::Record(src)) => {
+                *dst = Register::Record(ImmutableRecord::copy_payload(
+                    src.get_payload(),
+                    RecordBuf::alloc(),
+                )?);
+            }
+            (dst, Register::Aggregate(src)) => *dst = Register::Aggregate(src.try_clone()?),
+        }
+        Ok(())
+    }
+
+    /// Fallibly sets the register to a copy of `val`, reusing the register's
+    /// existing allocation when possible; see [Value::try_clone_from].
+    #[inline]
+    pub fn try_clone_value_from(&mut self, val: &Value) -> crate::Result<()> {
+        match self {
+            Register::Value(v) => v.try_clone_from(val)?,
+            _ => {
+                let mut value = Value::Null;
+                value.try_clone_from(val)?;
+                *self = Register::Value(value);
+            }
+        }
+        Ok(())
+    }
+
     #[inline]
     pub const fn is_null(&self) -> bool {
         matches!(self, Register::Value(Value::Null))
@@ -760,6 +815,9 @@ pub struct ProgramState {
     pub explain_state: RwLock<ExplainState>,
     /// Scratch buffer for [Insn::HashDistinct] to avoid per-row allocations.
     distinct_key_values: Vec<Value>,
+    /// Scratch for AggStep's second argument (delimiter/fraction), copied in
+    /// fallibly each row so its buffer is reused instead of allocating.
+    agg_arg2_scratch: Value,
     hash_tables: HashMap<usize, HashTable>,
     /// TempFile handles for ephemeral cursors, keyed by cursor_id.
     /// Dropping removes the temp file from disk.
@@ -846,6 +904,7 @@ impl ProgramState {
             seek_state: OpSeekState::Start,
             metrics: StatementMetrics::new(),
             distinct_key_values: Vec::new(),
+            agg_arg2_scratch: Value::Null,
             current_collation: None,
             op_vacuum_state: VacuumOpState::None,
             view_delta_state: ViewDeltaCommitState::NotStarted,
@@ -990,6 +1049,7 @@ impl ProgramState {
         self.is_active_write = false;
         self.has_stmt_transaction = false;
         self.distinct_key_values.clear();
+        self.agg_arg2_scratch = Value::Null;
         self.attached_savepoint_pagers.clear();
         self.n_change.store(0, Ordering::SeqCst);
         self.n_total_change.store(0, Ordering::SeqCst);
@@ -2827,15 +2887,6 @@ impl Deref for Program {
     }
 }
 
-pub(crate) fn make_record(
-    registers: &[Register],
-    start_reg: &usize,
-    count: &usize,
-) -> Result<ImmutableRecord> {
-    let regs = &registers[*start_reg..*start_reg + *count];
-    ImmutableRecord::from_registers(regs, regs.len())
-}
-
 /// Split a register slice into an immutable ref and a mutable ref at two distinct indices.
 pub(crate) fn split_registers(
     registers: &mut [Register],
@@ -3244,6 +3295,117 @@ mod tests {
             OpInsertSubState::Seek
         ));
         assert!(matches!(state.seek_state, OpSeekState::MoveLast));
+    }
+
+    #[test]
+    fn register_try_clone_from_reuses_matching_allocations() {
+        use crate::types::Text;
+
+        // Value -> Value: the destination Text buffer is reused.
+        let src = Register::Value(Value::Text(Text::new(String::from("short"))));
+        let mut dst = Register::Value(Value::Text(Text::new(String::from(
+            "a destination string with plenty of capacity",
+        ))));
+        let ptr = match &dst {
+            Register::Value(Value::Text(t)) => t.as_str().as_ptr(),
+            _ => unreachable!(),
+        };
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        match &dst {
+            Register::Value(Value::Text(t)) => assert_eq!(t.as_str().as_ptr(), ptr),
+            _ => unreachable!(),
+        }
+
+        // Record -> Record: the destination payload buffer is reused.
+        let values = [Value::from_i64(1), Value::build_text("record payload")];
+        let src = Register::Record(
+            ImmutableRecord::from_registers(
+                &[
+                    Register::Value(values[0].clone()),
+                    Register::Value(values[1].clone()),
+                ],
+                2,
+            )
+            .unwrap(),
+        );
+        let big = [Value::build_text(
+            "a much longer record payload that dwarfs the source record",
+        )];
+        let mut dst = Register::Record(
+            ImmutableRecord::from_registers(&[Register::Value(big[0].clone())], 1).unwrap(),
+        );
+        let ptr = match &dst {
+            Register::Record(r) => r.get_payload().as_ptr(),
+            _ => unreachable!(),
+        };
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        match &dst {
+            Register::Record(r) => assert_eq!(r.get_payload().as_ptr(), ptr),
+            _ => unreachable!(),
+        }
+
+        // Aggregate source goes through the fallible clone.
+        let src = Register::Aggregate(AggContext::Builtin(crate::alloc::vec![
+            Value::build_text("agg state"),
+            Value::from_i64(2),
+        ]));
+        let mut dst = Register::Value(Value::Null);
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn register_take_buf_recycles_record_allocations() {
+        let values = [Register::Value(Value::build_text("some record payload"))];
+        let record = ImmutableRecord::from_registers(&values, 1).unwrap();
+        let capacity = record.as_blob().capacity();
+        let ptr = record.get_payload().as_ptr();
+
+        let mut reg = Register::Record(record);
+        let buf = reg.take_buf();
+        assert!(reg.is_null(), "take_buf leaves the register NULL");
+
+        // Building into the recycled buffer reuses the allocation.
+        let rebuilt = ImmutableRecord::build_from_registers(&values, buf).unwrap();
+        assert_eq!(rebuilt.as_blob().capacity(), capacity);
+        assert_eq!(rebuilt.get_payload().as_ptr(), ptr);
+
+        // Non-record registers hand out an empty buffer.
+        let mut reg = Register::Value(Value::from_i64(1));
+        let rebuilt = ImmutableRecord::build_from_registers(&values, reg.take_buf()).unwrap();
+        assert_eq!(
+            rebuilt.get_payload(),
+            ImmutableRecord::from_registers(&values, 1)
+                .unwrap()
+                .get_payload()
+        );
+    }
+
+    #[test]
+    fn register_try_clone_value_from_reuses_value_slot() {
+        let val = Value::build_text(String::from("payload"));
+        let mut reg = Register::Value(Value::Text(crate::types::Text::new(String::from(
+            "existing buffer with plenty of capacity to reuse",
+        ))));
+        let ptr = match &reg {
+            Register::Value(Value::Text(t)) => t.as_str().as_ptr(),
+            _ => unreachable!(),
+        };
+        reg.try_clone_value_from(&val).unwrap();
+        assert_eq!(reg, Register::Value(val.clone()));
+        match &reg {
+            Register::Value(Value::Text(t)) => assert_eq!(t.as_str().as_ptr(), ptr),
+            _ => unreachable!(),
+        }
+
+        // A non-Value register is replaced by a fresh fallible copy.
+        let mut reg = Register::Record(
+            ImmutableRecord::from_registers(&[Register::Value(Value::from_i64(1))], 1).unwrap(),
+        );
+        reg.try_clone_value_from(&val).unwrap();
+        assert_eq!(reg, Register::Value(val));
     }
 }
 

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -18,7 +18,7 @@ use crate::{
     io::{Buffer, Completion, CompletionGroup, File, IO},
     storage::sqlite3_ondisk::{read_varint, varint_len, write_varint},
     translate::collate::CollationSeq,
-    types::{IOResult, ImmutableRecord, KeyInfo, ValueRef},
+    types::{IOResult, ImmutableRecord, KeyInfo, RecordBuf, ValueRef},
     Result,
 };
 use crate::{io_yield_one, return_if_io, CompletionError};
@@ -359,6 +359,17 @@ impl Sorter {
 
     pub const fn record(&self) -> Option<&ImmutableRecord> {
         self.current.as_ref()
+    }
+
+    /// Moves the current record out of the sorter, seeding the next
+    /// [Sorter::next] call with `spent`'s allocation. This lets SorterData
+    /// transfer records to a register with no allocation or payload copy.
+    pub fn take_current(&mut self, spent: RecordBuf) -> Option<ImmutableRecord> {
+        let current = self.current.take();
+        if current.is_some() {
+            self.current = Some(ImmutableRecord::from_buf(spent));
+        }
+        current
     }
 
     pub fn insert(&mut self, record: &ImmutableRecord) -> Result<IOResult<()>> {

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1399,6 +1399,44 @@ impl Value {
         text.value.to_mut().push_str(&other.to_string());
     }
 
+    /// Fallibly appends `other`, rendered as text, onto this Text
+    /// accumulator, growing the accumulator's buffer in place. Text sources
+    /// append directly without an intermediate String. Panics if self is not
+    /// a Text value.
+    pub fn try_group_concat_push(
+        &mut self,
+        other: &Value,
+    ) -> std::result::Result<(), crate::alloc::TryReserveError> {
+        let Value::Text(text) = self else {
+            panic!("group_concat accumulator must be a Text value");
+        };
+        let acc = match &mut text.value {
+            std::borrow::Cow::Owned(s) => s,
+            borrowed => {
+                let mut s = String::new();
+                s.try_reserve(borrowed.len())?;
+                s.push_str(borrowed);
+                *borrowed = std::borrow::Cow::Owned(s);
+                let std::borrow::Cow::Owned(s) = borrowed else {
+                    unreachable!("accumulator was just converted to Owned");
+                };
+                s
+            }
+        };
+        match other {
+            Value::Text(t) => {
+                acc.try_reserve(t.as_str().len())?;
+                acc.push_str(t.as_str());
+            }
+            other => {
+                let rendered = other.to_string();
+                acc.try_reserve(rendered.len())?;
+                acc.push_str(&rendered);
+            }
+        }
+        Ok(())
+    }
+
     pub fn exec_concat_strings<'a, T: Iterator<Item = &'a Self>>(registers: T) -> Self {
         let mut result = String::new();
         for val in registers {

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -228,6 +228,10 @@ fn allocation_site_id(site: AllocationSite) -> u64 {
             ValueBlobAllocationSite::JsonbCopy => 26,
             ValueBlobAllocationSite::Hash128 => 27,
             ValueBlobAllocationSite::JsonbConstruction => 28,
+            ValueBlobAllocationSite::CloneFrom => 29,
+            ValueBlobAllocationSite::RecordBuild => 30,
+            ValueBlobAllocationSite::RecordCopy => 31,
+            ValueBlobAllocationSite::AggAccumulate => 32,
         },
         AllocationSite::Vector(site) => match site {
             VectorAllocationSite::Parse => 15,


### PR DESCRIPTION
Per-row copies in the interpreter reuse the destination's existing allocation instead of allocating fresh.

- `Value::try_clone_from` and `Register::try_clone_from`/`try_clone_value_from` copy values while reusing the destination's Text/Blob or record payload buffer. Applied to Copy, RegCopyOffset, hash-join probe writeback, hash-DISTINCT key staging, min/max aggregates, first_value/last_value window captures, and VFilter/VUpdate argument staging.
- `RecordBuf` is a spent record buffer: retiring a record keeps its allocation, and hot-path record construction consumes one, so per-row callers either recycle or allocate through the single explicit entry point. MakeRecord serializes into the destination register's recycled buffer (sizing the header without a scratch Vec); RowData copies the row into it; MVCC index seeks recycle a per-cursor buffer.
- SorterData moves the record out of the sorter into the pseudo cursor's content register and hands the register's spent buffer back to the sorter; Column ops decode straight from that register. One register's buffer circulates through the whole sort pipeline with zero steady-state allocations and payload copies. The translator must pair OpenPseudo's content register with SorterData's destination; the VDBE verifies the pairing and returns an error on violation, as it does for a MakeRecord destination overlapping its source range.
- Aggregate accumulators grow fallibly: group_concat/string_agg append Text arguments directly with no per-row temporary String, json_group_*/array_agg/mode/percentile reserve before growing, and AggStep's second argument (delimiter/fraction) is staged in a reused per-statement scratch value. Cast evaluates without cloning its argument registers.

All growth is fallible (`try_reserve`) and tagged with allocation sites (CloneFrom, RecordBuild, RecordCopy, AggAccumulate), so failures surface as statement errors and allocation-fault injection exercises them. A dedicated fault test drives failure and recovery, proves the recycled-buffer paths allocate nothing, and runs SQL end-to-end under injection.

| benchmark | before | after | delta |
|---|---|---|---|
| Execute GROUP BY state/limbo_execute_group_by | 3992 us | 3679 us | -7.8% |
| mvcc-recovery/wide-frame/1000 | 778 us | 758 us | -2.6% |

Tests: workspace clippy with denied warnings, full turso_core suite, sqlite conformance, nightly allocation-fault tests (`RUSTFLAGS="--cfg nightly" cargo +nightly test -p turso_core --features allocation_metric --test record_alloc_fault`), direct unit tests for the new contract-violation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
