### PR TITLE
core/vdbe: recycle records through pseudo registers

### DIFF
--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -1,24 +1,19 @@
-use crate::types::ImmutableRecord;
-
+/// A pseudo cursor exposes the record stored in its content register as a
+/// one-row table, mirroring SQLite's OpenPseudo. It holds no data itself:
+/// SorterData moves each record into the content register and Column ops
+/// decode straight out of it.
 pub struct PseudoCursor {
-    current: Option<ImmutableRecord>,
-}
-
-impl Default for PseudoCursor {
-    #[inline]
-    fn default() -> Self {
-        Self { current: None }
-    }
+    content_reg: usize,
 }
 
 impl PseudoCursor {
     #[inline]
-    pub fn record(&self) -> Option<&ImmutableRecord> {
-        self.current.as_ref()
+    pub fn new(content_reg: usize) -> Self {
+        Self { content_reg }
     }
 
     #[inline]
-    pub fn insert(&mut self, record: ImmutableRecord) {
-        self.current = Some(record);
+    pub fn content_reg(&self) -> usize {
+        self.content_reg
     }
 }

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -451,6 +451,8 @@ fn emit_refill_index(
             order_collations_nulls,
             comparators: crate::alloc::vec![],
         });
+        // SorterData moves each sorted record into the pseudo cursor's
+        // content register; the two must name the same register.
         let content_reg = program.alloc_register();
         program.emit_insn(Insn::OpenPseudo {
             cursor_id: pseudo_cursor_id,
@@ -551,8 +553,6 @@ fn emit_refill_index(
             pc_if_empty: sorted_loop_end,
         });
 
-        let sorted_record_reg = program.alloc_register();
-
         if idx.unique {
             let goto_label = program.allocate_label();
             let label_after_sorter_compare = program.allocate_label();
@@ -563,7 +563,7 @@ fn emit_refill_index(
             program.preassign_label_to_next_insn(sorted_loop_start);
             program.emit_insn(Insn::SorterCompare {
                 cursor_id: sorter_cursor_id,
-                sorted_record_reg,
+                sorted_record_reg: content_reg,
                 num_regs: columns.len(),
                 pc_when_nonequal: goto_label,
             });
@@ -581,7 +581,7 @@ fn emit_refill_index(
         program.emit_insn(Insn::SorterData {
             pseudo_cursor: pseudo_cursor_id,
             cursor_id: sorter_cursor_id,
-            dest_reg: sorted_record_reg,
+            dest_reg: content_reg,
         });
 
         program.emit_insn(Insn::SeekEnd {
@@ -589,7 +589,7 @@ fn emit_refill_index(
         });
         program.emit_insn(Insn::IdxInsert {
             cursor_id: index_cursor_id,
-            record_reg: sorted_record_reg,
+            record_reg: content_reg,
             unpacked_start: None,
             unpacked_count: None,
             flags: IdxInsertFlags::new().use_seek(false),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1656,14 +1656,14 @@ pub fn op_open_pseudo(
     load_insn!(
         OpenPseudo {
             cursor_id,
-            content_reg: _,
+            content_reg,
             num_fields: _,
         },
         insn
     );
     {
         let cursors = &mut state.cursors;
-        let cursor = PseudoCursor::default();
+        let cursor = PseudoCursor::new(*content_reg);
         cursors
             .get_mut(*cursor_id)
             .expect("cursor_id should be valid")
@@ -1964,14 +1964,25 @@ fn op_column_fetch(
             }
         }
         CursorType::Pseudo(_) => {
-            let cursor = crate::get_cursor!(state, cursor_id);
-            let cursor = cursor.as_pseudo_mut();
-            match cursor.record() {
-                Some(record) => {
+            let content_reg = crate::get_cursor!(state, cursor_id)
+                .as_pseudo_mut()
+                .content_reg();
+            // The record is read while decoding into the destination register,
+            // so the two registers must be distinct.
+            let [content, dest_reg] = state
+                .registers
+                .get_disjoint_mut([content_reg, dest])
+                .map_err(|_| {
+                    LimboError::InternalError(format!(
+                        "Column: pseudo-cursor content register {content_reg} and destination register {dest} must be distinct"
+                    ))
+                })?;
+            match content {
+                Register::Record(record) => {
                     // Decode straight into the register; going through an owned
                     // Value would allocate for every TEXT/BLOB column on every row.
                     let mut payload_iterator = record.iter()?;
-                    match payload_iterator.nth_into_register(column, &mut state.registers[dest]) {
+                    match payload_iterator.nth_into_register(column, dest_reg) {
                         Some(result) => result?,
                         // A pseudo cursor is opened with num_fields matching the
                         // record built for it, so every emitted Column index is in
@@ -1982,11 +1993,11 @@ fn op_column_fetch(
                                 "pseudo-cursor column out of range for record",
                                 { "column": column }
                             );
-                            state.registers[dest].set_null();
+                            dest_reg.set_null();
                         }
                     }
                 }
-                None => state.registers[dest].set_null(),
+                _ => dest_reg.set_null(),
             }
         }
         CursorType::IndexMethod(..) => {
@@ -7393,23 +7404,37 @@ pub fn op_sorter_data(
         },
         insn
     );
-    let record = {
+    // Column ops read the record through the pseudo cursor's content register,
+    // so SorterData's destination must be that same register.
+    {
+        let content_reg = state
+            .get_cursor(*pseudo_cursor)
+            .as_pseudo_mut()
+            .content_reg();
+        if content_reg != *dest_reg {
+            return Err(LimboError::InternalError(format!(
+                "SorterData: destination register {dest_reg} must be pseudo-cursor {pseudo_cursor}'s content register {content_reg}"
+            )));
+        }
+    }
+    {
         let cursor = state.get_cursor(*cursor_id);
-        let cursor = cursor.as_sorter_mut();
-        cursor.record().cloned()
-    };
-    let record = match record {
-        Some(record) => record,
-        None => {
+        if cursor.as_sorter_mut().record().is_none() {
             state.pc += 1;
             return Ok(InsnFunctionStepResult::Step);
         }
-    };
-    state.registers[*dest_reg] = Register::Record(record.clone());
-    {
-        let pseudo_cursor = state.get_cursor(*pseudo_cursor);
-        pseudo_cursor.as_pseudo_mut().insert(record);
     }
+    // Move the record into the content register with no allocation or copy;
+    // the register's spent buffer seeds the sorter's next row.
+    let buf = state.registers[*dest_reg].take_buf();
+    let record = {
+        let cursor = state.get_cursor(*cursor_id);
+        cursor
+            .as_sorter_mut()
+            .take_current(buf)
+            .expect("sorter record checked above")
+    };
+    state.registers[*dest_reg] = Register::Record(record);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -17832,6 +17857,29 @@ mod tests {
         };
         assert!(
             matches!(err, LimboError::InternalError(ref message) if message.contains("overlaps its source range")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_sorter_data_unpaired_content_register_returns_error() {
+        let stmt = prepare_test_statement();
+
+        // Pseudo cursor 1 exposes register 2, but SorterData targets register 3.
+        let mut state = ProgramState::new(4, 2);
+        state.cursors[1] = Some(Cursor::new_pseudo(crate::pseudo::PseudoCursor::new(2)));
+        let insn = Insn::SorterData {
+            cursor_id: 0,
+            dest_reg: 3,
+            pseudo_cursor: 1,
+        };
+
+        let err = match op_sorter_data(stmt.get_program(), &mut state, &insn, stmt.get_pager()) {
+            Ok(_) => panic!("unpaired content register must fail"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, LimboError::InternalError(ref message) if message.contains("content register")),
             "unexpected error: {err:?}"
         );
     }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -18,7 +18,7 @@ use crate::{
     io::{Buffer, Completion, CompletionGroup, File, IO},
     storage::sqlite3_ondisk::{read_varint, varint_len, write_varint},
     translate::collate::CollationSeq,
-    types::{IOResult, ImmutableRecord, KeyInfo, ValueRef},
+    types::{IOResult, ImmutableRecord, KeyInfo, RecordBuf, ValueRef},
     Result,
 };
 use crate::{io_yield_one, return_if_io, CompletionError};
@@ -359,6 +359,17 @@ impl Sorter {
 
     pub const fn record(&self) -> Option<&ImmutableRecord> {
         self.current.as_ref()
+    }
+
+    /// Moves the current record out of the sorter, seeding the next
+    /// [Sorter::next] call with `spent`'s allocation. This lets SorterData
+    /// transfer records to a register with no allocation or payload copy.
+    pub fn take_current(&mut self, spent: RecordBuf) -> Option<ImmutableRecord> {
+        let current = self.current.take();
+        if current.is_some() {
+            self.current = Some(ImmutableRecord::from_buf(spent));
+        }
+        current
     }
 
     pub fn insert(&mut self, record: &ImmutableRecord) -> Result<IOResult<()>> {


### PR DESCRIPTION
## Description

- reuse spent destination `RecordBuf` allocations in `MakeRecord` and `RowData`
- move sorter records into pseudo-cursor content registers without allocating or copying payloads
- enforce register-layout invariants for `MakeRecord`, `SorterData`, and pseudo-cursor column decoding
- add focused regression coverage for overlapping and mismatched registers

## Context

Record-producing opcodes rebuilt or cloned records into fresh allocations for every row, even when destination registers already owned reusable capacity. Sorter records were also duplicated between the sorter, a destination register, and the pseudo cursor.

Recycling destination buffers makes steady-state row processing allocation-free for these paths. The recorded benchmark result reduces sorter allocations by 33% and allocated bytes by 19%.


