### PR TITLE
core/translate: run upsert DO UPDATE arms with ABORT conflict resolution

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -672,6 +672,7 @@ fn emit_add_virtual_column_validation(
                 }),
             connection,
             ast::ResolveType::Abort,
+            None,
             skip_row_label,
             None,
         )?;

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -2085,11 +2085,13 @@ fn emit_index_column_value_new_image(
 
 /// Emit bytecode for evaluating CHECK constraints.
 /// Assumes the resolver cache is already populated with column-to-register mappings.
+#[allow(clippy::too_many_arguments)]
 fn emit_check_constraint_bytecode(
     program: &mut ProgramBuilder,
     check_constraints: &[CheckConstraint],
     resolver: &mut Resolver,
     or_conflict: ResolveType,
+    halt_on_error: Option<ResolveType>,
     skip_row_label: BranchOffset,
     referenced_tables: Option<&TableReferences>,
     table_name: &str,
@@ -2158,7 +2160,7 @@ fn emit_check_constraint_bytecode(
                 program.emit_insn(Insn::Halt {
                     err_code: SQLITE_CONSTRAINT_CHECK,
                     description: constraint_name.to_string(),
-                    on_error: None,
+                    on_error: halt_on_error,
                     description_reg: None,
                 });
             }
@@ -2191,6 +2193,11 @@ pub(crate) fn emit_check_constraints<'a>(
     column_mappings: impl Iterator<Item = (&'a str, usize)>,
     connection: &Arc<Connection>,
     or_conflict: ResolveType,
+    // Per-instruction conflict resolution override for the emitted Halt, like
+    // `Insn::Halt`'s `on_error`. The DO UPDATE arm of an upsert always runs
+    // with ABORT semantics regardless of the statement's OR clause (issue
+    // #7839); all other callers pass None.
+    halt_on_error: Option<ResolveType>,
     skip_row_label: BranchOffset,
     referenced_tables: Option<&TableReferences>,
 ) -> Result<()> {
@@ -2274,6 +2281,7 @@ pub(crate) fn emit_check_constraints<'a>(
         check_constraints,
         resolver,
         or_conflict,
+        halt_on_error,
         skip_row_label,
         referenced_tables,
         table_name,

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -574,6 +574,7 @@ fn emit_notnull_constraint_check(
                     target_reg,
                     err_code: SQLITE_CONSTRAINT_NOTNULL,
                     description: description(),
+                    on_error: None,
                 });
             }
         }
@@ -582,6 +583,7 @@ fn emit_notnull_constraint_check(
                 target_reg,
                 err_code: SQLITE_CONSTRAINT_NOTNULL,
                 description: description(),
+                on_error: None,
             });
         }
     }
@@ -1746,6 +1748,7 @@ fn emit_update_insns<'a>(
                     }),
                 connection,
                 or_conflict,
+                None,
                 skip_row_label,
                 Some(&check_constraint_tables),
             )?;

--- a/core/translate/expr/custom_types.rs
+++ b/core/translate/expr/custom_types.rs
@@ -447,6 +447,7 @@ pub(super) fn emit_domain_cast_constraints(
                 "domain {} does not allow null values",
                 chain.first().map(|td| td.name.as_str()).unwrap_or("?")
             ),
+            on_error: None,
         });
     }
 

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -803,6 +803,7 @@ pub fn translate_insert(
         }),
         connection,
         ctx.on_conflict,
+        None,
         ctx.loop_labels.row_done,
         Some(&table_references),
     )?;
@@ -1881,6 +1882,7 @@ fn emit_notnulls(
                     );
                     description
                 },
+                on_error: None,
             });
         }
     }

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -689,6 +689,10 @@ pub fn emit_upsert(
                 target_reg: layout.to_register(new_start, *col_idx),
                 err_code: SQLITE_CONSTRAINT_NOTNULL,
                 description: String::from(table.get_name()) + "." + col.name.as_ref().unwrap(),
+                // The DO UPDATE arm always runs with ABORT conflict
+                // resolution, regardless of the statement's OR clause
+                // (issue #7839).
+                on_error: Some(ast::ResolveType::Abort),
             });
         }
         if col.is_rowid_alias() {
@@ -791,6 +795,9 @@ pub fn emit_upsert(
             }),
             connection,
             ast::ResolveType::Abort,
+            // The DO UPDATE arm always runs with ABORT conflict resolution,
+            // regardless of the statement's OR clause (issue #7839).
+            Some(ast::ResolveType::Abort),
             ctx.loop_labels.row_done,
             Some(table_references),
         )?;
@@ -1005,7 +1012,9 @@ pub fn emit_upsert(
                     .and_then(|c| c.name.as_deref())
                     .unwrap_or("rowid")
             ),
-            on_error: None,
+            // The DO UPDATE arm always runs with ABORT conflict resolution,
+            // regardless of the statement's OR clause (issue #7839).
+            on_error: Some(ast::ResolveType::Abort),
             description_reg: None,
         });
         program.preassign_label_to_next_insn(ok);
@@ -1153,7 +1162,10 @@ pub fn emit_upsert(
                 program.emit_insn(Insn::Halt {
                     err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
                     description,
-                    on_error: None,
+                    // The DO UPDATE arm always runs with ABORT conflict
+                    // resolution, regardless of the statement's OR clause
+                    // (issue #7839).
+                    on_error: Some(ast::ResolveType::Abort),
                     description_reg: None,
                 });
                 program.preassign_label_to_next_insn(ok);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3131,8 +3131,23 @@ pub fn halt(
         vtab_rollback_all(&program.connection)?;
     }
 
+    // A Halt for a genuine constraint violation may carry a per-instruction
+    // conflict resolution override in `on_error`: the DO UPDATE arm of an
+    // upsert always runs with ABORT semantics regardless of the statement's
+    // OR clause (issue #7839). Such halts still surface a regular constraint
+    // error — only the effective resolve type changes. RAISE() halts use
+    // SQLITE_CONSTRAINT_TRIGGER/SQLITE_ERROR err_codes, so they are not
+    // affected by this and keep their own error variant below.
+    let constraint_override = match err_code {
+        SQLITE_CONSTRAINT_PRIMARYKEY
+        | SQLITE_CONSTRAINT_UNIQUE
+        | SQLITE_CONSTRAINT_CHECK
+        | SQLITE_CONSTRAINT_NOTNULL => on_error,
+        _ => None,
+    };
+
     // Handle RAISE errors - these carry their own resolve type
-    if let Some(resolve_type) = on_error {
+    if let Some(resolve_type) = on_error.filter(|_| constraint_override.is_none()) {
         // RAISE(IGNORE) signals the parent to skip the current row
         if resolve_type == ResolveType::Ignore {
             return Err(LimboError::RaiseIgnore);
@@ -3186,10 +3201,14 @@ pub fn halt(
 
     // Handle constraint errors
     if let Some(error) = constraint_error {
+        // Make the per-halt override visible to abort(), which otherwise
+        // resolves constraint errors with the statement-level clause.
+        state.constraint_resolve_override = constraint_override;
+        let effective_resolve = constraint_override.unwrap_or(program.resolve_type);
         // For FAIL mode with autocommit, commit partial changes before returning error.
         // This matches SQLite behavior where FAIL keeps changes made before the error.
         // Note: ON CONFLICT FAIL does NOT apply to FK violations, so we check for those first.
-        if program.resolve_type == ResolveType::Fail && can_autocommit_now {
+        if effective_resolve == ResolveType::Fail && can_autocommit_now {
             // Check for immediate FK violations - FK errors don't respect ON CONFLICT
             if program.connection.foreign_keys_enabled()
                 && state.get_fk_immediate_violations_during_stmt() > 0
@@ -3438,11 +3457,12 @@ pub fn op_halt_if_null(
             target_reg,
             err_code,
             description,
+            on_error,
         },
         insn
     );
     if state.registers[*target_reg].get_value() == &Value::Null {
-        halt(program, state, pager, *err_code, description, None)
+        halt(program, state, pager, *err_code, description, *on_error)
     } else {
         state.pc += 1;
         Ok(InsnFunctionStepResult::Step)

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -936,15 +936,26 @@ pub fn insn_to_row(
                 err_code,
                 target_reg,
                 description,
-            } => (
-                "HaltIfNull",
-                *err_code as i64,
-                0,
-                *target_reg as i64,
-                Value::build_text(description.clone()),
-                0,
-                "".to_string(),
-            ),
+                on_error,
+            } => {
+                let p2 = match on_error {
+                    Some(ResolveType::Rollback) => 1,
+                    Some(ResolveType::Abort) => 2,
+                    Some(ResolveType::Fail) => 3,
+                    Some(ResolveType::Ignore) => 4,
+                    Some(ResolveType::Replace) => 5,
+                    None => 0,
+                };
+                (
+                    "HaltIfNull",
+                    *err_code as i64,
+                    p2,
+                    *target_reg as i64,
+                    Value::build_text(description.clone()),
+                    0,
+                    "".to_string(),
+                )
+            }
             Insn::Transaction { db, tx_mode, schema_cookie} => (
                 "Transaction",
                 *db as i64,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -837,6 +837,10 @@ pub enum Insn {
         target_reg: usize,   // P3
         description: String, // p4
         err_code: usize,     // p1
+        /// Per-instruction conflict resolution override, like `Insn::Halt`'s.
+        /// The DO UPDATE arm of an upsert always runs with ABORT semantics
+        /// regardless of the statement's OR clause (issue #7839).
+        on_error: Option<ResolveType>, // P2
     },
 
     /// Start a transaction.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -770,6 +770,12 @@ pub struct ProgramState {
     /// When a constraint error occurs with FAIL resolve type in autocommit mode,
     /// we need to commit partial changes before returning the error.
     pub(crate) pending_fail_error: Option<LimboError>,
+    /// Per-halt conflict resolution override for constraint errors.
+    /// Set by halt() when the failing Halt carries `on_error` for a genuine
+    /// constraint violation (e.g. an upsert DO UPDATE arm, which always uses
+    /// ABORT semantics regardless of the statement's OR clause, issue #7839);
+    /// read by abort() in place of the statement-level resolve type.
+    pub(crate) constraint_resolve_override: Option<ResolveType>,
     /// Pending CDC info to apply after the program completes successfully.
     /// Set by InitCdcVersion opcode, applied at Halt/Done so that if the
     /// transaction rolls back, the connection's CDC state remains unchanged.
@@ -864,6 +870,7 @@ impl ProgramState {
             n_total_change: AtomicI64::new(0),
             explain_state: RwLock::new(ExplainState::default()),
             pending_fail_error: None,
+            constraint_resolve_override: None,
             pending_cdc_info: None,
             subprogram_stmt_cache: HashMap::default(),
         }
@@ -995,6 +1002,7 @@ impl ProgramState {
         self.n_total_change.store(0, Ordering::SeqCst);
         *self.explain_state.write() = ExplainState::default();
         self.pending_fail_error = None;
+        self.constraint_resolve_override = None;
         self.pending_cdc_info = None;
         self.subprogram_stmt_cache.clear();
     }
@@ -2600,12 +2608,20 @@ impl Program {
                 // is rolling back the whole MVCC transaction.
             }
             let must_rollback_tx_if_needed = can_autocommit_now || changed_shared_mvcc_auto_txn;
+            // The failing halt may carry a per-instruction conflict resolution
+            // override for its constraint error (upsert DO UPDATE arms always
+            // use ABORT semantics regardless of the statement's OR clause,
+            // issue #7839). It replaces the statement-level resolve type.
+            let stmt_resolve = state
+                .constraint_resolve_override
+                .take()
+                .unwrap_or(self.resolve_type);
             if err.is_some() && !pager.is_checkpointing() {
                 // For ON CONFLICT FAIL, do NOT rollback the statement savepoint —
                 // changes made before the error should persist.
                 // For all other resolve types (ABORT, ROLLBACK, etc.), rollback the statement.
                 let is_fail_constraint = (matches!(err, Some(LimboError::Constraint(_)))
-                    && self.resolve_type == ResolveType::Fail)
+                    && stmt_resolve == ResolveType::Fail)
                     || matches!(err, Some(LimboError::Raise(ResolveType::Fail, _)));
                 if !is_fail_constraint {
                     if let Err(end_stmt_err) = state.end_statement(
@@ -2667,7 +2683,7 @@ impl Program {
                 Some(LimboError::Constraint(_)) | Some(LimboError::Raise(_, _)) => {
                     let effective_resolve = match err {
                         Some(LimboError::Raise(rt, _)) => *rt,
-                        _ => self.resolve_type,
+                        _ => stmt_resolve,
                     };
                     match effective_resolve {
                         ResolveType::Rollback => {

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -506,6 +506,190 @@ fn test_multi_row_partial_conflict(tmp_db: TempDatabase) -> anyhow::Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// Upsert DO UPDATE arm conflict semantics (issue #7839)
+// ---------------------------------------------------------------------------
+
+/// The UPDATE arm of an upsert always runs with ABORT conflict resolution,
+/// regardless of the statement-level OR clause (SQLite upsert.c). A constraint
+/// failure raised inside the DO UPDATE arm must roll back the whole statement:
+/// under INSERT OR FAIL rows inserted earlier in the statement must not
+/// persist, and under INSERT OR ROLLBACK the enclosing transaction must not be
+/// rolled back.
+///
+/// `INSERT OR IGNORE` is excluded from the matrix: Turso currently rewrites
+/// its upsert clause to DO NOTHING at translate time, which is a separate
+/// divergence from SQLite not addressed by the DO UPDATE arm fix.
+const UPSERT_ARM_SEED: &str = "INSERT INTO t VALUES(1,1,10),(2,2,20)";
+/// (scenario, DDL, DO UPDATE SET clause, expected error fragment).
+/// In every scenario row (10,5,50) inserts cleanly and row (11,1,60) hits
+/// ON CONFLICT(u); the DO UPDATE arm then violates a different constraint
+/// kind on column c — UNIQUE (c=20 collides with row 2), NOT NULL, or CHECK.
+const UPSERT_ARM_SCENARIOS: &[(&str, &str, &str, &str)] = &[
+    (
+        "unique",
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, c INT UNIQUE)",
+        "SET c=20",
+        "UNIQUE constraint failed: t.c",
+    ),
+    (
+        "notnull",
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, c INT NOT NULL)",
+        "SET c=NULL",
+        "NOT NULL constraint failed: t.c",
+    ),
+    (
+        "check",
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, c INT CHECK(c<100))",
+        "SET c=200",
+        "CHECK constraint failed",
+    ),
+];
+const UPSERT_ARM_CLAUSES: &[(&str, &str)] = &[
+    ("INSERT", "plain"),
+    ("INSERT OR FAIL", "or_fail"),
+    ("INSERT OR ABORT", "or_abort"),
+    ("INSERT OR ROLLBACK", "or_rollback"),
+    ("INSERT OR REPLACE", "or_replace"),
+];
+const UPSERT_ARM_VERIFY: &str = "SELECT id, u, c FROM t ORDER BY id";
+
+#[turso_macros::test]
+fn test_upsert_do_update_arm_always_aborts(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for &(scenario, ddl, set_clause, expected_msg) in UPSERT_ARM_SCENARIOS {
+        for &(clause, clause_name) in UPSERT_ARM_CLAUSES {
+            let label = format!("upsert_arm_autocommit__{scenario}__{clause_name}");
+
+            let limbo_db = TempDatabase::builder()
+                .with_db_name(format!("{label}.db"))
+                .build();
+            let limbo_conn = limbo_db.connect_limbo();
+            let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+            for setup in [ddl, UPSERT_ARM_SEED] {
+                limbo_conn.execute(setup).unwrap();
+                sqlite_conn.execute_batch(setup).unwrap();
+            }
+
+            let sql = format!(
+                "{clause} INTO t VALUES(10,5,50),(11,1,60) ON CONFLICT(u) DO UPDATE {set_clause}"
+            );
+            // Both engines must reject the statement with the same constraint
+            // violation; the message must keep its SQLite-compatible shape.
+            match limbo_try_exec(&limbo_conn, &sql) {
+                Err(e) if e.contains(expected_msg) => {}
+                other => failures.push(format!(
+                    "[{label}] limbo: expected error containing {expected_msg:?}, got {other:?}"
+                )),
+            }
+            if sqlite_try_exec(&sqlite_conn, &sql).is_ok() {
+                failures.push(format!("[{label}] sqlite unexpectedly succeeded"));
+            }
+
+            if let Some(e) = compare_tables(&label, &sqlite_conn, &limbo_conn, UPSERT_ARM_VERIFY) {
+                failures.push(e);
+            }
+
+            let db_path = limbo_db.path.clone();
+            drop(limbo_conn);
+            drop(limbo_db);
+            let ic = sqlite_integrity_check(&db_path);
+            if ic != "ok" {
+                failures.push(format!("[{label}] integrity_check: {ic}"));
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} failure(s) in upsert DO UPDATE arm autocommit test:\n{}",
+            failures.len(),
+            failures.join("\n")
+        );
+    }
+
+    Ok(())
+}
+
+/// Same scenario inside an explicit transaction: the failing DO UPDATE arm
+/// must roll back only its own statement. Rows inserted by earlier statements
+/// of the transaction survive, the transaction stays open, and COMMIT
+/// succeeds — even under INSERT OR ROLLBACK, whose statement-level semantics
+/// would otherwise kill the whole transaction.
+#[turso_macros::test]
+fn test_upsert_do_update_arm_aborts_in_transaction(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for &(scenario, ddl, set_clause, expected_msg) in UPSERT_ARM_SCENARIOS {
+        for &(clause, clause_name) in UPSERT_ARM_CLAUSES {
+            let label = format!("upsert_arm_txn__{scenario}__{clause_name}");
+
+            let limbo_db = TempDatabase::builder()
+                .with_db_name(format!("{label}.db"))
+                .build();
+            let limbo_conn = limbo_db.connect_limbo();
+            let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+            for setup in [ddl, UPSERT_ARM_SEED] {
+                limbo_conn.execute(setup).unwrap();
+                sqlite_conn.execute_batch(setup).unwrap();
+            }
+
+            for stmt in ["BEGIN", "INSERT INTO t VALUES(90,9,90)"] {
+                if let Err(e) = exec_and_compare(&label, &sqlite_conn, &limbo_conn, stmt) {
+                    failures.push(e);
+                }
+            }
+
+            let sql = format!(
+                "{clause} INTO t VALUES(10,5,50),(11,1,60) ON CONFLICT(u) DO UPDATE {set_clause}"
+            );
+            match limbo_try_exec(&limbo_conn, &sql) {
+                Err(e) if e.contains(expected_msg) => {}
+                other => failures.push(format!(
+                    "[{label}] limbo: expected error containing {expected_msg:?}, got {other:?}"
+                )),
+            }
+            if sqlite_try_exec(&sqlite_conn, &sql).is_ok() {
+                failures.push(format!("[{label}] sqlite unexpectedly succeeded"));
+            }
+
+            // The transaction must still be alive with row 90 intact.
+            if let Some(e) = compare_tables(&label, &sqlite_conn, &limbo_conn, UPSERT_ARM_VERIFY) {
+                failures.push(e);
+            }
+            if let Err(e) = exec_and_compare(&label, &sqlite_conn, &limbo_conn, "COMMIT") {
+                failures.push(e);
+            }
+            if let Some(e) = compare_tables(&label, &sqlite_conn, &limbo_conn, UPSERT_ARM_VERIFY) {
+                failures.push(e);
+            }
+
+            let db_path = limbo_db.path.clone();
+            drop(limbo_conn);
+            drop(limbo_db);
+            let ic = sqlite_integrity_check(&db_path);
+            if ic != "ok" {
+                failures.push(format!("[{label}] integrity_check: {ic}"));
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} failure(s) in upsert DO UPDATE arm transaction test:\n{}",
+            failures.len(),
+            failures.join("\n")
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // ROLLBACK inside explicit transaction
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Cleanup for a failed statement is decided at two points: the FAIL fast-path in `halt()` that commits partial changes (`core/vdbe/execute.rs:3211`) and the savepoint/transaction rollback in `abort()` (`core/vdbe/mod.rs:2615`). Rather than special-casing upserts at each point, the fix changes the resolve type that flows into them: the arm's constraint halts (unique probes, `HaltIfNull`, CHECK) are emitted with `on_error: Some(Abort)`, and `halt()` treats `on_error` on a genuine constraint err_code as a per-instruction conflict-resolution override that replaces the statement-level clause everywhere downstream. Both cleanup points then take the ABORT path without knowing about upserts.

The override travels to `abort()` through `ProgramState` (mirroring `pending_fail_error`) rather than the `LimboError::Raise` variant, so the error keeps its `LimboError::Constraint` shape — same message text and same C-API error code as before.

`INSERT OR IGNORE` upserts are unaffected: their DO UPDATE clause is currently rewritten to DO NOTHING at translate time, which is a separate divergence from SQLite.

Repro (matches SQLite after this change):

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, c INT UNIQUE);
INSERT INTO t VALUES(1,1,10),(2,2,20);
INSERT OR FAIL INTO t VALUES(10,5,50),(11,1,60) ON CONFLICT(u) DO UPDATE SET c=20;
-- SQLite:       UNIQUE constraint failed: t.c; table unchanged (row 10 rolled back)
-- Turso before: same error, but row (10,5,50) persisted
-- Turso after:  matches SQLite; message and error code unchanged
```

Tests: tests/integration/conflict_resolution.rs differential matrix of {UNIQUE, NOT NULL, CHECK} arm failures × 5 OR clauses × {autocommit, explicit txn} against rusqlite; fails without the fix. Also validated: full integration suite, conformance suite, C-API compat tests, make test, clippy --deny=warnings.

## Motivation and context

SQLite hardcodes OE_Abort for the UPDATE inside an upsert (sqlite3UpsertDoUpdate), so a constraint failure raised by the DO UPDATE arm always rolls back the whole statement. Turso's arm inherited the statement-level OR clause instead: under INSERT OR FAIL, rows inserted earlier by the same statement survived the failure, and under INSERT OR ROLLBACK an arm failure rolled back the entire transaction.

Fixes #7839. Related context: #6858, #6859, #7830, #7836.

## Description of AI Usage

this PR was made in pair-programming mode with Claude code (Opus 4.8). The Ai did the codebase navigation, root-cause tracing (from the emitted Halt instructions through halt()/abort()), drafted the implementation and the test matrix, runned validations suites (but i re-checked manualy). I drove the design discussion — surfacing the two-cleanup-point problem and requiring alternatives to the naive hardcode — which led to carrying the override through ProgramState instead of LimboError::Raise to preserve the error variant and message. I reviewed the changes and am responsible for them.
