### PR TITLE
core/mvcc: fence temporary ID commits during passive checkpoint

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -224,6 +224,9 @@ pub struct CheckpointStateMachine<Clock: LogicalClock, A: ConcurrentAllocator = 
     mvcc_meta_table: Option<(MVTableId, usize)>,
     /// File-backed databases must persist replay boundary durably.
     durable_mvcc_metadata: bool,
+    /// True after the durable-storage checkpoint start hook is invoked and
+    /// until its matching end hook has run.
+    storage_checkpoint_started: bool,
     /// Header staged into pager page 1 before commit; published to global_header on success.
     staged_checkpoint_header: Option<DatabaseHeader>,
     /// Guard to avoid restaging page 1 across CommitPagerTxn async retries.
@@ -817,6 +820,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             mode,
             mvcc_meta_table,
             durable_mvcc_metadata,
+            storage_checkpoint_started: false,
             staged_checkpoint_header: None,
             header_staged_for_commit: false,
             pager_commit_done: false,
@@ -857,8 +861,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     /// of `step()`. This mirrors `step()` error handling and also resets pager/WAL
     /// checkpoint bookkeeping.
     pub fn cleanup_after_external_io_error(&mut self, err: LimboError) -> Result<()> {
-        // run storage cleanup within proper checkpoint context (e.g. pager has pending read/write txn)
-        let result = self.mvstore.storage.on_checkpoint_end(Err(err));
+        // Run storage cleanup only for a checkpoint whose start hook was invoked.
+        // Early passive no-op paths finish before on_checkpoint_start.
+        let result = if std::mem::take(&mut self.storage_checkpoint_started) {
+            self.mvstore.storage.on_checkpoint_end(Err(err))
+        } else {
+            Ok(())
+        };
 
         // Drop this checkpoint's staged (not-yet-applied) root-map mutations. They were never
         // written to the shared map (deferred to the post-commit publish window), so a failed
@@ -1142,7 +1151,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
             let row_versions = entry.value().read();
 
-            for version in self.maybe_get_checkpointable_versions(&row_versions, key.table_id) {
+            for mut version in self.maybe_get_checkpointable_versions(&row_versions, key.table_id) {
+                // Old or externally recovered state can retain a negative
+                // sqlite_schema root after its physical mapping is already
+                // published. Normalize the checkpoint clone before deciding
+                // whether this is CREATE/DROP work, preventing duplicate root
+                // allocation or a skipped physical destroy.
+                self.mvstore
+                    .canonicalize_schema_root_if_published(&mut version)?;
                 let is_delete = version.end().is_some();
 
                 let mut special_write = None;
@@ -1940,27 +1956,42 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     .connection
                     .experimental_mvcc_passive_checkpoint_enabled();
                 if passive {
-                    // The passive checkpoint acquires the blocking lock only after
-                    // collection, so it needs an explicit single-orchestrator gate. The
-                    // blocking (flag-off) path takes the lock up front and gets that
-                    // invariant — plus Busy-on-contention — from the lock itself, so it
-                    // must NOT use this gate, which would turn a contended explicit
-                    // TRUNCATE into a silent no-op.
+                    if !self.checkpoint_lock.write() {
+                        return Ok(TransitionResult::Io(IOCompletions(Completion::new_yield())));
+                    }
+                    // Freeze the snapshot while temporary-ID commits are drained.
+                    // A lower-ts Preparing transaction can clamp the snapshot
+                    // below a later committed frame, so do not publish roots
+                    // until every durable temporary-ID frame is covered.
+                    let snapshot_ts = self.mvstore.checkpoint_snapshot_ts();
+                    let temporary_id_commit_ts = self
+                        .mvstore
+                        .last_temporary_id_commit_ts
+                        .load(Ordering::Acquire);
+                    if snapshot_ts < temporary_id_commit_ts {
+                        self.checkpoint_lock.unlock();
+                        self.state = CheckpointState::Finalize;
+                        return Ok(TransitionResult::Done(CheckpointResult::default()));
+                    }
+                    // Publish the single-orchestrator gate before releasing the
+                    // fence so no new temporary-ID commit can miss this snapshot.
                     if self
                         .mvstore
                         .checkpoint_in_progress
                         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                         .is_err()
                     {
+                        self.checkpoint_lock.unlock();
                         // Another checkpoint is already running: no-op (no work, no resources).
                         self.state = CheckpointState::Finalize;
                         return Ok(TransitionResult::Done(CheckpointResult::default()));
                     }
                     self.owns_checkpoint_in_progress = true;
+                    self.snapshot_ts = snapshot_ts;
+                    self.checkpoint_lock.unlock();
                 }
 
                 if passive {
-                    self.snapshot_ts = self.mvstore.checkpoint_snapshot_ts();
                     // Checkpoint state machines can be created before they are run.
                     // Resample after serializing so already-durable index deletes are not replayed.
                     self.refresh_checkpoint_bounds();
@@ -2099,6 +2130,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 self.durable_txid_max_new = durable_old.max(self.snapshot_ts);
                 self.maybe_stage_mvcc_metadata_write()?;
 
+                self.storage_checkpoint_started = true;
                 self.mvstore.storage.on_checkpoint_start()?;
 
                 if self.write_set.is_empty() && self.index_write_set.is_empty() {
@@ -2995,7 +3027,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition
                 res
             }
             Ok(TransitionResult::Done(ref result)) => {
-                self.mvstore.storage.on_checkpoint_end(Ok(result))?;
+                if std::mem::take(&mut self.storage_checkpoint_started) {
+                    self.mvstore.storage.on_checkpoint_end(Ok(result))?;
+                }
                 res
             }
             Ok(result) => Ok(result),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1017,8 +1017,11 @@ pub struct Transaction<A: RowVersionAllocator = TursoAllocator> {
     /// Hekaton Section 2.7: "CommitDepSet, that stores transaction IDs of the
     /// transactions that depend on T."
     commit_dep_set: Mutex<HashSet<TxID>>,
-    /// True when this transaction holds `blocking_checkpoint_lock` in read mode
-    /// (truncate / flag-off path only). Passive `begin_tx` does not pin the lock.
+    /// True when this transaction holds `blocking_checkpoint_lock` in read mode.
+    /// Truncate / flag-off transactions acquire it at begin. In passive mode,
+    /// a transaction acquires it lazily before allocating its first temporary
+    /// table ID, then retains it through commit or rollback so a checkpoint
+    /// cannot freeze a snapshot between ID allocation and commit.
     holds_blocking_checkpoint_read: AtomicBool,
     /// `MvStore::schema_generation` captured at `begin_tx` (passive root publication gate).
     schema_generation_at_begin: u64,
@@ -1624,6 +1627,9 @@ pub struct CommitStateMachine<Clock: LogicalClock, A: ConcurrentAllocator = Turs
     pager: Arc<Pager>,
     /// Bytes appended to the logical log for this commit; applied to writer offset only after durability and before lock release.
     pending_log_append_bytes: Option<u64>,
+    /// Read side of the passive-checkpoint start fence. Only commits whose
+    /// write set still contains temporary table IDs acquire it.
+    holds_passive_checkpoint_commit_fence: bool,
     /// The synchronous mode for fsync operations. When set to Off, fsync is skipped.
     sync_mode: SyncMode,
     _phantom: PhantomData<Clock>,
@@ -1720,13 +1726,80 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             pager,
             header,
             pending_log_append_bytes: None,
+            holds_passive_checkpoint_commit_fence: false,
             sync_mode,
             _phantom: PhantomData,
         }
     }
 
+    fn try_acquire_passive_checkpoint_commit_fence(&mut self) -> bool {
+        if self.holds_passive_checkpoint_commit_fence {
+            return true;
+        }
+        // Check both sides of the nonblocking read-lock acquisition. A
+        // checkpoint that wins between the first load and the lock acquisition
+        // must be allowed to publish the temporary-ID mappings first.
+        if self
+            .mvcc_store
+            .checkpoint_in_progress
+            .load(Ordering::Acquire)
+        {
+            return false;
+        }
+        if !self.mvcc_store.blocking_checkpoint_lock.read() {
+            return false;
+        }
+        if self
+            .mvcc_store
+            .checkpoint_in_progress
+            .load(Ordering::Acquire)
+        {
+            self.mvcc_store.blocking_checkpoint_lock.unlock();
+            return false;
+        }
+        self.holds_passive_checkpoint_commit_fence = true;
+        true
+    }
+
+    fn release_passive_checkpoint_commit_fence(&mut self) {
+        if self.holds_passive_checkpoint_commit_fence {
+            self.mvcc_store.blocking_checkpoint_lock.unlock();
+            self.holds_passive_checkpoint_commit_fence = false;
+        }
+    }
+
+    fn publish_committed_metadata(&self, end_ts: u64, tx_header: DatabaseHeader) {
+        {
+            // Keep the watermark and matching header publication ordered. An
+            // older commit can finish after a newer one, so neither value may
+            // move backwards.
+            let mut global_header = self.mvcc_store.global_header.write();
+            let last_committed_ts = self
+                .mvcc_store
+                .last_committed_tx_ts
+                .fetch_max(end_ts, Ordering::AcqRel);
+            if last_committed_ts <= end_ts {
+                global_header.replace(tx_header);
+            }
+        }
+        if self.did_commit_schema_change {
+            self.mvcc_store
+                .last_committed_schema_change_ts
+                .fetch_max(end_ts, Ordering::AcqRel);
+        }
+    }
+
     fn cleanup_unfinished_commit(&mut self) {
         if !self.is_finalized {
+            // CommitEnd makes the log frame durable and marks the transaction
+            // Committed before the chunked live-version rewrite. If the
+            // statement is dropped after that point, publish the same metadata
+            // as FinalizeCommit while the temporary-ID fence is still held.
+            if let Some(tx) = self.mvcc_store.txs.get(&self.tx_id) {
+                if let TransactionState::Committed(end_ts) = tx.value().state.load() {
+                    self.publish_committed_metadata(end_ts, *tx.value().header.read());
+                }
+            }
             self.cleanup_mvcc_checkpoint_state();
             if self.pending_log_append_bytes.take().is_some() {
                 if let Err(err) = self.mvcc_store.storage.discard_pending_log_write() {
@@ -1746,6 +1819,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                     .set_tx_state(crate::connection::TransactionState::None);
             }
         }
+        self.release_passive_checkpoint_commit_fence();
 
         let tx_id = self.tx_id;
         let db_id = self.db_id;
@@ -2087,6 +2161,27 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             )
         };
 
+        // A checkpoint can publish a physical root after DDL creates its
+        // replacement sqlite_schema version but before this commit builds the
+        // log record. Normalize every schema version contributed by this
+        // transaction before the identity analysis below; otherwise an ALTER
+        // can look like DELETE(+root) plus INSERT(-temporary) for two different
+        // B-trees.
+        {
+            let write_set = tx.write_set.lock();
+            for (id, row_versions) in &write_set.entries {
+                if id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+                    continue;
+                }
+                let mut versions = row_versions.write();
+                for version in versions.iter_mut() {
+                    if is_our_begin(version) || is_our_end(version) {
+                        mvcc_store.canonicalize_schema_root_if_published(version)?;
+                    }
+                }
+            }
+        }
+
         let mut btree_ids_created_and_dropped_in_tx: HashSet<MVTableId> = HashSet::default();
         let mut btree_ids_removed_from_schema_by_tx: HashSet<MVTableId> = HashSet::default();
         {
@@ -2153,23 +2248,23 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             }
         }
 
-        // Remap a table_id to its canonical form for the log. After checkpoint,
-        // a table's in-memory table_id (e.g. -53) may differ from -(root_page)
-        // (e.g. -58). On recovery, bootstrap reconstructs the map using
-        // -(root_page), so log records must use that canonical form to be found.
-        let canonicalize_table_id = |version: &mut RowVersion| {
+        // Remap B-tree identities to their durable form for the log. After a
+        // checkpoint, a table's in-memory table_id (e.g. -53) may differ from
+        // -(root_page) (e.g. -58). sqlite_schema payloads use the positive
+        // physical root. Recovery reconstructs the map from those durable
+        // forms, so retained log records must not keep stale temporary IDs.
+        let canonicalize_btree_ids = |version: &mut RowVersion| -> Result<()> {
             let table_id = version.row.id.table_id;
             if table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                return;
+                return mvcc_store.canonicalize_schema_root_if_published(version);
             }
-            if let Some(entry) = mvcc_store.table_id_to_rootpage.get(&table_id) {
-                if let Some(root_page) = entry.value().root_page {
-                    let canonical = MVTableId::from(-(root_page as i64));
-                    if canonical != table_id {
-                        version.row.id.table_id = canonical;
-                    }
+            if let Some(root_page) = mvcc_store.published_root_page(&table_id) {
+                let canonical = MVTableId::from(-(root_page as i64));
+                if canonical != table_id {
+                    version.row.id.table_id = canonical;
                 }
             }
+            Ok(())
         };
 
         let collect_versions = |row_versions: &RowVersions<A>,
@@ -2319,7 +2414,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 let Some(mut committed_version) = our_committed_image(row_version) else {
                     continue;
                 };
-                canonicalize_table_id(&mut committed_version);
+                canonicalize_btree_ids(&mut committed_version)?;
                 let is_btree_resident_delete_marker =
                     |version: &RowVersion| version.btree_resident && version.end().is_some();
                 let replaces_last = entry_versions.last().is_some_and(|last| {
@@ -2936,7 +3031,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                  ** - Speculative reads/ignores call register_commit_dependency, which
                  **   increments CommitDepCounter and adds to CommitDepSet.
                  ** - WaitForDependencies checks AbortNow and waits for counter == 0.
-                 ** - CommitEnd / rollback_tx drain CommitDepSet, notifying dependents.
+                 ** - FinalizeCommit, abandoned-commit cleanup, and rollback_tx drain
+                 **   CommitDepSet, notifying dependents.
                  **
                  ** TODO: For full serializability (beyond snapshot isolation), we still need:
                  ** 1. Validate if all read versions are still visible by inspecting the read_set
@@ -3056,6 +3152,37 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                     inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;
                     return Ok(TransitionResult::Done(()));
+                }
+
+                let references_unpublished_btree =
+                    tx.write_set.lock().iter().any(|(row_id, row_versions)| {
+                        if row_id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+                            return !mvcc_store.has_published_root_page(&row_id.table_id);
+                        }
+                        row_versions.read().iter().any(|version| {
+                            let contributed_by_tx = matches!(
+                                version.begin(),
+                                Some(TxTimestampOrID::TxID(tx_id)) if tx_id == self.tx_id
+                            ) || matches!(
+                                version.end(),
+                                Some(TxTimestampOrID::TxID(tx_id)) if tx_id == self.tx_id
+                            );
+                            contributed_by_tx
+                                && sqlite_schema_btree_identity(version).is_some_and(|identity| {
+                                    identity.root_page < 0
+                                        && !mvcc_store.has_published_root_page(&MVTableId::from(
+                                            identity.root_page,
+                                        ))
+                                })
+                        })
+                    });
+                if self
+                    .connection
+                    .experimental_mvcc_passive_checkpoint_enabled()
+                    && references_unpublished_btree
+                    && !self.try_acquire_passive_checkpoint_commit_fence()
+                {
+                    return Ok(TransitionResult::Io(IOCompletions(Completion::new_yield())));
                 }
 
                 // All dependencies resolved. Initialize an empty log record
@@ -3193,6 +3320,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                         != Some(tx_header.schema_cookie.get());
                 self.did_commit_schema_change = schema_did_change;
                 if schema_did_change {
+                    self.connection.with_schema_mut(|schema| {
+                        mvcc_store.resolve_schema_negative_roots(schema);
+                    })?;
                     let schema = self.connection.schema.read().clone();
                     self.connection.db.update_schema_if_newer(schema);
                 }
@@ -3254,6 +3384,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 tx_unlocked
                     .state
                     .store(TransactionState::Committed(*end_ts));
+                if self.holds_passive_checkpoint_commit_fence {
+                    // The durable log record contains at least one temporary
+                    // table ID. Publish its timestamp before any yield so a
+                    // checkpoint cannot materialize roots below this frame.
+                    mvcc_store
+                        .last_temporary_id_commit_ts
+                        .fetch_max(*end_ts, Ordering::AcqRel);
+                }
 
                 // Hand off to the chunked rewriter. Between chunks readers
                 // resolve any unwritten TxID refs via `txs[tx_id]` which now
@@ -3268,52 +3406,21 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
             // helper-dispatch reason as BuildLogRecord above.
             CommitState::RewriteLiveVersions(_) => self.step_rewrite_live_versions(mvcc_store),
             CommitState::FinalizeCommit { end_ts } => {
+                let end_ts = *end_ts;
                 let tx = mvcc_store
                     .txs
                     .get(&self.tx_id)
                     .ok_or_else(|| LimboError::NoSuchTransactionID(self.tx_id.to_string()))?;
                 let tx_unlocked = tx.value();
 
-                // Hekaton Section 3.3: "The transaction then processes all outgoing
-                // commit dependencies listed in its CommitDepSet. If it committed, it
-                // decrements the target transaction's CommitDepCounter."
-                // IOW since this txn committed, let's signal waiting transactions.
-                let dependents = std::mem::take(&mut *tx_unlocked.commit_dep_set.lock());
-                for dep_tx_id in dependents {
-                    if let Some(dep_tx_entry) = mvcc_store.txs.get(&dep_tx_id) {
-                        dep_tx_entry
-                            .value()
-                            .commit_dep_counter
-                            .fetch_sub(1, Ordering::AcqRel);
-                    }
-                }
+                mvcc_store.notify_committed_dependents(tx_unlocked);
 
                 mvcc_store.unlock_commit_lock_if_held(tx_unlocked);
 
                 inject_transition_yield!(self, CommitYieldPoint::BeforeGlobalHeaderUpdate);
 
                 let tx_header = *tx_unlocked.header.read();
-                {
-                    // Hold the header lock across the watermark update and header
-                    // publish so the guard decision and replacement are serialized.
-                    let mut global_header = mvcc_store.global_header.write();
-                    // Since we assign a commit timestamp and then we drive the commit to completion,
-                    // it is totally possible for so an older transaction can finish after a newer one.
-                    // In such case, we should not let older commit to set lower value than previous.
-                    // This value is used in checkpointing as a watermark boundary, and an incorrect
-                    // lower value can cause data loss / corruption.
-                    let last_committed_ts = mvcc_store
-                        .last_committed_tx_ts
-                        .fetch_max(*end_ts, Ordering::AcqRel);
-                    if last_committed_ts <= *end_ts {
-                        global_header.replace(tx_header);
-                    }
-                }
-                if self.did_commit_schema_change {
-                    mvcc_store
-                        .last_committed_schema_change_ts
-                        .fetch_max(*end_ts, Ordering::AcqRel);
-                }
+                self.publish_committed_metadata(end_ts, tx_header);
 
                 // We have now updated all the versions with a reference to the
                 // transaction ID to a timestamp and can, therefore, remove the
@@ -3331,6 +3438,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 inject_transition_yield!(self, CommitYieldPoint::BeforeFinishCommittedTx);
                 mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)?;
                 inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
+                self.release_passive_checkpoint_commit_fence();
                 if mvcc_store.storage.should_checkpoint() {
                     let auto_checkpoint_mode = if self
                         .connection
@@ -3367,7 +3475,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 if mvcc_store.should_gc() {
                     mvcc_store.gc_incremental(MvStore::<Clock>::MAX_CHAINS_PER_GC);
                 }
-                tracing::trace!("logged(tx_id={}, end_ts={})", self.tx_id, *end_ts);
+                tracing::trace!("logged(tx_id={}, end_ts={})", self.tx_id, end_ts);
                 self.finalize(mvcc_store)?;
                 Ok(TransitionResult::Done(()))
             }
@@ -3403,6 +3511,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
     }
 
     fn finalize(&mut self, _context: &Self::Context) -> Result<()> {
+        self.release_passive_checkpoint_commit_fence();
         self.is_finalized = true;
         Ok(())
     }
@@ -3998,11 +4107,11 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     exclusive_tx: AtomicU64,
     commit_coordinator: Arc<CommitCoordinator>,
     global_header: Arc<RwLock<Option<DatabaseHeader>>>,
-    /// Held by checkpoints only during the brief in-memory publish phase; the I/O-heavy
-    /// MvStore → WAL write-out runs unlocked, so concurrent `BEGIN CONCURRENT`s aren't
-    /// blocked. Phases: (unlocked) snapshot + collect + write + commit pager txn;
-    /// (locked) publish durable_txid_max / global_header / schema roots; (unlocked) GC,
-    /// CheckpointWal, truncate logical log, TruncateWal.
+    /// A passive checkpoint briefly takes the write side before its snapshot,
+    /// ordering checkpoint start after any commits that still serialize
+    /// temporary table IDs. It takes the write side again for the brief
+    /// in-memory publish phase. The I/O-heavy MvStore to WAL write-out runs
+    /// unlocked, so ordinary concurrent commits are not blocked.
     blocking_checkpoint_lock: Arc<TursoRwLock>,
     /// Passive publish drain: set for the brief in-memory publish window so new `begin_tx`
     /// calls contend out instead of pinning a lifetime checkpoint read guard.
@@ -4010,11 +4119,17 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// Bumped when a passive checkpoint publishes physical btree roots into the shared schema.
     /// Open transactions compare their captured value and get [`LimboError::SchemaUpdated`].
     schema_generation: AtomicU64,
-    /// Single-orchestrator gate: set while a CheckpointStateMachine runs its unlocked
-    /// write-out phase, cleared on completion/error. Commits racing `should_checkpoint()`
-    /// contend on it; only one wins. Needed because the lock no longer guards the start
-    /// of the checkpoint (it's acquired after the pager-write phase, not before).
+    /// Single-orchestrator gate: set while a CheckpointStateMachine runs its
+    /// unlocked write-out phase and cleared on completion/error. Commits that
+    /// still reference temporary table IDs wait for this gate to clear before
+    /// serializing their logical-log record.
     checkpoint_in_progress: AtomicBool,
+    /// Highest commit timestamp whose durable logical-log record contains a
+    /// temporary table ID. A passive checkpoint may publish physical root
+    /// mappings only when its snapshot covers this watermark; otherwise the
+    /// retained log frame could alias the newly published physical root during
+    /// recovery.
+    last_temporary_id_commit_ts: AtomicU64,
     /// The highest transaction ID that has been made durable in the WAL.
     /// Used to skip checkpointing transactions from mv store to WAL that have already been processed.
     durable_txid_max: AtomicU64,
@@ -4210,6 +4325,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             checkpoint_publish_in_progress: AtomicBool::new(false),
             schema_generation: AtomicU64::new(0),
             checkpoint_in_progress: AtomicBool::new(false),
+            last_temporary_id_commit_ts: AtomicU64::new(0),
             durable_txid_max: AtomicU64::new(0),
             last_committed_schema_change_ts: AtomicU64::new(0),
             last_committed_tx_ts: AtomicU64::new(0),
@@ -4314,9 +4430,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         } else {
             table_id.into()
         };
-        if minimum <= self.next_table_id.load(Ordering::SeqCst) {
-            self.next_table_id.store(minimum - 1, Ordering::SeqCst);
-        }
+        self.next_table_id
+            .fetch_min(minimum.saturating_sub(1), Ordering::SeqCst);
     }
 
     /// Insert a live `table_id -> root_page` binding (bootstrap/recovery, or an
@@ -4338,6 +4453,46 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         self.table_id_to_rootpage
             .get(table_id)
             .and_then(|entry| entry.value().root_page)
+    }
+
+    /// Return `table_id`'s physical root only after its pager commit has been
+    /// published. A staged allocation must still be treated like a temporary
+    /// ID by commits because checkpoint failure can roll it back.
+    fn published_root_page(&self, table_id: &MVTableId) -> Option<u64> {
+        self.table_id_to_rootpage.get(table_id).and_then(|entry| {
+            let entry = entry.value();
+            if !entry.is_live() || entry.materialized_at == WalPos::STAGED {
+                None
+            } else {
+                entry.root_page
+            }
+        })
+    }
+
+    fn has_published_root_page(&self, table_id: &MVTableId) -> bool {
+        self.published_root_page(table_id).is_some()
+    }
+
+    fn canonicalize_schema_root_if_published(&self, version: &mut RowVersion) -> Result<()> {
+        let Some(identity) = sqlite_schema_btree_identity(version) else {
+            return Ok(());
+        };
+        if identity.root_page >= 0 {
+            return Ok(());
+        }
+        let temporary_id = MVTableId::from(identity.root_page);
+        let Some(root_page) = self.published_root_page(&temporary_id) else {
+            return Ok(());
+        };
+        let record = ImmutableRecordRef::from_bin_record(version.row.payload());
+        let mut values = record.get_values_owned()?;
+        values[3] = crate::Value::from_i64(root_page as i64);
+        let record = ImmutableRecord::from_values(&values, values.len())?;
+        version.row.data = Some(crate::alloc::try_arc_slice_from_slice_in(
+            record.get_payload(),
+            self.allocator(),
+        )?);
+        Ok(())
     }
 
     /// Record that a PASSIVE checkpoint allocated `root_page` for `table_id`. `begin_ts` is the
@@ -4425,10 +4580,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
     /// Acquire MVCC's stop-the-world gate for VACUUM.
     ///
-    /// This is the same lock used by MVCC checkpointing. All MVCC transactions
-    /// hold it in read mode for their whole lifetime, so acquiring it in write
-    /// mode proves there are no active MVCC transactions and prevents new ones
-    /// from starting until VACUUM releases it.
+    /// This is the same lock used by MVCC checkpointing. Truncate-mode
+    /// transactions hold it in read mode for their whole lifetime; passive
+    /// transactions acquire it before allocating a temporary table ID. The
+    /// explicit `txs` check below verifies that no other passive transaction is
+    /// active.
     pub(crate) fn try_begin_vacuum_gate(&self) -> Result<()> {
         if !self.blocking_checkpoint_lock.write() {
             return Err(LimboError::Busy);
@@ -4921,8 +5077,48 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// MVCC table ids are always negative. Their corresponding rootpage entry in sqlite_schema
     /// is the same negative value if the table has not been checkpointed yet. Otherwise, the root page
     /// will be positive and corresponds to the actual physical page.
-    pub fn get_next_table_id(&self) -> i64 {
-        self.next_table_id.fetch_sub(1, Ordering::SeqCst)
+    pub fn try_get_next_table_id(&self, tx_id: TxID) -> Result<Option<i64>> {
+        let tx = self
+            .txs
+            .get(&tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
+
+        if !tx
+            .value()
+            .holds_blocking_checkpoint_read
+            .load(Ordering::Acquire)
+        {
+            // Serialize the first temporary-ID allocation with passive
+            // checkpoint snapshot publication. Holding this read guard until
+            // transaction removal covers both directions of the race:
+            //
+            // * an allocation that wins first must commit/rollback before the
+            //   checkpoint can freeze its snapshot;
+            // * a checkpoint that wins first keeps later allocations parked
+            //   until all physical root-page mappings have been published.
+            if self.checkpoint_in_progress.load(Ordering::Acquire)
+                || !self.blocking_checkpoint_lock.read()
+            {
+                return Ok(None);
+            }
+            if self.checkpoint_in_progress.load(Ordering::Acquire) {
+                self.blocking_checkpoint_lock.unlock();
+                return Ok(None);
+            }
+
+            if tx
+                .value()
+                .holds_blocking_checkpoint_read
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                // Another allocator for this transaction installed the
+                // transaction-lifetime guard; drop only our redundant read.
+                self.blocking_checkpoint_lock.unlock();
+            }
+        }
+
+        Ok(Some(self.next_table_id.fetch_sub(1, Ordering::SeqCst)))
     }
 
     pub fn get_next_rowid(&self) -> i64 {
@@ -6077,7 +6273,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             }
             let dep_set = std::mem::take(&mut *tx.commit_dep_set.lock());
             // Invariant: commit_dep_set must be drained before removing the transaction.
-            // CommitEnd and rollback_tx both drain the commit_dep_set to notify dependencies.
+            // Committed finalization or cleanup, and rollback_tx, drain the set to notify
+            // dependencies.
             // If we remove a transaction with non-empty commit_dep_set, those dependencies will wait
             // forever (deadlock).
             turso_assert!(
@@ -6092,6 +6289,23 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         }
         self.txs.remove(&tx_id);
         Ok(())
+    }
+
+    /// Resolve every outgoing commit dependency after `tx` commits.
+    ///
+    /// Both the normal FinalizeCommit path and abandoned-commit cleanup must
+    /// drain this set before removing the transaction. Otherwise dependents
+    /// wait forever and `remove_tx` rejects the non-empty set.
+    fn notify_committed_dependents(&self, tx: &Transaction<A>) {
+        let dependents = std::mem::take(&mut *tx.commit_dep_set.lock());
+        for dep_tx_id in dependents {
+            if let Some(dep_tx_entry) = self.txs.get(&dep_tx_id) {
+                dep_tx_entry
+                    .value()
+                    .commit_dep_counter
+                    .fetch_sub(1, Ordering::AcqRel);
+            }
+        }
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::FinalizedTxStateInsert)]
@@ -6455,6 +6669,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 // removed TxID (https://github.com/tursodatabase/turso/issues/7477).
                 self.rewrite_live_versions_for_committed_tx(tx_id, end_ts);
                 if let Some(tx) = self.txs.get(&tx_id) {
+                    self.notify_committed_dependents(tx.value());
                     self.unlock_commit_lock_if_held(tx.value());
                 }
                 if self.is_exclusive_tx(&tx_id) {
@@ -8235,13 +8450,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             if root_page >= 0 {
                 return None;
             }
-            self.table_id_to_rootpage
-                .get(&MVTableId::from(root_page))
-                .filter(|e| e.value().is_live())
-                .and_then(|e| e.value().root_page)
-                .map(|r| r as i64)
+            self.published_root_page(&MVTableId::from(root_page))
+                .map(|root| root as i64)
         };
-        for table in schema.tables.values_mut() {
+        for (name, table) in schema.tables.iter_mut() {
+            #[cfg(not(feature = "conn_raw_api"))]
+            let _ = name;
             let needs = table
                 .btree()
                 .is_some_and(|b| resolve(b.root_page).is_some());
@@ -8251,8 +8465,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             let table = Arc::make_mut(table);
             if let Some(btree_table) = table.btree_mut() {
                 let btree_table = Arc::make_mut(btree_table);
+                #[cfg(feature = "conn_raw_api")]
+                let old_root_page = btree_table.root_page;
                 if let Some(rp) = resolve(btree_table.root_page) {
                     btree_table.root_page = rp;
+                    #[cfg(feature = "conn_raw_api")]
+                    {
+                        schema.table_names_by_root_page.remove(&old_root_page);
+                        schema
+                            .table_names_by_root_page
+                            .insert(btree_table.root_page, name.clone());
+                    }
                 }
             }
         }
@@ -9778,9 +10001,8 @@ fn register_commit_dependency<A: ConcurrentAllocator>(
         "transaction cannot depend on itself"
     );
     let Some(depended_on) = txs.get(&depended_on_tx_id) else {
-        // Transaction was already committed and removed from the map
-        // (CommitEnd calls remove_tx after setting Committed and draining
-        // CommitDepSet). Dependency is trivially resolved.
+        // The transaction was already finalized or rolled back and removed
+        // after its CommitDepSet was drained. The dependency is resolved.
         return;
     };
     let depended_on = depended_on.value();

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2593,6 +2593,221 @@ fn test_checkpoint_snapshot_ts_clamps_below_inflight_preparing() {
     assert_eq!(store.checkpoint_snapshot_ts(), 1000);
 }
 
+/// A passive checkpoint must not publish a physical root while its snapshot is
+/// clamped below a newer durable commit whose log record still uses that
+/// table's temporary ID.
+#[test]
+fn test_passive_checkpoint_waits_for_snapshot_to_cover_temporary_id_commit() {
+    let mut db = MvccTestDbNoConn::new_with_random_db_passive();
+
+    {
+        let setup = db.connect();
+        setup
+            .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
+        setup
+            .execute("CREATE TABLE anchor(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        setup
+            .execute("INSERT INTO anchor VALUES (1, 'base')")
+            .unwrap();
+        setup.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+        setup
+            .execute("CREATE TABLE pending(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+
+        let pending_root = get_rows(
+            &setup,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'pending'",
+        )[0][0]
+            .as_int()
+            .unwrap();
+        assert!(pending_root < 0);
+
+        // Park an older commit in Preparing before it takes the logical-log
+        // commit lock. A disjoint newer commit can then finish out of timestamp
+        // order, which forces checkpoint_snapshot_ts below the newer commit.
+        let lower = db.connect();
+        lower.execute("BEGIN CONCURRENT").unwrap();
+        lower
+            .execute("INSERT INTO anchor VALUES (2, 'lower')")
+            .unwrap();
+        let lower_tx_id = lower.get_mv_tx_id().unwrap();
+        let lower_parked = FixedYieldInjector::new([CommitYieldPoint::BuildLogRecordStart.point()]);
+        lower.set_yield_injector(Some(lower_parked.clone()));
+        let mut lower_commit = lower.prepare("COMMIT").unwrap();
+        let lower_io = lower.pager.load().io.clone();
+        let mut reached_park = false;
+        for _ in 0..10_000 {
+            match lower_commit.step().unwrap() {
+                StepResult::Yield if lower_parked.is_empty() => {
+                    reached_park = true;
+                    break;
+                }
+                StepResult::IO => lower_io.step().unwrap(),
+                StepResult::Yield => {}
+                StepResult::Done => panic!("lower commit completed before the injected yield"),
+                other => panic!("unexpected lower COMMIT result: {other:?}"),
+            }
+        }
+        assert!(
+            reached_park,
+            "lower commit never reached BuildLogRecordStart"
+        );
+
+        let store = db.get_mvcc_store();
+        let lower_end_ts = match store.txs.get(&lower_tx_id).unwrap().value().state.load() {
+            TransactionState::Preparing(end_ts) => end_ts,
+            state => panic!("lower transaction must be Preparing, got {state:?}"),
+        };
+
+        let higher = db.connect();
+        higher.execute("BEGIN CONCURRENT").unwrap();
+        higher
+            .execute("INSERT INTO pending VALUES (1, 'durable')")
+            .unwrap();
+        higher.execute("COMMIT").unwrap();
+        let temporary_id_commit_ts = store.last_temporary_id_commit_ts.load(Ordering::Acquire);
+        assert!(
+            temporary_id_commit_ts > lower_end_ts,
+            "newer temporary-ID commit must finish above the parked transaction"
+        );
+
+        let checkpoint = db.connect();
+        checkpoint
+            .execute("PRAGMA wal_checkpoint(PASSIVE)")
+            .unwrap();
+        let root_after_deferred_checkpoint = get_rows(
+            &setup,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'pending'",
+        )[0][0]
+            .as_int()
+            .unwrap();
+        assert!(
+            root_after_deferred_checkpoint < 0,
+            "checkpoint must not publish roots below the temporary-ID watermark"
+        );
+
+        // Dropping the parked commit rolls it back and removes the snapshot
+        // clamp. The next checkpoint can safely include the newer frame and
+        // publish the root mapping.
+        drop(lower_commit);
+        lower.set_yield_injector(None);
+        checkpoint
+            .execute("PRAGMA wal_checkpoint(PASSIVE)")
+            .unwrap();
+        let published_root = get_rows(
+            &setup,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'pending'",
+        )[0][0]
+            .as_int()
+            .unwrap();
+        assert!(published_root > 0);
+
+        checkpoint.close().unwrap();
+        higher.close().unwrap();
+        lower.close().unwrap();
+        setup.close().unwrap();
+    }
+
+    db.restart();
+    let recovered = db.connect();
+    let rows = get_rows(&recovered, "SELECT id, v FROM pending");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "durable");
+    assert_eq!(
+        get_rows(&recovered, "PRAGMA integrity_check")[0][0].to_string(),
+        "ok"
+    );
+}
+
+/// Dropping a COMMIT after its temporary-ID log frame became durable must
+/// publish the commit watermark before releasing the checkpoint fence.
+#[test]
+fn test_abandoned_temporary_id_commit_publishes_checkpoint_watermark() {
+    let mut db = MvccTestDbNoConn::new_with_random_db_passive();
+
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
+        conn.execute("CREATE TABLE pending(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("BEGIN CONCURRENT").unwrap();
+        conn.execute("INSERT INTO pending VALUES (1, 'durable')")
+            .unwrap();
+
+        let tx_id = conn.get_mv_tx_id().unwrap();
+        let before_metadata =
+            FixedYieldInjector::new([CommitYieldPoint::BeforeGlobalHeaderUpdate.point()]);
+        conn.set_yield_injector(Some(before_metadata.clone()));
+        let mut commit = conn.prepare("COMMIT").unwrap();
+        let commit_io = conn.pager.load().io.clone();
+        let mut reached_park = false;
+        for _ in 0..10_000 {
+            match commit.step().unwrap() {
+                StepResult::Yield if before_metadata.is_empty() => {
+                    reached_park = true;
+                    break;
+                }
+                StepResult::IO => commit_io.step().unwrap(),
+                StepResult::Yield => {}
+                StepResult::Done => panic!("commit completed before the injected yield"),
+                other => panic!("unexpected COMMIT result: {other:?}"),
+            }
+        }
+        assert!(
+            reached_park,
+            "commit never reached BeforeGlobalHeaderUpdate"
+        );
+
+        let store = db.get_mvcc_store();
+        let end_ts = match store.txs.get(&tx_id).unwrap().value().state.load() {
+            TransactionState::Committed(end_ts) => end_ts,
+            state => panic!("transaction must already be Committed, got {state:?}"),
+        };
+        assert_eq!(
+            store.last_temporary_id_commit_ts.load(Ordering::Acquire),
+            end_ts
+        );
+        assert!(
+            store.last_committed_tx_ts.load(Ordering::Acquire) < end_ts,
+            "injected yield must precede normal committed-watermark publication"
+        );
+
+        drop(commit);
+        conn.set_yield_injector(None);
+
+        assert!(!store.txs.contains_key(&tx_id));
+        assert!(
+            store.last_committed_tx_ts.load(Ordering::Acquire) >= end_ts,
+            "drop cleanup must publish the durable commit before releasing its fence"
+        );
+
+        conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+        let published_root = get_rows(
+            &conn,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'pending'",
+        )[0][0]
+            .as_int()
+            .unwrap();
+        assert!(published_root > 0);
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let recovered = db.connect();
+    let rows = get_rows(&recovered, "SELECT id, v FROM pending");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "durable");
+    assert_eq!(
+        get_rows(&recovered, "PRAGMA integrity_check")[0][0].to_string(),
+        "ok"
+    );
+}
+
 /// What this test checks: Startup recovery reconciles WAL/log artifacts into one consistent MVCC state and replay boundary.
 /// Why this matters: This path runs automatically after crashes; errors here can duplicate effects or drop durable data.
 #[test]
@@ -3964,6 +4179,11 @@ fn test_checkpoint_gc_anchor_loss_update_then_delete_strands_stale_row() {
     conn_v
         .execute("CREATE TABLE t (pk INTEGER PRIMARY KEY, u NUMERIC UNIQUE)")
         .unwrap();
+    // Publish the table and index roots before building the row-version chain.
+    // The later parked checkpoint must allow its synchronous concurrent writer
+    // to commit; commits against temporary roots intentionally wait for that
+    // checkpoint to finish.
+    conn_v.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
     conn_v.execute("INSERT INTO t VALUES (1, 724)").unwrap();
 
     let conn_c = db.connect();
@@ -4507,81 +4727,462 @@ fn test_conflict_abort_of_indexed_update_keeps_btree_resident_index_entry() {
 
 #[test]
 fn test_passive_checkpoint_tolerates_concurrent_create_after_snapshot() {
-    let db = MvccTestDbNoConn::new_with_random_db_passive();
-    let conn = db.connect();
-    conn.execute("CREATE TABLE t1(id INTEGER PRIMARY KEY, v TEXT)")
-        .unwrap();
-    conn.execute("INSERT INTO t1 VALUES (0, 'seed')").unwrap();
-    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
-    // Force an auto-checkpoint on the next commit.
-    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
-        .unwrap();
+    let mut db = MvccTestDbNoConn::new_with_random_db_passive();
+    let checkpointed_index_root;
+    let would_be_deferred_id;
+    let deferred_table_root;
 
-    // Drive the auto-checkpoint via this INSERT's commit and park it at
-    // BeforeAcquireLock (snapshot_ts captured in PrepareCheckpoint; blocking lock
-    // not yet held, so a concurrent writer can still commit).
-    let injector = FixedYieldInjector::new([CheckpointYieldPoint::BeforeAcquireLock.point()]);
-    conn.set_yield_injector(Some(injector.clone()));
-    let mut insert_stmt = conn.prepare("INSERT INTO t1 VALUES (1, 'a')").unwrap();
-    let mut parked = false;
-    for _ in 0..10_000 {
-        match insert_stmt.step().unwrap() {
-            StepResult::IO | StepResult::Yield if injector.is_empty() => {
-                parked = true;
-                break;
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
+        conn.execute(
+            "CREATE TABLE anchor(
+                 id INTEGER PRIMARY KEY,
+                 pad BLOB
+             )",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO anchor
+             SELECT value, zeroblob(1000)
+             FROM generate_series(1, 8)",
+        )
+        .unwrap();
+        conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+        assert_eq!(
+            get_rows(&conn, "PRAGMA page_count")[0][0].as_int().unwrap(),
+            5,
+            "fixture must preserve the allocator/root layout used by the alias assertion"
+        );
+
+        conn.execute("CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("CREATE INDEX a_v ON a(v)").unwrap();
+        conn.execute("CREATE TABLE dummy(id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        // Force an auto-checkpoint and park it after collection, before it
+        // allocates physical roots for a and a_v.
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+            .unwrap();
+        let injector = FixedYieldInjector::new([CheckpointYieldPoint::BeforeAcquireLock.point()]);
+        conn.set_yield_injector(Some(injector.clone()));
+        let mut trigger = conn
+            .prepare("INSERT INTO anchor VALUES (9, zeroblob(1000))")
+            .unwrap();
+        let checkpoint_io = conn.pager.load().io.clone();
+        let mut parked = false;
+        for _ in 0..100_000 {
+            match trigger.step().unwrap() {
+                StepResult::Yield if injector.is_empty() => {
+                    parked = true;
+                    break;
+                }
+                StepResult::IO => checkpoint_io.step().unwrap(),
+                StepResult::Yield => {}
+                StepResult::Done => {
+                    panic!("trigger completed before the checkpoint yield fired")
+                }
+                other => panic!("unexpected trigger result before yield: {other:?}"),
             }
-            StepResult::IO | StepResult::Yield => {}
-            StepResult::Done => {
-                panic!("INSERT completed before the checkpoint acquire-lock yield fired")
-            }
-            other => panic!("unexpected INSERT step result before yield: {other:?}"),
         }
-    }
-    assert!(
-        parked,
-        "auto-checkpoint should yield before acquiring the checkpoint lock"
-    );
-    conn.set_yield_injector(None);
+        assert!(parked, "checkpoint never reached the post-collection yield");
+        conn.set_yield_injector(None);
 
-    // Concurrent connection creates a table that commits AFTER the checkpoint's
-    // snapshot. It lands in the shared schema with a negative root page but is NOT
-    // part of this checkpoint's write set; the in-progress gate stops its own commit
-    // from checkpointing it.
-    let other = db.connect();
-    other
-        .execute("CREATE TABLE t2(id INTEGER PRIMARY KEY, v TEXT)")
-        .unwrap();
+        // The threshold is store-global. Keep the deferred CREATE in the
+        // logical log after its commit so cold recovery exercises its temp ID.
+        let config = db.connect();
+        config
+            .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
 
-    // Resume the parked checkpoint to completion. Before the fix this panics at the
-    // has_pending_root_publication assert in TruncateWal.
-    let mut done = false;
-    for _ in 0..100_000 {
-        match insert_stmt.step().unwrap() {
-            StepResult::Done => {
-                done = true;
-                break;
+        // A CREATE that starts after the checkpoint snapshot must not allocate
+        // the next temporary ID while this checkpoint is about to publish the
+        // matching positive root.
+        let store = db.get_mvcc_store();
+        would_be_deferred_id = store.next_table_id.load(Ordering::SeqCst);
+        assert!(would_be_deferred_id < 0);
+        let other = db.connect();
+        other.execute("BEGIN").unwrap();
+        let mut create = other
+            .prepare("CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        let create_io = other.pager.load().io.clone();
+        let mut other_tx_id = None;
+        for _ in 0..100_000 {
+            match create.step().unwrap() {
+                StepResult::IO => {
+                    assert_eq!(
+                        store.next_table_id.load(Ordering::SeqCst),
+                        would_be_deferred_id,
+                        "the parked CREATE must not consume the colliding temporary ID"
+                    );
+                    create_io.step().unwrap();
+                }
+                StepResult::Yield => {
+                    assert_eq!(
+                        store.next_table_id.load(Ordering::SeqCst),
+                        would_be_deferred_id,
+                        "the parked CREATE must not consume the colliding temporary ID"
+                    );
+                    other_tx_id = other.get_mv_tx_id();
+                    break;
+                }
+                StepResult::Done => {
+                    panic!(
+                        "post-snapshot CREATE allocated a temporary ID through the checkpoint gate"
+                    )
+                }
+                other => panic!("unexpected deferred CREATE result: {other:?}"),
             }
-            StepResult::IO | StepResult::Yield => {}
-            other => panic!("unexpected resume step result: {other:?}"),
         }
-    }
-    assert!(
-        done,
-        "checkpoint must complete despite a CREATE that committed after its snapshot"
-    );
-    drop(insert_stmt);
+        let other_tx_id =
+            other_tx_id.expect("CREATE did not reach the temporary-ID checkpoint gate");
+        assert!(
+            !store
+                .txs
+                .get(&other_tx_id)
+                .unwrap()
+                .value()
+                .holds_blocking_checkpoint_read
+                .load(Ordering::Acquire),
+            "the parked CREATE must not install a lifetime guard before allocation"
+        );
 
-    // Both tables survive; t2 is usable; integrity holds.
-    let tables = get_rows(
-        &conn,
-        "SELECT name FROM sqlite_schema WHERE type='table' AND name IN ('t1','t2') ORDER BY name",
+        let mut checkpoint_done = false;
+        for _ in 0..200_000 {
+            match trigger.step().unwrap() {
+                StepResult::Done => {
+                    checkpoint_done = true;
+                    break;
+                }
+                StepResult::IO => checkpoint_io.step().unwrap(),
+                StepResult::Yield => {}
+                other => panic!("unexpected checkpoint resume result: {other:?}"),
+            }
+        }
+        assert!(checkpoint_done, "checkpoint did not finish");
+        drop(trigger);
+
+        let mut create_done = false;
+        for _ in 0..100_000 {
+            match create.step().unwrap() {
+                StepResult::Done => {
+                    create_done = true;
+                    break;
+                }
+                StepResult::IO => create_io.step().unwrap(),
+                StepResult::Yield => {}
+                other => panic!("unexpected CREATE resume result: {other:?}"),
+            }
+        }
+        assert!(create_done, "CREATE did not resume after root publication");
+        drop(create);
+        other.execute("COMMIT").unwrap();
+
+        checkpointed_index_root = get_rows(
+            &conn,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'a_v'",
+        )[0][0]
+            .as_int()
+            .unwrap();
+        deferred_table_root = get_rows(
+            &other,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'b'",
+        )[0][0]
+            .as_int()
+            .unwrap();
+        assert_eq!(
+            checkpointed_index_root, -would_be_deferred_id,
+            "fixture must materialize a_v at the root the old allocator would reuse"
+        );
+        assert!(deferred_table_root < 0);
+        assert_ne!(
+            deferred_table_root, would_be_deferred_id,
+            "the resumed CREATE must allocate again after root publication"
+        );
+        for row in get_rows(
+            &conn,
+            "SELECT name, rootpage
+               FROM sqlite_schema
+              WHERE name IN ('a', 'a_v', 'dummy')
+              ORDER BY name",
+        ) {
+            let published_name = row[0].to_string();
+            let published_root = row[1].as_int().unwrap();
+            assert!(published_root > 0);
+            assert_ne!(
+                published_root, -deferred_table_root,
+                "b's deferred temporary ID must not alias published root {published_name}"
+            );
+        }
+
+        other
+            .execute("INSERT INTO b VALUES (1, 'survives')")
+            .unwrap();
+        assert_eq!(
+            get_rows(&conn, "PRAGMA integrity_check")[0][0].to_string(),
+            "ok"
+        );
+
+        other.close().unwrap();
+        config.close().unwrap();
+        conn.close().unwrap();
+    }
+
+    // Reopen before checkpointing b. Recovery derives a_v's table ID from its
+    // physical root and replays b's negative temporary ID from the logical log.
+    db.restart();
+    let recovered = db.connect();
+    assert_eq!(
+        get_rows(
+            &recovered,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'a_v'",
+        )[0][0]
+            .as_int()
+            .unwrap(),
+        checkpointed_index_root
     );
-    assert_eq!(tables.len(), 2, "t1 and t2 must both exist: {tables:?}");
-    other.execute("INSERT INTO t2 VALUES (1, 'x')").unwrap();
-    let rows = get_rows(&other, "SELECT id, v FROM t2");
+    assert_eq!(
+        get_rows(
+            &recovered,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'b'",
+        )[0][0]
+            .as_int()
+            .unwrap(),
+        deferred_table_root
+    );
+    let rows = get_rows(&recovered, "SELECT id, v FROM b");
     assert_eq!(rows.len(), 1);
-    let integrity = get_rows(&conn, "PRAGMA integrity_check");
-    assert_eq!(&integrity[0][0].to_string(), "ok");
+    assert_eq!(rows[0][1].to_string(), "survives");
+    assert_eq!(
+        get_rows(&recovered, "PRAGMA integrity_check")[0][0].to_string(),
+        "ok"
+    );
+}
+
+/// A schema-only commit that started after a checkpoint snapshot can still
+/// carry the table's temporary root in its sqlite_schema payload. It must wait
+/// for root publication and then serialize the positive physical root.
+#[test]
+fn test_schema_commit_canonicalizes_root_after_concurrent_passive_checkpoint() {
+    let mut db = MvccTestDbNoConn::new_with_random_db_passive();
+
+    let published_root = {
+        let setup = db.connect();
+        setup
+            .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
+        setup
+            .execute("CREATE TABLE anchor(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        setup
+            .execute("INSERT INTO anchor VALUES (1, 'base')")
+            .unwrap();
+        setup.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+        setup
+            .execute("CREATE TABLE pending(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        setup
+            .execute("INSERT INTO pending VALUES (1, 'kept')")
+            .unwrap();
+        let pending_schema = get_rows(
+            &setup,
+            "SELECT rowid, rootpage FROM sqlite_schema WHERE name = 'pending'",
+        );
+        let pending_schema_rowid = pending_schema[0][0].as_int().unwrap();
+        let temporary_root = pending_schema[0][1].as_int().unwrap();
+        assert!(temporary_root < 0);
+
+        let checkpoint_conn = db.connect();
+        checkpoint_conn
+            .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+            .unwrap();
+        let checkpoint_parked =
+            FixedYieldInjector::new([CheckpointYieldPoint::BeforeAcquireLock.point()]);
+        checkpoint_conn.set_yield_injector(Some(checkpoint_parked.clone()));
+        let mut checkpoint = checkpoint_conn
+            .prepare("INSERT INTO anchor VALUES (2, 'trigger')")
+            .unwrap();
+        let checkpoint_io = checkpoint_conn.pager.load().io.clone();
+        let mut reached_checkpoint_park = false;
+        for _ in 0..100_000 {
+            match checkpoint.step().unwrap() {
+                StepResult::Yield if checkpoint_parked.is_empty() => {
+                    reached_checkpoint_park = true;
+                    break;
+                }
+                StepResult::IO => checkpoint_io.step().unwrap(),
+                StepResult::Yield => {}
+                StepResult::Done => {
+                    panic!("checkpoint completed before the injected yield")
+                }
+                other => panic!("unexpected checkpoint step result: {other:?}"),
+            }
+        }
+        assert!(
+            reached_checkpoint_park,
+            "checkpoint never reached BeforeAcquireLock"
+        );
+        // The threshold is store-global. Disable it again before the ALTER
+        // resumes so its commit remains in the WAL for the cold-replay check.
+        setup
+            .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
+
+        let alter = db.connect();
+        alter.execute("BEGIN").unwrap();
+        alter
+            .execute("ALTER TABLE pending RENAME COLUMN v TO value")
+            .unwrap();
+        let mut alter_commit = alter.prepare("COMMIT").unwrap();
+        let alter_io = alter.pager.load().io.clone();
+        let mut alter_parked = false;
+        for _ in 0..100_000 {
+            match alter_commit.step().unwrap() {
+                StepResult::Yield => {
+                    alter_parked = true;
+                    break;
+                }
+                StepResult::IO => alter_io.step().unwrap(),
+                StepResult::Done => {
+                    panic!("schema commit bypassed the temporary-root checkpoint gate")
+                }
+                other => panic!("unexpected ALTER commit result: {other:?}"),
+            }
+        }
+        assert!(
+            alter_parked,
+            "ALTER commit never reached the checkpoint gate"
+        );
+
+        checkpoint_conn.set_yield_injector(None);
+        let mut checkpoint_done = false;
+        for _ in 0..100_000 {
+            match checkpoint.step().unwrap() {
+                StepResult::Done => {
+                    checkpoint_done = true;
+                    break;
+                }
+                StepResult::IO => checkpoint_io.step().unwrap(),
+                StepResult::Yield => {}
+                other => panic!("unexpected checkpoint resume result: {other:?}"),
+            }
+        }
+        assert!(checkpoint_done, "checkpoint did not finish");
+        drop(checkpoint);
+
+        let mut alter_done = false;
+        for _ in 0..100_000 {
+            match alter_commit.step().unwrap() {
+                StepResult::Done => {
+                    alter_done = true;
+                    break;
+                }
+                StepResult::IO => alter_io.step().unwrap(),
+                StepResult::Yield => {}
+                other => panic!("unexpected ALTER commit resume result: {other:?}"),
+            }
+        }
+        assert!(
+            alter_done,
+            "schema commit did not resume after root publication"
+        );
+        drop(alter_commit);
+
+        let store = db.get_mvcc_store();
+        let published_root = store
+            .published_root_page(&MVTableId::from(temporary_root))
+            .expect("checkpoint must publish pending's physical root before ALTER resumes");
+
+        let schema_key = RowID::new(
+            SQLITE_SCHEMA_MVCC_TABLE_ID,
+            RowKey::Int(pending_schema_rowid),
+        );
+        let schema_row = store
+            .rows
+            .get(&schema_key)
+            .expect("pending sqlite_schema row must remain in the version store");
+        let schema_versions = schema_row.value().read();
+        assert_eq!(
+            schema_versions
+                .iter()
+                .filter(|version| version.end().is_none())
+                .count(),
+            1,
+            "checkpoint root publication must not resurrect the pre-ALTER schema version"
+        );
+        drop(schema_versions);
+        drop(schema_row);
+
+        assert_eq!(
+            get_rows(
+                &alter,
+                "SELECT rootpage FROM sqlite_schema WHERE name = 'pending'",
+            )[0][0]
+                .as_int()
+                .unwrap(),
+            published_root as i64,
+            "the committing connection must adopt the published physical root"
+        );
+        let live_rows = get_rows(&alter, "SELECT id, value FROM pending");
+        assert_eq!(live_rows.len(), 1);
+        assert_eq!(live_rows[0][1].to_string(), "kept");
+        assert_eq!(
+            get_rows(&alter, "PRAGMA integrity_check")[0][0].to_string(),
+            "ok"
+        );
+
+        alter.close().unwrap();
+        checkpoint_conn.close().unwrap();
+        setup.close().unwrap();
+        published_root
+    };
+
+    // Reopen before another checkpoint so recovery must replay the ALTER frame.
+    // A stale negative root in that frame would collide with the published mapping.
+    db.restart();
+    let recovered = db.connect();
+    let rows = get_rows(&recovered, "SELECT id, value FROM pending");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "kept");
+    assert_eq!(
+        get_rows(
+            &recovered,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'pending'",
+        )[0][0]
+            .as_int()
+            .unwrap(),
+        published_root as i64,
+        "cold replay must retain the published physical root"
+    );
+    assert_eq!(
+        get_rows(&recovered, "PRAGMA integrity_check")[0][0].to_string(),
+        "ok"
+    );
+
+    // A later checkpoint must treat the ALTER as metadata for the existing
+    // B-tree, not as another CREATE with a fresh root.
+    recovered.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+    assert_eq!(
+        get_rows(
+            &recovered,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 'pending'",
+        )[0][0]
+            .as_int()
+            .unwrap(),
+        published_root as i64,
+        "checkpointing the ALTER must keep the original physical root"
+    );
+    let rows = get_rows(&recovered, "SELECT id, value FROM pending");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][1].to_string(), "kept");
+    assert_eq!(
+        get_rows(&recovered, "PRAGMA integrity_check")[0][0].to_string(),
+        "ok"
+    );
 }
 
 /// What this test checks: if one checkpoint makes a unique-index delete durable in the B-tree
@@ -18149,6 +18750,65 @@ fn abandoned_commit_in_committed_state_should_not_block_subsequent_checkpoint() 
     let _ = conn_a.prepare("COMMIT").unwrap().step();
 
     conn_b.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+}
+
+#[test]
+fn cleanup_dropped_committed_tx_notifies_dependents_and_releases_temp_id_guard() {
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let owner = db.connect();
+    let dependent = db.connect();
+    let store = db.get_mvcc_store();
+
+    owner.execute("BEGIN CONCURRENT").unwrap();
+    let owner_tx_id = owner.get_mv_tx_id().unwrap();
+    assert!(
+        store.try_get_next_table_id(owner_tx_id).unwrap().is_some(),
+        "temporary-ID allocation must acquire the transaction-lifetime checkpoint guard"
+    );
+
+    dependent.execute("BEGIN CONCURRENT").unwrap();
+    let dependent_tx_id = dependent.get_mv_tx_id().unwrap();
+
+    let owner_tx = store.txs.get(&owner_tx_id).unwrap();
+    owner_tx
+        .value()
+        .state
+        .store(TransactionState::Committed(100));
+    owner_tx
+        .value()
+        .commit_dep_set
+        .lock()
+        .insert(dependent_tx_id);
+    store
+        .txs
+        .get(&dependent_tx_id)
+        .unwrap()
+        .value()
+        .commit_dep_counter
+        .fetch_add(1, Ordering::AcqRel);
+    drop(owner_tx);
+
+    store.cleanup_dropped_commit(owner_tx_id, &owner, crate::MAIN_DB_ID);
+
+    assert!(store.txs.get(&owner_tx_id).is_none());
+    assert_eq!(
+        store
+            .txs
+            .get(&dependent_tx_id)
+            .unwrap()
+            .value()
+            .commit_dep_counter
+            .load(Ordering::Acquire),
+        0,
+        "abandoned committed owner must notify its waiting dependent"
+    );
+    assert!(
+        store.blocking_checkpoint_lock.write(),
+        "abandoned committed owner must release its temporary-ID checkpoint guard"
+    );
+    store.blocking_checkpoint_lock.unlock();
+
+    dependent.execute("ROLLBACK").unwrap();
 }
 
 /// A concurrent explicit rowid insert must raise the allocator watermark before

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12056,7 +12056,14 @@ pub fn op_create_btree(
     let mv_store = program.connection.mv_store_for_db(*db);
 
     if let Some(mv_store) = mv_store.as_ref() {
-        let root_page = mv_store.get_next_table_id();
+        let tx_id = program.connection.get_mv_tx_id_for_db(*db).ok_or_else(|| {
+            LimboError::InternalError("MVCC CreateBtree requires an active transaction".to_string())
+        })?;
+        let Some(root_page) = mv_store.try_get_next_table_id(tx_id)? else {
+            return Ok(InsnFunctionStepResult::IO(IOCompletions(
+                Completion::new_yield(),
+            )));
+        };
         state.registers[*root].set_int(root_page);
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);

--- a/testing/stress/tests/shuttle_mvcc.rs
+++ b/testing/stress/tests/shuttle_mvcc.rs
@@ -2,6 +2,7 @@
 
 use shuttle::scheduler::{PctScheduler, RandomScheduler};
 use shuttle::sync::Barrier;
+use std::future::Future;
 use turso::Builder;
 use turso_stress::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use turso_stress::sync::Arc;
@@ -736,4 +737,372 @@ async fn begin_publish_window_gc_scenario(num_readers: usize, rounds: i64) {
         !row_disappeared.load(Ordering::Acquire),
         "Observed a row, and then no row. This violates Snapshot Isolation"
     );
+}
+
+async fn passive_checkpoint_stale_table_id_aliases_index_root_scenario() {
+    const WRITES: i64 = 4;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("passive-checkpoint-table-index-alias.db");
+    let db_path = db_path.to_str().unwrap();
+
+    let db = Builder::new_local(db_path)
+        .experimental_mvcc_passive_checkpoint(true)
+        .build()
+        .await
+        .unwrap();
+
+    let setup = db.connect().unwrap();
+
+    {
+        let mut rows = setup
+            .query("PRAGMA journal_mode = 'experimental_mvcc'", ())
+            .await
+            .unwrap();
+
+        while rows.next().await.unwrap().is_some() {}
+    }
+
+    setup
+        .execute("PRAGMA mvcc_checkpoint_threshold = -1", ())
+        .await
+        .unwrap();
+
+    setup
+        .execute_batch(
+            "CREATE TABLE anchor(
+                 id  INTEGER PRIMARY KEY,
+                 pad BLOB
+             );
+
+             INSERT INTO anchor
+             SELECT value, zeroblob(1000)
+             FROM generate_series(1, 8);",
+        )
+        .await
+        .unwrap();
+
+    async fn passive_checkpoint(conn: &turso::Connection) {
+        let mut rows = conn
+            .query("PRAGMA wal_checkpoint(PASSIVE)", ())
+            .await
+            .unwrap();
+
+        while rows.next().await.unwrap().is_some() {}
+    }
+
+    passive_checkpoint(&setup).await;
+    turso_stress::note_progress();
+
+    assert_eq!(query_i64(&setup, "PRAGMA page_count").await, 5);
+
+    setup
+        .execute_batch(
+            "CREATE TABLE a(
+                 id INTEGER PRIMARY KEY,
+                 v  TEXT
+             );
+
+             CREATE INDEX a_v ON a(v);
+
+             CREATE TABLE dummy(
+                 id INTEGER PRIMARY KEY
+             );
+
+             CREATE TABLE b(
+                 id INTEGER PRIMARY KEY,
+                 v  TEXT
+             );
+
+             INSERT INTO anchor
+             SELECT value + 100, zeroblob(1)
+             FROM generate_series(1, 1025);",
+        )
+        .await
+        .unwrap();
+    turso_stress::note_progress();
+
+    assert!(
+        query_i64(
+            &setup,
+            "SELECT rootpage
+               FROM sqlite_schema
+              WHERE name = 'a_v'",
+        )
+        .await
+            < 0
+    );
+
+    let b_temporary_root = query_i64(
+        &setup,
+        "SELECT rootpage
+           FROM sqlite_schema
+          WHERE name = 'b'",
+    )
+    .await;
+
+    assert!(b_temporary_root < 0);
+
+    let writer_conn = db.connect().unwrap();
+    writer_conn.execute("BEGIN CONCURRENT", ()).await.unwrap();
+    writer_conn
+        .execute("INSERT INTO b VALUES(100000, 'ack-100000')", ())
+        .await
+        .unwrap();
+    turso_stress::note_progress();
+    let mut writer_commit_stmt = writer_conn.prepare("COMMIT").await.unwrap();
+
+    // The trigger's commit is visible before its retained auto-checkpoint
+    // future first parks. At that point PrepareCheckpoint has frozen its
+    // snapshot and raised the temporary-ID commit gate.
+    setup
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0", ())
+        .await
+        .unwrap();
+    let checkpoint_parked = Arc::new(AtomicBool::new(false));
+    let checkpoint_completed = Arc::new(AtomicBool::new(false));
+    let writer_commit_polled = Arc::new(AtomicBool::new(false));
+
+    let trigger_conn = db.connect().unwrap();
+    let observer = db.connect().unwrap();
+    let checkpoint_config = db.connect().unwrap();
+    let mut trigger_stmt = trigger_conn
+        .prepare("INSERT INTO anchor VALUES(9, zeroblob(1000))")
+        .await
+        .unwrap();
+    let checkpoint_parked_task = checkpoint_parked.clone();
+    let checkpoint_completed_task = checkpoint_completed.clone();
+    let writer_commit_polled_task = writer_commit_polled.clone();
+
+    let checkpoint = turso_stress::future::spawn(async move {
+        let mut trigger_future = std::pin::pin!(trigger_stmt.execute(()));
+        let observer_future = async move {
+            loop {
+                let mut rows = observer
+                    .query("SELECT count(*) FROM anchor WHERE id = 9", ())
+                    .await
+                    .unwrap();
+                let mut count = None;
+                while let Some(row) = rows.next().await.unwrap() {
+                    count = Some(row.get::<i64>(0).unwrap());
+                }
+                if count == Some(1) {
+                    return;
+                }
+                shuttle::future::yield_now().await;
+            }
+        };
+        let mut observer_future = std::pin::pin!(observer_future);
+        let mut parked_after_commit = false;
+
+        for _ in 0..1_000 {
+            let trigger_poll = std::future::poll_fn(|cx| {
+                std::task::Poll::Ready(match trigger_future.as_mut().poll(cx) {
+                    std::task::Poll::Pending => None,
+                    std::task::Poll::Ready(result) => Some(result),
+                })
+            })
+            .await;
+
+            if let Some(result) = trigger_poll {
+                result.unwrap();
+                panic!("auto-checkpoint completed before it could be parked");
+            }
+
+            let observer_done = std::future::poll_fn(|cx| {
+                std::task::Poll::Ready(matches!(
+                    observer_future.as_mut().poll(cx),
+                    std::task::Poll::Ready(())
+                ))
+            })
+            .await;
+            if observer_done {
+                parked_after_commit = true;
+                break;
+            }
+
+            shuttle::future::yield_now().await;
+        }
+
+        assert!(
+            parked_after_commit,
+            "trigger commit never reached its retained auto-checkpoint"
+        );
+        turso_stress::note_progress();
+
+        checkpoint_parked_task.store(true, Ordering::SeqCst);
+
+        let mut writer_was_polled = false;
+        for _ in 0..1_000 {
+            if writer_commit_polled_task.load(Ordering::SeqCst) {
+                writer_was_polled = true;
+                break;
+            }
+            shuttle::future::yield_now().await;
+        }
+        assert!(
+            writer_was_polled,
+            "writer never polled COMMIT after the checkpoint parked"
+        );
+
+        trigger_future.await.unwrap();
+        turso_stress::note_progress();
+
+        // The threshold is store-global. The writer waits for this post-
+        // checkpoint handoff before resuming COMMIT, so its durable frame stays
+        // in the logical log for cold recovery.
+        checkpoint_config
+            .execute("PRAGMA mvcc_checkpoint_threshold = -1", ())
+            .await
+            .unwrap();
+        checkpoint_completed_task.store(true, Ordering::SeqCst);
+        turso_stress::note_progress();
+    });
+
+    let writer_checkpoint_parked = checkpoint_parked.clone();
+    let writer_checkpoint_completed = checkpoint_completed.clone();
+    let writer_commit_polled_task = writer_commit_polled.clone();
+
+    let writer = turso_stress::future::spawn(async move {
+        let mut saw_parked_checkpoint = false;
+        for _ in 0..1_000 {
+            if writer_checkpoint_parked.load(Ordering::SeqCst) {
+                saw_parked_checkpoint = true;
+                break;
+            }
+            shuttle::future::yield_now().await;
+        }
+        assert!(
+            saw_parked_checkpoint,
+            "writer never observed the parked checkpoint"
+        );
+
+        // Preparation and the row write happened before the checkpoint. The
+        // only remaining work is COMMIT, so Pending here is the temporary-ID
+        // checkpoint fence rather than statement preparation or pager IO.
+        let mut writer_commit = std::pin::pin!(writer_commit_stmt.execute(()));
+        let first_poll = std::future::poll_fn(|cx| {
+            std::task::Poll::Ready(match writer_commit.as_mut().poll(cx) {
+                std::task::Poll::Pending => None,
+                std::task::Poll::Ready(result) => Some(result),
+            })
+        })
+        .await;
+        assert!(
+            first_poll.is_none(),
+            "prepared writer COMMIT bypassed the active checkpoint fence"
+        );
+        writer_commit_polled_task.store(true, Ordering::SeqCst);
+
+        let mut saw_completed_checkpoint = false;
+        for _ in 0..1_000 {
+            if writer_checkpoint_completed.load(Ordering::SeqCst) {
+                saw_completed_checkpoint = true;
+                break;
+            }
+            shuttle::future::yield_now().await;
+        }
+        assert!(
+            saw_completed_checkpoint,
+            "writer never observed checkpoint completion"
+        );
+
+        writer_commit.await.unwrap();
+        turso_stress::note_progress();
+
+        let mut acknowledged = 1;
+        for id in 100_001..100_000 + WRITES {
+            match writer_conn
+                .execute(format!("INSERT INTO b VALUES({id}, 'ack-{id}')"), ())
+                .await
+            {
+                Ok(_) => {
+                    acknowledged += 1;
+                }
+
+                Err(turso::Error::Busy(_) | turso::Error::BusySnapshot(_)) => {}
+
+                Err(error) => {
+                    panic!("unexpected INSERT error: {error:?}");
+                }
+            }
+
+            shuttle::future::yield_now().await;
+        }
+
+        acknowledged
+    });
+
+    checkpoint.await.unwrap();
+    let acknowledged = writer.await.unwrap();
+    turso_stress::note_progress();
+
+    assert!(acknowledged > 0);
+    assert!(
+        writer_commit_polled.load(Ordering::SeqCst),
+        "the prepared writer commit must be polled while the checkpoint is parked"
+    );
+
+    drop(setup);
+    drop(db);
+
+    let cold_db = Builder::new_local(db_path)
+        .experimental_mvcc_passive_checkpoint(true)
+        .build()
+        .await
+        .unwrap();
+
+    let cold = cold_db.connect().unwrap();
+
+    cold.execute("PRAGMA mvcc_checkpoint_threshold = -1", ())
+        .await
+        .unwrap();
+
+    let cold_index_root = query_i64(
+        &cold,
+        "SELECT rootpage
+           FROM sqlite_schema
+          WHERE name = 'a_v'",
+    )
+    .await;
+
+    assert_eq!(
+        cold_index_root, -b_temporary_root,
+        "fixture must preserve the stale-table-ID/index-root alias"
+    );
+
+    let recovered = query_i64(&cold, "SELECT count(*) FROM b WHERE id >= 100000").await;
+
+    assert_eq!(
+        recovered, acknowledged,
+        "cold recovery lost acknowledged writes to b"
+    );
+
+    assert_eq!(query_string(&cold, "PRAGMA integrity_check").await, "ok");
+    turso_stress::note_progress();
+
+    passive_checkpoint(&cold).await;
+
+    let recovered_after_checkpoint =
+        query_i64(&cold, "SELECT count(*) FROM b WHERE id >= 100000").await;
+
+    assert_eq!(
+        recovered_after_checkpoint, acknowledged,
+        "post-recovery checkpoint lost acknowledged writes to b"
+    );
+
+    assert_eq!(query_string(&cold, "PRAGMA integrity_check").await, "ok");
+}
+
+#[test]
+fn shuttle_test_passive_checkpoint_stale_table_id_aliases_index_root() {
+    // The explicit checkpoint/commit handshake above fixes the relevant
+    // ordering, so one deterministic execution covers the regression.
+    let scheduler = PctScheduler::new_from_seed(0xa903_398d_4995_8e14, 5, 1);
+
+    let runner = shuttle::Runner::new(scheduler, shuttle_config());
+
+    runner.run(|| {
+        shuttle::future::block_on(passive_checkpoint_stale_table_id_aliases_index_root_scenario())
+    });
 }


### PR DESCRIPTION
A commit can race the first passive checkpoint of a table. The checkpoint assigns positive physical roots while the commit is still serializing a logical-log frame with the old negative temporary ID. On recovery, that number may already belong to another B-tree, so rows can be replayed into an index and the next checkpoint can panic or lose data.

This closes both sides of the race. A transaction now keeps a checkpoint guard from its first temporary-ID allocation through commit or rollback. Commits that still touch unpublished roots take a narrow fence before building their log frame, while the passive checkpoint freezes its snapshot behind the matching write side and will not publish below the latest durable temporary-ID frame.

Root publication also canonicalizes schema and retained-log copies without overwriting concurrent schema-version metadata. Dropped committed statements finish their metadata and dependency cleanup and release their guards.

The I/O-heavy checkpoint phase remains concurrent; only snapshot selection and root publication are fenced.

The regression coverage includes the exact old ID/root alias under Shuttle, an out-of-order Preparing watermark, DDL after the snapshot, concurrent ALTER, abandoned commits, and cold recovery.

Fixes #7960