### PR TITLE
core/vdbe: reject even argument counts in json_insert/json_replace

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8031,6 +8031,9 @@ pub fn op_function(
                 }
             }
             JsonFunc::JsonReplace => {
+                if arg_count % 2 == 0 {
+                    bail_constraint_error!("json_replace() needs an odd number of arguments")
+                }
                 if let Ok(json) = json_replace(
                     registers_to_ref_values(&state.registers[*start_reg..*start_reg + arg_count]),
                     &state.json_cache,
@@ -8041,6 +8044,9 @@ pub fn op_function(
                 }
             }
             JsonFunc::JsonbReplace => {
+                if arg_count % 2 == 0 {
+                    bail_constraint_error!("json_replace() needs an odd number of arguments")
+                }
                 if let Ok(json) = jsonb_replace(
                     registers_to_ref_values(&state.registers[*start_reg..*start_reg + arg_count]),
                     &state.json_cache,
@@ -8051,6 +8057,9 @@ pub fn op_function(
                 }
             }
             JsonFunc::JsonInsert => {
+                if arg_count % 2 == 0 {
+                    bail_constraint_error!("json_insert() needs an odd number of arguments")
+                }
                 if let Ok(json) = json_insert(
                     registers_to_ref_values(&state.registers[*start_reg..*start_reg + arg_count]),
                     &state.json_cache,
@@ -8061,6 +8070,9 @@ pub fn op_function(
                 }
             }
             JsonFunc::JsonbInsert => {
+                if arg_count % 2 == 0 {
+                    bail_constraint_error!("json_insert() needs an odd number of arguments")
+                }
                 if let Ok(json) = jsonb_insert(
                     registers_to_ref_values(&state.registers[*start_reg..*start_reg + arg_count]),
                     &state.json_cache,

--- a/sqlite/conformance/sqlite-sqltests/json/json-insert-replace-odd-args.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/json/json-insert-replace-odd-args.sqltest
@@ -1,0 +1,48 @@
+# Regression test for https://github.com/tursodatabase/turso/issues/7758
+# json_insert(), json_replace(), and the jsonb_* variants require an odd
+# number of arguments (document + path/value pairs). A path without a value
+# must be rejected, matching SQLite.
+
+@database :memory:
+
+test json-insert-path-only-errors {
+    SELECT json_insert('{}', '$.a');
+}
+expect error {
+    json_insert\(\) needs an odd number of arguments
+}
+
+test json-replace-path-only-errors {
+    SELECT json_replace('{}', '$.a');
+}
+expect error {
+    json_replace\(\) needs an odd number of arguments
+}
+
+test jsonb-insert-path-only-errors {
+    SELECT jsonb_insert('{}', '$.a');
+}
+expect error {
+    json_insert\(\) needs an odd number of arguments
+}
+
+test jsonb-replace-path-only-errors {
+    SELECT jsonb_replace('{}', '$.a');
+}
+expect error {
+    json_replace\(\) needs an odd number of arguments
+}
+
+test json-insert-pair-still-works {
+    SELECT json_insert('{}', '$.a', 1);
+}
+expect {
+    {"a":1}
+}
+
+test json-replace-pair-still-works {
+    SELECT json_replace('{"a":2}', '$.a', 1);
+}
+expect {
+    {"a":1}
+}


### PR DESCRIPTION
SQLite requires json_insert(), json_replace(), and their jsonb_*
variants to take an odd number of arguments: one document followed by
path/value pairs. Turso silently accepted a trailing path with no value
and returned the document unchanged, diverging from SQLite.

Add the same arity check json_set()/jsonb_set() already perform in
op_function, before the call into the JSON ops layer. The check must
live in the opcode handler because these handlers intentionally map
ops-layer errors to NULL, so an error raised inside core/json/ops.rs
would be swallowed. The jsonb_* variants report json_insert()/
json_replace() in their messages, matching SQLite exactly.

Tests: make -C sqlite/conformance run-one FILE=sqlite-sqltests/json/json-insert-replace-odd-args.sqltest; all other json sqltests and cargo test -p turso_core json pass

Fixes #7758