### PR TITLE
Serverless transaction async no exec lock

### DIFF
--- a/serverless/javascript/integration-tests/serverless.test.mjs
+++ b/serverless/javascript/integration-tests/serverless.test.mjs
@@ -163,3 +163,91 @@ test.serial('transactionAsync.concurrent uses BEGIN CONCURRENT', async t => {
     await localClient.close();
   }
 });
+
+const withTimeout = (promise, timeoutMs, label) => {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+};
+
+// Each transactionAsync runs on its own dedicated stream, so all callbacks
+// can be open at the same time. The barrier resolves only once every
+// callback has been entered — if transactions were serialized on the
+// connection (the pre-dedicated-session behavior), the first callback
+// would wait on the barrier forever and the test would time out.
+test.serial('transactionAsync transactions run in parallel', async t => {
+  const N = 3;
+  let entered = 0;
+  let releaseBarrier;
+  const allEntered = new Promise(resolve => { releaseBarrier = resolve; });
+
+  const txn = client.transactionAsync(async (tx, i) => {
+    if (++entered === N) releaseBarrier();
+    await withTimeout(allEntered, 5000, 'all transaction callbacks open at once');
+    const row = await tx.get('SELECT ? AS i', [i]);
+    return row.i;
+  });
+
+  const results = await Promise.all(Array.from({ length: N }, (_, i) => txn(i)));
+  t.deepEqual(results.sort(), [0, 1, 2]);
+});
+
+// Statements on the connection are not blocked by an open transactionAsync
+// window; they run on the connection's own stream, outside the transaction,
+// so they must not observe its uncommitted writes. Under a connection-level
+// lock this await would deadlock the transaction.
+test.serial('connection statements proceed while transactionAsync is open', async t => {
+  await client.exec('DROP TABLE IF EXISTS txn_parallel');
+  await client.exec('CREATE TABLE txn_parallel (id INTEGER PRIMARY KEY, v TEXT)');
+
+  let uncommittedCount;
+  await withTimeout(client.transactionAsync(async tx => {
+    await tx.run('INSERT INTO txn_parallel (v) VALUES (?)', ['inside']);
+    const rows = await client.all('SELECT COUNT(*) AS n FROM txn_parallel');
+    uncommittedCount = rows[0].n;
+  })(), 5000, 'connection statement inside transactionAsync callback');
+
+  t.is(uncommittedCount, 0);
+  const rows = await client.all('SELECT COUNT(*) AS n FROM txn_parallel');
+  t.is(rows[0].n, 1);
+});
+
+// Two transactions with overlapping open windows commit and roll back
+// independently. The write sections are kept disjoint on purpose — the
+// overlap under test is the callback windows, not the server's write lock.
+test.serial('rollback of a parallel transactionAsync leaves the other intact', async t => {
+  await client.exec('DROP TABLE IF EXISTS txn_writers');
+  await client.exec('CREATE TABLE txn_writers (v TEXT)');
+
+  let entered = 0;
+  let releaseBarrier;
+  const bothOpen = new Promise(resolve => { releaseBarrier = resolve; });
+  let releaseOkDone;
+  const okDone = new Promise(resolve => { releaseOkDone = resolve; });
+
+  const ok = client.transactionAsync(async tx => {
+    if (++entered === 2) releaseBarrier();
+    await withTimeout(bothOpen, 5000, 'both transaction callbacks open');
+    await tx.run("INSERT INTO txn_writers (v) VALUES ('kept')");
+  });
+  const failing = client.transactionAsync(async tx => {
+    if (++entered === 2) releaseBarrier();
+    await withTimeout(bothOpen, 5000, 'both transaction callbacks open');
+    await withTimeout(okDone, 5000, 'parallel transaction commits first');
+    await tx.run("INSERT INTO txn_writers (v) VALUES ('discarded')");
+    throw new Error('boom');
+  });
+
+  const [, err] = await Promise.all([
+    ok().then(releaseOkDone),
+    failing().then(() => null, e => e),
+  ]);
+  t.is(err.message, 'boom');
+
+  const rows = await client.all('SELECT v FROM txn_writers ORDER BY v');
+  t.deepEqual(rows.map(r => r.v), ['kept']);
+});

--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -68,6 +68,10 @@ function toResultSet(result: any): any {
  * waits for the previous one to finish — just like the native
  * `@tursodatabase/database` binding.
  *
+ * The exception is `transactionAsync()`: each transaction runs on its own
+ * dedicated stream, so it does not block (and is not blocked by) statements
+ * on the connection itself.
+ *
  * ## Parallel queries
  *
  * For parallelism, create multiple connections. `connect()` is cheap — it just
@@ -121,6 +125,8 @@ export class Connection {
    * request), so it reflects the connection's real transaction state — the
    * same as `sqlite3_get_autocommit()` on the native bindings — including
    * transactions opened with a raw `BEGIN`, not just via `transaction()`.
+   * A `transactionAsync()` transaction runs on its own dedicated session,
+   * so it is not reflected here.
    */
   get inTransaction(): boolean {
     return this.session.inTransaction;
@@ -425,17 +431,17 @@ export class Connection {
   /**
    * Returns a function that executes the given function in a transaction.
    *
-   * The wrapper owns the connection for the whole BEGIN..COMMIT window: it
-   * acquires the connection's execution lock before BEGIN and releases it
-   * only after COMMIT/ROLLBACK, so no concurrent statement or transaction
-   * can interleave its own statements into the transaction's window. The
-   * callback receives a {@link Transaction} handle as its first argument,
-   * followed by the arguments the wrapped function was called with — all
-   * SQL inside the callback must go through that handle. Calls on the
-   * `Connection` itself (or statements prepared from it) queue on the lock
-   * until the transaction finishes, so awaiting them inside the callback
-   * deadlocks the transaction. Callbacks that do not declare the handle
-   * parameter are rejected.
+   * Each invocation runs the whole BEGIN..COMMIT window on its own
+   * dedicated session (a separate server stream), so it does not lock the
+   * connection: concurrent statements on the `Connection` proceed normally
+   * while the transaction is open. The callback receives a
+   * {@link Transaction} handle as its first argument, followed by the
+   * arguments the wrapped function was called with — all SQL of the
+   * transaction must go through that handle. Calls on the `Connection`
+   * itself (or statements prepared from it) execute on the connection's
+   * own stream, outside the transaction, and do not see its uncommitted
+   * changes. Callbacks that do not declare the handle parameter are
+   * rejected.
    *
    * @param fn - The function to wrap in a transaction; receives the
    *   transaction handle followed by the caller's arguments
@@ -470,10 +476,11 @@ export class Connection {
         if (!db.isOpen) {
           throw new TypeError("The database connection is not open");
         }
-        // own the session for the whole transaction: everything else
-        // queues on execLock until COMMIT/ROLLBACK releases it
-        await db.execLock.acquire();
-        const txn = new Transaction(db.session, db.defaultSafeIntegerMode);
+        // The transaction owns a dedicated session (server stream), so the
+        // connection is not locked for its duration: concurrent statements
+        // on the connection run on its own stream, outside the transaction.
+        const session = new Session(db.config);
+        const txn = new Transaction(session, db.defaultSafeIntegerMode);
         try {
           await txn.exec("BEGIN " + mode);
           try {
@@ -481,12 +488,18 @@ export class Connection {
             await txn.exec("COMMIT");
             return result;
           } catch (err) {
-            await txn.exec("ROLLBACK");
+            try {
+              await txn.exec("ROLLBACK");
+            } catch {
+              // The stream is dedicated to this transaction and is closed
+              // below, which discards the open transaction server-side —
+              // a failed ROLLBACK must not mask the original error.
+            }
             throw err;
           }
         } finally {
           txn.finish();
-          db.execLock.release();
+          await session.close();
         }
       };
     };
@@ -534,25 +547,24 @@ export class Connection {
 
 /**
  * A handle to an open transaction, passed as the first argument to the
- * callback of `Connection.transactionAsync()`. All SQL of the transaction
- * must go through this handle: the transaction wrapper holds the
- * connection's execution lock for the whole BEGIN..COMMIT window, so
- * `Connection` calls issued inside the callback wait for the transaction
- * to finish (and deadlock it if awaited), while the handle executes on the
- * already-owned session. Once the transaction commits or rolls back the
- * handle is closed and every method throws.
+ * callback of `Connection.transactionAsync()`. The transaction owns a
+ * dedicated session (server stream) for its whole BEGIN..COMMIT window, so
+ * all SQL of the transaction must go through this handle: `Connection`
+ * calls issued inside the callback execute on the connection's own stream,
+ * outside the transaction, and do not see its uncommitted changes. Once
+ * the transaction commits or rolls back the handle is closed and every
+ * method throws.
  */
 export class Transaction {
   private session: Session;
   private defaultSafeIntegerMode: boolean;
   private active: boolean = true;
-  // Per-transaction execution gate. The wrapper already holds the connection's
-  // execLock for the whole transaction, so this never contends with other
-  // transactions or connection-level calls; it serializes native calls *within*
-  // this transaction — the same invariant the connection's execLock enforces on
-  // the session — so statements issued concurrently in the callback cannot
-  // interleave on the shared session. It also rejects use of a completed
-  // transaction.
+  // Per-transaction execution gate. The transaction owns a dedicated
+  // session, so this never contends with connection-level calls; it
+  // serializes requests *within* this transaction — each request must
+  // carry the baton of the previous response, so statements issued
+  // concurrently in the callback cannot interleave on the transaction's
+  // stream. It also rejects use of a completed transaction.
   private gate: Lock;
 
   constructor(session: Session, defaultSafeIntegerMode: boolean) {

--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -443,6 +443,13 @@ export class Connection {
    * changes. Callbacks that do not declare the handle parameter are
    * rejected.
    *
+   * Because the session is fresh, session-scoped side effects applied to
+   * the connection earlier — `PRAGMA` settings such as `foreign_keys`,
+   * attached databases, temp tables, and other per-connection state — are
+   * NOT present inside the transaction. Anything the transaction's SQL
+   * depends on must either be committed database state or be re-applied
+   * through the transaction handle inside the callback.
+   *
    * @param fn - The function to wrap in a transaction; receives the
    *   transaction handle followed by the caller's arguments
    * @returns A function that will execute fn within a transaction
@@ -548,12 +555,14 @@ export class Connection {
 /**
  * A handle to an open transaction, passed as the first argument to the
  * callback of `Connection.transactionAsync()`. The transaction owns a
- * dedicated session (server stream) for its whole BEGIN..COMMIT window, so
- * all SQL of the transaction must go through this handle: `Connection`
- * calls issued inside the callback execute on the connection's own stream,
- * outside the transaction, and do not see its uncommitted changes. Once
- * the transaction commits or rolls back the handle is closed and every
- * method throws.
+ * dedicated, freshly created session (server stream) for its whole
+ * BEGIN..COMMIT window, so all SQL of the transaction must go through this
+ * handle: `Connection` calls issued inside the callback execute on the
+ * connection's own stream, outside the transaction, and do not see its
+ * uncommitted changes. Session-scoped state set up on the connection
+ * (`PRAGMA` settings, attached databases, temp tables) does not carry over
+ * to the fresh session. Once the transaction commits or rolls back the
+ * handle is closed and every method throws.
  */
 export class Transaction {
   private session: Session;

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -422,7 +422,7 @@ test.serial("Database.transactionAsync().deferred() [batch]", async (t) => {
   const db = t.context.db;
 
   const insertMany = db.transactionAsync(async (tx) => {
-    t.is(db.inTransaction, true);
+    t.is(db.inTransaction, process.env.PROVIDER !== "serverless");
     return await tx.batch([
       { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Joey", "joey@example.org"] },
       { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Sally", "sally@example.org"] },
@@ -512,11 +512,17 @@ test.serial("Database.inTransaction property", async (t) => {
   t.false(db.inTransaction, "autocommit after a one-shot query");
 
   // 3. The transaction() helper reports in-transaction inside its callback and
-  //    autocommit once it completes.
+  //    autocommit once it completes. The serverless driver runs the
+  //    transaction on its own dedicated session, so the connection itself
+  //    stays in autocommit.
   let insideTxn;
   const txn = db.transactionAsync(async (tx) => { insideTxn = db.inTransaction; });
   await txn();
-  t.true(insideTxn, "in a transaction inside the transactionAsync() callback");
+  if (process.env.PROVIDER === "serverless") {
+    t.false(insideTxn, "serverless transactionAsync() runs on a dedicated session");
+  } else {
+    t.true(insideTxn, "in a transaction inside the transactionAsync() callback");
+  }
   t.false(db.inTransaction, "autocommit after transactionAsync() completes");
 
   // 4. inTransaction must reflect the real transaction state, so it also tracks
@@ -573,10 +579,13 @@ test.serial("Database.transactionAsync()", async (t) => {
   const db = t.context.db;
 
   const insertMany = db.transactionAsync(async (tx, users) => {
-    t.is(db.inTransaction, true);
-    // statements of the transaction must be prepared from its handle: the
-    // wrapper owns the connection lock for the whole transaction, so
-    // database-level statements would wait for it instead of joining it
+    // the serverless driver runs the transaction on a dedicated session,
+    // so the connection itself stays in autocommit inside the callback
+    t.is(db.inTransaction, process.env.PROVIDER !== "serverless");
+    // statements of the transaction must be prepared from its handle:
+    // database-level statements never join the transaction — on the native
+    // driver they wait on the connection lock, on the serverless driver
+    // they run in autocommit on the connection's own stream
     const insert = await tx.prepare(
       "INSERT INTO users(name, email) VALUES (:name, :email)"
     );
@@ -626,7 +635,7 @@ test.serial("Database.transaction() [deprecated]", async (t) => {
 test.serial("Database.transactionAsync().immediate()", async (t) => {
   const db = t.context.db;
   const insertMany = db.transactionAsync(async (tx, users) => {
-    t.is(db.inTransaction, true);
+    t.is(db.inTransaction, process.env.PROVIDER !== "serverless");
     const insert = await tx.prepare(
       "INSERT INTO users(name, email) VALUES (:name, :email)"
     );


### PR DESCRIPTION
This PR makes `transactionAsync` method to execute inner transaction over fresh sql-over-http session for **serverless** driver.

The motivation is that having lock held during that operation is very bad as this will block any requests to the database for a period of transaction.

The trade-off is that side-effects applied for the connection will not be applied for the `transactionAsync` (it is documented at the `transactionAsync` docstring).