### PR TITLE
core/translate: evaluate subqueries in aggregate args/FILTER before group by loop

### DIFF
--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -370,10 +370,18 @@ fn collect_agg_leaf_columns(aggregates: &[Aggregate], plan: &SelectPlan) -> Resu
                     .iter()
                     .find(|s| s.internal_id == *subquery_id)
                     .is_some_and(|s| s.correlated);
-                if is_correlated && !leaf_columns.iter().any(|e| exprs_are_equivalent(e, expr)) {
-                    leaf_columns.push(expr.clone());
+                if is_correlated {
+                    if !leaf_columns.iter().any(|e| exprs_are_equivalent(e, expr)) {
+                        leaf_columns.push(expr.clone());
+                    }
+                    Ok(WalkControl::SkipChildren)
+                } else {
+                    // A non-correlated subquery is materialized once and probed
+                    // per row (e.g. the LHS of `x IN (SELECT ...)`), so the
+                    // probe's column references must be carried through the
+                    // sorter like any other aggregate input.
+                    Ok(WalkControl::Continue)
                 }
-                Ok(WalkControl::SkipChildren)
             }
             _ => Ok(WalkControl::Continue),
         }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -2099,9 +2099,30 @@ fn assign_select_subquery_eval_phases(plan: &mut SelectPlan) {
         .as_ref()
         .is_some_and(|group_by| !group_by.exprs.is_empty());
 
+    // Subqueries inside an aggregate's arguments or FILTER clause are evaluated
+    // per input row by the aggregate step code in the main loop, even when the
+    // aggregate itself belongs to HAVING or ORDER BY. Deferring them to the
+    // grouped output subroutine would emit their materialization after their
+    // first use, so they must keep their phase floor (issue #6807).
+    let mut aggregate_subquery_ids: Vec<ast::TableInternalId> = Vec::new();
+    for agg in &plan.aggregates {
+        for expr in agg.args.iter().chain(agg.filter_expr.iter()) {
+            walk_expr(expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
+                if let ast::Expr::SubqueryResult { subquery_id, .. } = e {
+                    aggregate_subquery_ids.push(*subquery_id);
+                }
+                Ok(WalkControl::Continue)
+            })
+            .expect("walking an expression with an infallible visitor cannot fail");
+        }
+    }
+
     for subquery in plan.non_from_clause_subqueries.iter_mut() {
         subquery.eval_phase = match subquery.origin {
-            SubqueryOrigin::SelectHaving | SubqueryOrigin::SelectOrderBy if has_grouped_output => {
+            SubqueryOrigin::SelectHaving | SubqueryOrigin::SelectOrderBy
+                if has_grouped_output
+                    && !aggregate_subquery_ids.contains(&subquery.internal_id) =>
+            {
                 SubqueryEvalPhase::GroupedOutput
             }
             _ => subquery.origin.phase_floor(),

--- a/sqlite/conformance/sqlite-sqltests/aggregate-filter-in-subquery-grouped.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/aggregate-filter-in-subquery-grouped.sqltest
@@ -1,0 +1,76 @@
+@database :memory:
+
+# Regression test for #6807: a subquery inside an aggregate's FILTER clause
+# (or arguments) is evaluated per input row in the main loop, even when the
+# aggregate belongs to HAVING or ORDER BY. Deferring its materialization to
+# the grouped output subroutine emitted OpenEphemeral after the first cursor
+# use, panicking with "cursor id 0 is None". The probe's LHS columns must
+# also be carried through the GROUP BY sorter, or the filter reads stale
+# values from the exhausted table cursor.
+
+setup schema {
+    CREATE TABLE t(c INT, d INT);
+    INSERT INTO t VALUES (1,10);
+    INSERT INTO t VALUES (2,20);
+    INSERT INTO t VALUES (2,30);
+    INSERT INTO t VALUES (3,40);
+}
+
+test having-filter-in-subquery-no-from {
+    SELECT 1 GROUP BY 1 HAVING COUNT(*) FILTER (WHERE 1 IN (SELECT 2)) = 1;
+}
+expect {
+}
+
+test having-filter-in-subquery-no-from-match {
+    SELECT 1 GROUP BY 1 HAVING COUNT(*) FILTER (WHERE 1 IN (SELECT 1)) = 1;
+}
+expect {
+    1
+}
+
+@setup schema
+test having-filter-in-subquery {
+    SELECT c FROM t GROUP BY c HAVING COUNT(*) FILTER (WHERE d IN (SELECT 20 UNION SELECT 40)) > 0;
+}
+expect {
+    2
+    3
+}
+
+@setup schema
+test orderby-filter-in-subquery {
+    SELECT c FROM t GROUP BY c ORDER BY COUNT(*) FILTER (WHERE d IN (SELECT 20 UNION SELECT 30)) DESC, c;
+}
+expect {
+    2
+    1
+    3
+}
+
+@setup schema
+test result-column-filter-not-in-subquery {
+    SELECT c, COUNT(*) FILTER (WHERE d NOT IN (SELECT 20)) FROM t GROUP BY c;
+}
+expect {
+    1|1
+    2|1
+    3|1
+}
+
+@setup schema
+test having-agg-arg-in-subquery {
+    SELECT c FROM t GROUP BY c HAVING SUM(d IN (SELECT 20)) > 0;
+}
+expect {
+    2
+}
+
+@setup schema
+test having-plain-in-subquery-still-deferred {
+    SELECT c FROM t GROUP BY c HAVING c IN (SELECT 2 UNION SELECT 3);
+}
+expect {
+    2
+    3
+}


### PR DESCRIPTION
fixes #6807

## Problem

Queries with an `IN (SELECT ...)` subquery inside an aggregate's `FILTER`
clause (or arguments), where the aggregate belongs to `HAVING` or
`ORDER BY` of a grouped query, panic with `cursor id 0 is None`:

```sql
SELECT 1 GROUP BY 1 HAVING COUNT(*) FILTER (WHERE 1 IN (SELECT 2)) = 1;
```

There are two bugs:

1. **Materialization emitted after first use.** Subqueries originating in
   `HAVING`/`ORDER BY` of a grouped query are assigned the `GroupedOutput`
   eval phase, so their materialization (`Once` + `OpenEphemeral` + populate)
   is emitted in the group-output subroutine. But a subquery inside an
   aggregate's arguments or `FILTER` clause is evaluated per input row by the
   aggregate step code in the main loop, the `NotFound`/`Rewind` probe runs
   before the output subroutine ever opens the cursor, and the VDBE panics.

2. **Probe LHS read from an exhausted cursor.** With the phase fixed, the
   probe's left-hand side (e.g. `c` in `c IN (SELECT 1)`) was still
   translated against the base table cursor. In the sorter-based GROUP BY
   path, that cursor is already exhausted when aggregate steps run from the
   sorter, so the filter compared stale values and produced wrong results:

   ```sql
   CREATE TABLE t(c INT); INSERT INTO t VALUES (1),(2);
   SELECT c FROM t GROUP BY c ORDER BY COUNT(*) FILTER (WHERE c IN (SELECT 1));
   -- sqlite: 2,1   turso (panics before both fixes, with only 1 fix it returns): 1,2
   ```
