### PR TITLE
core: fix RIGHT/FULL OUTER JOIN null-extended rows and column order

### DIFF
--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -528,19 +528,40 @@ pub fn join_lhs_and_rhs<'a>(
                         ..
                     } = &mut hash_join_method.params
                     {
+                        // A FULL OUTER JOIN NULL-extends the entire left side of the
+                        // join for unmatched probe rows, and replays the entire left
+                        // side in the unmatched-build scan. When the LHS contains
+                        // tables besides the build table, the only correct plan shape
+                        // is to materialize the whole join prefix as the hash-build
+                        // input (key+payload mode), so the prefix tables are pruned
+                        // from the main loop and their columns are NULL-extended
+                        // together with the build table's. Otherwise those tables
+                        // would remain as outer loops and leak live values into
+                        // NULL-extended rows (or suppress them entirely when the
+                        // prefix produces no rows).
+                        let full_outer_requires_prefix_materialization = rhs_table_reference
+                            .join_info
+                            .as_ref()
+                            .is_some_and(|ji| ji.is_full_outer())
+                            && !prior_mask.is_empty();
                         let needs_materialization = build_has_uncovered_prior_constraints(
                             lhs_constraints,
                             join_keys,
                             &prior_mask,
                             &prior_hash_build_mask,
                         ) || build_table_is_prior_probe
-                            || !build_table_is_last;
+                            || !build_table_is_last
+                            || full_outer_requires_prefix_materialization;
                         let estimated_filtered_rows = (*build_base_rows)
                             * build_self_selectivity
                             * prior_constraint_selectivity;
 
-                        // Hard cap: avoid materializing huge lists when materialization is required.
+                        // Hard cap: avoid materializing huge lists when materialization is
+                        // required. FULL OUTER is exempt: materialization is the only
+                        // correct plan shape there, so a large build must not push the
+                        // planner into an incorrect (or nonexistent) alternative.
                         let materialization_too_large = needs_materialization
+                            && !full_outer_requires_prefix_materialization
                             && estimated_filtered_rows > MAX_MATERIALIZED_BUILD_ROWS;
                         let can_materialize =
                             build_has_indexable_prior_constraints(lhs_constraints, &prior_mask);
@@ -3136,6 +3157,7 @@ mod tests {
                 Box::new(Expr::Literal(ast::Literal::Numeric(5.to_string()))),
             ),
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }];
 
@@ -3254,6 +3276,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(5.to_string()))),
                 ),
                 from_outer_join: None,
+                from_inner_join: false,
                 consumed: false,
             },
             WhereTerm {
@@ -3268,6 +3291,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(7.to_string()))),
                 ),
                 from_outer_join: None,
+                from_inner_join: false,
                 consumed: false,
             },
         ];
@@ -3392,6 +3416,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(5.to_string()))),
                 ),
                 from_outer_join: None,
+                from_inner_join: false,
                 consumed: false,
             },
             WhereTerm {
@@ -3406,6 +3431,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(10.to_string()))),
                 ),
                 from_outer_join: None,
+                from_inner_join: false,
                 consumed: false,
             },
             WhereTerm {
@@ -3420,6 +3446,7 @@ mod tests {
                     Box::new(Expr::Literal(ast::Literal::Numeric(7.to_string()))),
                 ),
                 from_outer_join: None,
+                from_inner_join: false,
                 consumed: false,
             },
         ];
@@ -3593,6 +3620,7 @@ mod tests {
         WhereTerm {
             expr: Expr::Binary(Box::new(lhs), op, Box::new(rhs)),
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }
     }

--- a/core/translate/optimizer/lift_common_subexpressions.rs
+++ b/core/translate/optimizer/lift_common_subexpressions.rs
@@ -41,6 +41,7 @@ pub(crate) fn lift_common_subexpressions_from_binary_or_terms(
         }
         let term_expr_owned = where_clause[i].expr.clone(); // Own the expression for flattening
         let term_from_outer_join = where_clause[i].from_outer_join; // This needs to be remembered for the new WhereTerms
+        let term_from_inner_join = where_clause[i].from_inner_join;
 
         // e.g. a OR b OR c becomes effectively OR [a,b,c].
         let or_operands = flatten_or_expr_owned(term_expr_owned)?;
@@ -125,6 +126,7 @@ pub(crate) fn lift_common_subexpressions_from_binary_or_terms(
             where_clause.push(WhereTerm {
                 expr: common_expr_to_add,
                 from_outer_join: term_from_outer_join,
+                from_inner_join: term_from_inner_join,
                 consumed: false,
             });
         }
@@ -258,6 +260,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr,
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }];
 
@@ -360,6 +363,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr,
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }];
 
@@ -427,6 +431,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr.clone(),
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }];
 
@@ -496,6 +501,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr,
             from_outer_join: Some(TableInternalId::default()), // Set from_outer_join
+            from_inner_join: false,
             consumed: false,
         }];
 
@@ -548,6 +554,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: single_expr.clone(),
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }];
 
@@ -597,6 +604,7 @@ mod tests {
         let mut where_clause = vec![WhereTerm {
             expr: or_expr,
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }];
 

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -764,8 +764,13 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
     let available_indexes =
         AvailableIndexes::for_table_references(resolver, &plan.table_references);
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
+    let has_full_outer = plan
+        .table_references
+        .joined_tables()
+        .iter()
+        .any(|t| t.join_info.as_ref().is_some_and(|ji| ji.is_full_outer()));
     if let ConstantConditionEliminationResult::ImpossibleCondition =
-        eliminate_constant_conditions(&mut plan.where_clause)?
+        eliminate_constant_conditions(&mut plan.where_clause, has_full_outer)?
     {
         plan.contains_constant_false_condition = true;
         return Ok(());
@@ -842,7 +847,7 @@ fn optimize_delete_plan(plan: &mut DeletePlan, resolver: &Resolver) -> Result<()
 
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
-        eliminate_constant_conditions(&mut plan.where_clause)?
+        eliminate_constant_conditions(&mut plan.where_clause, false)?
     {
         plan.contains_constant_false_condition = true;
         return Ok(());
@@ -888,8 +893,13 @@ fn optimize_update_plan(
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
     transform_match_to_fts_match(&mut plan.where_clause, schema, &target_tables)?;
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
+    let has_full_outer = plan
+        .from_tables
+        .joined_tables()
+        .iter()
+        .any(|t| t.join_info.as_ref().is_some_and(|ji| ji.is_full_outer()));
     if let ConstantConditionEliminationResult::ImpossibleCondition =
-        eliminate_constant_conditions(&mut plan.where_clause)?
+        eliminate_constant_conditions(&mut plan.where_clause, has_full_outer)?
     {
         plan.contains_constant_false_condition = true;
         if is_update_from {
@@ -2644,6 +2654,13 @@ fn optimize_table_access(
         if !hash_join_op.materialize_build_input {
             continue;
         }
+        // FULL OUTER JOIN correctness depends on the whole join prefix being
+        // materialized into the hash-build input: the unmatched-probe and
+        // unmatched-build paths NULL-extend (or replay) the build payload,
+        // which must cover every left-side table. Never undo that decision.
+        if hash_join_op.join_type == crate::translate::plan::HashJoinType::FullOuter {
+            continue;
+        }
         let Some(probe_pos) = best_join_order
             .iter()
             .position(|member| member.original_idx == hash_join_op.probe_table_idx)
@@ -2832,8 +2849,11 @@ enum ConstantConditionEliminationResult {
 /// Removes predicates that are always true.
 /// Returns a ConstantEliminationResult indicating whether any predicates are always false.
 /// This is used to determine whether the query can be aborted early.
+///
+/// `has_full_outer` must be true when the plan contains a FULL OUTER JOIN.
 fn eliminate_constant_conditions(
     where_clause: &mut [WhereTerm],
+    has_full_outer: bool,
 ) -> Result<ConstantConditionEliminationResult> {
     let mut i = 0;
     while i < where_clause.len() {
@@ -2844,8 +2864,14 @@ fn eliminate_constant_conditions(
             i += 1;
         } else if predicate.expr.is_always_false()? {
             // any false predicate in a list of conjuncts (AND-ed predicates) will make the whole list false,
-            // except an outer join condition, because that just results in NULLs, not skipping the whole loop
-            if predicate.from_outer_join.is_some() {
+            // except an outer join condition, because that just results in NULLs, not skipping the whole loop.
+            // Similarly, when the plan contains a FULL OUTER JOIN, an always-false INNER JOIN
+            // ON condition only empties that join's row pairs; the FULL OUTER JOIN still
+            // NULL-extends the rows of its preserved side, so the query result is not empty
+            // (e.g. `SELECT * FROM t1 JOIN t2 ON 0 FULL OUTER JOIN t3 ON true` returns
+            // one NULL-extended row per t3 row).
+            if predicate.from_outer_join.is_some() || (has_full_outer && predicate.from_inner_join)
+            {
                 i += 1;
                 continue;
             }

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -161,6 +161,7 @@ fn get_table_local_constraints_for_branch(
         .map(|expr| WhereTerm {
             expr,
             from_outer_join,
+            from_inner_join: false,
             consumed: false,
         })
         .collect::<Vec<_>>();
@@ -1458,6 +1459,7 @@ mod tests {
                 Box::new(right_disjunct),
             ),
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }];
 
@@ -1538,6 +1540,7 @@ mod tests {
                     Box::new(create_numeric_literal("10")),
                 ),
                 from_outer_join: None,
+                from_inner_join: false,
                 consumed: false,
             },
             WhereTerm {
@@ -1547,6 +1550,7 @@ mod tests {
                     Box::new(create_numeric_literal("7")),
                 ),
                 from_outer_join: None,
+                from_inner_join: false,
                 consumed: false,
             },
         ];
@@ -1737,6 +1741,7 @@ mod tests {
                 Box::new(right_disjunct),
             ),
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }];
 
@@ -1880,6 +1885,7 @@ mod tests {
                     Box::new(make_branch(1, 0, item_kind)),
                 ),
                 from_outer_join: None,
+                from_inner_join: false,
                 consumed: false,
             }]
         };

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -218,6 +218,14 @@ pub struct WhereTerm {
     /// right-side table of the OUTER JOIN (in this case, s). When evaluating conditions, if [WhereTerm::from_outer_join]
     /// is set, we force evaluation to happen during that table's loop.
     pub from_outer_join: Option<TableInternalId>,
+    /// Whether this term originated in the ON/USING clause of an INNER join
+    /// (as opposed to the WHERE clause). For plain queries the two are
+    /// equivalent, but when the query contains a FULL OUTER JOIN they are not:
+    /// an inner-join ON condition only restricts the join's own row pairs
+    /// (an always-false one merely empties that side of the FULL OUTER JOIN),
+    /// whereas an always-false WHERE condition empties the entire result,
+    /// including NULL-extended rows. Mirrors SQLite's EP_InnerON marking.
+    pub from_inner_join: bool,
     /// Whether the condition has been consumed by the optimizer in some way, and it should not be evaluated
     /// in the normal place where WHERE terms are evaluated.
     /// A term may have been consumed e.g. if:
@@ -273,6 +281,7 @@ impl From<Expr> for WhereTerm {
         Self {
             expr: value,
             from_outer_join: None,
+            from_inner_join: false,
             consumed: false,
         }
     }
@@ -944,12 +953,15 @@ pub fn select_star(
     right_join_swapped: bool,
     long_names: bool,
 ) -> crate::Result<()> {
-    // RIGHT JOIN swapped tables; iterate in reverse to restore original column order.
-    let table_iter: Vec<&JoinedTable> = if right_join_swapped {
-        tables.iter().rev().collect()
-    } else {
-        tables.iter().collect()
-    };
+    // The planner rewrites RIGHT JOIN by swapping the first two tables and
+    // treating it as a LEFT JOIN (the swap is only allowed on a two-table FROM
+    // prefix, so it always involves indices 0 and 1). Swap them back here so
+    // SELECT * expands columns in the original declaration order; any tables
+    // joined afterwards keep their positions.
+    let mut table_iter: Vec<&JoinedTable> = tables.iter().collect();
+    if right_join_swapped && table_iter.len() >= 2 {
+        table_iter.swap(0, 1);
+    }
     for table in table_iter {
         // Semi/anti-join tables are internal (from EXISTS/NOT EXISTS unnesting)
         // and should not contribute columns to SELECT *.

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1988,6 +1988,7 @@ fn parse_join(
                     } else {
                         None
                     };
+                    predicate.from_inner_join = !outer;
                     bind_and_rewrite_expr(
                         &mut predicate.expr,
                         Some(table_references),
@@ -2076,6 +2077,7 @@ fn parse_join(
                         } else {
                             None
                         },
+                        from_inner_join: !outer,
                         consumed: false,
                     });
                 }
@@ -2139,6 +2141,7 @@ pub(crate) fn append_vtab_predicates_to_where_clause(
         out_where_clause.push(WhereTerm {
             expr,
             from_outer_join,
+            from_inner_join: false,
             consumed: false,
         });
     }

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -988,6 +988,13 @@ pub struct HashTable {
     track_matched: bool,
     /// Parallel to `buckets`: one Vec<bool> per bucket tracking which entries were matched.
     matched_bits: Vec<Vec<bool>>,
+    /// Insertion-order log of `(bucket_idx, entry_idx)` pairs, maintained only
+    /// when `track_matched` is set and the table has not spilled. Used so the
+    /// unmatched scan emits build rows in build-side scan order (like SQLite),
+    /// rather than in hash-bucket order.
+    insertion_log: Vec<(usize, usize)>,
+    /// Position in `insertion_log` for the in-memory unmatched scan.
+    unmatched_scan_pos: usize,
     /// Bucket index for iterating unmatched entries.
     unmatched_scan_bucket: usize,
     /// Entry index within bucket for iterating unmatched entries.
@@ -1086,6 +1093,8 @@ impl HashTable {
             temp_store: config.temp_store,
             track_matched: config.track_matched,
             matched_bits,
+            insertion_log: vec![],
+            unmatched_scan_pos: 0,
             unmatched_scan_bucket: 0,
             unmatched_scan_entry: 0,
             unmatched_scan_partition: 0,
@@ -1246,6 +1255,11 @@ impl HashTable {
             self.buckets[bucket_idx].insert(entry)?;
             if self.track_matched {
                 self.matched_bits[bucket_idx].try_push(false)?;
+                // Record insertion order so the unmatched scan can replay build
+                // rows in build-side scan order. Once the table spills, the
+                // spilled scan paths take over and this log is no longer used.
+                self.insertion_log
+                    .try_push((bucket_idx, self.buckets[bucket_idx].entries.len() - 1))?;
             }
         }
 
@@ -1395,12 +1409,20 @@ impl HashTable {
             let bucket_count = self.initial_buckets.max(1);
             self.buckets = (0..bucket_count).map(|_| HashBucket::new()).try_collect()?;
             self.non_empty_buckets.clear();
+            if self.track_matched {
+                self.matched_bits = (0..bucket_count).map(|_| vec![]).try_collect()?;
+            }
         } else {
             for &idx in &self.non_empty_buckets {
                 self.buckets[idx].entries.clear();
+                if self.track_matched {
+                    self.matched_bits[idx].clear();
+                }
             }
             self.non_empty_buckets.clear();
         }
+        self.insertion_log.clear();
+        self.unmatched_scan_pos = 0;
 
         self.num_entries = 0;
         self.mem_used = 0;
@@ -1432,7 +1454,10 @@ impl HashTable {
             }
         }
         // Clear in-memory matched bits; spilled partitions will have their own.
+        // The insertion-order log only serves the never-spilled unmatched scan,
+        // so it is dropped along with the in-memory buckets.
         self.matched_bits.clear();
+        self.insertion_log.clear();
         Ok(())
     }
 
@@ -2089,6 +2114,7 @@ impl HashTable {
 
     /// Reset the unmatched scan state to the beginning.
     pub fn begin_unmatched_scan(&mut self) {
+        self.unmatched_scan_pos = 0;
         self.unmatched_scan_bucket = 0;
         self.unmatched_scan_entry = 0;
         self.unmatched_scan_partition = 0;
@@ -2119,18 +2145,15 @@ impl HashTable {
     }
 
     fn next_unmatched_main_buckets(&mut self) -> Option<&HashEntry> {
-        while self.unmatched_scan_bucket < self.buckets.len() {
-            let bucket = &self.buckets[self.unmatched_scan_bucket];
-            let matched = &self.matched_bits[self.unmatched_scan_bucket];
-            while self.unmatched_scan_entry < bucket.entries.len() {
-                let idx = self.unmatched_scan_entry;
-                self.unmatched_scan_entry += 1;
-                if !matched[idx] {
-                    return Some(&bucket.entries[idx]);
-                }
+        // Walk the insertion log so unmatched build rows come out in the order
+        // the build side produced them, matching SQLite's RIGHT/FULL OUTER JOIN
+        // output order for the NULL-extended second pass.
+        while self.unmatched_scan_pos < self.insertion_log.len() {
+            let (bucket_idx, entry_idx) = self.insertion_log[self.unmatched_scan_pos];
+            self.unmatched_scan_pos += 1;
+            if !self.matched_bits[bucket_idx][entry_idx] {
+                return Some(&self.buckets[bucket_idx].entries[entry_idx]);
             }
-            self.unmatched_scan_bucket += 1;
-            self.unmatched_scan_entry = 0;
         }
         None
     }
@@ -3269,6 +3292,7 @@ impl HashTable {
     pub fn close(&mut self) {
         self.state = HashTableState::Closed;
         self.buckets.clear();
+        self.insertion_log.clear();
         self.num_entries = 0;
         self.mem_used = 0;
         self.loaded_partitions_lru.borrow_mut().clear();

--- a/sqlite/conformance/sqlite-sqltests/right-full-join-null-extended-rows.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/right-full-join-null-extended-rows.sqltest
@@ -1,0 +1,72 @@
+@database :memory:
+
+# Regression tests for https://github.com/tursodatabase/turso/issues/7978
+# RIGHT/FULL OUTER JOIN: missing NULL-extended rows and misplaced output
+# columns.
+
+# Case 1: FULL OUTER JOIN must still emit the NULL-extended row for the
+# right table even when the left side of the join produces no rows.
+test full-outer-join-null-extended-row-on-0 {
+    CREATE TABLE t0(a INT);
+    INSERT INTO t0(a) VALUES (1);
+    CREATE TABLE t1(b INT);
+    INSERT INTO t1(b) VALUES (2);
+    CREATE VIEW v2(c) AS SELECT 3 FROM t1;
+    SELECT * FROM t1 JOIN v2 ON 0 FULL OUTER JOIN t0 ON true;
+}
+expect {
+    ||1
+}
+
+test full-outer-join-null-extended-row-on-false {
+    CREATE TABLE t0(a INT);
+    INSERT INTO t0(a) VALUES (1);
+    CREATE TABLE t1(b INT);
+    INSERT INTO t1(b) VALUES (2);
+    CREATE VIEW v2(c) AS SELECT 3 FROM t1;
+    SELECT * FROM t1 JOIN v2 ON false FULL OUTER JOIN t0 ON true;
+}
+expect {
+    ||1
+}
+
+test full-outer-join-null-extended-row-on-1eq0 {
+    CREATE TABLE t0(a INT);
+    INSERT INTO t0(a) VALUES (1);
+    CREATE TABLE t1(b INT);
+    INSERT INTO t1(b) VALUES (2);
+    CREATE VIEW v2(c) AS SELECT 3 FROM t1;
+    SELECT * FROM t1 JOIN v2 ON 1=0 FULL OUTER JOIN t0 ON true;
+}
+expect {
+    ||1
+}
+
+# Case 2: RIGHT JOIN followed by LEFT JOIN USING must keep the values in
+# the correct output columns (c0|x|c1 -> NULL|3|NULL).
+test right-join-then-left-join-using-column-order {
+    CREATE TABLE t1(c0 INT, c1 INT);
+    INSERT INTO t1(c0, c1) VALUES(NULL,11);
+    CREATE TABLE t2(c0 INT NOT NULL);
+    CREATE TABLE t3(x INT);
+    INSERT INTO t3(x) VALUES(3);
+    SELECT * FROM t2 RIGHT JOIN t3 ON true LEFT JOIN t1 USING(c0);
+}
+expect {
+    |3|
+}
+
+# Case 3: unmatched right-table rows must be emitted in right-table scan
+# order, interleaved with matched rows, as SQLite does.
+test right-join-unmatched-row-order {
+    CREATE TABLE a(value TEXT);
+    INSERT INTO a(value) VALUES ('a'),('b'),(NULL);
+    CREATE TABLE b(value TEXT);
+    INSERT INTO b(value) VALUES ('a'),('c'),(NULL);
+    SELECT a.value, b.value FROM a RIGHT JOIN b ON a.value = b.value;
+}
+expect {
+    a|a
+    |c
+    |
+}

--- a/sqlite/conformance/sqlite-sqltests/right-full-join-null-extended-rows.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/right-full-join-null-extended-rows.sqltest
@@ -1,0 +1,79 @@
+@database :memory:
+
+# Regression tests for https://github.com/tursodatabase/turso/issues/7978
+# RIGHT/FULL OUTER JOIN: missing NULL-extended rows and misplaced output
+# columns.
+
+# Case 1: FULL OUTER JOIN must still emit the NULL-extended row for the
+# right table even when the left side of the join produces no rows.
+test full-outer-join-null-extended-row-on-0 {
+    CREATE TABLE t0(a INT);
+    INSERT INTO t0(a) VALUES (1);
+    CREATE TABLE t1(b INT);
+    INSERT INTO t1(b) VALUES (2);
+    CREATE VIEW v2(c) AS SELECT 3 FROM t1;
+    SELECT * FROM t1 JOIN v2 ON 0 FULL OUTER JOIN t0 ON true;
+}
+expect {
+    ||1
+}
+
+test full-outer-join-null-extended-row-on-false {
+    CREATE TABLE t0(a INT);
+    INSERT INTO t0(a) VALUES (1);
+    CREATE TABLE t1(b INT);
+    INSERT INTO t1(b) VALUES (2);
+    CREATE VIEW v2(c) AS SELECT 3 FROM t1;
+    SELECT * FROM t1 JOIN v2 ON false FULL OUTER JOIN t0 ON true;
+}
+expect {
+    ||1
+}
+
+test full-outer-join-null-extended-row-on-1eq0 {
+    CREATE TABLE t0(a INT);
+    INSERT INTO t0(a) VALUES (1);
+    CREATE TABLE t1(b INT);
+    INSERT INTO t1(b) VALUES (2);
+    CREATE VIEW v2(c) AS SELECT 3 FROM t1;
+    SELECT * FROM t1 JOIN v2 ON 1=0 FULL OUTER JOIN t0 ON true;
+}
+expect {
+    ||1
+}
+
+# Case 2: RIGHT JOIN followed by LEFT JOIN USING must keep the values in
+# the correct output columns (c0|x|c1), both for a matched row and for a
+# NULL-extended one. The values are distinct so that any permutation of
+# the SELECT * columns is visible in the result.
+# The issue's original shape, where the USING key is NULL on both sides,
+# lives in turso-sqltests/right-join-using-null-key.sqltest because the
+# SQLite version pinned for the conformance runs still gets it wrong.
+test right-join-then-left-join-using-column-order {
+    CREATE TABLE t1(c0 INT, c1 INT);
+    INSERT INTO t1(c0, c1) VALUES(7,11);
+    CREATE TABLE t2(c0 INT NOT NULL);
+    INSERT INTO t2(c0) VALUES(7);
+    CREATE TABLE t3(x INT);
+    INSERT INTO t3(x) VALUES(3),(4);
+    SELECT * FROM t2 RIGHT JOIN t3 ON t3.x=3 LEFT JOIN t1 USING(c0);
+}
+expect {
+    7|3|11
+    |4|
+}
+
+# Case 3: unmatched right-table rows must be emitted in right-table scan
+# order, interleaved with matched rows, as SQLite does.
+test right-join-unmatched-row-order {
+    CREATE TABLE a(value TEXT);
+    INSERT INTO a(value) VALUES ('a'),('b'),(NULL);
+    CREATE TABLE b(value TEXT);
+    INSERT INTO b(value) VALUES ('a'),('c'),(NULL);
+    SELECT a.value, b.value FROM a RIGHT JOIN b ON a.value = b.value;
+}
+expect {
+    a|a
+    |c
+    |
+}

--- a/sqlite/conformance/turso-sqltests/right-join-using-null-key.sqltest
+++ b/sqlite/conformance/turso-sqltests/right-join-using-null-key.sqltest
@@ -1,0 +1,24 @@
+@database :memory:
+
+# Reproducer from https://github.com/tursodatabase/turso/issues/7978.
+#
+# t2 is empty, so `t2 RIGHT JOIN t3 ON true` produces the NULL-extended row
+# (c0=NULL, x=3). `LEFT JOIN t1 USING(c0)` must not match that NULL c0 against
+# t1's NULL c0, so t1 is NULL-extended too and the result is NULL|3|NULL.
+#
+# This case lives in turso-sqltests instead of sqlite-sqltests because the
+# SQLite binary pinned for the conformance runs (3.49.1) answers |3|11 here,
+# i.e. it lets the two NULL c0 values match. SQLite has fixed that since
+# (3.51.2 answers |3|), and Turso implements the corrected behavior, so the
+# case cannot be part of the corpus that is also run against pinned SQLite.
+test right-join-then-left-join-using-null-key {
+    CREATE TABLE t1(c0 INT, c1 INT);
+    INSERT INTO t1(c0, c1) VALUES(NULL,11);
+    CREATE TABLE t2(c0 INT NOT NULL);
+    CREATE TABLE t3(x INT);
+    INSERT INTO t3(x) VALUES(3);
+    SELECT * FROM t2 RIGHT JOIN t3 ON true LEFT JOIN t1 USING(c0);
+}
+expect {
+    |3|
+}


### PR DESCRIPTION
FULL OUTER JOIN dropped its NULL-extended rows whenever the left side of
the join was statically or dynamically empty. Two causes: (1) an
always-false INNER JOIN ON condition (e.g. `t1 JOIN t2 ON 0 FULL OUTER
JOIN t3 ON true`) short-circuited the entire query, even though it only
empties the left side while the FULL OUTER JOIN must still emit one
NULL-extended row per preserved-side row; (2) when the planner left some
left-side tables outside the hash-build input, their loops kept live
values (or suppressed emission entirely) in rows that should be fully
NULL-extended.

For (1), WhereTerm now records whether a term came from an INNER JOIN
ON/USING clause (mirroring SQLite's EP_InnerON), and constant-condition
elimination keeps such terms instead of declaring the whole query
impossible when a FULL OUTER JOIN is present; a genuine always-false
WHERE term still empties the result. For (2), the join planner now
forces hash-build-input materialization for a FULL OUTER probe whenever
the LHS contains tables besides the build table, so the whole left
composite is carried in the build payload and NULL-extended or replayed
as a unit; the post-pass that cancels materialization and the
materialization size cap are bypassed for FULL OUTER because that plan
shape is required for correctness, not just cost.

SELECT * after a RIGHT JOIN rewrite reversed the entire table list to
restore declaration order, but the planner only ever swaps the first two
tables, so any subsequently joined table's columns were emitted in the
wrong position; select_star now swaps the first two tables back instead.

The unmatched-build scan used for RIGHT/FULL OUTER JOIN emitted rows in
hash-bucket order; the in-memory hash table now keeps an insertion-order
log (only when match tracking is enabled) so unmatched rows replay in
build-side scan order like SQLite.

The column-order regression test uses distinct non-NULL values because
the SQLite version pinned for the conformance runs (3.49.1) answers the
issue's original NULL-keyed USING shape incorrectly; that shape is
covered in turso-sqltests instead, which is not run against sqlite3.

Tests: sqlite-sqltests/right-full-join-null-extended-rows.sqltest (5/5
against both tursodb and SQLite 3.49.1),
turso-sqltests/right-join-using-null-key.sqltest, full sqlite conformance
runs (test-sqlite, run-cli, run-rust, run-rust MVCC=1), upstream all.test
510/510, upstream join.test cases join-29.1..3/31.2..4/23.20..21 now
pass, cargo test -p turso_core, integration and fuzz suites.

Fixes #7978