### PR TITLE
core: prevent explicit checkpoints and root statements on the same connection

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -8,7 +8,7 @@ use crate::sync::{
     atomic::{
         AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, AtomicU8, Ordering,
     },
-    Arc, RwLock,
+    Arc, Mutex, RwLock,
 };
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
@@ -342,6 +342,30 @@ pub enum SyncRowStep {
     Upsert { stmt: Box<Statement> },
 }
 
+#[derive(Default)]
+pub(crate) struct StatementActivity {
+    explicit_checkpoint_active: bool,
+}
+
+pub(crate) struct ExplicitCheckpointGuard {
+    activity: Arc<Mutex<StatementActivity>>,
+    pager: Arc<Pager>,
+}
+
+impl Drop for ExplicitCheckpointGuard {
+    fn drop(&mut self) {
+        if self.pager.is_checkpointing() {
+            self.pager.cleanup_after_checkpoint_failure();
+        }
+        let mut activity = self.activity.lock();
+        turso_assert!(
+            activity.explicit_checkpoint_active,
+            "dropping an inactive explicit checkpoint guard"
+        );
+        activity.explicit_checkpoint_active = false;
+    }
+}
+
 /// Database connection handle.
 ///
 /// If you add a setting that affects SQL compilation or execution, call
@@ -483,6 +507,8 @@ pub struct Connection {
     /// (`db->nVdbeActive`) for user statements, excluding internal helpers and
     /// subprogram execution.
     pub(crate) n_active_root_statements: AtomicI32,
+    /// Prevents root statements and explicit checkpoints from overlapping on this connection.
+    pub(crate) statement_activity: Arc<Mutex<StatementActivity>>,
     /// Whether pragma ignore_check_constraints=ON for this connection
     pub(super) check_constraints_pragma: AtomicBool,
     /// Track when each virtual table instance is currently in transaction.
@@ -4695,6 +4721,36 @@ impl Connection {
         if self.n_active_root_statements.load(Ordering::SeqCst) == 0 {
             self.interrupt_requested.store(false, Ordering::SeqCst);
         }
+    }
+
+    pub(crate) fn start_root_statement(&self) -> Result<()> {
+        let activity = self.statement_activity.lock();
+        if activity.explicit_checkpoint_active {
+            return Err(LimboError::StatementsInProgress(
+                "cannot start a statement while a checkpoint is active",
+            ));
+        }
+        self.n_active_root_statements.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    pub(crate) fn begin_explicit_checkpoint(
+        &self,
+        pager: Arc<Pager>,
+    ) -> Result<ExplicitCheckpointGuard> {
+        let mut activity = self.statement_activity.lock();
+        if activity.explicit_checkpoint_active
+            || self.n_active_root_statements.load(Ordering::SeqCst) != 1
+        {
+            return Err(LimboError::StatementsInProgress(
+                "cannot checkpoint while another statement is active",
+            ));
+        }
+        activity.explicit_checkpoint_active = true;
+        Ok(ExplicitCheckpointGuard {
+            activity: self.statement_activity.clone(),
+            pager,
+        })
     }
 
     pub(crate) fn set_tx_state(&self, state: TransactionState) {

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -507,6 +507,14 @@ pub struct Connection {
     /// (`db->nVdbeActive`) for user statements, excluding internal helpers and
     /// subprogram execution.
     pub(crate) n_active_root_statements: AtomicI32,
+    /// How many of `n_active_root_statements` are parked incremental blob
+    /// handles. A blob handle keeps a Root statement open from `blob_open`
+    /// until close, but between blob operations it just sits on its row, so
+    /// explicit checkpoints subtract these instead of treating them as
+    /// statements in progress (SQLite checkpoints fine with open blob
+    /// handles; a handle re-positions on its next blob operation after the
+    /// checkpoint's cache clear).
+    pub(crate) n_active_blob_statements: AtomicI32,
     /// Prevents root statements and explicit checkpoints from overlapping on this connection.
     pub(crate) statement_activity: Arc<Mutex<StatementActivity>>,
     /// Whether pragma ignore_check_constraints=ON for this connection
@@ -2319,6 +2327,12 @@ impl Connection {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
+        // Checkpointing invalidates this connection's cursors and page cache,
+        // which breaks any statement suspended mid-execution, so refuse to run
+        // while statements are active — same rule as PRAGMA wal_checkpoint.
+        // The guard also rejects new statements until the checkpoint finishes
+        // and cleans up pager checkpoint state if we bail out mid-flight.
+        let _checkpoint_guard = self.begin_explicit_checkpoint(self.pager.load().clone(), false)?;
         if let Some(mv_store) = self.mv_store().as_ref() {
             let mode = if self.experimental_mvcc_passive_checkpoint_enabled() {
                 assert!(
@@ -4734,14 +4748,26 @@ impl Connection {
         Ok(())
     }
 
+    /// `from_statement` is true when the checkpoint runs inside a root
+    /// statement (PRAGMA wal_checkpoint), which itself counts as one active
+    /// root statement; the direct `Connection::checkpoint` API runs outside
+    /// any statement, so it requires zero.
     pub(crate) fn begin_explicit_checkpoint(
         &self,
         pager: Arc<Pager>,
+        from_statement: bool,
     ) -> Result<ExplicitCheckpointGuard> {
+        let statements_expected = if from_statement { 1 } else { 0 };
         let mut activity = self.statement_activity.lock();
-        if activity.explicit_checkpoint_active
-            || self.n_active_root_statements.load(Ordering::SeqCst) != 1
-        {
+        // Parked incremental blob handles don't count: they hold a Root
+        // statement open for their whole lifetime, but between blob
+        // operations they just sit on their row and re-position on their
+        // next blob operation after the checkpoint's cache clear. Counting
+        // them would make one open blob handle block every explicit
+        // checkpoint until it is closed.
+        let active_non_blob = self.n_active_root_statements.load(Ordering::SeqCst)
+            - self.n_active_blob_statements.load(Ordering::SeqCst);
+        if activity.explicit_checkpoint_active || active_non_blob != statements_expected {
             return Err(LimboError::StatementsInProgress(
                 "cannot checkpoint while another statement is active",
             ));

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -8,7 +8,7 @@ use crate::sync::{
     atomic::{
         AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, AtomicU8, Ordering,
     },
-    Arc, RwLock,
+    Arc, Mutex, RwLock,
 };
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
@@ -337,6 +337,30 @@ pub enum SyncRowStep {
     Upsert { stmt: Box<Statement> },
 }
 
+#[derive(Default)]
+pub(crate) struct StatementActivity {
+    explicit_checkpoint_active: bool,
+}
+
+pub(crate) struct ExplicitCheckpointGuard {
+    activity: Arc<Mutex<StatementActivity>>,
+    pager: Arc<Pager>,
+}
+
+impl Drop for ExplicitCheckpointGuard {
+    fn drop(&mut self) {
+        if self.pager.is_checkpointing() {
+            self.pager.cleanup_after_checkpoint_failure();
+        }
+        let mut activity = self.activity.lock();
+        turso_assert!(
+            activity.explicit_checkpoint_active,
+            "dropping an inactive explicit checkpoint guard"
+        );
+        activity.explicit_checkpoint_active = false;
+    }
+}
+
 /// Database connection handle.
 ///
 /// If you add a setting that affects SQL compilation or execution, call
@@ -475,6 +499,8 @@ pub struct Connection {
     /// (`db->nVdbeActive`) for user statements, excluding internal helpers and
     /// subprogram execution.
     pub(crate) n_active_root_statements: AtomicI32,
+    /// Prevents root statements and explicit checkpoints from overlapping on this connection.
+    pub(crate) statement_activity: Arc<Mutex<StatementActivity>>,
     /// Whether pragma ignore_check_constraints=ON for this connection
     pub(super) check_constraints_pragma: AtomicBool,
     /// Track when each virtual table instance is currently in transaction.
@@ -4615,6 +4641,36 @@ impl Connection {
         if self.n_active_root_statements.load(Ordering::SeqCst) == 0 {
             self.interrupt_requested.store(false, Ordering::SeqCst);
         }
+    }
+
+    pub(crate) fn start_root_statement(&self) -> Result<()> {
+        let activity = self.statement_activity.lock();
+        if activity.explicit_checkpoint_active {
+            return Err(LimboError::StatementsInProgress(
+                "cannot start a statement while a checkpoint is active",
+            ));
+        }
+        self.n_active_root_statements.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    pub(crate) fn begin_explicit_checkpoint(
+        &self,
+        pager: Arc<Pager>,
+    ) -> Result<ExplicitCheckpointGuard> {
+        let mut activity = self.statement_activity.lock();
+        if activity.explicit_checkpoint_active
+            || self.n_active_root_statements.load(Ordering::SeqCst) != 1
+        {
+            return Err(LimboError::StatementsInProgress(
+                "cannot checkpoint while another statement is active",
+            ));
+        }
+        activity.explicit_checkpoint_active = true;
+        Ok(ExplicitCheckpointGuard {
+            activity: self.statement_activity.clone(),
+            pager,
+        })
     }
 
     pub(crate) fn set_tx_state(&self, state: TransactionState) {

--- a/core/database.rs
+++ b/core/database.rs
@@ -2390,6 +2390,7 @@ impl Database {
             fk_deferred_violations: AtomicIsize::new(0),
             n_active_writes: AtomicI32::new(0),
             n_active_root_statements: AtomicI32::new(0),
+            n_active_blob_statements: AtomicI32::new(0),
             statement_activity: Arc::new(Mutex::new(
                 crate::connection::StatementActivity::default(),
             )),

--- a/core/database.rs
+++ b/core/database.rs
@@ -2390,6 +2390,9 @@ impl Database {
             fk_deferred_violations: AtomicIsize::new(0),
             n_active_writes: AtomicI32::new(0),
             n_active_root_statements: AtomicI32::new(0),
+            statement_activity: Arc::new(Mutex::new(
+                crate::connection::StatementActivity::default(),
+            )),
             check_constraints_pragma: AtomicBool::new(false),
             vtab_txn_states: RwLock::new(HashSet::default()),
             named_savepoints: RwLock::new(Vec::new()),

--- a/core/incremental_blob.rs
+++ b/core/incremental_blob.rs
@@ -340,6 +340,10 @@ impl Connection {
         let program = build_blob_program(self, table_ref, root, record_column, rowid, read_write)?;
         let pager = self.get_pager();
         let mut stmt = Statement::new(program, pager.clone(), QueryMode::Normal, 0);
+        // Excluded from the explicit-checkpoint guard's active-statement
+        // count: the handle parks at its row for its whole lifetime, and an
+        // open blob handle must not block checkpointing until it is closed.
+        stmt.mark_as_blob_handle();
         // Step to the "ready" row: the cursor is open and positioned on the row, and
         // the row carries the value's byte length (BlobLen), which also validated
         // that the value is byte-addressable (TEXT or BLOB, not null/integer/real).

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2343,6 +2343,7 @@ impl Database {
             fk_deferred_violations: AtomicIsize::new(0),
             n_active_writes: AtomicI32::new(0),
             n_active_root_statements: AtomicI32::new(0),
+            statement_activity: Arc::new(Mutex::new(connection::StatementActivity::default())),
             check_constraints_pragma: AtomicBool::new(false),
             vtab_txn_states: RwLock::new(HashSet::default()),
             named_savepoints: RwLock::new(Vec::new()),

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -506,10 +506,7 @@ impl Statement {
 
     fn _step(&mut self, waker: Option<&Waker>) -> Result<StepResult> {
         if !self.counted_as_active_root && matches!(self.origin, StatementOrigin::Root) {
-            self.program
-                .connection
-                .n_active_root_statements
-                .fetch_add(1, Ordering::SeqCst);
+            self.program.connection.start_root_statement()?;
             self.counted_as_active_root = true;
         }
         if matches!(self.state.execution_state, ProgramExecutionState::Init)

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -517,10 +517,7 @@ impl Statement {
 
     fn _step(&mut self, waker: Option<&Waker>) -> Result<StepResult> {
         if !self.counted_as_active_root && matches!(self.origin, StatementOrigin::Root) {
-            self.program
-                .connection
-                .n_active_root_statements
-                .fetch_add(1, Ordering::SeqCst);
+            self.program.connection.start_root_statement()?;
             self.counted_as_active_root = true;
         }
         if matches!(self.state.execution_state, ProgramExecutionState::Init)

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -1535,10 +1535,12 @@ impl Statement {
                 }
 
                 if !halt_completed {
-                    if let Err(abort_err) =
-                        self.program
-                            .abort(&self.pager, reset_error.as_ref(), &mut self.state)
-                    {
+                    if let Err(abort_err) = self.program.abort(
+                        &self.pager,
+                        reset_error.as_ref(),
+                        &mut self.state,
+                        self.counted_as_active_root,
+                    ) {
                         capture_reset_error(
                             &mut reset_error,
                             abort_err,
@@ -1551,7 +1553,12 @@ impl Statement {
                 // yielded a Row (DML still in progress or hit Busy/error), or a
                 // write statement without RETURNING. Rollback to avoid committing
                 // partial DML or silently retrying after transient errors (Busy).
-                if let Err(abort_err) = self.program.abort(&self.pager, None, &mut self.state) {
+                if let Err(abort_err) = self.program.abort(
+                    &self.pager,
+                    None,
+                    &mut self.state,
+                    self.counted_as_active_root,
+                ) {
                     capture_reset_error(
                         &mut reset_error,
                         abort_err,
@@ -1561,7 +1568,12 @@ impl Statement {
             }
         } else {
             // Statement not running (Done/Failed/Init) — cleanup only.
-            if let Err(abort_err) = self.program.abort(&self.pager, None, &mut self.state) {
+            if let Err(abort_err) = self.program.abort(
+                &self.pager,
+                None,
+                &mut self.state,
+                self.counted_as_active_root,
+            ) {
                 capture_reset_error(
                     &mut reset_error,
                     abort_err,

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -316,6 +316,11 @@ pub struct Statement {
     /// True once this root statement has started executing and incremented
     /// `Connection::n_active_root_statements`.
     counted_as_active_root: bool,
+    /// True for the parked statement backing an incremental blob handle.
+    /// Counted separately in `Connection::n_active_blob_statements` so
+    /// explicit checkpoints can subtract it — an open blob handle must not
+    /// block checkpointing for its whole lifetime.
+    is_blob_handle: bool,
     /// True if this statement called `Connection::start_nested()` during
     /// construction and therefore must call `end_nested()` on drop.
     nested_guard_active: bool,
@@ -378,8 +383,20 @@ impl Statement {
             tail_offset,
             origin,
             counted_as_active_root: false,
+            is_blob_handle: false,
             nested_guard_active,
         }
+    }
+
+    /// Mark this statement as the parked backing statement of an incremental
+    /// blob handle. Must be called before the first `step()` so the blob
+    /// accounting stays in lockstep with the root-statement count.
+    pub(crate) fn mark_as_blob_handle(&mut self) {
+        turso_assert!(
+            !self.counted_as_active_root,
+            "blob handle marked after its statement started executing"
+        );
+        self.is_blob_handle = true;
     }
 
     pub fn tail_offset(&self) -> usize {
@@ -503,6 +520,16 @@ impl Statement {
 
     fn release_active_root_if_counted(&mut self) {
         if self.counted_as_active_root {
+            // Blob count drops before the root count so a concurrent
+            // checkpoint-guard read never sees fewer non-blob statements
+            // than are really active (a stale-high read only causes a
+            // spurious StatementsInProgress, never a missed one).
+            if self.is_blob_handle {
+                self.program
+                    .connection
+                    .n_active_blob_statements
+                    .fetch_sub(1, Ordering::SeqCst);
+            }
             let previous = self
                 .program
                 .connection
@@ -519,6 +546,14 @@ impl Statement {
         if !self.counted_as_active_root && matches!(self.origin, StatementOrigin::Root) {
             self.program.connection.start_root_statement()?;
             self.counted_as_active_root = true;
+            // After the root count, so the checkpoint guard's subtraction
+            // can only read stale-high (see release_active_root_if_counted).
+            if self.is_blob_handle {
+                self.program
+                    .connection
+                    .n_active_blob_statements
+                    .fetch_add(1, Ordering::SeqCst);
+            }
         }
         if matches!(self.state.execution_state, ProgramExecutionState::Init)
             && self.origin != StatementOrigin::InternalHelper

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -587,6 +587,17 @@ pub fn op_checkpoint(
         },
         insn
     );
+    if !program.connection.is_nested_stmt()
+        && program
+            .connection
+            .n_active_root_statements
+            .load(Ordering::SeqCst)
+            != 1
+    {
+        return Err(LimboError::StatementsInProgress(
+            "cannot checkpoint while another statement is active",
+        ));
+    }
     if !program.connection.auto_commit.load(Ordering::SeqCst) {
         // TODO: sqlite returns "Runtime error: database table is locked (6)" when a table is in use
         // when a checkpoint is attempted. We don't have table locks, so return TableLocked for any

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3407,7 +3407,9 @@ pub fn halt(
 ) -> Result<InsnFunctionStepResult> {
     let mv_store = program.connection.mv_store();
     let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
-    let can_autocommit_now = state.can_autocommit_now(&program.connection);
+    // halt() runs while the statement is still stepping, so it is always
+    // counted in n_active_root_statements here.
+    let can_autocommit_now = state.can_autocommit_now(&program.connection, true);
 
     // Check if we're resuming from a FAIL commit I/O wait.
     // If pending_fail_error is set, we were in the middle of committing partial changes

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -582,6 +582,17 @@ pub fn op_checkpoint(
         },
         insn
     );
+    if !program.connection.is_nested_stmt()
+        && program
+            .connection
+            .n_active_root_statements
+            .load(Ordering::SeqCst)
+            != 1
+    {
+        return Err(LimboError::StatementsInProgress(
+            "cannot checkpoint while another statement is active",
+        ));
+    }
     if !program.connection.auto_commit.load(Ordering::SeqCst) {
         // TODO: sqlite returns "Runtime error: database table is locked (6)" when a table is in use
         // when a checkpoint is attempted. We don't have table locks, so return TableLocked for any

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -587,17 +587,6 @@ pub fn op_checkpoint(
         },
         insn
     );
-    if !program.connection.is_nested_stmt()
-        && program
-            .connection
-            .n_active_root_statements
-            .load(Ordering::SeqCst)
-            != 1
-    {
-        return Err(LimboError::StatementsInProgress(
-            "cannot checkpoint while another statement is active",
-        ));
-    }
     if !program.connection.auto_commit.load(Ordering::SeqCst) {
         // TODO: sqlite returns "Runtime error: database table is locked (6)" when a table is in use
         // when a checkpoint is attempted. We don't have table locks, so return TableLocked for any
@@ -616,6 +605,13 @@ pub fn op_checkpoint(
         set_not_in_wal_result(state, *dest);
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
+    }
+    if !program.connection.is_nested_stmt() && state.explicit_checkpoint_guard.is_none() {
+        state.explicit_checkpoint_guard = Some(
+            program
+                .connection
+                .begin_explicit_checkpoint(pager.clone())?,
+        );
     }
 
     // In autocommit mode, this statement can still hold an implicit read tx.
@@ -670,6 +666,7 @@ pub fn op_checkpoint(
         // 3rd col: # pages moved to db after checkpoint
         state.registers[*dest + 2].set_int(wal_total_backfilled as i64);
 
+        state.explicit_checkpoint_guard = None;
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
@@ -688,6 +685,7 @@ pub fn op_checkpoint(
             // 3rd col: # pages moved to db after checkpoint
             state.registers[*dest + 2].set_int(wal_total_backfilled as i64);
 
+            state.explicit_checkpoint_guard = None;
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
@@ -695,6 +693,7 @@ pub fn op_checkpoint(
         Err(err) => {
             tracing::debug!("PRAGMA wal_checkpoint failed: {err:?}");
             pager.clear_checkpoint_state();
+            state.explicit_checkpoint_guard = None;
             state.registers[*dest].set_int(1);
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -582,17 +582,6 @@ pub fn op_checkpoint(
         },
         insn
     );
-    if !program.connection.is_nested_stmt()
-        && program
-            .connection
-            .n_active_root_statements
-            .load(Ordering::SeqCst)
-            != 1
-    {
-        return Err(LimboError::StatementsInProgress(
-            "cannot checkpoint while another statement is active",
-        ));
-    }
     if !program.connection.auto_commit.load(Ordering::SeqCst) {
         // TODO: sqlite returns "Runtime error: database table is locked (6)" when a table is in use
         // when a checkpoint is attempted. We don't have table locks, so return TableLocked for any
@@ -611,6 +600,13 @@ pub fn op_checkpoint(
         set_not_in_wal_result(state, *dest);
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
+    }
+    if !program.connection.is_nested_stmt() && state.explicit_checkpoint_guard.is_none() {
+        state.explicit_checkpoint_guard = Some(
+            program
+                .connection
+                .begin_explicit_checkpoint(pager.clone())?,
+        );
     }
 
     // In autocommit mode, this statement can still hold an implicit read tx.
@@ -665,6 +661,7 @@ pub fn op_checkpoint(
         // 3rd col: # pages moved to db after checkpoint
         state.registers[*dest + 2].set_int(wal_total_backfilled as i64);
 
+        state.explicit_checkpoint_guard = None;
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
@@ -683,6 +680,7 @@ pub fn op_checkpoint(
             // 3rd col: # pages moved to db after checkpoint
             state.registers[*dest + 2].set_int(wal_total_backfilled as i64);
 
+            state.explicit_checkpoint_guard = None;
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
@@ -690,6 +688,7 @@ pub fn op_checkpoint(
         Err(err) => {
             tracing::debug!("PRAGMA wal_checkpoint failed: {err:?}");
             pager.clear_checkpoint_state();
+            state.explicit_checkpoint_guard = None;
             state.registers[*dest].set_int(1);
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -606,11 +606,19 @@ pub fn op_checkpoint(
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
-    if !program.connection.is_nested_stmt() && state.explicit_checkpoint_guard.is_none() {
+    if state.explicit_checkpoint_guard.is_none() {
+        // No exemption for nested statements: nothing in the engine prepares
+        // wal_checkpoint as a nested helper (VACUUM checkpoints through
+        // Connection::checkpoint), and nested statements are not counted in
+        // n_active_root_statements, so the guard's expected count still holds
+        // if one ever runs this opcode. Skipping the guard whenever *any*
+        // helper statement is alive on the connection would let a checkpoint
+        // clobber a suspended statement that holds one (e.g. a pragma vtab
+        // cursor's stored helper).
         state.explicit_checkpoint_guard = Some(
             program
                 .connection
-                .begin_explicit_checkpoint(pager.clone())?,
+                .begin_explicit_checkpoint(pager.clone(), true)?,
         );
     }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1089,7 +1089,14 @@ impl ProgramState {
     /// Whether this statement may finish the implicit autocommit transaction
     /// now, including re-entry while its commit is in progress.
     #[inline]
-    pub(crate) fn can_autocommit_now(&self, connection: &Connection) -> bool {
+    /// `self_counted` is true while this statement is still included in
+    /// `Connection::n_active_root_statements`. It is false when a statement
+    /// that already finished (released on Done or on its step error) is being
+    /// reset or dropped — then every counted statement is a *sibling*, and
+    /// treating the count as "just me" would make teardown finish or roll
+    /// back a transaction a suspended sibling is still using (e.g. a COMMIT
+    /// parked inside its post-commit auto-checkpoint).
+    pub(crate) fn can_autocommit_now(&self, connection: &Connection, self_counted: bool) -> bool {
         let is_already_committing = !matches!(self.commit_state, CommitState::Ready);
         if is_already_committing {
             return true;
@@ -1109,7 +1116,8 @@ impl ProgramState {
             // MVCC keeps one tx id on the connection. A writer waits for
             // sibling readers, and a reader waits for sibling readers/writers.
             return self.auto_txn_cleanup == TxnCleanup::RollbackTxn
-                && connection.n_active_root_statements.load(Ordering::SeqCst) == 1
+                && connection.n_active_root_statements.load(Ordering::SeqCst)
+                    == i32::from(self_counted)
                 && (self.is_active_write || active_writers == 0);
         }
         if self.auto_txn_cleanup == TxnCleanup::RollbackTxn && self.is_active_write {
@@ -1129,7 +1137,7 @@ impl ProgramState {
                     .any(|(_, pager)| pager.holds_read_lock() || pager.holds_write_lock())
             })
         };
-        if connection.n_active_root_statements.load(Ordering::SeqCst) > 1 {
+        if connection.n_active_root_statements.load(Ordering::SeqCst) > i32::from(self_counted) {
             // Readers can finish while sibling readers remain active, but a
             // shared attached transaction may only be finished by the last
             // active statement, like SQLite's btreeEndTransaction keeps the
@@ -1897,7 +1905,9 @@ impl Program {
                         // the write itself succeeded.
                         let checkpoint_err = LimboError::CheckpointFailed(err.to_string());
                         tracing::error!("Checkpoint failed: {checkpoint_err}");
-                        if let Err(abort_err) = self.abort(pager, Some(&checkpoint_err), state) {
+                        if let Err(abort_err) =
+                            self.abort(pager, Some(&checkpoint_err), state, true)
+                        {
                             tracing::error!(
                                 "Abort also failed during checkpoint error handling: {abort_err}"
                             );
@@ -1906,7 +1916,7 @@ impl Program {
                         return Err(checkpoint_err);
                     }
                     let err = err.into();
-                    if let Err(abort_err) = self.abort(pager, Some(&err), state) {
+                    if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
                         tracing::error!("Abort failed during error handling: {abort_err}");
                     }
                     return Err(err);
@@ -1923,7 +1933,7 @@ impl Program {
                     return Err(LimboError::InternalError("Connection closed".to_string()));
                 }
                 if self.maybe_request_interrupt(state, pager.io.as_ref()) {
-                    self.abort(pager, None, state)?;
+                    self.abort(pager, None, state, true)?;
                     return Ok(StepResult::Interrupt);
                 }
                 let (insn, _) = &self.insns[state.pc as usize];
@@ -2022,7 +2032,7 @@ impl Program {
                         return Ok(StepResult::Busy);
                     }
                     Err(err) => {
-                        if let Err(abort_err) = self.abort(pager, Some(&err), state) {
+                        if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
                             tracing::error!("Abort failed during error handling: {abort_err}");
                         }
                         return Err(err);
@@ -2603,11 +2613,18 @@ impl Program {
     /// Aborts the program due to various conditions (explicit error, interrupt or reset of unfinished statement) by rolling back the transaction
     /// This method is no-op if program was already finished (either aborted or executed to completion)
     /// Returns an error if cleanup operations (savepoint rollback/release) fail.
+    /// `self_counted` is true while this statement is still included in
+    /// `Connection::n_active_root_statements` (aborts during `step`).
+    /// Statement teardown passes its actual counted state: a statement that
+    /// already finished was released on Done or on its step error, so the
+    /// counted statements are all siblings (see
+    /// [`ProgramState::can_autocommit_now`]).
     pub fn abort(
         &self,
         pager: &Arc<Pager>,
         err: Option<&LimboError>,
         state: &mut ProgramState,
+        self_counted: bool,
     ) -> Result<()> {
         fn capture_abort_error(
             abort_error: &mut Option<LimboError>,
@@ -2744,7 +2761,7 @@ impl Program {
                 self.connection.mark_tx_poisoned();
             }
 
-            let can_autocommit_now = state.can_autocommit_now(&self.connection);
+            let can_autocommit_now = state.can_autocommit_now(&self.connection, self_counted);
             let is_mvcc = self.connection.mv_store().is_some();
             let changed_shared_mvcc_auto_txn = !can_autocommit_now
                 && state.auto_txn_cleanup == TxnCleanup::RollbackTxn

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -795,6 +795,8 @@ pub struct ProgramState {
     /// Per-execution statement deadline derived from the connection query timeout.
     /// `None` means no timeout.
     pub query_deadline: Option<crate::MonotonicInstant>,
+    /// Excludes new root statements while an explicit checkpoint is suspended.
+    pub(crate) explicit_checkpoint_guard: Option<crate::connection::ExplicitCheckpointGuard>,
     pub parameters: Vec<Value>,
     commit_state: CommitState,
     /// In-flight commit-state-machine for an autonomous sequence
@@ -912,6 +914,7 @@ impl ProgramState {
             once: SmallVec::<[u32; 4]>::new(),
             execution_state: ProgramExecutionState::Init,
             query_deadline: None,
+            explicit_checkpoint_guard: None,
             parameters: Vec::new(),
             commit_state: CommitState::Ready,
             sequence_inner_commit: None,
@@ -1032,6 +1035,7 @@ impl ProgramState {
         self.once.clear();
         self.execution_state = ProgramExecutionState::Init;
         self.query_deadline = None;
+        self.explicit_checkpoint_guard = None;
         #[cfg(feature = "json")]
         self.json_cache.clear();
 
@@ -2617,6 +2621,7 @@ impl Program {
         }
 
         let mut abort_error: Option<LimboError> = None;
+        state.explicit_checkpoint_guard = None;
         // PRAGMA journal_mode owns its MVCC checkpoint in active_op_state rather
         // than commit_state. Clean it before transaction abort logic inspects
         // pager checkpoint state or reset drops the opcode state.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -786,6 +786,8 @@ pub struct ProgramState {
     /// Per-execution statement deadline derived from the connection query timeout.
     /// `None` means no timeout.
     pub query_deadline: Option<crate::MonotonicInstant>,
+    /// Excludes new root statements while an explicit checkpoint is suspended.
+    pub(crate) explicit_checkpoint_guard: Option<crate::connection::ExplicitCheckpointGuard>,
     pub parameters: Vec<Value>,
     commit_state: CommitState,
     /// In-flight commit-state-machine for an autonomous sequence
@@ -903,6 +905,7 @@ impl ProgramState {
             once: SmallVec::<[u32; 4]>::new(),
             execution_state: ProgramExecutionState::Init,
             query_deadline: None,
+            explicit_checkpoint_guard: None,
             parameters: Vec::new(),
             commit_state: CommitState::Ready,
             sequence_inner_commit: None,
@@ -1023,6 +1026,7 @@ impl ProgramState {
         self.once.clear();
         self.execution_state = ProgramExecutionState::Init;
         self.query_deadline = None;
+        self.explicit_checkpoint_guard = None;
         #[cfg(feature = "json")]
         self.json_cache.clear();
 
@@ -2535,6 +2539,7 @@ impl Program {
         }
 
         let mut abort_error: Option<LimboError> = None;
+        state.explicit_checkpoint_guard = None;
         // PRAGMA journal_mode owns its MVCC checkpoint in active_op_state rather
         // than commit_state. Clean it before transaction abort logic inspects
         // pager checkpoint state or reset drops the opcode state.

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -21,7 +21,8 @@ use turso_core::SqliteDialect;
 use turso_core::WindowsIOCP;
 use turso_core::schema::SEQ_BACKING_TABLE_PREFIX;
 use turso_core::{
-    CipherMode, Connection, Database, DatabaseOpts, EncryptionOpts, IO, OpenFlags, Statement, Value,
+    CheckpointMode, CipherMode, Connection, Database, DatabaseOpts, EncryptionOpts, IO, LimboError,
+    OpenFlags, Statement, Value,
 };
 use turso_parser::ast::{ColumnConstraint, SortOrder};
 
@@ -307,6 +308,13 @@ pub struct WhopperOpts {
     pub reopen_probability: f64,
     /// Probability of failing a scoped Turso allocation while stepping a statement.
     pub allocation_fault_probability: f64,
+    /// Probability that, on a step where the chosen fiber's statement is
+    /// suspended mid-execution, the simulator attempts a checkpoint on that
+    /// same connection (PRAGMA wal_checkpoint or the Connection::checkpoint
+    /// API, chosen at random) and asserts the engine rejects it. Checkpoints
+    /// invalidate the connection's cursors and page cache, so allowing one
+    /// would break the suspended statement.
+    pub checkpoint_probe_probability: f64,
 }
 
 /// Schema-generation bias
@@ -356,6 +364,7 @@ impl Default for WhopperOpts {
             close_connections_gracefully: true,
             reopen_probability: 0.0,
             allocation_fault_probability: 0.0,
+            checkpoint_probe_probability: 0.01,
         }
     }
 }
@@ -504,6 +513,11 @@ impl WhopperOpts {
         self
     }
 
+    pub fn with_checkpoint_probe_probability(mut self, probability: f64) -> Self {
+        self.checkpoint_probe_probability = probability;
+        self
+    }
+
     pub fn with_allocation_fault_probability(mut self, probability: f64) -> Self {
         self.allocation_fault_probability = probability;
         self
@@ -542,6 +556,8 @@ pub struct Stats {
     pub corruption_events: usize,
     /// Sequence nextval calls
     pub sequence_nextvals: usize,
+    /// Same-connection checkpoint probes fired against suspended statements
+    pub checkpoint_probes: usize,
 }
 
 /// Result of a single simulation step.
@@ -666,6 +682,8 @@ pub struct Whopper {
     /// If false, drop fiber connections without first closing them.
     close_connections_gracefully: bool,
     allocation_fault_injector: Option<&'static SimulatorAllocationFaultInjector>,
+    /// See [`WhopperOpts::checkpoint_probe_probability`].
+    checkpoint_probe_probability: f64,
 }
 
 impl Whopper {
@@ -825,6 +843,7 @@ impl Whopper {
             experimental_mvcc_passive_checkpoint: opts.experimental_mvcc_passive_checkpoint,
             close_connections_gracefully: opts.close_connections_gracefully,
             allocation_fault_injector,
+            checkpoint_probe_probability: opts.checkpoint_probe_probability,
         };
 
         whopper.open_connections()?;
@@ -862,6 +881,83 @@ impl Whopper {
         }
 
         Ok(StepResult::Ok)
+    }
+
+    /// The fiber's statement is suspended mid-execution. Occasionally try to
+    /// checkpoint the same connection and check the contract the engine
+    /// promises: the checkpoint is refused (running it would invalidate the
+    /// suspended statement's cursors and page cache), and refusal leaves no
+    /// state behind — the suspended statement keeps running on later steps
+    /// and the rest of the workload continues on this connection.
+    ///
+    /// Regression coverage for checkpoints racing suspended statements: on
+    /// unguarded builds the checkpoint runs, and the suspended statement
+    /// either panics on resume, silently loses a write, or silently returns
+    /// wrong rows.
+    fn maybe_probe_checkpoint_on_suspended_statement(
+        &mut self,
+        fiber_idx: usize,
+    ) -> anyhow::Result<()> {
+        if self.checkpoint_probe_probability <= 0.0
+            || !self.rng.random_bool(self.checkpoint_probe_probability)
+        {
+            return Ok(());
+        }
+        self.stats.checkpoint_probes += 1;
+        let connection = self.context.fibers[fiber_idx].connection.clone();
+        let via_api = self.rng.random_bool(0.5);
+        let outcome: Result<(), LimboError> = if via_api {
+            connection
+                .checkpoint(CheckpointMode::Passive {
+                    upper_bound_inclusive: None,
+                })
+                .map(|_| ())
+        } else {
+            // Step the pragma until it resolves, driving any I/O it needs on
+            // the way to the checkpoint opcode (bounded, so an engine bug
+            // cannot hang the simulator).
+            let mut stmt = connection.prepare("PRAGMA wal_checkpoint(PASSIVE)")?;
+            let mut budget = 10_000usize;
+            loop {
+                match stmt.step() {
+                    Ok(turso_core::StepResult::IO) => self.io.step()?,
+                    Ok(turso_core::StepResult::Row | turso_core::StepResult::Yield) => {}
+                    Ok(turso_core::StepResult::Done) => break Ok(()),
+                    Ok(other) => {
+                        anyhow::bail!(
+                            "checkpoint probe: step={} fiber={fiber_idx}: unexpected step result {other:?}",
+                            self.current_step
+                        )
+                    }
+                    Err(err) => break Err(err),
+                }
+                budget -= 1;
+                if budget == 0 {
+                    anyhow::bail!(
+                        "checkpoint probe: step={} fiber={fiber_idx}: pragma did not resolve",
+                        self.current_step
+                    );
+                }
+            }
+        };
+        let via = if via_api {
+            "Connection::checkpoint"
+        } else {
+            "PRAGMA wal_checkpoint"
+        };
+        match outcome {
+            Ok(()) => anyhow::bail!(
+                "checkpoint probe: step={} fiber={fiber_idx}: {via} was allowed while \
+                 a statement on the same connection was suspended mid-execution",
+                self.current_step
+            ),
+            Err(LimboError::StatementsInProgress(_) | LimboError::TableLocked) => Ok(()),
+            Err(err) => anyhow::bail!(
+                "checkpoint probe: step={} fiber={fiber_idx}: expected {via} to be \
+                 rejected with StatementsInProgress or TableLocked, got: {err}",
+                self.current_step
+            ),
+        }
     }
 
     fn perform_work(&mut self, fiber_idx: usize) -> anyhow::Result<()> {
@@ -927,6 +1023,7 @@ impl Whopper {
 
         // If the statement has more work, we're done for this simulation step
         if let Ok(None) = step_result {
+            self.maybe_probe_checkpoint_on_suspended_statement(fiber_idx)?;
             return Ok(());
         }
 

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -905,18 +905,35 @@ impl Whopper {
         }
         self.stats.checkpoint_probes += 1;
         let connection = self.context.fibers[fiber_idx].connection.clone();
+        // Default-mode MVCC rejects PASSIVE at prepare time (it requires
+        // experimental_mvcc_passive_checkpoint), so probe with a checkpoint
+        // mode the engine's configuration supports — same selection as
+        // WalCheckpointWorkload's allow_passive. The guard must refuse any
+        // mode while a statement is suspended.
+        let passive_allowed =
+            !self.context.enable_mvcc || self.experimental_mvcc_passive_checkpoint;
         let via_api = self.rng.random_bool(0.5);
         let outcome: Result<(), LimboError> = if via_api {
-            connection
-                .checkpoint(CheckpointMode::Passive {
+            let mode = if passive_allowed {
+                CheckpointMode::Passive {
                     upper_bound_inclusive: None,
-                })
-                .map(|_| ())
+                }
+            } else {
+                CheckpointMode::Truncate {
+                    upper_bound_inclusive: None,
+                }
+            };
+            connection.checkpoint(mode).map(|_| ())
         } else {
             // Step the pragma until it resolves, driving any I/O it needs on
             // the way to the checkpoint opcode (bounded, so an engine bug
             // cannot hang the simulator).
-            let mut stmt = connection.prepare("PRAGMA wal_checkpoint(PASSIVE)")?;
+            let sql = if passive_allowed {
+                "PRAGMA wal_checkpoint(PASSIVE)"
+            } else {
+                "PRAGMA wal_checkpoint(TRUNCATE)"
+            };
+            let mut stmt = connection.prepare(sql)?;
             let mut budget = 10_000usize;
             loop {
                 match stmt.step() {

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -93,6 +93,10 @@ struct Args {
     /// Probability of failing a scoped Turso allocation while stepping a statement.
     #[arg(long, default_value_t = 0.05)]
     allocation_fault_probability: f64,
+    /// Probability of probing a same-connection checkpoint while a statement
+    /// is suspended (the checkpoint must be rejected).
+    #[arg(long)]
+    checkpoint_probe_probability: Option<f64>,
     /// Stream multiprocess operation/lifecycle history as JSONL for deterministic debugging
     #[arg(long)]
     history_output: Option<PathBuf>,
@@ -346,6 +350,13 @@ fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
         println!("\n{allocation_faults} allocation faults injected");
     }
 
+    if whopper.stats.checkpoint_probes > 0 {
+        println!(
+            "\n{} checkpoint probes fired against suspended statements (all rejected)",
+            whopper.stats.checkpoint_probes
+        );
+    }
+
     if args.elle.is_some() {
         println!("\nElle history exported to: {}", args.elle_output);
     }
@@ -525,6 +536,10 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         .with_properties(properties)
         .with_chaotic_profiles(chaotic_profiles)
         .with_allocation_fault_probability(args.allocation_fault_probability);
+    let opts = match args.checkpoint_probe_probability {
+        Some(probability) => opts.with_checkpoint_probe_probability(probability),
+        None => opts,
+    };
 
     Ok(opts)
 }

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -129,3 +129,55 @@ fn test_concurrent_commit_no_yield_spin() {
     }
     assert_eq!(count, 2, "both inserts should be visible");
 }
+
+/// End-to-end coverage for checkpoints racing suspended statements: with the
+/// probe probability at 1.0, every simulation step that leaves a statement
+/// suspended mid-execution fires a same-connection checkpoint attempt
+/// (PRAGMA wal_checkpoint or the Connection::checkpoint API) and the run
+/// fails unless the engine rejects it with StatementsInProgress/TableLocked.
+/// On unguarded builds the checkpoint runs and the suspended statement
+/// panics on resume, loses its write, or silently returns wrong rows.
+#[test]
+fn test_checkpoint_probe_rejects_checkpoints_while_statements_are_suspended() {
+    use turso_whopper::properties::{IntegrityCheckProperty, Property};
+    use turso_whopper::workloads::{
+        BeginWorkload, CommitWorkload, InsertWorkload, IntegrityCheckWorkload, RollbackWorkload,
+        SelectWorkload, UpdateWorkload, WalCheckpointWorkload, Workload,
+    };
+    use turso_whopper::{Whopper, WhopperOpts};
+
+    let workloads: Vec<(u32, Box<dyn Workload>)> = vec![
+        (30, Box::new(InsertWorkload)),
+        (20, Box::new(UpdateWorkload)),
+        (15, Box::new(SelectWorkload)),
+        (10, Box::new(BeginWorkload)),
+        (8, Box::new(CommitWorkload)),
+        (4, Box::new(RollbackWorkload)),
+        (5, Box::new(IntegrityCheckWorkload)),
+        (
+            5,
+            Box::new(WalCheckpointWorkload {
+                allow_passive: true,
+            }),
+        ),
+    ];
+    let properties: Vec<Box<dyn Property>> = vec![Box::new(IntegrityCheckProperty)];
+
+    let opts = WhopperOpts {
+        seed: Some(0xC0FFEE),
+        max_connections: 3,
+        max_steps: 5_000,
+        workloads,
+        properties,
+        checkpoint_probe_probability: 1.0,
+        ..WhopperOpts::default()
+    };
+    let mut whopper = Whopper::new(opts).expect("create whopper");
+    whopper
+        .run()
+        .expect("simulation must complete without contract violations");
+    assert!(
+        whopper.stats.checkpoint_probes > 0,
+        "the run never left a statement suspended, so the probe tested nothing"
+    );
+}

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -181,3 +181,61 @@ fn test_checkpoint_probe_rejects_checkpoints_while_statements_are_suspended() {
         "the run never left a statement suspended, so the probe tested nothing"
     );
 }
+
+/// While a COMMIT was suspended inside its post-commit auto-checkpoint, a
+/// failed statement on the same connection (a rejected checkpoint probe) was
+/// dropped. Its teardown decided it was the last active statement — a failed
+/// statement leaves the active count on its step error, so the count held
+/// only the suspended sibling — and "rolled back" the connection: it reset
+/// the pager's in-flight commit and checkpoint state and closed the shared
+/// attached write transaction. The resumed COMMIT then started over and
+/// panicked releasing a WAL write lock it no longer held.
+///
+/// The seed replays a CI failure of the btree-rebalance whopper profile; the
+/// panic fired around step 14700.
+#[test]
+fn test_dropped_failed_statement_keeps_suspended_sibling_commit_intact() {
+    use rand::Rng;
+    use turso_whopper::chaotic_btree::BtreeRebalanceProfile;
+    use turso_whopper::chaotic_elle::ChaoticWorkloadProfile;
+    use turso_whopper::properties::{IntegrityCheckProperty, Property};
+    use turso_whopper::workloads::{IntegrityCheckWorkload, WalCheckpointWorkload, Workload};
+    use turso_whopper::{Whopper, WhopperOpts};
+
+    let workloads: Vec<(u32, Box<dyn Workload>)> = vec![
+        (20, Box::new(IntegrityCheckWorkload)),
+        (
+            5,
+            Box::new(WalCheckpointWorkload {
+                allow_passive: false,
+            }),
+        ),
+    ];
+    let properties: Vec<Box<dyn Property>> = vec![Box::new(IntegrityCheckProperty)];
+    let chaotic: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)> = vec![(
+        1.0,
+        "btree-rebalance",
+        Box::new(BtreeRebalanceProfile::default()),
+    )];
+
+    let opts = WhopperOpts::btree_rebalance()
+        .with_seed(16427142037514425436)
+        .with_max_steps(20_000)
+        .with_max_connections(4)
+        .with_workloads(workloads)
+        .with_properties(properties)
+        .with_chaotic_profiles(chaotic)
+        .with_allocation_fault_probability(0.0);
+    let mut whopper = Whopper::new(opts).expect("create whopper");
+    // Mirror main.rs's run_inprocess loop instead of Whopper::run: the CLI
+    // burns one rng draw per step on its reopen check, and this seed replays
+    // a CLI failure, so the draw must stay in the stream for the schedule to
+    // match.
+    while !whopper.is_done() {
+        let _ = whopper.rng.random_bool(0.0);
+        match whopper.step() {
+            Ok(_) => {}
+            Err(e) => panic!("statement teardown must not clobber a suspended commit: {e}"),
+        }
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -23,6 +23,7 @@ mod statement_reset;
 mod stmt_journal;
 mod stmt_readonly;
 mod storage;
+mod suspended_statement_checkpoint;
 mod trigger;
 mod wal;
 

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -24,6 +24,7 @@ mod statement_reset;
 mod stmt_journal;
 mod stmt_readonly;
 mod storage;
+mod suspended_statement_checkpoint;
 mod trigger;
 mod unreliable_io;
 mod wal;

--- a/tests/integration/suspended_statement_checkpoint.rs
+++ b/tests/integration/suspended_statement_checkpoint.rs
@@ -1,0 +1,113 @@
+#![cfg(feature = "io_memory_yield")]
+
+use std::sync::Arc;
+
+use turso_core::{Connection, Database, LimboError, MemoryYieldIO, SqliteDialect, StepResult, IO};
+
+fn open_conn(io: Arc<MemoryYieldIO>, path: &str) -> Arc<Connection> {
+    Database::open_file(io, path, Arc::new(SqliteDialect))
+        .unwrap()
+        .connect()
+        .unwrap()
+}
+
+fn seed_freelist_db(io: &Arc<MemoryYieldIO>, path: &str) {
+    let conn = open_conn(io.clone(), path);
+    conn.execute("PRAGMA page_size=512").unwrap();
+    conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB)")
+        .unwrap();
+    conn.execute(
+        "INSERT INTO t VALUES
+         (1, zeroblob(50000)),
+         (2, zeroblob(50000)),
+         (3, zeroblob(50000)),
+         (4, zeroblob(50000)),
+         (5, zeroblob(50000))",
+    )
+    .unwrap();
+    conn.execute("DELETE FROM t WHERE id IN (2,3,4)").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+}
+
+#[test]
+fn test_wal_checkpoint_with_suspended_write_statement_keeps_statement_resumable() {
+    for target_io in 1..=512 {
+        let io = Arc::new(MemoryYieldIO::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join(format!("suspended-checkpoint-{target_io}.db"));
+        let path = path.to_str().unwrap();
+
+        seed_freelist_db(&io, path);
+        let conn = open_conn(io.clone(), path);
+        let mut stmt = conn
+            .prepare("INSERT INTO t VALUES (100, zeroblob(50000))")
+            .unwrap();
+
+        let mut io_count = 0;
+        let suspended = loop {
+            match stmt.step().unwrap() {
+                StepResult::IO => {
+                    io_count += 1;
+                    if io_count == target_io {
+                        break true;
+                    }
+                    io.step().unwrap();
+                }
+                StepResult::Done => break false,
+                StepResult::Yield => {}
+                other => panic!("unexpected INSERT step result: {other:?}"),
+            }
+        };
+        if !suspended {
+            assert!(
+                target_io > 1,
+                "INSERT completed without yielding at an I/O boundary"
+            );
+            break;
+        }
+
+        let err = conn
+            .prepare("PRAGMA wal_checkpoint(PASSIVE)")
+            .unwrap()
+            .run_collect_rows()
+            .expect_err("checkpoint must reject a concurrent statement");
+        assert!(
+            matches!(err, LimboError::StatementsInProgress(_)),
+            "unexpected checkpoint error: {err:?}"
+        );
+
+        loop {
+            match stmt
+                .step()
+                .unwrap_or_else(|err| panic!("target_io={target_io}: resumed INSERT failed: {err}"))
+            {
+                StepResult::IO => io.step().unwrap(),
+                StepResult::Done => break,
+                StepResult::Yield => {}
+                other => panic!("unexpected resumed INSERT step result: {other:?}"),
+            }
+        }
+        drop(stmt);
+
+        let ids = conn
+            .prepare("SELECT id FROM t ORDER BY id")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap()
+            .into_iter()
+            .map(|row| row[0].as_int().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![1, 5, 100], "target_io={target_io}");
+
+        let integrity = conn
+            .prepare("PRAGMA integrity_check")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(integrity.len(), 1, "target_io={target_io}");
+        assert_eq!(integrity[0][0].to_string(), "ok", "target_io={target_io}");
+    }
+}

--- a/tests/integration/suspended_statement_checkpoint.rs
+++ b/tests/integration/suspended_statement_checkpoint.rs
@@ -111,3 +111,53 @@ fn test_wal_checkpoint_with_suspended_write_statement_keeps_statement_resumable(
         assert_eq!(integrity[0][0].to_string(), "ok", "target_io={target_io}");
     }
 }
+
+#[test]
+fn test_suspended_wal_checkpoint_rejects_new_statement() {
+    let io = Arc::new(MemoryYieldIO::new());
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("checkpoint-before-insert.db");
+    let path = path.to_str().unwrap();
+
+    seed_freelist_db(&io, path);
+    open_conn(io.clone(), path)
+        .execute("UPDATE t SET b = zeroblob(51000) WHERE id = 1")
+        .unwrap();
+
+    let conn = open_conn(io.clone(), path);
+    let mut checkpoint = conn.prepare("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+    loop {
+        match checkpoint.step().unwrap() {
+            StepResult::IO if checkpoint.get_pager().is_checkpointing() => break,
+            StepResult::IO => io.step().unwrap(),
+            StepResult::Yield => {}
+            other => panic!("checkpoint completed before suspension: {other:?}"),
+        }
+    }
+
+    let mut insert = conn
+        .prepare("INSERT INTO t VALUES (100, zeroblob(50000))")
+        .unwrap();
+    let err = insert
+        .step()
+        .expect_err("suspended checkpoint must reject a new statement");
+    assert!(
+        matches!(err, LimboError::StatementsInProgress(_)),
+        "unexpected INSERT error: {err:?}"
+    );
+    drop(insert);
+
+    loop {
+        match checkpoint.step().unwrap() {
+            StepResult::IO => io.step().unwrap(),
+            StepResult::Row | StepResult::Yield => {}
+            StepResult::Done => break,
+            other => panic!("unexpected checkpoint result: {other:?}"),
+        }
+    }
+    drop(checkpoint);
+    assert!(!conn.get_pager().is_checkpointing());
+
+    conn.execute("INSERT INTO t VALUES (100, zeroblob(50000))")
+        .unwrap();
+}

--- a/tests/integration/suspended_statement_checkpoint.rs
+++ b/tests/integration/suspended_statement_checkpoint.rs
@@ -113,6 +113,116 @@ fn test_wal_checkpoint_with_suspended_write_statement_keeps_statement_resumable(
 }
 
 #[test]
+fn test_checkpoint_rejected_while_parked_statement_holds_pragma_helper() {
+    // A live pragma-vtab cursor stores a nested helper statement, so the
+    // connection counts as "inside a nested statement" for the whole time the
+    // outer SELECT is parked between rows. The checkpoint guard must not be
+    // skipped because of that: the parked root SELECT is still active, and a
+    // checkpoint would clear the page cache under its cursors.
+    let io = Arc::new(MemoryYieldIO::new());
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("pragma-helper-checkpoint.db");
+    let path = path.to_str().unwrap();
+
+    seed_freelist_db(&io, path);
+    let conn = open_conn(io.clone(), path);
+
+    let mut stmt = conn
+        .prepare("SELECT t.id FROM pragma_table_info('t') p, t")
+        .unwrap();
+    let mut ids = Vec::new();
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                ids.push(stmt.row().unwrap().get::<i64>(0).unwrap());
+                break;
+            }
+            StepResult::IO => io.step().unwrap(),
+            StepResult::Yield => {}
+            other => panic!("unexpected SELECT step result: {other:?}"),
+        }
+    }
+
+    let err = conn
+        .prepare("PRAGMA wal_checkpoint(PASSIVE)")
+        .unwrap()
+        .run_collect_rows()
+        .expect_err("checkpoint must reject the parked SELECT");
+    assert!(
+        matches!(err, LimboError::StatementsInProgress(_)),
+        "unexpected checkpoint error: {err:?}"
+    );
+
+    // The parked SELECT resumes cleanly and returns the full result:
+    // 2 pragma_table_info rows (id, b) crossed with t's rows (1, 5).
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => ids.push(stmt.row().unwrap().get::<i64>(0).unwrap()),
+            StepResult::IO => io.step().unwrap(),
+            StepResult::Yield => {}
+            StepResult::Done => break,
+            other => panic!("unexpected resumed SELECT step result: {other:?}"),
+        }
+    }
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 1, 5, 5]);
+    drop(stmt);
+
+    conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+}
+
+#[test]
+fn test_open_blob_handle_does_not_block_explicit_checkpoints() {
+    // A blob handle keeps a Root statement parked at its row until close.
+    // That must not count as "a statement in progress" for explicit
+    // checkpoints (SQLite checkpoints fine with open blob handles).
+    use turso_core::CheckpointMode;
+    let io = Arc::new(MemoryYieldIO::new());
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("blob-checkpoint.db");
+    let path = path.to_str().unwrap();
+
+    seed_freelist_db(&io, path);
+    let conn = open_conn(io.clone(), path);
+    conn.execute("UPDATE t SET b = x'00112233445566778899aabbccddeeff' WHERE id = 1")
+        .unwrap();
+
+    let mut blob = conn.blob_open("t", "b", 1, false).unwrap();
+    let mut buf = [0u8; 4];
+    blob.read(0, &mut buf).unwrap();
+    assert_eq!(buf, [0x00, 0x11, 0x22, 0x33]);
+
+    conn.prepare("PRAGMA wal_checkpoint(PASSIVE)")
+        .unwrap()
+        .run_collect_rows()
+        .expect("PRAGMA wal_checkpoint must run with an open blob handle");
+    conn.checkpoint(CheckpointMode::Passive {
+        upper_bound_inclusive: None,
+    })
+    .expect("Connection::checkpoint must run with an open blob handle");
+
+    // The checkpoint's cache clear may drop the handle's position, in which
+    // case the read fails cleanly with BlobHandleExpired (the behavior
+    // before the guard existed) — never with a checkpoint refusal, and
+    // never wrong bytes.
+    match blob.read(4, &mut buf) {
+        Ok(()) => assert_eq!(buf, [0x44, 0x55, 0x66, 0x77]),
+        Err(err) => assert!(
+            matches!(err, LimboError::BlobHandleExpired),
+            "unexpected blob read error: {err:?}"
+        ),
+    }
+    blob.close().unwrap();
+
+    // Closing the handle released its statement count: the counts are back
+    // in balance and an idle checkpoint still works.
+    conn.checkpoint(CheckpointMode::Passive {
+        upper_bound_inclusive: None,
+    })
+    .unwrap();
+}
+
+#[test]
 fn test_suspended_wal_checkpoint_rejects_new_statement() {
     let io = Arc::new(MemoryYieldIO::new());
     let temp_dir = tempfile::TempDir::new().unwrap();
@@ -160,4 +270,96 @@ fn test_suspended_wal_checkpoint_rejects_new_statement() {
 
     conn.execute("INSERT INTO t VALUES (100, zeroblob(50000))")
         .unwrap();
+}
+
+#[test]
+fn test_checkpoint_api_rejects_suspended_statement_and_keeps_it_resumable() {
+    use turso_core::CheckpointMode;
+    for target_io in 1..=512 {
+        let io = Arc::new(MemoryYieldIO::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join(format!("api-checkpoint-{target_io}.db"));
+        let path = path.to_str().unwrap();
+
+        seed_freelist_db(&io, path);
+        let conn = open_conn(io.clone(), path);
+        let mut stmt = conn
+            .prepare("INSERT INTO t VALUES (100, zeroblob(50000))")
+            .unwrap();
+
+        let mut io_count = 0;
+        let suspended = loop {
+            match stmt.step().unwrap() {
+                StepResult::IO => {
+                    io_count += 1;
+                    if io_count == target_io {
+                        break true;
+                    }
+                    io.step().unwrap();
+                }
+                StepResult::Done => break false,
+                StepResult::Yield => {}
+                other => panic!("unexpected INSERT step result: {other:?}"),
+            }
+        };
+        if !suspended {
+            assert!(
+                target_io > 1,
+                "INSERT completed without yielding at an I/O boundary"
+            );
+            break;
+        }
+
+        // The direct checkpoint API must refuse just like PRAGMA
+        // wal_checkpoint does: checkpointing invalidates this connection's
+        // cursors and page cache, which would break the suspended INSERT.
+        let err = conn
+            .checkpoint(CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            })
+            .expect_err("Connection::checkpoint must reject a suspended statement");
+        assert!(
+            matches!(err, LimboError::StatementsInProgress(_)),
+            "unexpected checkpoint error: {err:?}"
+        );
+
+        loop {
+            match stmt
+                .step()
+                .unwrap_or_else(|err| panic!("target_io={target_io}: resumed INSERT failed: {err}"))
+            {
+                StepResult::IO => io.step().unwrap(),
+                StepResult::Done => break,
+                StepResult::Yield => {}
+                other => panic!("unexpected resumed INSERT step result: {other:?}"),
+            }
+        }
+        drop(stmt);
+
+        // The rejected checkpoint must not leave checkpoint state behind:
+        // a fresh checkpoint on the idle connection succeeds.
+        conn.checkpoint(CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        })
+        .unwrap_or_else(|err| panic!("target_io={target_io}: idle checkpoint failed: {err}"));
+
+        let ids = conn
+            .prepare("SELECT id FROM t ORDER BY id")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap()
+            .into_iter()
+            .map(|row| row[0].as_int().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![1, 5, 100], "target_io={target_io}");
+
+        let integrity = conn
+            .prepare("PRAGMA integrity_check")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(integrity[0][0].to_string(), "ok", "target_io={target_io}");
+    }
 }


### PR DESCRIPTION
## Description

Fixes #8025

Preventns explicit checkpoints and root statements from overlapping on the same connection, similar direction of what sqllite does. 

More dump fix with `n_active_root_statements != 1`, implemented in the first commit, blocks checkpoints during active statements, but not statements during active checkpoints.

I also added tests in a separate file, but idk if this is something you want to keep in the current state.

## Motivation and context

Turso can suspend statements during io, allowing a checkpoint on the same connection to invalidate state owned by another suspended statement (both read and write statements) and wise versa.

## Description of AI Usage

Nothing unusual, this seemed straightforward, used claude do understand the code and cross check sqllite.
