### PR TITLE
core/translate: reject NULLS FIRST/LAST in index definitions and upsert targets

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -12,7 +12,9 @@ use crate::translate::emitter::Resolver;
 use crate::translate::expr::{
     bind_and_rewrite_expr, walk_expr, walk_expr_mut, BindingBehavior, WalkControl,
 };
-use crate::translate::index::{resolve_index_method_parameters, resolve_sorted_columns};
+use crate::translate::index::{
+    reject_explicit_nulls, resolve_index_method_parameters, resolve_sorted_columns,
+};
 use crate::translate::planner::ROWID_STRS;
 use crate::types::{IOResult, ImmutableRecord};
 use crate::util::{exprs_are_equivalent, normalize_ident};
@@ -4403,6 +4405,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     if *auto_increment {
                         has_autoincrement = true;
                     }
+                    reject_explicit_nulls(columns)?;
 
                     let mut pk_collations = Vec::try_with_capacity_ext(columns.len())?;
                     for column in columns {
@@ -4431,6 +4434,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     conflict_clause,
                 } = &c.constraint
                 {
+                    reject_explicit_nulls(columns)?;
                     let mut unique_columns = Vec::try_with_capacity_ext(columns.len())?;
                     let mut unique_collations = Vec::try_with_capacity_ext(columns.len())?;
                     for column in columns {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -882,11 +882,26 @@ pub fn resolve_sorted_columns(
     resolve_sorted_columns_with_resolver(table, cols, None)
 }
 
+/// SQLite rejects explicit `NULLS FIRST`/`NULLS LAST` wherever an index key
+/// is defined or matched: CREATE INDEX, table PRIMARY KEY/UNIQUE constraints,
+/// and UPSERT conflict targets (see `sqlite3HasExplicitNulls`). Accepting the
+/// clause in schema definitions would store SQL in `sqlite_schema` that
+/// SQLite refuses to load ("malformed database schema").
+pub fn reject_explicit_nulls(cols: &[SortedColumn]) -> crate::Result<()> {
+    for sc in cols {
+        if let Some(nulls) = sc.nulls {
+            crate::bail_parse_error!("unsupported use of {}", nulls);
+        }
+    }
+    Ok(())
+}
+
 fn resolve_sorted_columns_with_resolver(
     table: &BTreeTable,
     cols: &[SortedColumn],
     resolver: Option<&Resolver>,
 ) -> crate::Result<crate::alloc::Vec<IndexColumn>> {
+    reject_explicit_nulls(cols)?;
     let mut resolved =
         <crate::alloc::Vec<_> as crate::alloc::TursoTryWithCapacityExt>::try_with_capacity_ext(
             cols.len(),

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -427,9 +427,12 @@ pub fn resolve_upsert_target(
     upsert: &Upsert,
 ) -> crate::Result<ResolvedUpsertTarget> {
     // Omitted target, catch-all
-    if upsert.index.is_none() {
+    let Some(target) = upsert.index.as_ref() else {
         return Ok(ResolvedUpsertTarget::CatchAll);
-    }
+    };
+    // SQLite rejects explicit NULLS FIRST/LAST in conflict targets
+    // (sqlite3UpsertAnalyzeTarget -> sqlite3HasExplicitNulls).
+    crate::translate::index::reject_explicit_nulls(&target.targets)?;
 
     // Targeted: must match PK, only if PK is a rowid alias
     if upsert_matches_rowid_alias(upsert, table) {

--- a/sqlite/conformance/sqlite-sqltests/create_index.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/create_index.sqltest
@@ -302,3 +302,34 @@ test create-index-sqlite-source-id {
 }
 expect error {
 }
+
+# https://github.com/tursodatabase/turso/issues/7944
+# SQLite rejects NULLS FIRST/LAST in CREATE INDEX with
+# "unsupported use of NULLS FIRST/LAST". Turso must reject it too,
+# otherwise it writes a schema entry that SQLite cannot read back.
+@cross-check-integrity
+test create-index-nulls-first-rejected {
+    CREATE TABLE t1(a);
+    CREATE INDEX idx1 ON t1(a NULLS FIRST);
+}
+expect error {
+    NULLS
+}
+
+@cross-check-integrity
+test create-index-nulls-last-rejected {
+    CREATE TABLE t2(a);
+    CREATE INDEX idx2 ON t2(a NULLS LAST);
+}
+expect error {
+    NULLS
+}
+
+@cross-check-integrity
+test create-index-nulls-first-with-desc-rejected {
+    CREATE TABLE t3(a);
+    CREATE INDEX idx3 ON t3(a DESC NULLS FIRST);
+}
+expect error {
+    NULLS
+}

--- a/sqlite/conformance/sqlite-sqltests/create_table.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/create_table.sqltest
@@ -276,3 +276,31 @@ expect {
     b
     C
 }
+
+# https://github.com/tursodatabase/turso/issues/7944
+# SQLite rejects NULLS FIRST/LAST in PRIMARY KEY/UNIQUE table constraints
+# (sqlite3HasExplicitNulls). Turso must reject it too, otherwise it stores
+# a schema entry that SQLite refuses to load.
+@cross-check-integrity
+test create_table_primary_key_nulls_last_rejected {
+    CREATE TABLE t_pknulls(a, PRIMARY KEY(a NULLS LAST));
+}
+expect error {
+    NULLS
+}
+
+@cross-check-integrity
+test create_table_unique_nulls_first_rejected {
+    CREATE TABLE t_uqnulls(a, UNIQUE(a NULLS FIRST));
+}
+expect error {
+    NULLS
+}
+
+@cross-check-integrity
+test create_table_unique_desc_nulls_first_rejected {
+    CREATE TABLE t_uqnulls2(a, UNIQUE(a DESC NULLS FIRST));
+}
+expect error {
+    NULLS
+}

--- a/sqlite/conformance/sqlite-sqltests/upsert.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/upsert.sqltest
@@ -873,3 +873,16 @@ test upsert-do-update-set-expr-uses-column-collation {
 expect {
     1|A|1
 }
+
+# https://github.com/tursodatabase/turso/issues/7944
+# SQLite rejects NULLS FIRST/LAST in UPSERT conflict targets
+# (sqlite3UpsertAnalyzeTarget -> sqlite3HasExplicitNulls).
+@cross-check-integrity
+test upsert-conflict-target-nulls-first-rejected {
+    CREATE TABLE t_upnulls(a UNIQUE);
+    INSERT INTO t_upnulls VALUES (1)
+    ON CONFLICT (a NULLS FIRST) DO NOTHING;
+}
+expect error {
+    NULLS
+}


### PR DESCRIPTION
SQLite rejects explicit NULLS FIRST/LAST wherever an index key is
defined or matched (sqlite3HasExplicitNulls): CREATE INDEX, table
PRIMARY KEY/UNIQUE constraints, and UPSERT conflict targets. Turso
silently ignored the clause. For CREATE INDEX and table constraints
this stored the original SQL in sqlite_schema, and SQLite then refused
to open the database with "malformed database schema - unsupported use
of NULLS FIRST", so accepting the statement effectively produced a
database SQLite cannot read. For UPSERT targets it was a prepare-time
compatibility divergence.

Add a shared reject_explicit_nulls helper and call it from index
column resolution (covering both the CREATE INDEX translation path and
schema loading via Index::from_sql), from create_table (covering both
CREATE TABLE translation and schema loading of PRIMARY KEY/UNIQUE
table constraints), and from resolve_upsert_target. Emit SQLite's
exact error text ("unsupported use of NULLS FIRST"/"unsupported use of
NULLS LAST"). Explicit NULLS ordering in ORDER BY is unaffected.

Tests: make -C sqlite/conformance run-rust ARGS="--snapshot-filter __never__ --filter '*nulls*rejected'"

Fixes #7944