### PR TITLE
core/storage: reset suspended pager state machines before clearing the page cache

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2926,7 +2926,11 @@ impl Pager {
         };
         let changed = wal.begin_read_tx()?;
         if changed {
-            // Someone else changed the database -> assume our page cache is invalid (this is default SQLite behavior, we can probably do better with more granular invalidation)
+            // Someone else changed the database -> assume our page cache is invalid
+            // (this is default SQLite behavior, we can probably do better with more
+            // granular invalidation).
+            // Reset internal state machines first to release any pinned pages.
+            self.reset_internal_states();
             self.clear_page_cache(false);
             // Invalidate cached schema cookie to force re-read on next access
             self.set_schema_cookie(None);
@@ -5574,6 +5578,10 @@ impl Pager {
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn rollback(&self, schema_did_change: bool, connection: &Connection, is_write: bool) {
         tracing::debug!(schema_did_change);
+        // Reset internal state machines FIRST to release any pinned pages held by
+        // allocate_page, free_page, etc. This must happen before clear_page_cache
+        // so that pinned pages are unpinned and can be properly cleared.
+        self.reset_internal_states();
         if is_write {
             let clear_dirty = true;
             // The page cache only needs to be cleared if we are rolling back a write transaction.
@@ -5592,7 +5600,6 @@ impl Pager {
                 "dirty pages should be empty for read txn"
             );
         }
-        self.reset_internal_states();
         // Invalidate cached schema cookie since rollback may have restored the database schema cookie
         self.set_schema_cookie(None);
         if schema_did_change {
@@ -5610,8 +5617,43 @@ impl Pager {
         *self.checkpoint_state.write() = CheckpointState::default();
         self.syncing.store(false, Ordering::SeqCst);
         self.commit_info.write().reset();
-        *self.allocate_page_state.write() = AllocatePageState::Start;
-        *self.free_page_state.write() = FreePageState::Start;
+        // Release the pins held by suspended allocate_page / free_page state
+        // machines before discarding their state. pin()/unpin() is a manual
+        // atomic counter that is NOT tied to the PageRef's Drop, so simply
+        // overwriting these enums to Start would strand the pins. With the
+        // pin-preserving PageCache::clear(), a stranded pin keeps an
+        // uncommitted freelist page (trunk/leaf) alive across a rollback,
+        // poisoning the freelist. Every caller of this function abandons the
+        // suspended operation (it restarts from Start), so releasing the pins
+        // here is always correct.
+        {
+            let mut allocate_page_state = self.allocate_page_state.write();
+            match &*allocate_page_state {
+                AllocatePageState::SearchAvailableFreeListLeaf { trunk_page } => {
+                    trunk_page.unpin();
+                }
+                AllocatePageState::ReuseFreelistLeaf {
+                    trunk_page,
+                    leaf_page,
+                    ..
+                } => {
+                    trunk_page.unpin();
+                    leaf_page.unpin();
+                }
+                AllocatePageState::Start | AllocatePageState::AllocateNewPage { .. } => {}
+            }
+            *allocate_page_state = AllocatePageState::Start;
+        }
+        {
+            let mut free_page_state = self.free_page_state.write();
+            match &*free_page_state {
+                FreePageState::AddToTrunk { page } | FreePageState::NewTrunk { page } => {
+                    page.unpin();
+                }
+                FreePageState::Start => {}
+            }
+            *free_page_state = FreePageState::Start;
+        }
         *self.spill_state.write() = SpillState::Idle;
         #[cfg(not(feature = "omit_autovacuum"))]
         {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -6499,6 +6499,100 @@ mod ptrmap_tests {
             IOResult::IO(_) => panic!("loaded cache hit must not yield"),
         }
     }
+
+    /// Regression test for the "Freelist trunk page is not loaded" panic.
+    ///
+    /// `allocate_page` pins the freelist trunk page while its state machine is
+    /// suspended at an I/O yield (state `SearchAvailableFreeListLeaf`). If a
+    /// `begin_read_tx()` (db-changed branch) or `rollback()` then clears the page
+    /// cache while that machine is still suspended, the trunk's buffer is freed;
+    /// on the buggy code the machine later resumed straight into
+    /// `SearchAvailableFreeListLeaf` and hit
+    /// `turso_assert!(trunk_page.is_loaded(), "Freelist trunk page is not loaded")`.
+    ///
+    /// The fix is `reset_internal_states()`, which both callers now run *before*
+    /// clearing the cache: it releases the pins the suspended
+    /// allocate_page/free_page machines hold and resets them to `Start`, so the
+    /// machine can never resume into the freed trunk — it restarts a fresh
+    /// allocation instead. This is why the earlier pin-preserving `PageCache::clear`
+    /// is unnecessary (and was reverted: preserving pinned pages across a rollback
+    /// left uncommitted pages resident whose page-ids got reused once the rollback
+    /// shrank `database_size`, colliding in `force_insert_page`).
+    ///
+    /// This drives the interleaving deterministically at the pager level: no
+    /// materialized views, plain freelist allocation vs. the reset+clear sequence.
+    #[test]
+    fn suspended_allocate_reset_before_clear_releases_pins_and_resets() {
+        let page_size = 4096;
+        let pager = test_pager_setup(page_size, 10);
+
+        // Build a freelist out of two previously-allocated data pages. The first
+        // page freed becomes the freelist trunk; the second becomes a leaf pointer
+        // on that trunk. `allocate_page` will later read the trunk (pinning it) and
+        // then read the leaf.
+        let trunk_id = 5usize;
+        let leaf_id = 4usize;
+        run_until_done(|| pager.free_page(None, trunk_id), &pager).unwrap();
+        run_until_done(|| pager.free_page(None, leaf_id), &pager).unwrap();
+
+        // Arm a one-shot I/O yield on the leaf read. `allocate_page` reaches this
+        // read only after it has pinned the trunk and advanced to
+        // `SearchAvailableFreeListLeaf`, so this suspends the state machine with
+        // the trunk pinned — exactly the window the bug requires.
+        pager.arm_spill_yield_on_read(leaf_id as i64, 0);
+
+        // Drive allocate_page until it suspends inside SearchAvailableFreeListLeaf.
+        loop {
+            match pager.allocate_page().unwrap() {
+                IOResult::Done(_) => {
+                    panic!("allocate_page completed without suspending on the freelist leaf read")
+                }
+                IOResult::IO(io) => {
+                    if matches!(
+                        &*pager.allocate_page_state.read(),
+                        AllocatePageState::SearchAvailableFreeListLeaf { .. }
+                    ) {
+                        break;
+                    }
+                    io.wait(pager.io.as_ref()).unwrap();
+                }
+            }
+        }
+
+        // The trunk page is pinned by the suspended allocate_page state machine.
+        let trunk = pager.cache_get(trunk_id).unwrap().unwrap();
+        assert!(trunk.is_pinned(), "trunk must be pinned by allocate_page");
+        assert!(
+            trunk.is_loaded(),
+            "trunk must be loaded before the reset+clear"
+        );
+
+        // This is the step both begin_read_tx()/rollback() now perform BEFORE
+        // clearing the cache. It must release the pin the suspended allocate_page
+        // holds and reset the machine to Start. On the pre-fix code this only reset
+        // the enum without unpinning, so the trunk stayed pinned (the first
+        // assertion below is RED without the fix).
+        pager.reset_internal_states();
+
+        assert!(
+            !trunk.is_pinned(),
+            "reset_internal_states must release the suspended allocate_page's trunk pin"
+        );
+        assert!(
+            matches!(&*pager.allocate_page_state.read(), AllocatePageState::Start),
+            "reset_internal_states must reset the allocate_page machine to Start"
+        );
+
+        // Now the cache clear that follows in begin_read_tx()/rollback() is safe:
+        // the trunk buffer is freed, but because the machine is at Start it can
+        // never resume into SearchAvailableFreeListLeaf and hit the
+        // "Freelist trunk page is not loaded" assertion. clear must not panic.
+        pager.clear_page_cache(true);
+        assert!(
+            !trunk.is_loaded(),
+            "the unpinned trunk buffer is freed by the clear, which is now safe"
+        );
+    }
 }
 
 #[cfg(all(test, feature = "fs", host_shared_wal))]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -10253,4 +10253,63 @@ pub mod test {
             "checkpoint must succeed after rollback, not return Busy"
         );
     }
+
+    /// Regression test: rollback calls reset_internal_states(). If that function
+    /// resets max_frame_read_lock_index to NO_LOCK_HELD without actually releasing
+    /// the shared read lock, end_read_tx() becomes a no-op and the lock leaks.
+    /// A leaked read lock permanently blocks Restart/Truncate checkpoints.
+    #[test]
+    fn test_wal_rollback_does_not_leak_read_lock() {
+        let (db, _path) = get_database();
+        let conn1 = db.connect().unwrap();
+        let conn2 = db.connect().unwrap();
+
+        conn1
+            .execute("create table test(id integer primary key, value text)")
+            .unwrap();
+        bulk_inserts(&conn1, 5, 10);
+
+        // conn2: begin read tx — acquires a shared read lock on a non-zero slot
+        // (non-zero because the WAL has un-checkpointed frames)
+        {
+            let pager = conn2.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.begin_read_tx().unwrap();
+        }
+        assert!(
+            !check_read_lock_slot(&conn2, 0),
+            "conn2 should hold a non-zero read lock slot (WAL has frames)"
+        );
+
+        // conn2: begin write tx, then rollback — triggers reset_internal_states()
+        {
+            let pager = conn2.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.begin_write_tx(WalAutoActions::all_enabled()).unwrap();
+        }
+        {
+            let pager = conn2.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.rollback(None);
+            wal.end_write_tx();
+        }
+
+        // conn2: end read tx — must actually release the shared read lock
+        {
+            let pager = conn2.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.end_read_tx();
+        }
+
+        // If the read lock leaked, this Restart checkpoint will return Busy.
+        let result = {
+            let pager = conn1.pager.load();
+            run_checkpoint_until_done(&pager, CheckpointMode::Restart)
+        };
+        assert!(
+            result.everything_backfilled(),
+            "Restart checkpoint should succeed after conn2 released its read lock, \
+             but it didn't — read lock was leaked by rollback/reset_internal_states"
+        );
+    }
 }


### PR DESCRIPTION
## Invariant broken

`allocate_page` pins the freelist trunk page while its state machine is suspended at an I/O yield (`AllocatePageState::SearchAvailableFreeListLeaf`). If `begin_read_tx()` (the db-changed branch) or `rollback()` then clears the page cache **while that machine is still suspended**, the trunk's buffer is freed. When the machine later resumes it walks straight back into `SearchAvailableFreeListLeaf` and hits `turso_assert!(trunk_page.is_loaded(), "Freelist trunk page is not loaded")` and panics. Reachable on plain storage, no materialized views.

Root cause: a suspended pager state machine can outlive a cache clear, and nothing tore the machine down, so it resumed against a page the clear had freed.

## Fix

1. **`begin_read_tx()` (db-changed) and `rollback()` call `reset_internal_states()` before `clear_page_cache()`.** A reset machine restarts a fresh allocation from `Start` instead of resuming into the freed trunk, so the panic can no longer occur.

2. **`reset_internal_states()` releases the pins the suspended `allocate_page`/`free_page` machines hold** before resetting them to `Start`. `pin()`/`unpin()` is a manual atomic counter that is **not** tied to `PageRef`'s `Drop`, so overwriting the state enums to `Start` would otherwise leak those pins.

That's the whole fix — no change to `PageCache::clear`.

## Why an earlier approach was reverted (evidence)

An earlier version of this branch instead made `PageCache::clear` *preserve* pinned pages. That was reverted: preserving pinned pages left uncommitted pages resident across a rollback, and once the rollback shrank `database_size` the next `allocate_page` reused those page-ids and collided in `force_insert_page` (`Attempted to insert different page with same key`). The concurrent simulator (`turso_whopper`, built with `--cfg nightly`) reproduced it deterministically:

- **in-process fast, seeds 1–60:** 21/60 panic **with** pin-preservation; **0/60 with this design**.
- **release-nightly, all three previously-hanging CI modes** (`in-process`, `in-process-mvcc`, `schema-clone-faults`): all pass with this design.

## Test evidence

- `suspended_allocate_reset_before_clear_releases_pins_and_resets` (pager.rs, deterministic via the read-yield injector): suspends `allocate_page` with the trunk pinned, runs the `reset_internal_states()` step, and asserts the trunk pin is released and the machine reset to `Start`, then that the following `clear_page_cache` is safe.
- `test_wal_rollback_does_not_leak_read_lock` (wal.rs): guards `reset_internal_states()` against leaking a WAL shared read lock (which would block Restart/Truncate checkpoints forever).
- Also green: full `turso_core storage::` module (385 pass), the `io_memory_yield` abandoned-statement suite (incl. `test_abandoned_insert_savepoint_rollback_preserves_freelist`), `cargo fmt`, `clippy -p turso_core --all-features --deny=warnings`.

## Commit structure

Two commits so reviewers can check out each:

- **Commit 1** adds the tests. Without the fix, `suspended_allocate_reset_before_clear_releases_pins_and_resets` fails with:

  ```
  reset_internal_states must release the suspended allocate_page's trunk pin
  ```

  (`test_wal_rollback_does_not_leak_read_lock` is a forward-looking guard and passes in all configurations.)
- **Commit 2** is the fix; both tests pass.
