### PR TITLE
serverless/go: add serverless driver and conformance tests

### DIFF
--- a/serverless/go/README.md
+++ b/serverless/go/README.md
@@ -1,0 +1,79 @@
+# Turso Serverless Driver for Go
+
+A pure Go driver for Turso Cloud that speaks the [SQL over HTTP
+protocol](https://github.com/tursodatabase/turso/blob/main/serverless/PROTOCOL.md).
+Designed for serverless and edge environments: no persistent connections,
+no cgo, no native libraries, just HTTP requests from the standard library.
+
+The driver implements `database/sql` and mirrors the embedded
+[`turso.tech/database/tursogo`](https://github.com/tursodatabase/turso/tree/main/bindings/go)
+driver, so the same application code can run against a local database or
+Turso Cloud.
+
+## Usage
+
+```go
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	_ "turso.tech/database/tursogo-serverless"
+)
+
+func main() {
+	dsn := os.Getenv("TURSO_DATABASE_URL") + "?auth_token=" + os.Getenv("TURSO_AUTH_TOKEN")
+	db, err := sql.Open("turso-serverless", dsn)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	db.Exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+	db.Exec("INSERT INTO users (name) VALUES (?)", "Alice")
+
+	rows, _ := db.Query("SELECT id, name FROM users")
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		var name string
+		rows.Scan(&id, &name)
+		fmt.Println(id, name)
+	}
+}
+```
+
+To keep the auth token out of the connection string, open the database
+through a connector instead:
+
+```go
+import turso "turso.tech/database/tursogo-serverless"
+
+db := sql.OpenDB(turso.NewConnector(url, authToken))
+```
+
+Interactive transactions span multiple HTTP requests; the server keeps the
+connection state alive between them:
+
+```go
+tx, err := db.Begin()
+tx.Exec("UPDATE accounts SET balance = balance - 100 WHERE id = 1")
+tx.Exec("UPDATE accounts SET balance = balance + 100 WHERE id = 2")
+tx.Commit()
+```
+
+## Conformance tests
+
+The test suite runs against a live database. Point it at a Turso Cloud
+instance:
+
+```console
+$ export TURSO_DATABASE_URL=libsql://<your-db>.turso.io
+$ export TURSO_AUTH_TOKEN=<your-token>
+$ go test ./...
+```
+
+The tests that need a server skip themselves when the environment
+variables are not set.

--- a/serverless/go/driver.go
+++ b/serverless/go/driver.go
@@ -1,0 +1,471 @@
+// Package turso provides a database/sql driver for Turso Cloud that speaks
+// the SQL over HTTP protocol (see serverless/PROTOCOL.md). Designed for
+// serverless and edge environments: no persistent connections, no native
+// libraries, just HTTP requests.
+//
+// The driver registers as "turso-serverless" and mirrors the embedded
+// turso.tech/database/tursogo driver, so the same application code can run
+// against a local database or Turso Cloud:
+//
+//	db, err := sql.Open("turso-serverless", "turso://my-db.turso.io?auth_token=...")
+package turso
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Sentinel errors matching the embedded turso Go driver.
+var (
+	ErrTursoStmtClosed = errors.New("turso: statement closed")
+	ErrTursoConnClosed = errors.New("turso: connection closed")
+	ErrTursoTxDone     = errors.New("turso: transaction done")
+)
+
+func init() {
+	sql.Register("turso-serverless", &serverlessDriver{})
+}
+
+// Ensure interface compliance.
+var (
+	_ driver.Driver             = (*serverlessDriver)(nil)
+	_ driver.Connector          = (*Connector)(nil)
+	_ driver.Conn               = (*conn)(nil)
+	_ driver.ConnPrepareContext = (*conn)(nil)
+	_ driver.ExecerContext      = (*conn)(nil)
+	_ driver.QueryerContext     = (*conn)(nil)
+	_ driver.Pinger             = (*conn)(nil)
+	_ driver.ConnBeginTx        = (*conn)(nil)
+	_ driver.Stmt               = (*stmt)(nil)
+	_ driver.StmtExecContext    = (*stmt)(nil)
+	_ driver.StmtQueryContext   = (*stmt)(nil)
+	_ driver.Rows               = (*rows)(nil)
+	_ driver.Result             = (*execResult)(nil)
+	_ driver.Tx                 = (*tx)(nil)
+)
+
+// --- driver.Driver ---
+
+type serverlessDriver struct{}
+
+func (d *serverlessDriver) Open(dsn string) (driver.Conn, error) {
+	u, token, err := parseDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return newConn(u, token), nil
+}
+
+// parseDSN parses "<url>[?auth_token=<token>]" into a base URL and an auth
+// token. The URL can use the turso://, libsql://, https://, or http://
+// scheme; other query parameters are preserved.
+func parseDSN(dsn string) (string, string, error) {
+	if dsn == "" {
+		return "", "", errors.New("turso: empty DSN")
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", "", fmt.Errorf("turso: invalid DSN: %w", err)
+	}
+	q := u.Query()
+	token := q.Get("auth_token")
+	q.Del("auth_token")
+	u.RawQuery = q.Encode()
+	return normalizeURL(u.String()), token, nil
+}
+
+// --- driver.Connector ---
+
+// Connector opens serverless connections without going through a DSN. Use
+// it with sql.OpenDB when the auth token should not appear in a connection
+// string.
+type Connector struct {
+	url       string
+	authToken string
+}
+
+// NewConnector creates a connector for the given database URL (turso://,
+// libsql://, https://, or http://) and auth token.
+func NewConnector(url, authToken string) *Connector {
+	return &Connector{url: normalizeURL(url), authToken: authToken}
+}
+
+func (c *Connector) Connect(context.Context) (driver.Conn, error) {
+	return newConn(c.url, c.authToken), nil
+}
+
+func (c *Connector) Driver() driver.Driver {
+	return &serverlessDriver{}
+}
+
+// --- driver.Conn ---
+
+type conn struct {
+	sess   *session
+	mu     sync.Mutex
+	closed bool
+}
+
+func newConn(url, authToken string) *conn {
+	return &conn{sess: newSession(url, authToken)}
+}
+
+func (c *conn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	// Closing the stream rolls back any open transaction server-side,
+	// matching the embedded driver: uncommitted changes are lost on close.
+	c.sess.close()
+	return nil
+}
+
+func (c *conn) Prepare(query string) (driver.Stmt, error) {
+	return c.PrepareContext(context.Background(), query)
+}
+
+func (c *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, ErrTursoConnClosed
+	}
+	results, err := c.sess.executePipeline(ctx, []streamRequest{{Type: "describe", SQL: query}}, true)
+	if err != nil {
+		return nil, err
+	}
+	result := results[0]
+	if result.Error != nil {
+		return nil, serverError(result.Error)
+	}
+	if result.Response == nil || result.Response.Result == nil {
+		return nil, fmt.Errorf("turso: expected describe result in pipeline response")
+	}
+	var desc describeResult
+	if err := json.Unmarshal(result.Response.Result, &desc); err != nil {
+		return nil, fmt.Errorf("turso: invalid describe result: %w", err)
+	}
+	return &stmt{conn: c, sql: query, numInputs: len(desc.Params)}, nil
+}
+
+func (c *conn) Begin() (driver.Tx, error) {
+	return c.BeginTx(context.Background(), driver.TxOptions{})
+}
+
+func (c *conn) BeginTx(ctx context.Context, _ driver.TxOptions) (driver.Tx, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, ErrTursoConnClosed
+	}
+	if _, err := c.sess.executeStmt(ctx, rawStmt("BEGIN")); err != nil {
+		return nil, err
+	}
+	return &tx{conn: c}, nil
+}
+
+func (c *conn) Ping(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return ErrTursoConnClosed
+	}
+	_, err := c.sess.executeStmt(ctx, rawStmt("SELECT 1"))
+	return err
+}
+
+func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, ErrTursoConnClosed
+	}
+	// Multi-statement strings run through the sequence request
+	// (section 6.3): statements execute in order and execution stops at
+	// the first failure. Statement-level counts are not reported.
+	if len(args) == 0 && len(splitStatements(query)) > 1 {
+		results, err := c.sess.executePipeline(ctx, []streamRequest{{Type: "sequence", SQL: query}}, true)
+		if err != nil {
+			return nil, err
+		}
+		if results[0].Error != nil {
+			return nil, serverError(results[0].Error)
+		}
+		return &execResult{lastInsertId: c.sess.lastInsertRowid}, nil
+	}
+	body, err := buildStmt(query, args, false)
+	if err != nil {
+		return nil, err
+	}
+	out, err := c.sess.executeStmt(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return &execResult{
+		lastInsertId: c.sess.lastInsertRowid,
+		rowsAffected: out.rowsAffected,
+	}, nil
+}
+
+func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, ErrTursoConnClosed
+	}
+	body, err := buildStmt(query, args, true)
+	if err != nil {
+		return nil, err
+	}
+	out, err := c.sess.executeStmt(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return &rows{
+		columns:   out.columns,
+		decltypes: out.decltypes,
+		rows:      out.rows,
+	}, nil
+}
+
+// buildStmt encodes a query and its arguments into a protocol statement
+// (section 8.1).
+func buildStmt(query string, args []driver.NamedValue, wantRows bool) (stmtBody, error) {
+	positional := []protoValue{}
+	named := []namedArg{}
+	for _, nv := range args {
+		value, err := encodeValue(nv.Value)
+		if err != nil {
+			return stmtBody{}, err
+		}
+		if nv.Name != "" {
+			named = append(named, namedArg{Name: nv.Name, Value: value})
+		} else {
+			positional = append(positional, value)
+		}
+	}
+	return stmtBody{
+		SQL:       query,
+		Args:      positional,
+		NamedArgs: named,
+		WantRows:  wantRows,
+	}, nil
+}
+
+// rawStmt builds a protocol statement for driver-issued SQL with no
+// arguments.
+func rawStmt(query string) stmtBody {
+	return stmtBody{
+		SQL:       query,
+		Args:      []protoValue{},
+		NamedArgs: []namedArg{},
+		WantRows:  false,
+	}
+}
+
+// splitStatements splits a SQL string into individual statements at
+// semicolons outside of single- or double-quoted strings.
+func splitStatements(sqlText string) []string {
+	var stmts []string
+	var current strings.Builder
+	inSingleQuote := false
+	inDoubleQuote := false
+	for i := 0; i < len(sqlText); i++ {
+		ch := sqlText[i]
+		switch {
+		case ch == '\'' && !inDoubleQuote:
+			inSingleQuote = !inSingleQuote
+			current.WriteByte(ch)
+		case ch == '"' && !inSingleQuote:
+			inDoubleQuote = !inDoubleQuote
+			current.WriteByte(ch)
+		case ch == ';' && !inSingleQuote && !inDoubleQuote:
+			if s := strings.TrimSpace(current.String()); s != "" {
+				stmts = append(stmts, s)
+			}
+			current.Reset()
+		default:
+			current.WriteByte(ch)
+		}
+	}
+	if s := strings.TrimSpace(current.String()); s != "" {
+		stmts = append(stmts, s)
+	}
+	return stmts
+}
+
+// --- driver.Stmt ---
+
+type stmt struct {
+	conn      *conn
+	sql       string
+	numInputs int
+	closed    bool
+}
+
+func (s *stmt) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *stmt) NumInput() int {
+	return s.numInputs
+}
+
+func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+	return s.ExecContext(context.Background(), namedValues(args))
+}
+
+func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	if s.closed {
+		return nil, ErrTursoStmtClosed
+	}
+	return s.conn.ExecContext(ctx, s.sql, args)
+}
+
+func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+	return s.QueryContext(context.Background(), namedValues(args))
+}
+
+func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	if s.closed {
+		return nil, ErrTursoStmtClosed
+	}
+	return s.conn.QueryContext(ctx, s.sql, args)
+}
+
+func namedValues(args []driver.Value) []driver.NamedValue {
+	named := make([]driver.NamedValue, len(args))
+	for i, v := range args {
+		named[i] = driver.NamedValue{Ordinal: i + 1, Value: v}
+	}
+	return named
+}
+
+// --- driver.Rows ---
+
+type rows struct {
+	columns   []string
+	decltypes []string
+	rows      [][]any
+	pos       int
+	closed    bool
+}
+
+func (r *rows) Columns() []string {
+	return r.columns
+}
+
+func (r *rows) Close() error {
+	r.closed = true
+	return nil
+}
+
+func (r *rows) Next(dest []driver.Value) error {
+	if r.closed || r.pos >= len(r.rows) {
+		return io.EOF
+	}
+	row := r.rows[r.pos]
+	r.pos++
+	for i, v := range row {
+		if i >= len(dest) {
+			break
+		}
+		// Matches the embedded driver: text in a date-typed column scans
+		// as time.Time when it parses.
+		if s, ok := v.(string); ok && i < len(r.decltypes) && isTimeColumn(r.decltypes[i]) {
+			if t, err := parseTimeString(s); err == nil {
+				dest[i] = t
+				continue
+			}
+		}
+		dest[i] = v
+	}
+	return nil
+}
+
+// isTimeColumn reports whether the declared column type is a date or time
+// type, matching go-sqlite3 and the embedded driver.
+func isTimeColumn(decltype string) bool {
+	upper := strings.ToUpper(decltype)
+	return upper == "TIMESTAMP" || upper == "DATETIME" || upper == "DATE"
+}
+
+// sqliteTimestampFormats are the timestamp formats accepted by go-sqlite3.
+var sqliteTimestampFormats = []string{
+	"2006-01-02 15:04:05.999999999-07:00",
+	"2006-01-02T15:04:05.999999999-07:00",
+	"2006-01-02 15:04:05.999999999",
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02 15:04:05",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04",
+	"2006-01-02T15:04",
+	"2006-01-02",
+}
+
+func parseTimeString(s string) (time.Time, error) {
+	trimmed := strings.TrimSuffix(s, "Z")
+	for _, format := range sqliteTimestampFormats {
+		if t, err := time.ParseInLocation(format, trimmed, time.UTC); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("turso: cannot parse %q as time", s)
+}
+
+// --- driver.Result ---
+
+type execResult struct {
+	lastInsertId int64
+	rowsAffected int64
+}
+
+func (r *execResult) LastInsertId() (int64, error) {
+	return r.lastInsertId, nil
+}
+
+func (r *execResult) RowsAffected() (int64, error) {
+	return r.rowsAffected, nil
+}
+
+// --- driver.Tx ---
+
+type tx struct {
+	conn *conn
+	done bool
+}
+
+func (t *tx) Commit() error {
+	return t.finish("COMMIT")
+}
+
+func (t *tx) Rollback() error {
+	return t.finish("ROLLBACK")
+}
+
+func (t *tx) finish(sqlText string) error {
+	if t.done {
+		return ErrTursoTxDone
+	}
+	t.done = true
+	t.conn.mu.Lock()
+	defer t.conn.mu.Unlock()
+	if t.conn.closed {
+		return ErrTursoConnClosed
+	}
+	_, err := t.conn.sess.executeStmt(context.Background(), rawStmt(sqlText))
+	return err
+}

--- a/serverless/go/driver_test.go
+++ b/serverless/go/driver_test.go
@@ -1,0 +1,829 @@
+// Integration tests for the serverless driver against a live server.
+//
+// Configure with TURSO_DATABASE_URL and (optionally) TURSO_AUTH_TOKEN; the
+// tests that need a server skip themselves when TURSO_DATABASE_URL is
+// unset. Tests that exercise only local code run unconditionally.
+
+package turso
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"math"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func openDB(t *testing.T) *sql.DB {
+	t.Helper()
+	url := os.Getenv("TURSO_DATABASE_URL")
+	if url == "" {
+		t.Skip("TURSO_DATABASE_URL is not set")
+	}
+	db := sql.OpenDB(NewConnector(url, os.Getenv("TURSO_AUTH_TOKEN")))
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// ---------------------------------------------------------------------------
+// Query execution
+// ---------------------------------------------------------------------------
+
+func TestQuerySingleValue(t *testing.T) {
+	db := openDB(t)
+
+	var val int64
+	if err := db.QueryRow("SELECT 42").Scan(&val); err != nil {
+		t.Fatal(err)
+	}
+	if val != 42 {
+		t.Fatalf("got %d, want 42", val)
+	}
+}
+
+func TestQuerySingleRow(t *testing.T) {
+	db := openDB(t)
+
+	rows, err := db.Query("SELECT 1 AS one, 'two' AS two, 0.5 AS three")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cols, []string{"one", "two", "three"}) {
+		t.Fatalf("columns: got %v", cols)
+	}
+
+	if !rows.Next() {
+		t.Fatal("expected a row")
+	}
+	var one int64
+	var two string
+	var three float64
+	if err := rows.Scan(&one, &two, &three); err != nil {
+		t.Fatal(err)
+	}
+	if one != 1 || two != "two" || three != 0.5 {
+		t.Fatalf("got (%d, %q, %v)", one, two, three)
+	}
+}
+
+func TestQueryMultipleRows(t *testing.T) {
+	db := openDB(t)
+
+	rows, err := db.Query("VALUES (1, 'one'), (2, 'two'), (3, 'three')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	want := []struct {
+		n int64
+		s string
+	}{{1, "one"}, {2, "two"}, {3, "three"}}
+	i := 0
+	for rows.Next() {
+		var n int64
+		var s string
+		if err := rows.Scan(&n, &s); err != nil {
+			t.Fatal(err)
+		}
+		if i >= len(want) || n != want[i].n || s != want[i].s {
+			t.Fatalf("row %d: got (%d, %q)", i, n, s)
+		}
+		i++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if i != len(want) {
+		t.Fatalf("got %d rows, want %d", i, len(want))
+	}
+}
+
+func TestQueryErrorOnInvalidSQL(t *testing.T) {
+	db := openDB(t)
+
+	if _, err := db.Query("SELECT foobar"); err == nil {
+		t.Fatal("expected error for invalid SQL")
+	}
+}
+
+func TestInsertReturning(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_ret")
+	mustExec(t, db, "CREATE TABLE t_go_ret (a)")
+
+	var x int64
+	var y string
+	err := db.QueryRow("INSERT INTO t_go_ret VALUES (1) RETURNING 42 AS x, 'foo' AS y").Scan(&x, &y)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if x != 42 || y != "foo" {
+		t.Fatalf("got (%d, %q)", x, y)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Exec results
+// ---------------------------------------------------------------------------
+
+func TestRowsAffected(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_aff")
+	mustExec(t, db, "CREATE TABLE t_go_aff (a)")
+
+	result := mustExec(t, db, "INSERT INTO t_go_aff VALUES (1), (2), (3), (4), (5)")
+	if n, _ := result.RowsAffected(); n != 5 {
+		t.Fatalf("insert: got %d rows affected, want 5", n)
+	}
+
+	result = mustExec(t, db, "DELETE FROM t_go_aff WHERE a >= 3")
+	if n, _ := result.RowsAffected(); n != 3 {
+		t.Fatalf("delete: got %d rows affected, want 3", n)
+	}
+}
+
+func TestLastInsertId(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_rowid")
+	mustExec(t, db, "CREATE TABLE t_go_rowid (id INTEGER PRIMARY KEY, a)")
+
+	result := mustExec(t, db, "INSERT INTO t_go_rowid VALUES (7, 'x')")
+	if id, _ := result.LastInsertId(); id != 7 {
+		t.Fatalf("got rowid %d, want 7", id)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Value roundtrip
+// ---------------------------------------------------------------------------
+
+func TestValueRoundtrip(t *testing.T) {
+	db := openDB(t)
+
+	t.Run("text", func(t *testing.T) {
+		var val string
+		if err := db.QueryRow("SELECT ?", "žluťoučký kůň").Scan(&val); err != nil {
+			t.Fatal(err)
+		}
+		if val != "žluťoučký kůň" {
+			t.Fatalf("got %q", val)
+		}
+	})
+	t.Run("integer", func(t *testing.T) {
+		var val int64
+		if err := db.QueryRow("SELECT ?", int64(-2023)).Scan(&val); err != nil {
+			t.Fatal(err)
+		}
+		if val != -2023 {
+			t.Fatalf("got %d", val)
+		}
+	})
+	t.Run("large integer", func(t *testing.T) {
+		var val int64
+		if err := db.QueryRow("SELECT ?", int64(math.MaxInt64)).Scan(&val); err != nil {
+			t.Fatal(err)
+		}
+		if val != math.MaxInt64 {
+			t.Fatalf("got %d", val)
+		}
+	})
+	t.Run("float", func(t *testing.T) {
+		var val float64
+		if err := db.QueryRow("SELECT ?", 12.345).Scan(&val); err != nil {
+			t.Fatal(err)
+		}
+		if val != 12.345 {
+			t.Fatalf("got %v", val)
+		}
+	})
+	t.Run("null", func(t *testing.T) {
+		var val sql.NullString
+		if err := db.QueryRow("SELECT NULL").Scan(&val); err != nil {
+			t.Fatal(err)
+		}
+		if val.Valid {
+			t.Fatal("expected null")
+		}
+	})
+	t.Run("bool", func(t *testing.T) {
+		var vtrue, vfalse int64
+		if err := db.QueryRow("SELECT ?, ?", true, false).Scan(&vtrue, &vfalse); err != nil {
+			t.Fatal(err)
+		}
+		if vtrue != 1 || vfalse != 0 {
+			t.Fatalf("got (%d, %d), want (1, 0)", vtrue, vfalse)
+		}
+	})
+	t.Run("blob", func(t *testing.T) {
+		blob := make([]byte, 256)
+		for i := range blob {
+			blob[i] = byte(i) ^ 0xab
+		}
+		var val []byte
+		if err := db.QueryRow("SELECT ?", blob).Scan(&val); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(val, blob) {
+			t.Fatalf("blob mismatch: got %x", val)
+		}
+	})
+	t.Run("nan binds as null", func(t *testing.T) {
+		var val sql.NullFloat64
+		if err := db.QueryRow("SELECT ?", math.NaN()).Scan(&val); err != nil {
+			t.Fatal(err)
+		}
+		if val.Valid {
+			t.Fatalf("expected NULL, got %v", val.Float64)
+		}
+	})
+	t.Run("infinity is rejected", func(t *testing.T) {
+		if err := db.QueryRow("SELECT ?", math.Inf(1)).Scan(new(float64)); err == nil {
+			t.Fatal("expected error for infinite float")
+		}
+	})
+	t.Run("non-finite result decodes as NaN", func(t *testing.T) {
+		var val float64
+		if err := db.QueryRow("SELECT 1e308 * 10").Scan(&val); err != nil {
+			t.Fatal(err)
+		}
+		if !math.IsNaN(val) && !math.IsInf(val, 1) {
+			t.Fatalf("got %v, want a non-finite float", val)
+		}
+	})
+}
+
+func TestTimeRoundtrip(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_time")
+	mustExec(t, db, "CREATE TABLE t_go_time (ts DATETIME)")
+
+	want := time.Date(2026, 7, 27, 12, 34, 56, 0, time.UTC)
+	mustExec(t, db, "INSERT INTO t_go_time VALUES (?)", want)
+
+	var got time.Time
+	if err := db.QueryRow("SELECT ts FROM t_go_time").Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+
+func TestParametersPositional(t *testing.T) {
+	db := openDB(t)
+
+	var a, b string
+	if err := db.QueryRow("SELECT ?, ?", "one", "two").Scan(&a, &b); err != nil {
+		t.Fatal(err)
+	}
+	if a != "one" || b != "two" {
+		t.Fatalf("got (%q, %q)", a, b)
+	}
+}
+
+func TestParametersNamed(t *testing.T) {
+	db := openDB(t)
+
+	var a, b string
+	err := db.QueryRow("SELECT :a, :b", sql.Named("a", "one"), sql.Named("b", "two")).Scan(&a, &b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != "one" || b != "two" {
+		t.Fatalf("got (%q, %q)", a, b)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multi-statement exec
+// ---------------------------------------------------------------------------
+
+func TestMultiStatementExec(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, `
+		DROP TABLE IF EXISTS t_go_batch;
+		CREATE TABLE t_go_batch (a);
+		INSERT INTO t_go_batch VALUES (1), (2), (4), (8);
+	`)
+
+	var sum int64
+	if err := db.QueryRow("SELECT SUM(a) FROM t_go_batch").Scan(&sum); err != nil {
+		t.Fatal(err)
+	}
+	if sum != 15 {
+		t.Fatalf("got sum %d, want 15", sum)
+	}
+}
+
+func TestMultiStatementErrorStops(t *testing.T) {
+	db := openDB(t)
+
+	_, err := db.Exec(`
+		DROP TABLE IF EXISTS t_go_batch_err;
+		CREATE TABLE t_go_batch_err (a);
+		INSERT INTO t_go_batch_err VALUES (1), (2), (4);
+		INSERT INTO t_go_batch_err VALUES (foo());
+		INSERT INTO t_go_batch_err VALUES (8), (16);
+	`)
+	if err == nil {
+		t.Fatal("expected error from invalid statement")
+	}
+
+	var sum int64
+	if err := db.QueryRow("SELECT SUM(a) FROM t_go_batch_err").Scan(&sum); err != nil {
+		t.Fatal(err)
+	}
+	if sum != 7 {
+		t.Fatalf("got sum %d, want 7", sum)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Transactions
+// ---------------------------------------------------------------------------
+
+func TestTransactionCommit(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_tx_commit")
+	mustExec(t, db, "CREATE TABLE t_go_tx_commit (a)")
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec("INSERT INTO t_go_tx_commit VALUES ('one')"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec("INSERT INTO t_go_tx_commit VALUES ('two')"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	var count int64
+	if err := db.QueryRow("SELECT COUNT(*) FROM t_go_tx_commit").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("got count %d, want 2", count)
+	}
+}
+
+func TestTransactionRollback(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_tx_rb")
+	mustExec(t, db, "CREATE TABLE t_go_tx_rb (a)")
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec("INSERT INTO t_go_tx_rb VALUES ('one')"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	var count int64
+	if err := db.QueryRow("SELECT COUNT(*) FROM t_go_tx_rb").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("got count %d, want 0", count)
+	}
+}
+
+func TestTransactionQueryInside(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_tx_q")
+	mustExec(t, db, "CREATE TABLE t_go_tx_q (a)")
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec("INSERT INTO t_go_tx_q VALUES (1), (2)"); err != nil {
+		t.Fatal(err)
+	}
+	// Uncommitted writes are visible inside the transaction.
+	var count int64
+	if err := tx.QueryRow("SELECT COUNT(*) FROM t_go_tx_q").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("got count %d inside transaction, want 2", count)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTransactionErrorInsideKeepsStream(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_tx_err")
+	mustExec(t, db, "CREATE TABLE t_go_tx_err (a)")
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec("INSERT INTO t_go_tx_err VALUES (1)"); err != nil {
+		t.Fatal(err)
+	}
+	// A failed statement does not abort the transaction; later statements
+	// and the commit still apply.
+	if _, err := tx.Exec("INSERT INTO t_go_tx_err VALUES (foo())"); err == nil {
+		t.Fatal("expected error from invalid statement")
+	}
+	if _, err := tx.Exec("INSERT INTO t_go_tx_err VALUES (2)"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	var count int64
+	if err := db.QueryRow("SELECT COUNT(*) FROM t_go_tx_err").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("got count %d, want 2", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+func TestErrorRecoveryAfterError(t *testing.T) {
+	db := openDB(t)
+
+	if _, err := db.Query("SELECT foobar"); err == nil {
+		t.Fatal("expected error")
+	}
+
+	var val int64
+	if err := db.QueryRow("SELECT 42").Scan(&val); err != nil {
+		t.Fatalf("connection not usable after error: %v", err)
+	}
+	if val != 42 {
+		t.Fatalf("got %d, want 42", val)
+	}
+}
+
+func TestErrorConstraintViolation(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_uq")
+	mustExec(t, db, "CREATE TABLE t_go_uq (id INTEGER, name TEXT UNIQUE)")
+	mustExec(t, db, "INSERT INTO t_go_uq VALUES (1, 'unique_name')")
+
+	_, err := db.Exec("INSERT INTO t_go_uq VALUES (2, 'unique_name')")
+	if err == nil {
+		t.Fatal("expected UNIQUE constraint error")
+	}
+	var serr *Error
+	if !errors.As(err, &serr) {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+	if serr.Code != "" && !strings.HasPrefix(serr.Code, "SQLITE_CONSTRAINT") {
+		t.Fatalf("got code %q, want SQLITE_CONSTRAINT*", serr.Code)
+	}
+	if serr.Code == "" && !strings.Contains(strings.ToUpper(serr.Message), "UNIQUE") {
+		t.Fatalf("got message %q, want a UNIQUE constraint message", serr.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// database/sql compliance
+// ---------------------------------------------------------------------------
+
+func TestPing(t *testing.T) {
+	db := openDB(t)
+
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScanTypes(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_scan")
+	mustExec(t, db, "CREATE TABLE t_go_scan (i INTEGER, f REAL, t TEXT, b BLOB)")
+	mustExec(t, db, "INSERT INTO t_go_scan VALUES (42, 3.14, 'hello', X'deadbeef')")
+
+	var i int64
+	var f float64
+	var s string
+	var b []byte
+	if err := db.QueryRow("SELECT i, f, t, b FROM t_go_scan").Scan(&i, &f, &s, &b); err != nil {
+		t.Fatal(err)
+	}
+	if i != 42 || f != 3.14 || s != "hello" {
+		t.Fatalf("got (%d, %v, %q)", i, f, s)
+	}
+	if !reflect.DeepEqual(b, []byte{0xde, 0xad, 0xbe, 0xef}) {
+		t.Fatalf("blob: got %x, want deadbeef", b)
+	}
+}
+
+func TestPrepareAndQuery(t *testing.T) {
+	db := openDB(t)
+
+	mustExec(t, db, "DROP TABLE IF EXISTS t_go_prep")
+	mustExec(t, db, "CREATE TABLE t_go_prep (id INTEGER PRIMARY KEY, name TEXT)")
+	mustExec(t, db, "INSERT INTO t_go_prep VALUES (1, 'Alice'), (2, 'Bob')")
+
+	stmt, err := db.Prepare("SELECT name FROM t_go_prep WHERE id = ?")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	var name string
+	if err := stmt.QueryRow(int64(1)).Scan(&name); err != nil {
+		t.Fatal(err)
+	}
+	if name != "Alice" {
+		t.Fatalf("got %q, want Alice", name)
+	}
+}
+
+func TestPrepareWrongArgCount(t *testing.T) {
+	db := openDB(t)
+
+	stmt, err := db.Prepare("SELECT ?, ?")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	// NumInput comes from the describe request, so database/sql rejects
+	// the mismatch client-side.
+	if _, err := stmt.Query("only-one"); err == nil {
+		t.Fatal("expected argument count mismatch error")
+	}
+}
+
+func TestOpenDSN(t *testing.T) {
+	url := os.Getenv("TURSO_DATABASE_URL")
+	if url == "" {
+		t.Skip("TURSO_DATABASE_URL is not set")
+	}
+	dsn := url
+	if token := os.Getenv("TURSO_AUTH_TOKEN"); token != "" {
+		sep := "?"
+		if strings.Contains(dsn, "?") {
+			sep = "&"
+		}
+		dsn += sep + "auth_token=" + token
+	}
+	db, err := sql.Open("turso-serverless", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var val int64
+	if err := db.QueryRow("SELECT 1").Scan(&val); err != nil {
+		t.Fatal(err)
+	}
+	if val != 1 {
+		t.Fatalf("got %d, want 1", val)
+	}
+}
+
+func mustExec(t *testing.T, db *sql.DB, query string, args ...any) sql.Result {
+	t.Helper()
+	result, err := db.Exec(query, args...)
+	if err != nil {
+		t.Fatalf("%s: %v", query, err)
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// URL normalization and DSN parsing (no server needed)
+// ---------------------------------------------------------------------------
+
+func TestNormalizeURL(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"libsql://db.turso.io", "https://db.turso.io"},
+		{"turso://db.turso.io", "https://db.turso.io"},
+		{"https://db.turso.io", "https://db.turso.io"},
+		{"http://localhost:8080", "http://localhost:8080"},
+		{"https://db.turso.io/", "https://db.turso.io"},
+		{"libsql://db.turso.io/", "https://db.turso.io"},
+		{"turso://db.turso.io/", "https://db.turso.io"},
+	}
+	for _, c := range cases {
+		if got := normalizeURL(c.in); got != c.want {
+			t.Errorf("normalizeURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseDSN(t *testing.T) {
+	cases := []struct {
+		dsn       string
+		wantURL   string
+		wantToken string
+	}{
+		{"http://localhost:8080", "http://localhost:8080", ""},
+		{"http://localhost:8080?auth_token=mytoken", "http://localhost:8080", "mytoken"},
+		{"turso://my-db.turso.io?auth_token=xyz", "https://my-db.turso.io", "xyz"},
+		{"libsql://my-db.turso.io?auth_token=abc", "https://my-db.turso.io", "abc"},
+		{"turso://my-db.turso.io:443?auth_token=tok", "https://my-db.turso.io:443", "tok"},
+		{"https://my-db.turso.io/v1/db", "https://my-db.turso.io/v1/db", ""},
+		{"http://localhost:8080?auth_token=tok&other=val", "http://localhost:8080?other=val", "tok"},
+		{"http://localhost:8080?auth_token=", "http://localhost:8080", ""},
+	}
+	for _, c := range cases {
+		url, token, err := parseDSN(c.dsn)
+		if err != nil {
+			t.Errorf("parseDSN(%q): %v", c.dsn, err)
+			continue
+		}
+		if url != c.wantURL || token != c.wantToken {
+			t.Errorf("parseDSN(%q) = (%q, %q), want (%q, %q)", c.dsn, url, token, c.wantURL, c.wantToken)
+		}
+	}
+}
+
+func TestParseDSNEmpty(t *testing.T) {
+	if _, _, err := parseDSN(""); err == nil {
+		t.Fatal("expected error for empty DSN")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Value encoding and decoding (no server needed)
+// ---------------------------------------------------------------------------
+
+func TestEncodeValue(t *testing.T) {
+	cases := []struct {
+		in   driver.Value
+		want string
+	}{
+		{nil, `{"type":"null"}`},
+		{int64(42), `{"type":"integer","value":"42"}`},
+		{1.5, `{"type":"float","value":1.5}`},
+		{math.NaN(), `{"type":"null"}`},
+		{true, `{"type":"integer","value":"1"}`},
+		{false, `{"type":"integer","value":"0"}`},
+		{"hello", `{"type":"text","value":"hello"}`},
+		{[]byte{0xde, 0xad}, `{"type":"blob","base64":"3q0="}`},
+	}
+	for _, c := range cases {
+		pv, err := encodeValue(c.in)
+		if err != nil {
+			t.Errorf("encodeValue(%v): %v", c.in, err)
+			continue
+		}
+		got, _ := json.Marshal(pv)
+		if string(got) != c.want {
+			t.Errorf("encodeValue(%v) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEncodeValueInfinity(t *testing.T) {
+	for _, v := range []float64{math.Inf(1), math.Inf(-1)} {
+		if _, err := encodeValue(v); err == nil {
+			t.Errorf("encodeValue(%v): expected error", v)
+		}
+	}
+}
+
+func TestDecodeValue(t *testing.T) {
+	cases := []struct {
+		in   string
+		want any
+	}{
+		{`{"type":"null"}`, nil},
+		{`{"type":"integer","value":"42"}`, int64(42)},
+		{`{"type":"integer","value":"-9223372036854775808"}`, int64(math.MinInt64)},
+		{`{"type":"integer","value":7}`, int64(7)},
+		{`{"type":"float","value":1.5}`, 1.5},
+		{`{"type":"text","value":"hi"}`, "hi"},
+		{`{"type":"blob","base64":"3q2+7w=="}`, []byte{0xde, 0xad, 0xbe, 0xef}},
+		{`{"type":"blob","base64":"3q2+7w"}`, []byte{0xde, 0xad, 0xbe, 0xef}},
+	}
+	for _, c := range cases {
+		var pv protoValue
+		if err := json.Unmarshal([]byte(c.in), &pv); err != nil {
+			t.Fatal(err)
+		}
+		got, err := decodeValue(pv)
+		if err != nil {
+			t.Errorf("decodeValue(%s): %v", c.in, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("decodeValue(%s) = %v (%T), want %v (%T)", c.in, got, got, c.want, c.want)
+		}
+	}
+}
+
+func TestDecodeValueNullFloatIsNaN(t *testing.T) {
+	var pv protoValue
+	if err := json.Unmarshal([]byte(`{"type":"float","value":null}`), &pv); err != nil {
+		t.Fatal(err)
+	}
+	got, err := decodeValue(pv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := got.(float64)
+	if !ok || !math.IsNaN(f) {
+		t.Fatalf("got %v (%T), want NaN", got, got)
+	}
+}
+
+func TestDecodeValueErrors(t *testing.T) {
+	cases := []string{
+		`{"type":"integer","value":"not-a-number"}`,
+		`{"type":"blob"}`,
+		`{"type":"mystery"}`,
+	}
+	for _, c := range cases {
+		var pv protoValue
+		if err := json.Unmarshal([]byte(c), &pv); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := decodeValue(pv); err == nil {
+			t.Errorf("decodeValue(%s): expected error", c)
+		}
+	}
+}
+
+func TestParseRowid(t *testing.T) {
+	cases := []struct {
+		in   string
+		want *int64
+	}{
+		{`null`, nil},
+		{`"42"`, ptr(int64(42))},
+		{`42`, ptr(int64(42))},
+		{`"9223372036854775807"`, ptr(int64(math.MaxInt64))},
+		{`9223372036854775807`, ptr(int64(math.MaxInt64))},
+	}
+	for _, c := range cases {
+		got, err := parseRowid(json.RawMessage(c.in))
+		if err != nil {
+			t.Errorf("parseRowid(%s): %v", c.in, err)
+			continue
+		}
+		if (got == nil) != (c.want == nil) || (got != nil && *got != *c.want) {
+			t.Errorf("parseRowid(%s) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestSplitStatements(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"SELECT 1", []string{"SELECT 1"}},
+		{"SELECT 1;", []string{"SELECT 1"}},
+		{"SELECT 1; SELECT 2", []string{"SELECT 1", "SELECT 2"}},
+		{"SELECT 'a;b'; SELECT 2", []string{"SELECT 'a;b'", "SELECT 2"}},
+		{`SELECT "a;b"`, []string{`SELECT "a;b"`}},
+	}
+	for _, c := range cases {
+		if got := splitStatements(c.in); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("splitStatements(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/serverless/go/go.mod
+++ b/serverless/go/go.mod
@@ -1,0 +1,3 @@
+module turso.tech/database/tursogo-serverless
+
+go 1.24.0

--- a/serverless/go/protocol.go
+++ b/serverless/go/protocol.go
@@ -1,0 +1,283 @@
+// Value encoding and wire types for the SQL over HTTP protocol.
+
+package turso
+
+import (
+	"database/sql/driver"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Error is an error the server reported for a statement or stream request,
+// carrying the machine-readable error codes (PROTOCOL.md section 9.1) when
+// the server sent them.
+type Error struct {
+	Message      string
+	Code         string
+	ExtendedCode string
+}
+
+func (e *Error) Error() string {
+	return "turso: " + e.Message
+}
+
+// serverError builds an Error from a protocol error object (section 9.1),
+// tolerating missing fields.
+func serverError(pe *protoError) *Error {
+	e := &Error{Message: "unknown error"}
+	if pe != nil {
+		if pe.Message != "" {
+			e.Message = pe.Message
+		}
+		if pe.Code != nil {
+			e.Code = *pe.Code
+		}
+		if pe.ExtendedCode != nil {
+			e.ExtendedCode = *pe.ExtendedCode
+		}
+	}
+	return e
+}
+
+// protoValue is a protocol value (section 8.2), used in both directions.
+type protoValue struct {
+	Type   string          `json:"type"`
+	Value  json.RawMessage `json:"value,omitempty"`
+	Base64 *string         `json:"base64,omitempty"`
+}
+
+// encodeValue encodes a driver.Value to a protocol value (section 8.2).
+// The database/sql converter has already narrowed arguments to int64,
+// float64, bool, []byte, string, time.Time, or nil.
+func encodeValue(v driver.Value) (protoValue, error) {
+	switch x := v.(type) {
+	case nil:
+		return protoValue{Type: "null"}, nil
+	case int64:
+		raw, _ := json.Marshal(strconv.FormatInt(x, 10))
+		return protoValue{Type: "integer", Value: raw}, nil
+	case float64:
+		// The protocol forbids sending non-finite floats (section 8.2).
+		if math.IsNaN(x) {
+			// SQLite binds NaN as NULL; JSON cannot carry it.
+			return protoValue{Type: "null"}, nil
+		}
+		if math.IsInf(x, 0) {
+			return protoValue{}, fmt.Errorf("turso: infinite float values cannot be sent over the protocol")
+		}
+		return protoValue{Type: "float", Value: json.RawMessage(strconv.FormatFloat(x, 'g', -1, 64))}, nil
+	case bool:
+		if x {
+			return protoValue{Type: "integer", Value: json.RawMessage(`"1"`)}, nil
+		}
+		return protoValue{Type: "integer", Value: json.RawMessage(`"0"`)}, nil
+	case string:
+		raw, err := json.Marshal(x)
+		if err != nil {
+			return protoValue{}, fmt.Errorf("turso: failed to encode string value: %w", err)
+		}
+		return protoValue{Type: "text", Value: raw}, nil
+	case []byte:
+		b64 := base64.StdEncoding.EncodeToString(x)
+		return protoValue{Type: "blob", Base64: &b64}, nil
+	case time.Time:
+		// Matches the embedded driver: time binds as RFC3339Nano text.
+		raw, _ := json.Marshal(x.Format(time.RFC3339Nano))
+		return protoValue{Type: "text", Value: raw}, nil
+	default:
+		return protoValue{}, fmt.Errorf("turso: unsupported value type: %T", v)
+	}
+}
+
+// decodeValue decodes a protocol value (section 8.2).
+func decodeValue(pv protoValue) (any, error) {
+	switch pv.Type {
+	case "null":
+		return nil, nil
+	case "integer":
+		// Integers travel as decimal strings; tolerate a plain number.
+		var s string
+		if err := json.Unmarshal(pv.Value, &s); err != nil {
+			var n json.Number
+			if err := json.Unmarshal(pv.Value, &n); err != nil {
+				return nil, fmt.Errorf("turso: invalid integer value in server response: %s", pv.Value)
+			}
+			s = n.String()
+		}
+		i, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("turso: invalid integer value in server response: %q", s)
+		}
+		return i, nil
+	case "float":
+		// A null value encodes a non-finite float (section 8.2); the spec
+		// says to decode it as NaN.
+		if isJSONNull(pv.Value) {
+			return math.NaN(), nil
+		}
+		var f float64
+		if err := json.Unmarshal(pv.Value, &f); err != nil {
+			return nil, fmt.Errorf("turso: invalid float value in server response: %s", pv.Value)
+		}
+		return f, nil
+	case "text":
+		var s string
+		if err := json.Unmarshal(pv.Value, &s); err != nil {
+			return nil, fmt.Errorf("turso: invalid text value in server response: %s", pv.Value)
+		}
+		return s, nil
+	case "blob":
+		if pv.Base64 == nil {
+			return nil, fmt.Errorf("turso: blob value without base64 field in server response")
+		}
+		// The server may omit base64 padding (section 8.2).
+		b, err := base64.RawStdEncoding.DecodeString(strings.TrimRight(*pv.Base64, "="))
+		if err != nil {
+			return nil, fmt.Errorf("turso: invalid blob value in server response: %v", err)
+		}
+		return b, nil
+	default:
+		return nil, fmt.Errorf("turso: unsupported value type in server response: %q", pv.Type)
+	}
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return len(raw) == 0 || string(raw) == "null"
+}
+
+// parseRowid parses a last_insert_rowid field, which arrives as a decimal
+// string on the pipeline endpoint (section 8.4) and as a number on the
+// cursor endpoint (section 7.2.3), with 64-bit precision.
+func parseRowid(raw json.RawMessage) (*int64, error) {
+	if isJSONNull(raw) {
+		return nil, nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		var n json.Number
+		if err := json.Unmarshal(raw, &n); err != nil {
+			return nil, fmt.Errorf("turso: invalid rowid in server response: %s", raw)
+		}
+		s = n.String()
+	}
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("turso: invalid rowid in server response: %q", s)
+	}
+	return &i, nil
+}
+
+// --- Wire types ---
+
+type protoError struct {
+	Message      string  `json:"message"`
+	Code         *string `json:"code,omitempty"`
+	ExtendedCode *string `json:"extended_code,omitempty"`
+}
+
+type protoColumn struct {
+	Name     *string `json:"name"`
+	Decltype *string `json:"decltype"`
+}
+
+type namedArg struct {
+	Name  string     `json:"name"`
+	Value protoValue `json:"value"`
+}
+
+type stmtBody struct {
+	SQL       string       `json:"sql"`
+	Args      []protoValue `json:"args"`
+	NamedArgs []namedArg   `json:"named_args"`
+	WantRows  bool         `json:"want_rows"`
+}
+
+type batchCond struct {
+	Type string `json:"type"`
+}
+
+type batchStep struct {
+	Condition *batchCond `json:"condition,omitempty"`
+	Stmt      stmtBody   `json:"stmt"`
+}
+
+// --- Cursor endpoint (section 7) ---
+
+type cursorRequest struct {
+	Baton *string     `json:"baton"`
+	Batch cursorBatch `json:"batch"`
+}
+
+type cursorBatch struct {
+	Steps []batchStep `json:"steps"`
+}
+
+type cursorResponse struct {
+	Baton   *string `json:"baton"`
+	BaseURL *string `json:"base_url"`
+}
+
+// cursorEntry is a tagged union parsed from the newline-separated body
+// (section 7.2).
+type cursorEntry struct {
+	Type string `json:"type"`
+
+	// step_begin and step_error
+	Step *int `json:"step,omitempty"`
+
+	// step_begin
+	Cols []protoColumn `json:"cols,omitempty"`
+
+	// row
+	Row []protoValue `json:"row,omitempty"`
+
+	// step_end
+	AffectedRowCount int64           `json:"affected_row_count,omitempty"`
+	LastInsertRowid  json.RawMessage `json:"last_insert_rowid,omitempty"`
+
+	// step_error and error
+	Error *protoError `json:"error,omitempty"`
+}
+
+// --- Pipeline endpoint (section 5) ---
+
+type pipelineRequest struct {
+	Baton    *string         `json:"baton"`
+	Requests []streamRequest `json:"requests"`
+}
+
+type streamRequest struct {
+	Type string `json:"type"`
+	SQL  string `json:"sql,omitempty"`
+}
+
+type pipelineResponse struct {
+	Baton   *string        `json:"baton"`
+	BaseURL *string        `json:"base_url"`
+	Results []streamResult `json:"results"`
+}
+
+type streamResult struct {
+	Type     string          `json:"type"`
+	Response *streamResponse `json:"response,omitempty"`
+	Error    *protoError     `json:"error,omitempty"`
+}
+
+type streamResponse struct {
+	Type         string          `json:"type"`
+	Result       json.RawMessage `json:"result,omitempty"`
+	IsAutocommit *bool           `json:"is_autocommit,omitempty"`
+}
+
+type describeResult struct {
+	Params []describeParam `json:"params"`
+}
+
+type describeParam struct {
+	Name *string `json:"name,omitempty"`
+}

--- a/serverless/go/session.go
+++ b/serverless/go/session.go
@@ -1,0 +1,375 @@
+// HTTP session management: one session per connection, tracking the
+// stream baton, base URL, and transaction state.
+
+package turso
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// normalizeURL rewrites libsql:// and turso:// URLs to https:// and strips
+// any trailing slashes, since endpoint paths are appended with a leading
+// slash.
+func normalizeURL(url string) string {
+	if rest, ok := strings.CutPrefix(url, "libsql://"); ok {
+		url = "https://" + rest
+	} else if rest, ok := strings.CutPrefix(url, "turso://"); ok {
+		url = "https://" + rest
+	}
+	return strings.TrimRight(url, "/")
+}
+
+// stmtOutput is the decoded output of one executed statement.
+type stmtOutput struct {
+	columns      []string
+	decltypes    []string
+	rows         [][]any
+	rowsAffected int64
+}
+
+// session manages one server-side stream: the baton, the base URL, and the
+// server-reported transaction state.
+type session struct {
+	client    *http.Client
+	authToken string
+	baseURL   string
+	baton     *string
+	// autocommit is whether the connection is in autocommit mode, from the
+	// server's most recent authoritative answer. A non-null baton does NOT
+	// imply a transaction (section 4.3), so this is tracked explicitly:
+	// every pipeline carries a `get_autocommit` request and every cursor
+	// batch a trailing step gated on `is_autocommit`.
+	autocommit      bool
+	lastInsertRowid int64
+}
+
+func newSession(url, authToken string) *session {
+	return &session{
+		client:     &http.Client{},
+		authToken:  authToken,
+		baseURL:    normalizeURL(url),
+		autocommit: true,
+	}
+}
+
+// resetStream forgets the stream. Any transaction on it was (or will be)
+// rolled back by the server, so the connection is back in autocommit mode.
+func (s *session) resetStream() {
+	s.baton = nil
+	s.autocommit = true
+}
+
+func (s *session) updateStream(baton *string, baseURL *string) {
+	s.baton = baton
+	if baseURL != nil && *baseURL != "" {
+		s.baseURL = normalizeURL(*baseURL)
+	}
+}
+
+// httpError builds an error from a non-200 response, surfacing the JSON
+// error message when the body carries one (section 9.3).
+func httpError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	var parsed struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &parsed) == nil {
+		message := parsed.Error
+		if message == "" {
+			message = parsed.Message
+		}
+		if message != "" {
+			return fmt.Errorf("turso: HTTP status %d: %s", resp.StatusCode, message)
+		}
+	}
+	return fmt.Errorf("turso: HTTP status %d", resp.StatusCode)
+}
+
+// post sends a request that carries the current baton. Any failure,
+// including a non-200 response, is fatal for the stream (section 9.3): the
+// error surfaces to the caller and the next statement starts a fresh
+// stream. The driver never re-sends a request on its own; whether
+// re-running a failed statement is safe is the application's call.
+func (s *session) post(ctx context.Context, path string, body []byte) (*http.Response, error) {
+	url := s.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		s.resetStream()
+		return nil, fmt.Errorf("turso: request to %s failed: %w", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if s.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+s.authToken)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.resetStream()
+		return nil, fmt.Errorf("turso: request to %s failed: %w", url, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		s.resetStream()
+		return nil, httpError(resp)
+	}
+	return resp, nil
+}
+
+// executePipeline executes a pipeline (section 5). When trackAutocommit is
+// set, a `get_autocommit` request is appended and its answer refreshes the
+// cached transaction state; the returned results cover only the caller's
+// requests.
+func (s *session) executePipeline(ctx context.Context, requests []streamRequest, trackAutocommit bool) ([]streamResult, error) {
+	reqs := requests
+	if trackAutocommit {
+		reqs = append(append([]streamRequest{}, requests...), streamRequest{Type: "get_autocommit"})
+	}
+	body, err := json.Marshal(pipelineRequest{Baton: s.baton, Requests: reqs})
+	if err != nil {
+		return nil, fmt.Errorf("turso: failed to encode request: %w", err)
+	}
+	resp, err := s.post(ctx, "/v3/pipeline", body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var pr pipelineResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		s.resetStream()
+		return nil, fmt.Errorf("turso: invalid pipeline response: %w", err)
+	}
+	s.updateStream(pr.Baton, pr.BaseURL)
+	results := pr.Results
+	// The protocol guarantees one result per request (section 5.2); a
+	// mismatch would misattribute results to the wrong requests, and
+	// leaves the stream state unknown.
+	if len(results) != len(reqs) {
+		s.resetStream()
+		return nil, fmt.Errorf("turso: pipeline response has %d results for %d requests", len(results), len(reqs))
+	}
+	if trackAutocommit {
+		result := results[len(results)-1]
+		results = results[:len(results)-1]
+		if result.Error != nil {
+			return nil, serverError(result.Error)
+		}
+		if result.Response == nil || result.Response.Type != "get_autocommit" || result.Response.IsAutocommit == nil {
+			s.resetStream()
+			return nil, fmt.Errorf("turso: expected get_autocommit result in pipeline response")
+		}
+		s.autocommit = *result.Response.IsAutocommit
+	}
+	return results, nil
+}
+
+// refreshAutocommit refreshes the cached transaction state with a
+// standalone `get_autocommit` request. Failures are swallowed: this runs
+// on error paths where the original failure must not be masked, and a dead
+// stream already reset the state to autocommit.
+func (s *session) refreshAutocommit(ctx context.Context) {
+	_, _ = s.executePipeline(ctx, nil, true)
+}
+
+// probeStep is the index of the autocommit probe step appended to every
+// cursor batch.
+const probeStep = 1
+
+// autocommitProbeStep is the trailing batch step appended to every cursor
+// batch: a no-op statement gated on `is_autocommit`. The cursor endpoint
+// cannot carry a `get_autocommit` request, so whether this step executed
+// tells us the connection's transaction state without an extra round trip.
+func autocommitProbeStep() batchStep {
+	return batchStep{
+		Condition: &batchCond{Type: "is_autocommit"},
+		Stmt:      rawStmt("SELECT 1"),
+	}
+}
+
+// cursorDecoder folds streamed cursor entries (section 7.2) into a
+// statement result, tracking the trailing autocommit probe step separately
+// from the caller's step.
+type cursorDecoder struct {
+	output          stmtOutput
+	lastInsertRowid *int64
+	stepError       *Error
+	fatal           *Error
+	probeExecuted   bool
+	probeUnreliable bool
+	inProbe         bool
+}
+
+func (d *cursorDecoder) feed(entry *cursorEntry) error {
+	switch entry.Type {
+	case "step_begin":
+		if entry.Step != nil && *entry.Step == probeStep {
+			d.inProbe = true
+			d.probeExecuted = true
+		} else {
+			d.inProbe = false
+			for _, col := range entry.Cols {
+				name := ""
+				if col.Name != nil {
+					name = *col.Name
+				}
+				decltype := ""
+				if col.Decltype != nil {
+					decltype = *col.Decltype
+				}
+				d.output.columns = append(d.output.columns, name)
+				d.output.decltypes = append(d.output.decltypes, decltype)
+			}
+		}
+	case "row":
+		if d.inProbe || d.stepError != nil {
+			return nil
+		}
+		row := make([]any, len(entry.Row))
+		for i, pv := range entry.Row {
+			v, err := decodeValue(pv)
+			if err != nil {
+				return err
+			}
+			row[i] = v
+		}
+		d.output.rows = append(d.output.rows, row)
+	case "step_end":
+		if d.inProbe {
+			return nil
+		}
+		d.output.rowsAffected = entry.AffectedRowCount
+		rowid, err := parseRowid(entry.LastInsertRowid)
+		if err != nil {
+			return err
+		}
+		if rowid != nil {
+			d.lastInsertRowid = rowid
+		}
+	case "step_error":
+		if entry.Step != nil && *entry.Step == probeStep {
+			d.probeUnreliable = true
+		} else if d.stepError == nil {
+			d.stepError = serverError(entry.Error)
+		}
+		d.inProbe = false
+	case "error":
+		d.fatal = serverError(entry.Error)
+	}
+	// replication_index (section 7.2.6) and unknown entries are ignored;
+	// a cleanly ended body is complete without a terminator.
+	return nil
+}
+
+// executeStmt executes a single statement on the cursor endpoint
+// (section 7), decoding the streamed entries into a buffered result.
+func (s *session) executeStmt(ctx context.Context, stmt stmtBody) (*stmtOutput, error) {
+	steps := []batchStep{{Stmt: stmt}, autocommitProbeStep()}
+	body, err := json.Marshal(cursorRequest{Baton: s.baton, Batch: cursorBatch{Steps: steps}})
+	if err != nil {
+		return nil, fmt.Errorf("turso: failed to encode request: %w", err)
+	}
+	resp, err := s.post(ctx, "/v3/cursor", body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	firstLine, err := nextLine(reader)
+	if err != nil {
+		s.resetStream()
+		return nil, err
+	}
+	if firstLine == nil {
+		s.resetStream()
+		return nil, fmt.Errorf("turso: cursor response body ended before the cursor response line")
+	}
+	var cr cursorResponse
+	if err := json.Unmarshal(firstLine, &cr); err != nil {
+		s.resetStream()
+		return nil, fmt.Errorf("turso: invalid cursor response: %w", err)
+	}
+	s.updateStream(cr.Baton, cr.BaseURL)
+
+	decoder := &cursorDecoder{}
+	for decoder.fatal == nil {
+		line, err := nextLine(reader)
+		if err != nil {
+			// The body failed mid-stream; the stream is unusable.
+			s.resetStream()
+			if decoder.stepError != nil {
+				return nil, decoder.stepError
+			}
+			return nil, err
+		}
+		if line == nil {
+			break
+		}
+		var entry cursorEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			s.resetStream()
+			return nil, fmt.Errorf("turso: invalid cursor entry: %w", err)
+		}
+		if err := decoder.feed(&entry); err != nil {
+			// A malformed value from the server; abandon the stream
+			// rather than resume it in an unknown position.
+			s.resetStream()
+			return nil, err
+		}
+	}
+
+	if decoder.fatal != nil {
+		// The cursor died but the stream may survive; ask the server for
+		// the authoritative transaction state.
+		s.refreshAutocommit(ctx)
+		if decoder.stepError != nil {
+			return nil, decoder.stepError
+		}
+		return nil, decoder.fatal
+	}
+	if decoder.probeUnreliable {
+		s.refreshAutocommit(ctx)
+	} else {
+		s.autocommit = decoder.probeExecuted
+	}
+	if decoder.stepError != nil {
+		return nil, decoder.stepError
+	}
+	if decoder.lastInsertRowid != nil {
+		s.lastInsertRowid = *decoder.lastInsertRowid
+	}
+	return &decoder.output, nil
+}
+
+// nextLine reads the next non-empty newline-separated line from a cursor
+// response body (section 7.2), returning nil at a clean end of body.
+func nextLine(reader *bufio.Reader) ([]byte, error) {
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil && err != io.EOF {
+			return nil, fmt.Errorf("turso: cursor stream failed: %w", err)
+		}
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) > 0 {
+			return trimmed, nil
+		}
+		if err == io.EOF {
+			return nil, nil
+		}
+	}
+}
+
+// close closes the stream (section 6.8). Errors are ignored: the stream
+// may already have expired.
+func (s *session) close() {
+	if s.baton != nil {
+		_, _ = s.executePipeline(context.Background(), []streamRequest{{Type: "close"}}, false)
+	}
+	s.resetStream()
+}


### PR DESCRIPTION
Add a pure Go database/sql driver for Turso Cloud speaking the SQL over HTTP protocol, so Go applications in serverless and edge environments can reach a remote database without cgo or native libraries. The driver registers as "turso-serverless" and mirrors the embedded tursogo driver's API: same sentinel errors, RFC3339Nano time binding, decltype-based time.Time scanning, and multi-statement Exec.

Transaction state is server-authoritative rather than inferred from SQL text: every pipeline carries a get_autocommit request and every cursor batch a trailing step gated on is_autocommit, matching the Python and Rust drivers. Errors carry the protocol's machine-readable codes, NaN binds as NULL, infinity is rejected client-side, a null float decodes as NaN, and any transport or protocol failure resets the stream.

Tests: go test ./... in serverless/go against Turso Cloud (TURSO_DATABASE_URL/TURSO_AUTH_TOKEN); unit tests for DSN parsing, URL normalization, and value encoding run without a server.