### PR TITLE
core/translate: repay deferred FK violations per matching child on parent INSERT

### DIFF
--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -370,7 +370,7 @@ where
 ///
 /// Used when an FK parent-side probe needs the matching child rowid, for
 /// example to ignore the row currently being updated in a self-referential FK.
-fn index_scan_match_any<F>(
+pub(super) fn index_scan_match_any<F>(
     program: &mut ProgramBuilder,
     icur: usize,
     probe_start: usize,
@@ -429,7 +429,7 @@ where
     Ok(())
 }
 
-fn emit_skip_if_any_null(
+pub(super) fn emit_skip_if_any_null(
     program: &mut ProgramBuilder,
     reg_start: usize,
     nregs: usize,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -22,8 +22,8 @@ use crate::{
         },
         fkeys::{
             build_index_affinity_string, emit_fk_restrict_halt, emit_fk_violation,
-            emit_guarded_fk_decrement, index_probe, open_read_index, open_read_table,
-            ForeignKeyActions,
+            emit_guarded_fk_decrement, emit_skip_if_any_null, index_probe, index_scan_match_any,
+            open_read_index, open_read_table, ForeignKeyActions,
         },
         plan::{
             ColumnUsedMask, EvalAt, JoinedTable, Operation, QueryDestination, ResultSetColumn,
@@ -4219,8 +4219,19 @@ pub fn emit_parent_side_fk_decrement_on_insert(
         if !force_immediate && !pref.fk.deferred && !is_self_ref {
             continue;
         }
+        // Nothing to do if the parent counter is 0
+        let skip_fk = program.allocate_label();
+        program.emit_insn(Insn::FkIfZero {
+            deferred: pref.fk.deferred,
+            target_pc: skip_fk,
+        });
+
         let (new_pk_start, n_cols) =
             build_parent_key_image_for_insert(program, parent_table, &pref, insertion)?;
+
+        // Nothing to do if the key contains NULLs, because a NULL parent key
+        // never matches any child row (SQL NULL semantics)
+        emit_skip_if_any_null(program, new_pk_start, n_cols, skip_fk);
 
         let child_tbl = &pref.child_table;
         let child_cols = &pref.fk.child_columns;
@@ -4255,24 +4266,13 @@ pub fn emit_parent_side_fk_decrement_on_insert(
                 });
             }
 
-            let found = program.allocate_label();
-            program.emit_insn(Insn::Found {
-                cursor_id: icur,
-                target_pc: found,
-                record_reg: probe_start,
-                num_regs: n_cols,
-            });
-
-            // Not found, nothing to decrement
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            let skip = program.allocate_label();
-            program.emit_insn(Insn::Goto { target_pc: skip });
-
-            // Found: guarded counter decrement
-            program.preassign_label_to_next_insn(found);
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            emit_guarded_fk_decrement(program, skip, pref.fk.deferred);
-            program.preassign_label_to_next_insn(skip);
+            // Decrement once per matching child row
+            index_scan_match_any(program, icur, probe_start, n_cols, None, |p| {
+                let next = p.allocate_label();
+                emit_guarded_fk_decrement(p, next, pref.fk.deferred);
+                p.preassign_label_to_next_insn(next);
+                Ok(())
+            })?;
         } else {
             // fallback scan :(
             let ccur = open_read_table(program, child_tbl, database_id);
@@ -4325,6 +4325,7 @@ pub fn emit_parent_side_fk_decrement_on_insert(
             program.preassign_label_to_next_insn(done);
             program.emit_insn(Insn::Close { cursor_id: ccur });
         }
+        program.preassign_label_to_next_insn(skip_fk);
     }
     Ok(())
 }

--- a/sqlite/conformance/sqlite-sqltests/foreign_keys.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/foreign_keys.sqltest
@@ -4158,3 +4158,179 @@ test fk-alter-table-add-column-rejects-missing {
 }
 expect error {
 }
+
+# --- Parent-INSERT repayment of deferred FK violations (SQLite parity) ---
+# SQLite decrements the deferred counter once PER matching child row when the
+# parent key is inserted, so child-insert-then-parent-insert
+# must commit regardless of statement order or how many children came first.
+
+# Two children inserted before the parent, no index on the child FK column.
+@cross-check-integrity
+test fk-deferred-two-children-then-parent-noindex {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 99);
+    INSERT INTO c VALUES(2, 99);
+    INSERT INTO p VALUES(99);
+    COMMIT;
+    SELECT * FROM c ORDER BY 1;
+}
+expect {
+    1|99
+    2|99
+}
+
+# Same but with an index on the child FK column (exercises the index-probe path).
+@cross-check-integrity
+test fk-deferred-two-children-then-parent-indexed {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    CREATE INDEX c_pid ON c(pid);
+    BEGIN;
+    INSERT INTO c VALUES(1, 99);
+    INSERT INTO c VALUES(2, 99);
+    INSERT INTO p VALUES(99);
+    COMMIT;
+    SELECT * FROM c ORDER BY 1;
+}
+expect {
+    1|99
+    2|99
+}
+
+# Parent row arrives via INSERT ... SELECT.
+@cross-check-integrity
+test fk-deferred-parent-via-insert-select {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 77);
+    INSERT INTO p SELECT 77;
+    COMMIT;
+    SELECT * FROM c ORDER BY 1;
+}
+expect {
+    1|77
+}
+
+# Multi-column FK: children first, composite parent later.
+@cross-check-integrity
+test fk-deferred-multicol-children-then-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INT NOT NULL, b INT NOT NULL, PRIMARY KEY(a,b));
+    CREATE TABLE c(id INTEGER PRIMARY KEY, ca INT, cb INT,
+        FOREIGN KEY(ca,cb) REFERENCES p(a,b) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 4, 5);
+    INSERT INTO c VALUES(2, 4, 5);
+    INSERT INTO p VALUES(4, 5);
+    COMMIT;
+    SELECT * FROM c ORDER BY 1;
+}
+expect {
+    1|4|5
+    2|4|5
+}
+
+# Multi-column FK with an index on the child FK columns.
+@cross-check-integrity
+test fk-deferred-multicol-children-then-parent-indexed {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INT NOT NULL, b INT NOT NULL, PRIMARY KEY(a,b));
+    CREATE TABLE c(id INTEGER PRIMARY KEY, ca INT, cb INT,
+        FOREIGN KEY(ca,cb) REFERENCES p(a,b) DEFERRABLE INITIALLY DEFERRED);
+    CREATE INDEX c_cab ON c(ca,cb);
+    BEGIN;
+    INSERT INTO c VALUES(1, 4, 5);
+    INSERT INTO c VALUES(2, 4, 5);
+    INSERT INTO p VALUES(4, 5);
+    COMMIT;
+    SELECT * FROM c ORDER BY 1;
+}
+expect {
+    1|4|5
+    2|4|5
+}
+
+# A parent INSERT that does NOT satisfy the outstanding violation must still fail at COMMIT.
+@cross-check-integrity
+test fk-deferred-wrong-parent-key-still-fails {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 99);
+    INSERT INTO p VALUES(1);
+    COMMIT;
+}
+expect error {
+}
+
+# Two violations, only one repaid by the parent insert: still fails.
+@cross-check-integrity
+test fk-deferred-partial-repair-still-fails {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 99);
+    INSERT INTO c VALUES(2, 88);
+    INSERT INTO p VALUES(99);
+    COMMIT;
+}
+expect error {
+}
+
+# TEXT keys (Holon-shaped: TEXT ids, child rows created before their parent).
+@cross-check-integrity
+test fk-deferred-text-keys-children-then-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id TEXT PRIMARY KEY);
+    CREATE TABLE c(id TEXT PRIMARY KEY, pid TEXT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES('c1', 'root');
+    INSERT INTO c VALUES('c2', 'root');
+    INSERT INTO p VALUES('root');
+    COMMIT;
+    SELECT * FROM c ORDER BY 1;
+}
+expect {
+    c1|root
+    c2|root
+}
+
+# Multi-row VALUES parent insert repaying several distinct keys.
+@cross-check-integrity
+test fk-deferred-multirow-parent-insert {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 10);
+    INSERT INTO c VALUES(2, 20);
+    INSERT INTO p VALUES(10),(20);
+    COMMIT;
+    SELECT * FROM c ORDER BY 1;
+}
+expect {
+    1|10
+    2|20
+}
+
+# NULL parent key never repays a violation (FK on a UNIQUE parent column).
+@cross-check-integrity
+test fk-deferred-null-parent-key-does-not-repay {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pu INT REFERENCES p(u) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 99);
+    INSERT INTO p(u) VALUES(NULL);
+    COMMIT;
+}
+expect error {
+}


### PR DESCRIPTION
## What breaks

With `PRAGMA foreign_keys=ON` and a **deferred** FK, SQLite decrements the
deferred-violation counter once **per matching child row** when a parent key is
inserted (`fkScanChildren` called with `-1`). So inserting several children that
reference a not-yet-present parent key, then inserting the parent, must commit.

Turso's indexed repayment path instead emitted a single `OP_Found` existence
probe and decremented the counter **once**. When multiple children shared the
same new parent key, the parent INSERT under-repaid and `COMMIT` failed with a
spurious `deferred foreign key constraint failed on commit`. The path also
lacked the `OP_FkIfZero` gate and a NULL-parent-key short-circuit.

The non-indexed fallback already scanned all children and repaid per row, so the
bug only affected FKs whose child column is indexed.

## The fix (`core/translate/insert.rs`, `core/translate/fkeys.rs`)

- Replace the single `Found` probe with `index_scan_match_any`, running the
  guarded decrement once per matching child row.
- Gate the whole probe behind `OP_FkIfZero` (skip when nothing is outstanding).
- Skip when the parent key contains a NULL (a NULL key never matches a child, so
  it can never repay a violation).
- `index_scan_match_any` / `emit_skip_if_any_null` are made `pub(super)` for reuse.

## Red/green evidence

Two commits, reproducer first. Corpus:
`sqlite/conformance/sqlite-sqltests/foreign_keys.sqltest` (10 new `fk-deferred-*`
cases, all `@cross-check-integrity`).

Commit 1 (tests only) — **RED** on current `main`:

```
264 passed, 3 failed
  [FAIL] fk-deferred-two-children-then-parent-indexed
  [FAIL] fk-deferred-multicol-children-then-parent-indexed
  [FAIL] fk-deferred-null-parent-key-does-not-repay
   expected success but got error: deferred foreign key constraint failed on commit
```

Commit 2 (fix) — **GREEN**, full FK suite:

```
267 passed
All tests passed!
```

The non-indexed / negative cases (`...-noindex`, `...-wrong-parent-key-still-fails`,
`...-partial-repair-still-fails`, `...-multirow-parent-insert`) already passed on
`main` and continue to pass, providing parity coverage around the fix.
