### PR TITLE
core: make typed row conversions checked and accept integers as f64

### DIFF
--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1915,3 +1915,57 @@ async fn multiprocess_wal_second_open_child_process() {
     let row = rows.next().await.unwrap().unwrap();
     assert_eq!(row.get_value(0).unwrap(), Value::Integer(1));
 }
+
+#[tokio::test]
+async fn test_typed_numeric_row_conversions() {
+    let db = Builder::new_local(":memory:").build().await.unwrap();
+    let conn = db.connect().unwrap();
+
+    let mut rows = conn
+        .query(
+            "SELECT
+                -2147483649, -2147483648, 2147483647, 2147483648,
+                -1, 0, 4294967295, 4294967296, 9223372036854775807,
+                9007199254740993",
+            (),
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+
+    assert!(matches!(
+        row.get::<i32>(0),
+        Err(Error::ConversionFailure(message))
+            if message == "Runtime error: integer overflow"
+    ));
+    assert_eq!(row.get::<i32>(1).unwrap(), i32::MIN);
+    assert_eq!(row.get::<i32>(2).unwrap(), i32::MAX);
+    assert!(matches!(
+        row.get::<i32>(3),
+        Err(Error::ConversionFailure(message))
+            if message == "Runtime error: integer overflow"
+    ));
+
+    assert!(matches!(
+        row.get::<u32>(4),
+        Err(Error::ConversionFailure(message))
+            if message == "Runtime error: integer overflow"
+    ));
+    assert_eq!(row.get::<u32>(5).unwrap(), 0);
+    assert_eq!(row.get::<u32>(6).unwrap(), u32::MAX);
+    assert!(matches!(
+        row.get::<u32>(7),
+        Err(Error::ConversionFailure(message))
+            if message == "Runtime error: integer overflow"
+    ));
+
+    assert!(matches!(
+        row.get::<u64>(4),
+        Err(Error::ConversionFailure(message))
+            if message == "Runtime error: integer overflow"
+    ));
+    assert_eq!(row.get::<u64>(8).unwrap(), i64::MAX as u64);
+
+    assert_eq!(row.get::<f64>(4).unwrap(), -1.0);
+    assert_eq!(row.get::<f64>(9).unwrap(), 9_007_199_254_740_993_i64 as f64);
+}

--- a/core/types.rs
+++ b/core/types.rs
@@ -732,12 +732,14 @@ impl FromValue for Value {
 impl Sealed for crate::Value {}
 
 macro_rules! impl_int_from_value {
-    ($ty:ty, $cast:expr) => {
+    ($ty:ty) => {
         impl FromValue for $ty {
             fn from_sql(val: Value) -> Result<Self> {
                 match val {
                     Value::Null => Err(LimboError::NullValue),
-                    Value::Numeric(Numeric::Integer(i)) => Ok($cast(i)),
+                    Value::Numeric(Numeric::Integer(i)) => {
+                        <$ty>::try_from(i).map_err(|_| LimboError::IntegerOverflow)
+                    }
                     _ => Err(LimboError::InvalidColumnType),
                 }
             }
@@ -747,16 +749,17 @@ macro_rules! impl_int_from_value {
     };
 }
 
-impl_int_from_value!(i32, |i| i as i32);
-impl_int_from_value!(u32, |i| i as u32);
-impl_int_from_value!(i64, |i| i);
-impl_int_from_value!(u64, |i| i as u64);
+impl_int_from_value!(i32);
+impl_int_from_value!(u32);
+impl_int_from_value!(i64);
+impl_int_from_value!(u64);
 
 impl FromValue for f64 {
     fn from_sql(val: Value) -> Result<Self> {
         match val {
             Value::Null => Err(LimboError::NullValue),
             Value::Numeric(Numeric::Float(f)) => Ok(f64::from(f)),
+            Value::Numeric(Numeric::Integer(i)) => Ok(i as f64),
             _ => Err(LimboError::InvalidColumnType),
         }
     }
@@ -3510,6 +3513,65 @@ mod tests {
     use super::*;
     use crate::alloc::vec;
     use crate::translate::collate::CollationSeq;
+
+    fn assert_integer_conversions<T>(in_range: &[(i64, T)], out_of_range: &[i64])
+    where
+        T: Copy + std::fmt::Debug + PartialEq + FromValue,
+    {
+        for &(input, expected) in in_range {
+            assert_eq!(T::from_sql(Value::from_i64(input)).unwrap(), expected);
+        }
+        for &input in out_of_range {
+            assert!(
+                matches!(
+                    T::from_sql(Value::from_i64(input)),
+                    Err(LimboError::IntegerOverflow)
+                ),
+                "{input} should overflow {}",
+                std::any::type_name::<T>()
+            );
+        }
+    }
+
+    #[test]
+    fn from_value_checks_integer_ranges() {
+        assert_integer_conversions::<i32>(
+            &[
+                (i32::MIN as i64, i32::MIN),
+                (-1, -1),
+                (0, 0),
+                (1, 1),
+                (i32::MAX as i64, i32::MAX),
+            ],
+            &[i32::MIN as i64 - 1, i32::MAX as i64 + 1],
+        );
+        assert_integer_conversions::<u32>(
+            &[(0, 0), (1, 1), (u32::MAX as i64, u32::MAX)],
+            &[-2, -1, u32::MAX as i64 + 1],
+        );
+        assert_integer_conversions::<i64>(
+            &[
+                (i64::MIN, i64::MIN),
+                (-1, -1),
+                (0, 0),
+                (1, 1),
+                (i64::MAX, i64::MAX),
+            ],
+            &[],
+        );
+        assert_integer_conversions::<u64>(
+            &[(0, 0), (1, 1), (i64::MAX, i64::MAX as u64)],
+            &[-2, -1],
+        );
+    }
+
+    #[test]
+    fn from_value_converts_integers_to_f64() {
+        for input in [i64::MIN, -1, 0, 1, (1_i64 << 53) + 1, i64::MAX] {
+            assert_eq!(f64::from_sql(Value::from_i64(input)).unwrap(), input as f64);
+        }
+        assert_eq!(f64::from_sql(Value::from_f64(1.5)).unwrap(), 1.5);
+    }
 
     #[cfg(nightly)]
     #[test]


### PR DESCRIPTION
Row::get::<T> converted integer values with plain as casts, so out-of-range values silently wrapped instead of failing: reading 4294967296 as i32 returned 0 and reading -1 as u32 returned 4294967295. A database driver must never corrupt values on read, so convert with try_from and return IntegerOverflow when the value does not fit.

Row::get::<f64> also rejected INTEGER values with InvalidColumnType, while SQLite's column accessors convert integers to doubles. Accept integer values for f64 to match SQLite column access semantics.

Tests: bindings/rust integration test exercising the typed conversion contract, including the pre-existing bool and fixed-size byte array semantics so the whole contract is pinned down in one place.