### PR TITLE
core/translate: recheck uniqueness when REPLACE delete fires triggers

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -245,7 +245,7 @@ avoid this window.
 | PRAGMA query_only                | ✅ Yes        |                                              |
 | PRAGMA quick_check               | ✅ Yes        |                                              |
 | PRAGMA read_uncommitted          | ❌ No         |                                              |
-| PRAGMA recursive_triggers        | ❌ No         |                                              |
+| PRAGMA recursive_triggers        | ✅ Yes        | Controls whether REPLACE conflict deletes fire DELETE triggers; trigger self-recursion is not supported |
 | PRAGMA reverse_unordered_selects | ❌ No         |                                              |
 | PRAGMA schema_version            | ✅ Yes        | For writes, emulate defensive mode (always noop)|
 | PRAGMA secure_delete             | ❌ No         |                                              |

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -464,6 +464,8 @@ pub struct Connection {
     pub(super) is_mvcc_bootstrap_connection: AtomicBool,
     /// Whether pragma foreign_keys=ON for this connection
     pub(super) fk_pragma: AtomicBool,
+    /// Whether pragma recursive_triggers=ON for this connection
+    pub(super) recursive_triggers_pragma: AtomicBool,
     pub(crate) fk_deferred_violations: AtomicIsize,
     /// Number of active top-level write statements on this connection.
     ///
@@ -1845,6 +1847,21 @@ impl Connection {
 
     pub fn foreign_keys_enabled(&self) -> bool {
         self.fk_pragma.load(Ordering::Acquire)
+    }
+
+    /// Set PRAGMA recursive_triggers for this connection. Like in SQLite,
+    /// this controls whether REPLACE conflict-resolution deletes fire DELETE
+    /// triggers. Unlike SQLite, Turso's trigger programs are compiled
+    /// non-recursively, so a trigger never re-fires itself regardless of
+    /// this setting.
+    pub fn set_recursive_triggers_enabled(&self, enable: bool) {
+        self.recursive_triggers_pragma
+            .store(enable, Ordering::Release);
+        self.bump_prepare_context_generation();
+    }
+
+    pub fn recursive_triggers_enabled(&self) -> bool {
+        self.recursive_triggers_pragma.load(Ordering::Acquire)
     }
 
     pub fn set_check_constraints_ignored(&self, ignore: bool) {

--- a/core/database.rs
+++ b/core/database.rs
@@ -2334,6 +2334,7 @@ impl Database {
             short_column_names: AtomicBool::new(true),
             enable_load_extension: AtomicBool::new(self.can_load_extensions()),
             fk_pragma: AtomicBool::new(false),
+            recursive_triggers_pragma: AtomicBool::new(false),
             fk_deferred_violations: AtomicIsize::new(0),
             n_active_writes: AtomicI32::new(0),
             n_active_root_statements: AtomicI32::new(0),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2340,6 +2340,7 @@ impl Database {
             short_column_names: AtomicBool::new(true),
             enable_load_extension: AtomicBool::new(self.can_load_extensions()),
             fk_pragma: AtomicBool::new(false),
+            recursive_triggers_pragma: AtomicBool::new(false),
             fk_deferred_violations: AtomicIsize::new(0),
             n_active_writes: AtomicI32::new(0),
             n_active_root_statements: AtomicI32::new(0),

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -161,6 +161,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::Result0 | PragmaFlags::NoColumns1,
             &["query_only"],
         ),
+        RecursiveTriggers => Pragma::new(
+            PragmaFlags::Result0 | PragmaFlags::NoColumns1,
+            &["recursive_triggers"],
+        ),
         IAmADummy | RequireWhere => Pragma::new(
             PragmaFlags::Result0 | PragmaFlags::NoColumns1,
             &["require_where"],

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         expr::{
             bind_and_rewrite_expr, emit_returning_results, emit_returning_scan_back,
-            process_returning_clause, restore_returning_row_image_in_cache,
+            emit_table_column, process_returning_clause, restore_returning_row_image_in_cache,
             seed_returning_row_image_in_cache, translate_expr, translate_expr_no_constant_opt,
             walk_expr, BindingBehavior, NoConstantOptReason, ReturningBufferCtx, WalkControl,
         },
@@ -941,6 +941,30 @@ pub fn translate_insert(
     // guaranteed to be positioned.
     if matches!(ctx.on_conflict, ResolveType::Replace) || has_ddl_replace {
         insert_flags = insert_flags.require_seek();
+    }
+    // If a REPLACE conflict-resolution delete may have fired trigger programs
+    // (DELETE triggers or FK actions), one of them may have inserted a row with
+    // the rowid we are about to use — including a NewRowid computed before the
+    // delete ran. Silently overwriting it would lose that row, so re-check and
+    // abort like SQLite does in its post-replace constraint recheck.
+    if on_replace
+        && ctx.table.has_rowid
+        && !constraints.constraints_to_check.is_empty()
+        && replace_delete_may_fire_triggers(resolver, connection, ctx.database_id, ctx.table)
+    {
+        let rowid_ok = program.allocate_label();
+        program.emit_insn(Insn::NotExists {
+            cursor: ctx.cursor_id,
+            rowid_reg: insertion.key_register(),
+            target_pc: rowid_ok,
+        });
+        program.emit_insn(Insn::Halt {
+            err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
+            description: format!("{}.{}", ctx.table.name, insertion.key.column_name()),
+            on_error: None,
+            description_reg: None,
+        });
+        program.preassign_label_to_next_insn(rowid_ok);
     }
     program.emit_insn(Insn::Insert {
         cursor: ctx.cursor_id,
@@ -2928,9 +2952,32 @@ fn emit_pk_uniqueness_check(
                 ctx,
                 preflight.table_references,
             )?;
-            program.emit_insn(Insn::Goto {
-                target_pc: make_record_label,
-            });
+            if replace_delete_may_fire_triggers(
+                resolver,
+                preflight.connection,
+                ctx.database_id,
+                ctx.table,
+            ) {
+                // The delete may have fired trigger programs (DELETE triggers
+                // or FK actions) that re-inserted a row with this rowid.
+                // Re-check; on the recheck a conflict aborts instead of
+                // replacing again (matching SQLite).
+                program.emit_insn(Insn::NotExists {
+                    cursor: ctx.cursor_id,
+                    rowid_reg: insertion.key_register(),
+                    target_pc: make_record_label,
+                });
+                program.emit_insn(Insn::Halt {
+                    err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
+                    description: format!("{}.{}", ctx.table.name, rowid_column_name),
+                    on_error: None,
+                    description_reg: None,
+                });
+            } else {
+                program.emit_insn(Insn::Goto {
+                    target_pc: make_record_label,
+                });
+            }
             break 'emit_halt;
         }
         if let Some(position) = position.or(upsert_catch_all) {
@@ -3161,7 +3208,32 @@ fn emit_unique_index_check(
                 ctx,
                 preflight.table_references,
             )?;
-            program.emit_insn(Insn::Goto { target_pc: ok });
+            if replace_delete_may_fire_triggers(
+                resolver,
+                preflight.connection,
+                ctx.database_id,
+                ctx.table,
+            ) {
+                // The delete may have fired trigger programs (DELETE triggers
+                // or FK actions) that re-inserted the conflicting key. Re-probe
+                // the index; on the recheck a conflict aborts instead of
+                // replacing again (matching SQLite), otherwise the eager
+                // IdxInsert below would corrupt the unique index.
+                program.emit_insn(Insn::NoConflict {
+                    cursor_id: idx_cursor_id,
+                    target_pc: ok,
+                    record_reg: idx_start_reg,
+                    num_regs: num_cols,
+                });
+                program.emit_insn(Insn::Halt {
+                    err_code: SQLITE_CONSTRAINT_UNIQUE,
+                    description: format_unique_violation_desc(ctx.table.name.as_str(), index),
+                    on_error: None,
+                    description_reg: None,
+                });
+            } else {
+                program.emit_insn(Insn::Goto { target_pc: ok });
+            }
         } else if matches!(preflight.effective_on_conflict, ResolveType::Ignore) {
             // IGNORE: skip this row entirely on unique conflict.
             program.emit_insn(Insn::Goto {
@@ -3776,6 +3848,32 @@ fn emit_update_sqlite_sequence(
     Ok(())
 }
 
+/// Whether the REPLACE conflict-resolution delete of a conflicting row may run
+/// trigger programs that modify the database: DELETE triggers on the table
+/// (which fire during REPLACE only when PRAGMA recursive_triggers is enabled,
+/// matching SQLite), or foreign key actions (which may cascade into other
+/// tables and fire their triggers).
+///
+/// When this returns true, uniqueness must be re-checked after the delete,
+/// because a trigger may have re-inserted the conflicting key. On the recheck,
+/// a conflict aborts the statement (SQLite resolves recheck conflicts with
+/// OE_Abort instead of OE_Replace).
+fn replace_delete_may_fire_triggers(
+    resolver: &Resolver,
+    connection: &Arc<Connection>,
+    database_id: usize,
+    table: &BTreeTable,
+) -> bool {
+    let has_delete_triggers = connection.recursive_triggers_enabled()
+        && has_triggers_including_temp(resolver, database_id, TriggerEvent::Delete, None, table);
+    let fk_actions_possible = connection.foreign_keys_enabled()
+        && resolver.with_schema(database_id, |s| {
+            s.any_resolved_fks_referencing(table.name.as_str())
+                || s.has_child_fks(table.name.as_str())
+        });
+    has_delete_triggers || fk_actions_possible
+}
+
 fn emit_replace_delete_conflicting_row(
     program: &mut ProgramBuilder,
     resolver: &mut Resolver,
@@ -3788,6 +3886,94 @@ fn emit_replace_delete_conflicting_row(
         src_reg: ctx.conflict_rowid_reg,
         target_pc: ctx.halt_label,
     });
+
+    // When PRAGMA recursive_triggers is enabled, rows deleted by REPLACE
+    // conflict resolution fire DELETE triggers (matching SQLite: "delete
+    // triggers fire if and only if recursive triggers are enabled").
+    let (before_triggers, after_triggers) = if connection.recursive_triggers_enabled() {
+        (
+            get_triggers_including_temp(
+                resolver,
+                ctx.database_id,
+                TriggerEvent::Delete,
+                TriggerTime::Before,
+                None,
+                ctx.table,
+            ),
+            get_triggers_including_temp(
+                resolver,
+                ctx.database_id,
+                TriggerEvent::Delete,
+                TriggerTime::After,
+                None,
+                ctx.table,
+            ),
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    let delete_done = program.allocate_label();
+    // Capture the OLD row image for the trigger contexts while the cursor is
+    // positioned on the conflicting row.
+    let trigger_ctx = if before_triggers.is_empty() && after_triggers.is_empty() {
+        None
+    } else {
+        let cols_len = ctx.table.columns().len();
+        let columns_start_reg = program.alloc_registers(cols_len);
+        let internal_id = table_references.joined_tables()[0].internal_id;
+        for (i, column) in ctx.table.columns().iter().enumerate() {
+            emit_table_column(
+                program,
+                ctx.cursor_id,
+                internal_id,
+                table_references,
+                column,
+                i,
+                columns_start_reg + i,
+                resolver,
+            )?;
+        }
+        let old_registers = (0..cols_len)
+            .map(|i| columns_start_reg + i)
+            .chain(std::iter::once(ctx.conflict_rowid_reg))
+            .collect::<Vec<_>>();
+        // The delete happens as part of REPLACE conflict resolution, so the
+        // trigger bodies run with REPLACE conflict handling (SQLite passes
+        // OE_Replace as the trigger orconf), unless an outer statement already
+        // imposed an override.
+        let override_conflict = program
+            .trigger_conflict_override
+            .unwrap_or(ResolveType::Replace);
+        Some(TriggerContext::new_with_override_conflict(
+            Arc::clone(ctx.table),
+            None, // No NEW for DELETE
+            Some(old_registers),
+            override_conflict,
+        ))
+    };
+
+    if !before_triggers.is_empty() {
+        let trigger_ctx = trigger_ctx.as_ref().expect("trigger context must exist");
+        // RAISE(IGNORE) in a BEFORE DELETE trigger skips deleting this row.
+        for trigger in before_triggers {
+            fire_trigger(
+                program,
+                resolver,
+                trigger,
+                trigger_ctx,
+                connection,
+                ctx.database_id,
+                delete_done,
+            )?;
+        }
+        // BEFORE DELETE triggers may have deleted the conflicting row
+        // themselves; re-seek and skip the delete if it is gone.
+        program.emit_insn(Insn::NotExists {
+            cursor: ctx.cursor_id,
+            rowid_reg: ctx.conflict_rowid_reg,
+            target_pc: delete_done,
+        });
+    }
 
     // Phase 1: Before Delete - build parent key registers and handle NoAction/Restrict.
     // CASCADE/SetNull/SetDefault actions are prepared but deferred until after Delete.
@@ -3920,6 +4106,25 @@ fn emit_replace_delete_conflicting_row(
         connection,
         ctx.database_id,
     )?;
+
+    if !after_triggers.is_empty() {
+        let trigger_ctx = trigger_ctx.as_ref().expect("trigger context must exist");
+        // RAISE(IGNORE) in an AFTER DELETE trigger only aborts the trigger body.
+        let after_trigger_done = program.allocate_label();
+        for trigger in after_triggers {
+            fire_trigger(
+                program,
+                resolver,
+                trigger,
+                trigger_ctx,
+                connection,
+                ctx.database_id,
+                after_trigger_done,
+            )?;
+        }
+        program.preassign_label_to_next_insn(after_trigger_done);
+    }
+    program.preassign_label_to_next_insn(delete_done);
 
     Ok(())
 }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -703,6 +703,11 @@ fn update_pragma(
             connection.set_foreign_keys_enabled(enabled);
             Ok(TransactionMode::None)
         }
+        PragmaName::RecursiveTriggers => {
+            let enabled = parse_pragma_enabled(&value);
+            connection.set_recursive_triggers_enabled(enabled);
+            Ok(TransactionMode::None)
+        }
         PragmaName::IAmADummy | PragmaName::RequireWhere => {
             let enabled = parse_pragma_enabled(&value);
             connection.set_dml_require_where(enabled);
@@ -1579,6 +1584,14 @@ fn query_pragma(
         }
         PragmaName::ForeignKeys => {
             let enabled = connection.foreign_keys_enabled();
+            let register = program.alloc_register();
+            program.emit_int(enabled as i64, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::RecursiveTriggers => {
+            let enabled = connection.recursive_triggers_enabled();
             let register = program.alloc_register();
             program.emit_int(enabled as i64, register);
             program.emit_result_row(register, 1);

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -703,6 +703,11 @@ fn update_pragma(
             connection.set_foreign_keys_enabled(enabled);
             Ok(TransactionMode::None)
         }
+        PragmaName::RecursiveTriggers => {
+            let enabled = parse_pragma_enabled(&value);
+            connection.set_recursive_triggers_enabled(enabled);
+            Ok(TransactionMode::None)
+        }
         PragmaName::IAmADummy | PragmaName::RequireWhere => {
             let enabled = parse_pragma_enabled(&value);
             connection.set_dml_require_where(enabled);
@@ -1629,6 +1634,14 @@ fn query_pragma(
         }
         PragmaName::ForeignKeys => {
             let enabled = connection.foreign_keys_enabled();
+            let register = program.alloc_register();
+            program.emit_int(enabled as i64, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::RecursiveTriggers => {
+            let enabled = connection.recursive_triggers_enabled();
             let register = program.alloc_register();
             program.emit_int(enabled as i64, register);
             program.emit_result_row(register, 1);

--- a/sqlite/conformance/sqlite-sqltests/replace-delete-trigger-reinsert-unique.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/replace-delete-trigger-reinsert-unique.sqltest
@@ -1,0 +1,38 @@
+@database :memory:
+@requires-file trigger "trigger tests require trigger support"
+
+# Issue #7975: REPLACE with a delete trigger re-inserting the conflicting key
+# must re-check uniqueness. SQLite rejects the statement with
+# "UNIQUE constraint failed"; Turso used to let the duplicate through and
+# corrupt the unique index.
+
+# FK cascade delete fires a trigger that re-inserts the same UNIQUE key.
+@cross-check-integrity
+test replace-fk-cascade-trigger-reinsert-unique {
+    PRAGMA recursive_triggers = true;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE p1 (a, b UNIQUE);
+    CREATE TABLE c1 (c, d REFERENCES p1(b) ON DELETE CASCADE);
+    CREATE TRIGGER tr6 AFTER DELETE ON c1 BEGIN INSERT INTO p1 VALUES(4, 1); END;
+    INSERT INTO p1 VALUES(1, 1);
+    INSERT INTO c1 VALUES(2, 1);
+    REPLACE INTO p1 VALUES(3, 1);
+}
+expect error {
+    UNIQUE constraint failed: p1.b
+}
+
+# Simpler recursive-trigger variant: delete trigger on the same table
+# re-inserts the conflicting key during REPLACE.
+@cross-check-integrity
+test replace-recursive-delete-trigger-reinsert-unique {
+    PRAGMA recursive_triggers = true;
+    CREATE TABLE t0 (c0, c1);
+    CREATE UNIQUE INDEX i0 ON t0(c0);
+    INSERT INTO t0(c0, c1) VALUES(123, 1);
+    CREATE TRIGGER tr0 AFTER DELETE ON t0 BEGIN INSERT INTO t0 VALUES(123, 2); END;
+    REPLACE INTO t0(c0, c1) VALUES(123, 3);
+}
+expect error {
+    UNIQUE constraint failed: t0.c0
+}

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1828,6 +1828,9 @@ pub enum PragmaName {
     PageSize,
     /// make connection query only
     QueryOnly,
+    /// Enable or disable recursive triggers (also controls whether DELETE
+    /// triggers fire when REPLACE conflict resolution deletes rows)
+    RecursiveTriggers,
     /// Returns schema version of the database file.
     SchemaVersion,
     /// Deprecated: control whether unaliased column names omit the table name prefix

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1852,6 +1852,9 @@ pub enum PragmaName {
     PageSize,
     /// make connection query only
     QueryOnly,
+    /// Enable or disable recursive triggers (also controls whether DELETE
+    /// triggers fire when REPLACE conflict resolution deletes rows)
+    RecursiveTriggers,
     /// Returns schema version of the database file.
     SchemaVersion,
     /// Deprecated: control whether unaliased column names omit the table name prefix


### PR DESCRIPTION
When REPLACE conflict resolution deletes a conflicting row, that delete
can run trigger programs that re-insert the same key: FK ON DELETE
actions can cascade into child tables and fire their triggers, and (in
SQLite, with recursive_triggers enabled) DELETE triggers on the table
itself fire. Turso never re-checked uniqueness after the delete and
eagerly inserted the new index entry anyway, so the statement succeeded
with duplicate values in a UNIQUE column and integrity_check reported a
non-unique entry in the index.

Fix this in the INSERT REPLACE path by re-probing the constraint after
the conflicting-row delete whenever that delete may have fired trigger
programs, aborting with the usual UNIQUE-constraint error on a recheck
conflict (SQLite resolves recheck conflicts with OE_Abort instead of
OE_Replace). The recheck covers unique indexes (NoConflict re-probe),
the rowid PK path (NotExists re-check), and a final rowid probe before
the table Insert so a trigger that consumed a precomputed NewRowid
raises "UNIQUE constraint failed: t.rowid" instead of being silently
overwritten.

To match SQLite's rule that REPLACE deletes fire DELETE triggers if and
only if recursive triggers are enabled, implement PRAGMA
recursive_triggers as a per-connection flag (previously it was silently
ignored) and fire BEFORE/AFTER DELETE triggers around the REPLACE
conflict delete when it is set, including a re-seek that skips the
delete if a BEFORE trigger already removed the row.

Tests: sqlite-sqltests/replace-delete-trigger-reinsert-unique.sqltest
(also under --mvcc), full sqlite-sqltests and turso-sqltests suites,
cargo test -p turso_core -p core_tester, and manual differential checks
against sqlite3 for the upstream insert-16.x/17.x variants.

Fixes #7975