### PR TITLE
core/btree: rebuild required indexes for the ALTER column op

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1828,34 +1828,40 @@ pub fn translate_alter_table(
                 ));
             }
 
-            let (rewrites_physical_layout, replacement_column) = match rename {
-                true => (false, None),
-                false => {
-                    let replacement_column = Column::try_from(&definition)?;
-                    let old_column = &btree.columns()[column_index];
-                    let becomes_generated =
-                        !old_column.is_generated() && replacement_column.is_generated();
-                    // Toggling the virtual-generated bit changes whether the column
-                    // occupies a stored slot, so the on-disk row layout shifts even
-                    // if neither side is "becomes_generated" (e.g. virtual -> regular).
-                    // Without rewriting, post-ALTER reads use the new schema's column
-                    // indexes against rows that still hold the pre-ALTER layout, and
-                    // values land in the wrong logical columns. See issue #6624.
-                    let virtuality_changed = old_column.is_virtual_generated()
-                        != replacement_column.is_virtual_generated();
-                    // A change of declared type can change the column's affinity, in
-                    // which case existing on-disk values must be coerced to match the
-                    // new affinity. Without this, the row payload retains the old
-                    // serial type and SQLite's `PRAGMA integrity_check` reports the
-                    // file as corrupt (e.g. "NUMERIC value in <table>.<col>" when
-                    // changing NUMERIC -> TEXT). See issue #3706.
-                    let affinity_changed = old_column.affinity_with_strict(btree.is_strict)
-                        != replacement_column.affinity_with_strict(btree.is_strict);
-                    let rewrites_physical_layout =
-                        becomes_generated || virtuality_changed || affinity_changed;
-                    (rewrites_physical_layout, Some(replacement_column))
-                }
-            };
+            let (rewrites_physical_layout, virtual_generated_values_may_change, replacement_column) =
+                match rename {
+                    true => (false, false, None),
+                    false => {
+                        let replacement_column = Column::try_from(&definition)?;
+                        let old_column = &btree.columns()[column_index];
+                        let becomes_generated =
+                            !old_column.is_generated() && replacement_column.is_generated();
+                        // Toggling the virtual-generated bit changes whether the column
+                        // occupies a stored slot, so the on-disk row layout shifts even
+                        // if neither side is "becomes_generated" (e.g. virtual -> regular).
+                        // Without rewriting, post-ALTER reads use the new schema's column
+                        // indexes against rows that still hold the pre-ALTER layout, and
+                        // values land in the wrong logical columns. See issue #6624.
+                        let virtuality_changed = old_column.is_virtual_generated()
+                            != replacement_column.is_virtual_generated();
+                        // A change of declared type can change the column's affinity, in
+                        // which case existing on-disk values must be coerced to match the
+                        // new affinity. Without this, the row payload retains the old
+                        // serial type and SQLite's `PRAGMA integrity_check` reports the
+                        // file as corrupt (e.g. "NUMERIC value in <table>.<col>" when
+                        // changing NUMERIC -> TEXT). See issue #3706.
+                        let affinity_changed = old_column.affinity_with_strict(btree.is_strict)
+                            != replacement_column.affinity_with_strict(btree.is_strict);
+                        let rewrites_physical_layout =
+                            becomes_generated || virtuality_changed || affinity_changed;
+                        (
+                            rewrites_physical_layout,
+                            old_column.is_virtual_generated()
+                                || replacement_column.is_virtual_generated(),
+                            Some(replacement_column),
+                        )
+                    }
+                };
             let clears_autoincrement_sequence = !rename
                 && btree.has_autoincrement
                 && btree.columns()[column_index].is_rowid_alias()
@@ -1904,25 +1910,28 @@ pub fn translate_alter_table(
                 }
             }
 
-            let rewritten_table = if rewrites_physical_layout {
+            let altered_table = if let Some(replacement_column) = &replacement_column {
                 let mut table = btree.clone();
-                table.columns_mut()[column_index] =
-                    replacement_column.expect("replacement_column must exist for ALTER COLUMN");
+                table.columns_mut()[column_index] = replacement_column.clone();
                 table.prepare_generated_columns()?;
                 Some(table)
             } else {
                 None
             };
 
-            let indexes_to_rewrite = if let Some(rewritten_table) = &rewritten_table {
-                let indexes = indexes_affected_by_column_rewrite(
-                    &original_btree,
-                    rewritten_table,
-                    &table_indexes,
-                    column_index,
-                )?;
-                validate_indexes_can_be_rewritten(&indexes, from, connection, database_id)?;
-                indexes
+            let indexes_to_rewrite = if let Some(altered_table) = &altered_table {
+                if !rewrites_physical_layout && !virtual_generated_values_may_change {
+                    Vec::new()
+                } else {
+                    let indexes = indexes_affected_by_column_rewrite(
+                        &original_btree,
+                        altered_table,
+                        &table_indexes,
+                        column_index,
+                    )?;
+                    validate_indexes_can_be_rewritten(&indexes, from, connection, database_id)?;
+                    indexes
+                }
             } else {
                 Vec::new()
             };
@@ -2215,59 +2224,62 @@ pub fn translate_alter_table(
                 });
             }
 
-            if let Some(rewritten_table) = rewritten_table {
-                emit_add_virtual_column_validation(
-                    program,
-                    &rewritten_table,
-                    &rewritten_table.columns()[column_index],
-                    &definition.constraints,
-                    resolver,
-                    connection,
-                    database_id,
-                )?;
+            if let Some(altered_table) = altered_table {
+                let altered_table = Arc::new(altered_table);
+                if rewrites_physical_layout {
+                    emit_add_virtual_column_validation(
+                        program,
+                        &altered_table,
+                        &altered_table.columns()[column_index],
+                        &definition.constraints,
+                        resolver,
+                        connection,
+                        database_id,
+                    )?;
 
-                let original_columns = original_btree.columns();
-                let source_column_by_schema_idx: Vec<Option<usize>> = rewritten_table
-                    .columns()
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, column)| {
-                        if column.is_virtual_generated() {
-                            // Virtual columns don't occupy a slot in the rewritten record.
-                            None
-                        } else if original_columns
-                            .get(idx)
-                            .is_some_and(|c| c.is_virtual_generated())
-                        {
-                            // Newly-stored slot (the original column was virtual): no
-                            // source value exists on the old row image — leave NULL.
-                            None
-                        } else {
-                            // The cursor is opened on the original btree, so the logical
-                            // index passed here is mapped to the original physical slot
-                            // by `emit_column_or_rowid` via the original's logical-to-
-                            // physical map. Schema order is preserved by ALTER COLUMN,
-                            // so the rewritten schema_idx also identifies the same
-                            // logical column in the original.
-                            Some(idx)
-                        }
-                    })
-                    .collect();
-                let layout = rewritten_table.column_layout()?;
-                emit_rewrite_table_rows(
-                    program,
-                    original_btree.clone(),
-                    &rewritten_table,
-                    &source_column_by_schema_idx,
-                    &layout,
-                    connection,
-                    database_id,
-                );
+                    let original_columns = original_btree.columns();
+                    let source_column_by_schema_idx: Vec<Option<usize>> = altered_table
+                        .columns()
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, column)| {
+                            if column.is_virtual_generated() {
+                                // Virtual columns don't occupy a slot in the rewritten record.
+                                None
+                            } else if original_columns
+                                .get(idx)
+                                .is_some_and(|c| c.is_virtual_generated())
+                            {
+                                // Newly-stored slot (the original column was virtual): no
+                                // source value exists on the old row image — leave NULL.
+                                None
+                            } else {
+                                // The cursor is opened on the original btree, so the logical
+                                // index passed here is mapped to the original physical slot
+                                // by `emit_column_or_rowid` via the original's logical-to-
+                                // physical map. Schema order is preserved by ALTER COLUMN,
+                                // so the rewritten schema_idx also identifies the same
+                                // logical column in the original.
+                                Some(idx)
+                            }
+                        })
+                        .collect();
+                    let layout = altered_table.column_layout()?;
+                    emit_rewrite_table_rows(
+                        program,
+                        original_btree.clone(),
+                        &altered_table,
+                        &source_column_by_schema_idx,
+                        &layout,
+                        connection,
+                        database_id,
+                    );
+                }
                 emit_rewrite_table_indexes(
                     program,
                     resolver,
                     database_id,
-                    &Arc::new(rewritten_table),
+                    &altered_table,
                     &indexes_to_rewrite,
                 )?;
             }

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -2308,6 +2308,14 @@ pub fn translate_alter_table(
     Ok(())
 }
 
+// Return the indexes whose persisted entries may become stale after ALTER COLUMN,
+// rewritten to match the post-ALTER table metadata. We consider both the old and
+// new generated-column dependency graphs so direct indexes, expression indexes,
+// partial-index WHERE clauses, and indexes on dependent generated columns are
+// rebuilt when their computed keys can change.
+// Example: `x NUMERIC -> y TEXT` requires rebuilding `INDEX ON t(x)` with TEXT
+// keys; `g AS ('old:' || a) -> g AS ('new:' || a)` requires rebuilding
+// `INDEX ON t(g)` even though `g` is virtual and table rows are not rewritten.
 fn indexes_affected_by_column_rewrite(
     original_table: &BTreeTable,
     rewritten_table: &BTreeTable,
@@ -2365,6 +2373,12 @@ fn affected_column_names(
     names
 }
 
+// Return true if this index observes any column whose value may change under the
+// rewritten table schema. Direct index columns are checked by column position,
+// while expression-index terms and partial-index WHERE clauses are checked by
+// resolving their column dependencies.
+// Example: `INDEX ON t(z) WHERE typeof(x) = 'text'` must be rebuilt when
+// `x NUMERIC -> y TEXT`, even though `x` is not part of the stored index key.
 fn index_references_rewritten_column(
     index: &Index,
     table: &BTreeTable,
@@ -2398,6 +2412,12 @@ fn expr_references_any_affected_column(
         .any(|name| affected_names.contains(name))
 }
 
+// Build the post-ALTER index metadata used when refilling an affected index.
+// Expression-index terms and partial-index WHERE clauses need identifier
+// rewrites, while direct index columns need to be refreshed from the rewritten
+// table so renamed columns and generated-column expressions stay in sync.
+// Example: after `x NUMERIC -> y TEXT`, `INDEX ON t(typeof(x)) WHERE x IS NOT NULL`
+// must be refilled as `INDEX ON t(typeof(y)) WHERE y IS NOT NULL`.
 fn rewrite_index_for_column_rewrite(
     index: &Index,
     rewritten_table: &BTreeTable,

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1,19 +1,23 @@
 use crate::alloc::TursoIteratorExt;
 use crate::sync::Arc;
-use crate::{bail_parse_error, schema::BTreeTable, turso_assert_eq, turso_assert_ne};
+use crate::{bail_parse_error, turso_assert_eq, turso_assert_ne};
 use turso_parser::{
     ast::{self, TableInternalId},
     parser::Parser,
 };
 
 use super::{
+    index::emit_refill_index,
     schema::{validate_check_expr, SQLITE_TABLEID},
     update::translate_update_for_schema_change,
 };
 use crate::{
     error::SQLITE_CONSTRAINT_CHECK,
     function::{AlterTableFunc, Func},
-    schema::{CheckConstraint, Column, ColumnLayout, ForeignKey, Table, RESERVED_TABLE_PREFIXES},
+    schema::{
+        collect_column_dependencies_of_expr, BTreeTable, CheckConstraint, Column, ColumnLayout,
+        ForeignKey, Index, Table, EXPR_INDEX_SENTINEL, RESERVED_TABLE_PREFIXES,
+    },
     translate::{
         emitter::{emit_check_constraints, gencol::compute_virtual_columns, Resolver},
         expr::{translate_expr, walk_expr, walk_expr_mut, WalkControl},
@@ -22,8 +26,8 @@ use crate::{
     },
     util::{
         check_expr_references_column, escape_sql_string_literal, normalize_ident,
-        parse_numeric_literal, rewrite_check_expr_table_refs, rewrite_trigger_cmd_table_refs,
-        rewrite_view_sql_for_column_rename,
+        parse_numeric_literal, rename_identifiers, rewrite_check_expr_table_refs,
+        rewrite_trigger_cmd_table_refs, rewrite_view_sql_for_column_rename,
     },
     vdbe::{
         affinity::Affinity,
@@ -1910,6 +1914,19 @@ pub fn translate_alter_table(
                 None
             };
 
+            let indexes_to_rewrite = if let Some(rewritten_table) = &rewritten_table {
+                let indexes = indexes_affected_by_column_rewrite(
+                    &original_btree,
+                    rewritten_table,
+                    &table_indexes,
+                    column_index,
+                )?;
+                validate_indexes_can_be_rewritten(&indexes, from, connection, database_id)?;
+                indexes
+            } else {
+                Vec::new()
+            };
+
             // If renaming, rewrite trigger SQL for all triggers that reference this column
             // We'll collect the triggers to rewrite and update them in sqlite_schema
             let mut triggers_to_rewrite: Vec<(usize, String, String)> = Vec::new();
@@ -2246,6 +2263,13 @@ pub fn translate_alter_table(
                     connection,
                     database_id,
                 );
+                emit_rewrite_table_indexes(
+                    program,
+                    resolver,
+                    database_id,
+                    &Arc::new(rewritten_table),
+                    &indexes_to_rewrite,
+                )?;
             }
 
             if clears_autoincrement_sequence {
@@ -2269,6 +2293,185 @@ pub fn translate_alter_table(
         }
     };
 
+    Ok(())
+}
+
+fn indexes_affected_by_column_rewrite(
+    original_table: &BTreeTable,
+    rewritten_table: &BTreeTable,
+    indexes: &[Arc<Index>],
+    column_index: usize,
+) -> Result<Vec<Arc<Index>>> {
+    let mut affected_columns = original_table.columns_affected_by_update([column_index])?;
+    affected_columns.union_with(&rewritten_table.columns_affected_by_update([column_index])?)?;
+    let affected_names = affected_column_names(original_table, rewritten_table, &affected_columns);
+    let old_column_name = original_table.columns()[column_index]
+        .name
+        .as_deref()
+        .expect("ALTER COLUMN target must be named");
+    let new_column_name = rewritten_table.columns()[column_index]
+        .name
+        .as_deref()
+        .expect("ALTER COLUMN replacement must be named");
+
+    Ok(indexes
+        .iter()
+        .filter(|index| {
+            index_references_rewritten_column(
+                index.as_ref(),
+                original_table,
+                &affected_columns,
+                &affected_names,
+            )
+        })
+        .map(|index| {
+            rewrite_index_for_column_rewrite(
+                index.as_ref(),
+                rewritten_table,
+                old_column_name,
+                new_column_name,
+            )
+        })
+        .collect())
+}
+
+fn affected_column_names(
+    original_table: &BTreeTable,
+    rewritten_table: &BTreeTable,
+    affected_columns: &ColumnMask,
+) -> HashSet<String> {
+    let mut names = HashSet::default();
+    for table in [original_table, rewritten_table] {
+        for (idx, column) in table.columns().iter().enumerate() {
+            if affected_columns.get(idx) {
+                if let Some(name) = &column.name {
+                    names.insert(normalize_ident(name));
+                }
+            }
+        }
+    }
+    names
+}
+
+fn index_references_rewritten_column(
+    index: &Index,
+    table: &BTreeTable,
+    affected_columns: &ColumnMask,
+    affected_names: &HashSet<String>,
+) -> bool {
+    for column in &index.columns {
+        if column.pos_in_table != EXPR_INDEX_SENTINEL && affected_columns.get(column.pos_in_table) {
+            return true;
+        }
+        if let Some(expr) = &column.expr {
+            if expr_references_any_affected_column(expr, table, affected_names) {
+                return true;
+            }
+        }
+    }
+
+    index
+        .where_clause
+        .as_ref()
+        .is_some_and(|expr| expr_references_any_affected_column(expr, table, affected_names))
+}
+
+fn expr_references_any_affected_column(
+    expr: &ast::Expr,
+    table: &BTreeTable,
+    affected_names: &HashSet<String>,
+) -> bool {
+    collect_column_dependencies_of_expr(expr, table.columns())
+        .iter()
+        .any(|name| affected_names.contains(name))
+}
+
+fn rewrite_index_for_column_rewrite(
+    index: &Index,
+    rewritten_table: &BTreeTable,
+    old_column_name: &str,
+    new_column_name: &str,
+) -> Arc<Index> {
+    let mut rewritten_index = index.clone();
+    for column in &mut rewritten_index.columns {
+        if let Some(expr) = &mut column.expr {
+            rename_identifiers(expr.as_mut(), old_column_name, new_column_name);
+            if column.pos_in_table == EXPR_INDEX_SENTINEL {
+                column.name = expr.to_string();
+            }
+        }
+
+        if column.pos_in_table != EXPR_INDEX_SENTINEL {
+            let table_column = &rewritten_table.columns()[column.pos_in_table];
+            if let Some(name) = &table_column.name {
+                column.name = normalize_ident(name);
+            }
+            column.default.clone_from(&table_column.default);
+            column.expr = table_column
+                .generated_expr()
+                .map(|expr| Box::new(expr.clone()));
+        }
+    }
+
+    if let Some(where_clause) = &mut rewritten_index.where_clause {
+        rename_identifiers(where_clause, old_column_name, new_column_name);
+    }
+
+    Arc::new(rewritten_index)
+}
+
+fn validate_indexes_can_be_rewritten(
+    indexes: &[Arc<Index>],
+    column_name: &str,
+    connection: &Arc<crate::Connection>,
+    database_id: usize,
+) -> Result<()> {
+    if !indexes.is_empty() && database_uses_mvcc(connection, database_id) {
+        return Err(LimboError::ParseError(format!(
+            "cannot ALTER COLUMN \"{column_name}\": rebuilding affected indexes is not supported in MVCC mode"
+        )));
+    }
+
+    for index in indexes {
+        if !index.has_rowid {
+            return Err(LimboError::ParseError(format!(
+                "cannot ALTER COLUMN \"{column_name}\": rebuilding affected indexes is not supported for WITHOUT ROWID tables"
+            )));
+        }
+        if index
+            .index_method
+            .as_ref()
+            .is_some_and(|method| !method.definition().backing_btree)
+        {
+            return Err(LimboError::ParseError(format!(
+                "cannot ALTER COLUMN \"{column_name}\": rebuilding affected custom index {} is not supported",
+                index.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn emit_rewrite_table_indexes(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    database_id: usize,
+    rewritten_table: &Arc<BTreeTable>,
+    indexes: &[Arc<Index>],
+) -> Result<()> {
+    for index in indexes {
+        let index_cursor_id = program.alloc_cursor_index(None, index)?;
+        emit_refill_index(
+            program,
+            resolver,
+            database_id,
+            rewritten_table,
+            index,
+            index_cursor_id,
+            RegisterOrLiteral::Literal(index.root_page),
+            Some(index.root_page),
+        )?;
+    }
     Ok(())
 }
 

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -310,7 +310,7 @@ pub fn translate_create_index(
 /// records have been collected and sorted. Statement journaling is therefore required
 /// around REINDEX callers so any later refill error restores the original index b-tree.
 #[allow(clippy::too_many_arguments)]
-fn emit_refill_index(
+pub(crate) fn emit_refill_index(
     program: &mut ProgramBuilder,
     resolver: &Resolver,
     database_id: usize,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -15264,34 +15264,6 @@ pub fn op_alter_column(
             panic!("only btree tables can be altered");
         };
         let btree = Arc::make_mut(btree_arc);
-        let existing_column_name = btree
-            .columns()
-            .get(*column_index)
-            .expect("column being ALTERed should be in schema");
-        let existing_column_name = existing_column_name
-            .name
-            .as_ref()
-            .expect("btree column should be named")
-            .clone();
-
-        // Update this table's indexes that reference the old column.
-        if let Some(idxs) = schema.indexes.get_mut(&normalized_table_name) {
-            for idx in idxs {
-                let idx = Arc::make_mut(idx);
-                for ic in &mut idx.columns {
-                    if let Some(expr) = &mut ic.expr {
-                        rename_identifiers(expr.as_mut(), &old_column_name, &new_name);
-                        ic.name = expr.to_string();
-                    } else if ic.name.eq_ignore_ascii_case(&existing_column_name) {
-                        ic.name.clone_from(&new_name);
-                    }
-                }
-                // Update partial index WHERE clause column references
-                if let Some(ref mut wc) = idx.where_clause {
-                    rename_identifiers(wc, &old_column_name, &new_name);
-                }
-            }
-        }
         let clears_autoincrement_sequence = !*rename
             && btree.has_autoincrement
             && btree
@@ -15320,6 +15292,38 @@ pub fn op_alter_column(
         }
 
         btree.prepare_generated_columns()?;
+
+        // Update this table's indexes that reference the old column.
+        if let Some(idxs) = schema.indexes.get_mut(&normalized_table_name) {
+            for idx in idxs {
+                let idx = Arc::make_mut(idx);
+                for ic in &mut idx.columns {
+                    if let Some(expr) = &mut ic.expr {
+                        rename_identifiers(expr.as_mut(), &old_column_name, &new_name);
+                        if ic.pos_in_table == crate::schema::EXPR_INDEX_SENTINEL {
+                            ic.name = expr.to_string();
+                        }
+                    }
+                    if ic.pos_in_table != crate::schema::EXPR_INDEX_SENTINEL {
+                        let table_column = btree
+                            .columns()
+                            .get(ic.pos_in_table)
+                            .expect("indexed column position should exist");
+                        if let Some(name) = &table_column.name {
+                            ic.name.clone_from(name);
+                        }
+                        ic.default.clone_from(&table_column.default);
+                        ic.expr = table_column
+                            .generated_expr()
+                            .map(|expr| Box::new(expr.clone()));
+                    }
+                }
+                // Update partial index WHERE clause column references
+                if let Some(ref mut wc) = idx.where_clause {
+                    rename_identifiers(wc, &old_column_name, &new_name);
+                }
+            }
+        }
 
         // Keep primary_key_columns consistent (names may change on rename)
         for (pk_name, _ord) in &mut btree.primary_key_columns {

--- a/sqlite/conformance/turso-sqltests/alter_column.sqltest
+++ b/sqlite/conformance/turso-sqltests/alter_column.sqltest
@@ -1,5 +1,6 @@
 @database :memory:
 
+@skip-if mvcc "rebuilding affected indexes is not supported in MVCC mode"
 test alter-column-rename-and-type {
     CREATE TABLE t (a INTEGER);
     CREATE INDEX i ON t (a);

--- a/sqlite/conformance/turso-sqltests/alter_column.sqltest
+++ b/sqlite/conformance/turso-sqltests/alter_column.sqltest
@@ -630,6 +630,89 @@ expect {
     ok
 }
 
+test alter-column-rewrites-expression-index-affinity-change {
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE t(x NUMERIC, z INTEGER);
+    CREATE INDEX idx_expr ON t(typeof(x), x);
+    INSERT INTO t VALUES(10,1),(2,2),(30,3);
+    ALTER TABLE t ALTER COLUMN x TO y TEXT;
+    SELECT y FROM t INDEXED BY idx_expr WHERE typeof(y) = 'text' ORDER BY y;
+    PRAGMA integrity_check;
+}
+expect {
+    wal
+    10
+    2
+    30
+    ok
+}
+
+test alter-column-rewrites-partial-index-affinity-change {
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE t(x NUMERIC, z INTEGER);
+    CREATE INDEX idx_partial ON t(z) WHERE typeof(x) = 'text';
+    INSERT INTO t VALUES(10,1),(2,2),(30,3);
+    ALTER TABLE t ALTER COLUMN x TO y TEXT;
+    SELECT z FROM t INDEXED BY idx_partial WHERE typeof(y) = 'text' ORDER BY z;
+    PRAGMA integrity_check;
+}
+expect {
+    wal
+    1
+    2
+    3
+    ok
+}
+
+test alter-column-rewrites-generated-index-affinity-change {
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE t(x NUMERIC, g TEXT GENERATED ALWAYS AS (typeof(x) || ':' || x) VIRTUAL);
+    CREATE INDEX idx_g ON t(g);
+    INSERT INTO t(x) VALUES(10),(2),(30);
+    ALTER TABLE t ALTER COLUMN x TO y TEXT;
+    SELECT g FROM t INDEXED BY idx_g WHERE g >= 'text:' ORDER BY g;
+    PRAGMA integrity_check;
+}
+expect {
+    wal
+    text:10
+    text:2
+    text:30
+    ok
+}
+
+test alter-column-rewrites-indexed-virtual-to-regular {
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE t(id TEXT, g TEXT GENERATED ALWAYS AS ('old:' || id) VIRTUAL);
+    CREATE INDEX idx_g ON t(g);
+    INSERT INTO t(id) VALUES('a'),('b');
+    ALTER TABLE t ALTER COLUMN g TO h TEXT;
+    SELECT id, h FROM t INDEXED BY idx_g WHERE h IS NULL ORDER BY id;
+    PRAGMA integrity_check;
+}
+expect {
+    wal
+    a|
+    b|
+    ok
+}
+
+test alter-column-rewrites-indexed-regular-to-virtual {
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE t(a TEXT, b TEXT, c TEXT);
+    CREATE INDEX idx_b ON t(b);
+    INSERT INTO t VALUES('a','stale:2','2'),('a','stale:1','1');
+    ALTER TABLE t ALTER COLUMN b TO d TEXT GENERATED ALWAYS AS (a || ':' || c) VIRTUAL;
+    SELECT d FROM t INDEXED BY idx_b WHERE d >= 'a:' ORDER BY d;
+    PRAGMA integrity_check;
+}
+expect {
+    wal
+    a:1
+    a:2
+    ok
+}
+
 test alter-column-rewrites-indexed-virtual-expression-change {
     PRAGMA journal_mode=WAL;
     CREATE TABLE t(a TEXT, g TEXT GENERATED ALWAYS AS ('old:' || a) VIRTUAL);
@@ -644,6 +727,44 @@ expect {
     new:a
     new:b
     ok
+}
+
+test alter-column-rewrites-partial-index-virtual-expression-change {
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE t(a TEXT, g TEXT GENERATED ALWAYS AS ('old:' || a) VIRTUAL);
+    CREATE INDEX idx_partial ON t(a) WHERE g LIKE 'new:%';
+    INSERT INTO t(a) VALUES('b'),('a');
+    ALTER TABLE t ALTER COLUMN g TO h TEXT GENERATED ALWAYS AS ('new:' || a) VIRTUAL;
+    SELECT a FROM t INDEXED BY idx_partial WHERE h LIKE 'new:%' ORDER BY a;
+    PRAGMA integrity_check;
+}
+expect {
+    wal
+    a
+    b
+    ok
+}
+
+test alter-column-rejects-index-rewrite-mvcc {
+    PRAGMA journal_mode = 'mvcc';
+    CREATE TABLE t(x NUMERIC);
+    CREATE INDEX idx_x ON t(x);
+    INSERT INTO t VALUES(10),(2),(30);
+    ALTER TABLE t ALTER COLUMN x TO y TEXT;
+}
+expect error {
+    Parse error: cannot ALTER COLUMN "x": rebuilding affected indexes is not supported in MVCC mode
+}
+
+test alter-column-rejects-index-only-rewrite-mvcc {
+    PRAGMA journal_mode = 'mvcc';
+    CREATE TABLE t(a TEXT, g TEXT GENERATED ALWAYS AS ('old:' || a) VIRTUAL);
+    CREATE INDEX idx_g ON t(g);
+    INSERT INTO t(a) VALUES('a'),('b');
+    ALTER TABLE t ALTER COLUMN g TO h TEXT GENERATED ALWAYS AS ('new:' || a) VIRTUAL;
+}
+expect error {
+    Parse error: cannot ALTER COLUMN "g": rebuilding affected indexes is not supported in MVCC mode
 }
 
 test alter-column-text-to-integer-coerces-existing-rows {

--- a/sqlite/conformance/turso-sqltests/alter_column.sqltest
+++ b/sqlite/conformance/turso-sqltests/alter_column.sqltest
@@ -630,6 +630,22 @@ expect {
     ok
 }
 
+test alter-column-rewrites-indexed-virtual-expression-change {
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE t(a TEXT, g TEXT GENERATED ALWAYS AS ('old:' || a) VIRTUAL);
+    CREATE INDEX idx_g ON t(g);
+    INSERT INTO t(a) VALUES('a'),('b');
+    ALTER TABLE t ALTER COLUMN g TO h TEXT GENERATED ALWAYS AS ('new:' || a) VIRTUAL;
+    SELECT h FROM t INDEXED BY idx_g WHERE h >= 'new:' ORDER BY h;
+    PRAGMA integrity_check;
+}
+expect {
+    wal
+    new:a
+    new:b
+    ok
+}
+
 test alter-column-text-to-integer-coerces-existing-rows {
     CREATE TABLE t (x TEXT);
     INSERT INTO t VALUES ('42'), ('abc');

--- a/sqlite/conformance/turso-sqltests/alter_column.sqltest
+++ b/sqlite/conformance/turso-sqltests/alter_column.sqltest
@@ -611,6 +611,24 @@ expect {
     text|abc
 }
 
+# Regression test for https://github.com/tursodatabase/turso/issues/6876.
+test alter-column-rewrites-indexed-affinity-change {
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE t(x NUMERIC);
+    CREATE INDEX idx_x ON t(x);
+    INSERT INTO t VALUES(10),(2),(30);
+    ALTER TABLE t ALTER COLUMN x TO y TEXT;
+    SELECT y, typeof(y) FROM t INDEXED BY idx_x WHERE y >= '0' ORDER BY y;
+    PRAGMA integrity_check;
+}
+expect {
+    wal
+    10|text
+    2|text
+    30|text
+    ok
+}
+
 test alter-column-text-to-integer-coerces-existing-rows {
     CREATE TABLE t (x TEXT);
     INSERT INTO t VALUES ('42'), ('abc');

--- a/tests/integration/query_processing/test_ddl.rs
+++ b/tests/integration/query_processing/test_ddl.rs
@@ -74,6 +74,45 @@ fn test_fail_drop_partial_index_column(tmp_db: TempDatabase) -> anyhow::Result<(
     Ok(())
 }
 
+#[turso_macros::test]
+fn test_alter_column_rewrites_indexed_affinity_change(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(x NUMERIC)")?;
+    conn.execute("CREATE INDEX idx_x ON t(x)")?;
+    conn.execute("INSERT INTO t VALUES (10), (2), (30)")?;
+
+    conn.execute("ALTER TABLE t ALTER COLUMN x TO y TEXT")?;
+
+    let rows: Vec<(String, String)> = conn.exec_rows("SELECT y, typeof(y) FROM t ORDER BY rowid");
+    assert_eq!(
+        rows,
+        vec![
+            ("10".to_string(), "text".to_string()),
+            ("2".to_string(), "text".to_string()),
+            ("30".to_string(), "text".to_string()),
+        ]
+    );
+
+    let indexed_rows: Vec<(String,)> =
+        conn.exec_rows("SELECT y FROM t INDEXED BY idx_x WHERE y >= '0' ORDER BY y");
+    assert_eq!(
+        indexed_rows,
+        vec![("10".to_string(),), ("2".to_string(),), ("30".to_string(),),]
+    );
+
+    let integrity: Vec<(String,)> = conn.exec_rows("PRAGMA integrity_check");
+    assert_eq!(integrity, vec![("ok".to_string(),)]);
+
+    assert!(
+        conn.execute("SELECT x FROM t").is_err(),
+        "successful ALTER COLUMN must rename x to y"
+    );
+    Ok(())
+}
+
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b);")]
 fn test_fail_drop_view_column(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let _ = env_logger::try_init();


### PR DESCRIPTION
## Description

Fixes #6876

## Motivation and context

`ALTER COLUMN` can change more than sqlite_schema text.

There are two pieces of persisted state we need to keep consistent:

```text
table B-tree rows:
  store the row payload

index B-tree entries:
  store computed index keys
```

Before this patch, ALTER COLUMN already knew some changes require rewriting table rows.

Example:

```sql
ALTER TABLE t ALTER COLUMN x NUMERIC TO y TEXT;
```

The affinity changed, so existing row values must be coerced and rewritten. That part was already handled.

But indexes are separate B-trees. If an index key depends on the altered column, the index entries must also be rebuilt from the post-ALTER table schema.

### The bug

Consider:

```sql
CREATE TABLE t(x NUMERIC);
CREATE INDEX idx_x ON t(x);
INSERT INTO t VALUES(10),(2),(30);

ALTER TABLE t ALTER COLUMN x TO y TEXT;
```

The old code detected the affinity change and rewrote the table rows, so `x` became `y` and the row payloads were coerced to TEXT. But `idx_x` was not rebuilt. That means a query forced through the index, or `PRAGMA integrity_check`, can observe stale index contents.

There is another version of the same bug with virtual generated columns:

```sql
CREATE TABLE t(a TEXT, g TEXT GENERATED ALWAYS AS ('old:' || a) VIRTUAL);
CREATE INDEX idx_g ON t(g);

ALTER TABLE t ALTER COLUMN g TO h TEXT GENERATED ALWAYS AS ('new:' || a) VIRTUAL;
```

Here table rows do not need rewriting because `g/h` is virtual. But `idx_g` still needs rebuilding, because the stored index keys changed from `old:*` to `new:*`.

MVCC is a special case because existing MVCC already rejects `REINDEX` and `ClearBtree`. MVCC does not currently have a versioned bulk index rebuild operation for that.

## Description of AI Usage

Codex was used to debug the issue, write the regression tests, and iterate on the fix. I did review the slop.