### PR TITLE
bindings/tcl: resolve cargo target dir via scripts/cargo-target-dir

### DIFF
--- a/bindings/tcl/Makefile
+++ b/bindings/tcl/Makefile
@@ -19,7 +19,7 @@
 #   make clean
 
 ROOT_DIR  := $(shell cd ../.. && pwd)
-TURSO_LIB := $(ROOT_DIR)/target/debug
+TURSO_LIB := $(shell $(ROOT_DIR)/scripts/cargo-target-dir)/debug
 SRC       := $(ROOT_DIR)/bindings/tcl/turso_tcl.c
 INCLUDE   := $(ROOT_DIR)/bindings/c/include
 


### PR DESCRIPTION
The Makefile hardcoded $(ROOT_DIR)/target/debug for -L and the rpath,
which breaks linking when cargo places artefacts elsewhere, e.g. when
CARGO_TARGET_DIR points at a target directory shared across workspaces.
Ask cargo itself via scripts/cargo-target-dir so the link path always
matches where cargo built libturso_sqlite3.
