### PR TITLE
github: Switch workflows from EOL Node 20 to Node 22/24

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -101,15 +101,15 @@ jobs:
               yarn workspace @tursodatabase/database-wasm-common build
               yarn workspace @tursodatabase/sync-common build
               yarn workspace @tursodatabase/sync-wasm build
-    name: ${{ matrix.settings.artifact }} - node@20
+    name: ${{ matrix.settings.artifact }} - node@24
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: 20
+          node-version: 24
       - name: Install
         uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}
@@ -141,10 +141,10 @@ jobs:
       - name: Build common
         run: yarn workspace @tursodatabase/database-common build
       - name: Setup node x86
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         if: matrix.settings.target == 'x86_64-pc-windows-msvc'
         with:
-          node-version: 20
+          node-version: 24
           architecture: x64
       - name: Build in docker
         if: ${{ matrix.settings.docker }}
@@ -182,7 +182,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "20"
+          - "22"
+          - "24"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
@@ -214,12 +215,13 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "20"
+          - "22"
+          - "24"
     runs-on: blacksmith-4vcpu-windows-2025
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
           architecture: x64
@@ -239,15 +241,10 @@ jobs:
       - name: Test bindings
         run: yarn workspace @tursodatabase/database test
   test-db-wasm-binding:
-    name: Test DB bindings on browser@${{ matrix.node }}
+    name: Test DB bindings on browser
     timeout-minutes: 30
     needs:
       - build
-    strategy:
-      fail-fast: false
-      matrix:
-        node:
-          - "20"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     # Image ships node 20 + chromium + firefox + system deps. Bump the tag
     # whenever the `playwright` dep in bindings/javascript/yarn.lock changes.
@@ -285,7 +282,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "20"
+          - "22"
+          - "24"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
@@ -339,12 +337,13 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "20"
+          - "22"
+          - "24"
     runs-on: blacksmith-4vcpu-windows-2025
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
           architecture: x64
@@ -384,15 +383,10 @@ jobs:
           LOCAL_SYNC_SERVER: ${{ github.workspace }}/target/debug/tursodb
         run: yarn workspace @tursodatabase/sync test
   test-sync-wasm-binding:
-    name: Test sync bindings on browser@${{ matrix.node }}
+    name: Test sync bindings on browser
     timeout-minutes: 30
     needs:
       - build
-    strategy:
-      fail-fast: false
-      matrix:
-        node:
-          - "20"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     # Image ships node 20 + chromium + firefox + system deps. Bump the tag
     # whenever the `playwright` dep in bindings/javascript/yarn.lock changes.
@@ -462,9 +456,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
       - name: Update npm
         run: npm install -g npm@11
       - name: Download all DB artifacts

--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: useblacksmith/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
       #     cache: 'npm'
       # - name: Install dependencies
       #   run: npm install && npm run build
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: useblacksmith/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Clickbench
         run: make clickbench

--- a/.github/workflows/publish-cli-npm.yml
+++ b/.github/workflows/publish-cli-npm.yml
@@ -54,9 +54,9 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Update npm

--- a/.github/workflows/react-native.yml
+++ b/.github/workflows/react-native.yml
@@ -99,9 +99,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm install
@@ -134,9 +134,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -211,9 +211,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Update npm
         run: npm install -g npm@11

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -108,7 +108,7 @@ jobs:
           cache-on-failure: true
       - uses: useblacksmith/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Clickbench
         run: make clickbench

--- a/.github/workflows/sqltest.yml
+++ b/.github/workflows/sqltest.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Setup node
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
       - name: Install JS dependencies
         run: yarn install
       - name: Build common package

--- a/.github/workflows/turso-serverless.yml
+++ b/.github/workflows/turso-serverless.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Node.js
       uses: useblacksmith/setup-node@v5
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
         cache-dependency-path: ${{ env.working-directory }}/package-lock.json
     


### PR DESCRIPTION
Node 20 reached end of life in April 2026 and GitHub is deprecating it as the actions runtime. Move tooling, build, and publish jobs to node 24 (current LTS) and run the JS binding test matrices on node 22 and 24, making 22 the supported floor.

Also bump actions/setup-node@v4 to v5, whose node 24 runtime silences the deprecation warning, and drop the vestigial node matrix from the browser test jobs, which only ever run the node shipped in the Playwright container image.