### PR TITLE
core/vdbe: recycle register copies

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -864,6 +864,29 @@ pub enum AggContext {
     External(ExternalAggState),
 }
 
+impl TryClone for AggContext {
+    type Error = TryReserveError;
+
+    /// Fallible clone: the builtin payload's Vec and each contained Text/Blob
+    /// go through fallible reservation. External state holds only FFI
+    /// pointers and copies without allocating.
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::CloneFrom)]
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        match self {
+            Self::Builtin(payload) => {
+                let mut values = Vec::try_with_capacity_ext(payload.len())?;
+                for value in payload {
+                    let mut copy = Value::Null;
+                    copy.try_clone_from(value)?;
+                    values.push(copy);
+                }
+                Ok(Self::Builtin(values))
+            }
+            Self::External(_) => Ok(self.clone()),
+        }
+    }
+}
+
 impl AggContext {
     pub fn compute_external(&self) -> Result<Value> {
         if let Self::External(ext_state) = self {
@@ -1605,7 +1628,7 @@ mod immutable_record {
 
         /// A record holding a copy of `payload`, serialized into `buf`.
         #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::RecordCopy)]
-        pub fn copy_payload(payload: &[u8], buf: RecordBuf) -> Result<Self> {
+        pub fn copy_payload(payload: &[u8], buf: RecordBuf) -> Result<Self, TryReserveError> {
             let RecordBuf(mut buf) = buf;
             buf.try_extend(payload.iter().copied())?;
             Ok(Self {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1,6 +1,6 @@
 use crate::alloc::{
-    DynAllocator, TursoAllocExt, TursoIteratorExt, TursoSliceExt, TursoTryWithCapacityExt,
-    TursoVecExt,
+    DynAllocator, TryClone, TursoAllocExt, TursoIteratorExt, TursoSliceExt,
+    TursoTryWithCapacityExt, TursoVecExt,
 };
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::{AccumulatorFunc, AlterTableFunc, WindowFunc};
@@ -2631,7 +2631,14 @@ pub fn op_reg_copy_offset(
             state.registers.len()
         )));
     }
-    state.registers[dest] = state.registers[*src].clone();
+    if dest != *src {
+        // try_clone_from reuses the destination register's allocation.
+        let [src, dst] = state
+            .registers
+            .get_disjoint_mut([*src, dest])
+            .expect("RegCopyOffset source and destination registers are distinct");
+        dst.try_clone_from(src)?;
+    }
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -11754,7 +11761,16 @@ pub fn op_copy(
         insn
     );
     for i in 0..=*extra_amount {
-        state.registers[*dst_reg + i] = state.registers[*src_reg + i].clone();
+        let (src, dst) = (*src_reg + i, *dst_reg + i);
+        if src == dst {
+            continue;
+        }
+        // try_clone_from reuses the destination register's allocation.
+        let [src, dst] = state
+            .registers
+            .get_disjoint_mut([src, dst])
+            .expect("Copy source and destination registers are distinct");
+        dst.try_clone_from(src)?;
     }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -17,6 +17,7 @@
 //!
 //! https://www.sqlite.org/opcode.html
 
+use crate::alloc::{TryReserveError, TursoFromIterator};
 use crate::translate::plan::BitSet;
 use crate::types::{Extendable, Text, ValueBlob};
 use crate::{turso_assert, turso_assert_ne, turso_debug_assert, NonNan};
@@ -41,7 +42,7 @@ pub mod value;
 // for benchmarks
 pub use crate::translate::collate::CollationSeq;
 use crate::{
-    alloc::DynAllocator,
+    alloc::{DynAllocator, TryClone},
     error::LimboError,
     function::FuncCtx,
     mvcc::{database::CommitStateMachine, MvccClock},
@@ -73,7 +74,7 @@ use crate::sync::RwLock;
 use crate::{
     storage::pager::Pager,
     translate::plan::ResultSetColumn,
-    types::{AggContext, Cursor, ImmutableRecord, Value},
+    types::{AggContext, Cursor, ImmutableRecord, RecordBuf, Value},
     vdbe::{builder::CursorType, insn::Insn},
 };
 use crate::{
@@ -261,7 +262,76 @@ pub enum Register {
     Record(ImmutableRecord),
 }
 
+impl TryClone for Register {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        match self {
+            Register::Value(value) => Ok(Register::Value(value.try_clone()?)),
+            Register::Aggregate(context) => Ok(Register::Aggregate(context.try_clone()?)),
+            Register::Record(record) => Ok(Register::Record(ImmutableRecord::copy_payload(
+                record.get_payload(),
+                RecordBuf::alloc(),
+            )?)),
+        }
+    }
+
+    /// Fallibly copies `source` into this register, reusing the destination's
+    /// Value or record allocation when the variants match; see
+    /// [Value::try_clone_from].
+    #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::CloneFrom)]
+    fn try_clone_from(&mut self, source: &Self) -> Result<(), Self::Error> {
+        match (self, source) {
+            (Register::Value(dst), Register::Value(src)) => dst.try_clone_from(src)?,
+            (Register::Record(dst), Register::Record(src)) => {
+                let buf = dst.as_blob_mut();
+                buf.clear();
+                buf.try_extend(src.get_payload().iter().copied())?;
+            }
+            (dst, Register::Value(src)) => {
+                let mut value = Value::Null;
+                value.try_clone_from(src)?;
+                *dst = Register::Value(value);
+            }
+            (dst, Register::Record(src)) => {
+                *dst = Register::Record(ImmutableRecord::copy_payload(
+                    src.get_payload(),
+                    RecordBuf::alloc(),
+                )?);
+            }
+            (dst, Register::Aggregate(src)) => *dst = Register::Aggregate(src.try_clone()?),
+        }
+        Ok(())
+    }
+}
+
 impl Register {
+    /// Takes the register's spent record buffer for reuse, leaving NULL.
+    /// Callers about to overwrite the register use this to recycle its
+    /// allocation instead of dropping it.
+    #[inline]
+    pub fn take_buf(&mut self) -> RecordBuf {
+        match std::mem::replace(self, Register::Value(Value::Null)) {
+            Register::Record(record) => record.retire(),
+            _ => RecordBuf::alloc(),
+        }
+    }
+
+    /// Fallibly sets the register to a copy of `val`, reusing the register's
+    /// existing allocation when possible; see [Value::try_clone_from].
+    #[inline]
+    pub fn try_clone_value_from(&mut self, val: &Value) -> crate::Result<()> {
+        match self {
+            Register::Value(v) => v.try_clone_from(val)?,
+            _ => {
+                let mut value = Value::Null;
+                value.try_clone_from(val)?;
+                *self = Register::Value(value);
+            }
+        }
+        Ok(())
+    }
+
     #[inline]
     pub const fn is_null(&self) -> bool {
         matches!(self, Register::Value(Value::Null))
@@ -3239,6 +3309,104 @@ mod tests {
             OpInsertSubState::Seek
         ));
         assert!(matches!(state.seek_state, OpSeekState::MoveLast));
+    }
+
+    #[test]
+    fn register_try_clone_copies_each_variant() {
+        let record_values = [Value::from_i64(1), Value::build_text("record payload")];
+        let aggregate_values = crate::alloc::vec![Value::build_text("aggregate payload")];
+        let registers = [
+            Register::Value(Value::build_text("value")),
+            Register::Aggregate(AggContext::Builtin(aggregate_values)),
+            Register::Record(
+                ImmutableRecord::from_values(&record_values, record_values.len()).unwrap(),
+            ),
+        ];
+
+        for source in registers {
+            assert_eq!(source.try_clone().unwrap(), source);
+        }
+    }
+
+    #[test]
+    fn register_try_clone_from_reuses_matching_allocations() {
+        use crate::types::Text;
+
+        let src = Register::Value(Value::Text(Text::new(String::from("short"))));
+        let mut dst = Register::Value(Value::Text(Text::new(String::from(
+            "a destination string with plenty of capacity",
+        ))));
+        let ptr = match &dst {
+            Register::Value(Value::Text(t)) => t.as_str().as_ptr(),
+            _ => unreachable!(),
+        };
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        match &dst {
+            Register::Value(Value::Text(t)) => assert_eq!(t.as_str().as_ptr(), ptr),
+            _ => unreachable!(),
+        }
+
+        let src_values = [Value::from_i64(1), Value::build_text("record payload")];
+        let src =
+            Register::Record(ImmutableRecord::from_values(&src_values, src_values.len()).unwrap());
+        let large_values = [Value::build_text(
+            "a much longer record payload that dwarfs the source record",
+        )];
+        let mut dst = Register::Record(
+            ImmutableRecord::from_values(&large_values, large_values.len()).unwrap(),
+        );
+        let ptr = match &dst {
+            Register::Record(record) => record.get_payload().as_ptr(),
+            _ => unreachable!(),
+        };
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+        match &dst {
+            Register::Record(record) => assert_eq!(record.get_payload().as_ptr(), ptr),
+            _ => unreachable!(),
+        }
+
+        let src = Register::Aggregate(AggContext::Builtin(crate::alloc::vec![
+            Value::build_text("agg state"),
+            Value::from_i64(2),
+        ]));
+        let mut dst = Register::Value(Value::Null);
+        dst.try_clone_from(&src).unwrap();
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn register_take_buf_recycles_record_allocations() {
+        let values = [Value::build_text("some record payload")];
+        let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
+        let capacity = record.as_blob().capacity();
+        let ptr = record.get_payload().as_ptr();
+
+        let mut register = Register::Record(record);
+        let rebuilt = ImmutableRecord::build(&values, register.take_buf()).unwrap();
+        assert!(register.is_null());
+        assert_eq!(rebuilt.as_blob().capacity(), capacity);
+        assert_eq!(rebuilt.get_payload().as_ptr(), ptr);
+    }
+
+    #[test]
+    fn register_try_clone_value_from_reuses_value_slot() {
+        let value = Value::build_text(String::from("payload"));
+        let mut register = Register::Value(Value::build_text(String::from(
+            "existing buffer with plenty of capacity to reuse",
+        )));
+        let ptr = match &register {
+            Register::Value(Value::Text(text)) => text.as_str().as_ptr(),
+            _ => unreachable!(),
+        };
+
+        register.try_clone_value_from(&value).unwrap();
+        assert_eq!(register, Register::Value(value));
+        match &register {
+            Register::Value(Value::Text(text)) => assert_eq!(text.as_str().as_ptr(), ptr),
+            _ => unreachable!(),
+        }
     }
 }
 


### PR DESCRIPTION
## Description

- implement allocator-aware `TryClone` for aggregate contexts and VDBE registers
- route `Copy` and `RegCopyOffset` through `try_clone_from` so matching value and record buffers are reused
- avoid work for source/destination self-copies and cover each register variant

## Context

The copy opcodes previously cloned into fresh register values, discarding reusable destination allocations. The fallible clone path reduces allocation churn while preserving allocation-error propagation.
Register copies can reuse already-grown text, blob, and serialized-record buffers on hot execution paths.



