### PR TITLE
serverless/python: add serverless driver and conformance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 !bindings/dotnet/src/Turso.Data.Sqlite/
 !bindings/dotnet/src/Turso.Data.Sqlite/**
 # Python
+*.egg-info/
+.hypothesis/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/

--- a/serverless/python/README.md
+++ b/serverless/python/README.md
@@ -1,0 +1,70 @@
+# Turso Serverless Driver for Python
+
+A pure Python driver for Turso Cloud that speaks the [SQL over HTTP
+protocol](https://github.com/tursodatabase/turso/blob/main/serverless/PROTOCOL.md).
+Designed for serverless and edge environments: no persistent connections,
+no native extensions, just HTTP requests from the standard library.
+
+The API implements [DB-API 2.0](https://peps.python.org/pep-0249/) and
+mirrors the embedded [`turso`](https://pypi.org/project/turso/) driver, so
+the same application code can run against a local database or Turso Cloud.
+
+## Usage
+
+```python
+import turso_serverless
+
+conn = turso_serverless.connect(
+    "libsql://my-db.turso.io",
+    auth_token="...",
+)
+
+conn.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+conn.execute("INSERT INTO users (name) VALUES (?)", ("Alice",))
+conn.commit()
+
+for row in conn.execute("SELECT id, name FROM users"):
+    print(row)
+
+conn.close()
+```
+
+Interactive transactions span multiple HTTP requests; the server keeps the
+connection state alive between them:
+
+```python
+conn.execute("BEGIN")
+conn.execute("UPDATE accounts SET balance = balance - 100 WHERE id = 1")
+conn.execute("UPDATE accounts SET balance = balance + 100 WHERE id = 2")
+conn.commit()
+```
+
+## Conformance tests
+
+The test suite runs against a live database. Point it at a Turso Cloud
+instance:
+
+```console
+$ export TURSO_DATABASE_URL=libsql://<your-db>.turso.io
+$ export TURSO_AUTH_TOKEN=<your-token>
+$ uv run --extra dev pytest
+```
+
+The tests skip themselves when the environment variables are not set.
+
+## Differential tests
+
+[`differential`](differential/) holds property-based parity tests: random
+operation sequences generated from the shared spec
+([`serverless/conformance/differential/spec/ops.json`](../conformance/differential/spec/ops.json))
+run against both the embedded `pyturso` driver and this driver talking to
+Turso Cloud, and any divergence in results, result shapes, value types, or
+error outcomes fails the property. With the same environment variables set:
+
+```console
+$ uv run --extra differential pytest differential
+```
+
+The embedded driver is built from `bindings/python`, so a Rust toolchain
+is required. `HEGEL_NUM_RUNS` tunes iterations per property (default 10,
+sized for a remote database over the network).

--- a/serverless/python/differential/test_parity.py
+++ b/serverless/python/differential/test_parity.py
@@ -1,0 +1,792 @@
+"""Property-based differential tests for turso (embedded) vs turso_serverless.
+
+Generates random sequences of database operations from the shared spec
+(serverless/conformance/differential/spec/ops.json) and asserts that both
+drivers produce structurally identical results: same success/failure,
+same column counts/names, same row counts, same value types, and same
+cell values.
+
+Runs against a live Turso Cloud database configured with
+TURSO_DATABASE_URL and TURSO_AUTH_TOKEN and skips when they are unset.
+HEGEL_NUM_RUNS tunes iterations per property (default 10, sized for a
+remote database over the network). Use a scratch database: the tests
+create and drop tables.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+turso = pytest.importorskip("turso", reason="pyturso (bindings/python) is not installed")
+
+import hypothesis.strategies as st  # noqa: E402
+from hypothesis import HealthCheck, given, settings  # noqa: E402
+from turso_serverless import connect as remote_connect  # noqa: E402
+
+SERVER_URL = os.environ.get("TURSO_DATABASE_URL")
+AUTH_TOKEN = os.environ.get("TURSO_AUTH_TOKEN")
+NUM_RUNS = int(os.environ.get("HEGEL_NUM_RUNS", "10"))
+
+pytestmark = pytest.mark.skipif(
+    SERVER_URL is None,
+    reason="TURSO_DATABASE_URL is not set",
+)
+
+
+def make_remote():
+    kwargs = {}
+    if AUTH_TOKEN:
+        kwargs["auth_token"] = AUTH_TOKEN
+    return remote_connect(SERVER_URL, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Load spec from ops.json
+# ---------------------------------------------------------------------------
+
+_SPEC_PATH = (
+    Path(__file__).resolve().parents[2] / "conformance" / "differential" / "spec" / "ops.json"
+)
+with open(_SPEC_PATH) as _f:
+    _SPEC = json.load(_f)
+
+COL_TYPES = _SPEC["constants"]["col_types"]
+
+# Ops safe to nest inside a transaction workflow, matching the JavaScript
+# and Rust harnesses.
+_DML_OP_IDS = {
+    "create", "insert", "select", "select_value",
+    "insert_returning", "delete_returning", "update_returning",
+    "select_limit", "select_count", "select_expr",
+    "insert_affected", "delete_affected", "update_affected",
+}
+
+
+# ---------------------------------------------------------------------------
+# Strategies (operation generators)
+# ---------------------------------------------------------------------------
+
+table_names = st.integers(0, 5).map(lambda i: f"t_{i}")
+
+# Build value strategy dynamically from spec
+def _build_value_strategy(v):  # noqa: C901
+    """Convert a value spec entry into a Hypothesis strategy."""
+    vid = v["id"]
+    if vid == "null":
+        return st.none()
+    if "random" in v:
+        return st.integers(min_value=v["random"]["min"], max_value=v["random"]["max"])
+    if "random_scaled" in v:
+        r = v["random_scaled"]
+        return st.floats(
+            min_value=r["min"] / r["divisor"],
+            max_value=r["max"] / r["divisor"],
+            allow_nan=False,
+            allow_infinity=False,
+        )
+    if "random_string" in v:
+        return st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N", "P", "S", "Z")),
+            max_size=v["random_string"]["max_len"],
+        )
+    if "random_bytes" in v:
+        return st.binary(max_size=v["random_bytes"]["max_len"])
+    if "oneof" in v:
+        return st.sampled_from(v["oneof"])
+    if "oneof_float" in v:
+        return st.sampled_from(v["oneof_float"])
+    if vid == "large_or_unicode":
+        return st.one_of(
+            st.just(b"\xab" * 256),
+            st.sampled_from(_SPEC["unicode_options"]),
+        )
+    if "literal" in v:
+        return st.just(v["literal"])
+    if "literal_float" in v:
+        return st.just(v["literal_float"])
+    if "literal_bytes" in v:
+        return st.just(b"")
+    if "fill_bytes" in v:
+        fb = v["fill_bytes"]
+        return st.just(bytes([fb["byte"]]) * fb["len"])
+    if "repeat_char" in v:
+        rc = v["repeat_char"]
+        return st.just(rc["char"] * rc["len"])
+    raise ValueError(f"unknown value spec: {vid}")
+
+
+values = st.one_of(*[_build_value_strategy(v) for v in _SPEC["values"]])
+
+dynamic_cols = st.integers(1, _SPEC["constants"]["max_dynamic_cols"]).flatmap(
+    lambda n: st.tuples(
+        *[st.sampled_from(COL_TYPES).map(lambda t, i=i: (f"c{i}", t)) for i in range(n)]
+    ).map(list)
+)
+
+batch_sql = st.tuples(
+    st.integers(0, _SPEC["constants"]["num_tables"] - 1),
+    st.integers(-1000, 1000),
+).map(
+    lambda args: (
+        f"CREATE TABLE IF NOT EXISTS t_{args[0]} (a INTEGER, b TEXT); "
+        f"INSERT INTO t_{args[0]} VALUES ({args[1]}, 'batch')"
+    )
+)
+
+
+# Build op strategy dynamically from spec
+def _build_op_strategy(op_spec, dml_ops=None):  # noqa: C901
+    """Convert an op spec entry into a Hypothesis strategy."""
+    oid = op_spec["id"]
+    fields = op_spec.get("fields", {})
+
+    if oid in ("begin", "commit", "rollback"):
+        return st.just({"kind": oid})
+
+    if oid == "invalid":
+        return st.just({"kind": "invalid", "sql": op_spec["sql"]})
+
+    if fields.get("inner_ops") == "dml_ops" and fields.get("commit") == "bool":
+        return st.builds(
+            lambda inner, commit: {"kind": oid, "inner_ops": inner, "commit": commit},
+            st.lists(dml_ops, min_size=1, max_size=5),
+            st.booleans(),
+        )
+
+    if fields.get("good_op") == "dml_op" and fields.get("bad_sql") == "error_sql":
+        return st.builds(
+            lambda good, bad, rec: {
+                "kind": oid, "good_op": good, "bad_sql": bad, "recovery_op": rec,
+            },
+            dml_ops,
+            st.sampled_from(_SPEC["constants"]["error_sqls"]),
+            dml_ops,
+        )
+
+    d = {"kind": st.just(oid)}
+
+    if "table" in fields:
+        d["table"] = table_names
+
+    if fields.get("values") == "table_values":
+        d["values"] = st.tuples(values, values)
+
+    if fields.get("value") == "one_value":
+        d["value"] = values
+
+    if fields.get("params") == "two_values":
+        # Some ops with params also have a static SQL template (e.g. "param")
+        if "sql" not in fields and "sql" in op_spec:
+            d["sql"] = st.just(op_spec["sql"])
+        d["params"] = st.tuples(values, values)
+
+    if fields.get("expr") == "random_int_str":
+        d["expr"] = st.integers(-1000, 1000).map(str)
+
+    if fields.get("cols") == "dynamic_cols":
+        d["cols"] = dynamic_cols
+
+    if fields.get("sql") == "batch_sql":
+        d["sql"] = batch_sql
+
+    if fields.get("sql") == "error_sql":
+        d["sql"] = st.sampled_from(_SPEC["constants"]["error_sqls"])
+
+    if fields.get("named") == "named_values":
+        names = op_spec.get("named_params", [])
+        d["named"] = st.fixed_dictionaries({n: values for n in names})
+
+    if fields.get("params_sets") == "three_param_pairs":
+        d["params_sets"] = st.tuples(
+            st.tuples(values, values),
+            st.tuples(values, values),
+            st.tuples(values, values),
+        )
+
+    return st.fixed_dictionaries(d)
+
+
+dml_ops = st.one_of(
+    *[_build_op_strategy(op) for op in _SPEC["ops"] if op["id"] in _DML_OP_IDS]
+)
+
+ops = st.one_of(*[_build_op_strategy(op, dml_ops=dml_ops) for op in _SPEC["ops"]])
+
+
+# ---------------------------------------------------------------------------
+# Value comparison with float epsilon tolerance
+# ---------------------------------------------------------------------------
+
+
+def cell_equal(a, b):
+    """Compare two cell values with float epsilon tolerance and int/real crossover."""
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+
+    # Both float
+    if isinstance(a, float) and isinstance(b, float):
+        mx = max(abs(a), abs(b))
+        if mx == 0:
+            return True
+        return abs(a - b) / mx < 1e-12
+
+    # Int/float crossover
+    if isinstance(a, int) and isinstance(b, float):
+        return abs(float(a) - b) < 1e-12
+    if isinstance(a, float) and isinstance(b, int):
+        return abs(a - float(b)) < 1e-12
+
+    # Bytes
+    if isinstance(a, (bytes, bytearray, memoryview)) and isinstance(
+        b, (bytes, bytearray, memoryview)
+    ):
+        return bytes(a) == bytes(b)
+
+    return a == b
+
+
+def results_equal(a, b):  # noqa: C901
+    """Compare two result dicts with float epsilon tolerance on cell values."""
+    # Compare all keys except 'values'
+    for key in set(list(a.keys()) + list(b.keys())):
+        if key == "values":
+            continue
+        if a.get(key) != b.get(key):
+            return False
+
+    # Compare values with epsilon
+    a_vals = a.get("values")
+    b_vals = b.get("values")
+    if a_vals is None and b_vals is None:
+        return True
+    if a_vals is None or b_vals is None:
+        return False
+    if len(a_vals) != len(b_vals):
+        return False
+    for row_a, row_b in zip(a_vals, b_vals):
+        if len(row_a) != len(row_b):
+            return False
+        for ca, cb in zip(row_a, row_b):
+            if not cell_equal(ca, cb):
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Result structure
+# ---------------------------------------------------------------------------
+
+
+def value_type_tag(v):
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "integer"
+    if isinstance(v, int):
+        return "integer"
+    if isinstance(v, float):
+        return "real"
+    if isinstance(v, str):
+        return "text"
+    if isinstance(v, (bytes, bytearray, memoryview)):
+        return "blob"
+    return f"unknown({type(v).__name__})"
+
+
+def _query_result(cur):
+    """Extract a standard result dict from a cursor after a query."""
+    rows = cur.fetchall()
+    col_count = len(cur.description) if cur.description else 0
+    col_names = [d[0] for d in cur.description] if cur.description else []
+    types = [[value_type_tag(v) for v in row] for row in rows]
+    vals = [list(row) for row in rows]
+    return {
+        "success": True,
+        "column_count": col_count,
+        "column_names": col_names,
+        "row_count": len(rows),
+        "value_types": types,
+        "values": vals,
+    }
+
+
+def execute_op(conn, op):  # noqa: C901
+    """Execute an operation against a DB-API 2.0 connection, return result dict."""
+    try:
+        kind = op["kind"]
+
+        if kind == "create":
+            conn.execute(
+                f"CREATE TABLE IF NOT EXISTS {op['table']} (a INTEGER, b TEXT)"
+            )
+            return {"success": True, "column_count": 0, "row_count": 0}
+
+        elif kind == "create_dynamic":
+            col_defs = ", ".join(f"{n} {t}" for n, t in op["cols"])
+            conn.execute(
+                f"CREATE TABLE IF NOT EXISTS {op['table']} ({col_defs})"
+            )
+            return {"success": True, "column_count": 0, "row_count": 0}
+
+        elif kind == "insert":
+            placeholders = ", ".join("?" for _ in op["values"])
+            conn.execute(
+                f"INSERT INTO {op['table']} VALUES ({placeholders})", op["values"]
+            )
+            return {"success": True, "column_count": 0, "row_count": 1}
+
+        elif kind == "insert_returning":
+            placeholders = ", ".join("?" for _ in op["values"])
+            cur = conn.execute(
+                f"INSERT INTO {op['table']} VALUES ({placeholders}) RETURNING *",
+                op["values"],
+            )
+            return _query_result(cur)
+
+        elif kind == "delete_returning":
+            cur = conn.execute(f"DELETE FROM {op['table']} RETURNING *")
+            return _query_result(cur)
+
+        elif kind == "update_returning":
+            cur = conn.execute(
+                f"UPDATE {op['table']} SET a = ? RETURNING *",
+                (op["value"],),
+            )
+            return _query_result(cur)
+
+        elif kind == "select":
+            cur = conn.execute(f"SELECT * FROM {op['table']}")
+            return _query_result(cur)
+
+        elif kind == "select_value":
+            cur = conn.execute(f"SELECT {op['expr']}")
+            return _query_result(cur)
+
+        elif kind == "begin":
+            conn.execute("BEGIN")
+            return {"success": True, "column_count": 0, "row_count": 0}
+
+        elif kind == "commit":
+            conn.commit()
+            return {"success": True, "column_count": 0, "row_count": 0}
+
+        elif kind == "rollback":
+            conn.rollback()
+            return {"success": True, "column_count": 0, "row_count": 0}
+
+        elif kind == "invalid":
+            cur = conn.execute(op["sql"])
+            cur.fetchall()
+            return {"success": True, "column_count": 0, "row_count": 0}
+
+        elif kind == "param":
+            cur = conn.execute(op["sql"], op["params"])
+            return _query_result(cur)
+
+        elif kind == "insert_affected":
+            placeholders = ", ".join("?" for _ in op["values"])
+            cur = conn.execute(
+                f"INSERT INTO {op['table']} VALUES ({placeholders})", op["values"]
+            )
+            return {"success": True, "affected_rows": cur.rowcount}
+
+        elif kind == "delete_affected":
+            cur = conn.execute(f"DELETE FROM {op['table']}")
+            return {"success": True, "affected_rows": cur.rowcount}
+
+        elif kind == "update_affected":
+            cur = conn.execute(
+                f"UPDATE {op['table']} SET a = ?", (op["value"],)
+            )
+            return {"success": True, "affected_rows": cur.rowcount}
+
+        elif kind == "insert_rowid":
+            placeholders = ", ".join("?" for _ in op["values"])
+            cur = conn.execute(
+                f"INSERT INTO {op['table']} VALUES ({placeholders})", op["values"]
+            )
+            return {"success": True, "last_insert_rowid": cur.lastrowid}
+
+        elif kind == "batch":
+            conn.executescript(op["sql"])
+            return {"success": True, "column_count": 0, "row_count": 0}
+
+        elif kind == "select_limit":
+            cur = conn.execute(f"SELECT * FROM {op['table']} LIMIT 1")
+            return _query_result(cur)
+
+        elif kind == "select_count":
+            cur = conn.execute(f"SELECT COUNT(*), SUM(a) FROM {op['table']}")
+            return _query_result(cur)
+
+        elif kind == "select_expr":
+            cur = conn.execute(
+                "SELECT 1+1, 'hello'||'world', NULL, CAST(3.14 AS INTEGER), typeof(?)",
+                (op["value"],),
+            )
+            return _query_result(cur)
+
+        elif kind == "error_check":
+            try:
+                conn.execute(op["sql"])
+                return {"success": True}
+            except Exception:
+                return {"success": False}
+
+        elif kind == "prepared_reuse":
+            sql = "SELECT ?, ?"
+            all_results = []
+            for params in op["params_sets"]:
+                cur = conn.execute(sql, params)
+                result = _query_result(cur)
+                if result.get("values"):
+                    all_results.extend(result["values"])
+            col_names = ["?", "?"]
+            types = [[value_type_tag(v) for v in row] for row in all_results]
+            return {
+                "success": True,
+                "column_count": 2,
+                "column_names": col_names,
+                "row_count": len(all_results),
+                "value_types": types,
+                "values": all_results,
+            }
+
+        elif kind == "named_param":
+            named = op["named"]
+            cols = ", ".join(f":{k}" for k in named)
+            sql = f"SELECT {cols}"
+            cur = conn.execute(sql, named)
+            return _query_result(cur)
+
+        elif kind == "numbered_param":
+            params = op["params"]
+            cols = ", ".join(f"?{i+1}" for i in range(len(params)))
+            sql = f"SELECT {cols}"
+            cur = conn.execute(sql, params)
+            return _query_result(cur)
+
+        elif kind == "create_trigger":
+            table = op["table"]
+            audit = f"{table}_audit"
+            conn.execute(f"CREATE TABLE IF NOT EXISTS {audit} (src TEXT, val)")
+            trigger_sql = (
+                f"CREATE TRIGGER IF NOT EXISTS tr_{table}_ins AFTER INSERT ON {table} "
+                f"BEGIN "
+                f"INSERT INTO {audit} VALUES ('{table}', NEW.a); "
+                f"INSERT INTO {audit} VALUES ('{table}', NEW.a * 2); "
+                f"END"
+            )
+            conn.execute(trigger_sql)
+            conn.execute(
+                f"INSERT INTO {table} VALUES (42, 'trigger_test')"
+            )
+            cur = conn.execute(f"SELECT * FROM {audit} ORDER BY rowid")
+            return _query_result(cur)
+
+        elif kind == "transaction_workflow":
+            conn.execute("BEGIN")
+            for inner in op["inner_ops"]:
+                execute_op(conn, inner)
+            conn.execute("COMMIT" if op["commit"] else "ROLLBACK")
+            return {"success": True, "column_count": 0, "row_count": 0}
+
+        elif kind == "error_in_transaction":
+            conn.execute("BEGIN")
+            execute_op(conn, op["good_op"])
+            try:
+                conn.execute(op["bad_sql"])
+            except Exception:
+                pass
+            execute_op(conn, op["recovery_op"])
+            conn.execute("ROLLBACK")
+            return {"success": True, "column_count": 0, "row_count": 0}
+
+        else:
+            return {"success": False}
+
+    except Exception:
+        return {"success": False}
+
+
+# ---------------------------------------------------------------------------
+# Prefix helper — makes table names unique per test case so parallel tests
+# don't interfere. Transforms "t_N" → "t_{prefix}_N" in table fields and SQL.
+# ---------------------------------------------------------------------------
+
+_TABLE_RE = re.compile(r"\bt_(\d+)\b")
+
+
+def _apply_prefix(op, prefix):
+    op = dict(op)
+    repl = f"t_{prefix}_\\1"
+    if "table" in op:
+        op["table"] = _TABLE_RE.sub(repl, op["table"])
+    if isinstance(op.get("sql"), str):
+        op["sql"] = _TABLE_RE.sub(repl, op["sql"])
+    if "inner_ops" in op:
+        op["inner_ops"] = [_apply_prefix(o, prefix) for o in op["inner_ops"]]
+    for key in ("good_op", "recovery_op"):
+        if key in op:
+            op[key] = _apply_prefix(op[key], prefix)
+    if "bad_sql" in op:
+        op["bad_sql"] = _TABLE_RE.sub(repl, op["bad_sql"])
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Composite strategy: op sequence with table column tracking
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def op_sequence(draw):
+    prefix = draw(st.integers(0, 65535))
+    table_cols = {}
+    count = draw(st.integers(1, 20))
+    result = []
+    for _ in range(count):
+        op = draw(ops)
+        op = _apply_prefix(op, prefix)
+        # Track table schemas
+        if op["kind"] == "create":
+            table_cols[op["table"]] = 2
+        elif op["kind"] == "create_dynamic":
+            table_cols[op["table"]] = len(op["cols"])
+        # Adjust insert value counts to match table column count
+        elif op["kind"] in ("insert", "insert_returning", "insert_affected", "insert_rowid"):
+            n = table_cols.get(op["table"], 2)
+            op = dict(op)  # copy
+            op["values"] = tuple(draw(values) for _ in range(n))
+        result.append(op)
+    return (prefix, result)
+
+
+# ---------------------------------------------------------------------------
+# The property test
+# ---------------------------------------------------------------------------
+
+
+@given(data=op_sequence())
+@settings(
+    max_examples=NUM_RUNS,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+    database=None,
+)
+def test_api_parity(data):
+    prefix, op_seq = data
+    local = turso.connect(":memory:")
+    remote = make_remote()
+
+    try:
+        # Drop any leftover tables for this prefix (from prior runs or replays).
+        for i in range(_SPEC["constants"]["num_tables"]):
+            try:
+                remote.execute(f"DROP TABLE IF EXISTS t_{prefix}_{i}")
+            except Exception:
+                pass
+            try:
+                remote.execute(f"DROP TABLE IF EXISTS t_{prefix}_{i}_audit")
+            except Exception:
+                pass
+            try:
+                remote.execute(f"DROP TRIGGER IF EXISTS tr_t_{prefix}_{i}_ins")
+            except Exception:
+                pass
+
+        # Accumulate an operation trace so failures show the full history.
+        trace = []
+
+        for i, op in enumerate(op_seq):
+            local_result = execute_op(local, op)
+            remote_result = execute_op(remote, op)
+
+            trace.append(
+                f"  op[{i}]: kind={op['kind']} table={op.get('table', '')!r}\n"
+                f"    local:  ok={local_result.get('success')} rows={local_result.get('row_count')}\n"
+                f"    remote: ok={remote_result.get('success')} rows={remote_result.get('row_count')}"
+            )
+            trace_dump = "\n".join(trace)
+
+            # ErrorCheck only compares success/failure — error messages differ.
+            if op["kind"] == "error_check":
+                assert local_result.get("success") == remote_result.get("success"), (
+                    f"Parity violation on op #{i} {op}:\n"
+                    f"  local:  {local_result}\n"
+                    f"  remote: {remote_result}\n\n"
+                    f"Full trace (prefix={prefix}):\n{trace_dump}"
+                )
+                continue
+
+            assert results_equal(local_result, remote_result), (
+                f"Parity violation on op #{i} {op}:\n"
+                f"  local:  {local_result}\n"
+                f"  remote: {remote_result}\n\n"
+                f"Full trace (prefix={prefix}):\n{trace_dump}"
+            )
+
+            # If both failed, stop — continuing with diverged implicit
+            # transaction state leads to false positives.
+            if not local_result.get("success"):
+                break
+    finally:
+        local.close()
+        remote.close()
+
+
+# ---------------------------------------------------------------------------
+# Error recovery property: errors must never prevent subsequent commands
+# ---------------------------------------------------------------------------
+
+ERROR_SQLS = st.sampled_from([
+    "SELECT * FROM nonexistent_table_xyz",
+    "SELECT * FROM nonexistent_table_abc",
+    "SELECT * FROM nonexistent_table_zzz",
+    "INSERT INTO nonexistent_table_xyz VALUES (1)",
+    "INSERT INTO t_0 VALUES (1, 2, 3)",
+    "SELECT length(1, 2, 3)",
+])
+
+
+@given(error_sql=ERROR_SQLS)
+@settings(
+    max_examples=NUM_RUNS,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+    database=None,
+)
+def test_error_recovery(error_sql):
+    remote = make_remote()
+
+    try:
+        # Send the error-inducing SQL (expected to fail)
+        try:
+            remote.execute(error_sql)
+        except Exception:
+            pass
+
+        # The critical assertion: SELECT 1 must succeed afterward
+        result = remote.execute("SELECT 1")
+        rows = result.fetchall()
+        assert len(rows) == 1, (
+            f"SELECT 1 returned {len(rows)} rows after error SQL {error_sql!r}"
+        )
+        assert rows[0][0] == 1, (
+            f"SELECT 1 returned {rows[0][0]!r} after error SQL {error_sql!r}"
+        )
+    finally:
+        remote.close()
+
+
+# ---------------------------------------------------------------------------
+# DDL visibility in transactions: CREATE TABLE must be visible to subsequent
+# statements within the same transaction.
+# ---------------------------------------------------------------------------
+
+DDL_PREFIXES = st.integers(min_value=200000, max_value=265535)
+DDL_TABLE_INDICES = st.integers(min_value=0, max_value=5)
+DDL_VALUES = st.integers(min_value=-1000, max_value=1000)
+
+
+@given(prefix=DDL_PREFIXES, table_idx=DDL_TABLE_INDICES, val=DDL_VALUES)
+@settings(
+    max_examples=NUM_RUNS,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+    database=None,
+)
+def test_ddl_in_transaction(prefix, table_idx, val):
+    table = f"t_{prefix}_{table_idx}"
+    local = turso.connect(":memory:")
+    remote = make_remote()
+
+    try:
+        # Drop any leftover from prior runs so the INSERT produces exactly 1 row.
+        try:
+            remote.execute(f"DROP TABLE IF EXISTS {table}")
+        except Exception:
+            pass
+
+        create_sql = f"CREATE TABLE IF NOT EXISTS {table} (a INTEGER, b TEXT)"
+        insert_sql = f"INSERT INTO {table} VALUES (?, 'txn_ddl')"
+        select_sql = f"SELECT a FROM {table}"
+
+        # Local: BEGIN → CREATE → INSERT → SELECT → COMMIT
+        local.execute("BEGIN")
+        local.execute(create_sql)
+        local.execute(insert_sql, [val])
+        local_rows = local.execute(select_sql).fetchall()
+        assert len(local_rows) == 1, (
+            f"local: expected 1 row inside txn, got {len(local_rows)}"
+        )
+        local.execute("COMMIT")
+
+        # Remote: BEGIN → CREATE → INSERT → SELECT → COMMIT
+        remote.execute("BEGIN")
+        remote.execute(create_sql)
+        remote.execute(insert_sql, [val])
+        remote_rows = remote.execute(select_sql).fetchall()
+        assert len(remote_rows) == 1, (
+            f"remote: expected 1 row inside txn, got {len(remote_rows)}"
+        )
+        remote.execute("COMMIT")
+    finally:
+        local.close()
+        remote.close()
+
+
+# Note: no ddl_prepare_in_transaction test for Python — DB-API2 has no
+# separate prepare() step; cursor.execute() is the only path and doesn't
+# call describe. The execute-based ddl_in_transaction test above covers
+# the Python driver.
+
+
+# ---------------------------------------------------------------------------
+# API surface parity: local public members must exist on remote
+# ---------------------------------------------------------------------------
+
+# Members that only make sense on the local driver (FFI, async I/O hook).
+_LOCAL_ONLY_CONN = {"extra_io"}
+_LOCAL_ONLY_CURSOR = set()
+
+
+def _public_members(obj):
+    """Return set of public (non-underscore) member names."""
+    return {m for m in dir(obj) if not m.startswith("_")}
+
+
+def test_api_surface_parity():
+    local = turso.connect(":memory:")
+    remote = make_remote()
+
+    try:
+        # Connection
+        local_conn_api = _public_members(local)
+        remote_conn_api = _public_members(remote)
+        missing_conn = sorted(local_conn_api - remote_conn_api - _LOCAL_ONLY_CONN)
+
+        # Cursor
+        local_cursor = local.execute("SELECT 1")
+        remote_cursor = remote.execute("SELECT 1")
+        local_cursor_api = _public_members(local_cursor)
+        remote_cursor_api = _public_members(remote_cursor)
+        missing_cursor = sorted(local_cursor_api - remote_cursor_api - _LOCAL_ONLY_CURSOR)
+
+        errors = []
+        if missing_conn:
+            errors.append(f"Remote Connection missing: {missing_conn}")
+        if missing_cursor:
+            errors.append(f"Remote Cursor missing: {missing_cursor}")
+
+        assert not errors, "\n".join(errors)
+    finally:
+        local.close()
+        remote.close()

--- a/serverless/python/pyproject.toml
+++ b/serverless/python/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "turso-serverless"
+version = "0.1.0"
+description = "Pure Python serverless driver for Turso databases (DB-API 2.0, SQL over HTTP)"
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Database",
+    "Topic :: Software Development :: Libraries",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+differential = [
+    "pytest>=8.0",
+    "hypothesis>=6.100",
+    "pyturso",
+]
+
+[tool.uv.sources]
+pyturso = { path = "../../bindings/python" }
+
+[project.urls]
+Homepage = "https://github.com/tursodatabase/turso"
+Source = "https://github.com/tursodatabase/turso"
+
+[tool.setuptools]
+packages = ["turso_serverless"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/serverless/python/tests/test_serverless.py
+++ b/serverless/python/tests/test_serverless.py
@@ -1,0 +1,631 @@
+"""DB-API 2.0 integration tests for turso_serverless against a live server.
+
+Configure with TURSO_DATABASE_URL and (optionally) TURSO_AUTH_TOKEN; the
+tests that need a server skip themselves when TURSO_DATABASE_URL is unset.
+"""
+
+from __future__ import annotations
+
+import http.client
+import math
+import os
+import urllib.request
+
+import pytest
+from turso_serverless import IntegrityError, OperationalError, connect
+from turso_serverless.connection import Connection, _classify_error
+from turso_serverless.protocol import ProtocolError, ServerError, decode_value, encode_value
+from turso_serverless.session import Session, _server_error, normalize_url
+
+SERVER_URL = os.environ.get("TURSO_DATABASE_URL")
+AUTH_TOKEN = os.environ.get("TURSO_AUTH_TOKEN")
+
+needs_server = pytest.mark.skipif(
+    SERVER_URL is None,
+    reason="TURSO_DATABASE_URL is not set",
+)
+
+
+def make_conn():
+    kwargs = {}
+    if AUTH_TOKEN:
+        kwargs["auth_token"] = AUTH_TOKEN
+    return connect(SERVER_URL, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Query execution
+# ---------------------------------------------------------------------------
+
+
+@needs_server
+class TestQueryExecution:
+    def test_single_value(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT 42")
+        assert cur.fetchone() == (42,)
+        conn.close()
+
+    def test_single_row(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT 1 AS one, 'two' AS two, 0.5 AS three")
+        assert cur.description is not None
+        names = [d[0] for d in cur.description]
+        assert names == ["one", "two", "three"]
+        row = cur.fetchone()
+        assert row == (1, "two", 0.5)
+        conn.close()
+
+    def test_multiple_rows(self):
+        conn = make_conn()
+        cur = conn.execute("VALUES (1, 'one'), (2, 'two'), (3, 'three')")
+        rows = cur.fetchall()
+        assert len(rows) == 3
+        assert rows[0] == (1, "one")
+        assert rows[1] == (2, "two")
+        assert rows[2] == (3, "three")
+        conn.close()
+
+    def test_error_on_invalid_sql(self):
+        conn = make_conn()
+        with pytest.raises(OperationalError):
+            conn.execute("SELECT foobar")
+        conn.close()
+
+    def test_insert_returning(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_ret_py")
+        conn.execute("CREATE TABLE t_ret_py (a)")
+        cur = conn.execute("INSERT INTO t_ret_py VALUES (1) RETURNING 42 AS x, 'foo' AS y")
+        assert cur.description is not None
+        names = [d[0] for d in cur.description]
+        assert names == ["x", "y"]
+        row = cur.fetchone()
+        assert row == (42, "foo")
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Rows affected
+# ---------------------------------------------------------------------------
+
+
+@needs_server
+class TestRowsAffected:
+    def test_insert_rowcount(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_ins_rc")
+        conn.execute("CREATE TABLE t_ins_rc (a)")
+        cur = conn.execute("INSERT INTO t_ins_rc VALUES (1), (2)")
+        assert cur.rowcount == 2
+        conn.close()
+
+    def test_delete_rowcount(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_del_rc")
+        conn.execute("CREATE TABLE t_del_rc (a)")
+        conn.execute("INSERT INTO t_del_rc VALUES (1), (2), (3), (4), (5)")
+        conn.commit()
+        cur = conn.execute("DELETE FROM t_del_rc WHERE a >= 3")
+        assert cur.rowcount == 3
+        conn.close()
+
+    def test_lastrowid(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_rowid_py")
+        conn.execute("CREATE TABLE t_rowid_py (id INTEGER PRIMARY KEY, a)")
+        cur = conn.execute("INSERT INTO t_rowid_py VALUES (7, 'x')")
+        assert cur.lastrowid == 7
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Value roundtrip
+# ---------------------------------------------------------------------------
+
+
+@needs_server
+class TestValueRoundtrip:
+    def test_string(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT ?", ("boomerang",))
+        assert cur.fetchone() == ("boomerang",)
+        conn.close()
+
+    def test_unicode(self):
+        conn = make_conn()
+        text = "žluťoučký kůň úpěl ďábelské ódy"
+        cur = conn.execute("SELECT ?", (text,))
+        assert cur.fetchone() == (text,)
+        conn.close()
+
+    def test_integer(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT ?", (-2023,))
+        assert cur.fetchone() == (-2023,)
+        conn.close()
+
+    def test_large_integer(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT ?", (2**62,))
+        assert cur.fetchone() == (2**62,)
+        conn.close()
+
+    def test_float(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT ?", (12.345,))
+        assert cur.fetchone() == (12.345,)
+        conn.close()
+
+    def test_null(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT ?", (None,))
+        assert cur.fetchone() == (None,)
+        conn.close()
+
+    def test_bool_true(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT ?", (True,))
+        # SQLite stores bools as integers
+        assert cur.fetchone() == (1,)
+        conn.close()
+
+    def test_bool_false(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT ?", (False,))
+        assert cur.fetchone() == (0,)
+        conn.close()
+
+    def test_blob(self):
+        conn = make_conn()
+        blob = bytes(range(256))
+        cur = conn.execute("SELECT ?", (blob,))
+        assert cur.fetchone() == (blob,)
+        conn.close()
+
+    def test_nan_binds_as_null(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT ?", (float("nan"),))
+        assert cur.fetchone() == (None,)
+        conn.close()
+
+    def test_non_finite_result_decodes_as_nan(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT 1e308 * 10")
+        (value,) = cur.fetchone()
+        assert math.isnan(value)
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Non-finite floats (no server needed)
+# ---------------------------------------------------------------------------
+
+
+class TestNonFiniteFloatEncoding:
+    def test_nan_encodes_as_null(self):
+        assert encode_value(float("nan")) == {"type": "null"}
+
+    def test_infinity_rejected(self):
+        with pytest.raises(ValueError):
+            encode_value(float("inf"))
+        with pytest.raises(ValueError):
+            encode_value(float("-inf"))
+
+    def test_finite_float_unchanged(self):
+        assert encode_value(12.345) == {"type": "float", "value": 12.345}
+
+    def test_null_float_decodes_as_nan(self):
+        assert math.isnan(decode_value({"type": "float", "value": None}))
+
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+
+
+@needs_server
+class TestParameters:
+    def test_positional(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT ?, ?", ("one", "two"))
+        assert cur.fetchone() == ("one", "two")
+        conn.close()
+
+    def test_named(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT :a, :b", {"a": "one", "b": "two"})
+        assert cur.fetchone() == ("one", "two")
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# executescript
+# ---------------------------------------------------------------------------
+
+
+@needs_server
+class TestExecuteScript:
+    def test_multiple_statements(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_batch_py")
+        cur = conn.cursor()
+        cur.executescript(
+            "CREATE TABLE t_batch_py (a);"
+            "INSERT INTO t_batch_py VALUES (1), (2), (4), (8);"
+        )
+        cur2 = conn.execute("SELECT SUM(a) FROM t_batch_py")
+        assert cur2.fetchone() == (15,)
+        conn.close()
+
+    def test_error_stops_execution(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_batch_err_py")
+        cur = conn.cursor()
+        with pytest.raises(OperationalError):
+            cur.executescript(
+                "CREATE TABLE t_batch_err_py (a);"
+                "INSERT INTO t_batch_err_py VALUES (1), (2), (4);"
+                "INSERT INTO t_batch_err_py VALUES (foo());"
+                "INSERT INTO t_batch_err_py VALUES (8), (16);"
+            )
+        conn.close()
+
+    def test_manual_transaction(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_batch_tx_py")
+        cur = conn.cursor()
+        cur.executescript(
+            "CREATE TABLE t_batch_tx_py (a);"
+            "BEGIN;"
+            "INSERT INTO t_batch_tx_py VALUES (1), (2), (4);"
+            "INSERT INTO t_batch_tx_py VALUES (8), (16);"
+            "COMMIT;"
+        )
+        cur2 = conn.execute("SELECT SUM(a) FROM t_batch_tx_py")
+        assert cur2.fetchone() == (31,)
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Transactions
+# ---------------------------------------------------------------------------
+
+
+@needs_server
+class TestTransaction:
+    def test_commit(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_tx_commit_py")
+        conn.execute("CREATE TABLE t_tx_commit_py (a)")
+        conn.execute("BEGIN")
+        conn.execute("INSERT INTO t_tx_commit_py VALUES ('one')")
+        conn.execute("INSERT INTO t_tx_commit_py VALUES ('two')")
+        conn.commit()
+        cur = conn.execute("SELECT COUNT(*) FROM t_tx_commit_py")
+        assert cur.fetchone() == (2,)
+        conn.close()
+
+    def test_rollback(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_tx_rb_py")
+        conn.execute("CREATE TABLE t_tx_rb_py (a)")
+        conn.execute("BEGIN")
+        conn.execute("INSERT INTO t_tx_rb_py VALUES ('one')")
+        conn.rollback()
+        cur = conn.execute("SELECT COUNT(*) FROM t_tx_rb_py")
+        assert cur.fetchone() == (0,)
+        conn.close()
+
+    def test_in_transaction_tracks_server_state(self):
+        conn = make_conn()
+        assert conn.in_transaction is False
+        conn.execute("BEGIN")
+        assert conn.in_transaction is True
+        conn.execute("SELECT 1")
+        assert conn.in_transaction is True
+        conn.commit()
+        assert conn.in_transaction is False
+        conn.close()
+
+    def test_in_transaction_survives_statement_error(self):
+        conn = make_conn()
+        conn.execute("BEGIN")
+        with pytest.raises(OperationalError):
+            conn.execute("SELECT foobar")
+        assert conn.in_transaction is True
+        conn.rollback()
+        assert conn.in_transaction is False
+        conn.close()
+
+    def test_implicit_transaction_on_dml(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_tx_impl_py")
+        conn.execute("CREATE TABLE t_tx_impl_py (a)")
+        conn.execute("INSERT INTO t_tx_impl_py VALUES (1)")
+        assert conn.in_transaction is True
+        conn.commit()
+        assert conn.in_transaction is False
+        cur = conn.execute("SELECT COUNT(*) FROM t_tx_impl_py")
+        assert cur.fetchone() == (1,)
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+@needs_server
+class TestErrorHandling:
+    def test_nonexistent_table(self):
+        conn = make_conn()
+        with pytest.raises(OperationalError):
+            conn.execute("SELECT * FROM nonexistent_table_py")
+        conn.close()
+
+    def test_recovery_after_error(self):
+        conn = make_conn()
+        with pytest.raises(OperationalError):
+            conn.execute("SELECT foobar")
+        # Connection should still be usable
+        cur = conn.execute("SELECT 42")
+        assert cur.fetchone() == (42,)
+        conn.close()
+
+    def test_pk_constraint(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_pk_err_py")
+        conn.execute("CREATE TABLE t_pk_err_py (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.execute("INSERT INTO t_pk_err_py VALUES (1, 'first')")
+        with pytest.raises(IntegrityError):
+            conn.execute("INSERT INTO t_pk_err_py VALUES (1, 'duplicate')")
+        conn.close()
+
+    def test_unique_constraint(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_uq_err_py")
+        conn.execute("CREATE TABLE t_uq_err_py (id INTEGER, name TEXT UNIQUE)")
+        conn.execute("INSERT INTO t_uq_err_py VALUES (1, 'unique_name')")
+        with pytest.raises(IntegrityError):
+            conn.execute("INSERT INTO t_uq_err_py VALUES (2, 'unique_name')")
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# DB-API compliance
+# ---------------------------------------------------------------------------
+
+
+class TestDBAPICompliance:
+    def test_module_attributes(self):
+        import turso_serverless
+
+        assert turso_serverless.apilevel == "2.0"
+        assert turso_serverless.paramstyle == "qmark"
+        assert turso_serverless.threadsafety == 1
+
+    def test_exception_hierarchy(self):
+        import turso_serverless
+
+        assert issubclass(turso_serverless.Warning, Exception)
+        assert issubclass(turso_serverless.Error, Exception)
+        assert issubclass(turso_serverless.InterfaceError, turso_serverless.Error)
+        assert issubclass(turso_serverless.DatabaseError, turso_serverless.Error)
+        assert issubclass(turso_serverless.DataError, turso_serverless.DatabaseError)
+        assert issubclass(turso_serverless.OperationalError, turso_serverless.DatabaseError)
+        assert issubclass(turso_serverless.IntegrityError, turso_serverless.DatabaseError)
+        assert issubclass(turso_serverless.InternalError, turso_serverless.DatabaseError)
+        assert issubclass(turso_serverless.ProgrammingError, turso_serverless.DatabaseError)
+        assert issubclass(turso_serverless.NotSupportedError, turso_serverless.DatabaseError)
+
+
+@needs_server
+class TestDBAPICursor:
+    def test_cursor_description(self):
+        conn = make_conn()
+        cur = conn.execute("SELECT 1 AS a, 2 AS b")
+        assert cur.description is not None
+        assert len(cur.description) == 2
+        assert cur.description[0][0] == "a"
+        assert cur.description[1][0] == "b"
+        # Remaining fields are None per DB-API spec
+        for desc in cur.description:
+            assert all(d is None for d in desc[1:])
+        conn.close()
+
+    def test_fetchone_fetchall(self):
+        conn = make_conn()
+        cur = conn.execute("VALUES (1), (2), (3)")
+        assert cur.fetchone() == (1,)
+        rest = cur.fetchall()
+        assert rest == [(2,), (3,)]
+        assert cur.fetchone() is None
+        conn.close()
+
+    def test_fetchmany(self):
+        conn = make_conn()
+        cur = conn.execute("VALUES (1), (2), (3), (4), (5)")
+        batch = cur.fetchmany(3)
+        assert len(batch) == 3
+        rest = cur.fetchall()
+        assert len(rest) == 2
+        conn.close()
+
+    def test_context_manager(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_ctx_py")
+        conn.execute("CREATE TABLE t_ctx_py (a)")
+        with conn:
+            conn.execute("INSERT INTO t_ctx_py VALUES (1)")
+        # After __exit__ without error, should be committed
+        cur = conn.execute("SELECT * FROM t_ctx_py")
+        assert cur.fetchone() == (1,)
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Close
+# ---------------------------------------------------------------------------
+
+
+@needs_server
+class TestClose:
+    def test_close_connection(self):
+        conn = make_conn()
+        conn.execute("SELECT 1")
+        conn.close()
+        # Calling close again should not error
+        conn.close()
+
+    def test_close_rolls_back_open_transaction(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_close_tx_py")
+        conn.execute("CREATE TABLE t_close_tx_py (a)")
+        conn.commit()
+        conn.execute("BEGIN")
+        conn.execute("INSERT INTO t_close_tx_py VALUES (1)")
+        conn.close()
+        conn2 = make_conn()
+        cur = conn2.execute("SELECT COUNT(*) FROM t_close_tx_py")
+        assert cur.fetchone() == (0,)
+        conn2.close()
+
+
+# ---------------------------------------------------------------------------
+# DB-API error classification (no server needed)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorClassification:
+    def test_constraint_code(self):
+        e = ServerError("UNIQUE constraint failed: t.x", code="SQLITE_CONSTRAINT")
+        assert isinstance(_classify_error(e), IntegrityError)
+
+    def test_extended_constraint_code(self):
+        e = ServerError(
+            "UNIQUE constraint failed: t.x",
+            code="SQLITE_CONSTRAINT_UNIQUE",
+            extended_code="SQLITE_CONSTRAINT_UNIQUE",
+        )
+        assert isinstance(_classify_error(e), IntegrityError)
+
+    def test_code_wins_over_message_text(self):
+        # The message echoes SQL text containing "unique"; the parse error
+        # code must prevent misclassification as IntegrityError.
+        e = ServerError('near "unique": syntax error', code="SQL_PARSE_ERROR")
+        assert isinstance(_classify_error(e), OperationalError)
+        assert not isinstance(_classify_error(e), IntegrityError)
+
+    def test_codeless_message_fallback(self):
+        e = ServerError("UNIQUE constraint failed: t.x")
+        assert isinstance(_classify_error(e), IntegrityError)
+
+    def test_server_error_carries_codes(self):
+        e = _server_error(
+            {
+                "message": "UNIQUE constraint failed: t.x",
+                "code": "SQLITE_CONSTRAINT",
+                "extended_code": "SQLITE_CONSTRAINT_UNIQUE",
+            }
+        )
+        assert str(e) == "UNIQUE constraint failed: t.x"
+        assert e.code == "SQLITE_CONSTRAINT"
+        assert e.extended_code == "SQLITE_CONSTRAINT_UNIQUE"
+
+    def test_server_error_tolerates_missing_fields(self):
+        e = _server_error(None)
+        assert str(e) == "unknown error"
+        assert e.code is None
+        assert e.extended_code is None
+
+
+# ---------------------------------------------------------------------------
+# Transport failures while reading the response body (no server needed)
+# ---------------------------------------------------------------------------
+
+
+class _FailingReadResponse:
+    """Stand-in for the urlopen response whose body read fails mid-stream."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def __enter__(self) -> _FailingReadResponse:
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        raise self._exc
+
+
+class TestBodyReadFailure:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            http.client.IncompleteRead(b"partial"),
+            ConnectionResetError(54, "Connection reset by peer"),
+            TimeoutError("timed out"),
+        ],
+        ids=["incomplete-read", "connection-reset", "timeout"],
+    )
+    def test_read_failure_is_fatal_for_stream(self, monkeypatch, exc):
+        session = Session("https://db.example.com")
+        session._baton = "baton-1"
+        session._autocommit = False
+        monkeypatch.setattr(
+            urllib.request, "urlopen", lambda req: _FailingReadResponse(exc)
+        )
+        with pytest.raises(ProtocolError):
+            session.execute_pipeline([], track_autocommit=True)
+        assert session._baton is None
+        assert session.autocommit
+
+    def test_read_failure_maps_to_dbapi_error(self, monkeypatch):
+        conn = Connection(Session("https://db.example.com"))
+        monkeypatch.setattr(
+            urllib.request,
+            "urlopen",
+            lambda req: _FailingReadResponse(http.client.IncompleteRead(b"partial")),
+        )
+        with pytest.raises(OperationalError):
+            conn.execute("SELECT 1")
+
+
+# ---------------------------------------------------------------------------
+# URL normalization (no server needed)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeUrl:
+    def test_libsql_scheme(self):
+        assert normalize_url("libsql://my-db.turso.io") == "https://my-db.turso.io"
+
+    def test_turso_scheme(self):
+        assert normalize_url("turso://my-db.turso.io") == "https://my-db.turso.io"
+
+    def test_https_passthrough(self):
+        assert normalize_url("https://my-db.turso.io") == "https://my-db.turso.io"
+
+    def test_http_passthrough(self):
+        assert normalize_url("http://localhost:8080") == "http://localhost:8080"
+
+    def test_trailing_slash_stripped(self):
+        assert normalize_url("https://my-db.turso.io/") == "https://my-db.turso.io"
+        assert normalize_url("libsql://my-db.turso.io/") == "https://my-db.turso.io"
+        assert normalize_url("turso://my-db.turso.io/") == "https://my-db.turso.io"
+        assert normalize_url("http://localhost:8080//") == "http://localhost:8080"
+
+    def test_turso_with_port(self):
+        assert normalize_url("turso://my-db.turso.io:443") == "https://my-db.turso.io:443"
+
+    def test_libsql_with_port(self):
+        assert normalize_url("libsql://my-db.turso.io:8080") == "https://my-db.turso.io:8080"
+
+    def test_with_path(self):
+        assert normalize_url("turso://my-db.turso.io/v1/db") == "https://my-db.turso.io/v1/db"
+
+    def test_with_query_params(self):
+        assert normalize_url("libsql://my-db.turso.io?foo=bar") == "https://my-db.turso.io?foo=bar"

--- a/serverless/python/turso_serverless/__init__.py
+++ b/serverless/python/turso_serverless/__init__.py
@@ -1,0 +1,57 @@
+"""Pure Python serverless Turso client (DB-API 2.0).
+
+Connects to a Turso database over HTTP using the SQL over HTTP protocol.
+No Rust FFI required — uses urllib.request from stdlib.
+
+Usage:
+    import turso_serverless
+
+    conn = turso_serverless.connect("libsql://my-db.turso.io", auth_token="...")
+    cursor = conn.execute("SELECT * FROM users")
+    rows = cursor.fetchall()
+    conn.close()
+"""
+
+from .connection import Connection, Cursor, connect
+from .dbapi import (
+    # Exception classes
+    DatabaseError,
+    DataError,
+    Error,
+    IntegrityError,
+    InterfaceError,
+    InternalError,
+    NotSupportedError,
+    OperationalError,
+    ProgrammingError,
+    # Helpers
+    Row,
+    Warning,
+)
+
+# DB-API 2.0 module-level attributes
+apilevel = "2.0"
+threadsafety = 1
+paramstyle = "qmark"
+
+__all__ = [
+    "connect",
+    "Connection",
+    "Cursor",
+    "Row",
+    # DB-API 2.0 module attributes
+    "apilevel",
+    "paramstyle",
+    "threadsafety",
+    # Exception classes
+    "Warning",
+    "Error",
+    "InterfaceError",
+    "DatabaseError",
+    "DataError",
+    "OperationalError",
+    "IntegrityError",
+    "InternalError",
+    "ProgrammingError",
+    "NotSupportedError",
+]

--- a/serverless/python/turso_serverless/connection.py
+++ b/serverless/python/turso_serverless/connection.py
@@ -1,0 +1,369 @@
+"""DB-API 2.0 Connection and Cursor backed by a SQL over HTTP session."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, Callable, Optional, TypeVar
+
+from .dbapi import (
+    DatabaseError,
+    DataError,
+    Error,
+    IntegrityError,
+    InterfaceError,
+    InternalError,
+    NotSupportedError,
+    OperationalError,
+    ProgrammingError,
+    Row,
+    Warning,
+    _is_dml,
+    _is_insert_or_replace,
+)
+from .session import Session, StmtResult, _server_error
+
+_DBCursorT = TypeVar("_DBCursorT", bound="Cursor")
+
+
+def _classify_error(e: Exception) -> Exception:
+    """Map a driver error onto the DB-API exception hierarchy using the
+    protocol error code (PROTOCOL.md section 9.2). Error messages echo SQL
+    text, so they are only matched as a fallback when the server sent no
+    code."""
+    msg = str(e)
+    code = getattr(e, "code", None)
+    if code:
+        if code.startswith("SQLITE_CONSTRAINT"):
+            return IntegrityError(msg)
+        return OperationalError(msg)
+    lower = msg.lower()
+    if "constraint" in lower or "unique" in lower or "primary key" in lower:
+        return IntegrityError(msg)
+    return OperationalError(msg)
+
+
+class Connection:
+    """DB-API 2.0 Connection backed by a remote SQL over HTTP session."""
+
+    # Exception classes as attributes (like sqlite3.Connection)
+    Error = Error
+    InterfaceError = InterfaceError
+    DatabaseError = DatabaseError
+    DataError = DataError
+    OperationalError = OperationalError
+    IntegrityError = IntegrityError
+    InternalError = InternalError
+    ProgrammingError = ProgrammingError
+    NotSupportedError = NotSupportedError
+    Warning = Warning
+
+    def __init__(
+        self,
+        session: Session,
+        *,
+        isolation_level: Optional[str] = "DEFERRED",
+    ) -> None:
+        self._session = session
+        self.isolation_level = isolation_level
+        self.row_factory: Callable | type[Row] | None = None
+        self.text_factory: Any = str
+        self._autocommit_mode: object | bool = "LEGACY"
+        self._closed = False
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise ProgrammingError("Cannot operate on a closed connection")
+
+    def _execute_stmt(
+        self,
+        sql: str,
+        params: Optional[list] = None,
+        named_params: Optional[list[tuple[str, Any]]] = None,
+        want_rows: bool = True,
+    ) -> StmtResult:
+        self._ensure_open()
+        try:
+            return self._session.execute_stmt(
+                sql, args=params, named_args=named_params, want_rows=want_rows
+            )
+        except RuntimeError as e:
+            raise _classify_error(e) from None
+
+    @property
+    def in_transaction(self) -> bool:
+        """Whether an explicit transaction is open, from the server's answer
+        as of the most recently completed statement."""
+        return not self._session.autocommit
+
+    @property
+    def autocommit(self) -> object | bool:
+        return self._autocommit_mode
+
+    @autocommit.setter
+    def autocommit(self, val: object | bool) -> None:
+        if val not in (True, False, "LEGACY"):
+            raise ProgrammingError("autocommit must be True, False, or 'LEGACY'")
+        self._autocommit_mode = val
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        try:
+            # Closing the stream rolls back any open transaction server-side,
+            # matching sqlite3: uncommitted changes are lost on close.
+            self._session.close()
+        finally:
+            self._closed = True
+
+    def commit(self) -> None:
+        self._ensure_open()
+        if self.in_transaction:
+            self._execute_stmt("COMMIT", want_rows=False)
+
+    def rollback(self) -> None:
+        self._ensure_open()
+        if self.in_transaction:
+            self._execute_stmt("ROLLBACK", want_rows=False)
+
+    def cursor(self, factory: Optional[Callable[[Connection], _DBCursorT]] = None) -> _DBCursorT | Cursor:
+        self._ensure_open()
+        if factory is None:
+            return Cursor(self)
+        return factory(self)
+
+    def execute(self, sql: str, parameters: Sequence[Any] | Mapping[str, Any] = ()) -> Cursor:
+        cur = self.cursor()
+        cur.execute(sql, parameters)
+        return cur
+
+    def executemany(self, sql: str, parameters: Iterable[Sequence[Any] | Mapping[str, Any]]) -> Cursor:
+        cur = self.cursor()
+        cur.executemany(sql, parameters)
+        return cur
+
+    def executescript(self, sql_script: str) -> Cursor:
+        cur = self.cursor()
+        cur.executescript(sql_script)
+        return cur
+
+    def _maybe_implicit_begin(self, sql: str) -> None:
+        """Legacy implicit transaction behavior."""
+        if self.isolation_level is not None and not self.in_transaction and _is_dml(sql):
+            level = self.isolation_level or "DEFERRED"
+            self._execute_stmt(f"BEGIN {level}", want_rows=False)
+
+    def __enter__(self) -> Connection:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if exc_type is None:
+            self.commit()
+        else:
+            self.rollback()
+        return False
+
+
+class Cursor:
+    """DB-API 2.0 Cursor backed by eager row fetching from the remote server."""
+
+    arraysize: int
+
+    def __init__(self, connection: Connection, /) -> None:
+        self._connection = connection
+        self.arraysize = 1
+        self.row_factory: Callable | type[Row] | None = connection.row_factory
+        self._rows: list[tuple] = []
+        self._row_index = 0
+        self._description: Optional[tuple[tuple[str, None, None, None, None, None, None], ...]] = None
+        self._lastrowid: Optional[int] = None
+        self._rowcount: int = -1
+        self._closed = False
+
+    @property
+    def connection(self) -> Connection:
+        return self._connection
+
+    @property
+    def description(self) -> tuple[tuple[str, None, None, None, None, None, None], ...] | None:
+        return self._description
+
+    @property
+    def lastrowid(self) -> int | None:
+        return self._lastrowid
+
+    @property
+    def rowcount(self) -> int:
+        return self._rowcount
+
+    def close(self) -> None:
+        self._closed = True
+        self._rows = []
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise ProgrammingError("Cannot operate on a closed cursor")
+
+    @staticmethod
+    def _convert_params(
+        parameters: Sequence[Any] | Mapping[str, Any],
+    ) -> tuple[Optional[list], Optional[list[tuple[str, Any]]]]:
+        """Convert DB-API parameters to protocol args/named_args."""
+        if isinstance(parameters, Mapping):
+            named = []
+            for key, val in parameters.items():
+                # Try :name, $name, @name prefixes
+                if isinstance(key, str) and not key.startswith((":", "$", "@")):
+                    named.append((f":{key}", val))
+                else:
+                    named.append((key, val))
+            return None, named
+        params = list(parameters) if parameters else []
+        return params if params else None, None
+
+    def execute(self, sql: str, parameters: Sequence[Any] | Mapping[str, Any] = ()) -> Cursor:
+        self._ensure_open()
+        self._rows = []
+        self._row_index = 0
+
+        # Implicit transaction
+        self._connection._maybe_implicit_begin(sql)
+
+        args, named_args = self._convert_params(parameters)
+        result = self._connection._execute_stmt(
+            sql, params=args, named_params=named_args, want_rows=True,
+        )
+
+        if result.columns:
+            self._description = tuple(
+                (name, None, None, None, None, None, None) for name in result.columns
+            )
+            self._rows = result.rows
+            self._rowcount = -1
+        else:
+            self._description = None
+            self._rows = []
+            self._rowcount = result.affected_rows
+
+        if result.last_insert_rowid is not None and _is_insert_or_replace(sql):
+            self._lastrowid = result.last_insert_rowid
+
+        return self
+
+    def executemany(self, sql: str, seq_of_parameters: Iterable[Sequence[Any] | Mapping[str, Any]]) -> Cursor:
+        self._ensure_open()
+        self._rows = []
+        self._row_index = 0
+        self._description = None
+
+        if not _is_dml(sql):
+            raise ProgrammingError("executemany() requires a single DML statement")
+
+        self._connection._maybe_implicit_begin(sql)
+
+        total = 0
+        for parameters in seq_of_parameters:
+            args, named_args = self._convert_params(parameters)
+            result = self._connection._execute_stmt(
+                sql, params=args, named_params=named_args, want_rows=False,
+            )
+            total += result.affected_rows
+
+        self._rowcount = total
+        return self
+
+    def executescript(self, sql_script: str) -> Cursor:
+        """Execute multiple statements via the pipeline sequence endpoint."""
+        self._ensure_open()
+        self._rows = []
+        self._row_index = 0
+        self._description = None
+
+        # Commit any pending transaction first (sqlite3 behavior)
+        if self._connection.in_transaction:
+            self._connection._execute_stmt("COMMIT", want_rows=False)
+
+        try:
+            results = self._connection._session.execute_pipeline(
+                [{"type": "sequence", "sql": sql_script}]
+            )
+        except RuntimeError as e:
+            raise _classify_error(e) from None
+
+        result = results[0]
+        if result.get("type") == "error":
+            raise _classify_error(_server_error(result.get("error")))
+
+        self._rowcount = -1
+        return self
+
+    def _apply_row_factory(self, row_values: tuple) -> Any:
+        rf = self.row_factory
+        if rf is None:
+            return row_values
+        if isinstance(rf, type) and issubclass(rf, Row):
+            return rf(self, Row(self, row_values))
+        if callable(rf):
+            return rf(self, Row(self, row_values))
+        return row_values
+
+    def fetchone(self) -> Any:
+        self._ensure_open()
+        if self._row_index >= len(self._rows):
+            return None
+        row = self._rows[self._row_index]
+        self._row_index += 1
+        return self._apply_row_factory(row)
+
+    def fetchmany(self, size: Optional[int] = None) -> list[Any]:
+        self._ensure_open()
+        if size is None:
+            size = self.arraysize
+        result = []
+        for _ in range(size):
+            row = self.fetchone()
+            if row is None:
+                break
+            result.append(row)
+        return result
+
+    def fetchall(self) -> list[Any]:
+        self._ensure_open()
+        result = []
+        while True:
+            row = self.fetchone()
+            if row is None:
+                break
+            result.append(row)
+        return result
+
+    def setinputsizes(self, sizes: Any, /) -> None:
+        return None
+
+    def setoutputsize(self, size: Any, column: Any = None, /) -> None:
+        return None
+
+    def __iter__(self) -> Cursor:
+        return self
+
+    def __next__(self) -> Any:
+        row = self.fetchone()
+        if row is None:
+            raise StopIteration
+        return row
+
+
+def connect(
+    url: str,
+    *,
+    auth_token: Optional[str] = None,
+    isolation_level: Optional[str] = "DEFERRED",
+) -> Connection:
+    """Open a remote connection to a Turso database.
+
+    Parameters:
+    - url: Database URL (turso://, https://, http://, or libsql://)
+    - auth_token: Authentication token
+    - isolation_level: Transaction isolation level (default: DEFERRED)
+    """
+    session = Session(url, auth_token=auth_token)
+    return Connection(session, isolation_level=isolation_level)

--- a/serverless/python/turso_serverless/dbapi.py
+++ b/serverless/python/turso_serverless/dbapi.py
@@ -1,0 +1,171 @@
+"""DB-API 2.0 exception hierarchy, Row class, and SQL classification helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+
+# DB-API 2.0 exception hierarchy
+class Warning(Exception):
+    pass
+
+
+class Error(Exception):
+    pass
+
+
+class InterfaceError(Error):
+    pass
+
+
+class DatabaseError(Error):
+    pass
+
+
+class DataError(DatabaseError):
+    pass
+
+
+class OperationalError(DatabaseError):
+    pass
+
+
+class IntegrityError(DatabaseError):
+    pass
+
+
+class InternalError(DatabaseError):
+    pass
+
+
+class ProgrammingError(DatabaseError):
+    pass
+
+
+class NotSupportedError(DatabaseError):
+    pass
+
+
+# SQL classification helpers
+
+def _first_keyword(sql: str) -> str:
+    """
+    Return the first SQL keyword (uppercased) ignoring leading whitespace
+    and single-line and multi-line comments.
+
+    This is intentionally minimal and only used to detect DML for implicit
+    transaction handling. It may not handle all edge cases (e.g. complex WITH).
+    """
+    i = 0
+    n = len(sql)
+    while i < n:
+        c = sql[i]
+        if c.isspace():
+            i += 1
+            continue
+        if c == "-" and i + 1 < n and sql[i + 1] == "-":
+            # line comment
+            i += 2
+            while i < n and sql[i] not in ("\r", "\n"):
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and sql[i + 1] == "*":
+            # block comment
+            i += 2
+            while i + 1 < n and not (sql[i] == "*" and sql[i + 1] == "/"):
+                i += 1
+            i = min(i + 2, n)
+            continue
+        break
+    # read token
+    j = i
+    while j < n and (sql[j].isalpha() or sql[j] == "_"):
+        j += 1
+    return sql[i:j].upper()
+
+
+def _is_dml(sql: str) -> bool:
+    kw = _first_keyword(sql)
+    if kw in ("INSERT", "UPDATE", "DELETE", "REPLACE"):
+        return True
+    # "WITH" can also prefix DML, but we conservatively skip it to avoid false positives.
+    return False
+
+
+def _is_insert_or_replace(sql: str) -> bool:
+    kw = _first_keyword(sql)
+    return kw in ("INSERT", "REPLACE")
+
+
+# Row class — duck-typed cursor (accepts Any for cursor parameter)
+
+class Row(Sequence[Any]):
+    """
+    sqlite3.Row-like container supporting index and name-based access.
+    """
+
+    def __new__(cls, cursor: Any, data: tuple[Any, ...], /) -> "Row":
+        obj = super().__new__(cls)
+        # Attach metadata
+        obj._cursor = cursor
+        obj._data = data
+        # Build mapping from column name to index
+        desc = cursor.description or ()
+        obj._keys = tuple(col[0] for col in desc)
+        obj._index = {name: idx for idx, name in enumerate(obj._keys)}
+        return obj
+
+    def keys(self) -> list[str]:
+        return list(self._keys)
+
+    def __getitem__(self, key: int | str | slice, /) -> Any:
+        if isinstance(key, slice):
+            return self._data[key]
+        if isinstance(key, int):
+            return self._data[key]
+        # key is column name
+        idx = self._index.get(key)
+        if idx is None:
+            raise KeyError(key)
+        return self._data[idx]
+
+    def __hash__(self) -> int:
+        return hash((self._keys, self._data))
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __eq__(self, value: object, /) -> bool:
+        if not isinstance(value, Row):
+            return NotImplemented  # type: ignore[return-value]
+        return self._keys == value._keys and self._data == value._data
+
+    def __ne__(self, value: object, /) -> bool:
+        if not isinstance(value, Row):
+            return NotImplemented  # type: ignore[return-value]
+        return not self.__eq__(value)
+
+    # The rest return NotImplemented for non-Row comparisons
+    def __lt__(self, value: object, /) -> bool:
+        if not isinstance(value, Row):
+            return NotImplemented  # type: ignore[return-value]
+        return (self._keys, self._data) < (value._keys, value._data)
+
+    def __le__(self, value: object, /) -> bool:
+        if not isinstance(value, Row):
+            return NotImplemented  # type: ignore[return-value]
+        return (self._keys, self._data) <= (value._keys, value._data)
+
+    def __gt__(self, value: object, /) -> bool:
+        if not isinstance(value, Row):
+            return NotImplemented  # type: ignore[return-value]
+        return (self._keys, self._data) > (value._keys, value._data)
+
+    def __ge__(self, value: object, /) -> bool:
+        if not isinstance(value, Row):
+            return NotImplemented  # type: ignore[return-value]
+        return (self._keys, self._data) >= (value._keys, value._data)

--- a/serverless/python/turso_serverless/protocol.py
+++ b/serverless/python/turso_serverless/protocol.py
@@ -1,0 +1,103 @@
+"""Value encoding and request building for the SQL over HTTP protocol."""
+
+from __future__ import annotations
+
+import base64
+import math
+from typing import Any, Optional
+
+
+class ServerError(RuntimeError):
+    """An error the server reported for a statement or stream request,
+    carrying the machine-readable error codes (section 9.1) when the
+    server sent them."""
+
+    def __init__(
+        self,
+        message: str,
+        code: Optional[str] = None,
+        extended_code: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.extended_code = extended_code
+
+
+class ProtocolError(RuntimeError):
+    """A transport failure or a response that violates the protocol."""
+
+
+def encode_value(value: Any) -> dict:
+    """Encode a Python value to a protocol value (section 8)."""
+    if value is None:
+        return {"type": "null"}
+    if isinstance(value, bool):
+        return {"type": "integer", "value": str(int(value))}
+    if isinstance(value, int):
+        return {"type": "integer", "value": str(value)}
+    if isinstance(value, float):
+        # The protocol forbids sending non-finite floats (section 8.2).
+        if math.isnan(value):
+            # SQLite binds NaN as NULL; JSON cannot carry it.
+            return {"type": "null"}
+        if math.isinf(value):
+            raise ValueError("infinite float values cannot be sent over the protocol")
+        return {"type": "float", "value": value}
+    if isinstance(value, str):
+        return {"type": "text", "value": value}
+    if isinstance(value, (bytes, bytearray)):
+        return {"type": "blob", "base64": base64.b64encode(value).decode("ascii")}
+    raise TypeError(f"Unsupported value type: {type(value).__name__}")
+
+
+def decode_value(pv: dict) -> Any:
+    """Decode a protocol value (section 8) to a Python value."""
+    try:
+        typ = pv["type"]
+        if typ == "null":
+            return None
+        if typ == "integer":
+            return int(pv["value"])
+        if typ == "float":
+            raw = pv["value"]
+            # A null value encodes a non-finite float (section 8.2); the
+            # spec says to decode it as NaN.
+            if raw is None:
+                return math.nan
+            return float(raw)
+        if typ == "text":
+            return pv["value"]
+        if typ == "blob":
+            # The server may omit base64 padding (section 8).
+            b64 = pv["base64"]
+            return base64.b64decode(b64 + "=" * (-len(b64) % 4))
+    except (KeyError, TypeError, ValueError) as e:
+        raise ProtocolError(f"invalid value in server response: {e}") from None
+    raise ProtocolError(f"unsupported value type in server response: {typ!r}")
+
+
+def build_batch_step(
+    sql: str,
+    args: Optional[list] = None,
+    named_args: Optional[list[tuple[str, Any]]] = None,
+    want_rows: bool = True,
+    condition: Optional[dict] = None,
+) -> dict:
+    """Build a batch step for a cursor request (section 7)."""
+    encoded_args = [encode_value(a) for a in args] if args else []
+    encoded_named = (
+        [{"name": name, "value": encode_value(val)} for name, val in named_args]
+        if named_args
+        else []
+    )
+    step: dict = {
+        "stmt": {
+            "sql": sql,
+            "args": encoded_args,
+            "named_args": encoded_named,
+            "want_rows": want_rows,
+        },
+    }
+    if condition is not None:
+        step["condition"] = condition
+    return step

--- a/serverless/python/turso_serverless/session.py
+++ b/serverless/python/turso_serverless/session.py
@@ -1,0 +1,316 @@
+"""HTTP session management: one session per connection, tracking the
+stream baton, base URL, and transaction state."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .protocol import ProtocolError, ServerError, build_batch_step, decode_value
+
+
+def normalize_url(url: str) -> str:
+    """Rewrite libsql:// and turso:// URLs to https:// and strip any
+    trailing slashes, since endpoint paths are appended with a leading
+    slash."""
+    if url.startswith("libsql://"):
+        url = "https://" + url[len("libsql://"):]
+    elif url.startswith("turso://"):
+        url = "https://" + url[len("turso://"):]
+    return url.rstrip("/")
+
+
+def _server_error(error: Optional[dict]) -> ServerError:
+    """Build a ServerError from a protocol error object (section 9.1),
+    tolerating missing fields."""
+    message = "unknown error"
+    code = None
+    extended_code = None
+    if isinstance(error, dict):
+        if isinstance(error.get("message"), str):
+            message = error["message"]
+        if isinstance(error.get("code"), str):
+            code = error["code"]
+        if isinstance(error.get("extended_code"), str):
+            extended_code = error["extended_code"]
+    return ServerError(message, code=code, extended_code=extended_code)
+
+
+@dataclass
+class StmtResult:
+    """The decoded output of one executed statement."""
+
+    columns: list[str]
+    rows: list[tuple]
+    affected_rows: int
+    last_insert_rowid: Optional[int]
+
+
+# Index of the autocommit probe step appended to every cursor batch.
+_PROBE_STEP = 1
+
+
+def _parse_cursor_body(raw: bytes) -> tuple[dict, list[dict]]:
+    """Split a cursor response body (section 7.1) into the cursor response
+    line and the decoded entries that follow it."""
+    lines = [line for line in raw.decode("utf-8").splitlines() if line.strip()]
+    if not lines:
+        raise ProtocolError("cursor response body ended before the cursor response line")
+    try:
+        cursor_resp = json.loads(lines[0])
+    except ValueError as e:
+        raise ProtocolError(f"invalid cursor response: {e}") from None
+    entries = []
+    for line in lines[1:]:
+        try:
+            entries.append(json.loads(line))
+        except ValueError as e:
+            raise ProtocolError(f"invalid cursor entry: {e}") from None
+    return cursor_resp, entries
+
+
+class _CursorDecoder:
+    """Folds streamed cursor entries (section 7.2) into a statement result,
+    tracking the trailing autocommit probe step separately from the caller's
+    step."""
+
+    def __init__(self) -> None:
+        self.result = StmtResult(columns=[], rows=[], affected_rows=0, last_insert_rowid=None)
+        self.step_error: Optional[ServerError] = None
+        self.fatal: Optional[ServerError] = None
+        self.probe_executed = False
+        self.probe_unreliable = False
+        self._in_probe = False
+
+    def feed(self, entry: dict) -> None:
+        etype = entry.get("type")
+        if etype == "step_begin":
+            self._step_begin(entry)
+        elif etype == "row":
+            self._row(entry)
+        elif etype == "step_end":
+            self._step_end(entry)
+        elif etype == "step_error":
+            self._step_error(entry)
+        elif etype == "error":
+            self.fatal = _server_error(entry.get("error"))
+        # replication_index (section 7.2.6) and unknown entries are
+        # ignored; a cleanly ended body is complete without a terminator.
+
+    def _step_begin(self, entry: dict) -> None:
+        if entry.get("step") == _PROBE_STEP:
+            self._in_probe = True
+            self.probe_executed = True
+        else:
+            self._in_probe = False
+            self.result.columns = [c.get("name") or "" for c in entry.get("cols") or []]
+
+    def _row(self, entry: dict) -> None:
+        if self._in_probe or self.step_error is not None:
+            return
+        self.result.rows.append(tuple(decode_value(v) for v in entry.get("row") or []))
+
+    def _step_end(self, entry: dict) -> None:
+        if self._in_probe:
+            return
+        self.result.affected_rows = entry.get("affected_row_count") or 0
+        rowid = entry.get("last_insert_rowid")
+        if rowid is not None:
+            try:
+                self.result.last_insert_rowid = int(rowid)
+            except (TypeError, ValueError) as e:
+                raise ProtocolError(f"invalid rowid in server response: {e}") from None
+
+    def _step_error(self, entry: dict) -> None:
+        if entry.get("step") == _PROBE_STEP:
+            self.probe_unreliable = True
+        elif self.step_error is None:
+            self.step_error = _server_error(entry.get("error"))
+        self._in_probe = False
+
+
+class Session:
+    """Manages one server-side stream: the baton, the base URL, and the
+    server-reported transaction state."""
+
+    def __init__(self, url: str, auth_token: Optional[str] = None) -> None:
+        self._auth_token = auth_token
+        self._base_url = normalize_url(url)
+        self._baton: Optional[str] = None
+        # Whether the connection is in autocommit mode, from the server's
+        # most recent authoritative answer. A non-null baton does NOT imply
+        # a transaction (section 4.3), so this is tracked explicitly: every
+        # pipeline carries a `get_autocommit` request and every cursor batch
+        # a trailing step gated on `is_autocommit`.
+        self._autocommit = True
+
+    @property
+    def autocommit(self) -> bool:
+        return self._autocommit
+
+    def _reset_stream(self) -> None:
+        """Forget the stream. Any transaction on it was (or will be) rolled
+        back by the server, so the connection is back in autocommit mode."""
+        self._baton = None
+        self._autocommit = True
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._auth_token:
+            headers["Authorization"] = f"Bearer {self._auth_token}"
+        return headers
+
+    def _post(self, path: str, body: dict) -> bytes:
+        """POST a request that carries the current baton. Any failure,
+        including a non-200 response, is fatal for the stream (section 9.3):
+        the error surfaces to the caller and the next statement starts a
+        fresh stream. The driver never re-sends a request on its own;
+        whether re-running a failed statement is safe is the application's
+        call."""
+        url = f"{self._base_url}{path}"
+        # allow_nan=False so a non-finite float can never leave the client
+        # as the invalid JSON tokens NaN/Infinity (section 8.2).
+        data = json.dumps(body, allow_nan=False).encode("utf-8")
+        req = urllib.request.Request(url, data=data, headers=self._headers(), method="POST")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as e:
+            raw = e.read().decode("utf-8", errors="replace")
+            self._reset_stream()
+            message = None
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, dict):
+                    for key in ("error", "message"):
+                        if isinstance(parsed.get(key), str):
+                            message = parsed[key]
+                            break
+            except ValueError:
+                pass
+            if message is not None:
+                raise ProtocolError(f"HTTP status {e.code}: {message}") from None
+            raise ProtocolError(f"HTTP status {e.code}") from None
+        except urllib.error.URLError as e:
+            self._reset_stream()
+            raise ProtocolError(f"request to {url} failed: {e.reason}") from None
+        except (http.client.HTTPException, OSError) as e:
+            # Reading the body can fail after urlopen returned, e.g. with
+            # IncompleteRead on a truncated chunked response or a connection
+            # reset; URLError does not cover these, but they are equally
+            # fatal for the stream.
+            self._reset_stream()
+            raise ProtocolError(f"request to {url} failed: {e!r}") from None
+
+    def _update_stream(self, baton: Optional[str], base_url: Optional[str]) -> None:
+        self._baton = baton
+        if base_url:
+            self._base_url = normalize_url(base_url)
+
+    def execute_pipeline(self, requests: list[dict], track_autocommit: bool = True) -> list[dict]:
+        """Execute a pipeline (section 5). When `track_autocommit` is set, a
+        `get_autocommit` request is appended and its answer refreshes the
+        cached transaction state; the returned results cover only the
+        caller's requests."""
+        reqs = list(requests)
+        if track_autocommit:
+            reqs.append({"type": "get_autocommit"})
+        raw = self._post("/v3/pipeline", {"baton": self._baton, "requests": reqs})
+        try:
+            resp: dict[str, Any] = json.loads(raw)
+        except ValueError as e:
+            self._reset_stream()
+            raise ProtocolError(f"invalid pipeline response: {e}") from None
+        self._update_stream(resp.get("baton"), resp.get("base_url"))
+        results = resp.get("results") or []
+        # The protocol guarantees one result per request (section 5.2); a
+        # mismatch would misattribute results to the wrong requests.
+        if len(results) != len(reqs):
+            raise ProtocolError(
+                f"pipeline response has {len(results)} results for {len(reqs)} requests"
+            )
+        if track_autocommit:
+            result = results.pop()
+            if result.get("type") == "error":
+                raise _server_error(result.get("error"))
+            response = result.get("response") or {}
+            if response.get("type") != "get_autocommit" or not isinstance(
+                response.get("is_autocommit"), bool
+            ):
+                raise ProtocolError(
+                    f"expected get_autocommit result in pipeline response, got {response}"
+                )
+            self._autocommit = response["is_autocommit"]
+        return results
+
+    def _refresh_autocommit(self) -> None:
+        """Refresh the cached transaction state with a standalone
+        `get_autocommit` request. Failures are swallowed: this runs on error
+        paths where the original failure must not be masked, and a dead
+        stream already reset the state to autocommit."""
+        try:
+            self.execute_pipeline([], track_autocommit=True)
+        except Exception:
+            pass
+
+    @staticmethod
+    def _autocommit_probe_step() -> dict:
+        """The trailing batch step appended to every cursor batch: a no-op
+        statement gated on `is_autocommit`. The cursor endpoint cannot carry
+        a `get_autocommit` request, so whether this step executed tells us
+        the connection's transaction state without an extra round trip."""
+        return build_batch_step("SELECT 1", want_rows=False, condition={"type": "is_autocommit"})
+
+    def execute_stmt(
+        self,
+        sql: str,
+        args: Optional[list] = None,
+        named_args: Optional[list[tuple[str, Any]]] = None,
+        want_rows: bool = True,
+    ) -> StmtResult:
+        """Execute a single statement on the cursor endpoint (section 7),
+        decoding the streamed entries into a buffered result."""
+        steps = [
+            build_batch_step(sql, args=args, named_args=named_args, want_rows=want_rows),
+            self._autocommit_probe_step(),
+        ]
+        raw = self._post("/v3/cursor", {"baton": self._baton, "batch": {"steps": steps}})
+        decoder = _CursorDecoder()
+        try:
+            cursor_resp, entries = _parse_cursor_body(raw)
+            self._update_stream(cursor_resp.get("baton"), cursor_resp.get("base_url"))
+            for entry in entries:
+                decoder.feed(entry)
+                if decoder.fatal is not None:
+                    break
+        except ProtocolError:
+            # A malformed body or value from the server; abandon the stream
+            # rather than resume it in an unknown position.
+            self._reset_stream()
+            raise
+        if decoder.fatal is not None:
+            # The cursor died but the stream may survive; ask the server
+            # for the authoritative transaction state.
+            self._refresh_autocommit()
+            raise decoder.step_error or decoder.fatal
+        if decoder.probe_unreliable:
+            self._refresh_autocommit()
+        else:
+            self._autocommit = decoder.probe_executed
+        if decoder.step_error is not None:
+            raise decoder.step_error
+        return decoder.result
+
+    def close(self) -> None:
+        """Close the stream (section 6.8). Errors are ignored: the stream
+        may already have expired."""
+        if self._baton is not None:
+            try:
+                self.execute_pipeline([{"type": "close"}], track_autocommit=False)
+            except Exception:
+                pass
+        self._reset_stream()

--- a/serverless/python/uv.lock
+++ b/serverless/python/uv.lock
@@ -1,0 +1,276 @@
+version = 1
+requires-python = ">=3.10"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740 },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.161.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/96/35022710908b82d20af0c57ab8be4d4a3e4045a74d3ae9c806eb4443297c/hypothesis-6.161.0.tar.gz", hash = "sha256:c357150f826fc7492304621d535a23e8f1b7440a3b10a337c23bea52102e2e7f", size = 485855 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/b9/c8b80fb7517e6f3039d0ef9a5df6aaee53667935e62c6c9d9d635436708d/hypothesis-6.161.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c9f877e288dfb46207b5c3bfcc8ab28e2613e529be8621816423960403377286", size = 766230 },
+    { url = "https://files.pythonhosted.org/packages/90/16/e5c1287fee682f7c1e9afccc91c07ae36a6855a5863d0b3c15d7bfa0b322/hypothesis-6.161.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b7b6980265cb04605b2b42132dc8ef5735917fc482869298611a49d2e06dc322", size = 761883 },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/d9792e24e53f82bb1455935f79cf3b56ccf556fac325c8a90f7968180706/hypothesis-6.161.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f10253cac459922cad3bc09e397718188e57dffefe810e5db1d444e7113d7fb5", size = 1091083 },
+    { url = "https://files.pythonhosted.org/packages/f7/15/33cba9c6bee8a80ab18f48e40669038275bf4b82e8dfb0fa9fe716925265/hypothesis-6.161.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:232ab78dd8cb0a891914d20697e0fd340ca1e6d4d8d5855df5e433d8161173e2", size = 1140530 },
+    { url = "https://files.pythonhosted.org/packages/bb/f6/30c421822cd65b8edd56b2b90a5e1acf4a624d5619067957668027ab7e46/hypothesis-6.161.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:264336ca1e9f31edd24a8885c4020db8e18986c51a255613db28c076ac4289a8", size = 1132680 },
+    { url = "https://files.pythonhosted.org/packages/e9/db/d18e45339b2ffda57a52395e03df6166bc4e428bc90e878dd3f20a7423c0/hypothesis-6.161.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:323aac4347e6ffa86929407b7f386cbf54e1c66faf923ffd6b4b86c21815d117", size = 1264892 },
+    { url = "https://files.pythonhosted.org/packages/c7/7e/f4b7600272fbc9a2b28c95b96059d89cf5093ae705e52360a818df8154a5/hypothesis-6.161.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5dc83c8e83b9d133babcf9468703cece0ddb25413983561f2516927edddcc52d", size = 1307563 },
+    { url = "https://files.pythonhosted.org/packages/d6/28/fa4f2d50c7434076ec7653a8372750531576e4d11cd5f3316ad83e12a553/hypothesis-6.161.0-cp310-abi3-win32.whl", hash = "sha256:75a3036121e6ae2cf55b7433f1953834cc9eca97c2e4e4be3369fe080c86b237", size = 652098 },
+    { url = "https://files.pythonhosted.org/packages/93/5c/6811eee772a5cc33f9bf863326983f493977e9aee9535c8dbb6c172575d3/hypothesis-6.161.0-cp310-abi3-win_amd64.whl", hash = "sha256:e3f5b2527789a748b54d6ef46b2b042f3225164d54c24ba74a137ddb10a39407", size = 658272 },
+    { url = "https://files.pythonhosted.org/packages/97/97/49216c1087962033451cc6e3093deb765b0d14eed7dda2980f6d8dfc9062/hypothesis-6.161.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:38eea270b81398c9e2c7eed028f53ba51dc7005eb97fa681c7c90007ba029423", size = 766930 },
+    { url = "https://files.pythonhosted.org/packages/9a/6d/766a280bea353045ae7311ba847a50ebb939155e2a990fd08040be2b6b5b/hypothesis-6.161.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b6b7183980c7729d7cf084ab26c127e4c591876536278ecb84ed2449d4d93f4e", size = 762699 },
+    { url = "https://files.pythonhosted.org/packages/62/86/f28648668b5ce18bba7ae846c629c54427aa622a76280309c3bc3dca4f2d/hypothesis-6.161.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3e60bbe528d6005373146808bd0b5e618bf1a20e912c0568ae56802e8c455fc", size = 1091551 },
+    { url = "https://files.pythonhosted.org/packages/52/e3/3ae24ad1056e1c992dade22e9c784c93d57ea0dc3ff9fa6a48683548489d/hypothesis-6.161.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3167e3153a9b8a8ad43284a22cbe1e3c1819d6d944f727f9810bb115a9c2ade", size = 1141106 },
+    { url = "https://files.pythonhosted.org/packages/c4/37/fa3a21edcd7c4a104d6782ee98135af8ef86ae42d39ea9eb55072f84b668/hypothesis-6.161.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1489ef3b86688fc0051d0c86db238ff8f3732bd353dc4b6b28a81c3897bd756e", size = 1265529 },
+    { url = "https://files.pythonhosted.org/packages/6e/2e/f377a5ea8aba231213da1b26f333a6af29c43fcdac7dda790304dd9c3ffc/hypothesis-6.161.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28a450d338067845870b03a8c61ba6d83cccf5d1ed360a6b1cfebb4f42818791", size = 1307881 },
+    { url = "https://files.pythonhosted.org/packages/8f/73/276defee614d45462a1512888283d4a9bdf852e3f9d74f564bd8d6cecd09/hypothesis-6.161.0-cp310-cp310-win_amd64.whl", hash = "sha256:170fc6fe2157c8e813818a08709d78c79ffa9171b015389c50f5538eab3de1bb", size = 658159 },
+    { url = "https://files.pythonhosted.org/packages/dc/1f/07054e18c7696fe5aa127952e1ff2b74c7917100e0998d77405f9aea7bbf/hypothesis-6.161.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:2658a95ac7cf1943b9397725d58481373a1709e79b6867628108f695b202ff3f", size = 766737 },
+    { url = "https://files.pythonhosted.org/packages/21/1b/6a04fbda729f5889b486aa3b20912ee6c7391c8db0a2926346a1b3ad0834/hypothesis-6.161.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:584906b4f8f9504d7c9d6fd3c42bf991fa42ab64c3a4490a84d6e4acf69fe7fe", size = 762514 },
+    { url = "https://files.pythonhosted.org/packages/35/12/609a956b716ab20cb81263d8e0cecfe442fb46e4d54ae9b82b453f2465fe/hypothesis-6.161.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87a996d0a1c865173ed67a0b3537efbe6736bcf9f58ac28826712a48ed8d2d23", size = 1091414 },
+    { url = "https://files.pythonhosted.org/packages/fc/99/093bc8aca6dddc05e88dd0baa64c5586e031737d798c66e770fbeb034510/hypothesis-6.161.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0250e209ed2401cf6c80c956c5c1906097b537d05fa748f03e9c53060a837d3f", size = 1140888 },
+    { url = "https://files.pythonhosted.org/packages/65/fc/f681828dc1ca13243622eb6ddc3f7370efb1cb7931ea7505f8ade4d37ba6/hypothesis-6.161.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:210024a6e84c361803545ca055218bcae06e17fcb53d5956db7db6a1e14d7769", size = 1265245 },
+    { url = "https://files.pythonhosted.org/packages/53/d4/98deace31c31369196ece4d6f32bb8c1820bf5cf5584721bda791bffa0cc/hypothesis-6.161.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c3e39be8141496a73115f1ea2c8fd7146f78d26f148e884f3d4a68dec06418a0", size = 1307841 },
+    { url = "https://files.pythonhosted.org/packages/c3/5d/d9bbe1fc769e46b21d368497d4739375fcb17270eba611bac1117473e337/hypothesis-6.161.0-cp311-cp311-win_amd64.whl", hash = "sha256:e234937af9de105e28dc7ffdac5d7932265abb5881f0264aff01d3515baee732", size = 657953 },
+    { url = "https://files.pythonhosted.org/packages/01/f5/b01692ea422f9995260435a5c2a425dd558ceb0b6544cf4037d312b52927/hypothesis-6.161.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8cf6149e5bcb1deaa3d029280c2c9a47fede2186ea58d8dc3e71864428b748b5", size = 767859 },
+    { url = "https://files.pythonhosted.org/packages/1e/ea/147f96f352a1c62f4fa4d46ec2d8b103d39cafce236826531aba9dfbf6fc/hypothesis-6.161.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:439b9ccefc2b87b9752752d2ec6c9d40f92de2acaf07f4da94c2ebcbde4eb660", size = 759491 },
+    { url = "https://files.pythonhosted.org/packages/44/05/c1ddd72ca9af054332a05bdb19b666b1dbb4ff904cac2b6e04bc483518fa/hypothesis-6.161.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35c577d4b635b914e2cdd59d144448e0de82e47f8422d8373cbb48daa5571686", size = 1089838 },
+    { url = "https://files.pythonhosted.org/packages/46/79/0d9adc2ca7fe226e4f81e0e9ff88ab9a2025395a705e55e8447e8833b2e2/hypothesis-6.161.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:894af9777f2fd51bca9625fd07573456c1fa67b6bed3f6aa1659cb60255594e0", size = 1139915 },
+    { url = "https://files.pythonhosted.org/packages/50/48/c557ee9899ab58e6d373712dcfe019b4eb65035f5bbffcb7624201984bd4/hypothesis-6.161.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c9f15d18d3041216d80d2a3203c1b8881efb7c20296f068651e2ad34f3852392", size = 1262692 },
+    { url = "https://files.pythonhosted.org/packages/1c/37/8eede820af48d8f7a73c0741c659b4839ffe9825b020affe43d52f58acb5/hypothesis-6.161.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f5588bde17a517c943b5ef6172cacfce6ef2d542c9249cc1bd86ce3c4c07161b", size = 1306904 },
+    { url = "https://files.pythonhosted.org/packages/ba/6b/16282f58b92b6698dbed7b23d7015fb9f7d5dfb78e7ba2e4b44c88116bca/hypothesis-6.161.0-cp312-cp312-win_amd64.whl", hash = "sha256:c7994d32bcca19b7cbf3c087172245fe9f4d55b21bccef81693efd5a0637d4d9", size = 655392 },
+    { url = "https://files.pythonhosted.org/packages/27/13/50b3fabaa9a52f82905d6bf70b0027cbc61972f0b60dcf68506e4a85674f/hypothesis-6.161.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:d5217e3df508ab71303bf1288b412548e96483eef195f6008b6472770e4fe4ed", size = 767734 },
+    { url = "https://files.pythonhosted.org/packages/72/0c/0176f7722896dffef2aa677699df75cd2a53ed00d4dc6b2959c40c1c8389/hypothesis-6.161.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ad4899908abec1888d0d16eb70acd54c9d8198b58410ec26a346ba35d384fc0d", size = 759394 },
+    { url = "https://files.pythonhosted.org/packages/97/1d/5ade6e0c80ce8160bbcd55c300d95a5450cdb82fa04fdcdd8a33f6198441/hypothesis-6.161.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fee553e5150af6d66ee058f3ccbc3b5b83e6df62139e8935abd0510254a2d4a7", size = 1089752 },
+    { url = "https://files.pythonhosted.org/packages/99/02/14c6d54e60159ba9991a52b14ea5a9b6935d4878ffe9d0a8fabd2d166767/hypothesis-6.161.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f8110cd815f3a79e2351700654c21771eec47d98a78db56cc81879d41f08ed1", size = 1139731 },
+    { url = "https://files.pythonhosted.org/packages/36/98/c099c382b0fbf6dfd209d35961e6ee9739ad1d787288a40eb364b278217a/hypothesis-6.161.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:16aacb26a277d25da7466f0588c2687811334455753d513c55d8ca4dbbc5174e", size = 1262736 },
+    { url = "https://files.pythonhosted.org/packages/f1/3a/6b1fbde6e2a1c9bd54acb1e5d8fa866c6fef59a829a67ca310f5d12a8fbe/hypothesis-6.161.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eb24cf5f7f301ad3db14caa4462ebc2e693fe38815d793ff6dbc116820b18dff", size = 1306628 },
+    { url = "https://files.pythonhosted.org/packages/8b/c2/033da1694f956f0c566b12a1f0667138ad06a3b0a67837f17c6873cc2513/hypothesis-6.161.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4f715f5598444a0d569aa8a3e74ebc14a46c67a873193db38c8542b2838e91f", size = 655355 },
+    { url = "https://files.pythonhosted.org/packages/2b/26/29582b8ba467eedf270515422f41cb564d06b4eef38bdf06e236cc841546/hypothesis-6.161.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:a046954e17a1edd20b6c95e9d29f1df7bc20ccab94c01aa8b4177552896230fb", size = 767928 },
+    { url = "https://files.pythonhosted.org/packages/f7/25/bb7cfd851f6b0f4b0130485785a3447621523116b89f8d82042fb9897752/hypothesis-6.161.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2d503b0fdb916371d536b33fad0c4f909846af2fc4273d3049ca6fe661aa81ff", size = 759542 },
+    { url = "https://files.pythonhosted.org/packages/d9/ab/bc31d4aa5840c2438e011a615095b0e2fae5de94c3abfc18a01686825ea7/hypothesis-6.161.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df011a94870dc3e1b5fb4fb8d2c68dd641b412a3b73050288d85af1467c9a689", size = 1090304 },
+    { url = "https://files.pythonhosted.org/packages/51/ee/6304f6184aee6a1b91fff746a767b4f3aab58c29e48e64cc16d56fc6dedc/hypothesis-6.161.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4678e3988503b3bd5be0ed995f84cc15ac4f99c168bade32456a08c04868f3f3", size = 1139915 },
+    { url = "https://files.pythonhosted.org/packages/f5/6d/23efce26bf7f1773346732c58a23cbe33ed4f171da1bb3aa11bf349fdb4c/hypothesis-6.161.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:74c6e5b5623f37eb6af8be6f861d138fac3ee3528ee30c3b48ff11c39f7be4b7", size = 1263070 },
+    { url = "https://files.pythonhosted.org/packages/0b/a2/e0b4bf410630f16661eea6fdf9c3970e47c749a837de12098d63c81bb01b/hypothesis-6.161.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b841c25267ab360812a523d1861e0b0ed0f5cc4e6d7bcecc9d9eddd3f835aa0f", size = 1306929 },
+    { url = "https://files.pythonhosted.org/packages/03/13/58047eb148a31ae7cce26ec0b2f0e980c46874c6673c1110c53684ba181a/hypothesis-6.161.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:a0f3830c1e816e34bd8cd940244c8c877dedc2ecfea771d2ecea252bc35eb21d", size = 599455 },
+    { url = "https://files.pythonhosted.org/packages/f0/0e/a206013edd7dfd44b9a81ae1946a1ea30d878974850d60a61fa128cc170d/hypothesis-6.161.0-cp314-cp314-win_amd64.whl", hash = "sha256:d1d38f05acb9c25181157f1756f5faaa1759b4641ff6b32cb1d2ab1d55d6af2d", size = 655306 },
+    { url = "https://files.pythonhosted.org/packages/e2/74/32d224a0ccf4ca9af6acc1d805047e12cd13105e0769d54ac00a86f25850/hypothesis-6.161.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:81570959521eebd0172ea9132ffab71b90050e7cd44d045da67210aa9a594376", size = 766503 },
+    { url = "https://files.pythonhosted.org/packages/ce/5d/8b61c3490fd8195a25fdc37e951ccba3ae4df2c74839ffe6a6d5720fdb79/hypothesis-6.161.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:46a6039181337b85a995666e9bf87cc2390282720ba345479bb9be9c867914da", size = 758013 },
+    { url = "https://files.pythonhosted.org/packages/d9/11/ac4ab15ec4586a23bb4e2acdcbed814517e341f2940eeb74fbf428dac243/hypothesis-6.161.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f2d4141c952f522d6aae0e493d170f9b0127c001319bd312ee9cfba7ed419d4", size = 1088871 },
+    { url = "https://files.pythonhosted.org/packages/27/13/fd83965bcdd44dc5002c67fe8e8e2e974ed45c82dc6864e104c1c70093d5/hypothesis-6.161.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a6ed3e1b9c036954bfabe64899072a18e6b5113703d32a96645c6656a8cfc43e", size = 1138801 },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/a4ad5f3b0b805fd2e583d193e2a762cd413465b524ef07829452521dca6d/hypothesis-6.161.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:aba1508da6c317819305e875bf6c4d4dd0922193c76416d4cc907447ebe08fea", size = 1261305 },
+    { url = "https://files.pythonhosted.org/packages/38/54/35e1b62ece96c24921e9a1e811179d54a6429d9611a2cd49504f5b95382e/hypothesis-6.161.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:981acb3efa88df363a0d31e0f4bacd36ef739104eee789a6b12c7f7200a457fc", size = 1305689 },
+    { url = "https://files.pythonhosted.org/packages/04/87/6491e9a36d8e8df67a3b9c3eeb5a85c12c6b0d5302b5ce395b5427698b52/hypothesis-6.161.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e71e229f2dec694685245b8e55e908855b475c17ab8337bcf848768b4c32aa97", size = 655436 },
+    { url = "https://files.pythonhosted.org/packages/54/e2/0782e45562fb091cd75bd12f69932c8aa55a9e3bb699599f43e5258d013c/hypothesis-6.161.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:33a19886dc05b489f0ab632c89b8ca9dc6f89a0b380b6405671cecb2b0d5b5c4", size = 767674 },
+    { url = "https://files.pythonhosted.org/packages/03/46/eaccb5375ed83396be3153857f9de808b5d5ecc001fab8e30bf8e30d33d4/hypothesis-6.161.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b4fd38d0e757ae290583774b3695ab0d7f0da80e924c6473de84483449c6da8d", size = 763579 },
+    { url = "https://files.pythonhosted.org/packages/99/48/31ca6b9414cf30388ba825c740b13ab74f6afcf856a194a9256f7f1ca38d/hypothesis-6.161.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59dc6871e2fbbfd2d28e7e6f33d19bd8513a3b7510bd0b224a59bbebdd5cc1b3", size = 1092394 },
+    { url = "https://files.pythonhosted.org/packages/75/1d/709c03af162418c0b3e0cf624549b13ecacd8df0f2ca09d53214702cb1f8/hypothesis-6.161.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55ff16ec4b4e98bfd97e9a2a44905eaf7a3ec8f3f157d8c7eac2385a88059a29", size = 1142170 },
+    { url = "https://files.pythonhosted.org/packages/3a/ae/63458a5f80db8433beb7556482e3de1a6789b6c469a5f2f99c21aaa7fdef/hypothesis-6.161.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:77ae374d9ed7046b15443053b11f5b05e185bca24b3b849c3f473a9e4cc85451", size = 659069 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536 },
+]
+
+[[package]]
+name = "pyturso"
+source = { directory = "../../bindings/python" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "coverage", marker = "extra == 'dev'", specifier = "==7.6.1" },
+    { name = "maturin", marker = "extra == 'dev'", specifier = "==1.12.6" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.11.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==5.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.5.4" },
+    { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0.45" },
+    { name = "typing-extensions", specifier = ">=4.6.0,!=4.7.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "coverage", specifier = ">=7.6.1" },
+    { name = "iniconfig", specifier = ">=2.1.0" },
+    { name = "maturin", specifier = ">=1.12.6" },
+    { name = "mypy", specifier = ">=1.11.0" },
+    { name = "mypy-extensions", specifier = ">=1.1.0" },
+    { name = "pluggy", specifier = ">=1.6.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "requests", specifier = ">=2.32.5" },
+    { name = "ruff", specifier = ">=0.5.4" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704 },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454 },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561 },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824 },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227 },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859 },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204 },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084 },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285 },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924 },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018 },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948 },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341 },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159 },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290 },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141 },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847 },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088 },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866 },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887 },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704 },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628 },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180 },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674 },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976 },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755 },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265 },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726 },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859 },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713 },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084 },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973 },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223 },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973 },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082 },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490 },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263 },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736 },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717 },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461 },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855 },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144 },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683 },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196 },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393 },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583 },
+]
+
+[[package]]
+name = "turso-serverless"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+differential = [
+    { name = "hypothesis" },
+    { name = "pytest" },
+    { name = "pyturso" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "hypothesis", marker = "extra == 'differential'", specifier = ">=6.100" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest", marker = "extra == 'differential'", specifier = ">=8.0" },
+    { name = "pyturso", marker = "extra == 'differential'", directory = "../../bindings/python" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571 },
+]


### PR DESCRIPTION
Implement the client side of the SQL over HTTP protocol (serverless/PROTOCOL.md) so Python applications can talk to Turso Cloud from serverless and edge environments, where the only networking primitive is an HTTP request. The driver is pure Python on top of urllib, implements DB-API 2.0, and mirrors the embedded turso driver, so the same code runs against a local database or Turso Cloud.

The session layer follows the JavaScript and Rust serverless drivers: the baton is tracked on every request, transaction state comes from the server's authoritative get_autocommit answer piggybacked on every pipeline (and an is_autocommit-gated probe step on cursor batches), and statements run over the cursor endpoint. Pipeline responses are validated to carry one result per request. A failed request is never transparently retried: the stream is reset and the error surfaces, so the application decides whether re-running a statement is safe. Server-returned base URLs go through the same normalization as user-supplied ones, including trailing-slash stripping.

The conformance suite runs against a live database configured with TURSO_DATABASE_URL and TURSO_AUTH_TOKEN and skips when they are unset, covering queries, parameter binding, value round-trips, transactions, executescript, and DB-API error mapping.

Tests: pytest in serverless/python; protocol and URL handling unit tests run standalone, the conformance suite needs the environment variables set.