### PR TITLE
core/types: recycle serialized record buffers

### DIFF
--- a/.github/workflows/elle.yml
+++ b/.github/workflows/elle.yml
@@ -27,6 +27,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  ELLE_CLI_REV: 65fafcfa939cced8b7d279db1b2a666929885e65
 
 jobs:
   elle-check:
@@ -64,7 +65,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/elle-cli
-          key: elle-cli-${{ runner.os }}-${{ hashFiles('.github/workflows/elle.yml') }}
+          key: elle-cli-${{ runner.os }}-${{ env.ELLE_CLI_REV }}
 
       - name: Build simulator
         run: cargo build -p turso_whopper
@@ -100,8 +101,12 @@ jobs:
 
       - name: Build elle-cli
         run: |
-          if [ ! -d /tmp/elle-cli ]; then
-            git clone --depth 1 https://github.com/ligurio/elle-cli.git /tmp/elle-cli
+          if [ ! -d /tmp/elle-cli/.git ]; then
+            mkdir -p /tmp/elle-cli
+            git -C /tmp/elle-cli init
+            git -C /tmp/elle-cli remote add origin https://github.com/ligurio/elle-cli.git
+            git -C /tmp/elle-cli fetch --depth 1 origin "$ELLE_CLI_REV"
+            git -C /tmp/elle-cli checkout --detach FETCH_HEAD
           fi
           cd /tmp/elle-cli
           if [ ! -f target/*-standalone.jar ]; then

--- a/core/alloc/allocation_site.rs
+++ b/core/alloc/allocation_site.rs
@@ -19,6 +19,8 @@ pub enum ValueBlobAllocationSite {
     Hash128,
     RecordDecode,
     CloneFrom,
+    RecordBuild,
+    RecordCopy,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/core/types.rs
+++ b/core/types.rs
@@ -14,7 +14,9 @@ use crate::numeric::Numeric;
 use crate::pseudo::PseudoCursor;
 use crate::schema::Index;
 use crate::storage::btree::CursorTrait;
-use crate::storage::sqlite3_ondisk::{read_integer, read_value, read_varint, write_varint};
+use crate::storage::sqlite3_ondisk::{
+    read_integer, read_value, read_varint, varint_len, write_varint,
+};
 use crate::translate::collate::CollationSeq;
 use crate::translate::plan::IterationDirection;
 use crate::vdbe::sorter::Sorter;
@@ -1424,6 +1426,20 @@ mod immutable_record {
         iter(payload).map(|it| it.count()).unwrap_or_default()
     }
 
+    /// A spent record buffer, obtained by retiring a record ([ImmutableRecord::retire]).
+    /// Hot-path record construction requires one, so per-row callers either recycle a
+    /// previous record's allocation or go through the single explicit entry point,
+    /// [RecordBuf::alloc]. The wrapped buffer is always empty; only its capacity carries
+    /// over.
+    #[must_use = "dropping a RecordBuf discards a reusable allocation"]
+    pub struct RecordBuf(ValueBlob);
+
+    impl RecordBuf {
+        pub fn alloc() -> Self {
+            Self(crate::alloc::vec![])
+        }
+    }
+
     impl ImmutableRecord {
         // Don't use this in performance critical paths, prefer using `iter()` instead
         pub fn get_values(&self) -> Result<Vec<ValueRef<'_>>> {
@@ -1573,6 +1589,30 @@ mod immutable_record {
             })
         }
 
+        /// Consumes the record, keeping its allocation for reuse.
+        pub fn retire(self) -> RecordBuf {
+            let mut buf = self.into_payload();
+            buf.clear();
+            RecordBuf(buf)
+        }
+
+        /// An invalidated record backed by `buf`'s allocation.
+        pub fn from_buf(buf: RecordBuf) -> Self {
+            Self {
+                payload: Value::Blob(buf.0),
+            }
+        }
+
+        /// A record holding a copy of `payload`, serialized into `buf`.
+        #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::RecordCopy)]
+        pub fn copy_payload(payload: &[u8], buf: RecordBuf) -> Result<Self> {
+            let RecordBuf(mut buf) = buf;
+            buf.try_extend(payload.iter().copied())?;
+            Ok(Self {
+                payload: Value::Blob(buf),
+            })
+        }
+
         pub const fn from_bin_record(payload: ValueBlob) -> Self {
             Self {
                 payload: Value::Blob(payload),
@@ -1594,42 +1634,59 @@ mod immutable_record {
             Self::from_values(registers.into_iter().map(|x| x.get_value()), len)
         }
 
+        /// Like [Self::from_registers], but serializes into `buf`; see [Self::build].
+        pub fn build_from_registers<'a, I: Iterator<Item = &'a Register> + Clone>(
+            registers: impl IntoIterator<Item = &'a Register, IntoIter = I>,
+            buf: RecordBuf,
+        ) -> Result<Self> {
+            Self::build(registers.into_iter().map(|x| x.get_value()), buf)
+        }
+
         pub fn from_values<'a>(
             values: impl IntoIterator<Item = impl AsValueRef + 'a> + Clone,
-            len: usize,
+            _len: usize,
         ) -> Result<Self> {
-            let mut serials = Vec::try_with_capacity_ext(len)?;
+            Self::build(values, RecordBuf::alloc())
+        }
+
+        /// Serializes `values` into `buf`, allocating only when the buffer's
+        /// capacity is insufficient. Per-row callers recycle the destination
+        /// register's previous record buffer, making steady-state record
+        /// construction allocation-free.
+        #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::RecordBuild)]
+        pub fn build<'a>(
+            values: impl IntoIterator<Item = impl AsValueRef + 'a> + Clone,
+            buf: RecordBuf,
+        ) -> Result<Self> {
+            let RecordBuf(mut buf) = buf;
             let mut size_header = 0;
             let mut size_values = 0;
 
             let mut serial_type_buf = [0; 9];
-            // write serial types
+            // Sizing pass: the cloneable iterator is re-walked below to write
+            // the serial types, so no scratch buffer is needed.
             for value in values.clone() {
                 let serial_type = SerialType::from(value.as_value_ref());
-                let n = write_varint(&mut serial_type_buf[0..], serial_type.into());
-                serials.push((serial_type_buf, n));
-
-                let value_size = serial_type.size();
-
-                size_header += n;
-                size_values += value_size;
+                size_header += varint_len(serial_type.into());
+                size_values += serial_type.size();
             }
 
             let header_size = Record::calc_header_size(size_header);
 
             // 1. write header size
-            let mut buf = crate::alloc::vec![];
-            buf.try_reserve_exact(header_size + size_values)?;
-            assert_eq!(buf.capacity(), header_size + size_values);
+            let total_size = header_size + size_values;
+            buf.try_reserve_exact(total_size)?;
             let n = write_varint(&mut serial_type_buf, header_size as u64);
 
-            buf.resize(buf.capacity(), 0);
+            buf.resize(total_size, 0);
             let mut writer = AppendWriter::new(&mut buf, 0);
             writer.extend_from_slice(&serial_type_buf[..n]);
 
-            // 2. Write serial
-            for (value, n) in serials {
-                writer.extend_from_slice(&value[..n]);
+            // 2. Write serial types
+            for value in values.clone() {
+                let serial_type = SerialType::from(value.as_value_ref());
+                let n = write_varint(&mut serial_type_buf[0..], serial_type.into());
+                writer.extend_from_slice(&serial_type_buf[..n]);
             }
 
             // write content
@@ -1707,6 +1764,7 @@ mod immutable_record {
         }
 
         #[inline]
+        #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::RecordCopy)]
         pub fn start_serialization(&mut self, payload: &[u8]) -> Result<()> {
             let blob = self.as_blob_mut();
             blob.try_reserve(payload.len())?;
@@ -1773,7 +1831,7 @@ mod immutable_record {
     }
 }
 
-pub use immutable_record::{ImmutableRecord, ImmutableRecordRef};
+pub use immutable_record::{ImmutableRecord, ImmutableRecordRef, RecordBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Record {
@@ -4604,6 +4662,46 @@ mod tests {
         let mut dst = Value::from_i64(3);
         dst.try_clone_from(&src).unwrap();
         assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn test_build_reuses_retired_buffer_and_matches_from_values() {
+        let mut blob: ValueBlob = vec![];
+        blob.extend(0u8..64);
+        let big = vec![
+            Value::build_text("a longer text value that forces a real allocation"),
+            Value::Blob(blob),
+            Value::from_i64(42),
+        ];
+        let small = vec![Value::from_i64(1), Value::Null];
+
+        let expected_big = ImmutableRecord::from_values(&big, big.len()).unwrap();
+        let expected_small = ImmutableRecord::from_values(&small, small.len()).unwrap();
+
+        let record = ImmutableRecord::build(&big, RecordBuf::alloc()).unwrap();
+        assert_eq!(record.get_payload(), expected_big.get_payload());
+
+        let capacity = record.as_blob().capacity();
+        let ptr = record.get_payload().as_ptr();
+        let record = ImmutableRecord::build(&small, record.retire()).unwrap();
+        assert_eq!(record.get_payload(), expected_small.get_payload());
+        assert_eq!(record.as_blob().capacity(), capacity);
+        assert_eq!(record.get_payload().as_ptr(), ptr);
+
+        let record = ImmutableRecord::build(&big, expected_small.retire()).unwrap();
+        assert_eq!(record.get_payload(), expected_big.get_payload());
+    }
+
+    #[test]
+    fn test_copy_payload_reuses_buffer() {
+        let values = vec![Value::build_text("payload to copy"), Value::from_i64(7)];
+        let source = ImmutableRecord::from_values(&values, values.len()).unwrap();
+        let spare = ImmutableRecord::from_values(&values, values.len()).unwrap();
+
+        let ptr = spare.get_payload().as_ptr();
+        let copy = ImmutableRecord::copy_payload(source.get_payload(), spare.retire()).unwrap();
+        assert_eq!(copy.get_payload(), source.get_payload());
+        assert_eq!(copy.get_payload().as_ptr(), ptr);
     }
 
     #[test]

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -229,6 +229,8 @@ fn allocation_site_id(site: AllocationSite) -> u64 {
             ValueBlobAllocationSite::Hash128 => 27,
             ValueBlobAllocationSite::JsonbConstruction => 28,
             ValueBlobAllocationSite::CloneFrom => 29,
+            ValueBlobAllocationSite::RecordBuild => 30,
+            ValueBlobAllocationSite::RecordCopy => 31,
         },
         AllocationSite::Vector(site) => match site {
             VectorAllocationSite::Parse => 15,


### PR DESCRIPTION
## Description

- add an explicit `RecordBuf` type for retiring and reusing serialized-record allocations
- serialize record headers in two passes so record construction no longer needs a temporary serial-type vector
- add allocation-site tracking and unit coverage for record building and payload copying

## Context

Record construction currently allocates a fresh payload buffer and a temporary serial-type vector for every row. This change makes the destination allocation reusable and removes the scratch vector while preserving SQLite-compatible record encoding.

The result is an allocation-free steady state when callers recycle the previous record buffer and its capacity is sufficient.

