### PR TITLE
core/vdbe: recycle record-producing opcode buffers

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -16,7 +16,6 @@ use crate::types::{
     compare_immutable, IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekKey, SeekOp,
     SeekResult, Value,
 };
-use crate::vdbe::make_record;
 use crate::vdbe::Register;
 use crate::{return_if_io, Completion, Connection, LimboError, Pager, Result};
 use std::any::Any;
@@ -1486,7 +1485,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         registers: &[Register],
         op: SeekOp,
     ) -> Result<IOResult<SeekResult>> {
-        let record = make_record(registers, &0, &registers.len())?;
+        let record = ImmutableRecord::from_registers(registers, registers.len())?;
         self.seek(SeekKey::IndexKey(record.as_record_ref()), op)
     }
 

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1708,7 +1708,7 @@ pub fn translate_create_virtual_table(
     let module_name_reg = program.emit_string8_new_reg(module_name_str.clone());
     let table_name_reg = program.emit_string8_new_reg(table_name.clone());
     let args_reg = if !args_vec.is_empty() {
-        let args_start = program.alloc_register();
+        let args_start = program.alloc_registers(args_vec.len());
 
         // Emit string8 instructions for each arg
         for (i, arg) in args_vec.iter().enumerate() {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -154,7 +154,7 @@ use crate::{
     json::jsonb_patch, json::jsonb_remove, json::jsonb_replace, json::jsonb_set, json::Conv,
 };
 
-use super::{make_record, Program, ProgramState, Register};
+use super::{Program, ProgramState, Register};
 
 #[cfg(feature = "fs")]
 use crate::connection::resolve_ext_path;
@@ -2822,7 +2822,18 @@ pub fn op_make_record(
         }
     }
 
-    let record = make_record(&state.registers, &start_reg, &count)?;
+    if dest_reg >= start_reg && dest_reg - start_reg < count {
+        return Err(LimboError::InternalError(format!(
+            "MakeRecord: destination register {dest_reg} overlaps its source range {start_reg}..{}",
+            start_reg + count
+        )));
+    }
+
+    // Serialize into the destination register's spent record buffer: per-row
+    // paths become allocation-free once the buffer has grown to the row size.
+    let buf = state.registers[dest_reg].take_buf();
+    let regs = &state.registers[start_reg..start_reg + count];
+    let record = ImmutableRecord::build_from_registers(regs, buf)?;
     state.registers[dest_reg] = Register::Record(record);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -5079,6 +5090,9 @@ pub fn op_row_data(
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(RowData { cursor_id, dest }, insn);
 
+    // Copy the row into the destination register's spent record buffer: one
+    // payload copy, no allocation once the buffer has grown to the row size.
+    let buf = state.registers[*dest].take_buf();
     let record = {
         let cursor_ref = must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "RowData");
         let cursor = cursor_ref.as_btree_mut();
@@ -5089,7 +5103,7 @@ pub fn op_row_data(
             LimboError::InternalError("RowData: cursor has no record".to_string())
         })?;
 
-        record.clone()
+        ImmutableRecord::copy_payload(record.get_payload(), buf)?
     };
 
     let reg = &mut state.registers[*dest];
@@ -17796,6 +17810,32 @@ mod tests {
         };
         assert!(matches!(err, LimboError::Constraint(message) if message == "datatype mismatch"));
         assert_eq!(state.pc, 0);
+    }
+
+    #[test]
+    fn test_make_record_overlapping_dest_returns_error() {
+        let stmt = prepare_test_statement();
+
+        let mut state = ProgramState::new(3, 0);
+        for i in 0..3 {
+            state.set_register(i, Register::Value(Value::from_i64(i as i64)));
+        }
+        let insn = Insn::MakeRecord {
+            start_reg: 0,
+            count: 3,
+            dest_reg: 1,
+            index_name: None,
+            affinity_str: None,
+        };
+
+        let err = match op_make_record(stmt.get_program(), &mut state, &insn, stmt.get_pager()) {
+            Ok(_) => panic!("overlapping destination register must fail"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, LimboError::InternalError(ref message) if message.contains("overlaps its source range")),
+            "unexpected error: {err:?}"
+        );
     }
 
     #[test]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2892,15 +2892,6 @@ impl Deref for Program {
     }
 }
 
-pub(crate) fn make_record(
-    registers: &[Register],
-    start_reg: &usize,
-    count: &usize,
-) -> Result<ImmutableRecord> {
-    let regs = &registers[*start_reg..*start_reg + *count];
-    ImmutableRecord::from_registers(regs, regs.len())
-}
-
 /// Split a register slice into an immutable ref and a mutable ref at two distinct indices.
 pub(crate) fn split_registers(
     registers: &mut [Register],

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -916,7 +916,11 @@ def test_csv():
         "Empty CSV table without header should not have columns other than 'c0'",
     )
 
-    turso.run_debug("create virtual table t2 using csv(data='', header=true);")
+    turso.run_test_fn(
+        "create virtual table t2 using csv(data='', header=true);",
+        null,
+        "Create empty CSV table with header",
+    )
     turso.run_test_fn(
         'SELECT "(NULL)" FROM t2;',
         lambda res: res == "",


### PR DESCRIPTION
## Description

- reuse destination-register `RecordBuf` capacity in `MakeRecord`
- reuse destination record capacity when `RowData` copies cursor payloads
- reject overlapping `MakeRecord` source and destination registers before consuming the destination
- remove the redundant `make_record` helper and inline its remaining MVCC caller

## Context

Record-producing opcodes allocated a fresh serialized record for every row even when their destination register already owned sufficient capacity. Reusing the spent buffer removes steady-state per-row allocations.

## Benchmark

`cargo bench --bench record_recycling`, compared with parent `60864170`:

| Case | Allocations | Allocated bytes |
| --- | ---: | ---: |
| `sorter_record_round_trip` | 6,174 → 4,127 (-33%) | 2.575 → 2.074 MB (-19%) |
| `last_value_blob_capture` | 4,141 → 2,094 (-49%) | 552 → 278 KB (-50%) |
