### PR TITLE
build: Switch to O1 optimization level for dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,12 @@ either = { version = "1.15" }
 loom = { version = "0.7" }
 shuttle = { version = "0.8.1" }
 
+# O0 does no stack slot reuse, which makes stack usage in debug builds
+# excessive enough to overflow on deeply nested queries. O1 keeps debug
+# assertions and debuginfo while reusing stack slots.
+[profile.dev]
+opt-level = 1
+
 [profile.dev.package.similar]
 opt-level = 3
 

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -2007,13 +2007,6 @@ const fn get_insn_virtual_table() -> [InsnFunction; InsnVariants::COUNT] {
 const INSN_VTABLE: [InsnFunction; InsnVariants::COUNT] = get_insn_virtual_table();
 
 impl InsnVariants {
-    // This function is used for testing
-    #[allow(dead_code)]
-    #[inline(always)]
-    pub(crate) const fn to_function_fast(self) -> InsnFunction {
-        INSN_VTABLE[self as usize]
-    }
-
     // This function is used for generating `INSN_VTABLE`.
     // We need to keep this function to make sure we implement all opcodes
     pub(crate) const fn to_function(self) -> InsnFunction {
@@ -2236,8 +2229,6 @@ impl Insn {
 
     #[inline(always)]
     pub const fn to_function(&self) -> InsnFunction {
-        // dont use this because its still using match
-        // InsnVariants::from(self).to_function_fast()
         INSN_VTABLE[self.discriminant() as usize]
     }
 

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -2320,21 +2320,3 @@ pub enum Cookie {
     /// The application ID as set by the application_id pragma.
     ApplicationId = 8,
 }
-
-#[cfg(test)]
-mod tests {
-    use strum::VariantArray;
-
-    #[test]
-    fn test_make_sure_correct_insn_table() {
-        for variant in super::InsnVariants::VARIANTS {
-            let func1 = variant.to_function();
-            let func2 = variant.to_function_fast();
-            assert_eq!(
-                func1 as usize, func2 as usize,
-                "Variant {:?} does not match in fast table at index {}",
-                variant, *variant as usize
-            );
-        }
-    }
-}


### PR DESCRIPTION
At -O0 the Rust compiler does no stack slot reuse, so debug-build stack frames
are large enough to overflow on deeply nested queries. -O1 reuses stack slots
while keeping debug assertions, overflow checks, and debuginfo.
