### PR TITLE
ci: use canonical bindings/* labels in auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,23 +28,23 @@ perf/benchmarks:
   - changed-files:
       - any-glob-to-any-file: ["perf/**/*", "core/benches/*"]
 
-go-bindings:
+bindings/go:
   - changed-files:
       - any-glob-to-any-file: "bindings/go/**/*"
 
-python-bindings:
+bindings/python:
   - changed-files:
       - any-glob-to-any-file: "bindings/python/**/*"
 
-js-bindings:
+bindings/javascript:
   - changed-files:
       - any-glob-to-any-file: "bindings/javascript/**/*"
 
-rust-bindings:
+bindings/rust:
   - changed-files:
       - any-glob-to-any-file: "bindings/rust/**/*"
 
-java-bindings:
+bindings/java:
   - changed-files:
       - any-glob-to-any-file: "bindings/java/**/*"
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 simulator:
   - changed-files:
       - any-glob-to-any-file: "testing/simulator/**/*"
-docs:
+documentation:
   - changed-files:
       - any-glob-to-any-file: "docs/**/*"
 
@@ -92,7 +92,7 @@ storage:
   - changed-files:
       - any-glob-to-any-file: "core/storage/*"
 
-vector:
+vector search:
   - changed-files:
       - any-glob-to-any-file: "core/vector/*"
 


### PR DESCRIPTION
The auto-labeler applies `js-bindings`, `go-bindings`, `python-bindings`, `rust-bindings`, and `java-bindings` to PRs, while issue triage uses the `bindings/<language>` labels, so every binding has two parallel labels. This points the labeler at the canonical names; the duplicate labels are being retired separately.