### PR TITLE
core/types: add fallible reusable value cloning

### DIFF
--- a/core/alloc/allocation_site.rs
+++ b/core/alloc/allocation_site.rs
@@ -18,6 +18,7 @@ pub enum ValueBlobAllocationSite {
     JsonbCopy,
     Hash128,
     RecordDecode,
+    CloneFrom,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -119,6 +119,14 @@ pub trait TryClone: Sized {
     type Error;
 
     fn try_clone(&self) -> Result<Self, Self::Error>;
+
+    /// Replaces `self` with a fallible clone of `source`.
+    ///
+    /// Implementors can override this to reuse owned resources.
+    fn try_clone_from(&mut self, source: &Self) -> Result<(), Self::Error> {
+        *self = source.try_clone()?;
+        Ok(())
+    }
 }
 
 /// Forward `TryClone` to `Clone` for element types whose clone either cannot

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -438,6 +438,16 @@ impl TryClone for FallibleElem {
 }
 
 #[test]
+fn try_clone_from_uses_default_replacement() {
+    let source = 7_u32;
+    let mut destination = 3_u32;
+
+    destination.try_clone_from(&source).unwrap();
+
+    assert_eq!(destination, source);
+}
+
+#[test]
 fn vec_try_clone_clones_elements_fallibly() {
     let mut source: Vec<FallibleElem> = self::vec![];
     source.try_push(FallibleElem).unwrap();

--- a/core/types.rs
+++ b/core/types.rs
@@ -340,6 +340,62 @@ pub enum Value {
     Blob(#[cfg_attr(feature = "serde", serde(with = "value_blob_serde"))] ValueBlob),
 }
 
+impl TryClone for Value {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        match self {
+            Self::Null => Ok(Self::Null),
+            Self::Numeric(numeric) => Ok(Self::Numeric(*numeric)),
+            Self::Text(text) => {
+                let mut value = String::new();
+                value.try_reserve(text.as_str().len())?;
+                value.push_str(text.as_str());
+                Ok(Self::Text(Text {
+                    value: Cow::Owned(value),
+                    subtype: text.subtype,
+                }))
+            }
+            Self::Blob(blob) => Self::from_slice(blob),
+        }
+    }
+
+    /// Fallibly copies `source` into `self`, reusing the existing Text/Blob
+    /// allocation when the variants match, so hot per-row copies are
+    /// allocation-free once buffers have grown to the row size. On allocation
+    /// failure `self` is left valid but unspecified (an empty Text/Blob).
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::CloneFrom)]
+    fn try_clone_from(&mut self, source: &Self) -> Result<(), Self::Error> {
+        match (self, source) {
+            (Self::Text(dst), Self::Text(src)) => {
+                let src_str = src.as_str();
+                match &mut dst.value {
+                    Cow::Owned(s) => {
+                        s.clear();
+                        s.try_reserve(src_str.len())?;
+                        s.push_str(src_str);
+                    }
+                    borrowed => {
+                        let mut s = String::new();
+                        s.try_reserve(src_str.len())?;
+                        s.push_str(src_str);
+                        *borrowed = Cow::Owned(s);
+                    }
+                }
+                dst.subtype = src.subtype;
+            }
+            (Self::Blob(dst), Self::Blob(src)) => {
+                dst.clear();
+                dst.try_extend(src.iter().copied())?;
+            }
+            (dst, src) => {
+                *dst = src.try_clone()?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Copy)]
 pub enum ValueRef<'a> {
     Null,
@@ -4502,6 +4558,65 @@ mod tests {
                 cnt, num_values,
                 "column_count should be {num_values}, not {cnt}"
             );
+        }
+    }
+
+    #[test]
+    fn test_value_try_clone_from_reuses_allocations() {
+        let src = Value::build_text(String::from("short"));
+        let mut dst =
+            Value::build_text(String::from("a destination string with plenty of capacity"));
+        let ptr = match &dst {
+            Value::Text(t) => t.as_str().as_ptr(),
+            _ => unreachable!(),
+        };
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        match &dst {
+            Value::Text(t) => assert_eq!(t.as_str().as_ptr(), ptr),
+            _ => unreachable!(),
+        }
+
+        let mut dst = Value::build_text("static text");
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+
+        let src = Value::Blob(vec![1, 2, 3]);
+        let mut big_blob: ValueBlob = vec![];
+        big_blob.extend(0u8..32);
+        let mut dst = Value::Blob(big_blob);
+        let ptr = match &dst {
+            Value::Blob(b) => b.as_ptr(),
+            _ => unreachable!(),
+        };
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        match &dst {
+            Value::Blob(b) => assert_eq!(b.as_ptr(), ptr),
+            _ => unreachable!(),
+        }
+
+        let src = Value::from_i64(9);
+        let mut dst = Value::build_text("text");
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        let src = Value::build_text("into an integer slot");
+        let mut dst = Value::from_i64(3);
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn test_value_try_clone() {
+        let values = [
+            Value::Null,
+            Value::from_i64(7),
+            Value::build_text("text"),
+            Value::Blob(vec![1, 2, 3]),
+        ];
+
+        for value in values {
+            assert_eq!(value.try_clone().unwrap(), value);
         }
     }
 }

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -228,6 +228,7 @@ fn allocation_site_id(site: AllocationSite) -> u64 {
             ValueBlobAllocationSite::JsonbCopy => 26,
             ValueBlobAllocationSite::Hash128 => 27,
             ValueBlobAllocationSite::JsonbConstruction => 28,
+            ValueBlobAllocationSite::CloneFrom => 29,
         },
         AllocationSite::Vector(site) => match site {
             VectorAllocationSite::Parse => 15,


### PR DESCRIPTION
## Description

- add `TryClone::try_clone_from` with a default replacement implementation
- implement fallible `try_clone` and allocation-reusing `try_clone_from` for `Value`
- register value clone allocation failures and cover the trait default, all `Value` variants, buffer reuse, and injected allocation failure

## Context

`Value` copies can allocate for text and blob payloads, so they need to surface allocation failures. Moving `try_clone_from` onto `TryClone` also gives generic callers the same resource-reuse hook as `Clone::clone_from`, while the `Value` override preserves existing text and blob capacity in hot per-row copy paths.

