### PR TITLE
core/vdbe: fix dropped comparison result in spilled sort merge

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -2503,6 +2503,7 @@ pub fn cmp_in_column(a: &ValueRef, b: &ValueRef, key: &KeyInfo) -> Ordering {
 }
 
 /// Outputs a modified [Ordering] that takes into account the sort order and the NULLS order.
+#[must_use]
 pub fn cmp_with_sort(cmp: Ordering, a: &ValueRef, b: &ValueRef, key: &KeyInfo) -> Ordering {
     if cmp != Ordering::Equal {
         let involves_null = matches!(a, ValueRef::Null) || matches!(b, ValueRef::Null);

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1078,7 +1078,10 @@ impl BoxedSortableRecord {
                     _ => self_val.partial_cmp(&other_val).unwrap_or(Ordering::Equal),
                 }
             };
-            cmp_with_sort(cmp, &self_val, &other_val, key_info);
+            let cmp = cmp_with_sort(cmp, &self_val, &other_val, key_info);
+            if cmp != Ordering::Equal {
+                return cmp;
+            }
         }
         Ordering::Equal
     }
@@ -1403,6 +1406,57 @@ mod tests {
                 .expect("Failed to get the next record");
         }
         assert_eq!(idx, expected.len());
+    }
+
+    #[test]
+    fn spilled_sort_orders_secondary_key_across_chunks() {
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let mut sorter = Sorter::new(
+            &[SortOrder::Asc, SortOrder::Asc],
+            try_vec![CollationSeq::Binary, CollationSeq::Binary].unwrap(),
+            try_vec![None, None].unwrap(),
+            try_vec![None, None].unwrap(),
+            // Tiny buffer so the sorter spills to multiple chunk files.
+            256,
+            64,
+            io.clone(),
+            crate::TempStore::Default,
+        )
+        .unwrap();
+
+        let n = 200;
+        // Equal first key, ascending second key on insert.
+        for x in 0..n {
+            let values = try_vec![Value::from_i64(1), Value::from_i64(x)].unwrap();
+            let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
+            io.block(|| sorter.insert(&record))
+                .expect("Failed to insert the record");
+        }
+
+        io.block(|| sorter.sort())
+            .expect("Failed to sort the records");
+        assert!(
+            !sorter.chunks.is_empty(),
+            "test requires the sorter to have spilled to chunks"
+        );
+
+        let mut idx = 0;
+        while sorter.has_more() {
+            {
+                let record = sorter.record().unwrap();
+                let vals = record.get_values().unwrap();
+                assert_eq!(vals[0], ValueRef::from_i64(1));
+                assert_eq!(
+                    vals[1],
+                    ValueRef::from_i64(idx),
+                    "secondary key out of order at position {idx}"
+                );
+            }
+            idx += 1;
+            io.block(|| sorter.next())
+                .expect("Failed to get the next record");
+        }
+        assert_eq!(idx, n);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The `tpc-h` CI job has been failing since #7964 landed (first failing commit `4ce36aa59`): queries 1, 9, and 16 return wrong results — e.g. q1 emits ~190 partial `N|F`/`N|O` groups instead of 4 rows.

The sorter refactor (`61c9d70de`, "reuse cmp_with_sort in sorter") replaced the sort-direction handling in `BoxedSortableRecord::full_cmp` with a call to `cmp_with_sort`, but left it as a bare expression statement:

```rust
cmp_with_sort(cmp, &self_val, &other_val, key_info);
```

The result was discarded and the early return was lost, so `full_cmp` always returned `Ordering::Equal`. There was no compiler warning because `cmp_with_sort` is a plain function without `#[must_use]`. (The sibling `ArenaSortableRecord` hunk in the same PR was refactored correctly.)

## Impact

`BoxedSortableRecord` orders the k-way merge heap for spilled sort chunks, and its normalized first-key fast path is never decisive for multi-column keys, so every tie fell through to the broken `full_cmp`. Any sort that spilled to disk with a multi-column key (or first-key ties) returned chunk-by-chunk concatenation instead of merged order — silently wrong query results. TPC-H q1 sorts 6M rows on `(l_returnflag, l_linestatus)` for GROUP BY, spills, and the grouping sees equal keys non-adjacent.

## Fix

* Restore the early return in `full_cmp`.
* Mark `cmp_with_sort` `#[must_use]` so a discarded result is a compile error next time.

## Tests

New `spilled_sort_orders_secondary_key_across_chunks` unit test forces a spill (256-byte buffer, 200 records, equal first key). It fails without the fix (record 179 surfaces first instead of 0) and passes with it. The test inserts the secondary key in **ascending** order on purpose: with the broken comparator the heap drains chunks in reverse index order, so descending insertion order accidentally produces sorted output and masks the bug.

`cargo test -p turso_core --lib sorter`: 6 passed. `cargo clippy -p turso_core --all-features --all-targets -- --deny=warnings`: clean.

This PR was created with Claude Code (Fable 5). The model bisected the tpc-h CI failure to the sorter refactor, identified the dropped comparison result, and verified the fix with a spill-forcing regression test (including a revert check). The committer reviewed the output.