### PR TITLE
core/translate: Fix "no such column" error to echo query casing, not schema casing

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -972,7 +972,7 @@ fn reject_outer_query_refs_in_group_by_expr(
                     crate::bail_parse_error!(
                         "no such column: {}.{}",
                         outer_ref.identifier,
-                        column_name
+                        normalize_ident(column_name)
                     );
                 }
             }
@@ -1045,7 +1045,11 @@ fn reject_outer_scope_refs_inside_select_plan(
                 .get(col_idx)
                 .and_then(|col| col.name.as_deref())
                 .expect("bound outer-scope Expr::Column must point to a named column in schema");
-            crate::bail_parse_error!("no such column: {}.{}", outer_ref.identifier, column_name);
+            crate::bail_parse_error!(
+                "no such column: {}.{}",
+                outer_ref.identifier,
+                normalize_ident(column_name)
+            );
         }
         if outer_ref.rowid_referenced {
             crate::bail_parse_error!("no such column: {}.rowid", outer_ref.identifier);

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -29,7 +29,7 @@ source $testdir/selectF.test
 # FIXME: source $testdir/insert2.test
 # FIXME: source $testdir/insert3.test
 # FIXME: source $testdir/insert4.test
-# FIXME: source $testdir/insert5.test
+source $testdir/insert5.test
 
 # FIXME: source $testdir/join.test
 # FIXME: source $testdir/join2.test


### PR DESCRIPTION
## Description

When a `GROUP BY` inside a correlated subquery references a column from the outer query scope, Turso rejects it with `no such column`. The error message was built from the (already normalized) outer table alias plus the column name read straight from the schema. As a result it leaked the schema's casing rather than the resolved reference — e.g. for `... GROUP BY main.id` where the schema declares `Id`, Turso reported `no such column: main.Id` instead of `no such column: main.id`.

This passes the column name through `normalize_ident` at both outer-scope rejection sites in `core/translate/select.rs`, so the message now matches SQLite (`no such column: main.id`). The table portion was already normalized, so this simply makes the column portion consistent.

`sqlite/conformance/upstream/insert5.test` is re-enabled in `all.test`, since `insert5-2.9` was the only remaining failure in that file.

Reproduction (SQLite 3.51.2 reports `no such column: main.id`):

```sql
CREATE TABLE MAIN (Id INTEGER, Id1 INTEGER);
CREATE TABLE B (Id INTEGER, Id1 INTEGER);
CREATE VIEW v2 AS SELECT * FROM MAIN;
INSERT INTO B SELECT * FROM main WHERE id > 10
  AND (SELECT count(*) FROM v2 GROUP BY main.id);
```

Before: `Parse error: no such column: main.Id`
After: `Parse error: no such column: main.id`

Verified with the upstream TCL harness (`tclsh insert5.test`): all 11 tests pass with the fix, and `insert5-2.9` fails with `Got: no such column: main.Id` when the fix is reverted, confirming the change is what closes it. As noted in the issue, `.sqltest` error matching is case-insensitive, so this casing change cannot regress that corpus.

## Motivation and context

Fixes #7994.

## Description of AI Usage

This PR was created with Claude Code (Opus 4.8). The model located the offending error sites, implemented the `normalize_ident` fix, built the TCL conformance extension, and verified the fix against `insert5.test` (including a revert check to confirm the test guards the change). The committer reviewed the output.