### PR TITLE
core: add an opt-in shared clean-page cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7353,6 +7353,7 @@ dependencies = [
  "libloading 0.8.6",
  "libm",
  "loom",
+ "lru",
  "memory-stats",
  "miette",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ similar-asserts = { version = "1.7.0" }
 bitmaps = { version = "3.2.1", default-features = false }
 console-subscriber = { version = "0.4.1" }
 either = { version = "1.15" }
+lru = "0.16.4"
 
 # Multi threading testing
 loom = { version = "0.7" }

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -53,6 +53,11 @@ This project depends on pastey, distributed by the pastey authors:
 * License: licenses/core/pastey-mit-license.md (MIT License)
 * Homepage: https://github.com/AS1100K/pastey
 
+This project depends on lru, distributed by the lru-rs authors:
+
+* License: licenses/core/lru-mit-license.md (MIT License)
+* Homepage: https://github.com/jeromefroe/lru-rs
+
 This project depends on windows-sys, distributed by the Microsoft:
 
 * License: licenses/core/windows-apache.license.md (Apache License v2.0)

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -121,6 +121,7 @@ aes = { version = "0.8.4" }
 turso_parser = { workspace = true }
 twox-hash = "2.1.1"
 intrusive-collections = "0.9.7"
+lru = { workspace = true }
 roaring = "0.11.2"
 arc-swap = "1.7"
 rustc-hash = "2.0"

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -129,6 +129,7 @@ use std::{
 };
 #[cfg(feature = "fs")]
 use storage::database::DatabaseFile;
+use storage::shared_page_cache::{SharedPageCacheGeneration, SharedPageCacheNamespace};
 #[cfg(host_shared_wal)]
 use storage::shared_wal_coordination::MappedSharedWalCoordination;
 use storage::{page_cache::PageCache, sqlite3_ondisk::PageSize};
@@ -162,6 +163,9 @@ pub use io::{
 };
 pub use numeric::{nonnan::NonNan, Numeric};
 pub use statement::{ColumnTypeInfo, ColumnTypeKind, Statement, StatementStatusCounter};
+pub use storage::shared_page_cache::{
+    SharedPageCache, SharedPageCacheLookup, SharedPageCacheObserver, SharedPageCacheStats,
+};
 pub use storage::{
     buffer_pool::BufferPool,
     database::{DatabaseStorage, IOContext},
@@ -697,9 +701,9 @@ pub struct Database<A: alloc::ConcurrentAllocator = alloc::DynAllocator> {
     wal_path: String,
     pub io: Arc<dyn IO>,
     buffer_pool: Arc<BufferPool>,
-    // Shared structures of a Database are the parts that are common to multiple threads that might
-    // create DB connections.
-    _shared_page_cache: Arc<RwLock<PageCache>>,
+    /// Optional immutable page-byte cache used by future connection pagers.
+    shared_page_cache: RwLock<Option<SharedPageCacheNamespace>>,
+    shared_page_cache_generation: Arc<SharedPageCacheGeneration>,
 
     /// Optional per-database MVCC durable storage override.
     ///
@@ -769,12 +773,11 @@ impl fmt::Debug for Database {
         };
         debug_struct.field("wal_state", &wal_status);
 
-        // Page cache info (just basic stats, not full contents)
-        let cache_info = match self._shared_page_cache.try_read() {
-            Some(cache) => format!("( capacity {}, used: {} )", cache.capacity(), cache.len()),
-            None => "locked".to_string(),
-        };
-        debug_struct.field("page_cache", &cache_info);
+        let shared_page_cache = self
+            .shared_page_cache
+            .try_read()
+            .map(|cache| cache.is_some());
+        debug_struct.field("shared_page_cache", &shared_page_cache);
 
         debug_struct.field(
             "n_connections",
@@ -790,6 +793,19 @@ impl Database {
     /// Returns true if this database is backed by MemoryIO.
     pub fn is_in_memory_db(&self) -> bool {
         is_memory_like(&self.path)
+    }
+
+    /// Configure an immutable page-byte cache for pagers created by future connections.
+    ///
+    /// Existing connections keep their current pager. Configure this immediately after opening
+    /// the database and before accepting connection requests. Databases opened with encryption
+    /// enabled currently bypass this cache.
+    pub fn set_shared_page_cache(&self, cache: Option<Arc<SharedPageCache>>) -> Result<()> {
+        let namespace = cache
+            .map(|cache| cache.new_namespace(self.shared_page_cache_generation.clone()))
+            .transpose()?;
+        *self.shared_page_cache.write() = namespace;
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -811,7 +827,7 @@ impl Database {
 
         let db_size = db_file.size()?;
 
-        let shared_page_cache = Arc::new(RwLock::new(PageCache::default()));
+        let shared_page_cache_generation = Arc::new(SharedPageCacheGeneration::default());
         let syms = SymbolTable::new();
         let arena_size = if std::env::var("TESTING").is_ok_and(|v| v.eq_ignore_ascii_case("true")) {
             BufferPool::TEST_ARENA_SIZE
@@ -845,7 +861,8 @@ impl Database {
                 s.generated_columns_enabled = opts.enable_generated_columns;
                 s
             }))),
-            _shared_page_cache: shared_page_cache,
+            shared_page_cache: RwLock::new(None),
+            shared_page_cache_generation,
             shared_wal,
             #[cfg(host_shared_wal)]
             shared_wal_coordination: OnceLock::new(),
@@ -2166,6 +2183,7 @@ impl Database {
     /// Rebuild the process-local shared WAL view after a caller restores the
     /// database and WAL files outside the pager.
     pub fn reload_wal_after_external_restore(self: &Arc<Self>) -> Result<()> {
+        self.shared_page_cache_generation.advance()?;
         let flags = self.open_flags;
         #[cfg(host_shared_wal)]
         let shared_authority = self.open_shared_wal_coordination_for_open()?;
@@ -2883,8 +2901,13 @@ impl Database {
         } else {
             None
         };
+        let shared_page_cache = if self.opts.enable_encryption {
+            None
+        } else {
+            self.shared_page_cache.read().clone()
+        };
 
-        let pager = Pager::new(
+        let pager = Pager::new_with_shared_page_cache(
             self.db_file.clone(),
             pager_wal,
             self.io.clone(),
@@ -2892,6 +2915,7 @@ impl Database {
             buffer_pool,
             self.init_lock.clone(),
             self.init_page_1.clone(),
+            shared_page_cache,
         )?;
         pager.set_page_size(page_size);
         if let Some(reserved_bytes) = reserved_bytes {

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod journal_mode;
 pub(crate) mod page_cache;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;
+pub(crate) mod shared_page_cache;
 #[cfg(host_shared_wal)]
 #[allow(dead_code)]
 pub(crate) mod shared_wal_coordination;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -47,6 +47,9 @@ use super::btree::{
     btree_init_page, payload_overflow_threshold_max, payload_overflow_threshold_min,
 };
 use super::page_cache::{CacheError, CacheResizeResult, PageCache, PageCacheKey, SpillResult};
+use super::shared_page_cache::{
+    SharedPageCacheEntry, SharedPageCacheNamespace, SharedPageCachePublisher, SharedPageVersion,
+};
 use super::sqlite3_ondisk::read_varint;
 use super::sqlite3_ondisk::{
     begin_write_btree_page, read_btree_cell, read_u32, BTreeCell, FREELIST_LEAF_PTR_SIZE,
@@ -127,6 +130,8 @@ pub struct PageInner {
     pub buffer: Option<Arc<Buffer>>,
     /// Overflow cells during btree operations
     pub overflow_cells: crate::alloc::Vec<OverflowCell>,
+    /// Publishes a clean page image after its storage read completes.
+    shared_page_publisher: Option<SharedPageCachePublisher>,
 }
 
 // Methods moved from PageContent - these provide btree page access
@@ -140,6 +145,7 @@ impl PageInner {
             wal_tag: AtomicU64::new(TAG_UNSET),
             buffer: Some(buffer),
             overflow_cells: crate::alloc::vec![],
+            shared_page_publisher: None,
         }
     }
 
@@ -152,6 +158,7 @@ impl PageInner {
             wal_tag: AtomicU64::new(TAG_UNSET),
             buffer: Some(Arc::new(buffer)),
             overflow_cells: crate::alloc::vec![],
+            shared_page_publisher: None,
         }
     }
     /// Get the page buffer as a mutable slice. Panics if buffer not loaded.
@@ -751,6 +758,7 @@ impl Page {
                 wal_tag: AtomicU64::new(TAG_UNSET),
                 buffer: None,
                 overflow_cells: crate::alloc::vec![],
+                shared_page_publisher: None,
             }),
         }
     }
@@ -851,6 +859,14 @@ impl Page {
     pub fn clear_loaded(&self) {
         tracing::debug!("clear loaded {}", self.get().id);
         self.get().flags.fetch_and(!PAGE_LOADED, Ordering::Release);
+    }
+
+    pub(crate) fn set_shared_page_publisher(&self, publisher: Option<SharedPageCachePublisher>) {
+        self.get().shared_page_publisher = publisher;
+    }
+
+    pub(crate) fn take_shared_page_publisher(&self) -> Option<SharedPageCachePublisher> {
+        self.get().shared_page_publisher.take()
     }
 
     #[inline]
@@ -1340,6 +1356,8 @@ pub struct Pager {
     pub(crate) wal: Option<Arc<dyn Wal>>,
     /// A page cache for the database.
     page_cache: Arc<RwLock<PageCache>>,
+    /// Optional database-lifetime cache of immutable clean page bytes.
+    shared_page_cache: Option<SharedPageCacheNamespace>,
     /// Buffer pool for temporary data storage.
     pub buffer_pool: Arc<BufferPool>,
     /// I/O interface for input/output operations.
@@ -1452,6 +1470,46 @@ struct PendingRead {
     /// `None` if the page was satisfied from WAL/cache shortcut and no
     /// disk read completion needs to be surfaced to the caller.
     disk_read: Option<Completion>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ResolvedPageSource {
+    Database {
+        checkpoint_epoch: Option<u32>,
+    },
+    Wal {
+        frame_id: u64,
+        checkpoint_epoch: Option<u32>,
+    },
+}
+
+impl ResolvedPageSource {
+    fn shared_version(self) -> Option<SharedPageVersion> {
+        match self {
+            Self::Database {
+                checkpoint_epoch: Some(checkpoint_epoch),
+            } => Some(SharedPageVersion::Database { checkpoint_epoch }),
+            Self::Database {
+                checkpoint_epoch: None,
+            } => None,
+            Self::Wal {
+                frame_id,
+                checkpoint_epoch: Some(checkpoint_epoch),
+            } => Some(SharedPageVersion::Wal {
+                frame_id,
+                checkpoint_epoch,
+            }),
+            Self::Wal {
+                checkpoint_epoch: None,
+                ..
+            } => None,
+        }
+    }
+}
+
+enum SharedPageLookup {
+    Hit(PageRef),
+    Miss(Option<SharedPageCachePublisher>),
 }
 
 /// Test-only deterministic spill-yield injector for `Pager::read_page`. When
@@ -1627,6 +1685,29 @@ impl Pager {
         init_lock: Arc<Mutex<()>>,
         init_page_1: Arc<ArcSwapOption<Page>>,
     ) -> Result<Self> {
+        Self::new_with_shared_page_cache(
+            db_file,
+            wal,
+            io,
+            page_cache,
+            buffer_pool,
+            init_lock,
+            init_page_1,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_shared_page_cache(
+        db_file: Arc<dyn DatabaseStorage>,
+        wal: Option<Arc<dyn Wal>>,
+        io: Arc<dyn crate::io::IO>,
+        page_cache: PageCache,
+        buffer_pool: Arc<BufferPool>,
+        init_lock: Arc<Mutex<()>>,
+        init_page_1: Arc<ArcSwapOption<Page>>,
+        shared_page_cache: Option<SharedPageCacheNamespace>,
+    ) -> Result<Self> {
         let allocate_page1_state = if init_page_1.load().is_some() {
             RwLock::new(AllocatePage1State::Start)
         } else {
@@ -1636,6 +1717,7 @@ impl Pager {
             db_file,
             wal,
             page_cache: Arc::new(RwLock::new(page_cache)),
+            shared_page_cache,
             io,
             pending_reads: RwLock::new(HashMap::new()),
             #[cfg(test)]
@@ -3215,35 +3297,116 @@ impl Pager {
     ) -> Result<(PageRef, Completion)> {
         turso_assert_greater_than_or_equal!(page_idx, 0);
         tracing::debug!("read_page_no_cache(page_idx = {})", page_idx);
-        let page = Arc::new(Page::new(page_idx));
-        let io_ctx = self.io_ctx.read();
+        let source = self.resolve_page_source(page_idx, frame_watermark)?;
+        self.read_page_from_source(page_idx, source, allow_empty_read, None)
+    }
+
+    fn resolve_page_source(
+        &self,
+        page_idx: i64,
+        frame_watermark: Option<u64>,
+    ) -> Result<ResolvedPageSource> {
         let Some(wal) = self.wal.as_ref() else {
             turso_assert!(
                 matches!(frame_watermark, Some(0) | None),
                 "frame_watermark must be either None or Some(0) because DB has no WAL and read with other watermark is invalid"
             );
-
-            page.set_locked();
-            let c = self.begin_read_disk_page(
-                page_idx as usize,
-                page.clone(),
-                allow_empty_read,
-                &io_ctx,
-            )?;
-            return Ok((page, c));
+            return Ok(ResolvedPageSource::Database {
+                checkpoint_epoch: None,
+            });
         };
 
-        if let Some(frame_id) = wal.find_frame(page_idx as u64, frame_watermark)? {
-            let c = wal.read_frame(frame_id, page.clone(), self.buffer_pool.clone())?;
-            // TODO(pere) should probably first insert to page cache, and if successful,
-            // read frame or page
-            return Ok((page, c));
-        }
+        let frame_id = wal.find_frame(page_idx as u64, frame_watermark)?;
+        let checkpoint_epoch = self
+            .shared_page_cache
+            .as_ref()
+            .and_then(|_| wal.shared_page_cache_epoch());
+        Ok(match frame_id {
+            Some(frame_id) => {
+                // Durable spill frames are visible to their writer before commit, but they are
+                // not immutable across rollback and frame-slot reuse.
+                let checkpoint_epoch =
+                    checkpoint_epoch.filter(|_| frame_id <= wal.get_max_frame_in_wal());
+                ResolvedPageSource::Wal {
+                    frame_id,
+                    checkpoint_epoch,
+                }
+            }
+            None => ResolvedPageSource::Database { checkpoint_epoch },
+        })
+    }
 
-        page.set_locked();
-        let c =
-            self.begin_read_disk_page(page_idx as usize, page.clone(), allow_empty_read, &io_ctx)?;
-        Ok((page, c))
+    fn read_page_from_source(
+        &self,
+        page_idx: i64,
+        source: ResolvedPageSource,
+        allow_empty_read: bool,
+        publisher: Option<SharedPageCachePublisher>,
+    ) -> Result<(PageRef, Completion)> {
+        let page = Arc::new(Page::new(page_idx));
+        page.set_shared_page_publisher(publisher);
+        let completion = match source {
+            ResolvedPageSource::Database { .. } => {
+                page.set_locked();
+                self.begin_read_disk_page(
+                    page_idx as usize,
+                    page.clone(),
+                    allow_empty_read,
+                    &self.io_ctx.read(),
+                )?
+            }
+            ResolvedPageSource::Wal { frame_id, .. } => {
+                let wal = self
+                    .wal
+                    .as_ref()
+                    .expect("resolved WAL page source requires a WAL");
+                wal.read_frame(frame_id, page.clone(), self.buffer_pool.clone())?
+            }
+        };
+        Ok((page, completion))
+    }
+
+    fn lookup_shared_page(
+        &self,
+        page_idx: i64,
+        source: ResolvedPageSource,
+    ) -> Result<SharedPageLookup> {
+        let Some(namespace) = self.shared_page_cache.as_ref() else {
+            return Ok(SharedPageLookup::Miss(None));
+        };
+        let Some(version) = source.shared_version() else {
+            return Ok(SharedPageLookup::Miss(None));
+        };
+        let page_size = self.get_page_size_unchecked().get();
+        let bytes = match namespace.lookup(page_idx as usize, page_size, version) {
+            SharedPageCacheEntry::Hit(bytes) => bytes,
+            SharedPageCacheEntry::Miss(publisher) => {
+                return Ok(SharedPageLookup::Miss(Some(publisher)));
+            }
+        };
+        turso_assert_eq!(
+            bytes.len(),
+            page_size as usize,
+            "shared page cache returned an invalid page length"
+        );
+
+        let buffer = self.buffer_pool.get_page();
+        turso_assert_eq!(
+            buffer.len(),
+            bytes.len(),
+            "buffer pool page size must match the shared cache page size"
+        );
+        buffer.as_mut_slice().copy_from_slice(&bytes);
+        let page = Arc::new(Page::new(page_idx));
+        sqlite3_ondisk::finish_read_page(page_idx as usize, Arc::new(buffer), page.clone());
+        if let ResolvedPageSource::Wal {
+            frame_id,
+            checkpoint_epoch: Some(checkpoint_epoch),
+        } = source
+        {
+            page.set_wal_tag(frame_id, checkpoint_epoch);
+        }
+        Ok(SharedPageLookup::Hit(page))
     }
 
     /// Issue a non-blocking page read, inserting into the page cache, may spill to disk.
@@ -3305,16 +3468,27 @@ impl Pager {
                 }
             }
 
-            tracing::debug!("read_page(page_idx = {page_idx}) = reading page from disk");
-            let (page, c) = self.read_page_no_cache(page_idx, None, false)?;
+            let source = self.resolve_page_source(page_idx, None)?;
+            let (page, c_disk) = match self.lookup_shared_page(page_idx, source)? {
+                SharedPageLookup::Hit(page) => {
+                    tracing::debug!("read_page(page_idx = {page_idx}) = shared cache hit");
+                    (page, None)
+                }
+                SharedPageLookup::Miss(publisher) => {
+                    tracing::debug!("read_page(page_idx = {page_idx}) = reading page from storage");
+                    let (page, completion) =
+                        self.read_page_from_source(page_idx, source, false, publisher)?;
+                    (page, Some(completion))
+                }
+            };
             self.pending_reads.write().insert(
                 page_idx,
                 PendingRead {
                     page: page.clone(),
-                    disk_read: Some(c.clone()),
+                    disk_read: c_disk.clone(),
                 },
             );
-            (page, Some(c))
+            (page, c_disk)
         };
 
         match self.cache_insert(page_idx as usize, page.clone())? {
@@ -5957,17 +6131,32 @@ mod tests {
 
     use crate::sync::RwLock;
 
-    use crate::io::{MemoryIO, OpenFlags, IO};
+    use crate::io::{FileSyncType, MemoryIO, OpenFlags, IO};
     use crate::storage::buffer_pool::BufferPool;
     use crate::storage::database::DatabaseFile;
     use crate::storage::page_cache::{PageCache, PageCacheKey};
+    use crate::storage::shared_page_cache::{
+        SharedPageCache, SharedPageCacheGeneration, SharedPageCacheNamespace, SharedPageVersion,
+    };
     use crate::storage::wal::{Wal, WalFile, WalFileShared};
+    use crate::types::IOResult;
     use crate::util::IOExt;
     use arc_swap::ArcSwapOption;
 
-    use super::{default_page1, Page, PageRef, Pager};
+    use super::{
+        allocate_new_page, default_page1, Page, PageRef, PageSize, Pager, PendingRead,
+        ResolvedPageSource, SharedPageLookup,
+    };
 
     fn pager_with_cache_capacity(cache_capacity: usize, database_pages: u32) -> Arc<Pager> {
+        pager_with_cache_capacity_and_shared(cache_capacity, database_pages, None)
+    }
+
+    fn pager_with_cache_capacity_and_shared(
+        cache_capacity: usize,
+        database_pages: u32,
+        shared_page_cache: Option<SharedPageCacheNamespace>,
+    ) -> Arc<Pager> {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
         let buffer_pool = BufferPool::begin_init(&io, 4096 * 128);
 
@@ -5987,7 +6176,7 @@ mod tests {
 
         let init_page_1 = Arc::new(ArcSwapOption::new(Some(default_page1(None))));
         let pager = Arc::new(
-            Pager::new(
+            Pager::new_with_shared_page_cache(
                 db_file,
                 Some(wal),
                 io,
@@ -5995,6 +6184,7 @@ mod tests {
                 buffer_pool,
                 Arc::new(crate::sync::Mutex::new(())),
                 init_page_1,
+                shared_page_cache,
             )
             .unwrap(),
         );
@@ -6097,6 +6287,146 @@ mod tests {
         let page_key = PageCacheKey::new(1);
         let page = cache.get(&page_key).unwrap();
         assert_eq!(page.unwrap().get().id, 1);
+    }
+
+    #[test]
+    fn read_page_shared_hit_returns_loaded_private_page_without_io() {
+        let cache = Arc::new(SharedPageCache::new(64 * 1024));
+        let namespace = cache
+            .new_namespace(Arc::new(SharedPageCacheGeneration::default()))
+            .unwrap();
+        let pager = pager_with_cache_capacity_and_shared(4096, 10, Some(namespace.clone()));
+        pager.set_page_size(PageSize::new(4096).unwrap());
+        let page_id = 9999;
+        namespace
+            .publisher(
+                page_id,
+                4096,
+                SharedPageVersion::Database {
+                    checkpoint_epoch: 0,
+                },
+            )
+            .publish(&vec![0x5a; 4096]);
+
+        let result = pager.read_page(page_id as i64).unwrap();
+        let (page, completion) = match result {
+            IOResult::Done(result) => result,
+            IOResult::IO(_) => panic!("shared cache hit must not issue IO"),
+        };
+
+        assert!(completion.is_none());
+        assert!(page.is_loaded());
+        assert_eq!(page.get_contents().as_ptr(), &[0x5a; 4096]);
+        assert!(pager.pending_reads.read().is_empty());
+
+        page.set_dirty();
+        page.get_contents().as_ptr()[0] = 0xff;
+        let second = match pager
+            .lookup_shared_page(
+                page_id as i64,
+                ResolvedPageSource::Database {
+                    checkpoint_epoch: Some(0),
+                },
+            )
+            .unwrap()
+        {
+            SharedPageLookup::Hit(page) => page,
+            SharedPageLookup::Miss(_) => panic!("seeded shared page must hit"),
+        };
+        assert_eq!(second.get_contents().as_ptr()[0], 0x5a);
+        assert_eq!(cache.stats().hits, 2);
+    }
+
+    #[test]
+    fn shared_cache_is_bypassed_without_a_safe_wal_epoch() {
+        let cache = Arc::new(SharedPageCache::new(64 * 1024));
+        let namespace = cache
+            .new_namespace(Arc::new(SharedPageCacheGeneration::default()))
+            .unwrap();
+        let pager = pager_with_cache_capacity_and_shared(4096, 10, Some(namespace.clone()));
+        pager.set_page_size(PageSize::new(4096).unwrap());
+        namespace
+            .publisher(
+                1,
+                4096,
+                SharedPageVersion::Database {
+                    checkpoint_epoch: 0,
+                },
+            )
+            .publish(&vec![0x5a; 4096]);
+
+        let lookup = pager
+            .lookup_shared_page(
+                1,
+                ResolvedPageSource::Database {
+                    checkpoint_epoch: None,
+                },
+            )
+            .unwrap();
+
+        assert!(matches!(lookup, SharedPageLookup::Miss(None)));
+        assert_eq!(cache.stats().hits, 0);
+        assert_eq!(cache.stats().misses, 0);
+    }
+
+    #[test]
+    fn uncommitted_spill_frame_is_not_shared_cacheable() {
+        let cache = Arc::new(SharedPageCache::new(64 * 1024));
+        let namespace = cache
+            .new_namespace(Arc::new(SharedPageCacheGeneration::default()))
+            .unwrap();
+        let pager = pager_with_cache_capacity_and_shared(32, 1, Some(namespace));
+        let page_size = PageSize::new(4096).unwrap();
+        pager.set_page_size(page_size);
+        let wal = pager.wal.as_ref().unwrap();
+
+        if let Some(completion) = wal.prepare_wal_start(page_size).unwrap() {
+            pager.io.wait_for_completion(completion).unwrap();
+        }
+        let completion = wal.prepare_wal_finish(FileSyncType::Fsync).unwrap();
+        pager.io.wait_for_completion(completion).unwrap();
+
+        let spilled = allocate_new_page(7, &pager.buffer_pool);
+        let completion = wal
+            .append_frames_vectored(vec![spilled], page_size)
+            .unwrap();
+        pager.io.wait_for_completion(completion).unwrap();
+        assert_eq!(wal.get_max_frame(), 1);
+        assert_eq!(wal.get_max_frame_in_wal(), 0);
+
+        let source = pager.resolve_page_source(7, None).unwrap();
+        assert!(matches!(
+            source,
+            ResolvedPageSource::Wal {
+                frame_id: 1,
+                checkpoint_epoch: None,
+            }
+        ));
+        assert!(source.shared_version().is_none());
+    }
+
+    #[test]
+    fn shared_hit_reentry_reuses_pending_page_without_disk_completion() {
+        let pager = pager_with_cache_capacity(4096, 10);
+        let page_id = 9998;
+        let pending_page = Arc::new(Page::new(page_id));
+        pending_page.set_loaded();
+        pager.pending_reads.write().insert(
+            page_id,
+            PendingRead {
+                page: pending_page.clone(),
+                disk_read: None,
+            },
+        );
+
+        let (page, completion) = match pager.read_page(page_id).unwrap() {
+            IOResult::Done(result) => result,
+            IOResult::IO(_) => panic!("pending shared hit must resume without IO"),
+        };
+
+        assert!(Arc::ptr_eq(&page, &pending_page));
+        assert!(completion.is_none());
+        assert!(pager.pending_reads.read().get(&page_id).is_none());
     }
 }
 

--- a/core/storage/shared_page_cache.rs
+++ b/core/storage/shared_page_cache.rs
@@ -1,0 +1,585 @@
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    mem::size_of,
+};
+
+use lru::LruCache;
+use rustc_hash::FxHasher;
+
+use crate::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex, RwLock,
+    },
+    LimboError, Result,
+};
+
+const MAX_SHARDS: usize = 16;
+const TARGET_BYTES_PER_SHARD: usize = 1024 * 1024;
+const ENTRY_ALLOCATION_OVERHEAD: usize = 64;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum SharedPageVersion {
+    Database {
+        checkpoint_epoch: u32,
+    },
+    Wal {
+        frame_id: u64,
+        checkpoint_epoch: u32,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct SharedPageKey {
+    namespace: u64,
+    generation: u64,
+    page_id: usize,
+    page_size: u32,
+    version: SharedPageVersion,
+}
+
+impl SharedPageKey {
+    fn weight(self, value_len: usize) -> usize {
+        value_len
+            .saturating_add(size_of::<Self>())
+            .saturating_add(size_of::<Arc<[u8]>>())
+            .saturating_add(ENTRY_ALLOCATION_OVERHEAD)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SharedPageCacheStats {
+    /// Configured byte capacity.
+    pub capacity_bytes: u64,
+    /// Estimated bytes held by entries.
+    pub resident_bytes: u64,
+    /// Number of resident entries.
+    pub entries: u64,
+    /// Successful lookups.
+    pub hits: u64,
+    /// Unsuccessful lookups.
+    pub misses: u64,
+    /// First insertions for a key.
+    pub insertions: u64,
+    /// Replacements of an existing key.
+    pub replacements: u64,
+    /// Entries removed to honor capacity.
+    pub evictions: u64,
+    /// Entries rejected because they exceed a shard's capacity.
+    pub rejected: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SharedPageCacheLookup {
+    /// The exact requested page version was present.
+    Hit,
+    /// The exact requested page version was absent.
+    Miss,
+}
+
+/// Receives aggregate cache lookup outcomes from the Pager read path.
+///
+/// Implementations must not block or allocate high-cardinality data.
+pub trait SharedPageCacheObserver: Send + Sync {
+    fn record_lookup(&self, outcome: SharedPageCacheLookup);
+}
+
+struct CacheShard {
+    capacity_bytes: usize,
+    resident_bytes: usize,
+    entries: LruCache<SharedPageKey, Arc<[u8]>>,
+    hits: u64,
+    misses: u64,
+    insertions: u64,
+    replacements: u64,
+    evictions: u64,
+    rejected: u64,
+}
+
+impl CacheShard {
+    fn new(capacity_bytes: usize) -> Self {
+        Self {
+            capacity_bytes,
+            resident_bytes: 0,
+            entries: LruCache::unbounded(),
+            hits: 0,
+            misses: 0,
+            insertions: 0,
+            replacements: 0,
+            evictions: 0,
+            rejected: 0,
+        }
+    }
+
+    fn get(&mut self, key: &SharedPageKey) -> Option<Arc<[u8]>> {
+        let value = self.entries.get(key).cloned();
+        if value.is_some() {
+            self.hits = self.hits.saturating_add(1);
+        } else {
+            self.misses = self.misses.saturating_add(1);
+        }
+        value
+    }
+
+    fn insert(&mut self, key: SharedPageKey, value: Arc<[u8]>) {
+        let weight = key.weight(value.len());
+        if weight > self.capacity_bytes {
+            self.rejected = self.rejected.saturating_add(1);
+            return;
+        }
+
+        if let Some(previous) = self.entries.pop(&key) {
+            self.resident_bytes = self
+                .resident_bytes
+                .saturating_sub(key.weight(previous.len()));
+            self.replacements = self.replacements.saturating_add(1);
+        } else {
+            self.insertions = self.insertions.saturating_add(1);
+        }
+
+        self.resident_bytes = self.resident_bytes.saturating_add(weight);
+        self.entries.put(key, value);
+
+        while self.resident_bytes > self.capacity_bytes {
+            let Some((evicted_key, evicted_value)) = self.entries.pop_lru() else {
+                break;
+            };
+            self.resident_bytes = self
+                .resident_bytes
+                .saturating_sub(evicted_key.weight(evicted_value.len()));
+            self.evictions = self.evictions.saturating_add(1);
+        }
+    }
+
+    fn add_stats(&self, stats: &mut SharedPageCacheStats) {
+        stats.resident_bytes = stats
+            .resident_bytes
+            .saturating_add(self.resident_bytes as u64);
+        stats.entries = stats.entries.saturating_add(self.entries.len() as u64);
+        stats.hits = stats.hits.saturating_add(self.hits);
+        stats.misses = stats.misses.saturating_add(self.misses);
+        stats.insertions = stats.insertions.saturating_add(self.insertions);
+        stats.replacements = stats.replacements.saturating_add(self.replacements);
+        stats.evictions = stats.evictions.saturating_add(self.evictions);
+        stats.rejected = stats.rejected.saturating_add(self.rejected);
+    }
+}
+
+/// A byte-accounted process cache for immutable, clean database page images.
+///
+/// Cached bytes are copied into a private Pager buffer on lookup. Mutable page,
+/// transaction, dirty, spill, rollback, and pin state remain connection-local.
+/// Reads bypass this cache when their WAL cannot provide a safe version epoch
+/// or the database has encryption enabled.
+pub struct SharedPageCache {
+    capacity_bytes: usize,
+    shards: Box<[Mutex<CacheShard>]>,
+    next_namespace: AtomicU64,
+    observer: Option<Arc<dyn SharedPageCacheObserver>>,
+}
+
+impl fmt::Debug for SharedPageCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SharedPageCache")
+            .field("stats", &self.stats())
+            .finish()
+    }
+}
+
+impl SharedPageCache {
+    /// Create a shared cache with the given total byte capacity.
+    pub fn new(capacity_bytes: usize) -> Self {
+        Self::with_optional_observer(capacity_bytes, None)
+    }
+
+    /// Create a shared cache with a lookup observer.
+    pub fn with_observer(
+        capacity_bytes: usize,
+        observer: Arc<dyn SharedPageCacheObserver>,
+    ) -> Self {
+        Self::with_optional_observer(capacity_bytes, Some(observer))
+    }
+
+    fn with_optional_observer(
+        capacity_bytes: usize,
+        observer: Option<Arc<dyn SharedPageCacheObserver>>,
+    ) -> Self {
+        let shard_count = if capacity_bytes == 0 {
+            1
+        } else {
+            capacity_bytes
+                .div_ceil(TARGET_BYTES_PER_SHARD)
+                .clamp(1, MAX_SHARDS)
+        };
+        let base_capacity = capacity_bytes / shard_count;
+        let remainder = capacity_bytes % shard_count;
+        let shards = (0..shard_count)
+            .map(|index| {
+                let capacity = base_capacity + usize::from(index < remainder);
+                Mutex::new(CacheShard::new(capacity))
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            capacity_bytes,
+            shards,
+            next_namespace: AtomicU64::new(1),
+            observer,
+        }
+    }
+
+    /// Return aggregate statistics across all cache shards.
+    pub fn stats(&self) -> SharedPageCacheStats {
+        let mut stats = SharedPageCacheStats {
+            capacity_bytes: self.capacity_bytes as u64,
+            ..SharedPageCacheStats::default()
+        };
+        for shard in &self.shards {
+            shard.lock().add_stats(&mut stats);
+        }
+        stats
+    }
+
+    pub(crate) fn new_namespace(
+        self: &Arc<Self>,
+        generation: Arc<SharedPageCacheGeneration>,
+    ) -> Result<SharedPageCacheNamespace> {
+        let id = self
+            .next_namespace
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |next| {
+                next.checked_add(1)
+            })
+            .map_err(|_| {
+                LimboError::InternalError(
+                    "shared page cache exhausted its namespace identifiers".to_string(),
+                )
+            })?;
+        Ok(SharedPageCacheNamespace {
+            cache: self.clone(),
+            id,
+            generation,
+        })
+    }
+
+    fn shard_index(&self, key: &SharedPageKey) -> usize {
+        let mut hasher = FxHasher::default();
+        key.hash(&mut hasher);
+        (hasher.finish() as usize) % self.shards.len()
+    }
+
+    fn get(&self, key: &SharedPageKey) -> Option<Arc<[u8]>> {
+        self.shards[self.shard_index(key)].lock().get(key)
+    }
+
+    fn record_lookup(&self, hit: bool) {
+        if let Some(observer) = self.observer.as_ref() {
+            observer.record_lookup(if hit {
+                SharedPageCacheLookup::Hit
+            } else {
+                SharedPageCacheLookup::Miss
+            });
+        }
+    }
+
+    fn insert(&self, key: SharedPageKey, value: Arc<[u8]>) {
+        self.shards[self.shard_index(&key)]
+            .lock()
+            .insert(key, value);
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SharedPageCacheGeneration {
+    value: RwLock<u64>,
+}
+
+impl SharedPageCacheGeneration {
+    pub(crate) fn advance(&self) -> Result<()> {
+        let mut value = self.value.write();
+        *value = value.checked_add(1).ok_or_else(|| {
+            LimboError::InternalError(
+                "shared page cache exhausted its database generations".to_string(),
+            )
+        })?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SharedPageCacheNamespace {
+    cache: Arc<SharedPageCache>,
+    id: u64,
+    generation: Arc<SharedPageCacheGeneration>,
+}
+
+pub(crate) enum SharedPageCacheEntry {
+    Hit(Arc<[u8]>),
+    Miss(SharedPageCachePublisher),
+}
+
+impl fmt::Debug for SharedPageCacheNamespace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SharedPageCacheNamespace")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SharedPageCacheNamespace {
+    pub(crate) fn lookup(
+        &self,
+        page_id: usize,
+        page_size: u32,
+        version: SharedPageVersion,
+    ) -> SharedPageCacheEntry {
+        let generation = self.generation.value.read();
+        let key = SharedPageKey {
+            namespace: self.id,
+            generation: *generation,
+            page_id,
+            page_size,
+            version,
+        };
+        let value = self.cache.get(&key);
+        let entry = match value {
+            Some(value) => SharedPageCacheEntry::Hit(value),
+            None => SharedPageCacheEntry::Miss(SharedPageCachePublisher {
+                cache: self.cache.clone(),
+                key,
+            }),
+        };
+        drop(generation);
+        self.cache
+            .record_lookup(matches!(entry, SharedPageCacheEntry::Hit(_)));
+        entry
+    }
+
+    #[cfg(test)]
+    pub(crate) fn publisher(
+        &self,
+        page_id: usize,
+        page_size: u32,
+        version: SharedPageVersion,
+    ) -> SharedPageCachePublisher {
+        let generation = *self.generation.value.read();
+        SharedPageCachePublisher {
+            cache: self.cache.clone(),
+            key: SharedPageKey {
+                namespace: self.id,
+                generation,
+                page_id,
+                page_size,
+                version,
+            },
+        }
+    }
+}
+
+pub(crate) struct SharedPageCachePublisher {
+    cache: Arc<SharedPageCache>,
+    key: SharedPageKey,
+}
+
+impl SharedPageCachePublisher {
+    pub(crate) fn publish(&self, bytes: &[u8]) {
+        if bytes.len() != self.key.page_size as usize {
+            return;
+        }
+        self.cache.insert(self.key, Arc::<[u8]>::from(bytes));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{
+        AtomicBool as StdAtomicBool, AtomicU64 as StdAtomicU64, Ordering as StdOrdering,
+    };
+
+    fn version(frame_id: u64) -> SharedPageVersion {
+        SharedPageVersion::Wal {
+            frame_id,
+            checkpoint_epoch: 7,
+        }
+    }
+
+    fn namespace(cache: &Arc<SharedPageCache>) -> SharedPageCacheNamespace {
+        cache
+            .new_namespace(Arc::new(SharedPageCacheGeneration::default()))
+            .unwrap()
+    }
+
+    fn get(
+        namespace: &SharedPageCacheNamespace,
+        page_id: usize,
+        page_size: u32,
+        version: SharedPageVersion,
+    ) -> Option<Arc<[u8]>> {
+        match namespace.lookup(page_id, page_size, version) {
+            SharedPageCacheEntry::Hit(value) => Some(value),
+            SharedPageCacheEntry::Miss(_) => None,
+        }
+    }
+
+    #[test]
+    fn namespace_and_version_isolate_entries() {
+        let cache = Arc::new(SharedPageCache::new(64 * 1024));
+        let first = namespace(&cache);
+        let second = namespace(&cache);
+        first
+            .publisher(3, 4096, version(11))
+            .publish(&vec![1; 4096]);
+
+        assert_eq!(get(&first, 3, 4096, version(11)).unwrap()[0], 1);
+        assert!(get(&first, 3, 8192, version(11)).is_none());
+        assert!(get(&first, 3, 4096, version(12)).is_none());
+        assert!(get(&second, 3, 4096, version(11)).is_none());
+    }
+
+    #[test]
+    fn database_generation_invalidates_existing_namespaces() {
+        let cache = Arc::new(SharedPageCache::new(64 * 1024));
+        let generation = Arc::new(SharedPageCacheGeneration::default());
+        let namespace = cache.new_namespace(generation.clone()).unwrap();
+        namespace
+            .publisher(3, 4096, version(11))
+            .publish(&vec![1; 4096]);
+
+        assert!(get(&namespace, 3, 4096, version(11)).is_some());
+        generation.advance().unwrap();
+        assert!(get(&namespace, 3, 4096, version(11)).is_none());
+    }
+
+    #[test]
+    fn byte_capacity_evicts_and_never_exceeds_bound() {
+        let per_entry = SharedPageKey {
+            namespace: 1,
+            generation: 0,
+            page_id: 1,
+            page_size: 4096,
+            version: version(1),
+        }
+        .weight(4096);
+        let cache = Arc::new(SharedPageCache::new(per_entry * 2));
+        let namespace = namespace(&cache);
+
+        for page_id in 1..=3 {
+            namespace
+                .publisher(page_id, 4096, version(page_id as u64))
+                .publish(&vec![page_id as u8; 4096]);
+        }
+
+        let stats = cache.stats();
+        assert!(stats.resident_bytes <= stats.capacity_bytes);
+        assert!(stats.entries <= 2);
+        assert!(stats.evictions >= 1);
+    }
+
+    #[test]
+    fn oversized_and_wrong_sized_values_are_not_cached() {
+        let cache = Arc::new(SharedPageCache::new(1024));
+        let namespace = namespace(&cache);
+        namespace
+            .publisher(1, 4096, version(1))
+            .publish(&vec![0; 4096]);
+        namespace.publisher(2, 4096, version(1)).publish(&[0; 128]);
+
+        assert!(get(&namespace, 1, 4096, version(1)).is_none());
+        assert!(get(&namespace, 2, 4096, version(1)).is_none());
+        assert_eq!(cache.stats().rejected, 1);
+    }
+
+    #[derive(Default)]
+    struct LookupObserver {
+        hits: StdAtomicU64,
+        misses: StdAtomicU64,
+    }
+
+    impl SharedPageCacheObserver for LookupObserver {
+        fn record_lookup(&self, outcome: SharedPageCacheLookup) {
+            match outcome {
+                SharedPageCacheLookup::Hit => {
+                    self.hits.fetch_add(1, StdOrdering::Relaxed);
+                }
+                SharedPageCacheLookup::Miss => {
+                    self.misses.fetch_add(1, StdOrdering::Relaxed);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn observer_receives_aggregate_lookup_outcomes() {
+        let observer = Arc::new(LookupObserver::default());
+        let cache = Arc::new(SharedPageCache::with_observer(64 * 1024, observer.clone()));
+        let namespace = namespace(&cache);
+
+        assert!(get(&namespace, 1, 4096, version(1)).is_none());
+        namespace.publisher(1, 4096, version(1)).publish(&[7; 4096]);
+        assert!(get(&namespace, 1, 4096, version(1)).is_some());
+
+        assert_eq!(observer.hits.load(StdOrdering::Relaxed), 1);
+        assert_eq!(observer.misses.load(StdOrdering::Relaxed), 1);
+    }
+
+    struct ReentrantObserver {
+        generation: Arc<SharedPageCacheGeneration>,
+        acquired_generation: StdAtomicBool,
+    }
+
+    impl SharedPageCacheObserver for ReentrantObserver {
+        fn record_lookup(&self, _outcome: SharedPageCacheLookup) {
+            self.acquired_generation.store(
+                self.generation.value.try_write().is_some(),
+                StdOrdering::Relaxed,
+            );
+        }
+    }
+
+    #[test]
+    fn observer_runs_without_internal_locks() {
+        let generation = Arc::new(SharedPageCacheGeneration::default());
+        let observer = Arc::new(ReentrantObserver {
+            generation: generation.clone(),
+            acquired_generation: StdAtomicBool::new(false),
+        });
+        let cache = Arc::new(SharedPageCache::with_observer(64 * 1024, observer.clone()));
+        let namespace = cache.new_namespace(generation).unwrap();
+
+        assert!(get(&namespace, 1, 4096, version(1)).is_none());
+        assert!(observer.acquired_generation.load(StdOrdering::Relaxed));
+    }
+
+    struct AdvancingObserver {
+        generation: Arc<SharedPageCacheGeneration>,
+        advanced: StdAtomicBool,
+    }
+
+    impl SharedPageCacheObserver for AdvancingObserver {
+        fn record_lookup(&self, _outcome: SharedPageCacheLookup) {
+            if !self.advanced.swap(true, StdOrdering::Relaxed) {
+                self.generation.advance().unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn miss_publisher_keeps_the_lookup_generation() {
+        let generation = Arc::new(SharedPageCacheGeneration::default());
+        let observer = Arc::new(AdvancingObserver {
+            generation: generation.clone(),
+            advanced: StdAtomicBool::new(false),
+        });
+        let cache = Arc::new(SharedPageCache::with_observer(64 * 1024, observer));
+        let namespace = cache.new_namespace(generation).unwrap();
+
+        let SharedPageCacheEntry::Miss(publisher) = namespace.lookup(1, 4096, version(1)) else {
+            panic!("empty cache must miss");
+        };
+        publisher.publish(&[7; 4096]);
+
+        assert!(get(&namespace, 1, 4096, version(1)).is_none());
+    }
+}

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -560,6 +560,7 @@ pub fn begin_read_page(
     let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
         let Ok((buf, bytes_read)) = res else {
             page.clear_locked();
+            page.take_shared_page_publisher();
             return None; // IO error already captured in completion
         };
         let buf_len = buf.len();
@@ -569,6 +570,7 @@ pub fn begin_read_page(
             if !allow_empty_read {
                 tracing::error!("short read on page {page_idx}: expected {buf_len} bytes, got 0");
                 page.clear_locked();
+                page.take_shared_page_publisher();
                 return Some(CompletionError::ShortRead {
                     page_idx,
                     expected: buf_len,
@@ -580,6 +582,7 @@ pub fn begin_read_page(
                 "short read on page {page_idx}: expected {buf_len} bytes, got {bytes_read}"
             );
             page.clear_locked();
+            page.take_shared_page_publisher();
             return Some(CompletionError::ShortRead {
                 page_idx,
                 expected: buf_len,
@@ -602,7 +605,7 @@ pub fn begin_read_page(
 #[instrument(skip_all, level = Level::DEBUG)]
 pub fn finish_read_page(page_idx: usize, buffer: Arc<Buffer>, page: PageRef) {
     tracing::trace!("finish_read_page(page_idx = {page_idx})");
-    {
+    let publisher = {
         let inner = page.get();
         inner.buffer = Some(buffer);
         page.clear_locked();
@@ -610,6 +613,10 @@ pub fn finish_read_page(page_idx: usize, buffer: Arc<Buffer>, page: PageRef) {
         // we set the wal tag only when reading page from log, or in allocate_page,
         // we clear it here for safety in case page is being re-loaded.
         page.clear_wal_tag();
+        page.take_shared_page_publisher()
+    };
+    if let Some(publisher) = publisher {
+        publisher.publish(page.get_contents().as_ptr());
     }
 }
 
@@ -2213,6 +2220,158 @@ mod tests {
 
     use super::*;
     use rstest::rstest;
+
+    struct ErrorReadFile {
+        inner: Arc<dyn File>,
+    }
+
+    impl File for ErrorReadFile {
+        fn lock_file(&self, exclusive: bool) -> Result<()> {
+            self.inner.lock_file(exclusive)
+        }
+
+        fn unlock_file(&self) -> Result<()> {
+            self.inner.unlock_file()
+        }
+
+        fn pread(&self, _pos: u64, completion: Completion) -> Result<Completion> {
+            completion.error(CompletionError::IOError(
+                std::io::ErrorKind::Other,
+                "shared page cache test",
+            ));
+            Ok(completion)
+        }
+
+        fn pwrite(
+            &self,
+            pos: u64,
+            buffer: Arc<Buffer>,
+            completion: Completion,
+        ) -> Result<Completion> {
+            self.inner.pwrite(pos, buffer, completion)
+        }
+
+        fn sync(&self, completion: Completion, sync_type: FileSyncType) -> Result<Completion> {
+            self.inner.sync(completion, sync_type)
+        }
+
+        fn size(&self) -> Result<u64> {
+            self.inner.size()
+        }
+
+        fn truncate(&self, len: u64, completion: Completion) -> Result<Completion> {
+            self.inner.truncate(len, completion)
+        }
+    }
+
+    #[test]
+    fn database_read_error_does_not_publish_shared_cache_bytes() {
+        use crate::{
+            storage::{
+                database::DatabaseFile,
+                pager::Page,
+                shared_page_cache::{
+                    SharedPageCache, SharedPageCacheGeneration, SharedPageVersion,
+                },
+            },
+            MemoryIO, OpenFlags, IO,
+        };
+
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let inner = io
+            .open_file("read-error.db", OpenFlags::Create, false)
+            .unwrap();
+        let database_file = DatabaseFile::new(Arc::new(ErrorReadFile { inner }));
+        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        buffer_pool.finalize_with_page_size(512).unwrap();
+        let cache = Arc::new(SharedPageCache::new(64 * 1024));
+        let namespace = cache
+            .new_namespace(Arc::new(SharedPageCacheGeneration::default()))
+            .unwrap();
+        let page = Arc::new(Page::new(1));
+        page.set_shared_page_publisher(Some(namespace.publisher(
+            1,
+            512,
+            SharedPageVersion::Database {
+                checkpoint_epoch: 0,
+            },
+        )));
+
+        let completion = begin_read_page(
+            &database_file,
+            buffer_pool,
+            page.clone(),
+            1,
+            false,
+            &IOContext::default(),
+        )
+        .unwrap();
+        let result = io.wait_for_completion(completion);
+
+        assert!(matches!(
+            result,
+            Err(LimboError::CompletionError(CompletionError::IOError(
+                std::io::ErrorKind::Other,
+                _
+            )))
+        ));
+        assert_eq!(cache.stats().entries, 0);
+        assert!(page.take_shared_page_publisher().is_none());
+    }
+
+    #[test]
+    fn short_database_read_does_not_publish_shared_cache_bytes() {
+        use crate::{
+            storage::{
+                database::DatabaseFile,
+                pager::Page,
+                shared_page_cache::{
+                    SharedPageCache, SharedPageCacheGeneration, SharedPageVersion,
+                },
+            },
+            MemoryIO, OpenFlags, IO,
+        };
+
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        buffer_pool.finalize_with_page_size(512).unwrap();
+        let database_file = DatabaseFile::new(
+            io.open_file("short-read.db", OpenFlags::Create, false)
+                .unwrap(),
+        );
+        let cache = Arc::new(SharedPageCache::new(64 * 1024));
+        let namespace = cache
+            .new_namespace(Arc::new(SharedPageCacheGeneration::default()))
+            .unwrap();
+        let page = Arc::new(Page::new(1));
+        page.set_shared_page_publisher(Some(namespace.publisher(
+            1,
+            512,
+            SharedPageVersion::Database {
+                checkpoint_epoch: 0,
+            },
+        )));
+
+        let completion = begin_read_page(
+            &database_file,
+            buffer_pool,
+            page.clone(),
+            1,
+            false,
+            &IOContext::default(),
+        )
+        .unwrap();
+        let result = io.wait_for_completion(completion);
+
+        assert!(matches!(
+            result,
+            Err(LimboError::CompletionError(
+                CompletionError::ShortRead { .. }
+            ))
+        ));
+        assert_eq!(cache.stats().entries, 0);
+        assert!(page.take_shared_page_publisher().is_none());
+    }
 
     #[rstest]
     #[case(&[], SerialType::null(), Value::Null)]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -747,6 +747,14 @@ pub trait Wal: Debug + Send + Sync {
     fn is_dirty(&self) -> bool;
     fn get_max_frame_in_wal(&self) -> u64;
     fn get_checkpoint_seq(&self) -> u32;
+    /// Return an epoch that changes before database pages or WAL frame ids can be reused.
+    ///
+    /// WAL implementations that cannot provide this invariant leave shared clean-page caching
+    /// disabled for their reads by using the default `None`. Implementations that opt in must
+    /// expose their committed high-water mark through [`Wal::get_max_frame_in_wal`].
+    fn shared_page_cache_epoch(&self) -> Option<u32> {
+        None
+    }
     fn get_max_frame(&self) -> u64;
     /// This connection's frozen `(checkpoint_seq, max_frame)`: for a reader it is the WAL read
     /// mark installed at `begin_read_tx`; for a writer it is the position after its last commit.
@@ -3490,6 +3498,7 @@ impl Wal for WalFile {
                 tracing::debug!(err = ?res.unwrap_err());
                 page.clear_locked();
                 page.clear_wal_tag();
+                page.take_shared_page_publisher();
                 return None; // IO error already captured in completion
             };
             let buf_len = buf.len();
@@ -3499,6 +3508,7 @@ impl Wal for WalFile {
                 );
                 page.clear_locked();
                 page.clear_wal_tag();
+                page.take_shared_page_publisher();
                 return Some(CompletionError::ShortReadWalFrame {
                     offset,
                     expected: buf_len,
@@ -3950,6 +3960,10 @@ impl Wal for WalFile {
 
     fn get_checkpoint_seq(&self) -> u32 {
         self.load_coordination_snapshot().checkpoint_seq
+    }
+
+    fn shared_page_cache_epoch(&self) -> Option<u32> {
+        Some(self.coordination.checkpoint_epoch())
     }
 
     fn get_max_frame(&self) -> u64 {
@@ -5832,6 +5846,7 @@ pub mod test {
             buffer_pool::BufferPool,
             database::{DatabaseFile, DatabaseStorage},
             pager::{allocate_new_page, PageRef},
+            shared_page_cache::{SharedPageCache, SharedPageCacheGeneration, SharedPageVersion},
             sqlite3_ondisk::{self, PageSize, WAL_HEADER_SIZE},
             wal::READMARK_NOT_USED,
         },
@@ -6372,6 +6387,32 @@ pub mod test {
             Err(LimboError::CompletionError(err)) => err,
             other => panic!("expected completion error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn short_wal_read_does_not_publish_shared_cache_bytes() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let cache = Arc::new(SharedPageCache::new(64 * 1024));
+        let namespace = cache
+            .new_namespace(Arc::new(SharedPageCacheGeneration::default()))
+            .unwrap();
+        let page = Arc::new(crate::Page::new(7));
+        page.set_shared_page_publisher(Some(namespace.publisher(
+            7,
+            page_size,
+            SharedPageVersion::Wal {
+                frame_id: 1,
+                checkpoint_epoch: 0,
+            },
+        )));
+
+        let completion = wal.read_frame(1, page.clone(), buffer_pool).unwrap();
+        let error = wait_for_completion_error(&io, completion);
+
+        assert!(matches!(error, CompletionError::ShortReadWalFrame { .. }));
+        assert_eq!(cache.stats().entries, 0);
+        assert!(page.take_shared_page_publisher().is_none());
     }
 
     #[test]

--- a/licenses/core/lru-mit-license.md
+++ b/licenses/core/lru-mit-license.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Jerome Froelich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -18,6 +18,7 @@ mod query_processing;
 mod query_timeout;
 mod queued_io;
 mod reindex;
+mod shared_page_cache;
 mod statement_metadata;
 mod statement_reset;
 mod stmt_journal;

--- a/tests/integration/shared_page_cache.rs
+++ b/tests/integration/shared_page_cache.rs
@@ -1,0 +1,382 @@
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Barrier,
+};
+
+use turso_core::{
+    io::FileSyncType, Buffer, Completion, Connection, Database, DatabaseOpts, DatabaseStorage,
+    IOContext, OpenOptions, SharedPageCache, SqliteDialect,
+};
+
+use crate::common::{ExecRows, TempDatabase, TempDatabaseBuilder};
+
+const CACHE_CAPACITY: usize = 8 * 1024 * 1024;
+
+struct CountingDatabaseStorage {
+    inner: Arc<dyn DatabaseStorage>,
+    page_reads: AtomicU64,
+}
+
+impl CountingDatabaseStorage {
+    fn new(inner: Arc<dyn DatabaseStorage>) -> Self {
+        Self {
+            inner,
+            page_reads: AtomicU64::new(0),
+        }
+    }
+
+    fn reset_page_reads(&self) {
+        self.page_reads.store(0, Ordering::Relaxed);
+    }
+
+    fn page_reads(&self) -> u64 {
+        self.page_reads.load(Ordering::Relaxed)
+    }
+}
+
+impl DatabaseStorage for CountingDatabaseStorage {
+    fn read_header(&self, c: Completion) -> turso_core::Result<Completion> {
+        self.inner.read_header(c)
+    }
+
+    fn read_page(
+        &self,
+        page_idx: usize,
+        io_ctx: &IOContext,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        self.page_reads.fetch_add(1, Ordering::Relaxed);
+        self.inner.read_page(page_idx, io_ctx, c)
+    }
+
+    fn write_page(
+        &self,
+        page_idx: usize,
+        buffer: Arc<Buffer>,
+        io_ctx: &IOContext,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        self.inner.write_page(page_idx, buffer, io_ctx, c)
+    }
+
+    fn write_pages(
+        &self,
+        first_page_idx: usize,
+        page_size: usize,
+        buffers: Vec<Arc<Buffer>>,
+        io_ctx: &IOContext,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        self.inner
+            .write_pages(first_page_idx, page_size, buffers, io_ctx, c)
+    }
+
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> turso_core::Result<Completion> {
+        self.inner.sync(c, sync_type)
+    }
+
+    fn size(&self) -> turso_core::Result<u64> {
+        self.inner.size()
+    }
+
+    fn truncate(&self, len: usize, c: Completion) -> turso_core::Result<Completion> {
+        self.inner.truncate(len, c)
+    }
+}
+
+fn database_with_cache() -> (TempDatabase, Arc<SharedPageCache>) {
+    database_with_cache_capacity(CACHE_CAPACITY)
+}
+
+fn database_with_cache_capacity(capacity_bytes: usize) -> (TempDatabase, Arc<SharedPageCache>) {
+    let database = TempDatabaseBuilder::new()
+        .with_opts(DatabaseOpts::new())
+        .build();
+    let cache = Arc::new(SharedPageCache::new(capacity_bytes));
+    database
+        .db
+        .set_shared_page_cache(Some(cache.clone()))
+        .unwrap();
+    (database, cache)
+}
+
+fn seed_rows(connection: &Arc<Connection>, rows: usize) {
+    connection
+        .execute("CREATE TABLE test(id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+        .unwrap();
+    connection.execute("BEGIN").unwrap();
+    for id in 1..=rows {
+        connection
+            .execute(format!(
+                "INSERT INTO test VALUES ({id}, printf('%04d-', {id}) || hex(zeroblob(512)))"
+            ))
+            .unwrap();
+    }
+    connection.execute("COMMIT").unwrap();
+}
+
+fn table_summary(connection: &Arc<Connection>) -> (i64, i64) {
+    connection
+        .exec_rows("SELECT count(*), sum(length(value)) FROM test")
+        .into_iter()
+        .next()
+        .unwrap()
+}
+
+fn value(connection: &Arc<Connection>, id: usize) -> String {
+    let rows: Vec<(String,)> =
+        connection.exec_rows(&format!("SELECT value FROM test WHERE id = {id}"));
+    rows.into_iter().next().unwrap().0
+}
+
+#[cfg(unix)]
+fn seed_single_value(connection: &Arc<Connection>, value: &str) {
+    connection
+        .execute("CREATE TABLE test(id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+        .unwrap();
+    connection
+        .execute(format!(
+            "INSERT INTO test VALUES (1, '{}')",
+            value.replace('\'', "''")
+        ))
+        .unwrap();
+}
+
+#[cfg(unix)]
+fn sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut path = path.as_os_str().to_owned();
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
+#[test]
+fn fresh_connections_reuse_clean_pages() {
+    let (database, cache) = database_with_cache();
+    let writer = database.connect_limbo();
+    seed_rows(&writer, 256);
+
+    let first_reader = database.connect_limbo();
+    let expected = table_summary(&first_reader);
+    let after_first = cache.stats();
+    assert!(after_first.entries > 0);
+
+    let second_reader = database.connect_limbo();
+    assert_eq!(table_summary(&second_reader), expected);
+    let after_second = cache.stats();
+
+    assert!(after_second.hits > after_first.hits);
+    assert_eq!(after_second.misses, after_first.misses);
+    assert!(after_second.resident_bytes <= after_second.capacity_bytes);
+}
+
+#[test]
+fn warm_scan_avoids_database_storage_page_reads() {
+    let seeded = TempDatabaseBuilder::new()
+        .with_opts(DatabaseOpts::new())
+        .build();
+    let writer = seeded.connect_limbo();
+    seed_rows(&writer, 256);
+    let expected = table_summary(&writer);
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let path = seeded.path.to_str().unwrap().to_owned();
+    let io = seeded.io.clone();
+    let storage = Arc::new(CountingDatabaseStorage::new(seeded.db.db_file.clone()));
+    drop(writer);
+    drop(seeded);
+
+    let database = Database::do_open(
+        io,
+        &path,
+        OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(storage.clone())
+            .db_opts(DatabaseOpts::new()),
+    )
+    .unwrap();
+    let cache = Arc::new(SharedPageCache::new(CACHE_CAPACITY));
+    database.set_shared_page_cache(Some(cache.clone())).unwrap();
+
+    storage.reset_page_reads();
+    assert_eq!(table_summary(&database.connect().unwrap()), expected);
+    let cold_page_reads = storage.page_reads();
+    let after_cold_scan = cache.stats();
+
+    storage.reset_page_reads();
+    assert_eq!(table_summary(&database.connect().unwrap()), expected);
+    let warm_page_reads = storage.page_reads();
+    let after_warm_scan = cache.stats();
+
+    assert!(
+        cold_page_reads > 1,
+        "cold scan should read multiple database pages, got {cold_page_reads}"
+    );
+    assert_eq!(
+        warm_page_reads, 0,
+        "warm scan should be served by the shared page cache"
+    );
+    assert!(after_warm_scan.hits > after_cold_scan.hits);
+    assert_eq!(after_warm_scan.misses, after_cold_scan.misses);
+}
+
+#[test]
+fn encryption_enabled_database_bypasses_shared_decrypted_bytes() {
+    let database = TempDatabaseBuilder::new()
+        .with_opts(DatabaseOpts::new().with_encryption(true))
+        .build();
+    let cache = Arc::new(SharedPageCache::new(CACHE_CAPACITY));
+    database
+        .db
+        .set_shared_page_cache(Some(cache.clone()))
+        .unwrap();
+
+    let writer = database.connect_limbo();
+    seed_rows(&writer, 64);
+    assert_eq!(
+        table_summary(&database.connect_limbo()),
+        table_summary(&writer)
+    );
+
+    let stats = cache.stats();
+    assert_eq!(stats.entries, 0);
+    assert_eq!(stats.hits, 0);
+    assert_eq!(stats.misses, 0);
+}
+
+#[test]
+fn old_snapshot_reuses_its_version_after_a_new_commit() {
+    let (database, cache) = database_with_cache();
+    let writer = database.connect_limbo();
+    seed_rows(&writer, 64);
+
+    let old_snapshot = database.connect_limbo();
+    old_snapshot.execute("BEGIN").unwrap();
+    let old_value = value(&old_snapshot, 1);
+    let after_warm = cache.stats();
+
+    writer
+        .execute("UPDATE test SET value = 'new value' WHERE id = 1")
+        .unwrap();
+    assert_eq!(value(&database.connect_limbo(), 1), "new value");
+
+    old_snapshot.get_pager().clear_page_cache(false);
+    assert_eq!(value(&old_snapshot, 1), old_value);
+    let after_old_snapshot_reread = cache.stats();
+    assert!(after_old_snapshot_reread.hits > after_warm.hits);
+
+    writer.execute("BEGIN").unwrap();
+    writer
+        .execute("UPDATE test SET value = 'rolled back' WHERE id = 1")
+        .unwrap();
+    writer.execute("ROLLBACK").unwrap();
+    assert_eq!(value(&database.connect_limbo(), 1), "new value");
+    old_snapshot.execute("COMMIT").unwrap();
+}
+
+#[test]
+fn checkpoint_epoch_prevents_reusing_pre_checkpoint_bytes() {
+    let (database, cache) = database_with_cache();
+    let writer = database.connect_limbo();
+    seed_rows(&writer, 128);
+
+    writer
+        .execute("UPDATE test SET value = 'after checkpoint' WHERE id = 1")
+        .unwrap();
+    assert_eq!(value(&database.connect_limbo(), 1), "after checkpoint");
+    let before_checkpoint = cache.stats();
+
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let first_reader = database.connect_limbo();
+    assert_eq!(value(&first_reader, 1), "after checkpoint");
+    let after_first_reader = cache.stats();
+    assert!(after_first_reader.misses > before_checkpoint.misses);
+
+    let second_reader = database.connect_limbo();
+    assert_eq!(value(&second_reader, 1), "after checkpoint");
+    let after_second_reader = cache.stats();
+    assert!(after_second_reader.hits > after_first_reader.hits);
+}
+
+#[test]
+fn concurrent_readers_populate_a_cold_cache_without_sharing_pager_state() {
+    let database = TempDatabaseBuilder::new()
+        .with_opts(DatabaseOpts::new())
+        .build();
+    let writer = database.connect_limbo();
+    seed_rows(&writer, 256);
+    let expected = table_summary(&writer);
+    let cache = Arc::new(SharedPageCache::new(CACHE_CAPACITY));
+    database
+        .db
+        .set_shared_page_cache(Some(cache.clone()))
+        .unwrap();
+    let barrier = Arc::new(Barrier::new(9));
+
+    let readers = (0..8)
+        .map(|_| {
+            let database = database.db.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                let connection = database.connect().unwrap();
+                barrier.wait();
+                table_summary(&connection)
+            })
+        })
+        .collect::<Vec<_>>();
+    barrier.wait();
+
+    for reader in readers {
+        assert_eq!(reader.join().unwrap(), expected);
+    }
+
+    let stats = cache.stats();
+    assert!(stats.misses > 0);
+    assert!(stats.insertions > 0);
+    assert!(stats.entries > 0);
+    assert!(stats.resident_bytes <= stats.capacity_bytes);
+}
+
+#[test]
+fn eviction_falls_back_to_storage_and_repopulates_the_cache() {
+    let (database, cache) = database_with_cache_capacity(10 * 1024);
+    let writer = database.connect_limbo();
+    seed_rows(&writer, 128);
+
+    let expected = table_summary(&database.connect_limbo());
+    let after_first = cache.stats();
+    assert!(after_first.evictions > 0);
+
+    assert_eq!(table_summary(&database.connect_limbo()), expected);
+    let after_second = cache.stats();
+    assert!(after_second.misses > after_first.misses);
+    assert!(after_second.insertions > after_first.insertions);
+    assert!(after_second.resident_bytes <= after_second.capacity_bytes);
+}
+
+#[test]
+#[cfg(unix)]
+fn external_restore_invalidates_bytes_from_the_previous_file_generation() {
+    let (database, cache) = database_with_cache();
+    let original_writer = database.connect_limbo();
+    seed_single_value(&original_writer, "before restore");
+    assert_eq!(value(&database.connect_limbo(), 1), "before restore");
+    let before_restore = cache.stats();
+
+    let replacement = TempDatabase::new_empty();
+    let replacement_writer = replacement.connect_limbo();
+    seed_single_value(&replacement_writer, "after restore");
+
+    std::fs::copy(&replacement.path, &database.path).unwrap();
+    std::fs::copy(
+        sidecar_path(&replacement.path, "-wal"),
+        sidecar_path(&database.path, "-wal"),
+    )
+    .unwrap();
+    database.db.reload_wal_after_external_restore().unwrap();
+
+    assert_eq!(value(&database.connect_limbo(), 1), "after restore");
+    let after_restore = cache.stats();
+    assert!(after_restore.misses > before_restore.misses);
+}


### PR DESCRIPTION
## Description

This draft adds an opt-in cache that lets connections reuse clean page bytes loaded by earlier connections.

Each connection still keeps its own Pager, Page objects, and mutable transaction state. On a cache hit, the page bytes are copied into the connection's private buffer.

Cache entries are kept separate by database and WAL version, and are added only after a read completes successfully. Cases that cannot currently be reused safely bypass the cache.

Related to #318.

## Motivation and context

I encountered this in a workload that creates a new connection for each request. Even when the data was already warm, each new Pager read the same pages through storage again.

This draft tries sharing only clean page bytes without sharing mutable Pager state.

## Testing

- `cargo +1.88 fmt --all -- --check`
- `cargo +1.88 test -p turso_core --lib`
- `cargo +1.88 test -p core_tester --test integration_tests shared_page_cache:: -- --nocapture`
- Verified that a second connection reused 88 cached pages without reading those pages from database storage again

## Description of AI Usage

I used Codex to help compare a downstream prototype with the current upstream code, adapt the implementation, add tests, and review edge cases. I reviewed the changes and test results.
