### PR TITLE
core/incremental: exclude NULL operands from IVM filter comparisons

### DIFF
--- a/core/incremental/filter_operator.rs
+++ b/core/incremental/filter_operator.rs
@@ -61,6 +61,14 @@ pub struct FilterOperator {
     tracker: Option<Arc<Mutex<ComputationTracker>>>,
 }
 
+/// SQL three-valued logic: NULL on either side yields NULL (`None`), which WHERE treats as not-true.
+fn sql_compare(left: &Value, right: &Value) -> Option<Ordering> {
+    if matches!(left, Value::Null) || matches!(right, Value::Null) {
+        return None;
+    }
+    Some(left.cmp(right))
+}
+
 impl FilterOperator {
     pub fn new(predicate: FilterPredicate) -> Self {
         Self {
@@ -78,28 +86,22 @@ impl FilterOperator {
         match &self.predicate {
             FilterPredicate::None => true,
             FilterPredicate::Equals { column_idx, value } => {
-                let v = &values[*column_idx];
-                v == value
+                sql_compare(&values[*column_idx], value).is_some_and(|o| o == Ordering::Equal)
             }
             FilterPredicate::NotEquals { column_idx, value } => {
-                let v = &values[*column_idx];
-                v != value
+                sql_compare(&values[*column_idx], value).is_some_and(|o| o != Ordering::Equal)
             }
             FilterPredicate::GreaterThan { column_idx, value } => {
-                let v = &values[*column_idx];
-                v.cmp(value) == Ordering::Greater
+                sql_compare(&values[*column_idx], value).is_some_and(|o| o == Ordering::Greater)
             }
             FilterPredicate::GreaterThanOrEqual { column_idx, value } => {
-                let v = &values[*column_idx];
-                v.cmp(value) != Ordering::Less
+                sql_compare(&values[*column_idx], value).is_some_and(|o| o != Ordering::Less)
             }
             FilterPredicate::LessThan { column_idx, value } => {
-                let v = &values[*column_idx];
-                v.cmp(value) == Ordering::Less
+                sql_compare(&values[*column_idx], value).is_some_and(|o| o == Ordering::Less)
             }
             FilterPredicate::LessThanOrEqual { column_idx, value } => {
-                let v = &values[*column_idx];
-                v.cmp(value) != Ordering::Greater
+                sql_compare(&values[*column_idx], value).is_some_and(|o| o != Ordering::Greater)
             }
             FilterPredicate::And(left, right) => {
                 // Temporarily create sub-filters to evaluate
@@ -116,51 +118,33 @@ impl FilterOperator {
             FilterPredicate::ColumnEquals {
                 left_idx,
                 right_idx,
-            } => {
-                let left = &values[*left_idx];
-                let right = &values[*right_idx];
-                left == right
-            }
+            } => sql_compare(&values[*left_idx], &values[*right_idx])
+                .is_some_and(|o| o == Ordering::Equal),
             FilterPredicate::ColumnNotEquals {
                 left_idx,
                 right_idx,
-            } => {
-                let left = &values[*left_idx];
-                let right = &values[*right_idx];
-                left != right
-            }
+            } => sql_compare(&values[*left_idx], &values[*right_idx])
+                .is_some_and(|o| o != Ordering::Equal),
             FilterPredicate::ColumnGreaterThan {
                 left_idx,
                 right_idx,
-            } => {
-                let left = &values[*left_idx];
-                let right = &values[*right_idx];
-                left.cmp(right) == Ordering::Greater
-            }
+            } => sql_compare(&values[*left_idx], &values[*right_idx])
+                .is_some_and(|o| o == Ordering::Greater),
             FilterPredicate::ColumnGreaterThanOrEqual {
                 left_idx,
                 right_idx,
-            } => {
-                let left = &values[*left_idx];
-                let right = &values[*right_idx];
-                left.cmp(right) != Ordering::Less
-            }
+            } => sql_compare(&values[*left_idx], &values[*right_idx])
+                .is_some_and(|o| o != Ordering::Less),
             FilterPredicate::ColumnLessThan {
                 left_idx,
                 right_idx,
-            } => {
-                let left = &values[*left_idx];
-                let right = &values[*right_idx];
-                left.cmp(right) == Ordering::Less
-            }
+            } => sql_compare(&values[*left_idx], &values[*right_idx])
+                .is_some_and(|o| o == Ordering::Less),
             FilterPredicate::ColumnLessThanOrEqual {
                 left_idx,
                 right_idx,
-            } => {
-                let left = &values[*left_idx];
-                let right = &values[*right_idx];
-                left.cmp(right) != Ordering::Greater
-            }
+            } => sql_compare(&values[*left_idx], &values[*right_idx])
+                .is_some_and(|o| o != Ordering::Greater),
             FilterPredicate::IsNull { column_idx } => {
                 matches!(values[*column_idx], Value::Null)
             }

--- a/sqlite/conformance/turso-sqltests/ivm-null-where-filter.sqltest
+++ b/sqlite/conformance/turso-sqltests/ivm-null-where-filter.sqltest
@@ -1,0 +1,116 @@
+@database :memory:
+@skip-file-if mvcc "materialized views not supported in MVCC mode"
+@requires-file materialized_views ""
+
+# Rows inserted before the view exists: the from-scratch populate path.
+test ivm-null-where-neq-string {
+    CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT);
+    INSERT INTO items VALUES ('a', 'Alice');
+    INSERT INTO items VALUES ('b', 'Bob');
+    INSERT INTO items VALUES ('c', NULL);
+    INSERT INTO items VALUES ('d', NULL);
+    INSERT INTO items VALUES ('e', '');
+
+    CREATE MATERIALIZED VIEW named AS SELECT id, name FROM items WHERE name != '';
+
+    SELECT id, name FROM named ORDER BY id;
+}
+expect {
+    a|Alice
+    b|Bob
+}
+
+test ivm-null-where-lt-string {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t VALUES (1, 'apple');
+    INSERT INTO t VALUES (2, NULL);
+    INSERT INTO t VALUES (3, 'banana');
+    INSERT INTO t VALUES (4, NULL);
+    INSERT INTO t VALUES (5, 'cherry');
+
+    CREATE MATERIALIZED VIEW mv_lt AS SELECT id, val FROM t WHERE val < 'cherry';
+
+    SELECT id, val FROM mv_lt ORDER BY id;
+}
+expect {
+    1|apple
+    3|banana
+}
+
+test ivm-null-where-neq-incremental {
+    CREATE TABLE data (id INTEGER PRIMARY KEY, status TEXT);
+
+    CREATE MATERIALIZED VIEW active AS SELECT id, status FROM data WHERE status != 'deleted';
+
+    INSERT INTO data VALUES (1, 'active');
+    INSERT INTO data VALUES (2, NULL);
+    INSERT INTO data VALUES (3, 'pending');
+    INSERT INTO data VALUES (4, NULL);
+
+    SELECT id, status FROM active ORDER BY id;
+}
+expect {
+    1|active
+    3|pending
+}
+
+# `x <op> NULL` is NULL for every row, so none of these views may contain anything.
+test ivm-null-literal-comparisons {
+    CREATE TABLE nl (id INTEGER PRIMARY KEY, x TEXT);
+    CREATE MATERIALIZED VIEW nl_eq  AS SELECT id FROM nl WHERE x =  NULL;
+    CREATE MATERIALIZED VIEW nl_neq AS SELECT id FROM nl WHERE x != NULL;
+    CREATE MATERIALIZED VIEW nl_gt  AS SELECT id FROM nl WHERE x >  NULL;
+    CREATE MATERIALIZED VIEW nl_ge  AS SELECT id FROM nl WHERE x >= NULL;
+    CREATE MATERIALIZED VIEW nl_lt  AS SELECT id FROM nl WHERE x <  NULL;
+    CREATE MATERIALIZED VIEW nl_le  AS SELECT id FROM nl WHERE x <= NULL;
+    INSERT INTO nl VALUES (1, 'a');
+    INSERT INTO nl VALUES (2, NULL);
+    SELECT 'eq',  id FROM nl_eq;
+    SELECT 'neq', id FROM nl_neq;
+    SELECT 'gt',  id FROM nl_gt;
+    SELECT 'ge',  id FROM nl_ge;
+    SELECT 'lt',  id FROM nl_lt;
+    SELECT 'le',  id FROM nl_le;
+}
+expect {
+}
+
+# 3VL through AND/OR: NULL OR true is true, NULL AND anything is not true.
+test ivm-null-3vl-compound-and-or {
+    CREATE TABLE cp (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+    CREATE MATERIALIZED VIEW cp_or  AS SELECT id FROM cp WHERE a > 5 OR  b = 1;
+    CREATE MATERIALIZED VIEW cp_and AS SELECT id FROM cp WHERE a > 5 AND b = 1;
+    CREATE MATERIALIZED VIEW cp_col AS SELECT id FROM cp WHERE a < b;
+    INSERT INTO cp VALUES (1, NULL, 1);
+    INSERT INTO cp VALUES (2, 10, NULL);
+    INSERT INTO cp VALUES (3, NULL, NULL);
+    INSERT INTO cp VALUES (4, 10, 1);
+    INSERT INTO cp VALUES (5, 1, 2);
+    SELECT 'or',  id FROM cp_or  ORDER BY id;
+    SELECT 'and', id FROM cp_and ORDER BY id;
+    SELECT 'col', id FROM cp_col ORDER BY id;
+}
+expect {
+    or|1
+    or|2
+    or|4
+    and|4
+    col|5
+}
+
+test ivm-null-where-neq-after-update {
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, val TEXT);
+
+    CREATE MATERIALIZED VIEW mv2 AS SELECT id, val FROM t2 WHERE val != '';
+
+    INSERT INTO t2 VALUES (1, 'hello');
+    INSERT INTO t2 VALUES (2, NULL);
+    INSERT INTO t2 VALUES (3, 'world');
+
+    UPDATE t2 SET val = NULL WHERE id = 1;
+
+    SELECT id, val FROM mv2 ORDER BY id;
+}
+expect {
+    3|world
+}


### PR DESCRIPTION
`FilterOperator::evaluate_predicate` compared with Rust's operators (`==`, `!=`, `Ord::cmp`), which treat `NULL` as an ordinary value. Any comparison against `NULL` should yield `NULL` — not-true in `WHERE` — so a matview defined `... WHERE name != ''` kept rows whose `name` is `NULL`, and `... WHERE x != NULL` kept every row.

## The fix

All twelve comparison arms now derive their result from one helper that yields no ordering when either operand is `NULL`. Guarding operands individually per arm is what produced the original asymmetry — an earlier version of this PR checked only the row value and left the literal side unguarded, so `WHERE x != NULL` still leaked. One seam for the comparison keeps both sides covered and is 25 lines shorter.

`IS NULL` / `IS NOT NULL` are untouched; they are the operators that legitimately compare against `NULL`. `AND`/`OR` need no 3VL machinery here: the predicate tree contains only AND/OR over comparison leaves and has no `NOT` variant — `NOT`, `CASE` and functions route to the projection path or fail at `CREATE` — so "keep iff TRUE" composes exactly.

## Test

`sqlite/conformance/turso-sqltests/ivm-null-where-filter.sqltest`, 6 cases: `!=`/`<` on strings, empty-string vs `NULL`, incremental insert, update-to-`NULL`, all six operators against a `NULL` literal, and AND/OR compounds with `NULL` leaves.

- `6ff0ee6c` test only. **4 of the 6 are red on main.** The two populate-path cases already passed: from-scratch populate pushes the `WHERE` into generated SQL, so the VDBE drops `NULL` rows before `FilterOperator` sees them. They are kept as coverage of that path, not presented as regressions.
- `dab6da11` the fix. 6/6 green; `cargo test -p turso_core incremental::` 170 passed.

The suite lives in `turso-sqltests/` with the other matview suites — materialized views are Turso-specific, so this is not a differential test despite comparing against SQLite semantics by hand.

## Known gap, not fixed here

`FilterOperator` also ignores **affinity and collation**, and the same re-filtering makes it worse than a no-op:

```sql
CREATE TABLE n(id INTEGER PRIMARY KEY, x INTEGER);
INSERT INTO n VALUES (1, 5);
CREATE MATERIALIZED VIEW vn AS SELECT id, x FROM n WHERE x = '5';
INSERT INTO n VALUES (2, 5);
-- sqlite view: 2 rows.  Turso matview: 0 rows — including the populate row,
-- which the VDBE matched correctly and FilterOperator then discarded.
```

Same for `COLLATE NOCASE`. The engine's canonical comparison (`op_comparison` → `convert_for_compare` → `compare_immutable_single`) does NULL, affinity and collation together; `FilterOperator` reimplements only the middle. Threading column type and collation into predicate compilation is a design change and does not belong in a NULL-semantics fix, but the helper added here is the single seam where it lands. Happy to file it as its own issue.

Reproducer came from a materialized-view-heavy workload. Fix drafted with Claude Code, then adversarially reviewed by a separate model — which is what caught the one-sided guard; reviewed by me at the level I can judge.

