### PR TITLE
bindings/javascript: pin playwright to 1.61.0 to match container image

### DIFF
--- a/bindings/javascript/package.json
+++ b/bindings/javascript/package.json
@@ -16,6 +16,7 @@
     "sync/packages/wasm"
   ],
   "resolutions": {
+    "playwright": "1.61.0",
     "emnapi": "1.4.5",
     "@emnapi/core": "1.8.1",
     "@emnapi/runtime": "1.8.1",

--- a/bindings/javascript/yarn.lock
+++ b/bindings/javascript/yarn.lock
@@ -3152,27 +3152,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.62.0":
-  version: 1.62.0
-  resolution: "playwright-core@npm:1.62.0"
+"playwright-core@npm:1.61.0":
+  version: 1.61.0
+  resolution: "playwright-core@npm:1.61.0"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/bc7c770cc4118a7ea65d2c357fc271aaef49af6b5b8964aa19d765d4ea3473e56af926f693123fd63ed6e580830059905722ac68fbf22a31a5b1533e11600228
+  checksum: 10c0/64cbf5e9f4ad81cbb005d59417e96435e324a6e3801f1c79b36850ad99f6bb90853c4b569a32c49b9eca1e07925bbb2a5a864babdba2178c3c395e0c589d5941
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.55.0, playwright@npm:^1.57.0":
-  version: 1.62.0
-  resolution: "playwright@npm:1.62.0"
+"playwright@npm:1.61.0":
+  version: 1.61.0
+  resolution: "playwright@npm:1.61.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.62.0"
+    playwright-core: "npm:1.61.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/14d2d2c35e4ef88cf69d9e6c5bf351ff47fe9cd00da09da9f48da8aaf75ebdb266330c073cb217821785fb35d7e5d9d89789220b208329e4934aaaa43da260f3
+  checksum: 10c0/079dceebe8b745fa6062a3af928024d0c508177fbf15d61dba09ba173f277465ad3746fdc1b31788ade65428f4d3f92fc8083b44c07381b088721eaa2ea06513
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The browser binding test jobs run inside the Microsoft Playwright container, whose preinstalled browser binaries must match the `playwright` npm package version resolved at install time. The caret ranges in the wasm packages drifted to the newly released 1.62.0 while the container is pinned at `v1.61.0-jammy`, so `browserType.launch` failed with:

```
Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1234/chrome-headless-shell-linux64/chrome-headless-shell
║ Looks like Playwright was just updated to 1.62.0. ║
║ Please update docker image as well.               ║
```

Bumping the image to v1.62.0 is not possible: Microsoft has not published a v1.62.0 container image yet (all `v1.62.0` tags return 404 on mcr.microsoft.com, which is why the previous version of this PR failed at container pull with "manifest unknown"). Instead, add a yarn resolution pinning `playwright` to 1.61.0 to match the existing image. The resolution should be dropped once the v1.62.0 image is published.

Fixes the "Test DB bindings on browser" and "Test sync bindings on browser" failures in the Build & publish @tursodatabase/database workflow on main (e.g. https://github.com/tursodatabase/turso/actions/runs/30196985264).
