### PR TITLE
core/window: adopt SQLite's execution model, add lag/lead/ntile

### DIFF
--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -282,6 +282,18 @@ pub fn resolve_builtin_function(name: &str, arg_count: usize) -> crate::Result<O
             }
             Ok(Some(Func::Window(WindowFunc::NthValue)))
         }
+        "lag" => {
+            if !(1..=3).contains(&arg_count) {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::Lag)))
+        }
+        "lead" => {
+            if !(1..=3).contains(&arg_count) {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::Lead)))
+        }
         "timediff" => {
             if arg_count != 2 {
                 crate::bail_parse_error!("wrong number of arguments to function {}()", name)

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -294,6 +294,12 @@ pub fn resolve_builtin_function(name: &str, arg_count: usize) -> crate::Result<O
             }
             Ok(Some(Func::Window(WindowFunc::Lead)))
         }
+        "ntile" => {
+            if arg_count != 1 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::Ntile)))
+        }
         "timediff" => {
             if arg_count != 2 {
                 crate::bail_parse_error!("wrong number of arguments to function {}()", name)

--- a/core/function.rs
+++ b/core/function.rs
@@ -577,27 +577,6 @@ impl WindowFunc {
             ),
         }
     }
-
-    /// Returns true when the function waits for a row to be returned before
-    /// calculating that row's answer. Other functions build their answer as
-    /// input rows are read.
-    pub fn calculates_answer_when_row_is_returned(&self) -> bool {
-        matches!(
-            self,
-            Self::RowNumber
-                | Self::Ntile
-                | Self::Lag
-                | Self::Lead
-                | Self::NthValue
-                | Self::External(_)
-        )
-    }
-
-    /// Returns true when rows must remain saved after they have been returned
-    /// because a later result may need to read them again.
-    pub(crate) fn needs_rows_after_returning_them(&self) -> bool {
-        matches!(self, Self::NthValue)
-    }
 }
 
 impl PartialEq for WindowFunc {

--- a/core/function.rs
+++ b/core/function.rs
@@ -528,6 +528,7 @@ impl WindowFunc {
                 | Self::NthValue
                 | Self::Lag
                 | Self::Lead
+                | Self::Ntile
         )
     }
 

--- a/core/function.rs
+++ b/core/function.rs
@@ -526,6 +526,8 @@ impl WindowFunc {
                 | Self::FirstValue
                 | Self::LastValue
                 | Self::NthValue
+                | Self::Lag
+                | Self::Lead
         )
     }
 
@@ -539,6 +541,11 @@ impl WindowFunc {
         use crate::translate::plan::{Frame, FrameBoundary};
         use turso_parser::ast::{Expr, FrameMode, Literal};
         match self {
+            // Lag shares row_number's streaming frame even though its lookup
+            // can point forward (negative offset): SQLite emits a row as soon
+            // as the row after it is buffered, so a forward lookup past that
+            // one row misses and yields the default — behavior we match by
+            // using the same frame rather than caching the whole partition.
             Self::RowNumber | Self::Lag => Some(Frame {
                 mode: FrameMode::Rows,
                 start: FrameBoundary::UnboundedPreceding,

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -22,7 +22,7 @@ use crate::{
         select::emit_simple_count,
         subquery::{emit_from_clause_subqueries, emit_non_from_clause_subqueries_for_eval_at},
         values::emit_values,
-        window::{emit_window_results, EmitWindow},
+        window::{emit_window_flush, EmitWindow},
         ProgramBuilder, Resolver,
     },
     vdbe::insn::Insn,
@@ -285,7 +285,7 @@ pub fn emit_query<'a>(
         // Handle aggregation without GROUP BY (or HAVING without GROUP BY)
         emit_ungrouped_aggregation(program, t_ctx, plan)?;
     } else if plan.window.is_some() {
-        emit_window_results(program, t_ctx, plan)?;
+        emit_window_flush(program, t_ctx, plan)?;
     }
 
     // Process ORDER BY results if needed

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -441,7 +441,7 @@ fn emit_loop_source<'a>(
             Ok(())
         }
         LoopEmitTarget::Window => {
-            EmitWindow::emit_window_loop_source(program, t_ctx, plan)?;
+            EmitWindow::emit_window_step(program, t_ctx, plan)?;
 
             Ok(())
         }

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -1,5 +1,5 @@
 use crate::alloc::TursoSliceExt;
-use crate::function::AccumulatorFunc;
+use crate::function::{AccumulatorFunc, WindowFunc};
 use crate::schema::{BTreeCharacteristics, BTreeTable, Table};
 use crate::sync::Arc;
 use crate::translate::aggregation::{translate_aggregation_step, AggArgumentSource};
@@ -11,8 +11,8 @@ use crate::translate::expr::{
 };
 use crate::translate::order_by::EmitOrderBy;
 use crate::translate::plan::{
-    Aggregate, Distinctness, FrameBoundary, JoinOrderMember, JoinedTable, QueryDestination,
-    ResultSetColumn, RewrittenWindowCall, SelectPlan, TableReferences, Window, WindowFunction,
+    Aggregate, Distinctness, JoinOrderMember, JoinedTable, QueryDestination, ResultSetColumn,
+    RewrittenWindowCall, SelectPlan, TableReferences, Window, WindowFunction,
 };
 use crate::translate::planner::resolve_window_and_aggregate_functions;
 use crate::translate::result_row::emit_select_result;
@@ -21,7 +21,7 @@ use crate::types::KeyInfo;
 use crate::util::exprs_are_equivalent;
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
 use crate::vdbe::insn::{
-    to_u16, {CmpInsFlags, InsertFlags, Insn},
+    to_u16, {InsertFlags, Insn},
 };
 use crate::vdbe::{BranchOffset, CursorID};
 use crate::Connection;
@@ -29,7 +29,7 @@ use crate::Result;
 use crate::{turso_assert, turso_assert_eq};
 use std::mem;
 use turso_parser::ast::Name;
-use turso_parser::ast::{Expr, Literal, Over, ResolveType, SortOrder, TableInternalId};
+use turso_parser::ast::{Expr, Literal, Over, SortOrder, TableInternalId};
 
 const SUBQUERY_DATABASE_ID: usize = 0;
 
@@ -504,8 +504,6 @@ pub struct WindowMetadata<'a> {
     pub labels: WindowLabels,
     pub registers: WindowRegisters,
     pub cursors: WindowCursors,
-    buffer_mode: WindowBufferMode,
-    pub nth_value: Option<NthValueMetadata>,
     /// Number of input columns in the source subquery.
     pub src_column_count: usize,
     /// Maps expressions in the current query that reference subquery columns
@@ -514,65 +512,21 @@ pub struct WindowMetadata<'a> {
     pub buffer_table_name: String,
 }
 
-/// Controls whether a window may discard a saved row after returning it.
-/// Keeping a whole partition is more expensive, so it is only used when a
-/// later result may need to read an earlier row again.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WindowBufferMode {
-    DeleteReturnedRows,
-    KeepPartitionRows { rowid_one_register: usize },
-}
-
-impl WindowBufferMode {
-    fn for_window(window: &Window, program: &mut ProgramBuilder) -> Self {
-        let keeps_partition_rows = window.functions.iter().any(|function| {
-            matches!(
-                &function.func,
-                AccumulatorFunc::Window(window_function)
-                    if window_function.needs_rows_after_returning_them()
-            )
-        });
-        if keeps_partition_rows {
-            let rowid_one_register = program.alloc_register();
-            program.emit_insn(Insn::Integer {
-                value: 1,
-                dest: rowid_one_register,
-            });
-            Self::KeepPartitionRows { rowid_one_register }
-        } else {
-            Self::DeleteReturnedRows
-        }
-    }
-
-    fn keeps_partition_rows(self) -> bool {
-        matches!(self, Self::KeepPartitionRows { .. })
-    }
-}
-
-/// State used to find an `nth_value` result in the saved rows. Saved rows get
-/// rowids 1, 2, 3, and so on in window order within each partition. Custom
-/// frames are not supported, so every frame starts at rowid 1 and the position
-/// argument is also the rowid to read.
-#[derive(Debug)]
-pub struct NthValueMetadata {
-    /// Finds a saved row by its ordered position without moving the cursor
-    /// that returns rows.
-    pub row_by_position_cursor: CursorID,
-    /// Holds the rowid of the last row in the current window frame. The first
-    /// row of the next sort group is saved before the current group is
-    /// returned, so the lookup must not read beyond this rowid.
-    pub frame_end_rowid_register: usize,
-}
-
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct WindowLabels {
     /// Address of the subroutine for flushing buffered rows
     pub flush_buffer: BranchOffset,
+    /// Address of the subroutine that sends the populated result registers
+    /// to the outer query (select-result / order-by sorter insert). Mirrors
+    /// SQLite's `addrGosub` (window.c:1988): every RETURN_ROW site Gosubs
+    /// here, so per-row bookkeeping with a single jump target — SELECT
+    /// DISTINCT's on-conflict label in particular — is emitted exactly once.
+    pub row_output: BranchOffset,
     /// Address of the end of window processing
     pub window_processing_end: BranchOffset,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct WindowRegisters {
     /// Stores the ROWID of the last row inserted into the buffer table.
     /// If NULL, we are before inserting the first row of a new partition.
@@ -598,21 +552,98 @@ pub struct WindowRegisters {
     /// These registers are used to detect whether the current row is a "peer"
     /// (i.e., has identical ORDER BY values to the previous row).
     pub new_order_by_columns_start: Option<usize>,
-    /// Start of the register array holding ORDER BY column values from the previous row.
-    /// These are used to compare against the current row to determine peer relationships.
-    pub prev_order_by_columns_start: Option<usize>,
+    /// Per-cursor "peer reference" registers — each holds the ORDER BY
+    /// values of the first row of the peer group that cursor is currently
+    /// processing. The peer-loop inside `emit_window_op` compares the
+    /// next-advanced row's values against the cursor's reg and either
+    /// loops (peer) or falls through (new group, also updates the reg).
+    ///
+    /// `peer_end_reg` doubles as the "previous source row" tracker —
+    /// it's also used by `emit_window_step`'s pre-check that skips
+    /// AggStep / RETURN_ROW when consecutive source rows are peers,
+    /// because under our supported frames AGGSTEP's peer-loop on
+    /// csr_end and the source-row peer check share the same reference.
+    ///
+    /// `peer_start_reg` is `Some` only when the window has a moving
+    /// frame start (ntile, percent_rank, cume_dist); other windows
+    /// don't allocate `csr_start` so the start peer-loop never runs.
+    ///
+    /// Mirrors SQLite's `s.start.reg` / `s.current.reg` / `s.end.reg`
+    /// (window.c:2897-2899).
+    pub peer_start_reg: Option<usize>,
+    pub peer_current_reg: Option<usize>,
+    pub peer_end_reg: Option<usize>,
+    /// Return-address register for the `labels.row_output` Gosub. Mirrors
+    /// SQLite's `regGosub` (window.c:2793).
+    pub row_output_return: usize,
+    /// Rowid of the last row stepped into the frame (`AggStep` on `csr_end`).
+    /// This is the frame-end bound `first_value` / `nth_value` seek against:
+    /// under the default `RANGE UNBOUNDED PRECEDING TO CURRENT ROW` frame the
+    /// frame extends to the current row's last peer, so the *emitted* row's
+    /// own rowid would undercount it (a peer group's earlier rows would wrongly
+    /// see a truncated frame). `AggStep` peer-loops `csr_end` over the whole
+    /// group before the group's rows are returned, so capturing `csr_end`'s
+    /// rowid there yields the true frame end. Mirrors SQLite's `regApp+1`
+    /// (`window.c:1424`, maintained in `windowAggStep`). `None` unless the
+    /// window contains `first_value` / `nth_value`.
+    pub frame_end_rowid: Option<usize>,
 }
 
-/// Cursors that can move independently over the saved rows. Separate cursors
-/// are needed because inserting a row must not move the row being returned.
-#[derive(Debug)]
+/// Cursors on the ephemeral "buffer" B-tree that holds rows of the current
+/// partition. The four cursor roles mirror SQLite's `sqlite3WindowCodeStep`
+/// allocation (`window.c:2834-2837`).
+#[derive(Debug, Clone, Copy)]
 pub struct WindowCursors {
     /// Used to `Insert` newly-buffered source rows. Position is implicit
     /// (advances on each `NewRowid` + `Insert`).
     pub csr_write: CursorID,
-    /// The row currently being returned to the outer query; result-column
-    /// propagation reads from here.
+    /// The row currently being returned to the outer query. `AggValue` fires
+    /// when this advances; result-column propagation reads from here.
     pub csr_current: CursorID,
+    /// Tracks the frame-end boundary. `AggStep` reads from this cursor's
+    /// current row, then advances it. Under RANGE/GROUPS frames the advance
+    /// loops through peer-equal rows in one go.
+    pub csr_end: CursorID,
+    /// Tracks the frame-start boundary for windows whose coerced frame
+    /// doesn't start at UNBOUNDED PRECEDING (ntile, percent_rank,
+    /// cume_dist). `AggInverse` reads from this cursor's current row,
+    /// then advances it (peer-loop under GROUPS/RANGE mode). `None` when
+    /// the frame start is UNBOUNDED PRECEDING — the cursor would never
+    /// move so allocation would be wasted. Mirrors SQLite's
+    /// `s.start.csr` (`window.c:2836`).
+    pub csr_start: Option<CursorID>,
+    /// Per-row lookup cursor used at output time by functions whose
+    /// value is computed via `SeekRowid` rather than running aggregator
+    /// state — first_value, nth_value, and (once they land) lag, lead.
+    /// `OpenDup`'d off `csr_current` and only moved by `SeekRowid` at
+    /// output time, so it's independent of the frame-cursor positions.
+    /// Allocated lazily — `None` when no function in the window needs
+    /// positional lookup. Mirrors SQLite's `pWin->csrApp` (`window.c`).
+    pub csr_app: Option<CursorID>,
+}
+
+/// Builds `KeyInfo` entries for the window's ORDER BY columns, populating
+/// each entry's collation from the expression. Used by every peer-equality
+/// `Insn::Compare` site (source-row pre-check + per-cursor peer-loop in
+/// `emit_window_op`); `sort_order` and `nulls_order` are left at their
+/// `Insn::Compare` defaults — the peer check only inspects equality, not
+/// ordering direction.
+fn build_order_by_key_info(
+    window: &Window,
+    table_references: &crate::translate::plan::TableReferences,
+) -> crate::Result<Vec<KeyInfo>> {
+    window
+        .order_by
+        .iter()
+        .map(|(expr, _, _)| {
+            let collation = get_collseq_from_expr(expr, table_references)?.unwrap_or_default();
+            Ok(KeyInfo {
+                sort_order: SortOrder::Asc,
+                collation,
+                nulls_order: None,
+            })
+        })
+        .collect()
 }
 
 pub struct EmitWindow;
@@ -649,9 +680,7 @@ impl EmitWindow {
         let order_by_len = window.order_by.len();
         let window_function_count = window.functions.len();
 
-        // Save rows because a window result may depend on rows that arrived
-        // earlier. `nth_value` keeps every row already seen in the current
-        // partition so it can find one by its ordered position.
+        // An ephemeral table used to buffer rows for the current frame
         let buffer_table = Arc::new(BTreeTable::new(
             0,
             // TODO: Generating the name this way may cause collisions with real tables in the
@@ -667,13 +696,57 @@ impl EmitWindow {
             crate::alloc::vec![],
             None,
         ));
-        // The "current" cursor is the primary cursor on the ephemeral
-        // buffer; the write cursor is an OpenDup'd duplicate that shares
-        // the same underlying B-tree but tracks an independent position.
+        // `csr_current` is the primary cursor on the ephemeral buffer;
+        // the others are OpenDup'd duplicates that share the same B-tree
+        // with independent positions. `csr_start` is deliberately omitted
+        // until a moving-start frame needs it.
         let cursor_csr_current =
             program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));
         let cursor_csr_write =
             program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));
+        let cursor_csr_end = program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));
+        // `csr_start` tracks the frame-start cursor for functions whose
+        // coerced frame doesn't start at UNBOUNDED PRECEDING (ntile,
+        // percent_rank, cume_dist). AggInverse fires on this cursor as
+        // the frame shrinks from the left.
+        let has_moving_start = !matches!(
+            window.frame.start,
+            crate::translate::plan::FrameBoundary::UnboundedPreceding
+        );
+        let cursor_csr_start = if has_moving_start {
+            Some(program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone())))
+        } else {
+            None
+        };
+        // `csr_app` is the per-row lookup cursor used at output time by
+        // first_value / nth_value (positional seek). Mirrors SQLite's
+        // `csrApp` allocation (`window.c:1422-1426`). Allocate only when
+        // needed so unaffected windows don't pay the extra `OpenDup`.
+        let needs_csr_app = window.functions.iter().any(|f| {
+            matches!(
+                &f.func,
+                AccumulatorFunc::Window(WindowFunc::FirstValue | WindowFunc::NthValue),
+            )
+        });
+        let cursor_csr_app = if needs_csr_app {
+            Some(program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone())))
+        } else {
+            None
+        };
+        // Frame-end bound for the positional lookups; see
+        // `WindowRegisters::frame_end_rowid`. Only first_value / nth_value
+        // consult it — lag / lead seek relative to the emitted row's own
+        // rowid, not the frame end.
+        let frame_end_rowid = window
+            .functions
+            .iter()
+            .any(|f| {
+                matches!(
+                    &f.func,
+                    AccumulatorFunc::Window(WindowFunc::FirstValue | WindowFunc::NthValue),
+                )
+            })
+            .then(|| program.alloc_registers_and_init_w_null(1));
         program.emit_insn(Insn::OpenEphemeral {
             cursor_id: cursor_csr_current,
             is_table: true,
@@ -682,32 +755,22 @@ impl EmitWindow {
             original_cursor_id: cursor_csr_current,
             new_cursor_id: cursor_csr_write,
         });
-        let buffer_mode = WindowBufferMode::for_window(window, program);
-        let has_nth_value = window.functions.iter().any(|func| {
-            matches!(
-                &func.func,
-                AccumulatorFunc::Window(crate::function::WindowFunc::NthValue)
-            )
+        program.emit_insn(Insn::OpenDup {
+            original_cursor_id: cursor_csr_current,
+            new_cursor_id: cursor_csr_end,
         });
-        let nth_value = if has_nth_value {
-            turso_assert!(
-                matches!(&window.frame.start, FrameBoundary::UnboundedPreceding),
-                "nth_value row lookup requires a frame that starts at the first partition row"
-            );
-            let row_by_position_cursor =
-                program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));
+        if let Some(csr_start) = cursor_csr_start {
             program.emit_insn(Insn::OpenDup {
                 original_cursor_id: cursor_csr_current,
-                new_cursor_id: row_by_position_cursor,
+                new_cursor_id: csr_start,
             });
-            let frame_end_rowid_register = program.alloc_registers_and_init_w_null(1);
-            Some(NthValueMetadata {
-                row_by_position_cursor,
-                frame_end_rowid_register,
-            })
-        } else {
-            None
-        };
+        }
+        if let Some(csr_app) = cursor_csr_app {
+            program.emit_insn(Insn::OpenDup {
+                original_cursor_id: cursor_csr_current,
+                new_cursor_id: csr_app,
+            });
+        }
 
         // Window function processing is similar to aggregation processing in how results are mapped
         // to registers. Each function expression is stored in `expr_to_reg_cache` along with its
@@ -749,6 +812,7 @@ impl EmitWindow {
         t_ctx.meta_window = Some(WindowMetadata {
             labels: WindowLabels {
                 flush_buffer: program.allocate_label(),
+                row_output: program.allocate_label(),
                 window_processing_end: program.allocate_label(),
             },
             registers: WindowRegisters {
@@ -763,15 +827,36 @@ impl EmitWindow {
                 flush_buffer_return_offset: program.alloc_register(),
                 src_columns_start: reg_src_columns_start,
                 result_columns_start: reg_col_start,
-                prev_order_by_columns_start: alloc_optional_registers(program, order_by_len),
                 new_order_by_columns_start: alloc_optional_registers(program, order_by_len),
+                peer_start_reg: if has_moving_start {
+                    alloc_optional_registers(program, order_by_len)
+                } else {
+                    None
+                },
+                // `peer_current_reg` / `peer_end_reg` drive the AGGSTEP /
+                // RETURN_ROW peer-loops, which only run under RANGE / GROUPS
+                // (`b_peer` in `emit_window_op`). Under ROWS they're written
+                // by the seeding step but never read; skip the allocation.
+                peer_current_reg: if window.frame.mode != turso_parser::ast::FrameMode::Rows {
+                    alloc_optional_registers(program, order_by_len)
+                } else {
+                    None
+                },
+                peer_end_reg: if window.frame.mode != turso_parser::ast::FrameMode::Rows {
+                    alloc_optional_registers(program, order_by_len)
+                } else {
+                    None
+                },
+                row_output_return: program.alloc_register(),
+                frame_end_rowid,
             },
             cursors: WindowCursors {
                 csr_write: cursor_csr_write,
                 csr_current: cursor_csr_current,
+                csr_end: cursor_csr_end,
+                csr_start: cursor_csr_start,
+                csr_app: cursor_csr_app,
             },
-            buffer_mode,
-            nth_value,
             src_column_count,
             expressions_referencing_subquery,
             buffer_table_name: buffer_table.name.clone(),
@@ -779,87 +864,216 @@ impl EmitWindow {
 
         Ok(())
     }
-    /// Emits bytecode to process a single row of the window’s input (always a subquery).
+    /// Emits the per-source-row body for window processing.
     ///
-    /// Note:
-    /// The **buffer table** mentioned below saves rows because a window result may
-    /// depend on rows that arrived earlier. Most rows are removed after they are
-    /// returned. `nth_value` keeps them because later results may refer back to them.
+    /// This is the Rust port of the main loop in SQLite's
+    /// `sqlite3WindowCodeStep` (`window.c:2786-3037`), restricted to the
+    /// frames our planner coerces to: ROWS / RANGE / GROUPS with
+    /// `UNBOUNDED PRECEDING` start and `CURRENT ROW` end (and the moving
+    /// variants for the as-yet-unimplemented ntile / percent_rank /
+    /// cume_dist).
     ///
-    /// High-level overview:
-    /// - Each row from the subquery is read, and its ORDER BY columns are loaded into
-    ///   dedicated registers for comparison and partitioning purposes.
-    /// - If the row starts a new partition (based on PARTITION BY columns), the buffer
-    ///   and accumulators are flushed or reset as needed.
-    /// - Rows are compared against the previous row to determine if they are "peers"
-    ///   (i.e., have the same ORDER BY values). Non-peer rows may trigger flushing
-    ///   of intermediate results.
-    /// - The row is then inserted into the window’s buffer table.
-    /// - Aggregate steps for any window functions are executed.
-    pub fn emit_window_loop_source(
+    /// Pseudocode for the most common shape (`UNBOUNDED PRECEDING TO
+    /// CURRENT ROW`):
+    ///
+    /// ```text
+    ///   load ORDER BY columns into newPeer regs
+    ///   if partition_by_cols changed:
+    ///       Gosub flush_partition
+    ///       Null rowid_reg                 ; marks "first row of new partition"
+    ///       Copy partition_by_cols → prev_partition_regs
+    ///
+    ///   if rowid_reg is null:                       ; FIRST ROW OF PARTITION
+    ///       Copy newPeer → prevPeer
+    ///       Null accumulators
+    ///       Insert row into ephemeral via csr_write
+    ///       Rewind csr_current, csr_end, csr_start  ; position at row 1
+    ///       Goto loop_end
+    ///   else:                                       ; SUBSEQUENT ROW
+    ///       Insert row into ephemeral via csr_write
+    ///       if RANGE/GROUPS and newPeer == prevPeer:
+    ///           Goto loop_end                       ; defer step until peer break
+    ///       emit_window_op AGGSTEP        ; advance csr_end through peer rows; AggStep per row
+    ///       emit_window_op RETURN_ROW     ; advance csr_current; emit each row
+    ///       (emit_window_op AGGINVERSE is a no-op for UNBOUNDED start)
+    ///       Copy newPeer → prevPeer                 ; RANGE/GROUPS only
+    ///   loop_end:
+    /// ```
+    ///
+    /// Example — `row_number() OVER (ORDER BY salary DESC)` over 3 rows:
+    /// the source coroutine yields each row, this body inserts it, advances
+    /// `csr_end` (AggStep increments row_number's counter) and `csr_current`
+    /// (RETURN_ROW emits the previous row with its accumulated counter).
+    /// The very first row's emission is deferred to the flush subroutine
+    /// because `csr_current` was just rewound and there's no preceding row
+    /// to emit yet.
+    pub fn emit_window_step(
         program: &mut ProgramBuilder,
         t_ctx: &mut TranslateCtx,
         plan: &SelectPlan,
     ) -> crate::Result<()> {
-        let WindowMetadata {
-            labels,
-            registers,
-            cursors,
-            buffer_mode,
-            nth_value,
-            src_column_count: input_column_count,
-            buffer_table_name,
-            ..
-        } = t_ctx.meta_window.as_ref().expect("missing window metadata");
+        let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
         let window = plan.window.as_ref().expect("missing window");
 
-        emit_load_order_by_columns(program, window, registers);
-        emit_flush_buffer_if_new_partition(
-            program,
-            labels,
-            registers,
-            cursors,
-            *buffer_mode,
-            window,
-            plan,
-        )?;
-        emit_reset_state_if_new_partition(program, registers, nth_value.as_ref(), window);
-        if let WindowBufferMode::KeepPartitionRows { rowid_one_register } = *buffer_mode {
-            // Keep the return cursor on the first row of the next sort group,
-            // as SQLite does. That row must be inserted before the completed
-            // group is returned so the cursor does not run past the table.
-            emit_insert_row_into_buffer(
-                program,
-                registers,
-                cursors,
-                input_column_count,
-                buffer_table_name,
+        let labels = meta.labels;
+        let registers = meta.registers;
+        let cursors = meta.cursors;
+        let src_column_count = meta.src_column_count;
+        let buffer_table_name = meta.buffer_table_name.clone();
+
+        emit_load_order_by_columns(program, window, &registers);
+        emit_flush_buffer_if_new_partition(program, &labels, &registers, window, plan)?;
+
+        // `rowid_reg` was NULL'd at partition entry; it stays NULL until the
+        // first Insert of this partition. We use that to dispatch between
+        // the first-row branch (cold-start setup) and the subsequent-row
+        // branch (the steady-state AGGSTEP + RETURN_ROW pair).
+        let label_subsequent = program.allocate_label();
+        let label_step_end = program.allocate_label();
+        program.emit_insn(Insn::NotNull {
+            reg: registers.rowid,
+            target_pc: label_subsequent,
+        });
+
+        // --- FIRST ROW OF PARTITION ---
+        if let Some(new_ob) = registers.new_order_by_columns_start {
+            // Seed every per-cursor peer reference with the first row's
+            // ORDER BY values. Mirrors SQLite's three-cursor init at
+            // `window.c:2973-2976` (regNewPeer → s.start.reg / current.reg
+            // / end.reg). Doubling as the source-row peer-pre-check
+            // reference (`regPeer` in SQLite), `peer_end_reg` is set
+            // here and updated by AGGSTEP's peer-loop fall-through —
+            // we don't need a separate `regPeer` because the values
+            // they would hold are always identical at any program point.
+            program.add_comment(
+                program.offset(),
+                "initialize per-cursor peer-reference registers for new partition",
             );
-            emit_rewind_return_cursor_for_first_partition_row(
-                program,
-                cursors.csr_current,
-                registers.rowid,
-                rowid_one_register,
-            );
-            emit_flush_buffer_if_not_peer(program, labels, registers, window, plan)?;
-        } else {
-            emit_flush_buffer_if_not_peer(program, labels, registers, window, plan)?;
-            emit_insert_row_into_buffer(
-                program,
-                registers,
-                cursors,
-                input_column_count,
-                buffer_table_name,
-            );
+            let n = window.order_by.len() - 1;
+            for &peer_reg in [
+                registers.peer_start_reg,
+                registers.peer_current_reg,
+                registers.peer_end_reg,
+            ]
+            .iter()
+            .flatten()
+            {
+                program.emit_insn(Insn::Copy {
+                    src_reg: new_ob,
+                    dst_reg: peer_reg,
+                    extra_amount: n,
+                });
+            }
         }
-        emit_aggregation_step(program, window, &t_ctx.resolver, plan, registers)?;
-        if let Some(nth_value) = nth_value {
-            program.emit_insn(Insn::Copy {
-                src_reg: registers.rowid,
-                dst_reg: nth_value.frame_end_rowid_register,
-                extra_amount: 0,
+        program.add_comment(program.offset(), "reset accumulator registers");
+        program.emit_insn(Insn::Null {
+            dest: registers.acc_start,
+            dest_end: Some(registers.acc_start + window.functions.len() - 1),
+        });
+        emit_insert_row_into_buffer(
+            program,
+            &registers,
+            &cursors,
+            &src_column_count,
+            &buffer_table_name,
+        );
+        // Position each frame cursor at the just-inserted first row.
+        // Mirrors `window.c:2967-2971` — `csr_start` is rewound only when
+        // the frame start isn't UNBOUNDED PRECEDING (otherwise the
+        // cursor wasn't allocated and AggInverse is a no-op).
+        let label_unreachable_empty = program.allocate_label();
+        if let Some(csr_start) = cursors.csr_start {
+            program.emit_insn(Insn::Rewind {
+                cursor_id: csr_start,
+                pc_if_empty: label_unreachable_empty,
             });
         }
+        program.emit_insn(Insn::Rewind {
+            cursor_id: cursors.csr_current,
+            pc_if_empty: label_unreachable_empty,
+        });
+        program.emit_insn(Insn::Rewind {
+            cursor_id: cursors.csr_end,
+            pc_if_empty: label_unreachable_empty,
+        });
+        program.preassign_label_to_next_insn(label_unreachable_empty);
+        // First row contributes nothing to xStep here — the drain AGGSTEP
+        // in the flush subroutine processes it once at end-of-partition,
+        // and RETURN_ROW there emits it.
+        program.emit_insn(Insn::Goto {
+            target_pc: label_step_end,
+        });
+
+        // --- SUBSEQUENT ROW ---
+        program.preassign_label_to_next_insn(label_subsequent);
+        emit_insert_row_into_buffer(
+            program,
+            &registers,
+            &cursors,
+            &src_column_count,
+            &buffer_table_name,
+        );
+
+        let frame_mode = window.frame.mode;
+        let order_by_len = window.order_by.len();
+        let is_range_or_groups = frame_mode != turso_parser::ast::FrameMode::Rows;
+        if is_range_or_groups && order_by_len == 0 {
+            // RANGE/GROUPS with no ORDER BY: the entire partition is one
+            // peer group. The main body emits nothing — every step gets
+            // deferred to the flush subroutine, which drains all rows
+            // under one peer-equal loop and emits each with the same
+            // accumulated value.
+            program.emit_insn(Insn::Goto {
+                target_pc: label_step_end,
+            });
+        } else if is_range_or_groups {
+            // RANGE/GROUPS: if the new row is peer-equal with prevPeer, the
+            // frame doesn't advance yet — buffer the row and skip the step.
+            // The next non-peer row will trigger AGGSTEP, which loops
+            // through all peer-equal buffered rows in `emit_window_op`.
+            let label_step_body = program.allocate_label();
+            program.add_comment(program.offset(), "compare ORDER BY columns to detect peer");
+            let compare_key_info = build_order_by_key_info(window, &plan.table_references)?;
+            // Source-row peer pre-check — skip AGGSTEP / RETURN_ROW when
+            // the new source row is in the same peer group as the
+            // previous one. Uses `peer_end_reg` as the reference (which
+            // tracks the last AGGSTEP'd group); AGGSTEP's own peer-loop
+            // updates `peer_end_reg` so subsequent source rows see the
+            // correct comparison value.
+            //
+            // `Insn::Compare` requires `start_reg_a < start_reg_b`, so
+            // we put the earlier-allocated `new_order_by_columns_start`
+            // first. The Jump targets are symmetric on lt/gt
+            // (both go to step_body) so the operand order doesn't
+            // change the semantics.
+            program.emit_insn(Insn::Compare {
+                start_reg_a: registers
+                    .new_order_by_columns_start
+                    .expect("new_order_by_columns_start must exist"),
+                start_reg_b: registers
+                    .peer_end_reg
+                    .expect("peer_end_reg must exist under RANGE/GROUPS with ORDER BY"),
+                count: window.order_by.len(),
+                key_info: compare_key_info,
+            });
+            program.emit_insn(Insn::Jump {
+                target_pc_lt: label_step_body,
+                target_pc_eq: label_step_end,
+                target_pc_gt: label_step_body,
+            });
+            program.preassign_label_to_next_insn(label_step_body);
+        }
+
+        emit_window_op(program, t_ctx, plan, WindowOp::AggStep, None)?;
+        emit_window_op(program, t_ctx, plan, WindowOp::ReturnRow, None)?;
+
+        // No explicit peer-tracker update needed here: AGGSTEP's
+        // peer-loop fall-through copies `new` into `peer_end_reg`, and
+        // the (non-cached) RETURN_ROW peer-loop fall-through copies
+        // `new` into `peer_current_reg`. Mirrors SQLite's
+        // `windowIfNewPeer` Copy-on-fall-through (window.c:2074).
+
+        program.preassign_label_to_next_insn(label_step_end);
 
         Ok(())
     }
@@ -922,8 +1136,6 @@ fn emit_flush_buffer_if_new_partition(
     program: &mut ProgramBuilder,
     labels: &WindowLabels,
     registers: &WindowRegisters,
-    cursors: &WindowCursors,
-    buffer_mode: WindowBufferMode,
     window: &Window,
     plan: &SelectPlan,
 ) -> Result<()> {
@@ -983,11 +1195,6 @@ fn emit_flush_buffer_if_new_partition(
             target_pc: labels.flush_buffer,
             return_reg: registers.flush_buffer_return_offset,
         });
-        if buffer_mode.keeps_partition_rows() {
-            program.emit_insn(Insn::ResetSorter {
-                cursor_id: cursors.csr_current,
-            });
-        }
         // Reset rowid to signal the start of processing a new partition.
         program.emit_insn(Insn::Null {
             dest: registers.rowid,
@@ -1003,111 +1210,6 @@ fn emit_flush_buffer_if_new_partition(
     }
 
     Ok(())
-}
-
-fn emit_reset_state_if_new_partition(
-    program: &mut ProgramBuilder,
-    registers: &WindowRegisters,
-    nth_value: Option<&NthValueMetadata>,
-    window: &Window,
-) {
-    let label_skip_reset_state = program.allocate_label();
-
-    // If rowid is null, it means we are starting a new partition. It was either set by the code
-    // initializing window processing or by code detecting the start of a new partition.
-    program.emit_insn(Insn::NotNull {
-        reg: registers.rowid,
-        target_pc: label_skip_reset_state,
-    });
-    if let Some(dst_reg_start) = registers.new_order_by_columns_start {
-        // Initialize previous ORDER BY values for the new partition. The first row of the
-        // partition is compared to itself, not to the row from the previous partition.
-        program.add_comment(
-            program.offset(),
-            "initialize previous peer register for new partition",
-        );
-        program.emit_insn(Insn::Copy {
-            src_reg: dst_reg_start,
-            dst_reg: registers
-                .prev_order_by_columns_start
-                .expect("prev_order_by_columns_start must exist"),
-            extra_amount: window.order_by.len() - 1,
-        });
-    }
-    // Since this is a new partition, we must reset accumulator registers.
-    program.add_comment(program.offset(), "reset accumulator registers");
-    program.emit_insn(Insn::Null {
-        dest: registers.acc_start,
-        dest_end: Some(registers.acc_start + window.functions.len() - 1),
-    });
-    if let Some(nth_value) = nth_value {
-        program.emit_insn(Insn::Null {
-            dest: nth_value.frame_end_rowid_register,
-            dest_end: None,
-        });
-    }
-
-    program.preassign_label_to_next_insn(label_skip_reset_state);
-}
-
-fn emit_flush_buffer_if_not_peer(
-    program: &mut ProgramBuilder,
-    labels: &WindowLabels,
-    registers: &WindowRegisters,
-    window: &Window,
-    plan: &SelectPlan,
-) -> Result<()> {
-    if let Some(reg_new_order_by_columns_start) = registers.new_order_by_columns_start {
-        let label_peer = program.allocate_label();
-        let label_not_peer = program.allocate_label();
-        let order_by_len = window.order_by.len();
-        let reg_prev_order_by_columns_start = registers
-            .prev_order_by_columns_start
-            .expect("prev_order_by_columns_start must exist");
-
-        program.add_comment(program.offset(), "compare ORDER BY columns to detect peer");
-        program.emit_insn(Insn::Compare {
-            start_reg_a: reg_prev_order_by_columns_start,
-            start_reg_b: reg_new_order_by_columns_start,
-            count: order_by_len,
-            key_info: window_order_by_key_info(window, plan)?,
-        });
-        program.emit_insn(Insn::Jump {
-            target_pc_lt: label_not_peer,
-            target_pc_eq: label_peer,
-            target_pc_gt: label_not_peer,
-        });
-
-        program.preassign_label_to_next_insn(label_not_peer);
-        program.add_comment(program.offset(), "detected non-peer row");
-        program.emit_insn(Insn::Gosub {
-            target_pc: labels.flush_buffer,
-            return_reg: registers.flush_buffer_return_offset,
-        });
-        program.emit_insn(Insn::Copy {
-            src_reg: reg_new_order_by_columns_start,
-            dst_reg: reg_prev_order_by_columns_start,
-            extra_amount: order_by_len - 1,
-        });
-
-        program.preassign_label_to_next_insn(label_peer);
-    }
-
-    Ok(())
-}
-
-fn window_order_by_key_info(window: &Window, plan: &SelectPlan) -> Result<Vec<KeyInfo>> {
-    window
-        .order_by
-        .iter()
-        .map(|(expr, _, _)| {
-            Ok(KeyInfo {
-                sort_order: SortOrder::Asc,
-                collation: get_collseq_from_expr(expr, &plan.table_references)?.unwrap_or_default(),
-                nulls_order: None,
-            })
-        })
-        .collect()
 }
 
 fn emit_load_order_by_columns(
@@ -1159,85 +1261,342 @@ fn emit_insert_row_into_buffer(
         cursor: cursors.csr_write,
         key_reg: registers.rowid,
         record_reg: reg_record,
-        flag: InsertFlags::new(),
+        flag: InsertFlags::new().require_seek(),
         table_name: table_name.to_string(),
     });
 }
 
-fn emit_rewind_return_cursor_for_first_partition_row(
-    program: &mut ProgramBuilder,
-    return_cursor: CursorID,
-    inserted_rowid_register: usize,
-    rowid_one_register: usize,
-) {
-    let cursor_ready = program.allocate_label();
-    program.emit_insn(Insn::Ne {
-        lhs: inserted_rowid_register,
-        rhs: rowid_one_register,
-        target_pc: cursor_ready,
-        flags: CmpInsFlags::default(),
-        collation: None,
-    });
-    program.emit_insn(Insn::Rewind {
-        cursor_id: return_cursor,
-        pc_if_empty: cursor_ready,
-    });
-    program.preassign_label_to_next_insn(cursor_ready);
+/// The three frame-cursor operations. Mirrors SQLite's `WINDOW_AGGSTEP`,
+/// `WINDOW_RETURN_ROW`, and `WINDOW_AGGINVERSE` constants in
+/// `window.c:1765-1773`. Each operation reads from one cursor, fires the
+/// per-function callback for it, then advances that cursor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WindowOp {
+    /// A row entered the frame at its right edge: read `csr_end`, fire
+    /// each function's xStep, advance `csr_end`.
+    AggStep,
+    /// Emit the row at `csr_current` to the outer query, then advance
+    /// `csr_current`. xValue is computed for each function before the
+    /// emit.
+    ReturnRow,
+    /// A row left the frame at its left edge: read `csr_start`, fire
+    /// each function's xInverse, advance `csr_start`. No-op (and never
+    /// emitted) for windows whose frame start is UNBOUNDED PRECEDING.
+    AggInverse,
 }
 
-fn emit_aggregation_step(
+/// The window op after which a buffered row becomes unreachable and can be
+/// deleted from the ephemeral table. Mirrors SQLite's `s.eDelete`
+/// (`window.c:2839-2869`): the emitter deletes the row at
+/// `window.c:2346` (`if( op==p->eDelete ) OP_Delete`). `None` is SQLite's
+/// `eDelete == 0` — never delete, keep the whole partition buffered.
+///
+/// Frame-caching functions (`first_value` / `nth_value` / `lag` / `lead`)
+/// seek arbitrary rows through `csr_app` at output time, so their rows must
+/// survive until the partition is flushed. SQLite's `windowCacheFrame` forces
+/// `eDelete == 0` for exactly that set; we detect it via `has_csr_app`.
+///
+/// Only frames with an UNBOUNDED PRECEDING start (delete at `RETURN_ROW`) or a
+/// sliding start (delete at `AGGINVERSE`) are reachable today — explicit frame
+/// clauses, and therefore SQLite's offset-bearing arms (`ROWS ... N PRECEDING`
+/// end → `AGGSTEP`, `ROWS N FOLLOWING` start → `RETURN_ROW`), are rejected
+/// before emit. The start-boundary split here matches the one the flush loop
+/// uses to decide whether to fire `AGGINVERSE` at all; a future `FOLLOWING`
+/// frame start needs both sites updated together.
+fn window_delete_op(window: &Window, has_csr_app: bool) -> Option<WindowOp> {
+    if has_csr_app {
+        return None;
+    }
+    match window.frame.start {
+        crate::translate::plan::FrameBoundary::UnboundedPreceding => Some(WindowOp::ReturnRow),
+        _ => Some(WindowOp::AggInverse),
+    }
+}
+
+/// Emit one of the three frame-cursor operations, mirroring SQLite's
+/// `windowCodeOp` helper (`window.c:2229-2376`).
+///
+/// `break_on_eof` is `Some(label)` only at flush time, when the caller wants
+/// the `RETURN_ROW` loop to exit cleanly on EOF instead of falling through.
+///
+/// Under RANGE/GROUPS frames (`bPeer == true`), the cursor advances loop
+/// through every peer-equal row before returning — one `AggStep` call
+/// xSteps the whole previous peer group, one `RETURN_ROW` call emits the
+/// whole previous peer group with the same accumulated state. Under ROWS
+/// frames (`bPeer == false`), each call advances by exactly one row.
+fn emit_window_op(
     program: &mut ProgramBuilder,
-    window: &Window,
-    resolver: &Resolver,
+    t_ctx: &mut TranslateCtx,
     plan: &SelectPlan,
-    registers: &WindowRegisters,
-) -> crate::Result<()> {
-    for (i, func) in window
-        .functions
-        .iter()
-        .enumerate()
-        .filter(|(_, func)| match &func.func {
-            // Aggregates and these window functions build their answers while
-            // input rows arrive. Functions that wait for a result row are
-            // handled later, when that row is returned.
-            AccumulatorFunc::Agg(_) => true,
-            AccumulatorFunc::Window(window_func) => {
-                !window_func.calculates_answer_when_row_is_returned()
+    op: WindowOp,
+    break_on_eof: Option<BranchOffset>,
+) -> Result<()> {
+    let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
+    let window = plan.window.as_ref().expect("missing window");
+    let registers = meta.registers;
+    let cursors = meta.cursors;
+    let buffer_table_name = meta.buffer_table_name.clone();
+    let order_by_len = window.order_by.len();
+    let frame_mode = window.frame.mode;
+    // bPeer mirrors SQLite's `WindowCodeArg.eFrmType != TK_ROWS` test
+    // (window.c:2247). Under RANGE / GROUPS frames, advances loop through
+    // peer-equal rows; with no ORDER BY every row is peer-equal so the
+    // loop runs to EOF.
+    let b_peer = frame_mode != turso_parser::ast::FrameMode::Rows;
+
+    let label_done = program.allocate_label();
+    // Cursor + per-cursor peer reference register for each op. Mirrors
+    // SQLite's switch at `window.c:2315-2344` plus the reg pickup at
+    // `window.c:2317-2336`.
+    let (cursor_for_op, peer_ref_reg) = match op {
+        WindowOp::AggStep => (cursors.csr_end, registers.peer_end_reg),
+        WindowOp::ReturnRow => (cursors.csr_current, registers.peer_current_reg),
+        WindowOp::AggInverse => (
+            cursors
+                .csr_start
+                .expect("AggInverse can only be emitted when the window has a moving frame start"),
+            registers.peer_start_reg,
+        ),
+    };
+
+    // RETURN_ROW finalizes accumulators before emitting (SQLite's
+    // windowAggFinal at window.c:2284). first_value / nth_value have
+    // no accumulator value to read — `emit_first_value_nth_value_lookup`
+    // writes their result registers directly inside `emit_return_one_row`.
+    if matches!(op, WindowOp::ReturnRow) {
+        for (i, func) in window.functions.iter().enumerate() {
+            if matches!(
+                &func.func,
+                AccumulatorFunc::Window(WindowFunc::FirstValue | WindowFunc::NthValue),
+            ) {
+                continue;
             }
-        })
-    {
-        let reg_acc_start = registers.acc_start + i;
+            program.emit_insn(Insn::AggValue {
+                acc_reg: registers.acc_start + i,
+                dest_reg: registers.acc_result_start + i,
+                func: func.func.clone(),
+            });
+        }
+    }
+
+    let label_continue = program.allocate_label();
+    program.preassign_label_to_next_insn(label_continue);
+
+    match op {
+        WindowOp::AggStep => {
+            emit_function_step(program, t_ctx, plan, cursors.csr_end)?;
+            // Record the rowid of the row just stepped into the frame. This
+            // runs once per row in the peer-loop, so after AGGSTEP has walked
+            // the whole peer group `frame_end_rowid` holds the group's last
+            // rowid — the frame end that first_value / nth_value seek against.
+            if let Some(frame_end_rowid) = registers.frame_end_rowid {
+                program.emit_insn(Insn::RowId {
+                    cursor_id: cursors.csr_end,
+                    dest: frame_end_rowid,
+                });
+            }
+        }
+        WindowOp::ReturnRow => {
+            emit_return_one_row(program, t_ctx, plan)?;
+        }
+        WindowOp::AggInverse => {
+            emit_function_inverse(program, t_ctx, plan)?;
+        }
+    }
+
+    // Delete the row that just left the reachable set (SQLite window.c:2346,
+    // `if( op==p->eDelete ) OP_Delete`), before advancing the cursor past it.
+    if window_delete_op(window, cursors.csr_app.is_some()) == Some(op) {
+        program.emit_insn(Insn::Delete {
+            cursor_id: cursor_for_op,
+            table_name: buffer_table_name,
+            is_part_of_update: false,
+        });
+    }
+
+    // Advance the cursor. Three control-flow shapes mirroring SQLite's
+    // `windowCodeOp` tail at window.c:2351-2361:
+    //   - break_on_eof=Some: Next; on EOF fall through to a Goto that
+    //     jumps to the caller's break label.
+    //   - bPeer=true: Next; on EOF fall through to Goto label_done; else
+    //     fall through to the peer-loop check below.
+    //   - bPeer=false, no break_on_eof: Next; on EOF fall through;
+    //     no peer check; label_done is the next instruction.
+    let label_after_next = program.allocate_label();
+    program.emit_insn(Insn::Next {
+        cursor_id: cursor_for_op,
+        pc_if_next: label_after_next,
+    });
+    if let Some(break_target) = break_on_eof {
+        program.emit_insn(Insn::Goto {
+            target_pc: break_target,
+        });
+    } else if b_peer {
+        program.emit_insn(Insn::Goto {
+            target_pc: label_done,
+        });
+    }
+    program.preassign_label_to_next_insn(label_after_next);
+
+    if b_peer && order_by_len > 0 {
+        // Peer-loop check, mirroring SQLite's `windowIfNewPeer` (which
+        // bundles the Compare + Jump-if-equal + Copy-on-fall-through
+        // at `window.c:2057-2078`). The peer reference register is
+        // per-cursor (`peer_start_reg` / `peer_current_reg` /
+        // `peer_end_reg`) so the start / current / end cursors can be
+        // at different peer groups during flush — required for
+        // percent_rank / cume_dist.
+        let temp_start = program.alloc_registers(order_by_len);
+        for (i, (expr, _, _)) in window.order_by.iter().enumerate() {
+            if let Expr::Column { column, .. } = expr {
+                program.emit_insn(Insn::Column {
+                    cursor_id: cursor_for_op,
+                    column: *column,
+                    dest: temp_start + i,
+                    default: None,
+                });
+            } else {
+                unreachable!("expected Column in window.order_by, got {:?}", expr);
+            }
+        }
+        let key_info = build_order_by_key_info(window, &plan.table_references)?;
+        let peer_ref = peer_ref_reg.expect(
+            "per-cursor peer reference register must exist under RANGE/GROUPS with ORDER BY",
+        );
+        let label_update_peer = program.allocate_label();
+        program.emit_insn(Insn::Compare {
+            start_reg_a: peer_ref,
+            start_reg_b: temp_start,
+            count: order_by_len,
+            key_info,
+        });
+        program.emit_insn(Insn::Jump {
+            target_pc_lt: label_update_peer,
+            target_pc_eq: label_continue,
+            target_pc_gt: label_update_peer,
+        });
+        // Fall-through path (new peer group): copy the new row's ORDER
+        // BY values into the cursor's peer reference register so the
+        // next peer-loop iteration compares against this group.
+        program.preassign_label_to_next_insn(label_update_peer);
+        program.emit_insn(Insn::Copy {
+            src_reg: temp_start,
+            dst_reg: peer_ref,
+            extra_amount: order_by_len - 1,
+        });
+    } else if b_peer {
+        // RANGE/GROUPS with no ORDER BY: every row in the partition is
+        // peer-equal, so the loop always continues until EOF (handled by
+        // the Next/Goto pair above).
+        program.emit_insn(Insn::Goto {
+            target_pc: label_continue,
+        });
+    }
+
+    program.preassign_label_to_next_insn(label_done);
+
+    Ok(())
+}
+
+/// Emit per-function xStep / xInverse calls reading from `read_csr`.
+///
+/// Mirrors SQLite's `windowAggStep` (`window.c:1658-1762`): for each
+/// function, each argument is loaded from the cursor's current row into a
+/// fresh register block (SQLite's `p->regArg`), then `AggStep` /
+/// `AggInverse` is emitted referencing that block. Crucially, the load
+/// destinations are *separate* from `src_columns_start` so the source
+/// coroutine's register block (which holds the new-partition row being
+/// processed) isn't trampled while we drain the previous partition.
+///
+/// Argument expressions are pushed into the resolver's expression cache
+/// during the call so `translate_aggregation_step`'s recursive
+/// `translate_expr` resolves each `Expr::Column` to the arg-load register
+/// we just populated, instead of to `src_columns_start`. The cache is
+/// restored on the way out.
+fn emit_function_step(
+    program: &mut ProgramBuilder,
+    t_ctx: &mut TranslateCtx,
+    plan: &SelectPlan,
+    read_csr: CursorID,
+) -> Result<()> {
+    let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
+    let window = plan.window.as_ref().expect("missing window");
+    let acc_start = meta.registers.acc_start;
+
+    // Save cache state so the per-arg overrides we push below don't leak
+    // out to other parts of the emit pipeline (e.g. emit_return_one_row).
+    let initial_cache_len = t_ctx.resolver.expr_to_reg_cache.len();
+    let cache_was_enabled = t_ctx.resolver.expr_to_reg_cache_enabled;
+
+    for (i, func) in window.functions.iter().enumerate() {
+        // first_value / nth_value are computed at output time via
+        // `SeekRowid` on `csr_app` (see
+        // `emit_first_value_nth_value_lookup`). They have no
+        // step-time accumulator update — mirrors SQLite's WINDOWFUNCNOOP
+        // pattern at `window.c:1727-1730`.
+        if matches!(
+            &func.func,
+            AccumulatorFunc::Window(WindowFunc::FirstValue | WindowFunc::NthValue)
+        ) {
+            continue;
+        }
+        let acc_reg = acc_start + i;
+        let args: Vec<Expr> = match func.current_expr() {
+            Expr::FunctionCall { args, .. } => args.iter().map(|a| (**a).clone()).collect(),
+            Expr::FunctionCallStar { .. } => vec![],
+            _ => unreachable!("window functions are FunctionCall or FunctionCallStar expressions"),
+        };
+
+        // Load each Expr::Column arg from the frame cursor into a fresh
+        // reg, then push a cache entry so translate_expr on that same Expr
+        // resolves to the freshly-loaded reg. Args that aren't simple
+        // column refs (rare after the planner rewrite) fall through to
+        // translate_expr's default path.
+        let arg_load_start = (!args.is_empty()).then(|| program.alloc_registers(args.len()));
+        if let Some(base) = arg_load_start {
+            for (j, arg) in args.iter().enumerate() {
+                if let Expr::Column { column, .. } = arg {
+                    program.emit_insn(Insn::Column {
+                        cursor_id: read_csr,
+                        column: *column,
+                        dest: base + j,
+                        default: None,
+                    });
+                    t_ctx.resolver.cache_expr_reg(
+                        std::borrow::Cow::Owned(arg.clone()),
+                        base + j,
+                        false,
+                        None,
+                    );
+                }
+            }
+        }
+        t_ctx.resolver.expr_to_reg_cache_enabled = true;
+
         match &func.func {
             AccumulatorFunc::Agg(agg_func) => {
-                // The aggregation step is performed incrementally as each row from the subquery is
-                // processed. Therefore, we don’t need to access the buffer table and can obtain
-                // argument values directly by evaluating the expressions that reference the
-                // subquery result columns. Use the rewritten form when available so the args
-                // reference the subquery rather than the (no-longer-visible) original tables.
-                let args = match func.current_expr() {
-                    Expr::FunctionCall { args, .. } => {
-                        args.iter().map(|a| (**a).clone()).collect()
-                    }
-                    Expr::FunctionCallStar { .. } => vec![],
-                    _ => unreachable!(
-                        "All window functions should be either FunctionCall or FunctionCallStar expressions"
-                    ),
-                };
-
-                // FILTER controls whether the current input row contributes to the
-                // running aggregate; it does not suppress the output row itself.
+                // FILTER predicate also loads from the frame cursor.
                 let filter_skip_label = if let Some(filter_expr) =
                     func.rewritten.as_ref().and_then(|r| r.filter_expr.as_ref())
                 {
                     let label = program.allocate_label();
                     let filter_reg = program.alloc_register();
-                    translate_expr(
-                        program,
-                        Some(&plan.table_references),
-                        filter_expr,
-                        filter_reg,
-                        resolver,
-                    )?;
+                    if let Expr::Column { column, .. } = filter_expr {
+                        program.emit_insn(Insn::Column {
+                            cursor_id: read_csr,
+                            column: *column,
+                            dest: filter_reg,
+                            default: None,
+                        });
+                    } else {
+                        translate_expr(
+                            program,
+                            Some(&plan.table_references),
+                            filter_expr,
+                            filter_reg,
+                            &t_ctx.resolver,
+                        )?;
+                    }
                     program.emit_insn(Insn::IfNot {
                         reg: filter_reg,
                         target_pc: label,
@@ -1256,35 +1615,21 @@ fn emit_aggregation_step(
                         &args,
                         &Distinctness::NonDistinct,
                     ),
-                    reg_acc_start,
-                    resolver,
+                    acc_reg,
+                    &t_ctx.resolver,
                     None,
                 )?;
+
                 if let Some(label) = filter_skip_label {
                     program.preassign_label_to_next_insn(label);
                 }
             }
             AccumulatorFunc::Window(win_func) => {
-                // These functions need at most their first argument while
-                // input rows arrive. Arguments that may differ for each result
-                // row are read later from that saved row.
-                let first_arg = match func.current_expr() {
-                    Expr::FunctionCall { args, .. } => args.first(),
-                    Expr::FunctionCallStar { .. } => None,
-                    _ => unreachable!("window function must be a function call"),
-                };
-                let arg_reg = if let Some(arg) = first_arg {
-                    let reg = program.alloc_register();
-                    translate_expr(program, Some(&plan.table_references), arg, reg, resolver)?;
-                    reg
-                } else {
-                    // TODO: Make `AggStep::col` optional. It currently requires a
-                    // register number, so reserved register 0 means no argument.
-                    0
-                };
+                // 0-ary window funcs (row_number) ignore `col`; the runtime
+                // only reads `state.registers[col + i]` for i in 0..arity.
                 program.emit_insn(Insn::AggStep {
-                    acc_reg: reg_acc_start,
-                    col: arg_reg,
+                    acc_reg,
+                    col: arg_load_start.unwrap_or(0),
                     delimiter: 0,
                     func: AccumulatorFunc::Window(win_func.clone()),
                     comparator: None,
@@ -1294,266 +1639,295 @@ fn emit_aggregation_step(
         }
     }
 
+    // Restore expr-cache state so the per-function arg overrides don't
+    // leak into later emit calls (e.g. emit_return_one_row's outer-query
+    // result emission, which expects its own result_columns_start mapping).
+    t_ctx.resolver.expr_to_reg_cache.truncate(initial_cache_len);
+    t_ctx.resolver.expr_to_reg_cache_enabled = cache_was_enabled;
+
     Ok(())
 }
 
-/// Emits bytecode to output all buffered rows produced by window processing.
+/// Emit per-function `AggInverse` calls — the counterpart of
+/// `emit_function_step` for the frame-start side. Mirrors the xInverse
+/// dispatch inside SQLite's `windowAggStep(... bInverse=1, ...)`
+/// (window.c:2329).
 ///
-/// The generated code has two possible entry points:
-/// * **Fallthrough mode** (normal flow): After all source rows have been processed,
-///   this code executes inline to flush any remaining buffered rows, then continues execution.
-/// * **Subroutine mode** (jump into `labels.flush_buffer`): In this case the code
-///   returns control to the address stored in `registers.flush_buffer_return_offset`
-///   once all buffered rows are processed.
-pub fn emit_window_results(
+/// For our supported moving-start frames (ntile, percent_rank,
+/// cume_dist) xInverse is purely state-mutating: it increments a
+/// counter the function's xValue reads. We pass `col = 0` because none
+/// of these read leaving-row columns. Aggregate inverses (sum / count
+/// / avg under a sliding frame) would need the leaving row's args loaded
+/// from `csr_start` first — that path lands when we accept user-specified
+/// custom frames.
+fn emit_function_inverse(
     program: &mut ProgramBuilder,
     t_ctx: &mut TranslateCtx,
     plan: &SelectPlan,
-) -> crate::Result<()> {
-    let WindowMetadata {
-        labels,
-        registers,
-        cursors,
-        buffer_mode,
-        ..
-    } = t_ctx.meta_window.as_ref().expect("missing window metadata");
+) -> Result<()> {
+    let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
     let window = plan.window.as_ref().expect("missing window");
-
-    let label_empty = program.allocate_label();
-    let label_window_processing_end = labels.window_processing_end;
-    let label_flush_buffer = labels.flush_buffer;
-    let reg_flush_buffer_return_offset = registers.flush_buffer_return_offset;
-    let cursor_csr_current = cursors.csr_current;
-    let keeps_partition_rows = buffer_mode.keeps_partition_rows();
-
-    // All source rows have already been processed at this point.
-    // In fallthrough mode, we are not returning to a caller — we just flush
-    // the buffered rows and continue execution.
-    program.add_comment(program.offset(), "return remaining buffered rows");
-    program.emit_insn(Insn::Null {
-        dest: reg_flush_buffer_return_offset,
-        dest_end: None,
-    });
-
-    // If control jumps here (labels.flush_buffer), we are in subroutine mode.
-    // In that case, after flushing the buffer, execution will return to the
-    // address stored in `flush_buffer_return_offset`.
-    program.preassign_label_to_next_insn(label_flush_buffer);
-
-    if keeps_partition_rows {
-        program.emit_insn(Insn::IsNull {
-            reg: registers.rowid,
-            target_pc: label_empty,
-        });
-    } else {
-        program.emit_insn(Insn::Rewind {
-            cursor_id: cursor_csr_current,
-            pc_if_empty: label_empty,
+    let acc_start = meta.registers.acc_start;
+    for (i, func) in window.functions.iter().enumerate() {
+        program.emit_insn(Insn::AggInverse {
+            acc_reg: acc_start + i,
+            col: 0,
+            delimiter: 0,
+            func: func.func.clone(),
+            comparator: None,
         });
     }
-
-    emit_peer_group_flush(program, window, t_ctx, plan)?;
-
-    program.preassign_label_to_next_insn(label_empty);
-
-    if !keeps_partition_rows {
-        program.emit_insn(Insn::ResetSorter {
-            cursor_id: cursor_csr_current,
-        });
-    }
-    program.emit_insn(Insn::Return {
-        return_reg: reg_flush_buffer_return_offset,
-        can_fallthrough: true,
-    });
-
-    program.preassign_label_to_next_insn(label_window_processing_end);
-
     Ok(())
 }
 
-fn emit_peer_group_flush(
+/// Emit per-output-row positional lookup for every `first_value` /
+/// `nth_value` in the current window. Mirrors SQLite's first_value /
+/// nth_value arms in `windowReturnOneRow` (`window.c:1940-1965`):
+///
+/// ```text
+///   reg_result := NULL
+///   tmp := 1                                 (first_value, N=1)
+///     -- or --
+///   tmp := arg[1] from csr_current           (nth_value, per-row N)
+///   MustBeInt tmp; if tmp <= 0: error
+///   tmp := tmp + frame_start_rowid - 1       (frame_start_rowid = 1 for UB-CR)
+///   if tmp > frame_end_rowid: goto lbl       (target past frame end → NULL)
+///   SeekRowid(csr_app, tmp)
+///   reg_result := Column(csr_app, arg[0])
+///   lbl:
+/// ```
+///
+/// The frames the planner currently lets first_value/nth_value through
+/// with all have `frame_start_rowid = 1` (RANGE UNBOUNDED PRECEDING TO
+/// CURRENT ROW). Sliding `ROWS BETWEEN N PRECEDING AND CURRENT ROW` for
+/// these functions is rejected at parse — it needs a stable
+/// per-partition N register (parallel to SQLite's `pWin->regApp`) to
+/// compute `frame_start_rowid` at emit time.
+fn emit_first_value_nth_value_lookup(
     program: &mut ProgramBuilder,
-    window: &Window,
     t_ctx: &mut TranslateCtx,
     plan: &SelectPlan,
-) -> crate::Result<()> {
-    let WindowMetadata {
-        labels,
-        registers,
-        cursors,
-        buffer_mode,
-        nth_value,
-        expressions_referencing_subquery,
-        ..
-    } = t_ctx.meta_window.as_ref().expect("missing window metadata");
+) -> Result<()> {
+    let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
+    let window = plan.window.as_ref().expect("missing window");
+    let registers = meta.registers;
+    let cursors = meta.cursors;
+    let acc_result_start = registers.acc_result_start;
+    let csr_current = cursors.csr_current;
 
-    // Calculate shared answers before returning rows with equal sort values,
-    // so every such row reuses the same answer. `nth_value` is calculated
-    // below because its second argument is read separately from each row.
     for (i, func) in window.functions.iter().enumerate() {
-        let answer_is_shared = match &func.func {
-            AccumulatorFunc::Agg(_) => true,
-            AccumulatorFunc::Window(window_func) => {
-                !window_func.calculates_answer_when_row_is_returned()
-            }
+        let is_nth = match &func.func {
+            AccumulatorFunc::Window(WindowFunc::FirstValue) => false,
+            AccumulatorFunc::Window(WindowFunc::NthValue) => true,
+            _ => continue,
         };
-        if answer_is_shared {
-            program.emit_insn(Insn::AggValue {
-                acc_reg: registers.acc_start + i,
-                dest_reg: registers.acc_result_start + i,
-                func: func.func.clone(),
+        let csr_app = cursors
+            .csr_app
+            .expect("csr_app must exist when a window contains first_value or nth_value");
+        let result_reg = acc_result_start + i;
+
+        let args: Vec<&Expr> = match func.current_expr() {
+            Expr::FunctionCall { args, .. } => args.iter().map(|a| a.as_ref()).collect(),
+            _ => unreachable!("first_value / nth_value are always Expr::FunctionCall"),
+        };
+        let arg_value_col = match args.first() {
+            Some(Expr::Column { column, .. }) => *column,
+            other => unreachable!(
+                "first_value/nth_value arg[0] must be a subquery column ref \
+                 after planner rewrite, got {other:?}"
+            ),
+        };
+
+        // Default result: NULL (stays NULL on seek miss or N past frame end).
+        program.emit_insn(Insn::Null {
+            dest: result_reg,
+            dest_end: None,
+        });
+
+        // Compute target rowid. For UB-CR frames, frame_start_rowid = 1,
+        // so target = N (read fresh per output row for nth_value, 1 for
+        // first_value).
+        let target_reg = program.alloc_register();
+        if is_nth {
+            let n_col = match args.get(1) {
+                Some(Expr::Column { column, .. }) => *column,
+                other => unreachable!(
+                    "nth_value arg[1] must be a subquery column ref \
+                     after planner rewrite, got {other:?}"
+                ),
+            };
+            program.emit_insn(Insn::Column {
+                cursor_id: csr_current,
+                column: n_col,
+                dest: target_reg,
+                default: None,
+            });
+            // Validate N: must be a positive integer. Matches SQLite's
+            // `windowCheckValue(eCond=2)` at `window.c:1490-1506` — the
+            // error message is the verbatim SQLite string.
+            let lbl_n_ok = program.allocate_label();
+            let lbl_n_err = program.allocate_label();
+            program.emit_insn(Insn::MustBeInt {
+                reg: target_reg,
+                target_pc: Some(lbl_n_err),
+            });
+            let reg_zero = program.alloc_register();
+            program.emit_insn(Insn::Integer {
+                value: 0,
+                dest: reg_zero,
+            });
+            program.emit_insn(Insn::Gt {
+                lhs: target_reg,
+                rhs: reg_zero,
+                target_pc: lbl_n_ok,
+                flags: crate::vdbe::insn::CmpInsFlags::default(),
+                collation: None,
+            });
+            program.preassign_label_to_next_insn(lbl_n_err);
+            program.emit_insn(Insn::Halt {
+                err_code: crate::error::SQLITE_ERROR,
+                description: "second argument to nth_value must be a positive integer".to_string(),
+                on_error: None,
+                description_reg: None,
+            });
+            program.preassign_label_to_next_insn(lbl_n_ok);
+        } else {
+            program.emit_insn(Insn::Integer {
+                value: 1,
+                dest: target_reg,
             });
         }
+
+        // Two distinct "no value" outcomes, kept separate:
+        //
+        // * target past the frame end — a legitimate NULL (the Nth row lies
+        //   outside this row's frame). `frame_end_rowid` is the last rowid
+        //   stepped into the frame, NOT the emitted row's own rowid: under
+        //   RANGE the frame runs to the current row's last peer, so an early
+        //   row of a peer group must still see its whole group.
+        //
+        // * target within the frame but `SeekRowid` misses — impossible:
+        //   frame rows carry dense rowids 1..frame_end and are all buffered
+        //   by emit time. Treat it as an invariant violation and Halt rather
+        //   than silently returning NULL. Mirrors SQLite finding its row via
+        //   csrApp unconditionally.
+        let frame_end_rowid = registers
+            .frame_end_rowid
+            .expect("frame_end_rowid must exist when a window contains first_value/nth_value");
+        let lbl_past_frame_end = program.allocate_label();
+        let lbl_missing_row = program.allocate_label();
+        let lbl_done = program.allocate_label();
+        program.emit_insn(Insn::Gt {
+            lhs: target_reg,
+            rhs: frame_end_rowid,
+            target_pc: lbl_past_frame_end,
+            flags: crate::vdbe::insn::CmpInsFlags::default(),
+            collation: None,
+        });
+        program.emit_insn(Insn::SeekRowid {
+            cursor_id: csr_app,
+            src_reg: target_reg,
+            target_pc: lbl_missing_row,
+        });
+        program.emit_insn(Insn::Column {
+            cursor_id: csr_app,
+            column: arg_value_col,
+            dest: result_reg,
+            default: None,
+        });
+        program.emit_insn(Insn::Goto {
+            target_pc: lbl_done,
+        });
+        program.preassign_label_to_next_insn(lbl_missing_row);
+        program.emit_insn(Insn::Halt {
+            err_code: crate::error::SQLITE_ERROR,
+            description: "first_value/nth_value could not find a saved row within its frame"
+                .to_string(),
+            on_error: None,
+            description_reg: None,
+        });
+        // Past frame end falls through here with `result_reg` still NULL.
+        program.preassign_label_to_next_insn(lbl_past_frame_end);
+        program.preassign_label_to_next_insn(lbl_done);
     }
 
-    let label_skip_returning_row = program.allocate_label();
-    let label_loop_start = program.allocate_label();
-    program.preassign_label_to_next_insn(label_loop_start);
+    Ok(())
+}
 
-    // Propagate subquery result column values to the outer query (if any) or directly to
-    // the final output that will be returned to the user, by copying them from the buffer table
-    // into the dedicated registers.
+/// Emit one output row's worth of work: populate `result_columns_start` from
+/// `csr_current`, run the positional lookups for functions computed at
+/// output time, then Gosub to the shared row-output subroutine. Mirrors
+/// SQLite's `windowReturnOneRow` (`window.c:1816-1990`), restricted to the
+/// streaming code path.
+fn emit_return_one_row(
+    program: &mut ProgramBuilder,
+    t_ctx: &mut TranslateCtx,
+    plan: &SelectPlan,
+) -> Result<()> {
+    let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
+    let labels = meta.labels;
+    let registers = meta.registers;
+    let cursors = meta.cursors;
+    let expressions_referencing_subquery = meta.expressions_referencing_subquery.clone();
+
     for (i, (_, col_idx)) in expressions_referencing_subquery.iter().enumerate() {
         let reg_result = registers.result_columns_start + i;
         program.emit_column_or_rowid(cursors.csr_current, *col_idx, reg_result);
     }
-    // Calculate these answers while returning each row because rows with equal
-    // sort values may still have different answers.
-    for (i, func) in window.functions.iter().enumerate() {
-        if let AccumulatorFunc::Window(win_func) = &func.func {
-            if !win_func.calculates_answer_when_row_is_returned() {
-                continue;
-            }
-            let dest_reg = registers.acc_result_start + i;
-            if matches!(win_func, crate::function::WindowFunc::NthValue) {
-                let Expr::FunctionCall { args, .. } = func.current_expr() else {
-                    unreachable!("nth_value must be a function call");
-                };
-                let Expr::Column {
-                    column: value_column,
-                    ..
-                } = args[0].as_ref()
-                else {
-                    unreachable!("rewritten nth_value value must be a subquery column");
-                };
-                let Expr::Column {
-                    column: position_column,
-                    ..
-                } = args[1].as_ref()
-                else {
-                    unreachable!("rewritten nth_value position argument must be a subquery column");
-                };
-                let nth_value = nth_value
-                    .as_ref()
-                    .expect("nth_value requires a partition lookup cursor");
-                let position_lookup_done = program.allocate_label();
-                let missing_saved_row = program.allocate_label();
-                let invalid_position = program.allocate_label();
-                let valid_position = program.allocate_label();
-                let position_register = program.alloc_register();
-                let zero_register = program.alloc_register();
-                program.emit_insn(Insn::Null {
-                    dest: dest_reg,
-                    dest_end: None,
-                });
-                program.emit_column_or_rowid(
-                    cursors.csr_current,
-                    *position_column,
-                    position_register,
-                );
-                program.emit_insn(Insn::MustBeInt {
-                    reg: position_register,
-                    target_pc: Some(invalid_position),
-                });
-                program.emit_insn(Insn::Integer {
-                    value: 0,
-                    dest: zero_register,
-                });
-                program.emit_insn(Insn::Gt {
-                    lhs: position_register,
-                    rhs: zero_register,
-                    target_pc: valid_position,
-                    flags: CmpInsFlags::default(),
-                    collation: None,
-                });
-                program.preassign_label_to_next_insn(invalid_position);
-                program.emit_insn(Insn::Halt {
-                    err_code: crate::error::SQLITE_ERROR,
-                    description: "second argument to nth_value must be a positive integer"
-                        .to_string(),
-                    on_error: Some(ResolveType::Abort),
-                    description_reg: None,
-                });
-                program.preassign_label_to_next_insn(valid_position);
-                program.emit_insn(Insn::Gt {
-                    lhs: position_register,
-                    rhs: nth_value.frame_end_rowid_register,
-                    target_pc: position_lookup_done,
-                    flags: CmpInsFlags::default(),
-                    collation: None,
-                });
-                program.emit_insn(Insn::SeekRowid {
-                    cursor_id: nth_value.row_by_position_cursor,
-                    src_reg: position_register,
-                    target_pc: missing_saved_row,
-                });
-                program.emit_column_or_rowid(
-                    nth_value.row_by_position_cursor,
-                    *value_column,
-                    dest_reg,
-                );
-                program.emit_insn(Insn::Goto {
-                    target_pc: position_lookup_done,
-                });
-                program.preassign_label_to_next_insn(missing_saved_row);
-                program.emit_insn(Insn::Halt {
-                    err_code: crate::error::SQLITE_ERROR,
-                    description: "nth_value could not find a saved row within its frame"
-                        .to_string(),
-                    on_error: None,
-                    description_reg: None,
-                });
-                program.preassign_label_to_next_insn(position_lookup_done);
-                continue;
-            }
 
-            let acc_reg = registers.acc_start + i;
-            // TODO: Make `AggStep::col` optional. It currently requires a
-            // register number, so reserved register 0 means no argument.
-            program.emit_insn(Insn::AggStep {
-                acc_reg,
-                col: 0,
-                delimiter: 0,
-                func: AccumulatorFunc::Window(win_func.clone()),
-                comparator: None,
-                collation: None,
-            });
-            program.emit_insn(Insn::AggValue {
-                acc_reg,
-                dest_reg,
-                func: AccumulatorFunc::Window(win_func.clone()),
-            });
-        }
-    }
+    // Per-row lookups for functions whose value is computed at output
+    // time (first_value / nth_value). Each writes the function's value
+    // register before the outer query reads it via `emit_select_result`'s
+    // expression-cache lookup.
+    emit_first_value_nth_value_lookup(program, t_ctx, plan)?;
+
+    // The select-result / sorter-insert code is a shared subroutine —
+    // RETURN_ROW is emitted at several sites (streaming step + flush
+    // loops), and jump targets inside the row-output code (SELECT
+    // DISTINCT's on-conflict label in particular) must resolve to exactly
+    // one address. Mirrors SQLite's `OP_Gosub regGosub, addrGosub` at the
+    // end of `windowReturnOneRow` (window.c:1988).
+    program.emit_insn(Insn::Gosub {
+        target_pc: labels.row_output,
+        return_reg: registers.row_output_return,
+    });
+
+    Ok(())
+}
+
+/// Emit the single row-output subroutine that every RETURN_ROW site Gosubs
+/// to: send the populated result registers to the outer query (or the
+/// order-by sorter), applying OFFSET, LIMIT and SELECT DISTINCT
+/// deduplication. This is the window-loop half of what SQLite emits once
+/// as the `addrGosub` target in `select.c`.
+fn emit_row_output_subroutine(
+    program: &mut ProgramBuilder,
+    t_ctx: &mut TranslateCtx,
+    plan: &SelectPlan,
+) -> Result<()> {
+    let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
+    let labels = meta.labels;
+    let registers = meta.registers;
+
+    program.preassign_label_to_next_insn(labels.row_output);
+
+    let label_skip_returning_row = program.allocate_label();
     t_ctx.resolver.enable_expr_to_reg_cache();
 
-    match plan.order_by.is_empty() {
-        true => {
-            emit_select_result(
-                program,
-                &t_ctx.resolver,
-                plan,
-                Some(labels.window_processing_end),
-                Some(label_skip_returning_row),
-                t_ctx.reg_nonagg_emit_once_flag,
-                t_ctx.reg_offset,
-                t_ctx.reg_result_cols_start.unwrap(),
-                t_ctx.limit_ctx,
-            )?;
-        }
-        false => {
-            EmitOrderBy::sorter_insert(program, t_ctx, plan)?;
-        }
+    if plan.order_by.is_empty() {
+        emit_select_result(
+            program,
+            &t_ctx.resolver,
+            plan,
+            Some(labels.window_processing_end),
+            Some(label_skip_returning_row),
+            t_ctx.reg_nonagg_emit_once_flag,
+            t_ctx.reg_offset,
+            t_ctx.reg_result_cols_start.unwrap(),
+            t_ctx.limit_ctx,
+        )?;
+    } else {
+        EmitOrderBy::sorter_insert(program, t_ctx, plan)?;
     }
 
     program.preassign_label_to_next_insn(label_skip_returning_row);
@@ -1563,50 +1937,120 @@ fn emit_peer_group_flush(
         program.preassign_label_to_next_insn(distinct_ctx.label_on_conflict);
     }
 
-    let must_stop_return_cursor_at_next_peer_group =
-        buffer_mode.keeps_partition_rows() && !window.order_by.is_empty();
-    if must_stop_return_cursor_at_next_peer_group {
-        // The first row of the next sort group was inserted before this group
-        // was returned. Stop on that row so this cursor can continue from it
-        // when the next group is ready.
-        let next_row_found = program.allocate_label();
-        let finished_returning_group = program.allocate_label();
-        program.emit_insn(Insn::Next {
-            cursor_id: cursors.csr_current,
-            pc_if_next: next_row_found,
-        });
-        program.emit_insn(Insn::Goto {
-            target_pc: finished_returning_group,
-        });
+    program.emit_insn(Insn::Return {
+        return_reg: registers.row_output_return,
+        can_fallthrough: false,
+    });
 
-        program.preassign_label_to_next_insn(next_row_found);
-        let current_order_by_start = program.alloc_registers(window.order_by.len());
-        for (i, (expr, _, _)) in window.order_by.iter().enumerate() {
-            let Expr::Column { column, .. } = expr else {
-                unreachable!("rewritten window ORDER BY term must be a subquery column");
-            };
-            program.emit_column_or_rowid(cursors.csr_current, *column, current_order_by_start + i);
-        }
-        program.emit_insn(Insn::Compare {
-            start_reg_a: registers
-                .prev_order_by_columns_start
-                .expect("window ORDER BY values must be saved"),
-            start_reg_b: current_order_by_start,
-            count: window.order_by.len(),
-            key_info: window_order_by_key_info(window, plan)?,
-        });
-        program.emit_insn(Insn::Jump {
-            target_pc_lt: finished_returning_group,
-            target_pc_eq: label_loop_start,
-            target_pc_gt: finished_returning_group,
-        });
-        program.preassign_label_to_next_insn(finished_returning_group);
-    } else {
-        program.emit_insn(Insn::Next {
-            cursor_id: cursors.csr_current,
-            pc_if_next: label_loop_start,
-        });
+    Ok(())
+}
+
+/// Emit the flush subroutine for window processing — the partition-end /
+/// end-of-source code that drains any remaining rows still ahead of the
+/// frame-end cursor and emits all rows still ahead of the current cursor.
+///
+/// This is the Rust port of SQLite's flush block at `window.c:3043-3105`,
+/// restricted to the `UNBOUNDED PRECEDING TO CURRENT ROW` path
+/// (`window.c:3085-3094`):
+///
+/// ```text
+///   Rewind csr_write → if empty, jump to label_empty
+///   emit_window_op AGGSTEP, break_on_eof=None
+///       ↑ drains the last buffered row whose AggStep was deferred
+///   addr_loop_start:
+///   emit_window_op RETURN_ROW, break_on_eof=label_break
+///   emit_window_op AGGINVERSE (no-op for UNBOUNDED start)
+///   Goto addr_loop_start
+///   label_break:
+///   label_empty:
+///   ResetSorter csr_current
+///   Return flush_buffer_return_offset
+/// ```
+///
+/// Entered two ways, just like SQLite's flush block:
+/// - **Fallthrough** (end of source): the inline code immediately preceding
+///   sets `flush_buffer_return_offset` to NULL so the `Return` falls through.
+/// - **Subroutine** (partition boundary): the main loop body Gosubs to
+///   `labels.flush_buffer`; `Return` jumps back to the address stored in
+///   `flush_buffer_return_offset`.
+pub fn emit_window_flush(
+    program: &mut ProgramBuilder,
+    t_ctx: &mut TranslateCtx,
+    plan: &SelectPlan,
+) -> crate::Result<()> {
+    let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
+    let labels = meta.labels;
+    let registers = meta.registers;
+    let cursors = meta.cursors;
+
+    let label_empty = program.allocate_label();
+    let label_break = program.allocate_label();
+
+    // Fallthrough entry: the source loop just ended. Null the return
+    // register so the trailing Return falls through past this subroutine.
+    program.add_comment(program.offset(), "return remaining buffered rows");
+    program.emit_insn(Insn::Null {
+        dest: registers.flush_buffer_return_offset,
+        dest_end: None,
+    });
+
+    // Subroutine entry: partition boundary Gosub lands here.
+    program.preassign_label_to_next_insn(labels.flush_buffer);
+
+    // Detect empty partition. Rewind csr_write sets its position to the
+    // first row and jumps to label_empty when the table is empty; csr_write
+    // isn't used past flush so resetting its position is harmless.
+    program.emit_insn(Insn::Rewind {
+        cursor_id: cursors.csr_write,
+        pc_if_empty: label_empty,
+    });
+
+    // Drain step: the very last row inserted in the main loop hasn't had
+    // AggStep called against it (under ROWS) or its peer group might still
+    // be incomplete (under RANGE). One AGGSTEP advances csr_end through the
+    // remaining rows.
+    emit_window_op(program, t_ctx, plan, WindowOp::AggStep, None)?;
+
+    let label_loop_start = program.allocate_label();
+    program.preassign_label_to_next_insn(label_loop_start);
+    emit_window_op(program, t_ctx, plan, WindowOp::ReturnRow, Some(label_break))?;
+    // Functions with a moving frame start (ntile, percent_rank,
+    // cume_dist) fire AggInverse between output rows so xValue's next
+    // read sees the advanced state. The window is split per-coerced-frame
+    // at plan time, so every function in this window has the same start
+    // boundary — one window-level gate. Mirrors SQLite's flush block at
+    // window.c:3091 (`windowCodeOp(..., WINDOW_AGGINVERSE, regStart, 0)`).
+    let window = plan.window.as_ref().expect("missing window");
+    if !matches!(
+        window.frame.start,
+        crate::translate::plan::FrameBoundary::UnboundedPreceding
+    ) {
+        emit_window_op(program, t_ctx, plan, WindowOp::AggInverse, None)?;
     }
+    program.emit_insn(Insn::Goto {
+        target_pc: label_loop_start,
+    });
+
+    program.preassign_label_to_next_insn(label_break);
+    program.preassign_label_to_next_insn(label_empty);
+
+    program.emit_insn(Insn::ResetSorter {
+        cursor_id: cursors.csr_current,
+    });
+    program.emit_insn(Insn::Return {
+        return_reg: registers.flush_buffer_return_offset,
+        can_fallthrough: true,
+    });
+
+    // The fallthrough entry (end of source) continues past the Return;
+    // jump over the row-output subroutine body that follows.
+    program.emit_insn(Insn::Goto {
+        target_pc: labels.window_processing_end,
+    });
+
+    emit_row_output_subroutine(program, t_ctx, plan)?;
+
+    program.preassign_label_to_next_insn(labels.window_processing_end);
 
     Ok(())
 }

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -614,11 +614,11 @@ pub struct WindowCursors {
     pub csr_start: Option<CursorID>,
     /// Per-row lookup cursor used at output time by functions whose
     /// value is computed via `SeekRowid` rather than running aggregator
-    /// state — first_value, nth_value, and (once they land) lag, lead.
-    /// `OpenDup`'d off `csr_current` and only moved by `SeekRowid` at
-    /// output time, so it's independent of the frame-cursor positions.
-    /// Allocated lazily — `None` when no function in the window needs
-    /// positional lookup. Mirrors SQLite's `pWin->csrApp` (`window.c`).
+    /// state — first_value, nth_value, lag, lead. `OpenDup`'d off
+    /// `csr_current` and only moved by `SeekRowid` at output time, so
+    /// it's independent of the frame-cursor positions. Allocated
+    /// lazily — `None` when no function in the window needs positional
+    /// lookup. Mirrors SQLite's `pWin->csrApp` (`window.c`).
     pub csr_app: Option<CursorID>,
 }
 
@@ -698,8 +698,7 @@ impl EmitWindow {
         ));
         // `csr_current` is the primary cursor on the ephemeral buffer;
         // the others are OpenDup'd duplicates that share the same B-tree
-        // with independent positions. `csr_start` is deliberately omitted
-        // until a moving-start frame needs it.
+        // with independent positions.
         let cursor_csr_current =
             program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));
         let cursor_csr_write =
@@ -719,13 +718,19 @@ impl EmitWindow {
             None
         };
         // `csr_app` is the per-row lookup cursor used at output time by
-        // first_value / nth_value (positional seek). Mirrors SQLite's
-        // `csrApp` allocation (`window.c:1422-1426`). Allocate only when
-        // needed so unaffected windows don't pay the extra `OpenDup`.
+        // first_value / nth_value / lag / lead (positional seek). Mirrors
+        // SQLite's `csrApp` allocation (`window.c:1422-1426`). Allocate
+        // only when needed so unaffected windows don't pay the extra
+        // `OpenDup`.
         let needs_csr_app = window.functions.iter().any(|f| {
             matches!(
                 &f.func,
-                AccumulatorFunc::Window(WindowFunc::FirstValue | WindowFunc::NthValue),
+                AccumulatorFunc::Window(
+                    WindowFunc::FirstValue
+                        | WindowFunc::NthValue
+                        | WindowFunc::Lag
+                        | WindowFunc::Lead
+                ),
             )
         });
         let cursor_csr_app = if needs_csr_app {
@@ -1065,7 +1070,19 @@ impl EmitWindow {
         }
 
         emit_window_op(program, t_ctx, plan, WindowOp::AggStep, None)?;
-        emit_window_op(program, t_ctx, plan, WindowOp::ReturnRow, None)?;
+        // Frames whose end is UNBOUNDED FOLLOWING (lead's and lag's
+        // coerced frames) cache the entire partition before any RETURN_ROW
+        // fires — every output row's frame depends on rows yet to be
+        // inserted, so we can only emit at flush time. SQLite's
+        // `windowCacheFrame` (`window.c:2031`) selects the same control
+        // flow when a lead/lag function is present.
+        let cache_frame = matches!(
+            window.frame.end,
+            crate::translate::plan::FrameBoundary::UnboundedFollowing
+        );
+        if !cache_frame {
+            emit_window_op(program, t_ctx, plan, WindowOp::ReturnRow, None)?;
+        }
 
         // No explicit peer-tracker update needed here: AGGSTEP's
         // peer-loop fall-through copies `new` into `peer_end_reg`, and
@@ -1360,14 +1377,20 @@ fn emit_window_op(
     };
 
     // RETURN_ROW finalizes accumulators before emitting (SQLite's
-    // windowAggFinal at window.c:2284). first_value / nth_value have
-    // no accumulator value to read — `emit_first_value_nth_value_lookup`
-    // writes their result registers directly inside `emit_return_one_row`.
+    // windowAggFinal at window.c:2284). first_value / nth_value / lag /
+    // lead have no accumulator value to read — their result registers
+    // are written directly inside `emit_return_one_row` via positional
+    // lookup helpers.
     if matches!(op, WindowOp::ReturnRow) {
         for (i, func) in window.functions.iter().enumerate() {
             if matches!(
                 &func.func,
-                AccumulatorFunc::Window(WindowFunc::FirstValue | WindowFunc::NthValue),
+                AccumulatorFunc::Window(
+                    WindowFunc::FirstValue
+                        | WindowFunc::NthValue
+                        | WindowFunc::Lag
+                        | WindowFunc::Lead
+                ),
             ) {
                 continue;
             }
@@ -1529,14 +1552,15 @@ fn emit_function_step(
     let cache_was_enabled = t_ctx.resolver.expr_to_reg_cache_enabled;
 
     for (i, func) in window.functions.iter().enumerate() {
-        // first_value / nth_value are computed at output time via
-        // `SeekRowid` on `csr_app` (see
-        // `emit_first_value_nth_value_lookup`). They have no
-        // step-time accumulator update — mirrors SQLite's WINDOWFUNCNOOP
-        // pattern at `window.c:1727-1730`.
+        // first_value / nth_value / lag / lead are WINDOWFUNCNOOP in
+        // SQLite (window.c:591, 1727-1730): no step function — the value
+        // is computed at output time via `SeekRowid` on `csr_app`. See
+        // `emit_first_value_nth_value_lookup` and `emit_lag_lead_lookup`.
         if matches!(
             &func.func,
-            AccumulatorFunc::Window(WindowFunc::FirstValue | WindowFunc::NthValue)
+            AccumulatorFunc::Window(
+                WindowFunc::FirstValue | WindowFunc::NthValue | WindowFunc::Lag | WindowFunc::Lead
+            )
         ) {
             continue;
         }
@@ -1680,6 +1704,150 @@ fn emit_function_inverse(
     Ok(())
 }
 
+/// Emit the per-output-row lookup for every `lag` / `lead` function in the
+/// current window. Mirrors SQLite's lag/lead arm in `windowReturnOneRow`
+/// (`window.c:1958`):
+///
+/// ```text
+///   reg_result := arg[2] from csr_current   (default; NULL if nArg < 3)
+///   tmp := rowid(csr_current)
+///   tmp := tmp ± offset                     (offset = 1 if nArg < 2,
+///                                             else arg[1] from csr_current)
+///   if SeekRowid(csr_app, tmp) succeeds:
+///       reg_result := Column(csr_app, arg_col[0])
+///   lbl_miss:
+/// ```
+///
+/// `csr_app` is OpenDup'd off `csr_current` and only seeks at output time, so
+/// it doesn't disturb the frame-cursor positions. The function's result is
+/// written to its cached `acc_result_start + i` register, which the
+/// expression-cache then resolves to when `emit_select_result` reads the
+/// function expression.
+fn emit_lag_lead_lookup(
+    program: &mut ProgramBuilder,
+    t_ctx: &mut TranslateCtx,
+    plan: &SelectPlan,
+) -> Result<()> {
+    let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
+    let window = plan.window.as_ref().expect("missing window");
+    let registers = meta.registers;
+    let cursors = meta.cursors;
+    let acc_result_start = registers.acc_result_start;
+    let csr_current = cursors.csr_current;
+
+    for (i, func) in window.functions.iter().enumerate() {
+        let is_lead = match &func.func {
+            AccumulatorFunc::Window(WindowFunc::Lag) => false,
+            AccumulatorFunc::Window(WindowFunc::Lead) => true,
+            _ => continue,
+        };
+        let csr_app = cursors
+            .csr_app
+            .expect("csr_app must exist when a window contains lag / lead");
+        let result_reg = acc_result_start + i;
+
+        let args: Vec<&Expr> = match func.current_expr() {
+            Expr::FunctionCall { args, .. } => args.iter().map(|a| a.as_ref()).collect(),
+            _ => unreachable!("lag / lead are always Expr::FunctionCall"),
+        };
+
+        let arg0_col = match args.first() {
+            Some(Expr::Column { column, .. }) => *column,
+            other => unreachable!(
+                "lag/lead arg[0] must be a buffer column reference after planner rewrite, got {other:?}"
+            ),
+        };
+
+        // Default value first: NULL when nArg < 3, else read arg[2] from csr_current.
+        if args.len() < 3 {
+            program.emit_insn(Insn::Null {
+                dest: result_reg,
+                dest_end: None,
+            });
+        } else if let Expr::Column { column, .. } = args[2] {
+            program.emit_insn(Insn::Column {
+                cursor_id: csr_current,
+                column: *column,
+                dest: result_reg,
+                default: None,
+            });
+        } else {
+            unreachable!(
+                "lag/lead arg[2] must be a buffer column reference after planner rewrite, got {:?}",
+                args[2]
+            );
+        }
+
+        // tmp = rowid(csr_current) ± offset.
+        let tmp_reg = program.alloc_register();
+        program.emit_insn(Insn::RowId {
+            cursor_id: csr_current,
+            dest: tmp_reg,
+        });
+        if args.len() < 2 {
+            // Default offset = 1.
+            program.emit_insn(Insn::AddImm {
+                register: tmp_reg,
+                value: if is_lead { 1 } else { -1 },
+            });
+        } else {
+            let offset_col = match args[1] {
+                Expr::Column { column, .. } => *column,
+                other => unreachable!(
+                    "lag/lead arg[1] must be a buffer column reference after planner rewrite, got {other:?}"
+                ),
+            };
+            let offset_reg = program.alloc_register();
+            program.emit_insn(Insn::Column {
+                cursor_id: csr_current,
+                column: offset_col,
+                dest: offset_reg,
+                default: None,
+            });
+            // Insn::Subtract is `dest = lhs - rhs`; Insn::Add is
+            // `dest = lhs + rhs`. We want `tmp = tmp ± offset`, so tmp
+            // is the lhs in both cases.
+            if is_lead {
+                program.emit_insn(Insn::Add {
+                    lhs: tmp_reg,
+                    rhs: offset_reg,
+                    dest: tmp_reg,
+                });
+            } else {
+                program.emit_insn(Insn::Subtract {
+                    lhs: tmp_reg,
+                    rhs: offset_reg,
+                    dest: tmp_reg,
+                });
+            }
+        }
+
+        // SeekRowid on csr_app — on hit, overwrite result with the
+        // column from the target row; on miss, fall through to lbl_miss
+        // and the default register value (set above) stays put.
+        let lbl_miss = program.allocate_label();
+        program.emit_insn(Insn::SeekRowid {
+            cursor_id: csr_app,
+            src_reg: tmp_reg,
+            target_pc: lbl_miss,
+        });
+        program.emit_insn(Insn::Column {
+            cursor_id: csr_app,
+            column: arg0_col,
+            dest: result_reg,
+            default: None,
+        });
+        program.preassign_label_to_next_insn(lbl_miss);
+    }
+
+    Ok(())
+}
+
+/// Emit one output row's worth of work: populate `result_columns_start` from
+/// `csr_current`, then either send the row to the outer query (no ORDER BY)
+/// or insert it into the order-by sorter. Mirrors SQLite's
+/// `windowReturnOneRow` (`window.c:1816-1990`), restricted to the
+/// streaming code path.
 /// Emit per-output-row positional lookup for every `first_value` /
 /// `nth_value` in the current window. Mirrors SQLite's first_value /
 /// nth_value arms in `windowReturnOneRow` (`window.c:1940-1965`):
@@ -1876,10 +2044,11 @@ fn emit_return_one_row(
     }
 
     // Per-row lookups for functions whose value is computed at output
-    // time (first_value / nth_value). Each writes the function's value
-    // register before the outer query reads it via `emit_select_result`'s
-    // expression-cache lookup.
+    // time (first_value / nth_value / lag / lead). Each writes the
+    // function's value register before the outer query reads it via
+    // `emit_select_result`'s expression-cache lookup.
     emit_first_value_nth_value_lookup(program, t_ctx, plan)?;
+    emit_lag_lead_lookup(program, t_ctx, plan)?;
 
     // The select-result / sorter-insert code is a shared subroutine —
     // RETURN_ROW is emitted at several sites (streaming step + flush

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6753,8 +6753,13 @@ fn ordered_set_percentile_disc(values: &[Value], fraction: f64, collation: Colla
     sorted[index.min(n - 1)].clone()
 }
 
-/// Records what a window function needs from one row so its answer can be read
-/// later. Functions without arguments do not read `arg_reg`.
+/// Per-row step for pure window functions (those carried in
+/// `AccumulatorFunc::Window`). Mirrors `op_agg_step` but with no FILTER and
+/// per-function state semantics. State lives in the same
+/// `Register::Aggregate(AggContext::Builtin(_))` slot used by built-in
+/// aggregates so AggValue can read it back via the standard path. The `col`
+/// argument is the register holding the function's single argument (when it
+/// has one — 0-ary functions like row_number ignore it).
 fn op_window_step(
     state: &mut ProgramState,
     acc_reg: usize,
@@ -6848,49 +6853,6 @@ fn op_window_step(
             *pending = 1;
         }
         // first_value(expr) — captures the argument value of the first row
-        // of the partition once, then never updates. Under our default
-        // RANGE UNBOUNDED PRECEDING TO CURRENT ROW frame this corresponds
-        // to "value at frame start = partition start" (matches SQLite's
-        // first_valueStepFunc behavior on the same frame).
-        //
-        // State: payload[0] = captured value, payload[1] = captured flag
-        // (Integer 0 = not yet captured, 1 = captured). The flag lets us
-        // distinguish "no captures yet" from "captured a NULL".
-        WindowFunc::FirstValue => {
-            if let Register::Value(Value::Null) = state.registers[acc_reg] {
-                state.registers[acc_reg] =
-                    Register::Aggregate(AggContext::Builtin(crate::alloc::try_vec![
-                        Value::Null,
-                        Value::from_i64(0),
-                    ]?));
-            }
-            // Most steps past the first per partition are no-ops; check the
-            // capture flag with an immutable borrow first so we don't clone
-            // the arg (potentially a Text/Blob allocation) on every row.
-            let already_captured = {
-                let Register::Aggregate(AggContext::Builtin(payload)) = &state.registers[acc_reg]
-                else {
-                    unreachable!("first_value accumulator must be a Builtin payload");
-                };
-                let Value::Numeric(Numeric::Integer(captured)) = &payload[1] else {
-                    unreachable!("first_value capture flag must be Integer");
-                };
-                *captured != 0
-            };
-            if !already_captured {
-                let arg_value = state.registers[arg_reg].get_value().clone();
-                let Register::Aggregate(AggContext::Builtin(payload)) =
-                    &mut state.registers[acc_reg]
-                else {
-                    unreachable!("first_value accumulator must be a Builtin payload");
-                };
-                payload[0] = arg_value;
-                let Value::Numeric(Numeric::Integer(captured)) = &mut payload[1] else {
-                    unreachable!("first_value capture flag must be Integer");
-                };
-                *captured = 1;
-            }
-        }
         // last_value(expr) — captures the argument value of every source row,
         // so payload[0] always holds the value of the most recently stepped
         // row. With our default RANGE frame, AggValue is called once per

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7008,6 +7008,49 @@ fn op_window_value(
     Ok(InsnFunctionStepResult::Step)
 }
 
+/// Per-row inverse-step for pure window functions. Companion to
+/// `op_window_step`: fires when a row crosses the frame-start cursor on its
+/// way out of the function's frame.
+fn op_window_inverse(
+    _state: &mut ProgramState,
+    _acc_reg: usize,
+    _arg_reg: usize,
+    func: &WindowFunc,
+) -> Result<InsnFunctionStepResult> {
+    unreachable!("AggInverse fired for {func} but no inverse arm is wired");
+}
+
+pub fn op_agg_inverse(
+    _program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(
+        AggInverse {
+            acc_reg,
+            col,
+            delimiter: _,
+            func,
+            comparator: _,
+        },
+        insn
+    );
+
+    if let AccumulatorFunc::Window(win_func) = func {
+        return op_window_inverse(state, *acc_reg, *col, win_func);
+    }
+
+    // Aggregate window functions all carry RANGE UNBOUNDED PRECEDING TO
+    // CURRENT ROW as their coerced frame, so the frame start never moves
+    // and AggInverse is never emitted for them. Reaching this arm is a
+    // planner bug.
+    unreachable!(
+        "AggInverse fired for aggregate {} but no inverse arm is wired",
+        func.expect_agg()
+    );
+}
+
 pub fn op_agg_step(
     program: &Program,
     state: &mut ProgramState,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6852,7 +6852,6 @@ fn op_window_step(
             };
             *pending = 1;
         }
-        // first_value(expr) — captures the argument value of the first row
         // last_value(expr) — captures the argument value of every source row,
         // so payload[0] always holds the value of the most recently stepped
         // row. With our default RANGE frame, AggValue is called once per
@@ -6869,6 +6868,46 @@ fn op_window_step(
                 unreachable!("last_value accumulator must be a Builtin payload");
             };
             payload[0] = arg_value;
+        }
+        // ntile(N) — mirrors SQLite's NtileCtx (window.c:410). Frame is
+        // ROWS CURRENT ROW TO UNBOUNDED FOLLOWING. The step fires for
+        // every row entering the frame end (i.e. every row in the
+        // partition); the inverse fires for every row leaving the
+        // frame start, advancing the iRow counter that xValue uses to
+        // pick a bucket.
+        //
+        // State (payload):
+        //   [0] = nTotal — partition row count, incremented per step.
+        //   [1] = nParam — the bucket count, captured from arg[0] on
+        //         first step.
+        //   [2] = iRow   — current output-row index within the
+        //         partition, incremented per inverse.
+        WindowFunc::Ntile => {
+            if let Register::Value(Value::Null) = state.registers[acc_reg] {
+                // ntile(N): N is coerced with SQLite's `sqlite3_value_int64`
+                // rules — the leading integer prefix of text, blobs read as
+                // text, floats truncated toward zero — then must be positive.
+                let nparam = extract_int_value(state.registers[arg_reg].get_value());
+                if nparam <= 0 {
+                    return Err(LimboError::InvalidArgument(
+                        "argument of ntile must be a positive integer".into(),
+                    ));
+                }
+                state.registers[acc_reg] =
+                    Register::Aggregate(AggContext::Builtin(crate::alloc::try_vec![
+                        Value::from_i64(0),
+                        Value::from_i64(nparam),
+                        Value::from_i64(0),
+                    ]?));
+            }
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                unreachable!("ntile accumulator must be a Builtin payload");
+            };
+            let Value::Numeric(Numeric::Integer(ntotal)) = &mut payload[0] else {
+                unreachable!("ntile nTotal counter must be Integer");
+            };
+            *ntotal += 1;
         }
         other => {
             return Err(LimboError::InternalError(format!(
@@ -6959,6 +6998,42 @@ fn op_window_value(
             };
             std::mem::replace(&mut payload[0], Value::Null)
         }
+        // ntile bucket computation — mirrors SQLite's ntileValueFunc
+        // (window.c:453). The partition is split into nParam buckets;
+        // when nTotal isn't a clean multiple, the first nLarge buckets
+        // get one extra row each (size nSize+1) and the rest get nSize.
+        // iRow is the 0-based output position within the partition.
+        WindowFunc::Ntile => {
+            let Register::Aggregate(AggContext::Builtin(payload)) = &state.registers[acc_reg]
+            else {
+                unreachable!("ntile accumulator must be a Builtin payload (xStep runs first)");
+            };
+            let Value::Numeric(Numeric::Integer(ntotal)) = &payload[0] else {
+                unreachable!("ntile nTotal must be Integer");
+            };
+            let Value::Numeric(Numeric::Integer(nparam)) = &payload[1] else {
+                unreachable!("ntile nParam must be Integer");
+            };
+            let Value::Numeric(Numeric::Integer(irow)) = &payload[2] else {
+                unreachable!("ntile iRow must be Integer");
+            };
+            let ntotal = *ntotal;
+            let nparam = *nparam;
+            let irow = *irow;
+            let nsize = ntotal / nparam;
+            let bucket = if nsize == 0 {
+                irow + 1
+            } else {
+                let nlarge = ntotal - nparam * nsize;
+                let ismall = nlarge * (nsize + 1);
+                if irow < ismall {
+                    1 + irow / (nsize + 1)
+                } else {
+                    1 + nlarge + (irow - ismall) / nsize
+                }
+            };
+            Value::from_i64(bucket)
+        }
         other => {
             return Err(LimboError::InternalError(format!(
                 "window function {other} reached runtime dispatch but has no handler"
@@ -6974,12 +7049,32 @@ fn op_window_value(
 /// `op_window_step`: fires when a row crosses the frame-start cursor on its
 /// way out of the function's frame.
 fn op_window_inverse(
-    _state: &mut ProgramState,
-    _acc_reg: usize,
+    state: &mut ProgramState,
+    acc_reg: usize,
     _arg_reg: usize,
     func: &WindowFunc,
 ) -> Result<InsnFunctionStepResult> {
-    unreachable!("AggInverse fired for {func} but no inverse arm is wired");
+    match func {
+        // ntile's xInverse advances iRow — the output-row position
+        // within the partition that xValue reads. xStep has already
+        // populated nTotal and nParam by the time the flush loop fires
+        // inverse, so the payload is always Builtin here.
+        WindowFunc::Ntile => {
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                unreachable!(
+                    "ntile accumulator must be a Builtin payload at inverse (xStep runs first)"
+                );
+            };
+            let Value::Numeric(Numeric::Integer(irow)) = &mut payload[2] else {
+                unreachable!("ntile iRow must be Integer");
+            };
+            *irow += 1;
+            state.pc += 1;
+            Ok(InsnFunctionStepResult::Step)
+        }
+        _ => unreachable!("AggInverse fired for {func} but no inverse arm is wired"),
+    }
 }
 
 pub fn op_agg_inverse(

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1274,6 +1274,21 @@ pub fn insn_to_row(
                 0,
                 format!("accum=r[{}] step(r[{}])", *acc_reg, *col),
             ),
+            Insn::AggInverse {
+                func,
+                acc_reg,
+                delimiter: _,
+                col,
+                comparator: _,
+            } => (
+                "AggInverse",
+                0,
+                *col as i64,
+                *acc_reg as i64,
+                Value::build_text(func.as_str()),
+                0,
+                format!("accum=r[{}] inverse(r[{}])", *acc_reg, *col),
+            ),
             Insn::AggFinal { register, func } => (
                 "AggFinal",
                 0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1077,6 +1077,18 @@ pub enum Insn {
         collation: Option<CollationSeq>,
     },
 
+    /// Mirror-image of AggStep: fires when a row crosses the frame-start
+    /// cursor on its way out of the frame. The runtime arm undoes the
+    /// matching xStep — sum subtracts, count decrements, position
+    /// counters advance.
+    AggInverse {
+        acc_reg: usize,
+        col: usize,
+        delimiter: usize,
+        func: AccumulatorFunc,
+        comparator: Option<SortComparatorType>,
+    },
+
     AggFinal {
         register: usize,
         func: AccumulatorFunc,
@@ -2099,6 +2111,7 @@ impl InsnVariants {
             InsnVariants::IdxLT => execute::op_idx_lt,
             InsnVariants::DecrJumpZero => execute::op_decr_jump_zero,
             InsnVariants::AggStep => execute::op_agg_step,
+            InsnVariants::AggInverse => execute::op_agg_inverse,
             InsnVariants::AggFinal | InsnVariants::AggValue => execute::op_agg_final,
             InsnVariants::SorterOpen => execute::op_sorter_open,
             InsnVariants::SorterInsert => execute::op_sorter_insert,

--- a/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
@@ -319,12 +319,30 @@ expect {
     nth_value|w|2
 }
 
+# lag and lead each appear three times (one row per accepted arity).
+test pragma-function-list-window-lag {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'lag' ORDER BY narg;
+}
+expect {
+    lag|w|1
+    lag|w|2
+    lag|w|3
+}
+
+test pragma-function-list-window-lead {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'lead' ORDER BY narg;
+}
+expect {
+    lead|w|1
+    lead|w|2
+    lead|w|3
+}
+
 @skip-if sqlite "Turso should not list window functions that it cannot run"
 test pragma-function-list-omits-unimplemented-window-functions {
     SELECT COUNT(*) FROM pragma_function_list
     WHERE name IN (
-        'percent_rank','cume_dist','ntile',
-        'lag','lead'
+        'percent_rank','cume_dist','ntile'
     );
 }
 expect {

--- a/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
@@ -338,11 +338,18 @@ expect {
     lead|w|3
 }
 
+test pragma-function-list-window-ntile {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'ntile';
+}
+expect {
+    ntile|w|1
+}
+
 @skip-if sqlite "Turso should not list window functions that it cannot run"
 test pragma-function-list-omits-unimplemented-window-functions {
     SELECT COUNT(*) FROM pragma_function_list
     WHERE name IN (
-        'percent_rank','cume_dist','ntile'
+        'percent_rank','cume_dist'
     );
 }
 expect {

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
@@ -26,106 +26,185 @@ QUERY PLAN
       `--SCAN employees USING INDEX idx_employees_department
 
 BYTECODE
-addr  opcode              p1  p2  p3  p4                     p5  comment
-   0      Init             0  98   0                          0  Start at 98
-   1      InitCoroutine    1  61   2                          0
-   2      InitCoroutine    2  14   3                          0
-   3      OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   4      OpenRead         1   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
-   5      Rewind           1  13   0                          0  Rewind index idx_employees_department
-   6        DeferredSeek   1   0   0                          0
-   7        Column         1   0   3                          0  r[3]=idx_employees_department.department
-   8        IdxRowId       1   4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
-   9        Column         0   1   5                          0  r[5]=employees.name
-  10        Column         0   3   6                          0  r[6]=employees.salary
-  11        Yield          2   0   0                          0
-  12      Next             1   6   0                          0
-  13      EndCoroutine     2   0   0                          0
-  14      OpenEphemeral    2   1   0                          0  cursor=2 is_table=true
-  15      OpenDup          3   2   0                          0  new_cursor=3, original_cursor=2
-  16      Null             0  27   0                          0  r[27]=NULL
-  17      Null             0  28   0                          0  r[28]=NULL
-  18      InitCoroutine    2   0   3                          0
-  19        Yield          2  38   0                          0
-  20        Compare        3  28   1  k(1, Binary)            0  r[3..3]==r[28..28]; compare partition keys to detect new partition
-  21        Jump          22  25  22                          0
-  22        Gosub         29  39   0                          0  ; detected new partition
-  23        Null           0  27   0                          0  r[27]=NULL
-  24        Copy           3  28   0                          0  r[28]=r[3]
-  25        NotNull       27  27   0                          0  r[27]!=NULL -> goto 27
-  26        Null           0  15  18                          0  r[15..18]=NULL; reset accumulator registers
-  27        MakeRecord     3   4  30                          0  r[30]=mkrec(r[3..6])
-  28        NewRowid       3  27   0                          0  r[27]=rowid
-  29        Insert         3  30  27  buffer_table_window_1   0  intkey=r[27] data=r[30]
-  30        AggStep        0  31  15  count                   0  accum=r[15] step(r[31])
-  31        Copy           6  32   0                          0  r[32]=r[6]
-  32        AggStep        0  32  16  min(Binary)             0  accum=r[16] step(r[32])
-  33        Copy           6  33   0                          0  r[33]=r[6]
-  34        AggStep        0  33  17  max(Binary)             0  accum=r[17] step(r[33])
-  35        Copy           6  34   0                          0  r[34]=r[6]
-  36        AggStep        0  34  18  avg                     0  accum=r[18] step(r[34])
-  37      Goto             0  19   0                          0
-  38      Null             0  29   0                          0  r[29]=NULL; return remaining buffered rows
-  39      Rewind           2  58   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  40      AggValue         0  15  19  count                   0  accum=r[15] dest=r[19]
-  41      AggValue         0  16  20  min                     0  accum=r[16] dest=r[20]
-  42      AggValue         0  17  21  max                     0  accum=r[17] dest=r[21]
-  43      AggValue         0  18  22  avg                     0  accum=r[18] dest=r[22]
-  44        Column         2   1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
-  45        Column         2   2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
-  46        Column         2   0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
-  47        Column         2   3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
-  48        Copy          23   7   0                          0  r[7]=r[23]
-  49        Copy          24   8   0                          0  r[8]=r[24]
-  50        Copy          25   9   0                          0  r[9]=r[25]
-  51        Copy          26  10   0                          0  r[10]=r[26]
-  52        Copy          19  11   0                          0  r[11]=r[19]
-  53        Copy          20  12   0                          0  r[12]=r[20]
-  54        Copy          21  13   0                          0  r[13]=r[21]
-  55        Copy          22  14   0                          0  r[14]=r[22]
-  56        Yield          1   0   0                          0
-  57      Next             2  44   0                          0
-  58      ResetSorter      2   0   0                          0  cursor=2
-  59    Return            29   0   1                          0
-  60    EndCoroutine       1   0   0                          0
-  61    OpenEphemeral      4   1   0                          0  cursor=4 is_table=true
-  62    OpenDup            5   4   0                          0  new_cursor=5, original_cursor=4
-  63    Null               0  54   0                          0  r[54]=NULL
-  64    InitCoroutine      1   0   2                          0
-  65      Yield            1  73   0                          0
-  66      NotNull         54  68   0                          0  r[54]!=NULL -> goto 68
-  67      Null             0  44  44                          0  r[44..44]=NULL; reset accumulator registers
-  68      MakeRecord       7   8  56                          0  r[56]=mkrec(r[7..14])
-  69      NewRowid         5  54   0                          0  r[54]=rowid
-  70      Insert           5  56  54  buffer_table_window_0   0  intkey=r[54] data=r[56]
-  71      AggStep          0  57  44  count                   0  accum=r[44] step(r[57])
-  72    Goto               0  65   0                          0
-  73    Null               0  55   0                          0  r[55]=NULL; return remaining buffered rows
-  74    Rewind             4  95   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  75    AggValue           0  44  45  count                   0  accum=r[44] dest=r[45]
-  76      Column           4   0  46                          0  r[46]=ephemeral(buffer_table_window_0).emp_id
-  77      Column           4   1  47                          0  r[47]=ephemeral(buffer_table_window_0).name
-  78      Column           4   2  48                          0  r[48]=ephemeral(buffer_table_window_0).department
-  79      Column           4   3  49                          0  r[49]=ephemeral(buffer_table_window_0).salary
-  80      Column           4   4  50                          0  r[50]=ephemeral(buffer_table_window_0).column 4
-  81      Column           4   5  51                          0  r[51]=ephemeral(buffer_table_window_0).column 5
-  82      Column           4   6  52                          0  r[52]=ephemeral(buffer_table_window_0).column 6
-  83      Column           4   7  53                          0  r[53]=ephemeral(buffer_table_window_0).column 7
-  84      Copy            46  35   0                          0  r[35]=r[46]
-  85      Copy            47  36   0                          0  r[36]=r[47]
-  86      Copy            48  37   0                          0  r[37]=r[48]
-  87      Copy            49  38   0                          0  r[38]=r[49]
-  88      Copy            45  39   0                          0  r[39]=r[45]
-  89      Copy            50  40   0                          0  r[40]=r[50]
-  90      Copy            51  41   0                          0  r[41]=r[51]
-  91      Copy            52  42   0                          0  r[42]=r[52]
-  92      Copy            53  43   0                          0  r[43]=r[53]
-  93      ResultRow       35   9   0                          0  output=r[35..43]
-  94    Next               4  76   0                          0
-  95    ResetSorter        4   0   0                          0  cursor=4
-  96  Return              55   0   1                          0
-  97  Halt                 0   0   0                          0
-  98  Transaction          0   1   7                          0  iDb=0 tx_mode=Read
-  99  Integer              1  31   0                          0  r[31]=1
- 100  Integer              1  57   0                          0  r[57]=1
- 101  Goto                 0   1   0                          0
+addr  opcode                  p1   p2  p3  p4                     p5  comment
+   0          Init             0  175   0                          0  Start at 175
+   1          InitCoroutine    1  102   2                          0
+   2          InitCoroutine    2   14   3                          0
+   3          OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   4          OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   5          Rewind           1   13   0                          0  Rewind index idx_employees_department
+   6            DeferredSeek   1    0   0                          0
+   7            Column         1    0   3                          0  r[3]=idx_employees_department.department
+   8            IdxRowId       1    4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
+   9            Column         0    1   5                          0  r[5]=employees.name
+  10            Column         0    3   6                          0  r[6]=employees.salary
+  11            Yield          2    0   0                          0
+  12          Next             1    6   0                          0
+  13          EndCoroutine     2    0   0                          0
+  14          OpenEphemeral    2    1   0                          0  cursor=2 is_table=true
+  15          OpenDup          3    2   0                          0  new_cursor=3, original_cursor=2
+  16          OpenDup          4    2   0                          0  new_cursor=4, original_cursor=2
+  17          Null             0   27   0                          0  r[27]=NULL
+  18          Null             0   28   0                          0  r[28]=NULL
+  19          InitCoroutine    2    0   3                          0
+  20            Yield          2   62   0                          0
+  21            Compare        3   28   1  k(1, Binary)            0  r[3..3]==r[28..28]; compare partition keys to detect new partition
+  22            Jump          23   26  23                          0
+  23            Gosub         29   63   0                          0  ; detected new partition
+  24            Null           0   27   0                          0  r[27]=NULL
+  25            Copy           3   28   0                          0  r[28]=r[3]
+  26            NotNull       27   34   0                          0  r[27]!=NULL -> goto 34
+  27            Null           0   15  18                          0  r[15..18]=NULL; reset accumulator registers
+  28            MakeRecord     3    4  31                          0  r[31]=mkrec(r[3..6])
+  29            NewRowid       3   27   0                          0  r[27]=rowid
+  30            Insert         3   31  27  buffer_table_window_1   2  intkey=r[27] data=r[31]
+  31            Rewind         2   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  32            Rewind         4   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  33            Goto           0   61   0                          0
+  34            MakeRecord     3    4  32                          0  r[32]=mkrec(r[3..6])
+  35            NewRowid       3   27   0                          0  r[27]=rowid
+  36            Insert         3   32  27  buffer_table_window_1   2  intkey=r[27] data=r[32]
+  37            Goto           0   61   0                          0
+  38            AggStep        0   33  15  count                   0  accum=r[15] step(r[33])
+  39            Column         4    3  34                          0  r[34]=ephemeral(buffer_table_window_1).salary
+  40            AggStep        0   34  16  min(Binary)             0  accum=r[16] step(r[34])
+  41            Column         4    3  35                          0  r[35]=ephemeral(buffer_table_window_1).salary
+  42            AggStep        0   35  17  max(Binary)             0  accum=r[17] step(r[35])
+  43            Column         4    3  36                          0  r[36]=ephemeral(buffer_table_window_1).salary
+  44            AggStep        0   36  18  avg                     0  accum=r[18] step(r[36])
+  45            Next           4   47   0                          0
+  46            Goto           0   48   0                          0
+  47            Goto           0   38   0                          0
+  48            AggValue       0   15  19  count                   0  accum=r[15] dest=r[19]
+  49            AggValue       0   16  20  min                     0  accum=r[16] dest=r[20]
+  50            AggValue       0   17  21  max                     0  accum=r[17] dest=r[21]
+  51            AggValue       0   18  22  avg                     0  accum=r[18] dest=r[22]
+  52            Column         2    1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
+  53            Column         2    2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
+  54            Column         2    0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
+  55            Column         2    3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
+  56            Gosub         30   91   0                          0
+  57            Delete         2    0   0  buffer_table_window_1   0
+  58            Next           2   60   0                          0
+  59            Goto           0   61   0                          0
+  60            Goto           0   52   0                          0
+  61          Goto             0   20   0                          0
+  62          Null             0   29   0                          0  r[29]=NULL; return remaining buffered rows
+  63          Rewind           3   88   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  64          AggStep          0   37  15  count                   0  accum=r[15] step(r[37])
+  65          Column           4    3  38                          0  r[38]=ephemeral(buffer_table_window_1).salary
+  66          AggStep          0   38  16  min(Binary)             0  accum=r[16] step(r[38])
+  67          Column           4    3  39                          0  r[39]=ephemeral(buffer_table_window_1).salary
+  68          AggStep          0   39  17  max(Binary)             0  accum=r[17] step(r[39])
+  69          Column           4    3  40                          0  r[40]=ephemeral(buffer_table_window_1).salary
+  70          AggStep          0   40  18  avg                     0  accum=r[18] step(r[40])
+  71          Next             4   73   0                          0
+  72          Goto             0   74   0                          0
+  73          Goto             0   64   0                          0
+  74          AggValue         0   15  19  count                   0  accum=r[15] dest=r[19]
+  75          AggValue         0   16  20  min                     0  accum=r[16] dest=r[20]
+  76          AggValue         0   17  21  max                     0  accum=r[17] dest=r[21]
+  77          AggValue         0   18  22  avg                     0  accum=r[18] dest=r[22]
+  78          Column           2    1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
+  79          Column           2    2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
+  80          Column           2    0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
+  81          Column           2    3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
+  82          Gosub           30   91   0                          0
+  83          Delete           2    0   0  buffer_table_window_1   0
+  84          Next             2   86   0                          0
+  85          Goto             0   88   0                          0
+  86          Goto             0   78   0                          0
+  87          Goto             0   74   0                          0
+  88          ResetSorter      2    0   0                          0  cursor=2
+  89        Return            29    0   1                          0
+  90        Goto               0  101   0                          0
+  91        Copy              23    7   0                          0  r[7]=r[23]
+  92        Copy              24    8   0                          0  r[8]=r[24]
+  93        Copy              25    9   0                          0  r[9]=r[25]
+  94        Copy              26   10   0                          0  r[10]=r[26]
+  95        Copy              19   11   0                          0  r[11]=r[19]
+  96        Copy              20   12   0                          0  r[12]=r[20]
+  97        Copy              21   13   0                          0  r[13]=r[21]
+  98        Copy              22   14   0                          0  r[14]=r[22]
+  99        Yield              1    0   0                          0
+ 100      Return              30    0   0                          0
+ 101      EndCoroutine         1    0   0                          0
+ 102      OpenEphemeral        5    1   0                          0  cursor=5 is_table=true
+ 103      OpenDup              6    5   0                          0  new_cursor=6, original_cursor=5
+ 104      OpenDup              7    5   0                          0  new_cursor=7, original_cursor=5
+ 105      Null                 0   60   0                          0  r[60]=NULL
+ 106      InitCoroutine        1    0   2                          0
+ 107        Yield              1  139   0                          0
+ 108        NotNull           60  116   0                          0  r[60]!=NULL -> goto 116
+ 109        Null               0   50  50                          0  r[50..50]=NULL; reset accumulator registers
+ 110        MakeRecord         7    8  63                          0  r[63]=mkrec(r[7..14])
+ 111        NewRowid           6   60   0                          0  r[60]=rowid
+ 112        Insert             6   63  60  buffer_table_window_0   2  intkey=r[60] data=r[63]
+ 113        Rewind             5  115   0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 114        Rewind             7  115   0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 115        Goto               0  138   0                          0
+ 116        MakeRecord         7    8  64                          0  r[64]=mkrec(r[7..14])
+ 117        NewRowid           6   60   0                          0  r[60]=rowid
+ 118        Insert             6   64  60  buffer_table_window_0   2  intkey=r[60] data=r[64]
+ 119        Goto               0  138   0                          0
+ 120        AggStep            0   65  50  count                   0  accum=r[50] step(r[65])
+ 121        Next               7  123   0                          0
+ 122        Goto               0  124   0                          0
+ 123        Goto               0  120   0                          0
+ 124        AggValue           0   50  51  count                   0  accum=r[50] dest=r[51]
+ 125        Column             5    0  52                          0  r[52]=ephemeral(buffer_table_window_0).emp_id
+ 126        Column             5    1  53                          0  r[53]=ephemeral(buffer_table_window_0).name
+ 127        Column             5    2  54                          0  r[54]=ephemeral(buffer_table_window_0).department
+ 128        Column             5    3  55                          0  r[55]=ephemeral(buffer_table_window_0).salary
+ 129        Column             5    4  56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
+ 130        Column             5    5  57                          0  r[57]=ephemeral(buffer_table_window_0).column 5
+ 131        Column             5    6  58                          0  r[58]=ephemeral(buffer_table_window_0).column 6
+ 132        Column             5    7  59                          0  r[59]=ephemeral(buffer_table_window_0).column 7
+ 133        Gosub             62  163   0                          0
+ 134        Delete             5    0   0  buffer_table_window_0   0
+ 135        Next               5  137   0                          0
+ 136        Goto               0  138   0                          0
+ 137        Goto               0  125   0                          0
+ 138      Goto                 0  107   0                          0
+ 139      Null                 0   61   0                          0  r[61]=NULL; return remaining buffered rows
+ 140      Rewind               6  160   0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 141      AggStep              0   66  50  count                   0  accum=r[50] step(r[66])
+ 142      Next                 7  144   0                          0
+ 143      Goto                 0  145   0                          0
+ 144      Goto                 0  141   0                          0
+ 145      AggValue             0   50  51  count                   0  accum=r[50] dest=r[51]
+ 146      Column               5    0  52                          0  r[52]=ephemeral(buffer_table_window_0).emp_id
+ 147      Column               5    1  53                          0  r[53]=ephemeral(buffer_table_window_0).name
+ 148      Column               5    2  54                          0  r[54]=ephemeral(buffer_table_window_0).department
+ 149      Column               5    3  55                          0  r[55]=ephemeral(buffer_table_window_0).salary
+ 150      Column               5    4  56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
+ 151      Column               5    5  57                          0  r[57]=ephemeral(buffer_table_window_0).column 5
+ 152      Column               5    6  58                          0  r[58]=ephemeral(buffer_table_window_0).column 6
+ 153      Column               5    7  59                          0  r[59]=ephemeral(buffer_table_window_0).column 7
+ 154      Gosub               62  163   0                          0
+ 155      Delete               5    0   0  buffer_table_window_0   0
+ 156      Next                 5  158   0                          0
+ 157      Goto                 0  160   0                          0
+ 158      Goto                 0  146   0                          0
+ 159      Goto                 0  145   0                          0
+ 160      ResetSorter          5    0   0                          0  cursor=5
+ 161    Return                61    0   1                          0
+ 162    Goto                   0  174   0                          0
+ 163    Copy                  52   41   0                          0  r[41]=r[52]
+ 164    Copy                  53   42   0                          0  r[42]=r[53]
+ 165    Copy                  54   43   0                          0  r[43]=r[54]
+ 166    Copy                  55   44   0                          0  r[44]=r[55]
+ 167    Copy                  51   45   0                          0  r[45]=r[51]
+ 168    Copy                  56   46   0                          0  r[46]=r[56]
+ 169    Copy                  57   47   0                          0  r[47]=r[57]
+ 170    Copy                  58   48   0                          0  r[48]=r[58]
+ 171    Copy                  59   49   0                          0  r[49]=r[59]
+ 172    ResultRow             41    9   0                          0  output=r[41..49]
+ 173  Return                  62    0   0                          0
+ 174  Halt                     0    0   0                          0
+ 175  Transaction              0    1   7                          0  iDb=0 tx_mode=Read
+ 176  Integer                  1   33   0                          0  r[33]=1
+ 177  Integer                  1   37   0                          0  r[37]=1
+ 178  Integer                  1   65   0                          0  r[65]=1
+ 179  Integer                  1   66   0                          0  r[66]=1
+ 180  Goto                     0    1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
@@ -36,254 +36,372 @@ QUERY PLAN
    `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                   p1   p2   p3  p4                     p5  comment
-   0          Init              0  248    0                          0  Start at 248
-   1          InitCoroutine     1  197    2                          0
-   2          InitCoroutine     2  132    3                          0
-   3          InitCoroutine     3   75    4                          0
-   4          InitCoroutine     4   21    5                          0
-   5          OpenRead          0    2    0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   6          OpenRead          1    3    0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
-   7          OpenRead          2    8    0  k(2,B)                  0  index=idx_sales_region, root=8, iDb=0
-   8          Rewind            2   20    0                          0  Rewind index idx_sales_region
-   9            DeferredSeek    2    1    0                          0
-  10            Column          1    1   11                          0  r[11]=sales.emp_id
-  11            SeekRowid       0   11   19                          0  if (r[11]!=cursor 0 for table employees.rowid) goto 19
-  12            Column          2    0    5                          0  r[5]=idx_sales_region.region
-  13            Column          0    2    6                          0  r[6]=employees.department
-  14            Column          1    3    7                          0  r[7]=sales.amount
-  15            Column          0    3    8                          0  r[8]=employees.salary
-  16            RowId           0    9    0                          0  r[9]=employees.rowid
-  17            Column          0    1   10                          0  r[10]=employees.name
-  18            Yield           4    0    0                          0
-  19          Next              2    9    0                          0
-  20          EndCoroutine      4    0    0                          0
-  21          SorterOpen        3    1    0  k(1,B)                  0  cursor=3
-  22          OpenEphemeral     4    1    0                          0  cursor=4 is_table=true
-  23          OpenDup           5    4    0                          0  new_cursor=5, original_cursor=4
-  24          Null              0   28    0                          0  r[28]=NULL
-  25          Null              0   29    0                          0  r[29]=NULL
-  26          InitCoroutine     4    0    5                          0
-  27            Yield           4   41    0                          0
-  28            Compare         5   29    1  k(1, Binary)            0  r[5..5]==r[29..29]; compare partition keys to detect new partition
-  29            Jump           30   33   30                          0
-  30            Gosub          30   42    0                          0  ; detected new partition
-  31            Null            0   28    0                          0  r[28]=NULL
-  32            Copy            5   29    0                          0  r[29]=r[5]
-  33            NotNull        28   35    0                          0  r[28]!=NULL -> goto 35
-  34            Null            0   20   20                          0  r[20..20]=NULL; reset accumulator registers
-  35            MakeRecord      5    6   31                          0  r[31]=mkrec(r[5..10])
-  36            NewRowid        5   28    0                          0  r[28]=rowid
-  37            Insert          5   31   28  buffer_table_window_3   0  intkey=r[28] data=r[31]
-  38            Copy            8   32    0                          0  r[32]=r[8]
-  39            AggStep         0   32   20  avg                     0  accum=r[20] step(r[32])
-  40          Goto              0   27    0                          0
-  41          Null              0   30    0                          0  r[30]=NULL; return remaining buffered rows
-  42          Rewind            4   60    0                          0  Rewind  ephemeral(buffer_table_window_3)
-  43          AggValue          0   20   21  avg                     0  accum=r[20] dest=r[21]
-  44            Column          4    1   22                          0  r[22]=ephemeral(buffer_table_window_3).department
-  45            Column          4    0   23                          0  r[23]=ephemeral(buffer_table_window_3).region
-  46            Column          4    2   24                          0  r[24]=ephemeral(buffer_table_window_3).amount
-  47            Column          4    3   25                          0  r[25]=ephemeral(buffer_table_window_3).salary
-  48            Column          4    4   26                          0  r[26]=ephemeral(buffer_table_window_3).emp_id
-  49            Column          4    5   27                          0  r[27]=ephemeral(buffer_table_window_3).name
-  50            Copy           22   33    0                          0  r[33]=r[22]
-  51            Copy           23   34    0                          0  r[34]=r[23]
-  52            Copy           24   35    0                          0  r[35]=r[24]
-  53            Copy           25   36    0                          0  r[36]=r[25]
-  54            Copy           26   37    0                          0  r[37]=r[26]
-  55            Copy           27   38    0                          0  r[38]=r[27]
-  56            Copy           21   39    0                          0  r[39]=r[21]
-  57            MakeRecord     33    7   19                          0  r[19]=mkrec(r[33..39])
-  58            SorterInsert    3   19    0  0                       0  key=r[19]
-  59          Next              4   44    0                          0
-  60          ResetSorter       4    0    0                          0  cursor=4
-  61        Return             30    0    1                          0
-  62        OpenPseudo          6   19    7                          0  7 columns in r[19]
-  63        SorterSort          3   74    0                          0
-  64          SorterData        3   19    6                          0  r[19]=data
-  65          Column            6    0   12                          0  r[12]=pseudo.column 0
-  66          Column            6    1   13                          0  r[13]=pseudo.column 1
-  67          Column            6    2   14                          0  r[14]=pseudo.column 2
-  68          Column            6    3   15                          0  r[15]=pseudo.column 3
-  69          Column            6    4   16                          0  r[16]=pseudo.column 4
-  70          Column            6    5   17                          0  r[17]=pseudo.column 5
-  71          Column            6    6   18                          0  r[18]=pseudo.column 6
-  72          Yield             3    0    0                          0
-  73        SorterNext          3   64    0                          0
-  74        EndCoroutine        3    0    0                          0
-  75        SorterOpen          7    2    0  k(2,B,-B)               0  cursor=7
-  76        OpenEphemeral       8    1    0                          0  cursor=8 is_table=true
-  77        OpenDup             9    8    0                          0  new_cursor=9, original_cursor=8
-  78        Null                0   58    0                          0  r[58]=NULL
-  79        Null                0   59    0                          0  r[59]=NULL
-  80        InitCoroutine       3    0    4                          0
-  81          Yield             3   95    0                          0
-  82          Compare          12   59    1  k(1, Binary)            0  r[12..12]==r[59..59]; compare partition keys to detect new partition
-  83          Jump             84   87   84                          0
-  84          Gosub            60   96    0                          0  ; detected new partition
-  85          Null              0   58    0                          0  r[58]=NULL
-  86          Copy             12   59    0                          0  r[59]=r[12]
-  87          NotNull          58   89    0                          0  r[58]!=NULL -> goto 89
-  88          Null              0   49   49                          0  r[49..49]=NULL; reset accumulator registers
-  89          MakeRecord       12    7   61                          0  r[61]=mkrec(r[12..18])
-  90          NewRowid          9   58    0                          0  r[58]=rowid
-  91          Insert            9   61   58  buffer_table_window_2   0  intkey=r[58] data=r[61]
-  92          Copy             14   62    0                          0  r[62]=r[14]
-  93          AggStep           0   62   49  sum                     0  accum=r[49] step(r[62])
-  94        Goto                0   81    0                          0
-  95        Null                0   60    0                          0  r[60]=NULL; return remaining buffered rows
-  96        Rewind              8  116    0                          0  Rewind  ephemeral(buffer_table_window_2)
-  97        AggValue            0   49   50  sum                     0  accum=r[49] dest=r[50]
-  98          Column            8    1   51                          0  r[51]=ephemeral(buffer_table_window_2).region
-  99          Column            8    2   52                          0  r[52]=ephemeral(buffer_table_window_2).amount
- 100          Column            8    0   53                          0  r[53]=ephemeral(buffer_table_window_2).department
- 101          Column            8    3   54                          0  r[54]=ephemeral(buffer_table_window_2).salary
- 102          Column            8    4   55                          0  r[55]=ephemeral(buffer_table_window_2).emp_id
- 103          Column            8    5   56                          0  r[56]=ephemeral(buffer_table_window_2).name
- 104          Column            8    6   57                          0  r[57]=ephemeral(buffer_table_window_2).column 6
- 105          Copy             51   63    0                          0  r[63]=r[51]
- 106          Copy             52   64    0                          0  r[64]=r[52]
- 107          Copy             53   65    0                          0  r[65]=r[53]
- 108          Copy             54   66    0                          0  r[66]=r[54]
- 109          Copy             55   67    0                          0  r[67]=r[55]
- 110          Copy             56   68    0                          0  r[68]=r[56]
- 111          Copy             50   69    0                          0  r[69]=r[50]
- 112          Copy             57   70    0                          0  r[70]=r[57]
- 113          MakeRecord       63    8   48                          0  r[48]=mkrec(r[63..70])
- 114          SorterInsert      7   48    0  0                       0  key=r[48]
- 115        Next                8   98    0                          0
- 116        ResetSorter         8    0    0                          0  cursor=8
- 117      Return               60    0    1                          0
- 118      OpenPseudo           10   48    8                          0  8 columns in r[48]
- 119      SorterSort            7  131    0                          0
- 120        SorterData          7   48   10                          0  r[48]=data
- 121        Column             10    0   40                          0  r[40]=pseudo.column 0
- 122        Column             10    1   41                          0  r[41]=pseudo.column 1
- 123        Column             10    2   42                          0  r[42]=pseudo.column 2
- 124        Column             10    3   43                          0  r[43]=pseudo.column 3
- 125        Column             10    4   44                          0  r[44]=pseudo.column 4
- 126        Column             10    5   45                          0  r[45]=pseudo.column 5
- 127        Column             10    6   46                          0  r[46]=pseudo.column 6
- 128        Column             10    7   47                          0  r[47]=pseudo.column 7
- 129        Yield               2    0    0                          0
- 130      SorterNext            7  120    0                          0
- 131      EndCoroutine          2    0    0                          0
- 132      SorterOpen           11    2    0  k(2,B,-B)               0  cursor=11
- 133      OpenEphemeral        12    1    0                          0  cursor=12 is_table=true
- 134      OpenDup              13   12    0                          0  new_cursor=13, original_cursor=12
- 135      Null                  0   91    0                          0  r[91]=NULL
- 136      Null                  0   92    0                          0  r[92]=NULL
- 137      InitCoroutine         2    0    3                          0
- 138        Yield               2  156    0                          0
- 139        Copy               41   95    0                          0  r[95]=r[41]
- 140        Compare            40   92    1  k(1, Binary)            0  r[40..40]==r[92..92]; compare partition keys to detect new partition
- 141        Jump              142  145  142                          0
- 142        Gosub              93  157    0                          0  ; detected new partition
- 143        Null                0   91    0                          0  r[91]=NULL
- 144        Copy               40   92    0                          0  r[92]=r[40]
- 145        NotNull            91  148    0                          0  r[91]!=NULL -> goto 148
- 146        Copy               95   94    0                          0  r[94]=r[95]; initialize previous peer register for new partition
- 147        Null                0   81   81                          0  r[81..81]=NULL; reset accumulator registers
- 148        Compare            94   95    1  k(1, Binary)            0  r[94..94]==r[95..95]; compare ORDER BY columns to detect peer
- 149        Jump              150  152  150                          0
- 150        Gosub              93  157    0                          0  ; detected non-peer row
- 151        Copy               95   94    0                          0  r[94]=r[95]
- 152        MakeRecord         40    8   96                          0  r[96]=mkrec(r[40..47])
- 153        NewRowid           13   91    0                          0  r[91]=rowid
- 154        Insert             13   96   91  buffer_table_window_1   0  intkey=r[91] data=r[96]
- 155      Goto                  0  138    0                          0
- 156      Null                  0   93    0                          0  r[93]=NULL; return remaining buffered rows
- 157      Rewind               12  180    0                          0  Rewind  ephemeral(buffer_table_window_1)
- 158        Column             12    2   83                          0  r[83]=ephemeral(buffer_table_window_1).department
- 159        Column             12    3   84                          0  r[84]=ephemeral(buffer_table_window_1).salary
- 160        Column             12    4   85                          0  r[85]=ephemeral(buffer_table_window_1).emp_id
- 161        Column             12    5   86                          0  r[86]=ephemeral(buffer_table_window_1).name
- 162        Column             12    1   87                          0  r[87]=ephemeral(buffer_table_window_1).amount
- 163        Column             12    0   88                          0  r[88]=ephemeral(buffer_table_window_1).region
- 164        Column             12    6   89                          0  r[89]=ephemeral(buffer_table_window_1).column 6
- 165        Column             12    7   90                          0  r[90]=ephemeral(buffer_table_window_1).column 7
- 166        AggStep             0    0   81  row_number              0  accum=r[81] step(r[0])
- 167        AggValue            0   81   82  row_number              0  accum=r[81] dest=r[82]
- 168        Copy               83   97    0                          0  r[97]=r[83]
- 169        Copy               84   98    0                          0  r[98]=r[84]
- 170        Copy               85   99    0                          0  r[99]=r[85]
- 171        Copy               86  100    0                          0  r[100]=r[86]
- 172        Copy               87  101    0                          0  r[101]=r[87]
- 173        Copy               88  102    0                          0  r[102]=r[88]
- 174        Copy               82  103    0                          0  r[103]=r[82]
- 175        Copy               89  104    0                          0  r[104]=r[89]
- 176        Copy               90  105    0                          0  r[105]=r[90]
- 177        MakeRecord         97    9   80                          0  r[80]=mkrec(r[97..105])
- 178        SorterInsert       11   80    0  0                       0  key=r[80]
- 179      Next                 12  158    0                          0
- 180      ResetSorter          12    0    0                          0  cursor=12
- 181    Return                 93    0    1                          0
- 182    OpenPseudo             14   80    9                          0  9 columns in r[80]
- 183    SorterSort             11  196    0                          0
- 184      SorterData           11   80   14                          0  r[80]=data
- 185      Column               14    0   71                          0  r[71]=pseudo.column 0
- 186      Column               14    1   72                          0  r[72]=pseudo.column 1
- 187      Column               14    2   73                          0  r[73]=pseudo.column 2
- 188      Column               14    3   74                          0  r[74]=pseudo.column 3
- 189      Column               14    4   75                          0  r[75]=pseudo.column 4
- 190      Column               14    5   76                          0  r[76]=pseudo.column 5
- 191      Column               14    6   77                          0  r[77]=pseudo.column 6
- 192      Column               14    7   78                          0  r[78]=pseudo.column 7
- 193      Column               14    8   79                          0  r[79]=pseudo.column 8
- 194      Yield                 1    0    0                          0
- 195    SorterNext             11  184    0                          0
- 196    EndCoroutine            1    0    0                          0
- 197    OpenEphemeral          15    1    0                          0  cursor=15 is_table=true
- 198    OpenDup                16   15    0                          0  new_cursor=16, original_cursor=15
- 199    Null                    0  127    0                          0  r[127]=NULL
- 200    Null                    0  128    0                          0  r[128]=NULL
- 201    InitCoroutine           1    0    2                          0
- 202      Yield                 1  220    0                          0
- 203      Copy                 72  131    0                          0  r[131]=r[72]
- 204      Compare              71  128    1  k(1, Binary)            0  r[71..71]==r[128..128]; compare partition keys to detect new partition
- 205      Jump                206  209  206                          0
- 206      Gosub               129  221    0                          0  ; detected new partition
- 207      Null                  0  127    0                          0  r[127]=NULL
- 208      Copy                 71  128    0                          0  r[128]=r[71]
- 209      NotNull             127  212    0                          0  r[127]!=NULL -> goto 212
- 210      Copy                131  130    0                          0  r[130]=r[131]; initialize previous peer register for new partition
- 211      Null                  0  116  116                          0  r[116..116]=NULL; reset accumulator registers
- 212      Compare             130  131    1  k(1, Binary)            0  r[130..130]==r[131..131]; compare ORDER BY columns to detect peer
- 213      Jump                214  216  214                          0
- 214      Gosub               129  221    0                          0  ; detected non-peer row
- 215      Copy                131  130    0                          0  r[130]=r[131]
- 216      MakeRecord           71    9  132                          0  r[132]=mkrec(r[71..79])
- 217      NewRowid             16  127    0                          0  r[127]=rowid
- 218      Insert               16  132  127  buffer_table_window_0   0  intkey=r[127] data=r[132]
- 219    Goto                    0  202    0                          0
- 220    Null                    0  129    0                          0  r[129]=NULL; return remaining buffered rows
- 221    Rewind                 15  245    0                          0  Rewind  ephemeral(buffer_table_window_0)
- 222      Column               15    2  118                          0  r[118]=ephemeral(buffer_table_window_0).emp_id
- 223      Column               15    3  119                          0  r[119]=ephemeral(buffer_table_window_0).name
- 224      Column               15    0  120                          0  r[120]=ephemeral(buffer_table_window_0).department
- 225      Column               15    1  121                          0  r[121]=ephemeral(buffer_table_window_0).salary
- 226      Column               15    4  122                          0  r[122]=ephemeral(buffer_table_window_0).amount
- 227      Column               15    5  123                          0  r[123]=ephemeral(buffer_table_window_0).region
- 228      Column               15    6  124                          0  r[124]=ephemeral(buffer_table_window_0).column 6
- 229      Column               15    7  125                          0  r[125]=ephemeral(buffer_table_window_0).column 7
- 230      Column               15    8  126                          0  r[126]=ephemeral(buffer_table_window_0).column 8
- 231      AggStep               0    0  116  row_number              0  accum=r[116] step(r[0])
- 232      AggValue              0  116  117  row_number              0  accum=r[116] dest=r[117]
- 233      Copy                118  106    0                          0  r[106]=r[118]
- 234      Copy                119  107    0                          0  r[107]=r[119]
- 235      Copy                120  108    0                          0  r[108]=r[120]
- 236      Copy                121  109    0                          0  r[109]=r[121]
- 237      Copy                122  110    0                          0  r[110]=r[122]
- 238      Copy                123  111    0                          0  r[111]=r[123]
- 239      Copy                117  112    0                          0  r[112]=r[117]
- 240      Copy                124  113    0                          0  r[113]=r[124]
- 241      Copy                125  114    0                          0  r[114]=r[125]
- 242      Copy                126  115    0                          0  r[115]=r[126]
- 243      ResultRow           106   10    0                          0  output=r[106..115]
- 244    Next                   15  222    0                          0
- 245    ResetSorter            15    0    0                          0  cursor=15
- 246  Return                  129    0    1                          0
- 247  Halt                      0    0    0                          0
- 248  Transaction               0    1    7                          0  iDb=0 tx_mode=Read
- 249  Goto                      0    1    0                          0
+addr  opcode                           p1   p2   p3  p4                     p5  comment
+   0                  Init              0  366    0                          0  Start at 366
+   1                  InitCoroutine     1  291    2                          0
+   2                  InitCoroutine     2  203    3                          0
+   3                  InitCoroutine     3  110    4                          0
+   4                  InitCoroutine     4   21    5                          0
+   5                  OpenRead          0    2    0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   6                  OpenRead          1    3    0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
+   7                  OpenRead          2    8    0  k(2,B)                  0  index=idx_sales_region, root=8, iDb=0
+   8                  Rewind            2   20    0                          0  Rewind index idx_sales_region
+   9                    DeferredSeek    2    1    0                          0
+  10                    Column          1    1   11                          0  r[11]=sales.emp_id
+  11                    SeekRowid       0   11   19                          0  if (r[11]!=cursor 0 for table employees.rowid) goto 19
+  12                    Column          2    0    5                          0  r[5]=idx_sales_region.region
+  13                    Column          0    2    6                          0  r[6]=employees.department
+  14                    Column          1    3    7                          0  r[7]=sales.amount
+  15                    Column          0    3    8                          0  r[8]=employees.salary
+  16                    RowId           0    9    0                          0  r[9]=employees.rowid
+  17                    Column          0    1   10                          0  r[10]=employees.name
+  18                    Yield           4    0    0                          0
+  19                  Next              2    9    0                          0
+  20                  EndCoroutine      4    0    0                          0
+  21                  SorterOpen        3    1    0  k(1,B)                  0  cursor=3
+  22                  OpenEphemeral     4    1    0                          0  cursor=4 is_table=true
+  23                  OpenDup           5    4    0                          0  new_cursor=5, original_cursor=4
+  24                  OpenDup           6    4    0                          0  new_cursor=6, original_cursor=4
+  25                  Null              0   28    0                          0  r[28]=NULL
+  26                  Null              0   29    0                          0  r[29]=NULL
+  27                  InitCoroutine     4    0    5                          0
+  28                    Yield           4   64    0                          0
+  29                    Compare         5   29    1  k(1, Binary)            0  r[5..5]==r[29..29]; compare partition keys to detect new partition
+  30                    Jump           31   34   31                          0
+  31                    Gosub          30   65    0                          0  ; detected new partition
+  32                    Null            0   28    0                          0  r[28]=NULL
+  33                    Copy            5   29    0                          0  r[29]=r[5]
+  34                    NotNull        28   42    0                          0  r[28]!=NULL -> goto 42
+  35                    Null            0   20   20                          0  r[20..20]=NULL; reset accumulator registers
+  36                    MakeRecord      5    6   32                          0  r[32]=mkrec(r[5..10])
+  37                    NewRowid        5   28    0                          0  r[28]=rowid
+  38                    Insert          5   32   28  buffer_table_window_3   2  intkey=r[28] data=r[32]
+  39                    Rewind          4   41    0                          0  Rewind  ephemeral(buffer_table_window_3)
+  40                    Rewind          6   41    0                          0  Rewind  ephemeral(buffer_table_window_3)
+  41                    Goto            0   63    0                          0
+  42                    MakeRecord      5    6   33                          0  r[33]=mkrec(r[5..10])
+  43                    NewRowid        5   28    0                          0  r[28]=rowid
+  44                    Insert          5   33   28  buffer_table_window_3   2  intkey=r[28] data=r[33]
+  45                    Goto            0   63    0                          0
+  46                    Column          6    3   34                          0  r[34]=ephemeral(buffer_table_window_3).salary
+  47                    AggStep         0   34   20  avg                     0  accum=r[20] step(r[34])
+  48                    Next            6   50    0                          0
+  49                    Goto            0   51    0                          0
+  50                    Goto            0   46    0                          0
+  51                    AggValue        0   20   21  avg                     0  accum=r[20] dest=r[21]
+  52                    Column          4    1   22                          0  r[22]=ephemeral(buffer_table_window_3).department
+  53                    Column          4    0   23                          0  r[23]=ephemeral(buffer_table_window_3).region
+  54                    Column          4    2   24                          0  r[24]=ephemeral(buffer_table_window_3).amount
+  55                    Column          4    3   25                          0  r[25]=ephemeral(buffer_table_window_3).salary
+  56                    Column          4    4   26                          0  r[26]=ephemeral(buffer_table_window_3).emp_id
+  57                    Column          4    5   27                          0  r[27]=ephemeral(buffer_table_window_3).name
+  58                    Gosub          31   87    0                          0
+  59                    Delete          4    0    0  buffer_table_window_3   0
+  60                    Next            4   62    0                          0
+  61                    Goto            0   63    0                          0
+  62                    Goto            0   52    0                          0
+  63                  Goto              0   28    0                          0
+  64                  Null              0   30    0                          0  r[30]=NULL; return remaining buffered rows
+  65                  Rewind            5   84    0                          0  Rewind  ephemeral(buffer_table_window_3)
+  66                  Column            6    3   35                          0  r[35]=ephemeral(buffer_table_window_3).salary
+  67                  AggStep           0   35   20  avg                     0  accum=r[20] step(r[35])
+  68                  Next              6   70    0                          0
+  69                  Goto              0   71    0                          0
+  70                  Goto              0   66    0                          0
+  71                  AggValue          0   20   21  avg                     0  accum=r[20] dest=r[21]
+  72                  Column            4    1   22                          0  r[22]=ephemeral(buffer_table_window_3).department
+  73                  Column            4    0   23                          0  r[23]=ephemeral(buffer_table_window_3).region
+  74                  Column            4    2   24                          0  r[24]=ephemeral(buffer_table_window_3).amount
+  75                  Column            4    3   25                          0  r[25]=ephemeral(buffer_table_window_3).salary
+  76                  Column            4    4   26                          0  r[26]=ephemeral(buffer_table_window_3).emp_id
+  77                  Column            4    5   27                          0  r[27]=ephemeral(buffer_table_window_3).name
+  78                  Gosub            31   87    0                          0
+  79                  Delete            4    0    0  buffer_table_window_3   0
+  80                  Next              4   82    0                          0
+  81                  Goto              0   84    0                          0
+  82                  Goto              0   72    0                          0
+  83                  Goto              0   71    0                          0
+  84                  ResetSorter       4    0    0                          0  cursor=4
+  85                Return             30    0    1                          0
+  86                Goto                0   97    0                          0
+  87                Copy               22   36    0                          0  r[36]=r[22]
+  88                Copy               23   37    0                          0  r[37]=r[23]
+  89                Copy               24   38    0                          0  r[38]=r[24]
+  90                Copy               25   39    0                          0  r[39]=r[25]
+  91                Copy               26   40    0                          0  r[40]=r[26]
+  92                Copy               27   41    0                          0  r[41]=r[27]
+  93                Copy               21   42    0                          0  r[42]=r[21]
+  94                MakeRecord         36    7   19                          0  r[19]=mkrec(r[36..42])
+  95                SorterInsert        3   19    0  0                       0  key=r[19]
+  96              Return               31    0    0                          0
+  97              OpenPseudo            7   19    7                          0  7 columns in r[19]
+  98              SorterSort            3  109    0                          0
+  99                SorterData          3   19    7                          0  r[19]=data
+ 100                Column              7    0   12                          0  r[12]=pseudo.column 0
+ 101                Column              7    1   13                          0  r[13]=pseudo.column 1
+ 102                Column              7    2   14                          0  r[14]=pseudo.column 2
+ 103                Column              7    3   15                          0  r[15]=pseudo.column 3
+ 104                Column              7    4   16                          0  r[16]=pseudo.column 4
+ 105                Column              7    5   17                          0  r[17]=pseudo.column 5
+ 106                Column              7    6   18                          0  r[18]=pseudo.column 6
+ 107                Yield               3    0    0                          0
+ 108              SorterNext            3   99    0                          0
+ 109              EndCoroutine          3    0    0                          0
+ 110              SorterOpen            8    2    0  k(2,B,-B)               0  cursor=8
+ 111              OpenEphemeral         9    1    0                          0  cursor=9 is_table=true
+ 112              OpenDup              10    9    0                          0  new_cursor=10, original_cursor=9
+ 113              OpenDup              11    9    0                          0  new_cursor=11, original_cursor=9
+ 114              Null                  0   61    0                          0  r[61]=NULL
+ 115              Null                  0   62    0                          0  r[62]=NULL
+ 116              InitCoroutine         3    0    4                          0
+ 117                Yield               3  154    0                          0
+ 118                Compare            12   62    1  k(1, Binary)            0  r[12..12]==r[62..62]; compare partition keys to detect new partition
+ 119                Jump              120  123  120                          0
+ 120                Gosub              63  155    0                          0  ; detected new partition
+ 121                Null                0   61    0                          0  r[61]=NULL
+ 122                Copy               12   62    0                          0  r[62]=r[12]
+ 123                NotNull            61  131    0                          0  r[61]!=NULL -> goto 131
+ 124                Null                0   52   52                          0  r[52..52]=NULL; reset accumulator registers
+ 125                MakeRecord         12    7   65                          0  r[65]=mkrec(r[12..18])
+ 126                NewRowid           10   61    0                          0  r[61]=rowid
+ 127                Insert             10   65   61  buffer_table_window_2   2  intkey=r[61] data=r[65]
+ 128                Rewind              9  130    0                          0  Rewind  ephemeral(buffer_table_window_2)
+ 129                Rewind             11  130    0                          0  Rewind  ephemeral(buffer_table_window_2)
+ 130                Goto                0  153    0                          0
+ 131                MakeRecord         12    7   66                          0  r[66]=mkrec(r[12..18])
+ 132                NewRowid           10   61    0                          0  r[61]=rowid
+ 133                Insert             10   66   61  buffer_table_window_2   2  intkey=r[61] data=r[66]
+ 134                Goto                0  153    0                          0
+ 135                Column             11    2   67                          0  r[67]=ephemeral(buffer_table_window_2).amount
+ 136                AggStep             0   67   52  sum                     0  accum=r[52] step(r[67])
+ 137                Next               11  139    0                          0
+ 138                Goto                0  140    0                          0
+ 139                Goto                0  135    0                          0
+ 140                AggValue            0   52   53  sum                     0  accum=r[52] dest=r[53]
+ 141                Column              9    1   54                          0  r[54]=ephemeral(buffer_table_window_2).region
+ 142                Column              9    2   55                          0  r[55]=ephemeral(buffer_table_window_2).amount
+ 143                Column              9    0   56                          0  r[56]=ephemeral(buffer_table_window_2).department
+ 144                Column              9    3   57                          0  r[57]=ephemeral(buffer_table_window_2).salary
+ 145                Column              9    4   58                          0  r[58]=ephemeral(buffer_table_window_2).emp_id
+ 146                Column              9    5   59                          0  r[59]=ephemeral(buffer_table_window_2).name
+ 147                Column              9    6   60                          0  r[60]=ephemeral(buffer_table_window_2).column 6
+ 148                Gosub              64  178    0                          0
+ 149                Delete              9    0    0  buffer_table_window_2   0
+ 150                Next                9  152    0                          0
+ 151                Goto                0  153    0                          0
+ 152                Goto                0  141    0                          0
+ 153              Goto                  0  117    0                          0
+ 154              Null                  0   63    0                          0  r[63]=NULL; return remaining buffered rows
+ 155              Rewind               10  175    0                          0  Rewind  ephemeral(buffer_table_window_2)
+ 156              Column               11    2   68                          0  r[68]=ephemeral(buffer_table_window_2).amount
+ 157              AggStep               0   68   52  sum                     0  accum=r[52] step(r[68])
+ 158              Next                 11  160    0                          0
+ 159              Goto                  0  161    0                          0
+ 160              Goto                  0  156    0                          0
+ 161              AggValue              0   52   53  sum                     0  accum=r[52] dest=r[53]
+ 162              Column                9    1   54                          0  r[54]=ephemeral(buffer_table_window_2).region
+ 163              Column                9    2   55                          0  r[55]=ephemeral(buffer_table_window_2).amount
+ 164              Column                9    0   56                          0  r[56]=ephemeral(buffer_table_window_2).department
+ 165              Column                9    3   57                          0  r[57]=ephemeral(buffer_table_window_2).salary
+ 166              Column                9    4   58                          0  r[58]=ephemeral(buffer_table_window_2).emp_id
+ 167              Column                9    5   59                          0  r[59]=ephemeral(buffer_table_window_2).name
+ 168              Column                9    6   60                          0  r[60]=ephemeral(buffer_table_window_2).column 6
+ 169              Gosub                64  178    0                          0
+ 170              Delete                9    0    0  buffer_table_window_2   0
+ 171              Next                  9  173    0                          0
+ 172              Goto                  0  175    0                          0
+ 173              Goto                  0  162    0                          0
+ 174              Goto                  0  161    0                          0
+ 175              ResetSorter           9    0    0                          0  cursor=9
+ 176            Return                 63    0    1                          0
+ 177            Goto                    0  189    0                          0
+ 178            Copy                   54   69    0                          0  r[69]=r[54]
+ 179            Copy                   55   70    0                          0  r[70]=r[55]
+ 180            Copy                   56   71    0                          0  r[71]=r[56]
+ 181            Copy                   57   72    0                          0  r[72]=r[57]
+ 182            Copy                   58   73    0                          0  r[73]=r[58]
+ 183            Copy                   59   74    0                          0  r[74]=r[59]
+ 184            Copy                   53   75    0                          0  r[75]=r[53]
+ 185            Copy                   60   76    0                          0  r[76]=r[60]
+ 186            MakeRecord             69    8   51                          0  r[51]=mkrec(r[69..76])
+ 187            SorterInsert            8   51    0  0                       0  key=r[51]
+ 188          Return                   64    0    0                          0
+ 189          OpenPseudo               12   51    8                          0  8 columns in r[51]
+ 190          SorterSort                8  202    0                          0
+ 191            SorterData              8   51   12                          0  r[51]=data
+ 192            Column                 12    0   43                          0  r[43]=pseudo.column 0
+ 193            Column                 12    1   44                          0  r[44]=pseudo.column 1
+ 194            Column                 12    2   45                          0  r[45]=pseudo.column 2
+ 195            Column                 12    3   46                          0  r[46]=pseudo.column 3
+ 196            Column                 12    4   47                          0  r[47]=pseudo.column 4
+ 197            Column                 12    5   48                          0  r[48]=pseudo.column 5
+ 198            Column                 12    6   49                          0  r[49]=pseudo.column 6
+ 199            Column                 12    7   50                          0  r[50]=pseudo.column 7
+ 200            Yield                   2    0    0                          0
+ 201          SorterNext                8  191    0                          0
+ 202          EndCoroutine              2    0    0                          0
+ 203          SorterOpen               13    2    0  k(2,B,-B)               0  cursor=13
+ 204          OpenEphemeral            14    1    0                          0  cursor=14 is_table=true
+ 205          OpenDup                  15   14    0                          0  new_cursor=15, original_cursor=14
+ 206          OpenDup                  16   14    0                          0  new_cursor=16, original_cursor=14
+ 207          Null                      0   97    0                          0  r[97]=NULL
+ 208          Null                      0   98    0                          0  r[98]=NULL
+ 209          InitCoroutine             2    0    3                          0
+ 210            Yield                   2  243    0                          0
+ 211            Copy                   44  100    0                          0  r[100]=r[44]
+ 212            Compare                43   98    1  k(1, Binary)            0  r[43..43]==r[98..98]; compare partition keys to detect new partition
+ 213            Jump                  214  217  214                          0
+ 214            Gosub                  99  244    0                          0  ; detected new partition
+ 215            Null                    0   97    0                          0  r[97]=NULL
+ 216            Copy                   43   98    0                          0  r[98]=r[43]
+ 217            NotNull                97  225    0                          0  r[97]!=NULL -> goto 225
+ 218            Null                    0   87   87                          0  r[87..87]=NULL; initialize per-cursor peer-reference registers for new partition
+ 219            MakeRecord             43    8  102                          0  r[102]=mkrec(r[43..50])
+ 220            NewRowid               15   97    0                          0  r[97]=rowid
+ 221            Insert                 15  102   97  buffer_table_window_1   2  intkey=r[97] data=r[102]
+ 222            Rewind                 14  224    0                          0  Rewind  ephemeral(buffer_table_window_1)
+ 223            Rewind                 16  224    0                          0  Rewind  ephemeral(buffer_table_window_1)
+ 224            Goto                    0  242    0                          0
+ 225            MakeRecord             43    8  103                          0  r[103]=mkrec(r[43..50])
+ 226            NewRowid               15   97    0                          0  r[97]=rowid
+ 227            Insert                 15  103   97  buffer_table_window_1   2  intkey=r[97] data=r[103]
+ 228            AggStep                 0    0   87  row_number              0  accum=r[87] step(r[0])
+ 229            Next                   16  230    0                          0
+ 230            AggValue                0   87   88  row_number              0  accum=r[87] dest=r[88]
+ 231            Column                 14    2   89                          0  r[89]=ephemeral(buffer_table_window_1).department
+ 232            Column                 14    3   90                          0  r[90]=ephemeral(buffer_table_window_1).salary
+ 233            Column                 14    4   91                          0  r[91]=ephemeral(buffer_table_window_1).emp_id
+ 234            Column                 14    5   92                          0  r[92]=ephemeral(buffer_table_window_1).name
+ 235            Column                 14    1   93                          0  r[93]=ephemeral(buffer_table_window_1).amount
+ 236            Column                 14    0   94                          0  r[94]=ephemeral(buffer_table_window_1).region
+ 237            Column                 14    6   95                          0  r[95]=ephemeral(buffer_table_window_1).column 6
+ 238            Column                 14    7   96                          0  r[96]=ephemeral(buffer_table_window_1).column 7
+ 239            Gosub                 101  264    0                          0
+ 240            Delete                 14    0    0  buffer_table_window_1   0
+ 241            Next                   14  242    0                          0
+ 242          Goto                      0  210    0                          0
+ 243          Null                      0   99    0                          0  r[99]=NULL; return remaining buffered rows
+ 244          Rewind                   15  261    0                          0  Rewind  ephemeral(buffer_table_window_1)
+ 245          AggStep                   0    0   87  row_number              0  accum=r[87] step(r[0])
+ 246          Next                     16  247    0                          0
+ 247          AggValue                  0   87   88  row_number              0  accum=r[87] dest=r[88]
+ 248          Column                   14    2   89                          0  r[89]=ephemeral(buffer_table_window_1).department
+ 249          Column                   14    3   90                          0  r[90]=ephemeral(buffer_table_window_1).salary
+ 250          Column                   14    4   91                          0  r[91]=ephemeral(buffer_table_window_1).emp_id
+ 251          Column                   14    5   92                          0  r[92]=ephemeral(buffer_table_window_1).name
+ 252          Column                   14    1   93                          0  r[93]=ephemeral(buffer_table_window_1).amount
+ 253          Column                   14    0   94                          0  r[94]=ephemeral(buffer_table_window_1).region
+ 254          Column                   14    6   95                          0  r[95]=ephemeral(buffer_table_window_1).column 6
+ 255          Column                   14    7   96                          0  r[96]=ephemeral(buffer_table_window_1).column 7
+ 256          Gosub                   101  264    0                          0
+ 257          Delete                   14    0    0  buffer_table_window_1   0
+ 258          Next                     14  260    0                          0
+ 259          Goto                      0  261    0                          0
+ 260          Goto                      0  247    0                          0
+ 261          ResetSorter              14    0    0                          0  cursor=14
+ 262        Return                     99    0    1                          0
+ 263        Goto                        0  276    0                          0
+ 264        Copy                       89  104    0                          0  r[104]=r[89]
+ 265        Copy                       90  105    0                          0  r[105]=r[90]
+ 266        Copy                       91  106    0                          0  r[106]=r[91]
+ 267        Copy                       92  107    0                          0  r[107]=r[92]
+ 268        Copy                       93  108    0                          0  r[108]=r[93]
+ 269        Copy                       94  109    0                          0  r[109]=r[94]
+ 270        Copy                       88  110    0                          0  r[110]=r[88]
+ 271        Copy                       95  111    0                          0  r[111]=r[95]
+ 272        Copy                       96  112    0                          0  r[112]=r[96]
+ 273        MakeRecord                104    9   86                          0  r[86]=mkrec(r[104..112])
+ 274        SorterInsert               13   86    0  0                       0  key=r[86]
+ 275      Return                      101    0    0                          0
+ 276      OpenPseudo                   17   86    9                          0  9 columns in r[86]
+ 277      SorterSort                   13  290    0                          0
+ 278        SorterData                 13   86   17                          0  r[86]=data
+ 279        Column                     17    0   77                          0  r[77]=pseudo.column 0
+ 280        Column                     17    1   78                          0  r[78]=pseudo.column 1
+ 281        Column                     17    2   79                          0  r[79]=pseudo.column 2
+ 282        Column                     17    3   80                          0  r[80]=pseudo.column 3
+ 283        Column                     17    4   81                          0  r[81]=pseudo.column 4
+ 284        Column                     17    5   82                          0  r[82]=pseudo.column 5
+ 285        Column                     17    6   83                          0  r[83]=pseudo.column 6
+ 286        Column                     17    7   84                          0  r[84]=pseudo.column 7
+ 287        Column                     17    8   85                          0  r[85]=pseudo.column 8
+ 288        Yield                       1    0    0                          0
+ 289      SorterNext                   13  278    0                          0
+ 290      EndCoroutine                  1    0    0                          0
+ 291      OpenEphemeral                18    1    0                          0  cursor=18 is_table=true
+ 292      OpenDup                      19   18    0                          0  new_cursor=19, original_cursor=18
+ 293      OpenDup                      20   18    0                          0  new_cursor=20, original_cursor=18
+ 294      Null                          0  134    0                          0  r[134]=NULL
+ 295      Null                          0  135    0                          0  r[135]=NULL
+ 296      InitCoroutine                 1    0    2                          0
+ 297        Yield                       1  331    0                          0
+ 298        Copy                       78  137    0                          0  r[137]=r[78]
+ 299        Compare                    77  135    1  k(1, Binary)            0  r[77..77]==r[135..135]; compare partition keys to detect new partition
+ 300        Jump                      301  304  301                          0
+ 301        Gosub                     136  332    0                          0  ; detected new partition
+ 302        Null                        0  134    0                          0  r[134]=NULL
+ 303        Copy                       77  135    0                          0  r[135]=r[77]
+ 304        NotNull                   134  312    0                          0  r[134]!=NULL -> goto 312
+ 305        Null                        0  123  123                          0  r[123..123]=NULL; initialize per-cursor peer-reference registers for new partition
+ 306        MakeRecord                 77    9  139                          0  r[139]=mkrec(r[77..85])
+ 307        NewRowid                   19  134    0                          0  r[134]=rowid
+ 308        Insert                     19  139  134  buffer_table_window_0   2  intkey=r[134] data=r[139]
+ 309        Rewind                     18  311    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 310        Rewind                     20  311    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 311        Goto                        0  330    0                          0
+ 312        MakeRecord                 77    9  140                          0  r[140]=mkrec(r[77..85])
+ 313        NewRowid                   19  134    0                          0  r[134]=rowid
+ 314        Insert                     19  140  134  buffer_table_window_0   2  intkey=r[134] data=r[140]
+ 315        AggStep                     0    0  123  row_number              0  accum=r[123] step(r[0])
+ 316        Next                       20  317    0                          0
+ 317        AggValue                    0  123  124  row_number              0  accum=r[123] dest=r[124]
+ 318        Column                     18    2  125                          0  r[125]=ephemeral(buffer_table_window_0).emp_id
+ 319        Column                     18    3  126                          0  r[126]=ephemeral(buffer_table_window_0).name
+ 320        Column                     18    0  127                          0  r[127]=ephemeral(buffer_table_window_0).department
+ 321        Column                     18    1  128                          0  r[128]=ephemeral(buffer_table_window_0).salary
+ 322        Column                     18    4  129                          0  r[129]=ephemeral(buffer_table_window_0).amount
+ 323        Column                     18    5  130                          0  r[130]=ephemeral(buffer_table_window_0).region
+ 324        Column                     18    6  131                          0  r[131]=ephemeral(buffer_table_window_0).column 6
+ 325        Column                     18    7  132                          0  r[132]=ephemeral(buffer_table_window_0).column 7
+ 326        Column                     18    8  133                          0  r[133]=ephemeral(buffer_table_window_0).column 8
+ 327        Gosub                     138  353    0                          0
+ 328        Delete                     18    0    0  buffer_table_window_0   0
+ 329        Next                       18  330    0                          0
+ 330      Goto                          0  297    0                          0
+ 331      Null                          0  136    0                          0  r[136]=NULL; return remaining buffered rows
+ 332      Rewind                       19  350    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 333      AggStep                       0    0  123  row_number              0  accum=r[123] step(r[0])
+ 334      Next                         20  335    0                          0
+ 335      AggValue                      0  123  124  row_number              0  accum=r[123] dest=r[124]
+ 336      Column                       18    2  125                          0  r[125]=ephemeral(buffer_table_window_0).emp_id
+ 337      Column                       18    3  126                          0  r[126]=ephemeral(buffer_table_window_0).name
+ 338      Column                       18    0  127                          0  r[127]=ephemeral(buffer_table_window_0).department
+ 339      Column                       18    1  128                          0  r[128]=ephemeral(buffer_table_window_0).salary
+ 340      Column                       18    4  129                          0  r[129]=ephemeral(buffer_table_window_0).amount
+ 341      Column                       18    5  130                          0  r[130]=ephemeral(buffer_table_window_0).region
+ 342      Column                       18    6  131                          0  r[131]=ephemeral(buffer_table_window_0).column 6
+ 343      Column                       18    7  132                          0  r[132]=ephemeral(buffer_table_window_0).column 7
+ 344      Column                       18    8  133                          0  r[133]=ephemeral(buffer_table_window_0).column 8
+ 345      Gosub                       138  353    0                          0
+ 346      Delete                       18    0    0  buffer_table_window_0   0
+ 347      Next                         18  349    0                          0
+ 348      Goto                          0  350    0                          0
+ 349      Goto                          0  335    0                          0
+ 350      ResetSorter                  18    0    0                          0  cursor=18
+ 351    Return                        136    0    1                          0
+ 352    Goto                            0  365    0                          0
+ 353    Copy                          125  113    0                          0  r[113]=r[125]
+ 354    Copy                          126  114    0                          0  r[114]=r[126]
+ 355    Copy                          127  115    0                          0  r[115]=r[127]
+ 356    Copy                          128  116    0                          0  r[116]=r[128]
+ 357    Copy                          129  117    0                          0  r[117]=r[129]
+ 358    Copy                          130  118    0                          0  r[118]=r[130]
+ 359    Copy                          124  119    0                          0  r[119]=r[124]
+ 360    Copy                          131  120    0                          0  r[120]=r[131]
+ 361    Copy                          132  121    0                          0  r[121]=r[132]
+ 362    Copy                          133  122    0                          0  r[122]=r[133]
+ 363    ResultRow                     113   10    0                          0  output=r[113..122]
+ 364  Return                          138    0    0                          0
+ 365  Halt                              0    0    0                          0
+ 366  Transaction                       0    1    7                          0  iDb=0 tx_mode=Read
+ 367  Goto                              0    1    0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
@@ -23,98 +23,165 @@ QUERY PLAN
       `--SCAN employees USING INDEX idx_employees_department
 
 BYTECODE
-addr  opcode              p1  p2  p3  p4                     p5  comment
-   0      Init             0  90   0                          0  Start at 90
-   1      InitCoroutine    1  50   2                          0
-   2      InitCoroutine    2  14   3                          0
-   3      OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   4      OpenRead         1   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
-   5      Rewind           1  13   0                          0  Rewind index idx_employees_department
-   6        DeferredSeek   1   0   0                          0
-   7        Column         1   0   3                          0  r[3]=idx_employees_department.department
-   8        IdxRowId       1   4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
-   9        Column         0   1   5                          0  r[5]=employees.name
-  10        Column         0   3   6                          0  r[6]=employees.salary
-  11        Yield          2   0   0                          0
-  12      Next             1   6   0                          0
-  13      EndCoroutine     2   0   0                          0
-  14      OpenEphemeral    2   1   0                          0  cursor=2 is_table=true
-  15      OpenDup          3   2   0                          0  new_cursor=3, original_cursor=2
-  16      Null             0  18   0                          0  r[18]=NULL
-  17      Null             0  19   0                          0  r[19]=NULL
-  18      InitCoroutine    2   0   3                          0
-  19        Yield          2  33   0                          0
-  20        Compare        3  19   1  k(1, Binary)            0  r[3..3]==r[19..19]; compare partition keys to detect new partition
-  21        Jump          22  25  22                          0
-  22        Gosub         20  34   0                          0  ; detected new partition
-  23        Null           0  18   0                          0  r[18]=NULL
-  24        Copy           3  19   0                          0  r[19]=r[3]
-  25        NotNull       18  27   0                          0  r[18]!=NULL -> goto 27
-  26        Null           0  12  12                          0  r[12..12]=NULL; reset accumulator registers
-  27        MakeRecord     3   4  21                          0  r[21]=mkrec(r[3..6])
-  28        NewRowid       3  18   0                          0  r[18]=rowid
-  29        Insert         3  21  18  buffer_table_window_1   0  intkey=r[18] data=r[21]
-  30        Copy           6  22   0                          0  r[22]=r[6]
-  31        AggStep        0  22  12  sum                     0  accum=r[12] step(r[22])
-  32      Goto             0  19   0                          0
-  33      Null             0  20   0                          0  r[20]=NULL; return remaining buffered rows
-  34      Rewind           2  47   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  35      AggValue         0  12  13  sum                     0  accum=r[12] dest=r[13]
-  36        Column         2   1  14                          0  r[14]=ephemeral(buffer_table_window_1).emp_id
-  37        Column         2   2  15                          0  r[15]=ephemeral(buffer_table_window_1).name
-  38        Column         2   0  16                          0  r[16]=ephemeral(buffer_table_window_1).department
-  39        Column         2   3  17                          0  r[17]=ephemeral(buffer_table_window_1).salary
-  40        Copy          14   7   0                          0  r[7]=r[14]
-  41        Copy          15   8   0                          0  r[8]=r[15]
-  42        Copy          16   9   0                          0  r[9]=r[16]
-  43        Copy          17  10   0                          0  r[10]=r[17]
-  44        Copy          13  11   0                          0  r[11]=r[13]
-  45        Yield          1   0   0                          0
-  46      Next             2  36   0                          0
-  47      ResetSorter      2   0   0                          0  cursor=2
-  48    Return            20   0   1                          0
-  49    EndCoroutine       1   0   0                          0
-  50    OpenEphemeral      4   1   0                          0  cursor=4 is_table=true
-  51    OpenDup            5   4   0                          0  new_cursor=5, original_cursor=4
-  52    Null               0  36   0                          0  r[36]=NULL
-  53    InitCoroutine      1   0   2                          0
-  54      Yield            1  63   0                          0
-  55      NotNull         36  57   0                          0  r[36]!=NULL -> goto 57
-  56      Null             0  29  29                          0  r[29..29]=NULL; reset accumulator registers
-  57      MakeRecord       7   5  38                          0  r[38]=mkrec(r[7..11])
-  58      NewRowid         5  36   0                          0  r[36]=rowid
-  59      Insert           5  38  36  buffer_table_window_0   0  intkey=r[36] data=r[38]
-  60      Copy            10  39   0                          0  r[39]=r[10]
-  61      AggStep          0  39  29  sum                     0  accum=r[29] step(r[39])
-  62    Goto               0  54   0                          0
-  63    Null               0  37   0                          0  r[37]=NULL; return remaining buffered rows
-  64    Rewind             4  87   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  65    AggValue           0  29  30  sum                     0  accum=r[29] dest=r[30]
-  66      Column           4   0  31                          0  r[31]=ephemeral(buffer_table_window_0).emp_id
-  67      Column           4   1  32                          0  r[32]=ephemeral(buffer_table_window_0).name
-  68      Column           4   2  33                          0  r[33]=ephemeral(buffer_table_window_0).department
-  69      Column           4   3  34                          0  r[34]=ephemeral(buffer_table_window_0).salary
-  70      Column           4   4  35                          0  r[35]=ephemeral(buffer_table_window_0).column 4
-  71      Copy            31  23   0                          0  r[23]=r[31]
-  72      Copy            32  24   0                          0  r[24]=r[32]
-  73      Copy            33  25   0                          0  r[25]=r[33]
-  74      Copy            34  26   0                          0  r[26]=r[34]
-  75      Copy            34  42   0                          0  r[42]=r[34]
-  76      Cast            42   0   0                          0  affinity(r[42]=Real)
-  77      Multiply        42  43  40                          0  r[40]=r[42]*r[43]
-  78      Copy            30  41   0                          0  r[41]=r[30]
-  79      Divide          40  41  27                          0  r[27]=r[40]/r[41]
-  80      Copy            34  46   0                          0  r[46]=r[34]
-  81      Cast            46   0   0                          0  affinity(r[46]=Real)
-  82      Multiply        46  47  44                          0  r[44]=r[46]*r[47]
-  83      Copy            35  45   0                          0  r[45]=r[35]
-  84      Divide          44  45  28                          0  r[28]=r[44]/r[45]
-  85      ResultRow       23   6   0                          0  output=r[23..28]
-  86    Next               4  66   0                          0
-  87    ResetSorter        4   0   0                          0  cursor=4
-  88  Return              37   0   1                          0
-  89  Halt                 0   0   0                          0
-  90  Transaction          0   1   7                          0  iDb=0 tx_mode=Read
-  91  Real                 0  43   0  100.0                   0  r[43]=100
-  92  Real                 0  47   0  100.0                   0  r[47]=100
-  93  Goto                 0   1   0                          0
+addr  opcode                  p1   p2  p3  p4                     p5  comment
+   0          Init             0  157   0                          0  Start at 157
+   1          InitCoroutine    1   83   2                          0
+   2          InitCoroutine    2   14   3                          0
+   3          OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   4          OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   5          Rewind           1   13   0                          0  Rewind index idx_employees_department
+   6            DeferredSeek   1    0   0                          0
+   7            Column         1    0   3                          0  r[3]=idx_employees_department.department
+   8            IdxRowId       1    4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
+   9            Column         0    1   5                          0  r[5]=employees.name
+  10            Column         0    3   6                          0  r[6]=employees.salary
+  11            Yield          2    0   0                          0
+  12          Next             1    6   0                          0
+  13          EndCoroutine     2    0   0                          0
+  14          OpenEphemeral    2    1   0                          0  cursor=2 is_table=true
+  15          OpenDup          3    2   0                          0  new_cursor=3, original_cursor=2
+  16          OpenDup          4    2   0                          0  new_cursor=4, original_cursor=2
+  17          Null             0   18   0                          0  r[18]=NULL
+  18          Null             0   19   0                          0  r[19]=NULL
+  19          InitCoroutine    2    0   3                          0
+  20            Yield          2   54   0                          0
+  21            Compare        3   19   1  k(1, Binary)            0  r[3..3]==r[19..19]; compare partition keys to detect new partition
+  22            Jump          23   26  23                          0
+  23            Gosub         20   55   0                          0  ; detected new partition
+  24            Null           0   18   0                          0  r[18]=NULL
+  25            Copy           3   19   0                          0  r[19]=r[3]
+  26            NotNull       18   34   0                          0  r[18]!=NULL -> goto 34
+  27            Null           0   12  12                          0  r[12..12]=NULL; reset accumulator registers
+  28            MakeRecord     3    4  22                          0  r[22]=mkrec(r[3..6])
+  29            NewRowid       3   18   0                          0  r[18]=rowid
+  30            Insert         3   22  18  buffer_table_window_1   2  intkey=r[18] data=r[22]
+  31            Rewind         2   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  32            Rewind         4   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  33            Goto           0   53   0                          0
+  34            MakeRecord     3    4  23                          0  r[23]=mkrec(r[3..6])
+  35            NewRowid       3   18   0                          0  r[18]=rowid
+  36            Insert         3   23  18  buffer_table_window_1   2  intkey=r[18] data=r[23]
+  37            Goto           0   53   0                          0
+  38            Column         4    3  24                          0  r[24]=ephemeral(buffer_table_window_1).salary
+  39            AggStep        0   24  12  sum                     0  accum=r[12] step(r[24])
+  40            Next           4   42   0                          0
+  41            Goto           0   43   0                          0
+  42            Goto           0   38   0                          0
+  43            AggValue       0   12  13  sum                     0  accum=r[12] dest=r[13]
+  44            Column         2    1  14                          0  r[14]=ephemeral(buffer_table_window_1).emp_id
+  45            Column         2    2  15                          0  r[15]=ephemeral(buffer_table_window_1).name
+  46            Column         2    0  16                          0  r[16]=ephemeral(buffer_table_window_1).department
+  47            Column         2    3  17                          0  r[17]=ephemeral(buffer_table_window_1).salary
+  48            Gosub         21   75   0                          0
+  49            Delete         2    0   0  buffer_table_window_1   0
+  50            Next           2   52   0                          0
+  51            Goto           0   53   0                          0
+  52            Goto           0   44   0                          0
+  53          Goto             0   20   0                          0
+  54          Null             0   20   0                          0  r[20]=NULL; return remaining buffered rows
+  55          Rewind           3   72   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  56          Column           4    3  25                          0  r[25]=ephemeral(buffer_table_window_1).salary
+  57          AggStep          0   25  12  sum                     0  accum=r[12] step(r[25])
+  58          Next             4   60   0                          0
+  59          Goto             0   61   0                          0
+  60          Goto             0   56   0                          0
+  61          AggValue         0   12  13  sum                     0  accum=r[12] dest=r[13]
+  62          Column           2    1  14                          0  r[14]=ephemeral(buffer_table_window_1).emp_id
+  63          Column           2    2  15                          0  r[15]=ephemeral(buffer_table_window_1).name
+  64          Column           2    0  16                          0  r[16]=ephemeral(buffer_table_window_1).department
+  65          Column           2    3  17                          0  r[17]=ephemeral(buffer_table_window_1).salary
+  66          Gosub           21   75   0                          0
+  67          Delete           2    0   0  buffer_table_window_1   0
+  68          Next             2   70   0                          0
+  69          Goto             0   72   0                          0
+  70          Goto             0   62   0                          0
+  71          Goto             0   61   0                          0
+  72          ResetSorter      2    0   0                          0  cursor=2
+  73        Return            20    0   1                          0
+  74        Goto               0   82   0                          0
+  75        Copy              14    7   0                          0  r[7]=r[14]
+  76        Copy              15    8   0                          0  r[8]=r[15]
+  77        Copy              16    9   0                          0  r[9]=r[16]
+  78        Copy              17   10   0                          0  r[10]=r[17]
+  79        Copy              13   11   0                          0  r[11]=r[13]
+  80        Yield              1    0   0                          0
+  81      Return              21    0   0                          0
+  82      EndCoroutine         1    0   0                          0
+  83      OpenEphemeral        5    1   0                          0  cursor=5 is_table=true
+  84      OpenDup              6    5   0                          0  new_cursor=6, original_cursor=5
+  85      OpenDup              7    5   0                          0  new_cursor=7, original_cursor=5
+  86      Null                 0   39   0                          0  r[39]=NULL
+  87      InitCoroutine        1    0   2                          0
+  88        Yield              1  118   0                          0
+  89        NotNull           39   97   0                          0  r[39]!=NULL -> goto 97
+  90        Null               0   32  32                          0  r[32..32]=NULL; reset accumulator registers
+  91        MakeRecord         7    5  42                          0  r[42]=mkrec(r[7..11])
+  92        NewRowid           6   39   0                          0  r[39]=rowid
+  93        Insert             6   42  39  buffer_table_window_0   2  intkey=r[39] data=r[42]
+  94        Rewind             5   96   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  95        Rewind             7   96   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  96        Goto               0  117   0                          0
+  97        MakeRecord         7    5  43                          0  r[43]=mkrec(r[7..11])
+  98        NewRowid           6   39   0                          0  r[39]=rowid
+  99        Insert             6   43  39  buffer_table_window_0   2  intkey=r[39] data=r[43]
+ 100        Goto               0  117   0                          0
+ 101        Column             7    3  44                          0  r[44]=ephemeral(buffer_table_window_0).salary
+ 102        AggStep            0   44  32  sum                     0  accum=r[32] step(r[44])
+ 103        Next               7  105   0                          0
+ 104        Goto               0  106   0                          0
+ 105        Goto               0  101   0                          0
+ 106        AggValue           0   32  33  sum                     0  accum=r[32] dest=r[33]
+ 107        Column             5    0  34                          0  r[34]=ephemeral(buffer_table_window_0).emp_id
+ 108        Column             5    1  35                          0  r[35]=ephemeral(buffer_table_window_0).name
+ 109        Column             5    2  36                          0  r[36]=ephemeral(buffer_table_window_0).department
+ 110        Column             5    3  37                          0  r[37]=ephemeral(buffer_table_window_0).salary
+ 111        Column             5    4  38                          0  r[38]=ephemeral(buffer_table_window_0).column 4
+ 112        Gosub             41  140   0                          0
+ 113        Delete             5    0   0  buffer_table_window_0   0
+ 114        Next               5  116   0                          0
+ 115        Goto               0  117   0                          0
+ 116        Goto               0  107   0                          0
+ 117      Goto                 0   88   0                          0
+ 118      Null                 0   40   0                          0  r[40]=NULL; return remaining buffered rows
+ 119      Rewind               6  137   0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 120      Column               7    3  45                          0  r[45]=ephemeral(buffer_table_window_0).salary
+ 121      AggStep              0   45  32  sum                     0  accum=r[32] step(r[45])
+ 122      Next                 7  124   0                          0
+ 123      Goto                 0  125   0                          0
+ 124      Goto                 0  120   0                          0
+ 125      AggValue             0   32  33  sum                     0  accum=r[32] dest=r[33]
+ 126      Column               5    0  34                          0  r[34]=ephemeral(buffer_table_window_0).emp_id
+ 127      Column               5    1  35                          0  r[35]=ephemeral(buffer_table_window_0).name
+ 128      Column               5    2  36                          0  r[36]=ephemeral(buffer_table_window_0).department
+ 129      Column               5    3  37                          0  r[37]=ephemeral(buffer_table_window_0).salary
+ 130      Column               5    4  38                          0  r[38]=ephemeral(buffer_table_window_0).column 4
+ 131      Gosub               41  140   0                          0
+ 132      Delete               5    0   0  buffer_table_window_0   0
+ 133      Next                 5  135   0                          0
+ 134      Goto                 0  137   0                          0
+ 135      Goto                 0  126   0                          0
+ 136      Goto                 0  125   0                          0
+ 137      ResetSorter          5    0   0                          0  cursor=5
+ 138    Return                40    0   1                          0
+ 139    Goto                   0  156   0                          0
+ 140    Copy                  34   26   0                          0  r[26]=r[34]
+ 141    Copy                  35   27   0                          0  r[27]=r[35]
+ 142    Copy                  36   28   0                          0  r[28]=r[36]
+ 143    Copy                  37   29   0                          0  r[29]=r[37]
+ 144    Copy                  37   48   0                          0  r[48]=r[37]
+ 145    Cast                  48    0   0                          0  affinity(r[48]=Real)
+ 146    Multiply              48   49  46                          0  r[46]=r[48]*r[49]
+ 147    Copy                  33   47   0                          0  r[47]=r[33]
+ 148    Divide                46   47  30                          0  r[30]=r[46]/r[47]
+ 149    Copy                  37   52   0                          0  r[52]=r[37]
+ 150    Cast                  52    0   0                          0  affinity(r[52]=Real)
+ 151    Multiply              52   53  50                          0  r[50]=r[52]*r[53]
+ 152    Copy                  38   51   0                          0  r[51]=r[38]
+ 153    Divide                50   51  31                          0  r[31]=r[50]/r[51]
+ 154    ResultRow             26    6   0                          0  output=r[26..31]
+ 155  Return                  41    0   0                          0
+ 156  Halt                     0    0   0                          0
+ 157  Transaction              0    1   7                          0  iDb=0 tx_mode=Read
+ 158  Real                     0   49   0  100.0                   0  r[49]=100
+ 159  Real                     0   53   0  100.0                   0  r[53]=100
+ 160  Goto                     0    1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
@@ -21,54 +21,73 @@ QUERY PLAN
    `--SCAN employees USING INDEX idx_employees_salary
 
 BYTECODE
-addr  opcode            p1  p2  p3  p4                     p5  comment
-   0    Init             0  48   0                          0  Start at 48
-   1    InitCoroutine    1  13   2                          0
-   2    OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   3    OpenRead         1   5   0  k(2,B)                  0  index=idx_employees_salary, root=5, iDb=0
-   4    Last             1  12   0                          0
-   5      DeferredSeek   1   0   0                          0
-   6      Column         1   0   2                          0  r[2]=idx_employees_salary.salary
-   7      IdxRowId       1   3   0                          0  r[3]=cursor 1 for index idx_employees_salary.rowid
-   8      Column         0   1   4                          0  r[4]=employees.name
-   9      Column         0   2   5                          0  r[5]=employees.department
-  10      Yield          1   0   0                          0
-  11    Prev             1   5   0                          0
-  12    EndCoroutine     1   0   0                          0
-  13    OpenEphemeral    2   1   0                          0  cursor=2 is_table=true
-  14    OpenDup          3   2   0                          0  new_cursor=3, original_cursor=2
-  15    Null             0  17   0                          0  r[17]=NULL
-  16    InitCoroutine    1   0   2                          0
-  17      Yield          1  30   0                          0
-  18      Copy           2  20   0                          0  r[20]=r[2]
-  19      NotNull       17  22   0                          0  r[17]!=NULL -> goto 22
-  20      Copy          20  19   0                          0  r[19]=r[20]; initialize previous peer register for new partition
-  21      Null           0  11  11                          0  r[11..11]=NULL; reset accumulator registers
-  22      Compare       19  20   1  k(1, Binary)            0  r[19..19]==r[20..20]; compare ORDER BY columns to detect peer
-  23      Jump          24  26  24                          0
-  24      Gosub         18  31   0                          0  ; detected non-peer row
-  25      Copy          20  19   0                          0  r[19]=r[20]
-  26      MakeRecord     2   4  21                          0  r[21]=mkrec(r[2..5])
-  27      NewRowid       3  17   0                          0  r[17]=rowid
-  28      Insert         3  21  17  buffer_table_window_0   0  intkey=r[17] data=r[21]
-  29    Goto             0  17   0                          0
-  30    Null             0  18   0                          0  r[18]=NULL; return remaining buffered rows
-  31    Rewind           2  45   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  32      Column         2   1  13                          0  r[13]=ephemeral(buffer_table_window_0).emp_id
-  33      Column         2   2  14                          0  r[14]=ephemeral(buffer_table_window_0).name
-  34      Column         2   3  15                          0  r[15]=ephemeral(buffer_table_window_0).department
-  35      Column         2   0  16                          0  r[16]=ephemeral(buffer_table_window_0).salary
-  36      AggStep        0   0  11  row_number              0  accum=r[11] step(r[0])
-  37      AggValue       0  11  12  row_number              0  accum=r[11] dest=r[12]
-  38      Copy          13   6   0                          0  r[6]=r[13]
-  39      Copy          14   7   0                          0  r[7]=r[14]
-  40      Copy          15   8   0                          0  r[8]=r[15]
-  41      Copy          16   9   0                          0  r[9]=r[16]
-  42      Copy          12  10   0                          0  r[10]=r[12]
-  43      ResultRow      6   5   0                          0  output=r[6..10]
-  44    Next             2  32   0                          0
-  45    ResetSorter      2   0   0                          0  cursor=2
-  46  Return            18   0   1                          0
-  47  Halt               0   0   0                          0
-  48  Transaction        0   1   7                          0  iDb=0 tx_mode=Read
-  49  Goto               0   1   0                          0
+addr  opcode              p1  p2  p3  p4                     p5  comment
+   0      Init             0  67   0                          0  Start at 67
+   1      InitCoroutine    1  13   2                          0
+   2      OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   3      OpenRead         1   5   0  k(2,B)                  0  index=idx_employees_salary, root=5, iDb=0
+   4      Last             1  12   0                          0
+   5        DeferredSeek   1   0   0                          0
+   6        Column         1   0   2                          0  r[2]=idx_employees_salary.salary
+   7        IdxRowId       1   3   0                          0  r[3]=cursor 1 for index idx_employees_salary.rowid
+   8        Column         0   1   4                          0  r[4]=employees.name
+   9        Column         0   2   5                          0  r[5]=employees.department
+  10        Yield          1   0   0                          0
+  11      Prev             1   5   0                          0
+  12      EndCoroutine     1   0   0                          0
+  13      OpenEphemeral    2   1   0                          0  cursor=2 is_table=true
+  14      OpenDup          3   2   0                          0  new_cursor=3, original_cursor=2
+  15      OpenDup          4   2   0                          0  new_cursor=4, original_cursor=2
+  16      Null             0  17   0                          0  r[17]=NULL
+  17      InitCoroutine    1   0   2                          0
+  18        Yield          1  42   0                          0
+  19        Copy           2  19   0                          0  r[19]=r[2]
+  20        NotNull       17  28   0                          0  r[17]!=NULL -> goto 28
+  21        Null           0  11  11                          0  r[11..11]=NULL; initialize per-cursor peer-reference registers for new partition
+  22        MakeRecord     2   4  21                          0  r[21]=mkrec(r[2..5])
+  23        NewRowid       3  17   0                          0  r[17]=rowid
+  24        Insert         3  21  17  buffer_table_window_0   2  intkey=r[17] data=r[21]
+  25        Rewind         2  27   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  26        Rewind         4  27   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  27        Goto           0  41   0                          0
+  28        MakeRecord     2   4  22                          0  r[22]=mkrec(r[2..5])
+  29        NewRowid       3  17   0                          0  r[17]=rowid
+  30        Insert         3  22  17  buffer_table_window_0   2  intkey=r[17] data=r[22]
+  31        AggStep        0   0  11  row_number              0  accum=r[11] step(r[0])
+  32        Next           4  33   0                          0
+  33        AggValue       0  11  12  row_number              0  accum=r[11] dest=r[12]
+  34        Column         2   1  13                          0  r[13]=ephemeral(buffer_table_window_0).emp_id
+  35        Column         2   2  14                          0  r[14]=ephemeral(buffer_table_window_0).name
+  36        Column         2   3  15                          0  r[15]=ephemeral(buffer_table_window_0).department
+  37        Column         2   0  16                          0  r[16]=ephemeral(buffer_table_window_0).salary
+  38        Gosub         20  59   0                          0
+  39        Delete         2   0   0  buffer_table_window_0   0
+  40        Next           2  41   0                          0
+  41      Goto             0  18   0                          0
+  42      Null             0  18   0                          0  r[18]=NULL; return remaining buffered rows
+  43      Rewind           3  56   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  44      AggStep          0   0  11  row_number              0  accum=r[11] step(r[0])
+  45      Next             4  46   0                          0
+  46      AggValue         0  11  12  row_number              0  accum=r[11] dest=r[12]
+  47      Column           2   1  13                          0  r[13]=ephemeral(buffer_table_window_0).emp_id
+  48      Column           2   2  14                          0  r[14]=ephemeral(buffer_table_window_0).name
+  49      Column           2   3  15                          0  r[15]=ephemeral(buffer_table_window_0).department
+  50      Column           2   0  16                          0  r[16]=ephemeral(buffer_table_window_0).salary
+  51      Gosub           20  59   0                          0
+  52      Delete           2   0   0  buffer_table_window_0   0
+  53      Next             2  55   0                          0
+  54      Goto             0  56   0                          0
+  55      Goto             0  46   0                          0
+  56      ResetSorter      2   0   0                          0  cursor=2
+  57    Return            18   0   1                          0
+  58    Goto               0  66   0                          0
+  59    Copy              13   6   0                          0  r[6]=r[13]
+  60    Copy              14   7   0                          0  r[7]=r[14]
+  61    Copy              15   8   0                          0  r[8]=r[15]
+  62    Copy              16   9   0                          0  r[9]=r[16]
+  63    Copy              12  10   0                          0  r[10]=r[12]
+  64    ResultRow          6   5   0                          0  output=r[6..10]
+  65  Return              20   0   0                          0
+  66  Halt                 0   0   0                          0
+  67  Transaction          0   1   7                          0  iDb=0 tx_mode=Read
+  68  Goto                 0   1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
@@ -28,121 +28,208 @@ QUERY PLAN
    `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode              p1   p2  p3  p4                     p5  comment
-   0      Init             0  115   0                          0  Start at 115
-   1      InitCoroutine    1   77   2                          0
-   2      InitCoroutine    2   23   3                          0
-   3      SorterOpen       0    2   0  k(2,B,B)                0  cursor=0
-   4      OpenRead         1    3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
-   5      Rewind           1   13   0                          0  Rewind table sales
-   6        Column         1    1   8                          0  r[8]=sales.emp_id
-   7        Column         1    2   9                          0  r[9]=sales.sale_date
-   8        RowId          1   10   0                          0  r[10]=sales.rowid
-   9        Column         1    3  11                          0  r[11]=sales.amount
-  10        MakeRecord     8    4   7                          0  r[7]=mkrec(r[8..11])
-  11        SorterInsert   0    7   0  0                       0  key=r[7]
-  12      Next             1    6   0                          0
-  13      OpenPseudo       2    7   4                          0  4 columns in r[7]
-  14      SorterSort       0   22   0                          0
-  15        SorterData     0    7   2                          0  r[7]=data
-  16        Column         2    0   3                          0  r[3]=pseudo.column 0
-  17        Column         2    1   4                          0  r[4]=pseudo.column 1
-  18        Column         2    2   5                          0  r[5]=pseudo.column 2
-  19        Column         2    3   6                          0  r[6]=pseudo.column 3
-  20        Yield          2    0   0                          0
-  21      SorterNext       0   15   0                          0
-  22      EndCoroutine     2    0   0                          0
-  23      SorterOpen       3    1   0  k(1,B)                  0  cursor=3
-  24      OpenEphemeral    4    1   0                          0  cursor=4 is_table=true
-  25      OpenDup          5    4   0                          0  new_cursor=5, original_cursor=4
-  26      Null             0   24   0                          0  r[24]=NULL
-  27      Null             0   25   0                          0  r[25]=NULL
-  28      InitCoroutine    2    0   3                          0
-  29        Yield          2   49   0                          0
-  30        Copy           4   28   0                          0  r[28]=r[4]
-  31        Compare        3   25   1  k(1, Binary)            0  r[3..3]==r[25..25]; compare partition keys to detect new partition
-  32        Jump          33   36  33                          0
-  33        Gosub         26   50   0                          0  ; detected new partition
-  34        Null           0   24   0                          0  r[24]=NULL
-  35        Copy           3   25   0                          0  r[25]=r[3]
-  36        NotNull       24   39   0                          0  r[24]!=NULL -> goto 39
-  37        Copy          28   27   0                          0  r[27]=r[28]; initialize previous peer register for new partition
-  38        Null           0   18  18                          0  r[18..18]=NULL; reset accumulator registers
-  39        Compare       27   28   1  k(1, Binary)            0  r[27..27]==r[28..28]; compare ORDER BY columns to detect peer
-  40        Jump          41   43  41                          0
-  41        Gosub         26   50   0                          0  ; detected non-peer row
-  42        Copy          28   27   0                          0  r[27]=r[28]
-  43        MakeRecord     3    4  29                          0  r[29]=mkrec(r[3..6])
-  44        NewRowid       5   24   0                          0  r[24]=rowid
-  45        Insert         5   29  24  buffer_table_window_1   0  intkey=r[24] data=r[29]
-  46        Copy           6   30   0                          0  r[30]=r[6]
-  47        AggStep        0   30  18  sum                     0  accum=r[18] step(r[30])
-  48      Goto             0   29   0                          0
-  49      Null             0   26   0                          0  r[26]=NULL; return remaining buffered rows
-  50      Rewind           4   64   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  51      AggValue         0   18  19  sum                     0  accum=r[18] dest=r[19]
-  52        Column         4    1  20                          0  r[20]=ephemeral(buffer_table_window_1).sale_date
-  53        Column         4    2  21                          0  r[21]=ephemeral(buffer_table_window_1).sale_id
-  54        Column         4    0  22                          0  r[22]=ephemeral(buffer_table_window_1).emp_id
-  55        Column         4    3  23                          0  r[23]=ephemeral(buffer_table_window_1).amount
-  56        Copy          20   31   0                          0  r[31]=r[20]
-  57        Copy          21   32   0                          0  r[32]=r[21]
-  58        Copy          22   33   0                          0  r[33]=r[22]
-  59        Copy          23   34   0                          0  r[34]=r[23]
-  60        Copy          19   35   0                          0  r[35]=r[19]
-  61        MakeRecord    31    5  17                          0  r[17]=mkrec(r[31..35])
-  62        SorterInsert   3   17   0  0                       0  key=r[17]
-  63      Next             4   52   0                          0
-  64      ResetSorter      4    0   0                          0  cursor=4
-  65    Return            26    0   1                          0
-  66    OpenPseudo         6   17   5                          0  5 columns in r[17]
-  67    SorterSort         3   76   0                          0
-  68      SorterData       3   17   6                          0  r[17]=data
-  69      Column           6    0  12                          0  r[12]=pseudo.column 0
-  70      Column           6    1  13                          0  r[13]=pseudo.column 1
-  71      Column           6    2  14                          0  r[14]=pseudo.column 2
-  72      Column           6    3  15                          0  r[15]=pseudo.column 3
-  73      Column           6    4  16                          0  r[16]=pseudo.column 4
-  74      Yield            1    0   0                          0
-  75    SorterNext         3   68   0                          0
-  76    EndCoroutine       1    0   0                          0
-  77    OpenEphemeral      7    1   0                          0  cursor=7 is_table=true
-  78    OpenDup            8    7   0                          0  new_cursor=8, original_cursor=7
-  79    Null               0   49   0                          0  r[49]=NULL
-  80    InitCoroutine      1    0   2                          0
-  81      Yield            1   96   0                          0
-  82      Copy            12   52   0                          0  r[52]=r[12]
-  83      NotNull         49   86   0                          0  r[49]!=NULL -> goto 86
-  84      Copy            52   51   0                          0  r[51]=r[52]; initialize previous peer register for new partition
-  85      Null             0   42  42                          0  r[42..42]=NULL; reset accumulator registers
-  86      Compare         51   52   1  k(1, Binary)            0  r[51..51]==r[52..52]; compare ORDER BY columns to detect peer
-  87      Jump            88   90  88                          0
-  88      Gosub           50   97   0                          0  ; detected non-peer row
-  89      Copy            52   51   0                          0  r[51]=r[52]
-  90      MakeRecord      12    5  53                          0  r[53]=mkrec(r[12..16])
-  91      NewRowid         8   49   0                          0  r[49]=rowid
-  92      Insert           8   53  49  buffer_table_window_0   0  intkey=r[49] data=r[53]
-  93      Copy            15   54   0                          0  r[54]=r[15]
-  94      AggStep          0   54  42  sum                     0  accum=r[42] step(r[54])
-  95    Goto               0   81   0                          0
-  96    Null               0   50   0                          0  r[50]=NULL; return remaining buffered rows
-  97    Rewind             7  112   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  98    AggValue           0   42  43  sum                     0  accum=r[42] dest=r[43]
-  99      Column           7    1  44                          0  r[44]=ephemeral(buffer_table_window_0).sale_id
- 100      Column           7    2  45                          0  r[45]=ephemeral(buffer_table_window_0).emp_id
- 101      Column           7    0  46                          0  r[46]=ephemeral(buffer_table_window_0).sale_date
- 102      Column           7    3  47                          0  r[47]=ephemeral(buffer_table_window_0).amount
- 103      Column           7    4  48                          0  r[48]=ephemeral(buffer_table_window_0).column 4
- 104      Copy            44   36   0                          0  r[36]=r[44]
- 105      Copy            45   37   0                          0  r[37]=r[45]
- 106      Copy            46   38   0                          0  r[38]=r[46]
- 107      Copy            47   39   0                          0  r[39]=r[47]
- 108      Copy            43   40   0                          0  r[40]=r[43]
- 109      Copy            48   41   0                          0  r[41]=r[48]
- 110      ResultRow       36    6   0                          0  output=r[36..41]
- 111    Next               7   99   0                          0
- 112    ResetSorter        7    0   0                          0  cursor=7
- 113  Return              50    0   1                          0
- 114  Halt                 0    0   0                          0
- 115  Transaction          0    1   7                          0  iDb=0 tx_mode=Read
- 116  Goto                 0    1   0                          0
+addr  opcode                   p1   p2   p3  p4                     p5  comment
+   0          Init              0  202    0                          0  Start at 202
+   1          InitCoroutine     1  120    2                          0
+   2          InitCoroutine     2   23    3                          0
+   3          SorterOpen        0    2    0  k(2,B,B)                0  cursor=0
+   4          OpenRead          1    3    0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
+   5          Rewind            1   13    0                          0  Rewind table sales
+   6            Column          1    1    8                          0  r[8]=sales.emp_id
+   7            Column          1    2    9                          0  r[9]=sales.sale_date
+   8            RowId           1   10    0                          0  r[10]=sales.rowid
+   9            Column          1    3   11                          0  r[11]=sales.amount
+  10            MakeRecord      8    4    7                          0  r[7]=mkrec(r[8..11])
+  11            SorterInsert    0    7    0  0                       0  key=r[7]
+  12          Next              1    6    0                          0
+  13          OpenPseudo        2    7    4                          0  4 columns in r[7]
+  14          SorterSort        0   22    0                          0
+  15            SorterData      0    7    2                          0  r[7]=data
+  16            Column          2    0    3                          0  r[3]=pseudo.column 0
+  17            Column          2    1    4                          0  r[4]=pseudo.column 1
+  18            Column          2    2    5                          0  r[5]=pseudo.column 2
+  19            Column          2    3    6                          0  r[6]=pseudo.column 3
+  20            Yield           2    0    0                          0
+  21          SorterNext        0   15    0                          0
+  22          EndCoroutine      2    0    0                          0
+  23          SorterOpen        3    1    0  k(1,B)                  0  cursor=3
+  24          OpenEphemeral     4    1    0                          0  cursor=4 is_table=true
+  25          OpenDup           5    4    0                          0  new_cursor=5, original_cursor=4
+  26          OpenDup           6    4    0                          0  new_cursor=6, original_cursor=4
+  27          Null              0   24    0                          0  r[24]=NULL
+  28          Null              0   25    0                          0  r[25]=NULL
+  29          InitCoroutine     2    0    3                          0
+  30            Yield           2   74    0                          0
+  31            Copy            4   27    0                          0  r[27]=r[4]
+  32            Compare         3   25    1  k(1, Binary)            0  r[3..3]==r[25..25]; compare partition keys to detect new partition
+  33            Jump           34   37   34                          0
+  34            Gosub          26   75    0                          0  ; detected new partition
+  35            Null            0   24    0                          0  r[24]=NULL
+  36            Copy            3   25    0                          0  r[25]=r[3]
+  37            NotNull        24   47    0                          0  r[24]!=NULL -> goto 47
+  38            Copy           27   28    0                          0  r[28]=r[27]; initialize per-cursor peer-reference registers for new partition
+  39            Copy           27   29    0                          0  r[29]=r[27]
+  40            Null            0   18   18                          0  r[18..18]=NULL; reset accumulator registers
+  41            MakeRecord      3    4   31                          0  r[31]=mkrec(r[3..6])
+  42            NewRowid        5   24    0                          0  r[24]=rowid
+  43            Insert          5   31   24  buffer_table_window_1   2  intkey=r[24] data=r[31]
+  44            Rewind          4   46    0                          0  Rewind  ephemeral(buffer_table_window_1)
+  45            Rewind          6   46    0                          0  Rewind  ephemeral(buffer_table_window_1)
+  46            Goto            0   73    0                          0
+  47            MakeRecord      3    4   32                          0  r[32]=mkrec(r[3..6])
+  48            NewRowid        5   24    0                          0  r[24]=rowid
+  49            Insert          5   32   24  buffer_table_window_1   2  intkey=r[24] data=r[32]
+  50            Compare        27   29    1  k(1, Binary)            0  r[27..27]==r[29..29]; compare ORDER BY columns to detect peer
+  51            Jump           52   73   52                          0
+  52            Column          6    3   33                          0  r[33]=ephemeral(buffer_table_window_1).amount
+  53            AggStep         0   33   18  sum                     0  accum=r[18] step(r[33])
+  54            Next            6   56    0                          0
+  55            Goto            0   60    0                          0
+  56            Column          6    1   34                          0  r[34]=ephemeral(buffer_table_window_1).sale_date
+  57            Compare        29   34    1  k(1, Binary)            0  r[29..29]==r[34..34]
+  58            Jump           59   52   59                          0
+  59            Copy           34   29    0                          0  r[29]=r[34]
+  60            AggValue        0   18   19  sum                     0  accum=r[18] dest=r[19]
+  61            Column          4    1   20                          0  r[20]=ephemeral(buffer_table_window_1).sale_date
+  62            Column          4    2   21                          0  r[21]=ephemeral(buffer_table_window_1).sale_id
+  63            Column          4    0   22                          0  r[22]=ephemeral(buffer_table_window_1).emp_id
+  64            Column          4    3   23                          0  r[23]=ephemeral(buffer_table_window_1).amount
+  65            Gosub          30  101    0                          0
+  66            Delete          4    0    0  buffer_table_window_1   0
+  67            Next            4   69    0                          0
+  68            Goto            0   73    0                          0
+  69            Column          4    1   35                          0  r[35]=ephemeral(buffer_table_window_1).sale_date
+  70            Compare        28   35    1  k(1, Binary)            0  r[28..28]==r[35..35]
+  71            Jump           72   61   72                          0
+  72            Copy           35   28    0                          0  r[28]=r[35]
+  73          Goto              0   30    0                          0
+  74          Null              0   26    0                          0  r[26]=NULL; return remaining buffered rows
+  75          Rewind            5   98    0                          0  Rewind  ephemeral(buffer_table_window_1)
+  76          Column            6    3   36                          0  r[36]=ephemeral(buffer_table_window_1).amount
+  77          AggStep           0   36   18  sum                     0  accum=r[18] step(r[36])
+  78          Next              6   80    0                          0
+  79          Goto              0   84    0                          0
+  80          Column            6    1   37                          0  r[37]=ephemeral(buffer_table_window_1).sale_date
+  81          Compare          29   37    1  k(1, Binary)            0  r[29..29]==r[37..37]
+  82          Jump             83   76   83                          0
+  83          Copy             37   29    0                          0  r[29]=r[37]
+  84          AggValue          0   18   19  sum                     0  accum=r[18] dest=r[19]
+  85          Column            4    1   20                          0  r[20]=ephemeral(buffer_table_window_1).sale_date
+  86          Column            4    2   21                          0  r[21]=ephemeral(buffer_table_window_1).sale_id
+  87          Column            4    0   22                          0  r[22]=ephemeral(buffer_table_window_1).emp_id
+  88          Column            4    3   23                          0  r[23]=ephemeral(buffer_table_window_1).amount
+  89          Gosub            30  101    0                          0
+  90          Delete            4    0    0  buffer_table_window_1   0
+  91          Next              4   93    0                          0
+  92          Goto              0   98    0                          0
+  93          Column            4    1   38                          0  r[38]=ephemeral(buffer_table_window_1).sale_date
+  94          Compare          28   38    1  k(1, Binary)            0  r[28..28]==r[38..38]
+  95          Jump             96   85   96                          0
+  96          Copy             38   28    0                          0  r[28]=r[38]
+  97          Goto              0   84    0                          0
+  98          ResetSorter       4    0    0                          0  cursor=4
+  99        Return             26    0    1                          0
+ 100        Goto                0  109    0                          0
+ 101        Copy               20   39    0                          0  r[39]=r[20]
+ 102        Copy               21   40    0                          0  r[40]=r[21]
+ 103        Copy               22   41    0                          0  r[41]=r[22]
+ 104        Copy               23   42    0                          0  r[42]=r[23]
+ 105        Copy               19   43    0                          0  r[43]=r[19]
+ 106        MakeRecord         39    5   17                          0  r[17]=mkrec(r[39..43])
+ 107        SorterInsert        3   17    0  0                       0  key=r[17]
+ 108      Return               30    0    0                          0
+ 109      OpenPseudo            7   17    5                          0  5 columns in r[17]
+ 110      SorterSort            3  119    0                          0
+ 111        SorterData          3   17    7                          0  r[17]=data
+ 112        Column              7    0   12                          0  r[12]=pseudo.column 0
+ 113        Column              7    1   13                          0  r[13]=pseudo.column 1
+ 114        Column              7    2   14                          0  r[14]=pseudo.column 2
+ 115        Column              7    3   15                          0  r[15]=pseudo.column 3
+ 116        Column              7    4   16                          0  r[16]=pseudo.column 4
+ 117        Yield               1    0    0                          0
+ 118      SorterNext            3  111    0                          0
+ 119      EndCoroutine          1    0    0                          0
+ 120      OpenEphemeral         8    1    0                          0  cursor=8 is_table=true
+ 121      OpenDup               9    8    0                          0  new_cursor=9, original_cursor=8
+ 122      OpenDup              10    8    0                          0  new_cursor=10, original_cursor=8
+ 123      Null                  0   57    0                          0  r[57]=NULL
+ 124      InitCoroutine         1    0    2                          0
+ 125        Yield               1  165    0                          0
+ 126        Copy               12   59    0                          0  r[59]=r[12]
+ 127        NotNull            57  137    0                          0  r[57]!=NULL -> goto 137
+ 128        Copy               59   60    0                          0  r[60]=r[59]; initialize per-cursor peer-reference registers for new partition
+ 129        Copy               59   61    0                          0  r[61]=r[59]
+ 130        Null                0   50   50                          0  r[50..50]=NULL; reset accumulator registers
+ 131        MakeRecord         12    5   63                          0  r[63]=mkrec(r[12..16])
+ 132        NewRowid            9   57    0                          0  r[57]=rowid
+ 133        Insert              9   63   57  buffer_table_window_0   2  intkey=r[57] data=r[63]
+ 134        Rewind              8  136    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 135        Rewind             10  136    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 136        Goto                0  164    0                          0
+ 137        MakeRecord         12    5   64                          0  r[64]=mkrec(r[12..16])
+ 138        NewRowid            9   57    0                          0  r[57]=rowid
+ 139        Insert              9   64   57  buffer_table_window_0   2  intkey=r[57] data=r[64]
+ 140        Compare            59   61    1  k(1, Binary)            0  r[59..59]==r[61..61]; compare ORDER BY columns to detect peer
+ 141        Jump              142  164  142                          0
+ 142        Column             10    3   65                          0  r[65]=ephemeral(buffer_table_window_0).amount
+ 143        AggStep             0   65   50  sum                     0  accum=r[50] step(r[65])
+ 144        Next               10  146    0                          0
+ 145        Goto                0  150    0                          0
+ 146        Column             10    0   66                          0  r[66]=ephemeral(buffer_table_window_0).sale_date
+ 147        Compare            61   66    1  k(1, Binary)            0  r[61..61]==r[66..66]
+ 148        Jump              149  142  149                          0
+ 149        Copy               66   61    0                          0  r[61]=r[66]
+ 150        AggValue            0   50   51  sum                     0  accum=r[50] dest=r[51]
+ 151        Column              8    1   52                          0  r[52]=ephemeral(buffer_table_window_0).sale_id
+ 152        Column              8    2   53                          0  r[53]=ephemeral(buffer_table_window_0).emp_id
+ 153        Column              8    0   54                          0  r[54]=ephemeral(buffer_table_window_0).sale_date
+ 154        Column              8    3   55                          0  r[55]=ephemeral(buffer_table_window_0).amount
+ 155        Column              8    4   56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
+ 156        Gosub              62  193    0                          0
+ 157        Delete              8    0    0  buffer_table_window_0   0
+ 158        Next                8  160    0                          0
+ 159        Goto                0  164    0                          0
+ 160        Column              8    0   67                          0  r[67]=ephemeral(buffer_table_window_0).sale_date
+ 161        Compare            60   67    1  k(1, Binary)            0  r[60..60]==r[67..67]
+ 162        Jump              163  151  163                          0
+ 163        Copy               67   60    0                          0  r[60]=r[67]
+ 164      Goto                  0  125    0                          0
+ 165      Null                  0   58    0                          0  r[58]=NULL; return remaining buffered rows
+ 166      Rewind                9  190    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 167      Column               10    3   68                          0  r[68]=ephemeral(buffer_table_window_0).amount
+ 168      AggStep               0   68   50  sum                     0  accum=r[50] step(r[68])
+ 169      Next                 10  171    0                          0
+ 170      Goto                  0  175    0                          0
+ 171      Column               10    0   69                          0  r[69]=ephemeral(buffer_table_window_0).sale_date
+ 172      Compare              61   69    1  k(1, Binary)            0  r[61..61]==r[69..69]
+ 173      Jump                174  167  174                          0
+ 174      Copy                 69   61    0                          0  r[61]=r[69]
+ 175      AggValue              0   50   51  sum                     0  accum=r[50] dest=r[51]
+ 176      Column                8    1   52                          0  r[52]=ephemeral(buffer_table_window_0).sale_id
+ 177      Column                8    2   53                          0  r[53]=ephemeral(buffer_table_window_0).emp_id
+ 178      Column                8    0   54                          0  r[54]=ephemeral(buffer_table_window_0).sale_date
+ 179      Column                8    3   55                          0  r[55]=ephemeral(buffer_table_window_0).amount
+ 180      Column                8    4   56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
+ 181      Gosub                62  193    0                          0
+ 182      Delete                8    0    0  buffer_table_window_0   0
+ 183      Next                  8  185    0                          0
+ 184      Goto                  0  190    0                          0
+ 185      Column                8    0   70                          0  r[70]=ephemeral(buffer_table_window_0).sale_date
+ 186      Compare              60   70    1  k(1, Binary)            0  r[60..60]==r[70..70]
+ 187      Jump                188  176  188                          0
+ 188      Copy                 70   60    0                          0  r[60]=r[70]
+ 189      Goto                  0  175    0                          0
+ 190      ResetSorter           8    0    0                          0  cursor=8
+ 191    Return                 58    0    1                          0
+ 192    Goto                    0  201    0                          0
+ 193    Copy                   52   44    0                          0  r[44]=r[52]
+ 194    Copy                   53   45    0                          0  r[45]=r[53]
+ 195    Copy                   54   46    0                          0  r[46]=r[54]
+ 196    Copy                   55   47    0                          0  r[47]=r[55]
+ 197    Copy                   51   48    0                          0  r[48]=r[51]
+ 198    Copy                   56   49    0                          0  r[49]=r[56]
+ 199    ResultRow              44    6    0                          0  output=r[44..49]
+ 200  Return                   62    0    0                          0
+ 201  Halt                      0    0    0                          0
+ 202  Transaction               0    1    7                          0  iDb=0 tx_mode=Read
+ 203  Goto                      0    1    0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
@@ -23,68 +23,88 @@ QUERY PLAN
    `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode            p1  p2  p3  p4                     p5  comment
-   0    Init             0  62   0                          0  Start at 62
-   1    InitCoroutine    1  24   2                          0
-   2    SorterOpen       0   2   0  k(2,B,-B)               0  cursor=0
-   3    OpenRead         1   3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
-   4    Rewind           1  13   0                          0  Rewind table sales
-   5      Column         1   2   8                          0  r[8]=sales.sale_date
-   6      Column         1   3   9                          0  r[9]=sales.amount
-   7      RowId          1  10   0                          0  r[10]=sales.rowid
-   8      Column         1   1  11                          0  r[11]=sales.emp_id
-   9      Column         1   4  12                          0  r[12]=sales.region
-  10      MakeRecord     8   5   7                          0  r[7]=mkrec(r[8..12])
-  11      SorterInsert   0   7   0  0                       0  key=r[7]
-  12    Next             1   5   0                          0
-  13    OpenPseudo       2   7   5                          0  5 columns in r[7]
-  14    SorterSort       0  23   0                          0
-  15      SorterData     0   7   2                          0  r[7]=data
-  16      Column         2   0   2                          0  r[2]=pseudo.column 0
-  17      Column         2   1   3                          0  r[3]=pseudo.column 1
-  18      Column         2   2   4                          0  r[4]=pseudo.column 2
-  19      Column         2   3   5                          0  r[5]=pseudo.column 3
-  20      Column         2   4   6                          0  r[6]=pseudo.column 4
-  21      Yield          1   0   0                          0
-  22    SorterNext       0  15   0                          0
-  23    EndCoroutine     1   0   0                          0
-  24    OpenEphemeral    3   1   0                          0  cursor=3 is_table=true
-  25    OpenDup          4   3   0                          0  new_cursor=4, original_cursor=3
-  26    Null             0  26   0                          0  r[26]=NULL
-  27    InitCoroutine    1   0   2                          0
-  28      Yield          1  42   0                          0
-  29      Copy           2  30   0                          0  r[30]=r[2]
-  30      Copy           3  31   0                          0  r[31]=r[3]
-  31      NotNull       26  34   0                          0  r[26]!=NULL -> goto 34
-  32      Copy          30  28   1                          0  r[28]=r[30]; initialize previous peer register for new partition
-  33      Null           0  19  19                          0  r[19..19]=NULL; reset accumulator registers
-  34      Compare       28  30   2  k(2, Binary, Binary)    0  r[28..29]==r[30..31]; compare ORDER BY columns to detect peer
-  35      Jump          36  38  36                          0
-  36      Gosub         27  43   0                          0  ; detected non-peer row
-  37      Copy          30  28   1                          0  r[28]=r[30]
-  38      MakeRecord     2   5  32                          0  r[32]=mkrec(r[2..6])
-  39      NewRowid       4  26   0                          0  r[26]=rowid
-  40      Insert         4  32  26  buffer_table_window_0   0  intkey=r[26] data=r[32]
-  41    Goto             0  28   0                          0
-  42    Null             0  27   0                          0  r[27]=NULL; return remaining buffered rows
-  43    Rewind           3  59   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  44      Column         3   2  21                          0  r[21]=ephemeral(buffer_table_window_0).sale_id
-  45      Column         3   3  22                          0  r[22]=ephemeral(buffer_table_window_0).emp_id
-  46      Column         3   0  23                          0  r[23]=ephemeral(buffer_table_window_0).sale_date
-  47      Column         3   1  24                          0  r[24]=ephemeral(buffer_table_window_0).amount
-  48      Column         3   4  25                          0  r[25]=ephemeral(buffer_table_window_0).region
-  49      AggStep        0   0  19  row_number              0  accum=r[19] step(r[0])
-  50      AggValue       0  19  20  row_number              0  accum=r[19] dest=r[20]
-  51      Copy          21  13   0                          0  r[13]=r[21]
-  52      Copy          22  14   0                          0  r[14]=r[22]
-  53      Copy          23  15   0                          0  r[15]=r[23]
-  54      Copy          24  16   0                          0  r[16]=r[24]
-  55      Copy          25  17   0                          0  r[17]=r[25]
-  56      Copy          20  18   0                          0  r[18]=r[20]
-  57      ResultRow     13   6   0                          0  output=r[13..18]
-  58    Next             3  44   0                          0
-  59    ResetSorter      3   0   0                          0  cursor=3
-  60  Return            27   0   1                          0
-  61  Halt               0   0   0                          0
-  62  Transaction        0   1   7                          0  iDb=0 tx_mode=Read
-  63  Goto               0   1   0                          0
+addr  opcode              p1  p2  p3  p4                     p5  comment
+   0      Init             0  82   0                          0  Start at 82
+   1      InitCoroutine    1  24   2                          0
+   2      SorterOpen       0   2   0  k(2,B,-B)               0  cursor=0
+   3      OpenRead         1   3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
+   4      Rewind           1  13   0                          0  Rewind table sales
+   5        Column         1   2   8                          0  r[8]=sales.sale_date
+   6        Column         1   3   9                          0  r[9]=sales.amount
+   7        RowId          1  10   0                          0  r[10]=sales.rowid
+   8        Column         1   1  11                          0  r[11]=sales.emp_id
+   9        Column         1   4  12                          0  r[12]=sales.region
+  10        MakeRecord     8   5   7                          0  r[7]=mkrec(r[8..12])
+  11        SorterInsert   0   7   0  0                       0  key=r[7]
+  12      Next             1   5   0                          0
+  13      OpenPseudo       2   7   5                          0  5 columns in r[7]
+  14      SorterSort       0  23   0                          0
+  15        SorterData     0   7   2                          0  r[7]=data
+  16        Column         2   0   2                          0  r[2]=pseudo.column 0
+  17        Column         2   1   3                          0  r[3]=pseudo.column 1
+  18        Column         2   2   4                          0  r[4]=pseudo.column 2
+  19        Column         2   3   5                          0  r[5]=pseudo.column 3
+  20        Column         2   4   6                          0  r[6]=pseudo.column 4
+  21        Yield          1   0   0                          0
+  22      SorterNext       0  15   0                          0
+  23      EndCoroutine     1   0   0                          0
+  24      OpenEphemeral    3   1   0                          0  cursor=3 is_table=true
+  25      OpenDup          4   3   0                          0  new_cursor=4, original_cursor=3
+  26      OpenDup          5   3   0                          0  new_cursor=5, original_cursor=3
+  27      Null             0  26   0                          0  r[26]=NULL
+  28      InitCoroutine    1   0   2                          0
+  29        Yield          1  55   0                          0
+  30        Copy           2  28   0                          0  r[28]=r[2]
+  31        Copy           3  29   0                          0  r[29]=r[3]
+  32        NotNull       26  40   0                          0  r[26]!=NULL -> goto 40
+  33        Null           0  19  19                          0  r[19..19]=NULL; initialize per-cursor peer-reference registers for new partition
+  34        MakeRecord     2   5  31                          0  r[31]=mkrec(r[2..6])
+  35        NewRowid       4  26   0                          0  r[26]=rowid
+  36        Insert         4  31  26  buffer_table_window_0   2  intkey=r[26] data=r[31]
+  37        Rewind         3  39   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  38        Rewind         5  39   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  39        Goto           0  54   0                          0
+  40        MakeRecord     2   5  32                          0  r[32]=mkrec(r[2..6])
+  41        NewRowid       4  26   0                          0  r[26]=rowid
+  42        Insert         4  32  26  buffer_table_window_0   2  intkey=r[26] data=r[32]
+  43        AggStep        0   0  19  row_number              0  accum=r[19] step(r[0])
+  44        Next           5  45   0                          0
+  45        AggValue       0  19  20  row_number              0  accum=r[19] dest=r[20]
+  46        Column         3   2  21                          0  r[21]=ephemeral(buffer_table_window_0).sale_id
+  47        Column         3   3  22                          0  r[22]=ephemeral(buffer_table_window_0).emp_id
+  48        Column         3   0  23                          0  r[23]=ephemeral(buffer_table_window_0).sale_date
+  49        Column         3   1  24                          0  r[24]=ephemeral(buffer_table_window_0).amount
+  50        Column         3   4  25                          0  r[25]=ephemeral(buffer_table_window_0).region
+  51        Gosub         30  73   0                          0
+  52        Delete         3   0   0  buffer_table_window_0   0
+  53        Next           3  54   0                          0
+  54      Goto             0  29   0                          0
+  55      Null             0  27   0                          0  r[27]=NULL; return remaining buffered rows
+  56      Rewind           4  70   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  57      AggStep          0   0  19  row_number              0  accum=r[19] step(r[0])
+  58      Next             5  59   0                          0
+  59      AggValue         0  19  20  row_number              0  accum=r[19] dest=r[20]
+  60      Column           3   2  21                          0  r[21]=ephemeral(buffer_table_window_0).sale_id
+  61      Column           3   3  22                          0  r[22]=ephemeral(buffer_table_window_0).emp_id
+  62      Column           3   0  23                          0  r[23]=ephemeral(buffer_table_window_0).sale_date
+  63      Column           3   1  24                          0  r[24]=ephemeral(buffer_table_window_0).amount
+  64      Column           3   4  25                          0  r[25]=ephemeral(buffer_table_window_0).region
+  65      Gosub           30  73   0                          0
+  66      Delete           3   0   0  buffer_table_window_0   0
+  67      Next             3  69   0                          0
+  68      Goto             0  70   0                          0
+  69      Goto             0  59   0                          0
+  70      ResetSorter      3   0   0                          0  cursor=3
+  71    Return            27   0   1                          0
+  72    Goto               0  81   0                          0
+  73    Copy              21  13   0                          0  r[13]=r[21]
+  74    Copy              22  14   0                          0  r[14]=r[22]
+  75    Copy              23  15   0                          0  r[15]=r[23]
+  76    Copy              24  16   0                          0  r[16]=r[24]
+  77    Copy              25  17   0                          0  r[17]=r[25]
+  78    Copy              20  18   0                          0  r[18]=r[20]
+  79    ResultRow         13   6   0                          0  output=r[13..18]
+  80  Return              30   0   0                          0
+  81  Halt                 0   0   0                          0
+  82  Transaction          0   1   7                          0  iDb=0 tx_mode=Read
+  83  Goto                 0   1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
@@ -22,91 +22,109 @@ QUERY PLAN
    `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4                     p5  comment
-   0            Init             0  84   0                          0  Start at 84
-   1            InitCoroutine    1  51   2                          0
-   2            SorterOpen       0   1   0  k(1,-B)                 0  cursor=0
-   3            Null             0  11  12                          0  r[11..12]=NULL
-   4            Integer          0   8   0                          0  r[8]=0; clear group by abort flag
-   5            Null             0   9   0                          0  r[9]=NULL; initialize group by comparison registers to NULL
-   6            Gosub           16  39   0                          0  ; go to clear accumulator subroutine
-   7            OpenRead         1   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   8            OpenRead         2   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
-   9            Rewind           2  25   0                          0  Rewind index idx_employees_department
-  10              DeferredSeek   2   1   0                          0
-  11              Column         2   0  14                          0  r[14]=idx_employees_department.department
-  12              Column         1   3  15                          0  r[15]=employees.salary
-  13              Compare        9  14   1  k(1, Binary)            0  r[9..9]==r[14..14]
-  14              Jump          15  19  15                          0  ; start new group if comparison is not equal
-  15              Gosub          6  29   0                          0  ; check if ended group had data, and output if so
-  16              Move          14   9   1                          0  r[9..9]=r[14..14]
-  17              IfPos          8  42   0                          0  r[8]>0 -> r[8]-=0, goto 42; check abort flag
-  18              Gosub         16  39   0                          0  ; goto clear accumulator subroutine
-  19              AggStep        0  15  11  sum                     0  accum=r[11] step(r[15])
-  20              AggStep        0  17  12  count                   0  accum=r[12] step(r[17])
-  21              If             7  23   0                          0  if r[7] goto 23; don't emit group columns if continuing existing group
-  22              Column         2   0  10                          0  r[10]=idx_employees_department.department
-  23              Integer        1   7   0                          0  r[7]=1; indicate data in accumulator
-  24            Next             2  10   0                          0
-  25            Gosub            6  29   0                          0  ; emit row for final group
-  26            Goto             0  42   0                          0  ; group by finished
-  27            Integer          1   8   0                          0  r[8]=1
-  28          Return             6   0   0                          0
-  29          IfPos              7  31   0                          0  r[7]>0 -> r[7]-=0, goto 31; output group by row subroutine start
-  30        Return               6   0   0                          0
-  31        AggFinal             0  11   0  sum                     0  accum=r[11]
-  32        AggFinal             0  12   0  count                   0  accum=r[12]
-  33        Copy                11  18   0                          0  r[18]=r[11]
-  34        Copy                10  19   0                          0  r[19]=r[10]
-  35        Copy                12  20   0                          0  r[20]=r[12]
-  36        MakeRecord          18   3   5                          0  r[5]=mkrec(r[18..20])
-  37        SorterInsert         0   5   0  0                       0  key=r[5]
-  38      Return                 6   0   0                          0
-  39      Null                   0  10  12                          0  r[10..12]=NULL; clear accumulator subroutine start
-  40      Integer                0   7   0                          0  r[7]=0
-  41    Return                  16   0   0                          0
-  42    OpenPseudo               3   5   3                          0  3 columns in r[5]
-  43    SorterSort               0  50   0                          0
-  44      SorterData             0   5   3                          0  r[5]=data
-  45      Column                 3   0   2                          0  r[2]=pseudo.column 0
-  46      Column                 3   1   3                          0  r[3]=pseudo.column 1
-  47      Column                 3   2   4                          0  r[4]=pseudo.column 2
-  48      Yield                  1   0   0                          0
-  49    SorterNext               0  44   0                          0
-  50    EndCoroutine             1   0   0                          0
-  51    OpenEphemeral            4   1   0                          0  cursor=4 is_table=true
-  52    OpenDup                  5   4   0                          0  new_cursor=5, original_cursor=4
-  53    Null                     0  30   0                          0  r[30]=NULL
-  54    InitCoroutine            1   0   2                          0
-  55      Yield                  1  68   0                          0
-  56      Copy                   2  33   0                          0  r[33]=r[2]
-  57      NotNull               30  60   0                          0  r[30]!=NULL -> goto 60
-  58      Copy                  33  32   0                          0  r[32]=r[33]; initialize previous peer register for new partition
-  59      Null                   0  25  25                          0  r[25..25]=NULL; reset accumulator registers
-  60      Compare               32  33   1  k(1, Binary)            0  r[32..32]==r[33..33]; compare ORDER BY columns to detect peer
-  61      Jump                  62  64  62                          0
-  62      Gosub                 31  69   0                          0  ; detected non-peer row
-  63      Copy                  33  32   0                          0  r[32]=r[33]
-  64      MakeRecord             2   3  34                          0  r[34]=mkrec(r[2..4])
-  65      NewRowid               5  30   0                          0  r[30]=rowid
-  66      Insert                 5  34  30  buffer_table_window_0   0  intkey=r[30] data=r[34]
-  67    Goto                     0  55   0                          0
-  68    Null                     0  31   0                          0  r[31]=NULL; return remaining buffered rows
-  69    Rewind                   4  81   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  70      Column                 4   1  27                          0  r[27]=ephemeral(buffer_table_window_0).department
-  71      Column                 4   2  28                          0  r[28]=ephemeral(buffer_table_window_0).column 2
-  72      Column                 4   0  29                          0  r[29]=ephemeral(buffer_table_window_0).column 0
-  73      AggStep                0   0  25  row_number              0  accum=r[25] step(r[0])
-  74      AggValue               0  25  26  row_number              0  accum=r[25] dest=r[26]
-  75      Copy                  27  21   0                          0  r[21]=r[27]
-  76      Copy                  28  22   0                          0  r[22]=r[28]
-  77      Copy                  29  23   0                          0  r[23]=r[29]
-  78      Copy                  26  24   0                          0  r[24]=r[26]
-  79      ResultRow             21   4   0                          0  output=r[21..24]
-  80    Next                     4  70   0                          0
-  81    ResetSorter              4   0   0                          0  cursor=4
-  82  Return                    31   0   1                          0
-  83  Halt                       0   0   0                          0
-  84  Transaction                0   1   7                          0  iDb=0 tx_mode=Read
-  85  Integer                    1  17   0                          0  r[17]=1
-  86  Goto                       0   1   0                          0
+addr  opcode                      p1   p2  p3  p4                     p5  comment
+   0              Init             0  102   0                          0  Start at 102
+   1              InitCoroutine    1   51   2                          0
+   2              SorterOpen       0    1   0  k(1,-B)                 0  cursor=0
+   3              Null             0   11  12                          0  r[11..12]=NULL
+   4              Integer          0    8   0                          0  r[8]=0; clear group by abort flag
+   5              Null             0    9   0                          0  r[9]=NULL; initialize group by comparison registers to NULL
+   6              Gosub           16   39   0                          0  ; go to clear accumulator subroutine
+   7              OpenRead         1    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   8              OpenRead         2    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   9              Rewind           2   25   0                          0  Rewind index idx_employees_department
+  10                DeferredSeek   2    1   0                          0
+  11                Column         2    0  14                          0  r[14]=idx_employees_department.department
+  12                Column         1    3  15                          0  r[15]=employees.salary
+  13                Compare        9   14   1  k(1, Binary)            0  r[9..9]==r[14..14]
+  14                Jump          15   19  15                          0  ; start new group if comparison is not equal
+  15                Gosub          6   29   0                          0  ; check if ended group had data, and output if so
+  16                Move          14    9   1                          0  r[9..9]=r[14..14]
+  17                IfPos          8   42   0                          0  r[8]>0 -> r[8]-=0, goto 42; check abort flag
+  18                Gosub         16   39   0                          0  ; goto clear accumulator subroutine
+  19                AggStep        0   15  11  sum                     0  accum=r[11] step(r[15])
+  20                AggStep        0   17  12  count                   0  accum=r[12] step(r[17])
+  21                If             7   23   0                          0  if r[7] goto 23; don't emit group columns if continuing existing group
+  22                Column         2    0  10                          0  r[10]=idx_employees_department.department
+  23                Integer        1    7   0                          0  r[7]=1; indicate data in accumulator
+  24              Next             2   10   0                          0
+  25              Gosub            6   29   0                          0  ; emit row for final group
+  26              Goto             0   42   0                          0  ; group by finished
+  27              Integer          1    8   0                          0  r[8]=1
+  28            Return             6    0   0                          0
+  29            IfPos              7   31   0                          0  r[7]>0 -> r[7]-=0, goto 31; output group by row subroutine start
+  30          Return               6    0   0                          0
+  31          AggFinal             0   11   0  sum                     0  accum=r[11]
+  32          AggFinal             0   12   0  count                   0  accum=r[12]
+  33          Copy                11   18   0                          0  r[18]=r[11]
+  34          Copy                10   19   0                          0  r[19]=r[10]
+  35          Copy                12   20   0                          0  r[20]=r[12]
+  36          MakeRecord          18    3   5                          0  r[5]=mkrec(r[18..20])
+  37          SorterInsert         0    5   0  0                       0  key=r[5]
+  38        Return                 6    0   0                          0
+  39        Null                   0   10  12                          0  r[10..12]=NULL; clear accumulator subroutine start
+  40        Integer                0    7   0                          0  r[7]=0
+  41      Return                  16    0   0                          0
+  42      OpenPseudo               3    5   3                          0  3 columns in r[5]
+  43      SorterSort               0   50   0                          0
+  44        SorterData             0    5   3                          0  r[5]=data
+  45        Column                 3    0   2                          0  r[2]=pseudo.column 0
+  46        Column                 3    1   3                          0  r[3]=pseudo.column 1
+  47        Column                 3    2   4                          0  r[4]=pseudo.column 2
+  48        Yield                  1    0   0                          0
+  49      SorterNext               0   44   0                          0
+  50      EndCoroutine             1    0   0                          0
+  51      OpenEphemeral            4    1   0                          0  cursor=4 is_table=true
+  52      OpenDup                  5    4   0                          0  new_cursor=5, original_cursor=4
+  53      OpenDup                  6    4   0                          0  new_cursor=6, original_cursor=4
+  54      Null                     0   30   0                          0  r[30]=NULL
+  55      InitCoroutine            1    0   2                          0
+  56        Yield                  1   79   0                          0
+  57        Copy                   2   32   0                          0  r[32]=r[2]
+  58        NotNull               30   66   0                          0  r[30]!=NULL -> goto 66
+  59        Null                   0   25  25                          0  r[25..25]=NULL; initialize per-cursor peer-reference registers for new partition
+  60        MakeRecord             2    3  34                          0  r[34]=mkrec(r[2..4])
+  61        NewRowid               5   30   0                          0  r[30]=rowid
+  62        Insert                 5   34  30  buffer_table_window_0   2  intkey=r[30] data=r[34]
+  63        Rewind                 4   65   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  64        Rewind                 6   65   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  65        Goto                   0   78   0                          0
+  66        MakeRecord             2    3  35                          0  r[35]=mkrec(r[2..4])
+  67        NewRowid               5   30   0                          0  r[30]=rowid
+  68        Insert                 5   35  30  buffer_table_window_0   2  intkey=r[30] data=r[35]
+  69        AggStep                0    0  25  row_number              0  accum=r[25] step(r[0])
+  70        Next                   6   71   0                          0
+  71        AggValue               0   25  26  row_number              0  accum=r[25] dest=r[26]
+  72        Column                 4    1  27                          0  r[27]=ephemeral(buffer_table_window_0).department
+  73        Column                 4    2  28                          0  r[28]=ephemeral(buffer_table_window_0).column 2
+  74        Column                 4    0  29                          0  r[29]=ephemeral(buffer_table_window_0).column 0
+  75        Gosub                 33   95   0                          0
+  76        Delete                 4    0   0  buffer_table_window_0   0
+  77        Next                   4   78   0                          0
+  78      Goto                     0   56   0                          0
+  79      Null                     0   31   0                          0  r[31]=NULL; return remaining buffered rows
+  80      Rewind                   5   92   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  81      AggStep                  0    0  25  row_number              0  accum=r[25] step(r[0])
+  82      Next                     6   83   0                          0
+  83      AggValue                 0   25  26  row_number              0  accum=r[25] dest=r[26]
+  84      Column                   4    1  27                          0  r[27]=ephemeral(buffer_table_window_0).department
+  85      Column                   4    2  28                          0  r[28]=ephemeral(buffer_table_window_0).column 2
+  86      Column                   4    0  29                          0  r[29]=ephemeral(buffer_table_window_0).column 0
+  87      Gosub                   33   95   0                          0
+  88      Delete                   4    0   0  buffer_table_window_0   0
+  89      Next                     4   91   0                          0
+  90      Goto                     0   92   0                          0
+  91      Goto                     0   83   0                          0
+  92      ResetSorter              4    0   0                          0  cursor=4
+  93    Return                    31    0   1                          0
+  94    Goto                       0  101   0                          0
+  95    Copy                      27   21   0                          0  r[21]=r[27]
+  96    Copy                      28   22   0                          0  r[22]=r[28]
+  97    Copy                      29   23   0                          0  r[23]=r[29]
+  98    Copy                      26   24   0                          0  r[24]=r[26]
+  99    ResultRow                 21    4   0                          0  output=r[21..24]
+ 100  Return                      33    0   0                          0
+ 101  Halt                         0    0   0                          0
+ 102  Transaction                  0    1   7                          0  iDb=0 tx_mode=Read
+ 103  Integer                      1   17   0                          0  r[17]=1
+ 104  Goto                         0    1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
@@ -34,123 +34,176 @@ QUERY PLAN
    `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode              p1   p2  p3  p4                     p5  comment
-   0      Init             0  117   0                          0  Start at 117
-   1      InitCoroutine    1   77   2                          0
-   2      InitCoroutine    2   51   3                          0
-   3      InitCoroutine    3   15   4                          0
-   4      OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   5      OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
-   6      Rewind           1   14   0                          0  Rewind index idx_employees_department
-   7        DeferredSeek   1    0   0                          0
-   8        Column         1    0   4                          0  r[4]=idx_employees_department.department
-   9        IdxRowId       1    5   0                          0  r[5]=cursor 1 for index idx_employees_department.rowid
-  10        Column         0    1   6                          0  r[6]=employees.name
-  11        Column         0    3   7                          0  r[7]=employees.salary
-  12        Yield          3    0   0                          0
-  13      Next             1    7   0                          0
-  14      EndCoroutine     3    0   0                          0
-  15      OpenEphemeral    2    1   0                          0  cursor=2 is_table=true
-  16      OpenDup          3    2   0                          0  new_cursor=3, original_cursor=2
-  17      Null             0   19   0                          0  r[19]=NULL
-  18      Null             0   20   0                          0  r[20]=NULL
-  19      InitCoroutine    3    0   4                          0
-  20        Yield          3   34   0                          0
-  21        Compare        4   20   1  k(1, Binary)            0  r[4..4]==r[20..20]; compare partition keys to detect new partition
-  22        Jump          23   26  23                          0
-  23        Gosub         21   35   0                          0  ; detected new partition
-  24        Null           0   19   0                          0  r[19]=NULL
-  25        Copy           4   20   0                          0  r[20]=r[4]
-  26        NotNull       19   28   0                          0  r[19]!=NULL -> goto 28
-  27        Null           0   13  13                          0  r[13..13]=NULL; reset accumulator registers
-  28        MakeRecord     4    4  22                          0  r[22]=mkrec(r[4..7])
-  29        NewRowid       3   19   0                          0  r[19]=rowid
-  30        Insert         3   22  19  buffer_table_window_0   0  intkey=r[19] data=r[22]
-  31        Copy           7   23   0                          0  r[23]=r[7]
-  32        AggStep        0   23  13  avg                     0  accum=r[13] step(r[23])
-  33      Goto             0   20   0                          0
-  34      Null             0   21   0                          0  r[21]=NULL; return remaining buffered rows
-  35      Rewind           2   48   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  36      AggValue         0   13  14  avg                     0  accum=r[13] dest=r[14]
-  37        Column         2    1  15                          0  r[15]=ephemeral(buffer_table_window_0).emp_id
-  38        Column         2    2  16                          0  r[16]=ephemeral(buffer_table_window_0).name
-  39        Column         2    0  17                          0  r[17]=ephemeral(buffer_table_window_0).department
-  40        Column         2    3  18                          0  r[18]=ephemeral(buffer_table_window_0).salary
-  41        Copy          15    8   0                          0  r[8]=r[15]
-  42        Copy          16    9   0                          0  r[9]=r[16]
-  43        Copy          17   10   0                          0  r[10]=r[17]
-  44        Copy          18   11   0                          0  r[11]=r[18]
-  45        Copy          14   12   0                          0  r[12]=r[14]
-  46        Yield          2    0   0                          0
-  47      Next             2   37   0                          0
-  48      ResetSorter      2    0   0                          0  cursor=2
-  49    Return            21    0   1                          0
-  50    EndCoroutine       2    0   0                          0
-  51    SorterOpen         4    1   0  k(1,-B)                 0  cursor=4
-  52    InitCoroutine      2    0   3                          0
-  53      Yield            2   65   0                          0
-  54      Copy            11   37   0                          0  r[37]=r[11]
-  55      Copy            12   38   0                          0  r[38]=r[12]
-  56      Subtract        37   38  31                          0  r[31]=r[37]-r[38]
-  57      Copy             8   32   0                          0  r[32]=r[8]
-  58      Copy             9   33   0                          0  r[33]=r[9]
-  59      Copy            10   34   0                          0  r[34]=r[10]
-  60      Copy            11   35   0                          0  r[35]=r[11]
-  61      Copy            12   36   0                          0  r[36]=r[12]
-  62      MakeRecord      31    6  30                          0  r[30]=mkrec(r[31..36])
-  63      SorterInsert     4   30   0  0                       0  key=r[30]
-  64    Goto               0   53   0                          0
-  65    OpenPseudo         5   30   6                          0  6 columns in r[30]
-  66    SorterSort         4   76   0                          0
-  67      SorterData       4   30   5                          0  r[30]=data
-  68      Column           5    0  24                          0  r[24]=pseudo.column 0
-  69      Column           5    1  25                          0  r[25]=pseudo.column 1
-  70      Column           5    2  26                          0  r[26]=pseudo.column 2
-  71      Column           5    3  27                          0  r[27]=pseudo.column 3
-  72      Column           5    4  28                          0  r[28]=pseudo.column 4
-  73      Column           5    5  29                          0  r[29]=pseudo.column 5
-  74      Yield            1    0   0                          0
-  75    SorterNext         4   67   0                          0
-  76    EndCoroutine       1    0   0                          0
-  77    OpenEphemeral      6    1   0                          0  cursor=6 is_table=true
-  78    OpenDup            7    6   0                          0  new_cursor=7, original_cursor=6
-  79    Null               0   53   0                          0  r[53]=NULL
-  80    InitCoroutine      1    0   2                          0
-  81      Yield            1   94   0                          0
-  82      Copy            24   56   0                          0  r[56]=r[24]
-  83      NotNull         53   86   0                          0  r[53]!=NULL -> goto 86
-  84      Copy            56   55   0                          0  r[55]=r[56]; initialize previous peer register for new partition
-  85      Null             0   46  46                          0  r[46..46]=NULL; reset accumulator registers
-  86      Compare         55   56   1  k(1, Binary)            0  r[55..55]==r[56..56]; compare ORDER BY columns to detect peer
-  87      Jump            88   90  88                          0
-  88      Gosub           54   95   0                          0  ; detected non-peer row
-  89      Copy            56   55   0                          0  r[55]=r[56]
-  90      MakeRecord      24    6  57                          0  r[57]=mkrec(r[24..29])
-  91      NewRowid         7   53   0                          0  r[53]=rowid
-  92      Insert           7   57  53  buffer_table_window_0   0  intkey=r[53] data=r[57]
-  93    Goto               0   81   0                          0
-  94    Null               0   54   0                          0  r[54]=NULL; return remaining buffered rows
-  95    Rewind             6  114   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  96      Column           6    1  48                          0  r[48]=ephemeral(buffer_table_window_0).emp_id
-  97      Column           6    2  49                          0  r[49]=ephemeral(buffer_table_window_0).name
-  98      Column           6    3  50                          0  r[50]=ephemeral(buffer_table_window_0).department
-  99      Column           6    4  51                          0  r[51]=ephemeral(buffer_table_window_0).salary
- 100      Column           6    5  52                          0  r[52]=ephemeral(buffer_table_window_0).dept_avg
- 101      AggStep          0    0  46  row_number              0  accum=r[46] step(r[0])
- 102      AggValue         0   46  47  row_number              0  accum=r[46] dest=r[47]
- 103      Copy            48   39   0                          0  r[39]=r[48]
- 104      Copy            49   40   0                          0  r[40]=r[49]
- 105      Copy            50   41   0                          0  r[41]=r[50]
- 106      Copy            51   42   0                          0  r[42]=r[51]
- 107      Copy            52   43   0                          0  r[43]=r[52]
- 108      Copy            51   58   0                          0  r[58]=r[51]
- 109      Copy            52   59   0                          0  r[59]=r[52]
- 110      Subtract        58   59  44                          0  r[44]=r[58]-r[59]
- 111      Copy            47   45   0                          0  r[45]=r[47]
- 112      ResultRow       39    7   0                          0  output=r[39..45]
- 113    Next               6   96   0                          0
- 114    ResetSorter        6    0   0                          0  cursor=6
- 115  Return              54    0   1                          0
- 116  Halt                 0    0   0                          0
- 117  Transaction          0    1   7                          0  iDb=0 tx_mode=Read
- 118  Goto                 0    1   0                          0
+addr  opcode                  p1   p2  p3  p4                     p5  comment
+   0          Init             0  170   0                          0  Start at 170
+   1          InitCoroutine    1  110   2                          0
+   2          InitCoroutine    2   84   3                          0
+   3          InitCoroutine    3   15   4                          0
+   4          OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   5          OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   6          Rewind           1   14   0                          0  Rewind index idx_employees_department
+   7            DeferredSeek   1    0   0                          0
+   8            Column         1    0   4                          0  r[4]=idx_employees_department.department
+   9            IdxRowId       1    5   0                          0  r[5]=cursor 1 for index idx_employees_department.rowid
+  10            Column         0    1   6                          0  r[6]=employees.name
+  11            Column         0    3   7                          0  r[7]=employees.salary
+  12            Yield          3    0   0                          0
+  13          Next             1    7   0                          0
+  14          EndCoroutine     3    0   0                          0
+  15          OpenEphemeral    2    1   0                          0  cursor=2 is_table=true
+  16          OpenDup          3    2   0                          0  new_cursor=3, original_cursor=2
+  17          OpenDup          4    2   0                          0  new_cursor=4, original_cursor=2
+  18          Null             0   19   0                          0  r[19]=NULL
+  19          Null             0   20   0                          0  r[20]=NULL
+  20          InitCoroutine    3    0   4                          0
+  21            Yield          3   55   0                          0
+  22            Compare        4   20   1  k(1, Binary)            0  r[4..4]==r[20..20]; compare partition keys to detect new partition
+  23            Jump          24   27  24                          0
+  24            Gosub         21   56   0                          0  ; detected new partition
+  25            Null           0   19   0                          0  r[19]=NULL
+  26            Copy           4   20   0                          0  r[20]=r[4]
+  27            NotNull       19   35   0                          0  r[19]!=NULL -> goto 35
+  28            Null           0   13  13                          0  r[13..13]=NULL; reset accumulator registers
+  29            MakeRecord     4    4  23                          0  r[23]=mkrec(r[4..7])
+  30            NewRowid       3   19   0                          0  r[19]=rowid
+  31            Insert         3   23  19  buffer_table_window_0   2  intkey=r[19] data=r[23]
+  32            Rewind         2   34   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  33            Rewind         4   34   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  34            Goto           0   54   0                          0
+  35            MakeRecord     4    4  24                          0  r[24]=mkrec(r[4..7])
+  36            NewRowid       3   19   0                          0  r[19]=rowid
+  37            Insert         3   24  19  buffer_table_window_0   2  intkey=r[19] data=r[24]
+  38            Goto           0   54   0                          0
+  39            Column         4    3  25                          0  r[25]=ephemeral(buffer_table_window_0).salary
+  40            AggStep        0   25  13  avg                     0  accum=r[13] step(r[25])
+  41            Next           4   43   0                          0
+  42            Goto           0   44   0                          0
+  43            Goto           0   39   0                          0
+  44            AggValue       0   13  14  avg                     0  accum=r[13] dest=r[14]
+  45            Column         2    1  15                          0  r[15]=ephemeral(buffer_table_window_0).emp_id
+  46            Column         2    2  16                          0  r[16]=ephemeral(buffer_table_window_0).name
+  47            Column         2    0  17                          0  r[17]=ephemeral(buffer_table_window_0).department
+  48            Column         2    3  18                          0  r[18]=ephemeral(buffer_table_window_0).salary
+  49            Gosub         22   76   0                          0
+  50            Delete         2    0   0  buffer_table_window_0   0
+  51            Next           2   53   0                          0
+  52            Goto           0   54   0                          0
+  53            Goto           0   45   0                          0
+  54          Goto             0   21   0                          0
+  55          Null             0   21   0                          0  r[21]=NULL; return remaining buffered rows
+  56          Rewind           3   73   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  57          Column           4    3  26                          0  r[26]=ephemeral(buffer_table_window_0).salary
+  58          AggStep          0   26  13  avg                     0  accum=r[13] step(r[26])
+  59          Next             4   61   0                          0
+  60          Goto             0   62   0                          0
+  61          Goto             0   57   0                          0
+  62          AggValue         0   13  14  avg                     0  accum=r[13] dest=r[14]
+  63          Column           2    1  15                          0  r[15]=ephemeral(buffer_table_window_0).emp_id
+  64          Column           2    2  16                          0  r[16]=ephemeral(buffer_table_window_0).name
+  65          Column           2    0  17                          0  r[17]=ephemeral(buffer_table_window_0).department
+  66          Column           2    3  18                          0  r[18]=ephemeral(buffer_table_window_0).salary
+  67          Gosub           22   76   0                          0
+  68          Delete           2    0   0  buffer_table_window_0   0
+  69          Next             2   71   0                          0
+  70          Goto             0   73   0                          0
+  71          Goto             0   63   0                          0
+  72          Goto             0   62   0                          0
+  73          ResetSorter      2    0   0                          0  cursor=2
+  74        Return            21    0   1                          0
+  75        Goto               0   83   0                          0
+  76        Copy              15    8   0                          0  r[8]=r[15]
+  77        Copy              16    9   0                          0  r[9]=r[16]
+  78        Copy              17   10   0                          0  r[10]=r[17]
+  79        Copy              18   11   0                          0  r[11]=r[18]
+  80        Copy              14   12   0                          0  r[12]=r[14]
+  81        Yield              2    0   0                          0
+  82      Return              22    0   0                          0
+  83      EndCoroutine         2    0   0                          0
+  84      SorterOpen           5    1   0  k(1,-B)                 0  cursor=5
+  85      InitCoroutine        2    0   3                          0
+  86        Yield              2   98   0                          0
+  87        Copy              11   40   0                          0  r[40]=r[11]
+  88        Copy              12   41   0                          0  r[41]=r[12]
+  89        Subtract          40   41  34                          0  r[34]=r[40]-r[41]
+  90        Copy               8   35   0                          0  r[35]=r[8]
+  91        Copy               9   36   0                          0  r[36]=r[9]
+  92        Copy              10   37   0                          0  r[37]=r[10]
+  93        Copy              11   38   0                          0  r[38]=r[11]
+  94        Copy              12   39   0                          0  r[39]=r[12]
+  95        MakeRecord        34    6  33                          0  r[33]=mkrec(r[34..39])
+  96        SorterInsert       5   33   0  0                       0  key=r[33]
+  97      Goto                 0   86   0                          0
+  98      OpenPseudo           6   33   6                          0  6 columns in r[33]
+  99      SorterSort           5  109   0                          0
+ 100        SorterData         5   33   6                          0  r[33]=data
+ 101        Column             6    0  27                          0  r[27]=pseudo.column 0
+ 102        Column             6    1  28                          0  r[28]=pseudo.column 1
+ 103        Column             6    2  29                          0  r[29]=pseudo.column 2
+ 104        Column             6    3  30                          0  r[30]=pseudo.column 3
+ 105        Column             6    4  31                          0  r[31]=pseudo.column 4
+ 106        Column             6    5  32                          0  r[32]=pseudo.column 5
+ 107        Yield              1    0   0                          0
+ 108      SorterNext           5  100   0                          0
+ 109      EndCoroutine         1    0   0                          0
+ 110      OpenEphemeral        7    1   0                          0  cursor=7 is_table=true
+ 111      OpenDup              8    7   0                          0  new_cursor=8, original_cursor=7
+ 112      OpenDup              9    7   0                          0  new_cursor=9, original_cursor=7
+ 113      Null                 0   56   0                          0  r[56]=NULL
+ 114      InitCoroutine        1    0   2                          0
+ 115        Yield              1  140   0                          0
+ 116        Copy              27   58   0                          0  r[58]=r[27]
+ 117        NotNull           56  125   0                          0  r[56]!=NULL -> goto 125
+ 118        Null               0   49  49                          0  r[49..49]=NULL; initialize per-cursor peer-reference registers for new partition
+ 119        MakeRecord        27    6  60                          0  r[60]=mkrec(r[27..32])
+ 120        NewRowid           8   56   0                          0  r[56]=rowid
+ 121        Insert             8   60  56  buffer_table_window_0   2  intkey=r[56] data=r[60]
+ 122        Rewind             7  124   0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 123        Rewind             9  124   0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 124        Goto               0  139   0                          0
+ 125        MakeRecord        27    6  61                          0  r[61]=mkrec(r[27..32])
+ 126        NewRowid           8   56   0                          0  r[56]=rowid
+ 127        Insert             8   61  56  buffer_table_window_0   2  intkey=r[56] data=r[61]
+ 128        AggStep            0    0  49  row_number              0  accum=r[49] step(r[0])
+ 129        Next               9  130   0                          0
+ 130        AggValue           0   49  50  row_number              0  accum=r[49] dest=r[50]
+ 131        Column             7    1  51                          0  r[51]=ephemeral(buffer_table_window_0).emp_id
+ 132        Column             7    2  52                          0  r[52]=ephemeral(buffer_table_window_0).name
+ 133        Column             7    3  53                          0  r[53]=ephemeral(buffer_table_window_0).department
+ 134        Column             7    4  54                          0  r[54]=ephemeral(buffer_table_window_0).salary
+ 135        Column             7    5  55                          0  r[55]=ephemeral(buffer_table_window_0).dept_avg
+ 136        Gosub             59  158   0                          0
+ 137        Delete             7    0   0  buffer_table_window_0   0
+ 138        Next               7  139   0                          0
+ 139      Goto                 0  115   0                          0
+ 140      Null                 0   57   0                          0  r[57]=NULL; return remaining buffered rows
+ 141      Rewind               8  155   0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 142      AggStep              0    0  49  row_number              0  accum=r[49] step(r[0])
+ 143      Next                 9  144   0                          0
+ 144      AggValue             0   49  50  row_number              0  accum=r[49] dest=r[50]
+ 145      Column               7    1  51                          0  r[51]=ephemeral(buffer_table_window_0).emp_id
+ 146      Column               7    2  52                          0  r[52]=ephemeral(buffer_table_window_0).name
+ 147      Column               7    3  53                          0  r[53]=ephemeral(buffer_table_window_0).department
+ 148      Column               7    4  54                          0  r[54]=ephemeral(buffer_table_window_0).salary
+ 149      Column               7    5  55                          0  r[55]=ephemeral(buffer_table_window_0).dept_avg
+ 150      Gosub               59  158   0                          0
+ 151      Delete               7    0   0  buffer_table_window_0   0
+ 152      Next                 7  154   0                          0
+ 153      Goto                 0  155   0                          0
+ 154      Goto                 0  144   0                          0
+ 155      ResetSorter          7    0   0                          0  cursor=7
+ 156    Return                57    0   1                          0
+ 157    Goto                   0  169   0                          0
+ 158    Copy                  51   42   0                          0  r[42]=r[51]
+ 159    Copy                  52   43   0                          0  r[43]=r[52]
+ 160    Copy                  53   44   0                          0  r[44]=r[53]
+ 161    Copy                  54   45   0                          0  r[45]=r[54]
+ 162    Copy                  55   46   0                          0  r[46]=r[55]
+ 163    Copy                  54   62   0                          0  r[62]=r[54]
+ 164    Copy                  55   63   0                          0  r[63]=r[55]
+ 165    Subtract              62   63  47                          0  r[47]=r[62]-r[63]
+ 166    Copy                  50   48   0                          0  r[48]=r[50]
+ 167    ResultRow             42    7   0                          0  output=r[42..48]
+ 168  Return                  59    0   0                          0
+ 169  Halt                     0    0   0                          0
+ 170  Transaction              0    1   7                          0  iDb=0 tx_mode=Read
+ 171  Goto                     0    1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/window/distinct.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/distinct.sqltest
@@ -1,0 +1,118 @@
+@database :memory:
+
+# SELECT DISTINCT over window functions. The row-output code (result-row /
+# sorter insert / dedup check) is emitted once as a shared subroutine that
+# every RETURN_ROW site Gosubs to. With the output code instead inlined per
+# site, the DISTINCT on-conflict label can only resolve to one of the
+# sites, so a duplicate detected at any other site jumps into unrelated
+# code — dropping rows or re-reading consumed accumulators.
+
+setup wd_base {
+    CREATE TABLE t (x INTEGER);
+    INSERT INTO t VALUES (1),(1),(2);
+}
+
+# rank's AggValue is take-and-reset (matches SQLite's rankValueFunc), so a
+# stray second read after a mis-targeted conflict jump used to surface as a
+# literal 0 in the output.
+@setup wd_base
+test distinct-rank {
+    SELECT DISTINCT rank() OVER (ORDER BY x) FROM t;
+}
+expect {
+    1
+    3
+}
+
+@setup wd_base
+test distinct-dense-rank {
+    SELECT DISTINCT dense_rank() OVER (ORDER BY x) FROM t;
+}
+expect {
+    1
+    2
+}
+
+# All rows distinct: nothing may be dropped.
+@setup wd_base
+test distinct-row-number {
+    SELECT DISTINCT row_number() OVER (ORDER BY x) FROM t;
+}
+expect {
+    1
+    2
+    3
+}
+
+# Aggregate window function: peers share a value, so the second peer row is
+# a genuine duplicate that must be skipped without derailing the flush.
+@setup wd_base
+test distinct-agg-window {
+    SELECT DISTINCT sum(x) OVER (ORDER BY x) FROM t;
+}
+expect {
+    2
+    4
+}
+
+setup wd_part {
+    CREATE TABLE t (p INTEGER, x INTEGER);
+    INSERT INTO t VALUES (1,1),(1,1),(1,2),(2,1),(2,1),(2,3);
+}
+
+# Duplicates recur across partition boundaries, so conflicts fire from both
+# the streaming site and the partition-boundary flush site.
+@setup wd_part
+test distinct-across-partitions {
+    SELECT DISTINCT dense_rank() OVER (PARTITION BY p ORDER BY x) FROM t;
+}
+expect {
+    1
+    2
+}
+
+@setup wd_part
+test distinct-multi-column {
+    SELECT DISTINCT p, rank() OVER (PARTITION BY p ORDER BY x) FROM t;
+}
+expect {
+    1|1
+    1|3
+    2|1
+    2|3
+}
+
+# Outer ORDER BY routes the deduplicated rows through the sorter instead of
+# directly to the result row.
+@setup wd_base
+test distinct-with-order-by {
+    SELECT DISTINCT rank() OVER (ORDER BY x) r FROM t ORDER BY r DESC;
+}
+expect {
+    3
+    1
+}
+
+setup wd_five {
+    CREATE TABLE t (x INTEGER);
+    INSERT INTO t VALUES (1),(1),(2),(2),(3);
+}
+
+# OFFSET/LIMIT count deduplicated rows, not source rows.
+@setup wd_five
+test distinct-limit-offset {
+    SELECT DISTINCT rank() OVER (ORDER BY x) FROM t LIMIT 2 OFFSET 1;
+}
+expect {
+    3
+    5
+}
+
+@setup wd_base
+test distinct-first-value {
+    SELECT DISTINCT first_value(x) OVER (ORDER BY x), last_value(x) OVER (ORDER BY x) FROM t;
+}
+expect {
+    1|1
+    1|2
+}

--- a/sqlite/conformance/sqlite-sqltests/window/lag_lead.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/lag_lead.sqltest
@@ -1,0 +1,655 @@
+@database :memory:
+
+# lag() and lead() — the lookup-style window functions. Implemented as
+# WINDOWFUNCNOOP in SQLite (window.c:591): no per-row step accumulator,
+# the result is computed at output time via a SeekRowid on a per-window
+# app cursor that's OpenDup'd off csr_current.
+
+setup vals {
+    CREATE TABLE v(x INTEGER);
+    INSERT INTO v VALUES (1),(2),(3),(4),(5);
+}
+
+@setup vals
+test lag-default-offset {
+    SELECT x, lag(x) OVER (ORDER BY x) FROM v;
+}
+expect {
+    1|
+    2|1
+    3|2
+    4|3
+    5|4
+}
+
+@setup vals
+test lead-default-offset {
+    SELECT x, lead(x) OVER (ORDER BY x) FROM v;
+}
+expect {
+    1|2
+    2|3
+    3|4
+    4|5
+    5|
+}
+
+@setup vals
+test lag-offset-2 {
+    SELECT x, lag(x, 2) OVER (ORDER BY x) FROM v;
+}
+expect {
+    1|
+    2|
+    3|1
+    4|2
+    5|3
+}
+
+@setup vals
+test lead-offset-2-with-default {
+    SELECT x, lead(x, 2, -1) OVER (ORDER BY x) FROM v;
+}
+expect {
+    1|3
+    2|4
+    3|5
+    4|-1
+    5|-1
+}
+
+@setup vals
+test lag-zero-offset {
+    SELECT x, lag(x, 0) OVER (ORDER BY x) FROM v;
+}
+expect {
+    1|1
+    2|2
+    3|3
+    4|4
+    5|5
+}
+
+setup parts {
+    CREATE TABLE p(g TEXT, x INTEGER);
+    INSERT INTO p VALUES ('a',1),('a',2),('a',3),('b',10),('b',20);
+}
+
+# Partition boundary resets the lookahead/lookback to NULL — lag/lead
+# can't cross the partition.
+@setup parts
+test lag-lead-partition-boundary {
+    SELECT g, x,
+           lag(x) OVER (PARTITION BY g ORDER BY x),
+           lead(x) OVER (PARTITION BY g ORDER BY x)
+    FROM p;
+}
+expect {
+    a|1||2
+    a|2|1|3
+    a|3|2|
+    b|10||20
+    b|20|10|
+}
+
+# Combination cases that the previous dual-mode emitter rejected because
+# rank() emitted per source row while lag() needed a buffered partition.
+# Under per-function coerced frames each function sees its own frame view,
+# so rank() + lag() and sum() + lead() compile cleanly.
+@setup vals
+test rank-with-lag {
+    SELECT x,
+           rank() OVER (ORDER BY x),
+           lag(x) OVER (ORDER BY x)
+    FROM v;
+}
+expect {
+    1|1|
+    2|2|1
+    3|3|2
+    4|4|3
+    5|5|4
+}
+
+@setup vals
+test sum-with-lead {
+    SELECT x,
+           sum(x) OVER (ORDER BY x),
+           lead(x) OVER (ORDER BY x)
+    FROM v;
+}
+expect {
+    1|1|2
+    2|3|3
+    3|6|4
+    4|10|5
+    5|15|
+}
+
+# 3-arg form: the default value can itself be an expression (here a
+# column reference computed in the source subquery).
+@setup vals
+test lag-default-is-column-expr {
+    SELECT x, lag(x, 1, x * 10) OVER (ORDER BY x) FROM v;
+}
+expect {
+    1|10
+    2|1
+    3|2
+    4|3
+    5|4
+}
+
+# Descending ORDER BY: csr_current still traverses in rowid (insertion)
+# order, which matches the sorted order — so lag still looks at the
+# previous-in-sort row.
+setup vals_8 {
+    CREATE TABLE v8(a INTEGER, b INTEGER);
+    INSERT INTO v8 VALUES (1,10),(2,20),(3,30),(4,40),(5,50),(6,60),(7,70),(8,80);
+}
+
+@setup vals_8
+test lag-lead-mixed-orders {
+    SELECT a,
+           lag(b, 2, -99) OVER (ORDER BY a),
+           lead(b * 2) OVER (ORDER BY a DESC)
+    FROM v8;
+}
+expect {
+    1|-99|
+    2|-99|20
+    3|10|40
+    4|20|60
+    5|30|80
+    6|40|100
+    7|50|120
+    8|60|140
+}
+
+# lag in a subquery feeding an outer aggregate. Exercises that the
+# window-function result register lives long enough to be read by the
+# outer aggregator.
+setup vals_20 {
+    CREATE TABLE v20(x INTEGER);
+    INSERT INTO v20 VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),
+        (11),(12),(13),(14),(15),(16),(17),(18),(19),(20);
+}
+
+@setup vals_20
+test lag-in-subquery-aggregate {
+    SELECT count(*), sum(diff)
+    FROM (SELECT x, x - lag(x) OVER (ORDER BY x) AS diff FROM v20);
+}
+expect {
+    20|19
+}
+
+# NULL values flow through unchanged; missing-default still returns NULL.
+setup nulls_mix {
+    CREATE TABLE m(x INTEGER);
+    INSERT INTO m VALUES (1),(NULL),(3),(NULL),(5);
+}
+
+@setup nulls_mix
+test lag-lead-nulls-in-source {
+    SELECT x, lag(x) OVER (ORDER BY rowid), lead(x) OVER (ORDER BY rowid) FROM m;
+}
+expect {
+    1||
+    |1|3
+    3||
+    |3|5
+    5||
+}
+
+# Offset > partition size → every row falls back to the default.
+@setup vals
+test lag-lead-large-offset {
+    SELECT lag(x, 100) OVER (ORDER BY x),
+           lead(x, 100, -1) OVER (ORDER BY x)
+    FROM v;
+}
+expect {
+    |-1
+    |-1
+    |-1
+    |-1
+    |-1
+}
+
+# A negative lead offset looks backward and always finds its target (the
+# whole prefix is buffered). A negative lag offset looks forward: SQLite
+# emits row i as soon as row i+1 is buffered, so lag(x, -1) finds the next
+# row but any farther forward lookup misses. Verified against sqlite3.
+@setup vals
+test lag-lead-negative-offset {
+    SELECT x,
+           lag(x, -1) OVER (ORDER BY x),
+           lead(x, -1) OVER (ORDER BY x)
+    FROM v;
+}
+expect {
+    1|2|
+    2|3|1
+    3|4|2
+    4|5|3
+    5||4
+}
+
+# lag with a forward lookup farther than one row always misses under the
+# streaming frame — only row i+1 is buffered when row i is emitted, so
+# lag(x, -3) is NULL everywhere. lead's backward lookup still resolves.
+# Verified against sqlite3.
+@setup vals
+test lag-lead-negative-offset-multi {
+    SELECT x,
+           lag(x, -3) OVER (ORDER BY x),
+           lead(x, -3) OVER (ORDER BY x)
+    FROM v;
+}
+expect {
+    1||
+    2||
+    3||
+    4||1
+    5||2
+}
+
+# Zero offset returns the current row unchanged. Default arg is ignored.
+@setup vals
+test lag-lead-zero-offset-with-default {
+    SELECT lag(x, 0, 999) OVER (ORDER BY x),
+           lead(x, 0, 999) OVER (ORDER BY x)
+    FROM v;
+}
+expect {
+    1|1
+    2|2
+    3|3
+    4|4
+    5|5
+}
+
+# Default arg can have a different type than the value being returned.
+@setup vals
+test lag-default-type-mix {
+    SELECT lag(x, 5, 'def') OVER (ORDER BY x),
+           lag(x, 5, 99) OVER (ORDER BY x),
+           lag(x, 5, NULL) OVER (ORDER BY x)
+    FROM v;
+}
+expect {
+    def|99|
+    def|99|
+    def|99|
+    def|99|
+    def|99|
+}
+
+# Single-row partition: no neighbor in either direction.
+setup single_row_partitions {
+    CREATE TABLE s(g INTEGER, x INTEGER);
+    INSERT INTO s VALUES (1,1),(2,1),(3,1);
+}
+
+@setup single_row_partitions
+test lag-lead-single-row-partition {
+    SELECT g, lag(x) OVER (PARTITION BY g ORDER BY x),
+              lead(x) OVER (PARTITION BY g ORDER BY x)
+    FROM s;
+}
+expect {
+    1||
+    2||
+    3||
+}
+
+# Empty input: no rows out.
+setup empty {
+    CREATE TABLE e(x INTEGER);
+}
+
+@setup empty
+test lag-lead-empty-input {
+    SELECT x, lag(x) OVER (ORDER BY x), lead(x) OVER (ORDER BY x) FROM e;
+}
+expect {
+}
+
+# Multi-column ORDER BY: peers of (a) are split apart by b.
+setup multi_order {
+    CREATE TABLE mc(a INTEGER, b INTEGER);
+    INSERT INTO mc VALUES (1,10),(2,20),(2,30),(2,40),(3,50);
+}
+
+@setup multi_order
+test lag-lead-multi-column-order {
+    SELECT a, b,
+           lag(b) OVER (ORDER BY a, b),
+           lead(b) OVER (ORDER BY a, b)
+    FROM mc;
+}
+expect {
+    1|10||20
+    2|20|10|30
+    2|30|20|40
+    2|40|30|50
+    3|50|40|
+}
+
+# OVER () — no PARTITION, no ORDER BY. The partition is the whole table;
+# the order is the source insertion order.
+@setup vals
+test lag-lead-over-empty {
+    SELECT lag(x) OVER (), lead(x) OVER () FROM v;
+}
+expect {
+    |2
+    1|3
+    2|4
+    3|5
+    4|
+}
+
+# Per-row dynamic offset.
+@setup vals
+test lag-dynamic-offset {
+    SELECT x, lag(x, x) OVER (ORDER BY x) FROM v;
+}
+expect {
+    1|
+    2|
+    3|
+    4|
+    5|
+}
+
+# NULL partition keys group together as their own partition.
+setup null_partition {
+    CREATE TABLE np(g TEXT, x INTEGER);
+    INSERT INTO np VALUES ('a',1),('a',2),(NULL,3),(NULL,4),('a',5);
+}
+
+@setup null_partition
+test lag-with-null-partition {
+    SELECT g, x, lag(x) OVER (PARTITION BY g ORDER BY x) FROM np;
+}
+expect {
+    |3|
+    |4|3
+    a|1|
+    a|2|1
+    a|5|2
+}
+
+# lag on the result of an aggregate after GROUP BY.
+setup grouped {
+    CREATE TABLE g(x INTEGER);
+    INSERT INTO g VALUES (1),(1),(2),(2),(3);
+}
+
+@setup grouped
+test lag-on-grouped-aggregate {
+    SELECT x, count(*), lag(count(*)) OVER (ORDER BY x)
+    FROM g GROUP BY x;
+}
+expect {
+    1|2|
+    2|2|2
+    3|1|2
+}
+
+# Mixed in a single SELECT with rank() and dense_rank() — the cases the
+# old dual-mode emitter rejected.
+@setup vals
+test lag-lead-mixed-with-rank-funcs {
+    SELECT lag(x) OVER (ORDER BY x),
+           rank() OVER (ORDER BY x),
+           dense_rank() OVER (ORDER BY x),
+           row_number() OVER (ORDER BY x),
+           lead(x) OVER (ORDER BY x)
+    FROM v;
+}
+expect {
+    |1|1|1|2
+    1|2|2|2|3
+    2|3|3|3|4
+    3|4|4|4|5
+    4|5|5|5|
+}
+
+# Mixed with first_value / last_value / nth_value in one SELECT — all
+# four functions coerce to compatible frames (UP→CURRENT) so they share
+# one ephemeral.
+@setup vals
+test lag-lead-mixed-with-value-funcs {
+    SELECT x,
+           first_value(x) OVER (ORDER BY x),
+           lag(x) OVER (ORDER BY x),
+           lead(x) OVER (ORDER BY x),
+           last_value(x) OVER (ORDER BY x),
+           nth_value(x, 2) OVER (ORDER BY x)
+    FROM v;
+}
+expect {
+    1|1||2|1|
+    2|1|1|3|2|2
+    3|1|2|4|3|2
+    4|1|3|5|4|2
+    5|1|4||5|2
+}
+
+# Two windows in one SELECT — one ascending, one descending. Each gets
+# its own ephemeral pass.
+@setup vals
+test lag-lead-distinct-windows {
+    SELECT lag(x) OVER w1, lead(x) OVER w2
+    FROM v
+    WINDOW w1 AS (ORDER BY x), w2 AS (ORDER BY x DESC);
+}
+expect {
+    |
+    1|1
+    2|2
+    3|3
+    4|4
+}
+
+# Arithmetic combining lag and lead in the same expression.
+@setup vals
+test lag-lead-arithmetic {
+    SELECT (lag(x, 1, 0) OVER (ORDER BY x))
+         + (lead(x, 1, 0) OVER (ORDER BY x))
+    FROM v;
+}
+expect {
+    2
+    4
+    6
+    8
+    4
+}
+
+# Non-integer offsets: SQLite truncates a lossless float to an integer.
+# 1.0 is fine; 1.5 is a parse error per SQLite (we match).
+@setup vals
+test lag-float-offset-lossless {
+    SELECT lag(x, 1.0) OVER (ORDER BY x) FROM v;
+}
+expect {
+
+    1
+    2
+    3
+    4
+}
+
+# Self-join with lag — exercises both the row-multiplication and the
+# fact that lag's lookup cursor (csr_app) must traverse the buffered
+# partition independently from csr_current.
+setup tiny_t {
+    CREATE TABLE t(x INTEGER);
+    INSERT INTO t VALUES (1),(2),(3);
+}
+
+@setup tiny_t
+test lag-with-self-join {
+    SELECT a.x, lag(a.x) OVER (ORDER BY a.x)
+    FROM t a JOIN t b ON a.x = b.x;
+}
+expect {
+    1|
+    2|1
+    3|2
+}
+
+# ---------------------------------------------------------------------------
+# Adversarial additions (differential-tested against sqlite3).
+# ---------------------------------------------------------------------------
+
+setup ll_offcol {
+    CREATE TABLE oc(x, o);
+    INSERT INTO oc VALUES (1,-1),(2,2),(3,-2),(4,1),(5,-3);
+}
+
+# A per-row offset column, mixing signs: a negative lag offset looks
+# forward (like lead) and vice versa, evaluated independently for each row.
+@setup ll_offcol
+test lag-lead-per-row-mixed-sign-offset {
+    SELECT x, o, lag(x,o) OVER (ORDER BY x), lead(x,o) OVER (ORDER BY x) FROM oc;
+}
+expect {
+    1|-1|2|
+    2|2||4
+    3|-2||1
+    4|1|3|5
+    5|-3||2
+}
+
+setup ll_three {
+    CREATE TABLE l3(x);
+    INSERT INTO l3 VALUES (1),(2),(3);
+}
+
+# i64 boundary offsets land far outside the partition: every lookup misses
+# and falls to the default (NULL here). Must not overflow the rowid math.
+@setup ll_three
+test lag-lead-offset-i64-boundaries {
+    SELECT lag(x,9223372036854775807) OVER (ORDER BY x),
+           lead(x,-9223372036854775808) OVER (ORDER BY x) FROM l3;
+}
+expect {
+    |
+    |
+    |
+}
+
+setup ll_selfval {
+    CREATE TABLE sv(x);
+    INSERT INTO sv VALUES (0),(1),(2),(3);
+}
+
+# Offset is the row's own value: lag(x,x). Row 0 looks back 0 (itself);
+# rows 1/2/3 each look back to row 0.
+@setup ll_selfval
+test lag-offset-is-row-value {
+    SELECT x, lag(x,x) OVER (ORDER BY x) FROM sv;
+}
+expect {
+    0|0
+    1|0
+    2|0
+    3|0
+}
+
+setup ll_five {
+    CREATE TABLE l5(x);
+    INSERT INTO l5 VALUES (1),(2),(3),(4),(5);
+}
+
+# Offset is an expression of the row: lead(x, x-1). The last rows look
+# past the partition end and fall to the default.
+@setup ll_five
+test lead-offset-expression {
+    SELECT x, lead(x, x-1) OVER (ORDER BY x) FROM l5;
+}
+expect {
+    1|1
+    2|3
+    3|5
+    4|
+    5|
+}
+
+setup ll_nulloff {
+    CREATE TABLE nol(x, o);
+    INSERT INTO nol VALUES (10,1),(20,NULL),(30,2);
+}
+
+# A NULL per-row offset yields the default, not a lookup — matches sqlite.
+@setup ll_nulloff
+test lag-null-column-offset-uses-default {
+    SELECT x, lag(x,o,-1) OVER (ORDER BY x) FROM nol;
+}
+expect {
+    10|-1
+    20|-1
+    30|10
+}
+
+setup ll_types {
+    CREATE TABLE vf(x, v);
+    INSERT INTO vf VALUES (1,NULL),(2,x'cafe'),(3,3.5),(4,'hi');
+}
+
+# Every storage class round-trips through the lookup (and the blob
+# default) untouched. quote() keeps the output printable.
+@setup ll_types
+test lag-lead-value-type-fidelity {
+    SELECT quote(lag(v) OVER (ORDER BY x)),
+           quote(lead(v,1,x'00') OVER (ORDER BY x)) FROM vf;
+}
+expect {
+    NULL|X'CAFE'
+    NULL|3.5
+    X'CAFE'|'hi'
+    3.5|X'00'
+}
+
+setup ll_multi {
+    CREATE TABLE lm(x);
+    INSERT INTO lm VALUES (10),(20),(30),(40),(50);
+}
+
+# Four independent offsets over one shared window definition.
+@setup ll_multi
+test lag-lead-multiple-offsets-one-window {
+    SELECT lag(x,1) OVER w, lag(x,2) OVER w, lead(x,1) OVER w, lead(x,2) OVER w
+    FROM lm WINDOW w AS (ORDER BY x);
+}
+expect {
+    ||20|30
+    10||30|40
+    20|10|40|50
+    30|20|50|
+    40|30||
+}
+
+setup ll_nocase {
+    CREATE TABLE cc(k TEXT, v);
+    INSERT INTO cc VALUES ('a',1),('A',2),('b',3),('B',4);
+}
+
+# The ORDER BY collation drives the row order the lookup walks: under
+# NOCASE 'a'/'A' and 'b'/'B' are adjacent (the v tiebreak fixes order).
+@setup ll_nocase
+test lag-lead-nocase-collation-order {
+    SELECT k, lag(v) OVER (ORDER BY k COLLATE NOCASE, v),
+           lead(v) OVER (ORDER BY k COLLATE NOCASE, v) FROM cc;
+}
+expect {
+    a||2
+    A|1|3
+    b|2|4
+    B|3|
+}

--- a/sqlite/conformance/sqlite-sqltests/window/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/memory.sqltest
@@ -497,15 +497,19 @@ setup named_window_ntile_data {
 }
 
 @setup named_window_ntile_data
-@skip-if sqlite "TODO: ntile() is not yet implemented."
 test named-window-ntile {
     SELECT a, ntile(3) OVER w1
     FROM t_nw_ntile
     WINDOW w1 AS (ORDER BY a)
     ORDER BY a;
 }
-expect error {
-    no such function: ntile
+expect {
+    1|1
+    2|1
+    3|2
+    4|2
+    5|3
+    6|3
 }
 
 setup named_window_sub_data {

--- a/sqlite/conformance/sqlite-sqltests/window/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/memory.sqltest
@@ -547,15 +547,17 @@ expect {
 }
 
 @setup named_window_sub_data
-@skip-if sqlite "TODO: lag() and lead() are not yet implemented."
 test named-window-lag-lead {
     SELECT a, lag(a) OVER w1, lead(a) OVER w1
     FROM t_nw_sub
     WINDOW w1 AS (PARTITION BY b ORDER BY a)
     ORDER BY a;
 }
-expect error {
-    no such function: lag
+expect {
+    1||2
+    2|1|
+    3||4
+    4|3|
 }
 
 setup named_window_multi_fn_data {

--- a/sqlite/conformance/sqlite-sqltests/window/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/memory.sqltest
@@ -280,6 +280,35 @@ expect {
     5|y|q|1
 }
 
+# Regression: streaming windows delete each buffered row from the ephemeral
+# table once it is returned (SQLite's eDelete == WINDOW_RETURN_ROW). With
+# several multi-row partitions, deleting a partition's rows empties the buffer
+# page before the next partition's first row is inserted. The insert cursor
+# must re-seek from the root (SQLite passes seekResult==0 to OP_Insert) rather
+# than trust its pre-delete position; otherwise it writes at a stale cell index
+# on the emptied page and corrupts the btree.
+@cross-check-integrity
+test window-streaming-delete-across-multi-row-partitions {
+    CREATE TABLE t_del (p INTEGER, x INTEGER, v INTEGER);
+    INSERT INTO t_del VALUES (1,1,10),(1,2,20),(1,3,30),
+                             (2,4,40),(2,5,50),
+                             (3,6,60),(3,7,70),(3,8,80);
+    SELECT p, x,
+        row_number() OVER (PARTITION BY p ORDER BY x) AS rn,
+        sum(v) OVER (PARTITION BY p ORDER BY x) AS running
+    FROM t_del ORDER BY p, x;
+}
+expect {
+    1|1|1|10
+    1|2|2|30
+    1|3|3|60
+    2|4|1|40
+    2|5|2|90
+    3|6|1|60
+    3|7|2|130
+    3|8|3|210
+}
+
 test window-row-number-multiple-different-windows {
     CREATE TABLE rn_multi_win (a INTEGER, b TEXT);
     INSERT INTO rn_multi_win VALUES (1, 'x'), (2, 'x'), (3, 'y'), (4, 'y');

--- a/sqlite/conformance/sqlite-sqltests/window/ntile.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/ntile.sqltest
@@ -1,0 +1,499 @@
+@database :memory:
+
+# ntile(N) splits each partition into N buckets and assigns each row a
+# bucket number 1..N. When partition size isn't a clean multiple of N,
+# the first (nTotal mod N) buckets get one extra row. Frame is
+# ROWS CURRENT ROW TO UNBOUNDED FOLLOWING — the entire partition is
+# buffered before any output, and xInverse advances iRow between rows.
+
+setup vals10 {
+    CREATE TABLE t(x INTEGER);
+    INSERT INTO t VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+}
+
+# Clean division: 10 rows / 5 buckets = 2 rows per bucket.
+@setup vals10
+test ntile-clean-division {
+    SELECT x, ntile(5) OVER (ORDER BY x) FROM t;
+}
+expect {
+    1|1
+    2|1
+    3|2
+    4|2
+    5|3
+    6|3
+    7|4
+    8|4
+    9|5
+    10|5
+}
+
+# Uneven: 10 rows / 3 buckets = 3,3,4 → first nLarge=1 bucket gets
+# nSize+1=4 rows, the remaining 2 buckets get nSize=3 rows each.
+@setup vals10
+test ntile-uneven-leading-larger {
+    SELECT x, ntile(3) OVER (ORDER BY x) FROM t;
+}
+expect {
+    1|1
+    2|1
+    3|1
+    4|1
+    5|2
+    6|2
+    7|2
+    8|3
+    9|3
+    10|3
+}
+
+# 10 / 4: nSize=2, nLarge=2 → first 2 buckets get 3 rows, rest get 2.
+@setup vals10
+test ntile-uneven-mixed-sizes {
+    SELECT x, ntile(4) OVER (ORDER BY x) FROM t;
+}
+expect {
+    1|1
+    2|1
+    3|1
+    4|2
+    5|2
+    6|2
+    7|3
+    8|3
+    9|4
+    10|4
+}
+
+# 20 / 7: nSize=2, nLarge=6. First 6 buckets get 3 rows, last 1 bucket
+# gets 2 rows.
+setup vals20 {
+    CREATE TABLE t20(x INTEGER);
+    INSERT INTO t20 VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),
+                          (11),(12),(13),(14),(15),(16),(17),(18),(19),(20);
+}
+
+@setup vals20
+test ntile-larger-partition {
+    SELECT x, ntile(7) OVER (ORDER BY x) FROM t20;
+}
+expect {
+    1|1
+    2|1
+    3|1
+    4|2
+    5|2
+    6|2
+    7|3
+    8|3
+    9|3
+    10|4
+    11|4
+    12|4
+    13|5
+    14|5
+    15|5
+    16|6
+    17|6
+    18|6
+    19|7
+    20|7
+}
+
+# N > partition size — each row is its own bucket starting at 1, no
+# bucket gets a second row. xValue's nSize=0 branch.
+setup vals3 {
+    CREATE TABLE t3(x INTEGER);
+    INSERT INTO t3 VALUES (1),(2),(3);
+}
+
+@setup vals3
+test ntile-N-larger-than-partition {
+    SELECT x, ntile(7) OVER (ORDER BY x) FROM t3;
+}
+expect {
+    1|1
+    2|2
+    3|3
+}
+
+# N=1: everything in one bucket.
+@setup vals3
+test ntile-N-equals-one {
+    SELECT ntile(1) OVER (ORDER BY x) FROM t3;
+}
+expect {
+    1
+    1
+    1
+}
+
+# Single-row partition: bucket 1 regardless of N.
+setup singletons {
+    CREATE TABLE s(g INTEGER, x INTEGER);
+    INSERT INTO s VALUES (1,1),(2,1),(3,1);
+}
+
+@setup singletons
+test ntile-single-row-partition {
+    SELECT g, ntile(5) OVER (PARTITION BY g ORDER BY x) FROM s;
+}
+expect {
+    1|1
+    2|1
+    3|1
+}
+
+# Empty input.
+setup empty {
+    CREATE TABLE e(x INTEGER);
+}
+
+@setup empty
+test ntile-empty-input {
+    SELECT ntile(3) OVER (ORDER BY x) FROM e;
+}
+expect {
+}
+
+# PARTITION BY: each partition counted and bucketed independently.
+setup partitioned {
+    CREATE TABLE p(g INTEGER, x INTEGER);
+    INSERT INTO p VALUES (1,1),(1,2),(1,3),(1,4),(2,5),(2,6),(2,7);
+}
+
+@setup partitioned
+test ntile-with-partition {
+    SELECT g, x, ntile(2) OVER (PARTITION BY g ORDER BY x) FROM p;
+}
+expect {
+    1|1|1
+    1|2|1
+    1|3|2
+    1|4|2
+    2|5|1
+    2|6|1
+    2|7|2
+}
+
+# ORDER BY DESC: rows are buffered in descending order of x, so the
+# first bucket gets the largest values.
+@setup vals10
+test ntile-order-by-desc {
+    SELECT x, ntile(3) OVER (ORDER BY x DESC) FROM t;
+}
+expect {
+    10|1
+    9|1
+    8|1
+    7|1
+    6|2
+    5|2
+    4|2
+    3|3
+    2|3
+    1|3
+}
+
+# Multiple ntile() calls in the same SELECT — each gets its own
+# accumulator slot in the same window.
+@setup vals10
+test ntile-multiple-in-same-select {
+    SELECT x,
+           ntile(2) OVER (ORDER BY x),
+           ntile(3) OVER (ORDER BY x),
+           ntile(5) OVER (ORDER BY x)
+    FROM t;
+}
+expect {
+    1|1|1|1
+    2|1|1|1
+    3|1|1|2
+    4|1|1|2
+    5|1|2|3
+    6|2|2|3
+    7|2|2|4
+    8|2|3|4
+    9|2|3|5
+    10|2|3|5
+}
+
+# NULLs in the ORDER BY column sort first (default ASC NULLS FIRST in
+# SQLite), so they get bucket 1.
+setup with_nulls {
+    CREATE TABLE n(x INTEGER);
+    INSERT INTO n VALUES (NULL),(NULL),(1),(2),(3);
+}
+
+@setup with_nulls
+test ntile-nulls-in-order-key {
+    SELECT x, ntile(2) OVER (ORDER BY x) FROM n;
+}
+expect {
+    |1
+    |1
+    1|1
+    2|2
+    3|2
+}
+
+# N expression: SQLite evaluates the arg once per row but captures it
+# only on the first xStep call. A constant expression like (2+1) is
+# fine; a per-row varying one would only matter if N changed mid-row.
+@setup vals3
+test ntile-N-is-expression {
+    SELECT ntile(2 + 1) OVER (ORDER BY x) FROM t3;
+}
+expect {
+    1
+    2
+    3
+}
+
+# Combined with rank() and lag(): three different coerced frames in
+# one query, each gets its own ephemeral pass.
+@setup vals10
+test ntile-mixed-with-other-window-funcs {
+    SELECT x,
+           ntile(3) OVER (ORDER BY x),
+           rank() OVER (ORDER BY x),
+           lag(x) OVER (ORDER BY x)
+    FROM t;
+}
+expect {
+    1|1|1|
+    2|1|2|1
+    3|1|3|2
+    4|1|4|3
+    5|2|5|4
+    6|2|6|5
+    7|2|7|6
+    8|3|8|7
+    9|3|9|8
+    10|3|10|9
+}
+
+# Invalid arguments. SQLite raises "argument of ntile must be a
+# positive integer" at execution; turso wraps it as a parse error.
+@setup vals3
+test ntile-zero {
+    SELECT ntile(0) OVER (ORDER BY x) FROM t3;
+}
+expect error {
+    argument of ntile must be a positive integer
+}
+
+@setup vals3
+test ntile-negative {
+    SELECT ntile(-1) OVER (ORDER BY x) FROM t3;
+}
+expect error {
+    argument of ntile must be a positive integer
+}
+
+@setup vals3
+test ntile-null {
+    SELECT ntile(NULL) OVER (ORDER BY x) FROM t3;
+}
+expect error {
+    argument of ntile must be a positive integer
+}
+
+# SQLite coerces N via sqlite3_value_int64 — text-affinity and float
+# truncation are both legal. Documented at window.c:432.
+@setup vals10
+test ntile-text-n-coerces {
+    SELECT ntile('3') OVER (ORDER BY x) FROM t;
+}
+expect {
+    1
+    1
+    1
+    1
+    2
+    2
+    2
+    3
+    3
+    3
+}
+
+@setup vals10
+test ntile-fractional-n-truncates {
+    SELECT ntile(2.5) OVER (ORDER BY x) FROM t;
+}
+expect {
+    1
+    1
+    1
+    1
+    1
+    2
+    2
+    2
+    2
+    2
+}
+
+@setup vals3
+test ntile-non-numeric-text-errors {
+    SELECT ntile('abc') OVER (ORDER BY x) FROM t3;
+}
+expect error {
+    argument of ntile must be a positive integer
+}
+
+# Float that truncates to 0 fails the positivity check.
+@setup vals3
+test ntile-fractional-below-one-errors {
+    SELECT ntile(0.5) OVER (ORDER BY x) FROM t3;
+}
+expect error {
+    argument of ntile must be a positive integer
+}
+
+# ---------------------------------------------------------------------------
+# Adversarial additions (differential-tested against sqlite3).
+# ---------------------------------------------------------------------------
+
+setup ntile_ties {
+    CREATE TABLE nt(x, tag);
+    INSERT INTO nt VALUES (5,'a'),(5,'b'),(5,'c'),(9,'d'),(9,'e');
+}
+
+# Rows tied on the ORDER BY key are numbered by position in the partition,
+# not lumped together: the three x=5 rows fill bucket 1, the two x=9 rows
+# fill bucket 2.
+@setup ntile_ties
+test ntile-ties-numbered-by-position {
+    SELECT tag, ntile(2) OVER (ORDER BY x) FROM nt;
+}
+expect {
+    a|1
+    b|1
+    c|1
+    d|2
+    e|2
+}
+
+setup ntile_ord {
+    CREATE TABLE no(x);
+    INSERT INTO no VALUES (30),(10),(20),(40);
+}
+
+# With no ORDER BY the whole partition is bucketed in row order.
+@setup ntile_ord
+test ntile-no-order-by {
+    SELECT ntile(2) OVER () FROM no;
+}
+expect {
+    1
+    1
+    2
+    2
+}
+
+setup ntile_coln {
+    CREATE TABLE nc(x, n);
+    INSERT INTO nc VALUES (1,2),(2,3),(3,4),(4,5);
+}
+
+# The bucket count is read once, from the first row of the partition — a
+# per-row column value does not re-split later rows. n=2 wins for the whole
+# partition; the 3/4/5 in later rows are ignored.
+@setup ntile_coln
+test ntile-n-read-once-from-first-row {
+    SELECT x, ntile(n) OVER (ORDER BY x) FROM nc;
+}
+expect {
+    1|1
+    2|1
+    3|2
+    4|2
+}
+
+setup ntile_small {
+    CREATE TABLE ns(x);
+    INSERT INTO ns VALUES (1),(2),(3);
+}
+
+# A bucket count far larger than the partition gives every row its own
+# bucket; i64::MAX must not overflow the bucket math.
+@setup ntile_small
+test ntile-n-i64-max {
+    SELECT x, ntile(9223372036854775807) OVER (ORDER BY x) FROM ns;
+}
+expect {
+    1|1
+    2|2
+    3|3
+}
+
+# Text with a numeric prefix coerces like sqlite's int cast: '2abc' -> 2.
+@setup ntile_small
+test ntile-n-text-prefix-coerces {
+    SELECT x, ntile('2abc') OVER (ORDER BY x) FROM ns;
+}
+expect {
+    1|1
+    2|1
+    3|2
+}
+
+setup ntile_seq13 {
+    CREATE TABLE n13(x);
+    INSERT INTO n13 SELECT value FROM generate_series(1, 13);
+}
+
+# Uneven split: 13 rows into 5 buckets. The first (13 mod 5 = 3) buckets get
+# one extra row each (size 3); the rest get size 2.
+@setup ntile_seq13
+test ntile-remainder-front-loaded {
+    SELECT b, count(*) FROM (SELECT ntile(5) OVER (ORDER BY x) b FROM n13) GROUP BY b ORDER BY b;
+}
+expect {
+    1|3
+    2|3
+    3|3
+    4|2
+    5|2
+}
+
+setup ntile_four {
+    CREATE TABLE n4(x);
+    INSERT INTO n4 VALUES (1),(2),(3),(4);
+}
+
+# N follows sqlite's `sqlite3_value_int64`: it reads the *integer prefix* of
+# text, so '1e2' is 1 (not the float 100). A numeric-affinity parse would
+# wrongly bucket into 100 groups.
+@setup ntile_four
+test ntile-n-scientific-text-is-integer-prefix {
+    SELECT x, ntile('1e2') OVER (ORDER BY x) FROM n4;
+}
+expect {
+    1|1
+    2|1
+    3|1
+    4|1
+}
+
+setup ntile_five {
+    CREATE TABLE n5(x);
+    INSERT INTO n5 VALUES (1),(2),(3),(4),(5);
+}
+
+# A blob is read as text for the int64 conversion: X'33' is the byte "3",
+# so N = 3.
+@setup ntile_five
+test ntile-n-blob-read-as-text {
+    SELECT x, ntile(X'33') OVER (ORDER BY x) FROM n5;
+}
+expect {
+    1|1
+    2|1
+    3|2
+    4|2
+    5|3
+}


### PR DESCRIPTION
## What this does

This reworks how window functions run so that Turso follows the same
execution model SQLite uses, and adds three more window functions:
`lag()`, `lead()`, and `ntile()`.

The main change is under the hood. Turso previously ran window functions
with a home-grown scheme that worked for the functions merged so far
(`row_number`, `rank`, `dense_rank`, `first_value`, `last_value`,
`nth_value`) but had no clean way to support the functions and frame
shapes still to come. This PR replaces that scheme with a port of
SQLite's single, unified pipeline. Every existing window function is
re-implemented on the new pipeline, and `lag`/`lead`/`ntile` are added on
top of it.

## Why change the engine now

The functions coming after this — and user-written frame clauses like
`ROWS BETWEEN 2 PRECEDING AND CURRENT ROW` — need a window that can
*move*: as the engine walks down the rows, the range of rows a function
looks at slides forward, and rows drop off the back. SQLite handles this
with one general mechanism. The old Turso scheme couldn't express it
without either recomputing from scratch on every row or growing into a
copy of SQLite's mechanism anyway. Matching SQLite now means the
remaining functions and frame clauses drop in cleanly instead of each
needing bespoke handling.

`ntile()` is included here specifically because it's the first function
that actually exercises the moving-window machinery, so this PR proves
that machinery works end to end rather than adding it unused.

## Full walkthrough of the internals refactor

### 1 — Refresher: what's a window function?

A window function computes something **for each row**, using a **range of
nearby rows** — without collapsing them like `GROUP BY` does.

```
SELECT day, sales,
       SUM(sales) OVER (ORDER BY day) AS running_total
FROM t;

 day | sales | running_total
-----+-------+---------------
  1  |  10   |     10          <- 10
  2  |  20   |     30          <- 10+20
  3  |  30   |     60          <- 10+20+30
```

Every row keeps its identity, but also gets an answer computed over a
"window" of rows around it. `rank()`, `row_number()`, `lag()`, moving
averages — all window functions.

---

### 2 — The key mental model: each row has a **frame**

For every row, the window function looks at a contiguous band of rows called
the **frame**. The frame has a **start edge** and an **end edge**.

```
rows:      r1  r2  r3  r4  r5  r6  r7
                    [===========]            <- frame for r5
                   start        end
```

Different functions/queries want different frames:

- `SUM(x) OVER (ORDER BY t)` → frame = *everything from the beginning up to me*
- `AVG(x) OVER (... ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)` → *me ± 1 row*
- `rank()` → *the beginning through the end of my tie-group*

**The whole game is: for each row, know where its frame's edges are, and
compute the function over what's inside.**

---

### 3 — The OLD way: two separate machines + a chooser

Turso used to have **two different code paths**, and a per-function rulebook
that picked one:

```
                    ┌─────────────────────────────┐
   which function?  │  "rank-family"              │ → Machine A:
   ─────────────►   │  (answer shared by a group) │   compute as rows stream in
                    ├─────────────────────────────┤
                    │  "everything else"          │ → Machine B:
                    │  (answer differs per row)   │   buffer the whole partition,
                    └─────────────────────────────┘   compute at the end
```

Plus a **second hand-written rulebook**: "does function X need us to keep all
the rows around after we've emitted them?" (a per-function `true/false` list).

It worked for the functions that existed. But it was two engines bolted
together, steered by lists of function names.

---

### 4 — Where the old way cracks

**Crack #1 — combinations it literally can't express.**
```
SELECT rank() OVER w, lag(v) OVER w FROM t WINDOW w AS (ORDER BY x);
```
`rank()` wants Machine A (stream). `lag()` wants Machine B (buffer). One
query, one window — but the two functions demand different machines. The old
design had no clean way to run both together.

**Crack #2 — no story for sliding aggregates.**
```
SUM(x) OVER (ORDER BY t ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)
```
The frame *slides* — it moves forward and drops rows off the back. Neither
machine knew how to shrink a running total. The only options were "recompute
from scratch every row" (slow) or "grow a third machine" (which would just be
the new design, below).

**Crack #3 — the rulebooks rot.**
Every new function had to be correctly slotted into two hand-maintained name
lists. Miss one, get a subtle bug.

---

### 5 — The insight

> **Every window function is the same shape:**
> *"maintain a running answer over a frame that slides across the rows."*

As you walk down the sorted rows, the frame's two edges also walk down. Only
three things ever happen:

```
   ┌────────────────────────────────────────────────────────┐
   │  a row ENTERS the frame at the end edge   →  ADD it     │
   │  a row LEAVES the frame at the start edge  →  REMOVE it  │
   │  we need the current row's answer          →  EMIT it    │
   └────────────────────────────────────────────────────────┘
```

`SUM` on ADD = "+= x". `SUM` on REMOVE = "-= x". `COUNT` on ADD = "+1".
`rank` counts rows seen. Each function just says what ADD/REMOVE/EMIT mean
*for it*. **One pipeline; the functions plug in.**

*(In the code these three are `AGGSTEP` / `AGGINVERSE` / `RETURN_ROW` — the
exact model SQLite uses in `windowCodeStep`.)*

---

### 6 — The NEW way: one buffer, cursors mark the edges

Buffer the partition's rows once in a little scratch table. Put **cursors**
(row pointers) on it — one marking each edge of the frame, one for the row
we're emitting:

```
 buffered rows:   r1   r2   r3   r4   r5   r6
                       ^         ^    ^
                     start     emit  end
                    cursor    cursor cursor

 walk forward:  end cursor moves right  → ADD each row it passes
                start cursor moves right → REMOVE each row it passes
                emit cursor              → EMIT that row's answer
```

The frame is just "the rows between the start and end cursors." Move the
cursors, run ADD/REMOVE/EMIT. That's the entire engine — for *all* functions
and *all* frame shapes.

---

### 7 — Worked example: running total (grow-only frame)

`SUM(x) OVER (ORDER BY t)` — frame is "from the start through me." The start
edge never moves; only the end edge advances. So we only ever **ADD**:

```
 step   row   action        running   EMIT
 ────   ───   ───────────   ───────   ────
  1     10    ADD 10          10        10
  2     20    ADD 20          30        30
  3     30    ADD 30          60        60
```

No removals. One pass. O(n).

---

### 8 — Worked example: moving 3-wide sum (add **and** remove)

`SUM(x) OVER (... ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)` over
`[10, 20, 30, 40, 50]`. The frame is a 3-row window that slides:

```
 emit row   frame         ADD    REMOVE   sum
 ────────   ───────────   ────   ──────   ───
   10       [10 20]       +20      —        30
   20       [10 20 30]    +30      —        60
   30       [20 30 40]    +40    −10        90
   40       [30 40 50]    +50    −20       120
   50       [40 50]        —     −30        90
```

Each step: **one add, one remove** — regardless of how wide the window is.

> Naive "recompute the frame each row" = **O(n · width)**.
> Add/remove incrementally = **O(n)**.

For a 1-million-row table with a 1000-wide window, that's the difference
between ~a billion operations and ~a million.

---

### 9 — Peer groups: ties share a frame edge (RANGE)

Under the default `RANGE` frame, rows **tied** on the ORDER BY value are
"peers" and share the same frame end — the last peer.

```
 x      SUM(x) OVER (ORDER BY x)
 ──     ────────────────────────
 10  ┐   the two 10s are peers; each one's frame runs
 10  ┘   through the *last* 10  →  both see 10+10 = 20
 20      frame runs through the 20        →  10+10+20 = 40
```

The engine handles this by advancing the end cursor across the *whole*
tie-group before emitting any row in it. Same cursors, same three verbs — the
peer rule is just "how far the end cursor jumps."

---

### 10 — Why the new way is better

**1. Generality.** One mechanism runs `rank`, `row_number`, `sum/avg/count`
windows, `first_value`/`last_value`/`nth_value`, `lag`/`lead`, `ntile`,
`percent_rank`/`cume_dist`, *and* arbitrary user frames. The old "which
machine?" question disappears — `rank() OVER w, lag(v) OVER w` just works.

**2. Performance.** Sliding aggregates are incremental (add/remove), not
recomputed — O(n) instead of O(n·width).

**3. No rulebooks.** Whether to keep or discard a buffered row falls out of
the **frame's shape**, not a hand-maintained list of function names. New
functions inherit correct behavior for free.

**4. It matches SQLite.** This is a port of SQLite's own window engine. Same
model ⇒ same results ⇒ we can check every query against SQLite and trust it.

---

### 11 — Before / after at a glance

```
                        OLD (dual-mode)            NEW (frame-cursor)
 ─────────────────────────────────────────────────────────────────────
 engines                two + a chooser            one
 sliding aggregates     no real support            incremental, O(n)
 rank + lag together    couldn't                   works
 "keep the rows?"       per-function name list     derived from the frame
 basis                  home-grown                 SQLite's proven model
 new functions          slot into 2 rulebooks      plug in ADD/REMOVE/EMIT
```

---

## The four commits

1. **Add the "remove a row" operation.** A small VDBE building block that
   undoes one row's contribution to a running result — the counterpart to
   the existing "add a row" step. This is what lets a moving window shrink
   from the back without redoing all its work.

2. **Port window execution to SQLite's model.** The core rework. Replaces
   the old two-mode approach with SQLite's unified pipeline and
   re-implements the already-merged functions on it. No new user-visible
   function here on its own — but see the note below, because this is the
   commit to review most carefully.

3. **Add `lag()` and `lead()`.** Return a value from a row a given number
   of positions before (`lag`) or after (`lead`) the current row, with the
   optional offset and default arguments SQLite supports.

4. **Add `ntile()`.** Splits each partition into N roughly equal buckets
   and numbers them 1..N. This is the first function that uses the moving
   window from commit 1.

## Important for review: this replaces the merged `nth_value`

Because the execution engine is rewritten, this PR re-implements
`nth_value` (and the other already-merged functions) rather than adding
alongside them. So the key question for review isn't "is the new code
correct in the abstract" — it's "do the already-merged functions still
behave exactly as before."

They do, and the rewrite also fixes one real `nth_value` bug in passing:
the old version could return NULL for some rows that are tied on the
ORDER BY value, where SQLite returns the value. The new version matches
SQLite.

Evidence:

- The existing `nth_value` test file (35 cases) passes unchanged.
- Every window-function test file is run twice — once against Turso and
  once against a real `sqlite3` binary — and the two agree on all of
  them (`row_number`, `rank`, `dense_rank`, `first_value`, `last_value`,
  `nth_value`, `lag`, `lead`, `ntile`).
- The full conformance suite passes.

## Scope / not in this PR

To keep this reviewable, this PR stops at `ntile`. Still to come in
follow-up PRs: `percent_rank` / `cume_dist`, and support for
user-written frame clauses (`ROWS BETWEEN ...`). Those build directly on
the engine landed here.
