### PR TITLE
core/storage: assert drop_cell is never handed a stray overflow cell

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10502,6 +10502,73 @@ mod tests {
         }
     }
 
+    /// Contract test: `drop_cell` must never be handed a page whose pending
+    /// overflow cell sits *after* the cell being dropped.
+    ///
+    /// A page only carries pending `overflow_cells` while a balance is in progress.
+    /// The sole sanctioned caller that drops cells from such a page —
+    /// `balance_non_root` dropping divider cells — always consumes the overflow
+    /// divider at or before the dropped index, so `overflow_cell.index <= cell_idx`
+    /// holds there. A pending overflow cell positioned strictly *after* the dropped
+    /// cell is therefore an ILLEGAL state: it can only arise if some operation
+    /// reached a page mid-balance, which no transaction, statement, or connection
+    /// can do through any sanctioned path (the engine enforces this at four layers;
+    /// the one way it was observed — IVM's WriteRow abandoning its own in-flight
+    /// balance by advancing state past a yielded cursor op — is fixed by the
+    /// re-poll-contract change in the companion PR).
+    ///
+    /// This test manufactures that illegal state on purpose and asserts drop_cell's
+    /// `turso_assert` fires, rather than silently renumbering the stray cell — which
+    /// would legitimize the mid-balance access instead of surfacing the bug.
+    #[test]
+    #[should_panic(expected = "pending overflow cell positioned after dropped cell")]
+    fn test_drop_cell_rejects_overflow_cell_after_dropped_cell() {
+        let (pager, _, _, _) = empty_btree();
+        let usable_space = pager.usable_space();
+
+        let page = run_until_done(|| pager.allocate_page(), &pager).unwrap();
+        btree_init_page(&page, PageType::TableLeaf, 0, usable_space);
+        let page_contents = page.get_contents();
+
+        // Populate the leaf with a handful of regular cells.
+        for i in 0..10 {
+            let regs = &[Register::Value(Value::from_i64(i))];
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
+            let mut payload = crate::alloc::vec![];
+            let mut fill_state = FillCellPayloadState::Start;
+            run_until_done(
+                || {
+                    fill_cell_payload(
+                        &PinGuard::new(page.clone()),
+                        Some(i),
+                        &mut payload,
+                        i as usize,
+                        &record,
+                        usable_space,
+                        pager.clone(),
+                        &mut fill_state,
+                    )
+                },
+                &pager,
+            )
+            .unwrap();
+            insert_into_cell(page_contents, &payload, i as usize, usable_space).unwrap();
+        }
+        assert_eq!(page_contents.cell_count(), 10);
+
+        // ILLEGAL STATE, constructed only to exercise the contract: a pending
+        // overflow cell whose intended position (index 8) is *after* the cell we
+        // are about to drop (index 5). No sanctioned path can produce this.
+        page_contents.overflow_cells.push(OverflowCell {
+            index: 8,
+            payload: std::pin::Pin::new(crate::alloc::vec![1, 2, 3, 4]),
+        });
+
+        // Dropping a cell before that pending overflow cell must trip the contract
+        // assertion, not silently renumber it.
+        let _ = drop_cell(page_contents, 5, usable_space);
+    }
+
     fn validate_btree(pager: Arc<Pager>, page_idx: i64) -> (usize, bool) {
         let num_columns = 5;
         let cursor = BTreeCursor::new_table(pager.clone(), page_idx, num_columns);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -9840,6 +9840,23 @@ fn drop_cell(page: &mut PageContent, cell_idx: usize, usable_space: usize) -> Re
         page.write_fragmented_bytes_count(0);
     }
     page.write_cell_count(page.cell_count() as u16 - 1);
+
+    // drop_cell removes a single regular cell; it must never be asked to renumber a
+    // pending overflow cell. A page carries pending overflow_cells only mid-balance,
+    // and the one sanctioned caller that drops cells from such a page
+    // (balance_non_root dropping divider cells) always consumes the overflow divider
+    // at or before the dropped index, so overflow_cell.index <= cell_idx there. A
+    // pending overflow cell strictly after cell_idx means an operation reached the
+    // page mid-balance -- a contract violation, surfaced here rather than silently
+    // mis-slotting the payload during the next balance.
+    for overflow_cell in page.overflow_cells.iter() {
+        turso_assert!(
+            overflow_cell.index <= cell_idx,
+            "drop_cell: pending overflow cell positioned after dropped cell",
+            { "overflow_index": overflow_cell.index, "cell_idx": cell_idx }
+        );
+    }
+
     debug_validate_cells!(page, usable_space);
     Ok(())
 }


### PR DESCRIPTION
## Background

Reworked per @LeMikaelF's root-cause analysis (https://github.com/tursodatabase/turso/pull/8020#issuecomment-5073444278). The original version of this PR silently adjusted `overflow_cells[].index` inside `drop_cell` to compensate for a page being modified while a balance was pending. As the analysis shows, **no transaction, statement, or connection can legally reach a b-tree page mid-balance** — the engine enforces this at four layers. The only way that state was ever observed is IVM's `WriteRow`/`WriteRowView` abandoning their own in-flight balance by advancing state past a yielded cursor op, which is a re-poll-contract violation fixed in the companion PR #8027.

Silently renumbering the stray overflow cell would legitimize an illegal mid-balance access and paper over the real bug. So this PR replaces the adjustment with an assertion.

## The change

`drop_cell` removes one regular cell and must never be asked to renumber a pending overflow cell. A page carries pending `overflow_cells` only while balancing, and the one sanctioned caller that drops cells from such a page — `balance_non_root` dropping divider cells — always consumes the overflow divider at or before the dropped index, so `overflow_cell.index <= cell_idx` holds there. (This matches SQLite: `dropCell` never touches `aiOvfl`; compensation is the caller's job.)

Replace the silent index adjustment with:

```rust
for overflow_cell in page.overflow_cells.iter() {
    turso_assert!(
        overflow_cell.index <= cell_idx,
        "drop_cell: pending overflow cell positioned after dropped cell",
        { "overflow_index": overflow_cell.index, "cell_idx": cell_idx }
    );
}
```

— true in the one legitimate caller, loud on any contract violation.

## Red/green evidence

The regression test is reworked into an explicit **contract** test that constructs the illegal state (a pending overflow cell positioned *after* the cell being dropped, clearly labelled as unreachable by any sanctioned path) and asserts `drop_cell` rejects it.

**Commit 1 (test) — RED** (no assertion yet, so the illegal drop is silently tolerated):

```
test storage::btree::tests::test_drop_cell_rejects_overflow_cell_after_dropped_cell - should panic ... FAILED
note: test did not panic as expected
test result: FAILED. 0 passed; 1 failed
```

**Commit 2 (assert) — GREEN:**

```
test storage::btree::tests::test_drop_cell_rejects_overflow_cell_after_dropped_cell - should panic ... ok
test result: ok. 1 passed; 0 failed
```

## Verification

- `cargo test -p turso_core storage::` — 384 passed, 0 failed (the assert never fires on any legitimate `balance_non_root` divider-drop path).
- `cargo fmt`; clippy clean on `turso_core`.

## Companion

Root-cause fix that removes the only path able to reach this illegal state: #8027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6V1HfTgjrjhERJJdHvhBh
