### PR TITLE
core/incremental: re-drive yielded cursor ops in WriteRow instead of advancing state

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -6159,4 +6159,89 @@ mod tests {
         assert_eq!(actual_right.name, "right_id");
         assert_eq!(right_idx, 0);
     }
+
+    mod write_row_view_repoll {
+        use super::super::WriteRowView;
+        use crate::incremental::yield_test_support::OneShotYieldInjector;
+        use crate::mvcc::yield_hooks::YieldPointMarker;
+        use crate::storage::btree::{
+            BTreeCursor, BTreeWriteYieldPoint, CursorTrait, BTREE_WRITE_YIELD_FAMILY,
+        };
+        use crate::storage::pager::CreateBTreeFlags;
+        use crate::sync::Arc;
+        use crate::types::{SeekKey, SeekOp, SeekResult};
+        use crate::util::IOExt;
+        use crate::{Connection, Database, MemoryIO, SqliteDialect, Value, IO};
+
+        fn setup() -> (Arc<Connection>, Arc<crate::Pager>, i64) {
+            let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+            let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+            let conn = db.connect().unwrap();
+            let pager = conn.pager.load().clone();
+            let _ = pager.io.block(|| pager.allocate_page1());
+            let root = pager
+                .io
+                .block(|| pager.btree_create(&CreateBTreeFlags::new_table()))
+                .unwrap() as i64;
+            (conn, pager, root)
+        }
+
+        /// Same re-poll contract as `persistence::WriteRow`, for the per-row view cursor:
+        /// a mid-balance yield must not lose the matview row.
+        #[test]
+        fn write_row_view_completes_yielded_overflowing_insert() {
+            let (conn, pager, root) = setup();
+
+            let injector = OneShotYieldInjector::new(
+                BTreeWriteYieldPoint::AfterInsertOverflowCellBeforeBalance.point(),
+                BTREE_WRITE_YIELD_FAMILY ^ root as u64,
+            );
+            conn.set_yield_injector(Some(injector.clone()));
+
+            // ~1200-byte on-page cells fill leaves; the insert that overflows a page
+            // triggers the mid-balance yield. Fresh per-row cursor, as in UpdateView.
+            let mut victim_rowid = None;
+            for rowid in 1i64..=200 {
+                let mut cursor = BTreeCursor::new_table(pager.clone(), root, 2);
+                cursor.install_yield_context(&conn);
+
+                let key = SeekKey::TableRowId(rowid);
+                let build = move |final_weight: isize| -> Vec<Value> {
+                    vec![
+                        Value::from_slice(&[0xcd_u8; 1200]).unwrap(),
+                        Value::from_i64(final_weight as i64),
+                    ]
+                };
+
+                let mut wr = WriteRowView::new();
+                pager
+                    .io
+                    .block(|| wr.write_row(&mut cursor, key.clone(), build, 1))
+                    .unwrap();
+
+                if injector.fired() {
+                    victim_rowid = Some(rowid);
+                    break;
+                }
+            }
+            let victim_rowid = victim_rowid
+                .expect("no insert ever overflowed a page; test does not exercise the bug");
+            conn.set_yield_injector(None);
+
+            let mut verify = BTreeCursor::new_table(pager.clone(), root, 2);
+            let found = pager
+                .io
+                .block(|| {
+                    verify.seek(
+                        SeekKey::TableRowId(victim_rowid),
+                        SeekOp::GE { eq_only: true },
+                    )
+                })
+                .unwrap();
+            assert!(
+                matches!(found, SeekResult::Found),
+                "matview row {victim_rowid} lost: WriteRowView advanced to Done past a yielded insert"
+            );
+        }
+    }
 }

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -32,12 +32,19 @@ use std::fmt::{self, Display, Formatter};
 const OPERATOR_COLUMNS: usize = 5;
 
 /// State machine for writing rows to simple materialized views (table-only, no index)
+///
+/// Each arm issues exactly one cursor op and advances only after it returns `Done`:
+/// `IOResult::IO` means "call me again", so advancing first abandons an in-flight
+/// balance. The seek therefore gets its own arm.
 #[derive(Debug, Default)]
 pub enum WriteRowView {
     #[default]
     GetRecord,
     Delete,
     Insert {
+        final_weight: isize,
+    },
+    InsertRow {
         final_weight: isize,
     },
     Done,
@@ -106,13 +113,16 @@ impl WriteRowView {
                     }
                 }
                 WriteRowView::Delete => {
-                    // Mark as Done before delete to avoid retry on I/O
-                    *self = WriteRowView::Done;
                     return_if_io!(cursor.delete());
+                    *self = WriteRowView::Done;
                 }
                 WriteRowView::Insert { final_weight } => {
                     return_if_io!(cursor.seek(key.clone(), SeekOp::GE { eq_only: true }));
-
+                    *self = WriteRowView::InsertRow {
+                        final_weight: *final_weight,
+                    };
+                }
+                WriteRowView::InsertRow { final_weight } => {
                     // Extract the row ID from the key
                     let key_i64 = match key {
                         SeekKey::TableRowId(id) => id,
@@ -131,9 +141,8 @@ impl WriteRowView {
                         ImmutableRecord::from_values(&record_values, record_values.len())?;
                     let btree_key = BTreeKey::new_table_rowid(key_i64, Some(&immutable_record));
 
-                    // Mark as Done before insert to avoid retry on I/O
-                    *self = WriteRowView::Done;
                     return_if_io!(cursor.insert(&btree_key));
+                    *self = WriteRowView::Done;
                 }
                 WriteRowView::Done => {
                     return Ok(IOResult::Done(()));

--- a/core/incremental/mod.rs
+++ b/core/incremental/mod.rs
@@ -11,3 +11,41 @@ pub mod operator;
 pub mod persistence;
 pub mod project_operator;
 pub mod view;
+
+#[cfg(test)]
+pub(crate) mod yield_test_support {
+    use crate::mvcc::yield_points::{YieldInjector, YieldPoint};
+    use crate::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Fires the requested yield point exactly once, for the btree whose write
+    /// selection key matches.
+    #[derive(Debug)]
+    pub(crate) struct OneShotYieldInjector {
+        point: YieldPoint,
+        selection_key: u64,
+        fired: AtomicBool,
+    }
+
+    impl OneShotYieldInjector {
+        pub(crate) fn new(point: YieldPoint, selection_key: u64) -> Arc<Self> {
+            Arc::new(Self {
+                point,
+                selection_key,
+                fired: AtomicBool::new(false),
+            })
+        }
+
+        pub(crate) fn fired(&self) -> bool {
+            self.fired.load(Ordering::Acquire)
+        }
+    }
+
+    impl YieldInjector for OneShotYieldInjector {
+        fn should_yield(&self, _instance_id: u64, selection_key: u64, point: YieldPoint) -> bool {
+            point == self.point
+                && selection_key == self.selection_key
+                && !self.fired.swap(true, Ordering::AcqRel)
+        }
+    }
+}

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -288,3 +288,109 @@ impl WriteRow {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::incremental::operator::{create_dbsp_state_index, DbspStateCursors};
+    use crate::incremental::yield_test_support::OneShotYieldInjector;
+    use crate::mvcc::yield_hooks::YieldPointMarker;
+    use crate::storage::btree::{
+        BTreeCursor, BTreeWriteYieldPoint, CursorTrait, BTREE_WRITE_YIELD_FAMILY,
+    };
+    use crate::storage::pager::CreateBTreeFlags;
+    use crate::sync::Arc;
+    use crate::util::IOExt;
+    use crate::{Connection, Database, MemoryIO, SqliteDialect, IO};
+
+    fn setup() -> (Arc<Connection>, Arc<crate::Pager>, i64, i64) {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        let pager = conn.pager.load().clone();
+        let _ = pager.io.block(|| pager.allocate_page1());
+        let table_root = pager
+            .io
+            .block(|| pager.btree_create(&CreateBTreeFlags::new_table()))
+            .unwrap() as i64;
+        let index_root = pager
+            .io
+            .block(|| pager.btree_create(&CreateBTreeFlags::new_index()))
+            .unwrap() as i64;
+        (conn, pager, table_root, index_root)
+    }
+
+    // ~1200-byte cells stay on the leaf, so enough of them overflow the page and trip
+    // AfterInsertOverflowCellBeforeBalance.
+    fn page_filling_record(op_id: i64, zset_id: i64, elem_id: i64) -> Vec<Value> {
+        vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(elem_id),
+            Value::from_slice(&[0xcd_u8; 1200]).unwrap(),
+        ]
+    }
+
+    /// If the table insert yields mid-balance, `WriteRow` must re-drive it before
+    /// advancing; advancing first strands the overflow cell and the row vanishes.
+    #[test]
+    fn write_row_completes_yielded_overflowing_table_insert() {
+        let (conn, pager, table_root, index_root) = setup();
+
+        let injector = OneShotYieldInjector::new(
+            BTreeWriteYieldPoint::AfterInsertOverflowCellBeforeBalance.point(),
+            BTREE_WRITE_YIELD_FAMILY ^ table_root as u64,
+        );
+        conn.set_yield_injector(Some(injector.clone()));
+
+        let mut table_cursor = BTreeCursor::new_table(pager.clone(), table_root, 5);
+        table_cursor.install_yield_context(&conn);
+        let index_def = create_dbsp_state_index(index_root);
+        let mut index_cursor =
+            BTreeCursor::new_index(pager.clone(), index_root, &index_def, 4).unwrap();
+        index_cursor.install_yield_context(&conn);
+        let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
+
+        let (op_id, zset_id) = (1i64, 1i64);
+        // rowid == elem_id here: ComputeNewRowId assigns last+1.
+        let mut victim_rowid = None;
+        for elem_id in 1i64..=200 {
+            let index_key = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(elem_id),
+            ];
+            let record_values = page_filling_record(op_id, zset_id, elem_id);
+
+            let mut wr = WriteRow::new();
+            pager
+                .io
+                .block(|| wr.write_row(&mut cursors, index_key.clone(), record_values.clone(), 1))
+                .unwrap();
+
+            if injector.fired() {
+                victim_rowid = Some(elem_id);
+                break;
+            }
+        }
+        let victim_rowid =
+            victim_rowid.expect("no insert ever overflowed a page; test does not exercise the bug");
+        conn.set_yield_injector(None);
+
+        // Fresh cursor: the working one may be parked mid-balance.
+        let mut verify_cursor = BTreeCursor::new_table(pager.clone(), table_root, 5);
+        let found = pager
+            .io
+            .block(|| {
+                verify_cursor.seek(
+                    SeekKey::TableRowId(victim_rowid),
+                    SeekOp::GE { eq_only: true },
+                )
+            })
+            .unwrap();
+        assert!(
+            matches!(found, SeekResult::Found),
+            "table row {victim_rowid} lost: WriteRow advanced past a yielded (mid-balance) insert"
+        );
+    }
+}

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -70,11 +70,16 @@ pub enum WriteRow {
     Delete {
         rowid: i64,
     },
+    DeleteTable,
     DeleteIndex,
     ComputeNewRowId {
         final_weight: isize,
     },
     InsertNew {
+        rowid: i64,
+        final_weight: isize,
+    },
+    InsertNewRow {
         rowid: i64,
         final_weight: isize,
     },
@@ -184,19 +189,18 @@ impl WriteRow {
                     }
                 }
                 WriteRow::Delete { rowid } => {
-                    // Seek to the row and delete it
                     return_if_io!(cursors
                         .table_cursor
                         .seek(SeekKey::TableRowId(*rowid), SeekOp::GE { eq_only: true }));
-
-                    // Transition to DeleteIndex to also delete the index entry
-                    *self = WriteRow::DeleteIndex;
+                    *self = WriteRow::DeleteTable;
+                }
+                WriteRow::DeleteTable => {
                     return_if_io!(cursors.table_cursor.delete());
+                    *self = WriteRow::DeleteIndex;
                 }
                 WriteRow::DeleteIndex => {
-                    // Mark as Done before delete to avoid retry on I/O
-                    *self = WriteRow::Done;
                     return_if_io!(cursors.index_cursor.delete());
+                    *self = WriteRow::Done;
                 }
                 WriteRow::ComputeNewRowId { final_weight } => {
                     // Find the last rowid to compute the next one
@@ -224,15 +228,22 @@ impl WriteRow {
                     rowid,
                     final_weight,
                 } => {
-                    let rowid_val = *rowid;
-                    let final_weight_val = *final_weight;
-
                     // Seek to where we want to insert
                     // The insert will position the cursor correctly
-                    return_if_io!(cursors.table_cursor.seek(
-                        SeekKey::TableRowId(rowid_val),
-                        SeekOp::GE { eq_only: false }
-                    ));
+                    return_if_io!(cursors
+                        .table_cursor
+                        .seek(SeekKey::TableRowId(*rowid), SeekOp::GE { eq_only: false }));
+                    *self = WriteRow::InsertNewRow {
+                        rowid: *rowid,
+                        final_weight: *final_weight,
+                    };
+                }
+                WriteRow::InsertNewRow {
+                    rowid,
+                    final_weight,
+                } => {
+                    let rowid_val = *rowid;
+                    let final_weight_val = *final_weight;
 
                     // Build the complete record with weight
                     // Use the function parameter record_values directly
@@ -244,9 +255,8 @@ impl WriteRow {
                         ImmutableRecord::from_values(&complete_record, complete_record.len())?;
                     let btree_key = BTreeKey::new_table_rowid(rowid_val, Some(&immutable_record));
 
-                    // Transition to InsertIndex state after table insertion
-                    *self = WriteRow::InsertIndex { rowid: rowid_val };
                     return_if_io!(cursors.table_cursor.insert(&btree_key));
+                    *self = WriteRow::InsertIndex { rowid: rowid_val };
                 }
                 WriteRow::InsertIndex { rowid } => {
                     // For has_rowid indexes, we need to append the rowid to the index key
@@ -259,9 +269,8 @@ impl WriteRow {
                         ImmutableRecord::from_values(&index_values, index_values.len())?;
                     let index_btree_key = BTreeKey::new_index_key(index_record.as_record_ref());
 
-                    // Mark as Done before index insert to avoid retry on I/O
-                    *self = WriteRow::Done;
                     return_if_io!(cursors.index_cursor.insert(&index_btree_key));
+                    *self = WriteRow::Done;
                 }
                 WriteRow::UpdateExisting {
                     rowid,
@@ -276,10 +285,9 @@ impl WriteRow {
                         ImmutableRecord::from_values(&complete_record, complete_record.len())?;
                     let btree_key = BTreeKey::new_table_rowid(*rowid, Some(&immutable_record));
 
-                    // Mark as Done before insert to avoid retry on I/O
-                    *self = WriteRow::Done;
                     // BTree insert with existing key will replace the old value
                     return_if_io!(cursors.table_cursor.insert(&btree_key));
+                    *self = WriteRow::Done;
                 }
                 WriteRow::Done => {
                     return Ok(IOResult::Done(()));

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -9936,6 +9936,15 @@ fn drop_cell(page: &mut PageContent, cell_idx: usize, usable_space: usize) -> Re
         page.write_fragmented_bytes_count(0);
     }
     page.write_cell_count(page.cell_count() as u16 - 1);
+
+    for overflow_cell in page.overflow_cells.iter() {
+        turso_debug_assert!(
+            overflow_cell.index <= cell_idx,
+            "drop_cell: pending overflow cell positioned after dropped cell",
+            { "overflow_index": overflow_cell.index, "cell_idx": cell_idx }
+        );
+    }
+
     debug_validate_cells!(page, usable_space);
     Ok(())
 }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -376,7 +376,7 @@ pub(crate) enum BTreeWriteYieldPoint {
 }
 
 #[cfg(any(test, injected_yields))]
-const BTREE_WRITE_YIELD_FAMILY: u64 = 0x4254_5245_5752_4954;
+pub(crate) const BTREE_WRITE_YIELD_FAMILY: u64 = 0x4254_5245_5752_4954;
 
 #[cfg(any(test, injected_yields))]
 impl YieldPointMarker for BTreeWriteYieldPoint {


### PR DESCRIPTION
`IOResult::IO` from a b-tree cursor op means the call is incomplete and must be re-polled, not that it is done and awaiting durability. IVM's `WriteRow` (`persistence.rs`) and `WriteRowView` (`compiler.rs`) advanced their state machine first:

```rust
// Mark as Done before insert to avoid retry on I/O
*self = WriteRow::Done;
return_if_io!(cursors.table_cursor.insert(&btree_key));
```

An insert that yields mid-balance is then never re-driven — the balance is abandoned with staged `overflow_cells` on shared cache pages. With persistent state cursors later delta rows write over those pages; with per-row view cursors the cursor is dropped and the insert is lost outright.

Root-cause analysis by @LeMikaelF: https://github.com/tursodatabase/turso/pull/8020#issuecomment-5073444278. This PR is that recommendation, both halves of it.

## The fix

Advance state only after the op returns `Done`. Arms that seek before mutating are split in two (`Delete`→`DeleteTable`, `InsertNew`→`InsertNewRow`, `Insert`→`InsertRow`) so re-entry re-drives the mutating op alone — re-running the seek would reposition the cursor and abandon the in-flight balance. Safe because `insert()`/`delete()` reset to `WriteState::Start` only when `CursorState::None`; otherwise they resume their own machine.

`drop_cell` gains a `turso_assert!` that no pending overflow cell sits after the dropped index. The one sanctioned caller that drops from a balancing page — `balance_non_root` dropping divider cells — always consumes the overflow divider at or before that index, matching SQLite, where `dropCell` never touches `aiOvfl`. This makes the restored contract loud instead of silently tolerated. (Folded in from #8020, now closed.)

## Commits

The two concerns are separate red→green pairs, so either can be cherry-picked without the other (the `drop_cell` pair applies cleanly on the base with no trace of the first two):

- `f8e76955` the WriteRow re-poll reproducers. Red: `table row 4 lost: WriteRow advanced past a yielded (mid-balance) insert`, `matview row 4 lost`.
- `d0228ad4` the re-drive fix. Both green.
- `1385de4b` the `drop_cell` contract test. Red: `should panic ... test did not panic as expected`.
- `028be150` the `drop_cell` assertion. Green.

Both reproducers park an insert at `AfterInsertOverflowCellBeforeBalance` and assert the row is retrievable.

## Verification

- `cargo test -p turso_core incremental::` 172 passed, `storage::` 384 passed, 0 failed.
- `cargo fmt --check`; clippy clean on `turso_core`.
- Nightly cfg: `RUSTFLAGS="--cfg nightly" cargo +nightly-2025-12-17 check -p turso_core --all-targets --locked` clean.
- Whopper concurrent-simulator, debug, seeds 1–60, `--mode fast --reopen-probability 0.001` — 0 failures.

Supersedes #7879 (closed): with the machine no longer advancing past a yielded op the index cursor is never left stale between the table and index insert, so that PR's `needs_seek` re-seek is unnecessary.

Known residual, not addressed here: the assert only fires for a drop left of the stray cell; a violating drop at `cell_idx >= overflow_cell.index` still passes.

Reproducer came from a materialized-view-heavy workload. Fix drafted with Claude Code, then adversarially reviewed by a separate model; reviewed by me at the level I can judge.


