### PR TITLE
postgres: honor NULLS FIRST/LAST in ORDER BY

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -174,8 +174,9 @@ INTEGER. Unknown type names pass through as custom types.
 | MERGE | ❌ Not supported | |
 | MERGE ... RETURNING | ❌ Not supported | |
 | Multirow VALUES | ✅ Supported | In INSERT and as standalone VALUES lists |
+| ORDER BY / LIMIT on a standalone VALUES list | ❌ Not supported | Rejected: "ORDER BY clause is not allowed with VALUES clause" |
 | Non-decimal integer literals | ✅ Supported | `0x`, `0o`, `0b` |
-| ORDER BY NULLS FIRST/LAST | ❌ Not supported | Accepted but silently ignored (wrong ordering); honored only in CREATE INDEX |
+| ORDER BY NULLS FIRST/LAST | ✅ Supported | Honored in SELECT, window, and compound SELECT ORDER BY; rejected (matching SQLite) in CREATE INDEX |
 | range_agg range type aggregation function | ❌ Not supported | |
 | Recursive queries | ❌ Not supported | WITH RECURSIVE translates but the engine rejects it ("Recursive CTEs are not yet supported") |
 | regexp_count, regexp_instr, regexp_like | ❌ Not supported | Regex *operators* (`~`, `~*`, SIMILAR TO) work |

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -3478,11 +3478,18 @@ impl PostgreSQLTranslator {
                         _ => None, // Default or undefined
                     };
 
-                    sorted_columns.push(ast::SortedColumn {
-                        expr,
-                        order,
-                        nulls: None,
-                    });
+                    let nulls =
+                        match pg_query::protobuf::SortByNulls::try_from(sort_by.sortby_nulls) {
+                            Ok(pg_query::protobuf::SortByNulls::SortbyNullsFirst) => {
+                                Some(ast::NullsOrder::First)
+                            }
+                            Ok(pg_query::protobuf::SortByNulls::SortbyNullsLast) => {
+                                Some(ast::NullsOrder::Last)
+                            }
+                            _ => None,
+                        };
+
+                    sorted_columns.push(ast::SortedColumn { expr, order, nulls });
                 }
                 _ => {
                     return Err(ParseError::ParseError(format!(
@@ -6558,6 +6565,104 @@ mod tests {
         } else {
             panic!("Expected Select statement");
         }
+    }
+
+    #[test]
+    fn test_order_by_nulls_ordering() {
+        let translator = PostgreSQLTranslator::new();
+
+        let cases = [
+            ("SELECT * FROM t ORDER BY a", None),
+            (
+                "SELECT * FROM t ORDER BY a NULLS FIRST",
+                Some(ast::NullsOrder::First),
+            ),
+            (
+                "SELECT * FROM t ORDER BY a NULLS LAST",
+                Some(ast::NullsOrder::Last),
+            ),
+            (
+                "SELECT * FROM t ORDER BY a DESC NULLS FIRST",
+                Some(ast::NullsOrder::First),
+            ),
+            (
+                "SELECT * FROM t ORDER BY a ASC NULLS LAST",
+                Some(ast::NullsOrder::Last),
+            ),
+        ];
+
+        for (sql, expected_nulls) in cases {
+            let parsed = crate::parse(sql).unwrap();
+            let translated = translator.translate(&parsed).unwrap();
+            let ast::Stmt::Select(select) = translated else {
+                panic!("expected Select statement for {sql}");
+            };
+            assert_eq!(select.order_by.len(), 1, "for {sql}");
+            assert_eq!(select.order_by[0].nulls, expected_nulls, "for {sql}");
+        }
+    }
+
+    #[test]
+    fn test_compound_select_order_by_nulls_ordering() {
+        let translator = PostgreSQLTranslator::new();
+        let sql = "SELECT a FROM t1 UNION SELECT a FROM t2 ORDER BY a NULLS LAST";
+        let parsed = crate::parse(sql).unwrap();
+        let translated = translator.translate(&parsed).unwrap();
+
+        let ast::Stmt::Select(select) = translated else {
+            panic!("expected Select statement");
+        };
+        assert_eq!(select.body.compounds.len(), 1, "expected one UNION arm");
+        assert_eq!(select.order_by.len(), 1);
+        assert_eq!(select.order_by[0].nulls, Some(ast::NullsOrder::Last));
+    }
+
+    #[test]
+    fn test_values_order_by_nulls_ordering() {
+        let translator = PostgreSQLTranslator::new();
+        let sql = "VALUES (1), (NULL), (2) ORDER BY 1 NULLS LAST";
+        let parsed = crate::parse(sql).unwrap();
+        let translated = translator.translate(&parsed).unwrap();
+
+        let ast::Stmt::Select(select) = translated else {
+            panic!("expected Select statement");
+        };
+        assert!(
+            matches!(select.body.select, ast::OneSelect::Values(_)),
+            "expected a VALUES body, got {:?}",
+            select.body.select
+        );
+        assert_eq!(select.order_by.len(), 1);
+        assert_eq!(select.order_by[0].nulls, Some(ast::NullsOrder::Last));
+    }
+
+    #[test]
+    fn test_window_order_by_nulls_ordering() {
+        let translator = PostgreSQLTranslator::new();
+        let sql = "SELECT ROW_NUMBER() OVER (ORDER BY salary NULLS LAST) FROM t";
+        let parsed = crate::parse(sql).unwrap();
+        let translated = translator.translate(&parsed).unwrap();
+
+        let ast::Stmt::Select(select) = translated else {
+            panic!("expected Select statement");
+        };
+        let ast::OneSelect::Select { columns, .. } = &select.body.select else {
+            panic!("expected Select body");
+        };
+        let ast::ResultColumn::Expr(expr, _) = &columns[0] else {
+            panic!("expected expression result column");
+        };
+        let ast::Expr::FunctionCall { filter_over, .. } = expr.as_ref() else {
+            panic!("expected function call expression, got {expr:?}");
+        };
+        let Some(ast::Over::Window(window)) = &filter_over.over_clause else {
+            panic!(
+                "expected inline OVER window, got {:?}",
+                filter_over.over_clause
+            );
+        };
+        assert_eq!(window.order_by.len(), 1);
+        assert_eq!(window.order_by[0].nulls, Some(ast::NullsOrder::Last));
     }
 
     #[test]

--- a/postgres/tests/integration/postgres/dialect.rs
+++ b/postgres/tests/integration/postgres/dialect.rs
@@ -1964,6 +1964,131 @@ fn test_postgres_similar_to(db: TempDatabase) {
 }
 
 #[turso_macros::test(mvcc)]
+fn test_postgres_order_by_nulls_first_last(db: TempDatabase) {
+    let conn = db.connect_postgres();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 10), (2, NULL), (3, 5), (4, NULL), (5, 20)")
+        .unwrap();
+
+    let run = |sql: &str| -> Vec<Option<i64>> {
+        let mut stmt = conn.prepare(sql).unwrap();
+        let mut results = Vec::new();
+        loop {
+            match stmt.step().unwrap() {
+                StepResult::Row => {
+                    let row = stmt.row().unwrap();
+                    let v = match row.get_value(0) {
+                        Value::Numeric(Numeric::Integer(v)) => Some(*v),
+                        Value::Null => None,
+                        other => panic!("unexpected value: {other:?}"),
+                    };
+                    results.push(v);
+                }
+                StepResult::Done => break,
+                _ => {}
+            }
+        }
+        results
+    };
+
+    // Default ASC ordering treats NULLs as smallest, matching PostgreSQL.
+    assert_eq!(
+        run("SELECT v FROM t ORDER BY v"),
+        vec![None, None, Some(5), Some(10), Some(20)]
+    );
+    assert_eq!(
+        run("SELECT v FROM t ORDER BY v NULLS FIRST"),
+        vec![None, None, Some(5), Some(10), Some(20)]
+    );
+    assert_eq!(
+        run("SELECT v FROM t ORDER BY v NULLS LAST"),
+        vec![Some(5), Some(10), Some(20), None, None]
+    );
+    assert_eq!(
+        run("SELECT v FROM t ORDER BY v DESC NULLS FIRST"),
+        vec![None, None, Some(20), Some(10), Some(5)]
+    );
+    assert_eq!(
+        run("SELECT v FROM t ORDER BY v DESC NULLS LAST"),
+        vec![Some(20), Some(10), Some(5), None, None]
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_compound_select_order_by_nulls_first_last(db: TempDatabase) {
+    let conn = db.connect_postgres();
+    conn.execute("CREATE TABLE t1 (v INTEGER)").unwrap();
+    conn.execute("CREATE TABLE t2 (v INTEGER)").unwrap();
+    conn.execute("INSERT INTO t1 VALUES (10), (NULL)").unwrap();
+    conn.execute("INSERT INTO t2 VALUES (5), (NULL)").unwrap();
+
+    let run = |sql: &str| -> Vec<Option<i64>> {
+        let mut stmt = conn.prepare(sql).unwrap();
+        let mut results = Vec::new();
+        loop {
+            match stmt.step().unwrap() {
+                StepResult::Row => {
+                    let row = stmt.row().unwrap();
+                    let v = match row.get_value(0) {
+                        Value::Numeric(Numeric::Integer(v)) => Some(*v),
+                        Value::Null => None,
+                        other => panic!("unexpected value: {other:?}"),
+                    };
+                    results.push(v);
+                }
+                StepResult::Done => break,
+                _ => {}
+            }
+        }
+        results
+    };
+
+    assert_eq!(
+        run("SELECT v FROM t1 UNION SELECT v FROM t2 ORDER BY v NULLS LAST"),
+        vec![Some(5), Some(10), None]
+    );
+    assert_eq!(
+        run("SELECT v FROM t1 UNION SELECT v FROM t2 ORDER BY v NULLS FIRST"),
+        vec![None, Some(5), Some(10)]
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_window_order_by_nulls_first_last(db: TempDatabase) {
+    let conn = db.connect_postgres();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 10), (2, NULL), (3, 5)")
+        .unwrap();
+
+    // ROW_NUMBER() OVER (ORDER BY v NULLS LAST) ranks NULL last within the
+    // window's own ordering, independent of the query's outer ORDER BY.
+    let mut stmt = conn
+        .prepare("SELECT id, ROW_NUMBER() OVER (ORDER BY v NULLS LAST) FROM t ORDER BY id")
+        .unwrap();
+    let mut results: Vec<(i64, i64)> = Vec::new();
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                let Value::Numeric(Numeric::Integer(id)) = row.get_value(0) else {
+                    panic!("expected integer id");
+                };
+                let Value::Numeric(Numeric::Integer(rank)) = row.get_value(1) else {
+                    panic!("expected integer row_number");
+                };
+                results.push((*id, *rank));
+            }
+            StepResult::Done => break,
+            _ => {}
+        }
+    }
+    // id=3 (v=5) ranks 1st, id=1 (v=10) ranks 2nd, id=2 (v=NULL) ranks last.
+    assert_eq!(results, vec![(1, 2), (2, 3), (3, 1)]);
+}
+
+#[turso_macros::test(mvcc)]
 fn test_postgres_generate_series(db: TempDatabase) {
     let conn = db.connect_postgres();
 


### PR DESCRIPTION
## Description

Adds Postgres dialect support for:
```sql
order by ... nulls first/last`
```

### Enables:
- Simple select statements
- Compound selects (unions)
- Window functions


### Does not enable:
- Ordering within aggregate e.g. `array_agg` *1
- raw `values ... order by` *2


*1 already tracked in COMPAT.md

*2 standalone `values ... order by` is rejected by the engine by `core/translate/select.rs` with "ORDER BY clause is not allowed with VALUES clause"). The new translator unit test confirms the translation itself is correct, but there is no accompanying integration test for that reason.

## Implementation
`turso_parser` already supported `NULLS FIRST/LAST` end to end.
`PostgreSQLTranslator::translate_order_by` in `postgres/parser/translator.rs` was hardcoded `nulls: None` when building the translated AST, which silently discards the clause. The core change is 12 LOC. Everything else is tests/docs.

`translate_order_by` is shared by four AST nodes: plain `SELECT`, window `ORDER BY`, compound `SELECT` (UNION/INTERSECT/EXCEPT), and standalone `VALUES ... ORDER BY`. This fix covers all four. Each has a parser unit test.

`COMPAT.md` has been updated to reflect everything above.

## Motivation and context

- Improve compatibility for the postgres path
- Remove silently incorrect behavior

## Test plan

Translator unit tests:
- `test_order_by_nulls_ordering`: plain `SELECT` ORDER BY, `ASC`/`DESC` combined with `NULLS FIRST`/`NULLS LAST`, and the no-clause default.
- `test_window_order_by_nulls_ordering`: inline `OVER (ORDER BY ... NULLS LAST)`.
- `test_compound_select_order_by_nulls_ordering`: `UNION ... ORDER BY ... NULLS LAST`.
- `test_values_order_by_nulls_ordering`: standalone `VALUES ... ORDER BY ... NULLS LAST` (translation only, see note above).

Integration tests:
- `test_postgres_order_by_nulls_first_last`: plain `SELECT`, ASC/DESC combined with FIRST/LAST against a table with NULLs.
- `test_postgres_window_order_by_nulls_first_last`: `ROW_NUMBER() OVER (ORDER BY v NULLS LAST)`.
- `test_postgres_compound_select_order_by_nulls_first_last`: `UNION ... ORDER BY ... NULLS FIRST/LAST`.

## Description of AI Usage

Shamelessly assisted by Claude code. Extensively edited and reviewed by me.