### PR TITLE
core/io: prevent TLS teardown aborts when dropping buffers

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -670,7 +670,9 @@ impl Drop for Buffer {
         match self {
             Self::Heap(buf) | Self::HeapView { data: buf, .. } => {
                 let underlying_len = buf.len();
-                TEMP_BUFFER_CACHE.with(|cache| {
+                // Another TLS value may drop a Buffer after this cache is destroyed.
+                // Avoid panicking from a TLS destructor, which would abort the process.
+                let _ = TEMP_BUFFER_CACHE.try_with(|cache| {
                     let mut cache = cache.borrow_mut();
                     // take ownership of the buffer by swapping it with a dummy
                     let buffer = std::mem::replace(buf, Pin::new(vec![].into_boxed_slice()));
@@ -809,6 +811,24 @@ crate::thread::thread_local! {
 #[cfg(test)]
 mod buffer_tests {
     use super::*;
+
+    std::thread_local! {
+        static BUFFER_DROPPED_DURING_THREAD_EXIT: RefCell<Option<Buffer>> =
+            const { RefCell::new(None) };
+    }
+
+    #[test]
+    fn heap_buffer_drop_tolerates_thread_local_teardown_order() {
+        std::thread::spawn(|| {
+            // Initialize the owning TLS before the buffer cache. Thread teardown
+            // can then destroy the cache before dropping the buffer it owns.
+            BUFFER_DROPPED_DURING_THREAD_EXIT.with(|slot| {
+                slot.replace(Some(Buffer::new_temporary(4_096)));
+            });
+        })
+        .join()
+        .expect("buffer drop must not panic during thread-local teardown");
+    }
 
     fn shared_bytes(bytes: &[u8]) -> Arc<DynBoxedSlice<u8>> {
         let mut data =


### PR DESCRIPTION
## Description

Prevent `Buffer::drop` from aborting the process during thread teardown by
replacing `TEMP_BUFFER_CACHE.with` with `TEMP_BUFFER_CACHE.try_with`.

This preserves the existing buffer-cache reuse path while the cache is
accessible. If the cache has already been destroyed, `Buffer::drop` skips the
cache return and allows the heap allocation to be freed normally instead of
panicking.

Add a regression test that reproduces this TLS destruction order by storing a
`Buffer` in another thread-local value.

## Motivation and context

A `Buffer` can be owned by a thread-local value whose destructor runs after
`TEMP_BUFFER_CACHE` has already been destroyed. `LocalKey::with` panics when it
attempts to access a destroyed TLS value. Because this panic occurs while a TLS
destructor is running, the process aborts with `thread local panicked on drop`.

Using `try_with` handles the destroyed-cache case without changing the normal
cache path. The buffer is moved into the cache only inside the closure, so if
the cache is no longer accessible, the `Buffer` retains ownership and ordinary
field destruction frees the allocation.

This was observed as an intermittent process abort while repeatedly running
parallel tests in a downstream consumer. The underlying issue is general to the
`Buffer` and TLS lifetimes and is not specific to the downstream feature.

## Testing

- `cargo +1.88 fmt --all -- --check`
- `cargo +1.88 clippy --workspace --all-features --all-targets --locked -- --deny=warnings`
- `cargo +1.88 test -p turso_core --lib`
- `cargo +1.88 test -p turso_core heap_buffer_drop_tolerates_thread_local_teardown_order -- --nocapture`
- Verified that the regression test aborts with the original `LocalKey::with`
  behavior and passes with `LocalKey::try_with`

## Description of AI Usage

This PR was developed with assistance from Codex. Codex was used to compare the
downstream fix with the current upstream implementation, inspect the TLS
lifetime behavior, adapt the focused change, add a deterministic regression
test, and review the final diff. I reviewed the implementation, reproduced the
abort with the original behavior, and ran the validation listed above.
