### PR TITLE
postgres: support CREATE TABLE AS and SELECT INTO

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -45,6 +45,7 @@ Basics not enumerated by the official feature matrix.
 | UPDATE (incl. FROM clause) | ✅ Supported | Multi-column `SET (a,b) = (...)` not supported |
 | DELETE | 🟡 Partial | `USING` clause silently dropped |
 | CREATE TABLE | ✅ Supported | PK, NOT NULL, UNIQUE, DEFAULT, CHECK, FK (with ON DELETE/UPDATE actions); IF NOT EXISTS; tables are created STRICT |
+| CREATE TABLE AS / SELECT INTO | ✅ Supported | Schema derived from the SELECT; WITH NO DATA supported (lowered to LIMIT 0, so errors in an overridden LIMIT go unreported); explicit column list rejected; INTO on the first leaf of a compound SELECT (legal in PG) rejected; TEMP silently ignored; completes with `SELECT n` like PostgreSQL, though an IF NOT EXISTS skip tags `SELECT 0` instead of `CREATE TABLE AS` |
 | ALTER TABLE | 🟡 Partial | ADD/DROP COLUMN, RENAME TABLE/COLUMN work; ALTER COLUMN TYPE translates but fails at execution; SET/DROP DEFAULT, SET/DROP NOT NULL, ADD CONSTRAINT rejected |
 | CREATE INDEX | ✅ Supported | UNIQUE, multi-column, partial (WHERE), expression indexes, IF NOT EXISTS |
 | CREATE VIEW | ✅ Supported | Column aliases supported; TEMP silently ignored |

--- a/postgres/cli/TODO.md
+++ b/postgres/cli/TODO.md
@@ -12,7 +12,7 @@ Sorted by implementation difficulty.
 
 ## Easy (a day or two)
 
-6. **CREATE TABLE AS / SELECT INTO** — translate to `CREATE TABLE ... AS SELECT` which Turso already supports
+6. ~~**CREATE TABLE AS / SELECT INTO**~~ — DONE (translates to `CREATE TABLE ... AS SELECT`; WITH NO DATA supported, explicit column list rejected)
 7. **ALTER COLUMN SET/DROP DEFAULT, SET/DROP NOT NULL** — Turso's ALTER TABLE is limited but these map to SQLite operations
 8. **CONCURRENTLY on CREATE INDEX** — just ignore the keyword (SQLite doesn't do concurrent DDL anyway)
 9. **COPY ... FROM/TO with simple CSV** — implement as INSERT loop or SELECT output (not the wire protocol COPY)

--- a/postgres/cli/tests/tursopg.rs
+++ b/postgres/cli/tests/tursopg.rs
@@ -763,6 +763,43 @@ fn comment_on_is_noop() {
 }
 
 // ---------------------------------------------------------------------------
+// CREATE TABLE AS / SELECT INTO
+//
+// Behavioral coverage lives in postgres/conformance/pg-sqltests/table.sqltest.
+// The sqltest runner also speaks the wire protocol, but it only compares
+// DataRow contents and discards CommandComplete tags, so the `SELECT n` /
+// `CREATE TABLE AS` completion tags are asserted here instead.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn wire_create_table_as_returns_select_n() {
+    with_pg_client(|c| {
+        c.query_command_tags("CREATE TABLE src(id INT)");
+        c.query_command_tags("INSERT INTO src VALUES (1), (2), (3)");
+
+        // PostgreSQL reports CREATE TABLE AS / SELECT INTO completion as
+        // `SELECT n` where n is the number of rows inserted.
+        let tags = c.query_command_tags("CREATE TABLE dst AS SELECT * FROM src WHERE id > 1");
+        assert!(
+            tags.iter().any(|t| t == "SELECT 2"),
+            "expected 'SELECT 2' tag for CTAS, got: {tags:?}"
+        );
+
+        let tags = c.query_command_tags("SELECT id INTO dst2 FROM src");
+        assert!(
+            tags.iter().any(|t| t == "SELECT 3"),
+            "expected 'SELECT 3' tag for SELECT INTO, got: {tags:?}"
+        );
+
+        let tags = c.query_command_tags("CREATE TABLE dst3 AS SELECT * FROM src WITH NO DATA");
+        assert!(
+            tags.iter().any(|t| t == "CREATE TABLE AS"),
+            "expected 'CREATE TABLE AS' tag for WITH NO DATA, got: {tags:?}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Named windows (WINDOW clause)
 // ---------------------------------------------------------------------------
 

--- a/postgres/conformance/pg-sqltests/table.sqltest
+++ b/postgres/conformance/pg-sqltests/table.sqltest
@@ -94,3 +94,76 @@ expect {
     eng|bob
     ops|carol
 }
+
+# ---------------------------------------------------------------------------
+# CREATE TABLE AS / SELECT INTO
+# ---------------------------------------------------------------------------
+
+@setup users
+test table-create-table-as {
+    CREATE TABLE adults AS SELECT id, name FROM users WHERE age >= 30;
+    SELECT id, name FROM adults ORDER BY id;
+}
+expect {
+    1|alice
+    3|carol
+}
+
+test table-create-table-as-snapshot-not-view {
+    CREATE TABLE src (id int);
+    INSERT INTO src VALUES (1), (2);
+    CREATE TABLE snap AS SELECT * FROM src;
+    INSERT INTO src VALUES (3);
+    SELECT count(*) FROM snap;
+}
+expect {
+    2
+}
+
+test table-create-table-as-with-no-data {
+    CREATE TABLE src (id int, name text);
+    INSERT INTO src VALUES (1, 'alice'), (2, 'bob');
+    CREATE TABLE dst AS SELECT * FROM src WITH NO DATA;
+    SELECT count(*) FROM dst;
+    INSERT INTO dst VALUES (7, 'new');
+    SELECT id, name FROM dst;
+}
+expect {
+    0
+    7|new
+}
+
+test table-create-table-as-compound {
+    CREATE TABLE dst AS SELECT 1 AS x UNION SELECT 2;
+    SELECT x FROM dst ORDER BY x;
+}
+expect {
+    1
+    2
+}
+
+test table-create-table-as-if-not-exists {
+    CREATE TABLE src (id int);
+    INSERT INTO src VALUES (1);
+    CREATE TABLE dst AS SELECT * FROM src;
+    CREATE TABLE IF NOT EXISTS dst AS SELECT * FROM src;
+    SELECT count(*) FROM dst;
+}
+expect {
+    1
+}
+
+test table-select-into {
+    CREATE TABLE src (id int, name text);
+    INSERT INTO src VALUES (1, 'alice'), (2, 'bob');
+    SELECT id, name INTO dst FROM src WHERE id = 2;
+    SELECT name FROM dst;
+}
+expect {
+    bob
+}
+
+test table-select-into-nested-rejected {
+    SELECT * FROM (SELECT 1 INTO dst) sub;
+}
+expect error {}

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -122,8 +122,14 @@ impl PostgreSQLTranslator {
         // All other statements have no prerequisites
         let stmt = match &node.0 {
             NodeRef::SelectStmt(select) => {
-                let select_ast = self.translate_select(select)?;
-                ast::Stmt::Select(select_ast)
+                // Top-level SELECT ... INTO is PG's legacy spelling of
+                // CREATE TABLE AS.
+                if select.into_clause.is_some() {
+                    self.translate_select_into(select)?
+                } else {
+                    let select_ast = self.translate_select(select)?;
+                    ast::Stmt::Select(select_ast)
+                }
             }
             NodeRef::InsertStmt(insert) => self.translate_insert(insert)?,
             NodeRef::UpdateStmt(update) => self.translate_update(update)?,
@@ -1020,8 +1026,8 @@ impl PostgreSQLTranslator {
         })
     }
 
-    /// Translate CREATE MATERIALIZED VIEW (parsed by PG as CreateTableAsStmt
-    /// with objtype = ObjectMatview).
+    /// Translate CREATE MATERIALIZED VIEW and CREATE TABLE AS (both parsed
+    /// by PG as CreateTableAsStmt, distinguished by objtype).
     fn translate_create_table_as(
         &self,
         ctas: &pg_query::protobuf::CreateTableAsStmt,
@@ -1031,15 +1037,37 @@ impl PostgreSQLTranslator {
         let objtype = ObjectType::try_from(ctas.objtype)
             .map_err(|_| ParseError::ParseError("CREATE TABLE AS: invalid object type".into()))?;
 
-        if objtype != ObjectType::ObjectMatview {
-            return Err(ParseError::ParseError(
-                "CREATE TABLE AS SELECT is not supported; use CREATE MATERIALIZED VIEW".into(),
-            ));
-        }
+        let label = match objtype {
+            ObjectType::ObjectMatview => "CREATE MATERIALIZED VIEW",
+            ObjectType::ObjectTable => "CREATE TABLE AS",
+            _ => {
+                return Err(ParseError::ParseError(
+                    "CREATE TABLE AS: unsupported object type".into(),
+                ));
+            }
+        };
 
-        let into_clause = ctas.into.as_ref().ok_or_else(|| {
-            ParseError::ParseError("CREATE MATERIALIZED VIEW: missing INTO clause".into())
-        })?;
+        let into_clause = ctas
+            .into
+            .as_ref()
+            .ok_or_else(|| ParseError::ParseError(format!("{label}: missing INTO clause")))?;
+
+        let query_node = ctas
+            .query
+            .as_ref()
+            .ok_or_else(|| ParseError::ParseError(format!("{label}: missing query")))?;
+        let select_stmt = match &query_node.node {
+            Some(pg_query::protobuf::node::Node::SelectStmt(s)) => s,
+            _ => {
+                return Err(ParseError::ParseError(format!(
+                    "{label}: expected SELECT statement"
+                )));
+            }
+        };
+
+        if objtype == ObjectType::ObjectTable {
+            return self.translate_ctas_table(into_clause, select_stmt, ctas.if_not_exists);
+        }
 
         let relation = into_clause.rel.as_ref().ok_or_else(|| {
             ParseError::ParseError("CREATE MATERIALIZED VIEW: missing view name".into())
@@ -1060,18 +1088,6 @@ impl PostgreSQLTranslator {
             })
             .collect();
 
-        // Translate the query
-        let query_node = ctas.query.as_ref().ok_or_else(|| {
-            ParseError::ParseError("CREATE MATERIALIZED VIEW: missing query".into())
-        })?;
-        let select_stmt = match &query_node.node {
-            Some(pg_query::protobuf::node::Node::SelectStmt(s)) => s,
-            _ => {
-                return Err(ParseError::ParseError(
-                    "CREATE MATERIALIZED VIEW: expected SELECT statement".into(),
-                ));
-            }
-        };
         let select = self.translate_select(select_stmt)?;
 
         Ok(ast::Stmt::CreateMaterializedView {
@@ -1080,6 +1096,66 @@ impl PostgreSQLTranslator {
             columns,
             select,
         })
+    }
+
+    /// Translate CREATE TABLE AS / SELECT INTO into Turso's
+    /// `CREATE TABLE ... AS SELECT`. The new table's schema is derived from
+    /// the SELECT by the engine. TEMP is silently ignored (the table is
+    /// persistent), like in CREATE TABLE.
+    fn translate_ctas_table(
+        &self,
+        into_clause: &pg_query::protobuf::IntoClause,
+        select_stmt: &pg_query::protobuf::SelectStmt,
+        if_not_exists: bool,
+    ) -> Result<ast::Stmt, ParseError> {
+        let relation = into_clause
+            .rel
+            .as_ref()
+            .ok_or_else(|| ParseError::ParseError("CREATE TABLE AS: missing table name".into()))?;
+        let tbl_name = self.qualified_name_from_range_var(relation);
+
+        // The engine names the new table's columns after the SELECT's output
+        // columns and has no way to override them, so reject an explicit
+        // column list rather than silently misname columns.
+        if !into_clause.col_names.is_empty() {
+            return Err(ParseError::ParseError(
+                "CREATE TABLE AS: explicit column list is not supported".into(),
+            ));
+        }
+
+        let mut select = self.translate_select(select_stmt)?;
+
+        // WITH NO DATA: create the table from the SELECT's shape without
+        // copying rows. LIMIT 0 keeps schema derivation intact while
+        // guaranteeing an empty result.
+        if into_clause.skip_data {
+            select.limit = Some(ast::Limit {
+                expr: Box::new(ast::Expr::Literal(ast::Literal::Numeric("0".into()))),
+                offset: None,
+            });
+        }
+
+        Ok(ast::Stmt::CreateTable {
+            temporary: false,
+            if_not_exists,
+            tbl_name,
+            body: ast::CreateTableBody::AsSelect(select),
+        })
+    }
+
+    /// Translate top-level `SELECT ... INTO table FROM ...`, which PG parses
+    /// as a SelectStmt carrying an IntoClause and treats as CREATE TABLE AS.
+    fn translate_select_into(
+        &self,
+        select: &pg_query::protobuf::SelectStmt,
+    ) -> Result<ast::Stmt, ParseError> {
+        let into_clause = select
+            .into_clause
+            .as_ref()
+            .expect("caller checked into_clause");
+        let mut inner = select.clone();
+        inner.into_clause = None;
+        self.translate_ctas_table(into_clause, &inner, false)
     }
 
     fn translate_insert(
@@ -1340,6 +1416,15 @@ impl PostgreSQLTranslator {
     ) -> Result<ast::Select, ParseError> {
         use pg_query::protobuf::SetOperation;
 
+        // Top-level SELECT INTO is intercepted (and its IntoClause stripped)
+        // before translation, so an INTO seen here is in a nested position,
+        // which PG rejects during parse analysis.
+        if select.into_clause.is_some() {
+            return Err(ParseError::ParseError(
+                "SELECT ... INTO is not allowed here".into(),
+            ));
+        }
+
         // Check if this is a UNION/INTERSECT/EXCEPT (set operation)
         let set_op = select.op();
         if set_op != SetOperation::SetopNone && set_op != SetOperation::Undefined {
@@ -1523,6 +1608,15 @@ impl PostgreSQLTranslator {
         &self,
         select: &pg_query::protobuf::SelectStmt,
     ) -> Result<ast::OneSelect, ParseError> {
+        // Compound-select leaves carry their own IntoClause. PG allows INTO
+        // only on the first leaf of a top-level compound; reject all of them
+        // rather than implement that form.
+        if select.into_clause.is_some() {
+            return Err(ParseError::ParseError(
+                "SELECT ... INTO is not allowed here".into(),
+            ));
+        }
+
         let from_clause = if !select.from_clause.is_empty() {
             Some(self.translate_from_items(&select.from_clause)?)
         } else {

--- a/postgres/server/lib.rs
+++ b/postgres/server/lib.rs
@@ -657,6 +657,15 @@ fn command_tag(query: &str, affected_rows: usize) -> Tag {
         Tag::new("CREATE INDEX")
     } else if upper.starts_with("CREATE SCHEMA") {
         Tag::new("CREATE SCHEMA")
+    } else if is_create_table_as(&upper) {
+        // PostgreSQL reports CREATE TABLE AS completion as `SELECT n` (the
+        // rows inserted), except WITH NO DATA which skips the insert and
+        // keeps the plain tag.
+        if ends_with_with_no_data(&upper) {
+            Tag::new("CREATE TABLE AS")
+        } else {
+            Tag::new("SELECT").with_rows(affected_rows)
+        }
     } else if upper.starts_with("CREATE") {
         Tag::new("CREATE TABLE")
     } else if upper.starts_with("DROP VIEW") {
@@ -685,9 +694,65 @@ fn command_tag(query: &str, affected_rows: usize) -> Tag {
         Tag::new("COPY").with_rows(affected_rows)
     } else if upper.starts_with("COMMENT") {
         Tag::new("COMMENT")
+    } else if upper.starts_with("SELECT") || upper.starts_with("WITH") {
+        // Row-returning SELECTs never reach command_tag (they take the
+        // query-response path), so a zero-column SELECT- or WITH-prefixed
+        // statement is SELECT ... INTO (writable CTEs are unsupported),
+        // which PostgreSQL reports as `SELECT n` like CREATE TABLE AS.
+        Tag::new("SELECT").with_rows(affected_rows)
     } else {
         Tag::new("OK")
     }
+}
+
+/// Whether the statement ends with `WITH NO DATA`, token-wise (ignoring
+/// trailing whitespace and statement terminators).
+fn ends_with_with_no_data(upper: &str) -> bool {
+    let mut tokens = upper
+        .trim_end()
+        .trim_end_matches(';')
+        .split_whitespace()
+        .rev();
+    tokens.next() == Some("DATA") && tokens.next() == Some("NO") && tokens.next() == Some("WITH")
+}
+
+/// Best-effort detection of `CREATE [TEMP|UNLOGGED] TABLE [IF NOT EXISTS]
+/// <name> AS ...` from the statement text, in the same spirit as the prefix
+/// matching in `command_tag`. Quoted table names containing whitespace are
+/// not recognized and fall back to the plain CREATE TABLE tag.
+fn is_create_table_as(upper: &str) -> bool {
+    let mut tokens = upper.split_whitespace();
+    if tokens.next() != Some("CREATE") {
+        return false;
+    }
+    let mut tok = tokens.next();
+    while matches!(
+        tok,
+        Some("TEMP" | "TEMPORARY" | "UNLOGGED" | "GLOBAL" | "LOCAL")
+    ) {
+        tok = tokens.next();
+    }
+    if tok != Some("TABLE") {
+        return false;
+    }
+    tok = tokens.next();
+    if tok == Some("IF") {
+        if tokens.next() != Some("NOT") || tokens.next() != Some("EXISTS") {
+            return false;
+        }
+        tok = tokens.next();
+    }
+    // `tok` is the table name; AS must follow it (possibly fused with an
+    // opening parenthesis, as in `AS(SELECT 1)`).
+    let Some(name) = tok else {
+        return false;
+    };
+    // A quoted name that opens without closing in the same token spans
+    // whitespace, so the next token is part of the name, not AS.
+    if name.starts_with('"') && (name.len() == 1 || !name.ends_with('"')) {
+        return false;
+    }
+    matches!(tokens.next(), Some(t) if t == "AS" || t.starts_with("AS("))
 }
 
 fn error_info(message: &str) -> ErrorInfo {
@@ -833,5 +898,37 @@ mod tests {
         // UNKNOWN type should keep text for non-numeric strings
         let val = pg_bytes_to_value(b"hello", &Type::UNKNOWN).unwrap();
         assert!(matches!(val, Value::Text(_)));
+    }
+
+    #[test]
+    fn test_is_create_table_as() {
+        assert!(is_create_table_as("CREATE TABLE T AS SELECT 1"));
+        assert!(is_create_table_as("CREATE TEMP TABLE T AS SELECT 1"));
+        assert!(is_create_table_as("CREATE UNLOGGED TABLE T AS SELECT 1"));
+        assert!(is_create_table_as(
+            "CREATE TABLE IF NOT EXISTS T AS SELECT 1"
+        ));
+        assert!(is_create_table_as("CREATE TABLE S.T AS SELECT 1"));
+        assert!(is_create_table_as("CREATE TABLE T AS(SELECT 1)"));
+        assert!(is_create_table_as("CREATE TABLE \"T\" AS SELECT 1"));
+
+        assert!(!is_create_table_as("CREATE TABLE T (X INT)"));
+        assert!(!is_create_table_as("CREATE INDEX I ON T (X)"));
+        assert!(!is_create_table_as("CREATE VIEW V AS SELECT 1"));
+        // Quoted name containing whitespace: `AS` is part of the name.
+        assert!(!is_create_table_as("CREATE TABLE \"A AS B\" (X INT)"));
+    }
+
+    #[test]
+    fn test_ends_with_with_no_data() {
+        assert!(ends_with_with_no_data(
+            "CREATE TABLE T AS SELECT 1 WITH NO DATA"
+        ));
+        assert!(ends_with_with_no_data(
+            "CREATE TABLE T AS SELECT 1 WITH  NO\nDATA ; "
+        ));
+
+        assert!(!ends_with_with_no_data("CREATE TABLE T AS SELECT 1"));
+        assert!(!ends_with_with_no_data("SELECT 'WITH NO DATA'"));
     }
 }

--- a/postgres/tests/integration/postgres/table.rs
+++ b/postgres/tests/integration/postgres/table.rs
@@ -134,3 +134,185 @@ fn test_postgres_where_clause(db: TempDatabase) {
         panic!("expected done");
     };
 }
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_create_table_as(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    conn.execute("CREATE TABLE users (id INT, name TEXT, age INT)")
+        .unwrap();
+    conn.execute("INSERT INTO users VALUES (1, 'Alice', 30), (2, 'Bob', 25), (3, 'Carol', 41)")
+        .unwrap();
+
+    conn.execute("CREATE TABLE adults AS SELECT id, name FROM users WHERE age >= 30")
+        .unwrap();
+
+    let mut rows = conn
+        .query("SELECT id, name FROM adults ORDER BY id")
+        .unwrap()
+        .unwrap();
+
+    let StepResult::Row = rows.step().unwrap() else {
+        panic!("expected row");
+    };
+    let row = rows.row().unwrap();
+    let Value::Numeric(Numeric::Integer(id)) = row.get_value(0) else {
+        panic!("expected integer for id");
+    };
+    assert_eq!(*id, 1);
+    let Value::Text(name) = row.get_value(1) else {
+        panic!("expected text for name");
+    };
+    assert_eq!(name.value, "Alice");
+
+    let StepResult::Row = rows.step().unwrap() else {
+        panic!("expected row");
+    };
+    let row = rows.row().unwrap();
+    let Value::Numeric(Numeric::Integer(id)) = row.get_value(0) else {
+        panic!("expected integer for id");
+    };
+    assert_eq!(*id, 3);
+
+    let StepResult::Done = rows.step().unwrap() else {
+        panic!("expected done");
+    };
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_create_table_as_with_no_data(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    conn.execute("CREATE TABLE src (id INT, name TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO src VALUES (1, 'Alice'), (2, 'Bob')")
+        .unwrap();
+
+    conn.execute("CREATE TABLE dst AS SELECT * FROM src WITH NO DATA")
+        .unwrap();
+
+    let mut rows = conn.query("SELECT COUNT(*) FROM dst").unwrap().unwrap();
+    let StepResult::Row = rows.step().unwrap() else {
+        panic!("expected row");
+    };
+    let row = rows.row().unwrap();
+    let Value::Numeric(Numeric::Integer(count)) = row.get_value(0) else {
+        panic!("expected integer count");
+    };
+    assert_eq!(*count, 0, "WITH NO DATA must not copy rows");
+
+    // The structure must exist and accept inserts.
+    conn.execute("INSERT INTO dst VALUES (7, 'New')").unwrap();
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_select_into(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    conn.execute("CREATE TABLE src (id INT, name TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO src VALUES (1, 'Alice'), (2, 'Bob')")
+        .unwrap();
+
+    conn.execute("SELECT id, name INTO dst FROM src WHERE id = 2")
+        .unwrap();
+
+    let mut rows = conn.query("SELECT name FROM dst").unwrap().unwrap();
+    let StepResult::Row = rows.step().unwrap() else {
+        panic!("expected row");
+    };
+    let row = rows.row().unwrap();
+    let Value::Text(name) = row.get_value(0) else {
+        panic!("expected text for name");
+    };
+    assert_eq!(name.value, "Bob");
+    let StepResult::Done = rows.step().unwrap() else {
+        panic!("expected done");
+    };
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_create_table_as_column_list_rejected(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    conn.execute("CREATE TABLE src (id INT, name TEXT)")
+        .unwrap();
+
+    let err = conn
+        .execute("CREATE TABLE dst (a, b) AS SELECT id, name FROM src")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("column list"),
+        "expected column list rejection, got: {err}"
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_create_table_as_if_not_exists(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    conn.execute("CREATE TABLE src (id INT)").unwrap();
+    conn.execute("INSERT INTO src VALUES (1)").unwrap();
+    conn.execute("CREATE TABLE dst AS SELECT * FROM src")
+        .unwrap();
+    conn.execute("CREATE TABLE IF NOT EXISTS dst AS SELECT * FROM src")
+        .unwrap();
+
+    let mut rows = conn.query("SELECT COUNT(*) FROM dst").unwrap().unwrap();
+    let StepResult::Row = rows.step().unwrap() else {
+        panic!("expected row");
+    };
+    let row = rows.row().unwrap();
+    let Value::Numeric(Numeric::Integer(count)) = row.get_value(0) else {
+        panic!("expected integer count");
+    };
+    assert_eq!(*count, 1, "IF NOT EXISTS must not error or re-insert");
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_create_table_as_compound_select(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    conn.execute("CREATE TABLE dst AS SELECT 1 AS x UNION SELECT 2")
+        .unwrap();
+
+    let mut rows = conn.query("SELECT x FROM dst ORDER BY x").unwrap().unwrap();
+    for expected in [1, 2] {
+        let StepResult::Row = rows.step().unwrap() else {
+            panic!("expected row");
+        };
+        let row = rows.row().unwrap();
+        let Value::Numeric(Numeric::Integer(x)) = row.get_value(0) else {
+            panic!("expected integer for x");
+        };
+        assert_eq!(*x, expected);
+    }
+    let StepResult::Done = rows.step().unwrap() else {
+        panic!("expected done");
+    };
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_select_into_compound_rejected(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    // PG allows INTO on the first leaf of a top-level compound; Turso
+    // rejects it explicitly rather than silently dropping the INTO.
+    let err = conn
+        .execute("SELECT 1 INTO dst UNION SELECT 2")
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("SELECT ... INTO is not allowed here"),
+        "expected compound INTO rejection, got: {err}"
+    );
+
+    let err = conn
+        .execute("SELECT * FROM (SELECT 1 INTO dst) sub")
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("SELECT ... INTO is not allowed here"),
+        "expected nested INTO rejection, got: {err}"
+    );
+}


### PR DESCRIPTION
## Description

Two commits:

 **core/translate: report zero result columns for CREATE TABLE ... AS SELECT.**
The CTAS emission left the source SELECT's result columns on the prepared
program, so a CTAS statement claimed result columns while never yielding a
row (sqlite3_column_count() reports 0 for CTAS). Cleared after emitting the
insert coroutine, mirroring INSERT ... SELECT. Without this, the wire server
classifies CTAS as row-returning and sends clients a spurious RowDescription.

**postgres: support CREATE TABLE AS and SELECT INTO** (TODO.md item 6).
Translates `CreateTableAsStmt` with objtype `ObjectTable`, and top-level
`SELECT ... INTO` (a `SelectStmt` carrying an `IntoClause` in the raw parse
tree), to Turso's native `CREATE TABLE ... AS SELECT`, which the engine
already executes. Previously CTAS errored and SELECT INTO silently ran as a
plain SELECT — returning rows and creating nothing.

- `WITH NO DATA` lowers to `LIMIT 0`: the table keeps the SELECT's shape,
  no rows copied.
- An explicit column list is rejected (the engine derives column names from
  the SELECT and cannot rename them) rather than silently misnaming columns.
- An `IntoClause` in a nested or compound position errors like PostgreSQL
  instead of being silently dropped. PG's `SELECT ... INTO x UNION ...`
  (INTO on the first leaf) also errors explicitly rather than losing the INTO.
- `TEMP` is silently ignored, consistent with CREATE TABLE.
- Wire completion tags match PostgreSQL: `SELECT n` for CTAS and SELECT INTO
  (per `createas.c`, which sets `CMDTAG_SELECT` with `es_processed`), and
  `CREATE TABLE AS` for `WITH NO DATA`, which skips the insert and sets no
  query completion.

Note: PostgreSQL supports INTO on the first leaf of a top-level compound; we 
reject it explicitly for now because the prior behavior silently returned rows and 
created nothing.

Tests: new coverage in postgres/tests/integration/postgres/table.rs
(translation semantics, both plain and mvcc), postgres/cli/tests/tursopg.rs
(REPL smoke + wire command tags), tests/integration/statement_metadata.rs
(zero-column CTAS metadata), and unit tests for the tag helpers in
postgres/server/lib.rs. All new tests fail without the change. COMPAT.md and
postgres/cli/TODO.md updated.

Also verified against a real PostgreSQL 16 (docker container): the pgregress 
transcript for a CTAS/SELECT INTO script is byte-identical apart from 
pre-existing gaps (aggregate column naming, IF NOT EXISTS NOTICE), and 
psycopg observes identical statusmessage/rowcount for all statement forms.

## Motivation and context

CREATE TABLE AS and SELECT INTO are common in migrations, ETL scripts, and
ORM-generated test setups; libpg_query already parses them, so the gap was
translation. The SELECT INTO half also fixes a silent wrong-result: it
previously executed as a plain SELECT without creating anything.

No related issue; item 6 in postgres/cli/TODO.md.

## Description of AI Usage

Developed with Claude Code driving under my direction: it scoped the TODO
list against the existing code, wrote failing tests first, implemented the
translator/server changes, and verified wire behavior against a live server
with a raw-socket client. PG semantics were checked against the PostgreSQL
source (src/backend/commands/createas.c) and docs.

SQLite parity (changes(), column count) was checked against sqlite3
directly. The result was then reviewed by independent review passes (style
vs docs/agent-guides/code-quality.md, adversarial correctness probes, test
placement vs docs/agent-guides/testing.md) and their findings folded in: in
particular, the compound-select INTO guard and wire-tag edge cases. 

I (theFestest) reviewed and take responsibility for the final diff. I think this 
accomplishes the intention behind item 6 in postgres/cli/TODO.md, but will
be happy to address any feedback. 

Side note: I read your Postgres blog post earlier and wanted to take a shot 
at contributing. If this contribution is desirable quality, I would be happy to 
pick up something else next.

Closes #7909