### PR TITLE
core/translate: report zero result columns for `CREATE TABLE ... AS SELECT`

### DIFF
--- a/bindings/c/tests/compat/mod.rs
+++ b/bindings/c/tests/compat/mod.rs
@@ -646,6 +646,31 @@ mod tests {
     }
 
     #[test]
+    fn test_ctas_column_count_is_zero() {
+        unsafe {
+            let mut db = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+
+            let mut stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"CREATE TABLE dst AS SELECT 1 AS a, 'x' AS b".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_column_count(stmt), 0);
+            assert_eq!(sqlite3_step(stmt), SQLITE_DONE);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
     #[cfg(not(target_os = "windows"))]
     fn column_text_is_nul_terminated_and_bytes_match() {
         unsafe {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1091,6 +1091,8 @@ fn emit_ctas_insert(
     program.preassign_label_to_next_insn(loop_end);
     program.preassign_label_to_next_insn(halt_label);
 
+    program.result_columns.clear();
+
     Ok(())
 }
 

--- a/tests/integration/statement_metadata.rs
+++ b/tests/integration/statement_metadata.rs
@@ -462,4 +462,30 @@ mod tests {
         assert_eq!(via_string_reverse, vec![("olleh".to_string(),)]);
         assert_eq!(via_reverse, vec![("olleh".to_string(),)]);
     }
+
+    /// `CREATE TABLE ... AS SELECT` returns no rows, so the prepared
+    /// statement must report zero result columns (sqlite3_column_count is 0
+    /// for CTAS). The source SELECT feeds the insert coroutine internally
+    /// and must not leak its columns into statement metadata.
+    #[test]
+    fn ctas_statement_reports_zero_columns() {
+        let db = TempDatabase::new_empty();
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE src(a INTEGER, b TEXT)").unwrap();
+        conn.execute("INSERT INTO src VALUES (1, 'x'), (2, 'y')")
+            .unwrap();
+
+        let mut stmt = conn
+            .prepare("CREATE TABLE dst AS SELECT a, b FROM src")
+            .unwrap();
+        assert_eq!(
+            stmt.num_columns(),
+            0,
+            "CTAS must report zero result columns"
+        );
+
+        stmt.run_ignore_rows().unwrap();
+        let copied: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM dst ORDER BY a");
+        assert_eq!(copied, vec![(1, "x".to_string()), (2, "y".to_string())]);
+    }
 }


### PR DESCRIPTION
The CTAS emission left the source SELECT's result columns on the program, so a prepared CTAS statement claimed result columns while never yielding a row. sqlite3_column_count() reports 0 for CTAS; clients that classify statements by column count (e.g. the postgres wire server) mis-route CTAS to the row-returning path and emit a spurious RowDescription.

Clear result_columns after emitting the insert coroutine, mirroring INSERT ... SELECT, which overwrites result_columns after emitting its source SELECT.

Tests: tests/integration/statement_metadata.rs pins num_columns() == 0 for CTAS and verifies the copy still lands.