### PR TITLE
core: add cume_dist()/percent_rank() window functions and add window funcs to fuzzer

### DIFF
--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -300,6 +300,18 @@ pub fn resolve_builtin_function(name: &str, arg_count: usize) -> crate::Result<O
             }
             Ok(Some(Func::Window(WindowFunc::Ntile)))
         }
+        "percent_rank" => {
+            if arg_count != 0 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::PercentRank)))
+        }
+        "cume_dist" => {
+            if arg_count != 0 {
+                crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+            }
+            Ok(Some(Func::Window(WindowFunc::CumeDist)))
+        }
         "timediff" => {
             if arg_count != 2 {
                 crate::bail_parse_error!("wrong number of arguments to function {}()", name)

--- a/core/function.rs
+++ b/core/function.rs
@@ -529,6 +529,8 @@ impl WindowFunc {
                 | Self::Lag
                 | Self::Lead
                 | Self::Ntile
+                | Self::PercentRank
+                | Self::CumeDist
         )
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3085,6 +3085,19 @@ impl Window {
         })
     }
 
+    /// Build an unnamed window from partition/order expressions inherited from
+    /// a named base window.
+    pub fn from_unnamed_bound(bound: NamedWindowBound, frame: Frame) -> Self {
+        Window {
+            name: None,
+            partition_by: bound.partition_by,
+            deduplicated_partition_by_len: None,
+            order_by: bound.order_by,
+            frame,
+            functions: vec![],
+        }
+    }
+
     /// Build a `Window` from a previously-bound named definition plus a
     /// resolved frame.
     pub fn from_named_bound(name: String, bound: NamedWindowBound, frame: Frame) -> Self {
@@ -3135,6 +3148,28 @@ impl Window {
             })
     }
 
+    pub fn is_equivalent_to_bound(&self, bound: &NamedWindowBound, frame: &Frame) -> bool {
+        if &self.frame != frame || self.partition_by.len() != bound.partition_by.len() {
+            return false;
+        }
+        if !self
+            .partition_by
+            .iter()
+            .zip(&bound.partition_by)
+            .all(|(a, b)| exprs_are_equivalent(a, b))
+        {
+            return false;
+        }
+        if self.order_by.len() != bound.order_by.len() {
+            return false;
+        }
+        self.order_by.iter().zip(&bound.order_by).all(
+            |((expr_a, order_a, nulls_a), (expr_b, order_b, nulls_b))| {
+                exprs_are_equivalent(expr_a, expr_b) && order_a == order_b && nulls_a == nulls_b
+            },
+        )
+    }
+
     pub(crate) fn is_default_frame_spec(frame: &Option<FrameClause>) -> bool {
         if let Some(frame_clause) = frame {
             let FrameClause {
@@ -3162,10 +3197,10 @@ impl Window {
     }
 }
 
-/// A named WINDOW clause definition, captured before any function
-/// references it. The frame is intentionally absent: it belongs to the
-/// resolved `Window` instance the planner spawns when a function
-/// attaches (the function's coerced frame decides).
+/// A named WINDOW clause definition, captured before any function references
+/// it. The effective frame belongs to the resolved `Window` instance the
+/// planner spawns when a function attaches. Whether the user wrote a frame is
+/// retained because SQLite forbids chaining from a framed base window.
 ///
 /// `bound` holds the already-bound `partition_by` / `order_by`. The
 /// first `resolve_window` that needs them *takes* them by moving;
@@ -3177,6 +3212,7 @@ impl Window {
 pub struct NamedWindowDef {
     pub name: String,
     pub bound: Option<NamedWindowBound>,
+    pub has_frame_clause: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -522,11 +522,62 @@ fn resolve_window<'a>(
     frame: crate::translate::plan::Frame,
 ) -> Result<&'a mut Window> {
     match over_clause {
-        Over::Window(window) => {
+        Over::Window(window) if window.base.is_none() => {
             if let Some(idx) = windows.iter().position(|w| w.is_equivalent(window, &frame)) {
                 return Ok(&mut windows[idx]);
             }
             windows.push(Window::new_unnamed(window, frame)?);
+            Ok(windows.last_mut().expect("just pushed, so must exist"))
+        }
+        Over::Window(window) => {
+            if !Window::is_default_frame_spec(&window.frame_clause) {
+                crate::bail_parse_error!("Custom frame specifications are not supported yet");
+            }
+            let base_name = normalize_ident(
+                window
+                    .base
+                    .as_ref()
+                    .expect("guarded by the preceding match arm")
+                    .as_str(),
+            );
+            let def = named_windows
+                .iter()
+                .rfind(|definition| definition.name == base_name)
+                .ok_or_else(|| {
+                    crate::LimboError::ParseError(format!("no such window: {base_name}"))
+                })?;
+            if !window.partition_by.is_empty() {
+                crate::bail_parse_error!("cannot override PARTITION clause of window: {base_name}");
+            }
+            if def.has_frame_clause {
+                crate::bail_parse_error!(
+                    "cannot override frame specification of window: {base_name}"
+                );
+            }
+            let mut bound = clone_named_window_bound(windows, def);
+            if !bound.order_by.is_empty() && !window.order_by.is_empty() {
+                crate::bail_parse_error!("cannot override ORDER BY clause of window: {base_name}");
+            }
+            if bound.order_by.is_empty() {
+                bound.order_by = window
+                    .order_by
+                    .iter()
+                    .map(|column| {
+                        (
+                            *column.expr.clone(),
+                            column.order.unwrap_or(ast::SortOrder::Asc),
+                            column.nulls,
+                        )
+                    })
+                    .collect();
+            }
+            if let Some(idx) = windows
+                .iter()
+                .position(|candidate| candidate.is_equivalent_to_bound(&bound, &frame))
+            {
+                return Ok(&mut windows[idx]);
+            }
+            windows.push(Window::from_unnamed_bound(bound, frame));
             Ok(windows.last_mut().expect("just pushed, so must exist"))
         }
         Over::Name(name) => {
@@ -567,6 +618,25 @@ fn resolve_window<'a>(
             };
             windows.push(Window::from_named_bound(window_name, bound, frame));
             Ok(windows.last_mut().expect("just pushed, so must exist"))
+        }
+    }
+}
+
+fn clone_named_window_bound(
+    windows: &[Window],
+    def: &crate::translate::plan::NamedWindowDef,
+) -> NamedWindowBound {
+    match def.bound.as_ref() {
+        Some(bound) => bound.clone(),
+        None => {
+            let sister = windows
+                .iter()
+                .rfind(|window| window.name.as_ref() == Some(&def.name))
+                .expect("sister Window must exist after the named def was taken");
+            NamedWindowBound {
+                partition_by: sister.partition_by.clone(),
+                order_by: sister.order_by.clone(),
+            }
         }
     }
 }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -423,12 +423,47 @@ fn prepare_one_select_plan(
                             BindingBehavior::ResultColumnsNotAllowed,
                         )?;
                     }
+                    if let Some(base_name) = window_def.window.base.as_ref() {
+                        let base_name = normalize_ident(base_name.as_str());
+                        // SQLite chains WINDOW-clause definitions only to an
+                        // earlier definition. An unresolved base here is left
+                        // alone and may still be used as an ordinary name.
+                        if let Some(base) = named_windows
+                            .iter()
+                            .rfind(|window| window.name == base_name)
+                        {
+                            if !partition_by.is_empty() {
+                                crate::bail_parse_error!(
+                                    "cannot override PARTITION clause of window: {base_name}"
+                                );
+                            }
+                            if base.has_frame_clause {
+                                crate::bail_parse_error!(
+                                    "cannot override frame specification of window: {base_name}"
+                                );
+                            }
+                            let base_bound = base
+                                .bound
+                                .as_ref()
+                                .expect("named windows are bound before functions are resolved");
+                            if !base_bound.order_by.is_empty() && !order_by.is_empty() {
+                                crate::bail_parse_error!(
+                                    "cannot override ORDER BY clause of window: {base_name}"
+                                );
+                            }
+                            partition_by.clone_from(&base_bound.partition_by);
+                            if order_by.is_empty() {
+                                order_by.clone_from(&base_bound.order_by);
+                            }
+                        }
+                    }
                     named_windows.push(NamedWindowDef {
                         name,
                         bound: Some(NamedWindowBound {
                             partition_by,
                             order_by,
                         }),
+                        has_frame_clause: window_def.window.frame_clause.is_some(),
                     });
                 }
             }

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -6,8 +6,8 @@ use crate::translate::aggregation::{translate_aggregation_step, AggArgumentSourc
 use crate::translate::collate::{get_collseq_from_expr, CollationSeq};
 use crate::translate::emitter::{Resolver, TranslateCtx};
 use crate::translate::expr::{
-    expr_contains_nondeterministic_scalar_function, translate_expr, walk_expr, walk_expr_mut,
-    WalkControl,
+    expr_contains_nondeterministic_scalar_function, translate_expr, translate_expr_no_constant_opt,
+    walk_expr, walk_expr_mut, NoConstantOptReason, WalkControl,
 };
 use crate::translate::order_by::EmitOrderBy;
 use crate::translate::plan::{
@@ -573,6 +573,13 @@ pub struct WindowRegisters {
     pub peer_start_reg: Option<usize>,
     pub peer_current_reg: Option<usize>,
     pub peer_end_reg: Option<usize>,
+    /// Register holding the runtime-evaluated offset N for frames
+    /// whose start boundary is `Following(_)` — `cume_dist()`'s
+    /// `Following(1)`. Used as an `OP_IfPos` countdown by whichever
+    /// frame-cursor op needs to be deferred; cume_dist gates RETURN_ROW
+    /// with it so the first emit waits for the first AGGINVERSE. Mirrors
+    /// SQLite's `regStart` (window.c:2883).
+    pub start_offset_reg: Option<usize>,
     /// Return-address register for the `labels.row_output` Gosub. Mirrors
     /// SQLite's `regGosub` (window.c:2793).
     pub row_output_return: usize,
@@ -852,6 +859,12 @@ impl EmitWindow {
                 } else {
                     None
                 },
+                start_offset_reg: match window.frame.start {
+                    crate::translate::plan::FrameBoundary::Following(_) => {
+                        Some(program.alloc_register())
+                    }
+                    _ => None,
+                },
                 row_output_return: program.alloc_register(),
                 frame_end_rowid,
             },
@@ -975,6 +988,26 @@ impl EmitWindow {
             dest: registers.acc_start,
             dest_end: Some(registers.acc_start + window.functions.len() - 1),
         });
+        // The offset register is reused across partitions, so re-evaluate
+        // here at each partition boundary — a hoisted constant init would
+        // leave the value drifted after the first partition's IfPos
+        // decrements ran. Mirrors SQLite's `regStart` init at `window.c:2942`.
+        if let Some(start_offset_reg) = registers.start_offset_reg {
+            let offset_expr = match &window.frame.start {
+                crate::translate::plan::FrameBoundary::Following(expr) => expr,
+                _ => {
+                    unreachable!("start_offset_reg is only allocated when frame.start is Following")
+                }
+            };
+            translate_expr_no_constant_opt(
+                program,
+                Some(&plan.table_references),
+                offset_expr,
+                start_offset_reg,
+                &t_ctx.resolver,
+                NoConstantOptReason::RegisterReuse,
+            )?;
+        }
         emit_insert_row_into_buffer(
             program,
             &registers,
@@ -1069,7 +1102,7 @@ impl EmitWindow {
             program.preassign_label_to_next_insn(label_step_body);
         }
 
-        emit_window_op(program, t_ctx, plan, WindowOp::AggStep, None)?;
+        emit_window_op(program, t_ctx, plan, WindowOp::AggStep, None, None)?;
         // Frames whose end is UNBOUNDED FOLLOWING (lead's and lag's
         // coerced frames) cache the entire partition before any RETURN_ROW
         // fires — every output row's frame depends on rows yet to be
@@ -1081,7 +1114,7 @@ impl EmitWindow {
             crate::translate::plan::FrameBoundary::UnboundedFollowing
         );
         if !cache_frame {
-            emit_window_op(program, t_ctx, plan, WindowOp::ReturnRow, None)?;
+            emit_window_op(program, t_ctx, plan, WindowOp::ReturnRow, None, None)?;
         }
 
         // No explicit peer-tracker update needed here: AGGSTEP's
@@ -1310,28 +1343,52 @@ enum WindowOp {
 ///
 /// Frame-caching functions (`first_value` / `nth_value` / `lag` / `lead`)
 /// seek arbitrary rows through `csr_app` at output time, so their rows must
-/// survive until the partition is flushed. SQLite's `windowCacheFrame` forces
-/// `eDelete == 0` for exactly that set; we detect it via `has_csr_app`.
+/// survive until the partition is flushed. SQLite gates only its
+/// `UNBOUNDED PRECEDING` arm on `windowCacheFrame`; because our positional
+/// `csr_app` lookups need every row regardless of frame start, we apply the
+/// guard to all frame shapes and never delete when a caching function is
+/// present (`has_csr_app`).
 ///
-/// Only frames with an UNBOUNDED PRECEDING start (delete at `RETURN_ROW`) or a
-/// sliding start (delete at `AGGINVERSE`) are reachable today — explicit frame
-/// clauses, and therefore SQLite's offset-bearing arms (`ROWS ... N PRECEDING`
-/// end → `AGGSTEP`, `ROWS N FOLLOWING` start → `RETURN_ROW`), are rejected
-/// before emit. The start-boundary split here matches the one the flush loop
-/// uses to decide whether to fire `AGGINVERSE` at all; a future `FOLLOWING`
-/// frame start needs both sites updated together.
+/// The remaining arms mirror SQLite's `switch(eStart)`:
+/// - `FOLLOWING` with a positive, non-RANGE offset → delete at `RETURN_ROW`
+///   (`window.c:2846-2852`). Reachable via cume_dist's coerced GROUPS
+///   `1 FOLLOWING` start.
+/// - `UNBOUNDED PRECEDING` → delete at `RETURN_ROW` (`window.c:2853-2864`).
+///   The `UNBOUNDED..N PRECEDING → AGGSTEP` sub-case has no reachable frame
+///   (no built-in or supported user frame ends at `N PRECEDING`).
+/// - `CURRENT ROW` / `N PRECEDING` → delete at `AGGINVERSE`
+///   (`window.c:2866-2868`). Covers percent_rank / ntile and the user
+///   `ROWS BETWEEN N PRECEDING AND CURRENT ROW` frame.
+///
+/// The `FOLLOWING`/`UNBOUNDED PRECEDING` split here must stay in sync with the
+/// flush loop's `AGGINVERSE` gate: a moving start (anything but
+/// `UNBOUNDED PRECEDING`) fires `AGGINVERSE` for its xInverse, but that op only
+/// *deletes* when it is the returned `eDelete`.
 fn window_delete_op(window: &Window, has_csr_app: bool) -> Option<WindowOp> {
+    use crate::translate::plan::FrameBoundary;
     if has_csr_app {
         return None;
     }
-    match window.frame.start {
-        crate::translate::plan::FrameBoundary::UnboundedPreceding => Some(WindowOp::ReturnRow),
-        _ => Some(WindowOp::AggInverse),
+    match &window.frame.start {
+        FrameBoundary::Following(_) if window.frame.mode != turso_parser::ast::FrameMode::Range => {
+            Some(WindowOp::ReturnRow)
+        }
+        FrameBoundary::UnboundedPreceding => Some(WindowOp::ReturnRow),
+        FrameBoundary::CurrentRow | FrameBoundary::Preceding(_) => Some(WindowOp::AggInverse),
+        // A FOLLOWING start under RANGE, or an UNBOUNDED FOLLOWING start,
+        // never deletes (SQLite leaves eDelete == 0).
+        FrameBoundary::Following(_) | FrameBoundary::UnboundedFollowing => None,
     }
 }
 
 /// Emit one of the three frame-cursor operations, mirroring SQLite's
 /// `windowCodeOp` helper (`window.c:2229-2376`).
+///
+/// `countdown_reg` is `Some(reg)` when the caller wants the op gated by
+/// an `OP_IfPos` countdown — the op is skipped (and the register
+/// decremented) while `reg > 0`. cume_dist uses this on RETURN_ROW to
+/// defer the first emit until after the first AGGINVERSE has fired.
+/// Matches SQLite's `regCountdown` parameter at `window.c:2238`.
 ///
 /// `break_on_eof` is `Some(label)` only at flush time, when the caller wants
 /// the `RETURN_ROW` loop to exit cleanly on EOF instead of falling through.
@@ -1346,6 +1403,7 @@ fn emit_window_op(
     t_ctx: &mut TranslateCtx,
     plan: &SelectPlan,
     op: WindowOp,
+    countdown_reg: Option<usize>,
     break_on_eof: Option<BranchOffset>,
 ) -> Result<()> {
     let meta = t_ctx.meta_window.as_ref().expect("missing window metadata");
@@ -1375,6 +1433,19 @@ fn emit_window_op(
             registers.peer_start_reg,
         ),
     };
+
+    // Optional `OP_IfPos` countdown — when the register is positive,
+    // decrement and skip the op body. Mirrors SQLite at `window.c:2279`.
+    // The caller decides which op gets the gate; cume_dist gates
+    // RETURN_ROW with `start_offset_reg` so the first emit waits for
+    // the first AGGINVERSE.
+    if let Some(reg) = countdown_reg {
+        program.emit_insn(Insn::IfPos {
+            reg,
+            target_pc: label_done,
+            decrement_by: 1,
+        });
+    }
 
     // RETURN_ROW finalizes accumulators before emitting (SQLite's
     // windowAggFinal at window.c:2284). first_value / nth_value / lag /
@@ -2178,27 +2249,117 @@ pub fn emit_window_flush(
     // AggStep called against it (under ROWS) or its peer group might still
     // be incomplete (under RANGE). One AGGSTEP advances csr_end through the
     // remaining rows.
-    emit_window_op(program, t_ctx, plan, WindowOp::AggStep, None)?;
+    emit_window_op(program, t_ctx, plan, WindowOp::AggStep, None, None)?;
 
-    let label_loop_start = program.allocate_label();
-    program.preassign_label_to_next_insn(label_loop_start);
-    emit_window_op(program, t_ctx, plan, WindowOp::ReturnRow, Some(label_break))?;
-    // Functions with a moving frame start (ntile, percent_rank,
-    // cume_dist) fire AggInverse between output rows so xValue's next
-    // read sees the advanced state. The window is split per-coerced-frame
-    // at plan time, so every function in this window has the same start
-    // boundary — one window-level gate. Mirrors SQLite's flush block at
-    // window.c:3091 (`windowCodeOp(..., WINDOW_AGGINVERSE, regStart, 0)`).
+    // The flush loop shape depends on the coerced frame's start
+    // boundary. Mirrors SQLite's three flush paths at window.c:3052-3094.
     let window = plan.window.as_ref().expect("missing window");
-    if !matches!(
-        window.frame.start,
-        crate::translate::plan::FrameBoundary::UnboundedPreceding
-    ) {
-        emit_window_op(program, t_ctx, plan, WindowOp::AggInverse, None)?;
+    match window.frame.start {
+        crate::translate::plan::FrameBoundary::Following(_) => {
+            // `N FOLLOWING` start (cume_dist's `1 FOLLOWING`). SQLite
+            // window.c:3068-3084: two-stage loop.
+            //
+            //   loop_1:
+            //     RETURN_ROW (with IfPos countdown → skips first call),
+            //                 break_on_eof = label_break
+            //     AGGINVERSE,  break_on_eof = label_after_inverse_eof
+            //     Goto loop_1
+            //   label_after_inverse_eof:
+            //   loop_2:
+            //     RETURN_ROW,  break_on_eof = label_break
+            //     Goto loop_2
+            //   label_break:
+            //
+            // The IfPos defers the first emit so AGGINVERSE fires for
+            // the first group before the first RETURN_ROW reads its
+            // value. After AGGINVERSE exhausts (csr_start EOF), the
+            // second loop drains the remaining csr_current rows with
+            // the now-final nStep.
+            let label_after_inverse_eof = program.allocate_label();
+            let label_loop_1 = program.allocate_label();
+            program.preassign_label_to_next_insn(label_loop_1);
+            emit_window_op(
+                program,
+                t_ctx,
+                plan,
+                WindowOp::ReturnRow,
+                registers.start_offset_reg,
+                Some(label_break),
+            )?;
+            emit_window_op(
+                program,
+                t_ctx,
+                plan,
+                WindowOp::AggInverse,
+                None,
+                Some(label_after_inverse_eof),
+            )?;
+            program.emit_insn(Insn::Goto {
+                target_pc: label_loop_1,
+            });
+
+            program.preassign_label_to_next_insn(label_after_inverse_eof);
+            let label_loop_2 = program.allocate_label();
+            program.preassign_label_to_next_insn(label_loop_2);
+            emit_window_op(
+                program,
+                t_ctx,
+                plan,
+                WindowOp::ReturnRow,
+                None,
+                Some(label_break),
+            )?;
+            program.emit_insn(Insn::Goto {
+                target_pc: label_loop_2,
+            });
+        }
+        crate::translate::plan::FrameBoundary::CurrentRow => {
+            // CURRENT ROW start (ntile, percent_rank). SQLite
+            // window.c:3088-3093: paired RETURN_ROW + AGGINVERSE in a
+            // single loop. AGGINVERSE never hits EOF before RETURN_ROW
+            // (csr_start advances in lockstep with csr_current within a
+            // group), so it doesn't need its own break.
+            let label_loop_start = program.allocate_label();
+            program.preassign_label_to_next_insn(label_loop_start);
+            emit_window_op(
+                program,
+                t_ctx,
+                plan,
+                WindowOp::ReturnRow,
+                None,
+                Some(label_break),
+            )?;
+            emit_window_op(program, t_ctx, plan, WindowOp::AggInverse, None, None)?;
+            program.emit_insn(Insn::Goto {
+                target_pc: label_loop_start,
+            });
+        }
+        crate::translate::plan::FrameBoundary::UnboundedPreceding => {
+            // UNBOUNDED PRECEDING start (everything else). No
+            // AGGINVERSE — the frame never shrinks from the left.
+            // SQLite window.c:3088-3093 with the AGGINVERSE no-op gate
+            // at window.c:2254.
+            let label_loop_start = program.allocate_label();
+            program.preassign_label_to_next_insn(label_loop_start);
+            emit_window_op(
+                program,
+                t_ctx,
+                plan,
+                WindowOp::ReturnRow,
+                None,
+                Some(label_break),
+            )?;
+            program.emit_insn(Insn::Goto {
+                target_pc: label_loop_start,
+            });
+        }
+        crate::translate::plan::FrameBoundary::UnboundedFollowing
+        | crate::translate::plan::FrameBoundary::Preceding(_) => {
+            unreachable!(
+                "neither UNBOUNDED FOLLOWING nor N PRECEDING can be a coerced frame start"
+            );
+        }
     }
-    program.emit_insn(Insn::Goto {
-        target_pc: label_loop_start,
-    });
 
     program.preassign_label_to_next_insn(label_break);
     program.preassign_label_to_next_insn(label_empty);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6908,6 +6908,32 @@ fn op_window_step(
             };
             payload[0].try_clone_from(arg_slot.get_value())?;
         }
+        // percent_rank() / cume_dist() — mirror SQLite's CallCount-based
+        // percent_rankStepFunc / cume_distStepFunc (window.c:328, :373).
+        // Both share the same xStep semantics: count every row entering
+        // the frame end. With end=UNBOUNDED FOLLOWING, that's every row
+        // in the partition. xInverse and xValue do the rest.
+        //
+        // State (payload):
+        //   [0] = nTotal (partition row count).
+        //   [1] = nStep  (rows that have left the frame start).
+        WindowFunc::PercentRank | WindowFunc::CumeDist => {
+            if let Register::Value(Value::Null) = state.registers[acc_reg] {
+                state.registers[acc_reg] =
+                    Register::Aggregate(AggContext::Builtin(crate::alloc::try_vec![
+                        Value::from_i64(0),
+                        Value::from_i64(0),
+                    ]?));
+            }
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                unreachable!("percent_rank/cume_dist accumulator must be a Builtin payload");
+            };
+            let Value::Numeric(Numeric::Integer(ntotal)) = &mut payload[0] else {
+                unreachable!("percent_rank/cume_dist nTotal must be Integer");
+            };
+            *ntotal += 1;
+        }
         // ntile(N) — mirrors SQLite's NtileCtx (window.c:410). Frame is
         // ROWS CURRENT ROW TO UNBOUNDED FOLLOWING. The step fires for
         // every row entering the frame end (i.e. every row in the
@@ -7037,6 +7063,57 @@ fn op_window_value(
             };
             std::mem::replace(&mut payload[0], Value::Null)
         }
+        // percent_rank() — mirrors SQLite's percent_rankValueFunc
+        // (window.c:352). The value is (rows in earlier peer groups) /
+        // (nTotal - 1); 0.0 when there's only one row in the partition.
+        WindowFunc::PercentRank => {
+            let Register::Aggregate(AggContext::Builtin(payload)) = &state.registers[acc_reg]
+            else {
+                return Err(LimboError::InternalError(format!(
+                    "percent_rank accumulator in unexpected register state: {:?}",
+                    state.registers[acc_reg]
+                )));
+            };
+            let Value::Numeric(Numeric::Integer(ntotal)) = &payload[0] else {
+                unreachable!("percent_rank nTotal must be Integer");
+            };
+            let Value::Numeric(Numeric::Integer(nstep)) = &payload[1] else {
+                unreachable!("percent_rank nStep must be Integer");
+            };
+            let ntotal = *ntotal;
+            let nstep = *nstep;
+            let r = if ntotal > 1 {
+                nstep as f64 / (ntotal - 1) as f64
+            } else {
+                0.0
+            };
+            Value::from_f64(r)
+        }
+        // cume_dist() — mirrors SQLite's cume_distValueFunc
+        // (window.c:397). value = nStep / nTotal.
+        WindowFunc::CumeDist => {
+            let Register::Aggregate(AggContext::Builtin(payload)) = &state.registers[acc_reg]
+            else {
+                return Err(LimboError::InternalError(format!(
+                    "cume_dist accumulator in unexpected register state: {:?}",
+                    state.registers[acc_reg]
+                )));
+            };
+            let Value::Numeric(Numeric::Integer(ntotal)) = &payload[0] else {
+                unreachable!("cume_dist nTotal must be Integer");
+            };
+            let Value::Numeric(Numeric::Integer(nstep)) = &payload[1] else {
+                unreachable!("cume_dist nStep must be Integer");
+            };
+            let ntotal = *ntotal;
+            let nstep = *nstep;
+            // nTotal is incremented per xStep, so it's always >= 1 once
+            // we're emitting rows from this partition. A divide-by-zero
+            // here would mean we're computing cume_dist on an empty
+            // partition, which can't happen.
+            let r = nstep as f64 / ntotal as f64;
+            Value::from_f64(r)
+        }
         // ntile bucket computation — mirrors SQLite's ntileValueFunc
         // (window.c:453). The partition is split into nParam buckets;
         // when nTotal isn't a clean multiple, the first nLarge buckets
@@ -7094,6 +7171,25 @@ fn op_window_inverse(
     func: &WindowFunc,
 ) -> Result<InsnFunctionStepResult> {
     match func {
+        // percent_rank / cume_dist xInverse — increment nStep, the
+        // count of rows that have left the frame start. Under GROUPS
+        // mode the AGGINVERSE peer-loop fires xInverse once per row of
+        // the leaving group, so a group of size G bumps nStep by G.
+        WindowFunc::PercentRank | WindowFunc::CumeDist => {
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                return Err(LimboError::InternalError(format!(
+                    "percent_rank/cume_dist accumulator in unexpected register state at inverse: {:?}",
+                    state.registers[acc_reg]
+                )));
+            };
+            let Value::Numeric(Numeric::Integer(nstep)) = &mut payload[1] else {
+                unreachable!("percent_rank/cume_dist nStep must be Integer");
+            };
+            *nstep += 1;
+            state.pc += 1;
+            Ok(InsnFunctionStepResult::Step)
+        }
         // ntile's xInverse advances iRow — the output-row position
         // within the partition that xValue reads. xStep has already
         // populated nTotal and nParam by the time the flush loop fires

--- a/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/default.sqltest
@@ -345,15 +345,18 @@ expect {
     ntile|w|1
 }
 
-@skip-if sqlite "Turso should not list window functions that it cannot run"
-test pragma-function-list-omits-unimplemented-window-functions {
-    SELECT COUNT(*) FROM pragma_function_list
-    WHERE name IN (
-        'percent_rank','cume_dist'
-    );
+test pragma-function-list-window-percent-rank {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'percent_rank';
 }
 expect {
-    0
+    percent_rank|w|0
+}
+
+test pragma-function-list-window-cume-dist {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'cume_dist';
+}
+expect {
+    cume_dist|w|0
 }
 
 @skip-if sqlite "sqlite will default to 'delete'"

--- a/sqlite/conformance/sqlite-sqltests/window/cume_dist.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/cume_dist.sqltest
@@ -1,0 +1,747 @@
+@database :memory:
+
+# cume_dist() computes (rows in groups ≤ current) / nTotal. Frame is
+# GROUPS 1 FOLLOWING TO UNBOUNDED FOLLOWING — the `1 FOLLOWING` means
+# AggInverse must fire for the current group BEFORE its xValue is read.
+# In the emitter this is the OP_IfPos countdown that skips the first
+# RETURN_ROW, plus the post-AGGINVERSE-EOF second loop that drains the
+# last group.
+
+setup vals5 {
+    CREATE TABLE t(x INTEGER);
+    INSERT INTO t VALUES (1),(2),(3),(4),(5);
+}
+
+# 5 distinct rows → cume_dist = 1/5, 2/5, 3/5, 4/5, 5/5. Picked 5
+# because the denominator's nice and every value has a clean f64.
+@setup vals5
+test cume-dist-no-peers {
+    SELECT x, cume_dist() OVER (ORDER BY x) FROM t;
+}
+expect {
+    1|0.2
+    2|0.4
+    3|0.6
+    4|0.8
+    5|1.0
+}
+expect @js {
+    1|0.2
+    2|0.4
+    3|0.6
+    4|0.8
+    5|1
+}
+
+# Peer groups share the same cume_dist value, with the group size
+# contributing to nStep all at once.
+setup peers4 {
+    CREATE TABLE p(x INTEGER);
+    INSERT INTO p VALUES (1),(1),(2),(2);
+}
+
+@setup peers4
+test cume-dist-with-peers {
+    SELECT x, cume_dist() OVER (ORDER BY x) FROM p;
+}
+expect {
+    1|0.5
+    1|0.5
+    2|1.0
+    2|1.0
+}
+expect @js {
+    1|0.5
+    1|0.5
+    2|1
+    2|1
+}
+
+# Single row → cume_dist = 1.0 (the only row covers the whole partition).
+setup one_row {
+    CREATE TABLE r(x INTEGER);
+    INSERT INTO r VALUES (1);
+}
+
+@setup one_row
+test cume-dist-single-row {
+    SELECT cume_dist() OVER (ORDER BY x) FROM r;
+}
+expect {
+    1.0
+}
+expect @js {
+    1
+}
+
+# Empty table → no rows out.
+setup empty {
+    CREATE TABLE e(x INTEGER);
+}
+
+@setup empty
+test cume-dist-empty {
+    SELECT x, cume_dist() OVER (ORDER BY x) FROM e;
+}
+expect {
+}
+
+# All rows peers → all 1.0 (the entire partition is one group, and
+# every row's "groups ≤ current" includes everything).
+setup all_peers {
+    CREATE TABLE ap(x INTEGER);
+    INSERT INTO ap VALUES (1),(1),(1),(1);
+}
+
+@setup all_peers
+test cume-dist-all-peers {
+    SELECT cume_dist() OVER (ORDER BY x) FROM ap;
+}
+expect {
+    1.0
+    1.0
+    1.0
+    1.0
+}
+expect @js {
+    1
+    1
+    1
+    1
+}
+
+# PARTITION BY resets cume_dist within each partition — exercises the
+# countdown register reinit at the partition boundary.
+setup partitioned {
+    CREATE TABLE pa(g INTEGER, x INTEGER);
+    INSERT INTO pa VALUES (1,1),(1,2),(1,3),(1,4),(2,10),(2,20);
+}
+
+@setup partitioned
+test cume-dist-with-partition {
+    SELECT g, x, cume_dist() OVER (PARTITION BY g ORDER BY x) FROM pa;
+}
+expect {
+    1|1|0.25
+    1|2|0.5
+    1|3|0.75
+    1|4|1.0
+    2|10|0.5
+    2|20|1.0
+}
+expect @js {
+    1|1|0.25
+    1|2|0.5
+    1|3|0.75
+    1|4|1
+    2|10|0.5
+    2|20|1
+}
+
+# Combine partition resets with peer groups inside each partition —
+# exercises the countdown-reset + two-loop flush path against
+# nontrivial GROUPS frames in every partition.
+setup partitioned_peers {
+    CREATE TABLE pap(g INTEGER, x INTEGER);
+    INSERT INTO pap VALUES (1,1),(1,1),(1,2),(1,2),(2,5),(2,5),(2,9);
+}
+
+@setup partitioned_peers
+test cume-dist-with-partition-and-peers {
+    SELECT g, x, printf('%.4f', cume_dist() OVER (PARTITION BY g ORDER BY x)) FROM pap;
+}
+expect {
+    1|1|0.5000
+    1|1|0.5000
+    1|2|1.0000
+    1|2|1.0000
+    2|5|0.6667
+    2|5|0.6667
+    2|9|1.0000
+}
+
+# DESC ordering — same values, in reverse traversal order.
+@setup vals5
+test cume-dist-order-desc {
+    SELECT x, cume_dist() OVER (ORDER BY x DESC) FROM t;
+}
+expect {
+    5|0.2
+    4|0.4
+    3|0.6
+    2|0.8
+    1|1.0
+}
+expect @js {
+    5|0.2
+    4|0.4
+    3|0.6
+    2|0.8
+    1|1
+}
+
+# Mixed with ntile() — different coerced frames (ntile's is ROWS
+# CURRENT→UF; cume_dist's is GROUPS 1F→UF), so the planner splits the
+# window into two passes.
+@setup vals5
+test cume-dist-mixed-with-ntile {
+    SELECT x, ntile(2) OVER (ORDER BY x), cume_dist() OVER (ORDER BY x) FROM t;
+}
+expect {
+    1|1|0.2
+    2|1|0.4
+    3|1|0.6
+    4|2|0.8
+    5|2|1.0
+}
+expect @js {
+    1|1|0.2
+    2|1|0.4
+    3|1|0.6
+    4|2|0.8
+    5|2|1
+}
+
+# OVER () — no PARTITION, no ORDER BY. With no ORDER BY every row is a
+# peer of every other row, so the whole partition is one group:
+# cume_dist = 1.0 for every row.
+@setup vals5
+test cume-dist-over-empty {
+    SELECT cume_dist() OVER () FROM t;
+}
+expect {
+    1.0
+    1.0
+    1.0
+    1.0
+    1.0
+}
+expect @js {
+    1
+    1
+    1
+    1
+    1
+}
+
+# Both percent_rank and cume_dist in the same SELECT. Their coerced
+# frames differ (CURRENT→UF vs 1F→UF), so each gets its own pass.
+@setup vals5
+test percent-rank-and-cume-dist-together {
+    SELECT x,
+           percent_rank() OVER (ORDER BY x),
+           cume_dist() OVER (ORDER BY x)
+    FROM t;
+}
+expect {
+    1|0.0|0.2
+    2|0.25|0.4
+    3|0.5|0.6
+    4|0.75|0.8
+    5|1.0|1.0
+}
+expect @js {
+    1|0|0.2
+    2|0.25|0.4
+    3|0.5|0.6
+    4|0.75|0.8
+    5|1|1
+}
+
+# printf to lock formatting for the awkward denominators.
+setup vals3 {
+    CREATE TABLE t3(x INTEGER);
+    INSERT INTO t3 VALUES (1),(2),(3);
+}
+
+@setup vals3
+test cume-dist-printf-format {
+    SELECT printf('%.4f', cume_dist() OVER (ORDER BY x)) FROM t3;
+}
+expect {
+    0.3333
+    0.6667
+    1.0000
+}
+
+# NULLs form their own peer group at the start of an ASC ordering.
+setup vals_nulls {
+    CREATE TABLE tn(v);
+    INSERT INTO tn VALUES (NULL),(1),(NULL),(2);
+}
+
+@setup vals_nulls
+test cume-dist-null-peers {
+    SELECT v, printf('%.4f', cume_dist() OVER (ORDER BY v)) FROM tn ORDER BY v;
+}
+expect {
+    |0.5000
+    |0.5000
+    1|0.7500
+    2|1.0000
+}
+
+# Regression: cume_dist's coerced frame starts at 1 FOLLOWING, so its
+# frame-start cursor runs AHEAD of the emit cursor. SQLite's eDelete
+# switch (window.c:2845-2852) therefore deletes its buffered rows at
+# RETURN_ROW, not AGGINVERSE — deleting at AGGINVERSE removes rows
+# before they are emitted and corrupted the ephemeral btree
+# (cell_get: idx out of bounds) once a later partition reused the
+# emptied pages. Multiple multi-row partitions is the crashing shape.
+setup stream_del {
+    CREATE TABLE sd(g INTEGER, x INTEGER);
+    INSERT INTO sd VALUES (1,10),(1,10),(1,20),(1,30),
+                          (2,5),(2,6),
+                          (3,1),(3,1),(3,2),(3,2);
+}
+
+@setup stream_del
+@cross-check-integrity
+test cume-dist-streaming-delete-multi-partition {
+    SELECT g, x, cume_dist() OVER (PARTITION BY g ORDER BY x) FROM sd;
+}
+expect {
+    1|10|0.5
+    1|10|0.5
+    1|20|0.75
+    1|30|1.0
+    2|5|0.5
+    2|6|1.0
+    3|1|0.5
+    3|1|0.5
+    3|2|1.0
+    3|2|1.0
+}
+expect @js {
+    1|10|0.5
+    1|10|0.5
+    1|20|0.75
+    1|30|1
+    2|5|0.5
+    2|6|1
+    3|1|0.5
+    3|1|0.5
+    3|2|1
+    3|2|1
+}
+
+# 2000 rows spanning many ephemeral-table pages: rows are deleted as
+# they stream out (eDelete = RETURN_ROW), so this exercises page
+# recycling inside one partition. sum(cume_dist) over n distinct rows
+# is (n+1)/2 exactly.
+setup gen2000 {
+    CREATE TABLE d(x);
+    INSERT INTO d VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+    CREATE TABLE n(i INTEGER PRIMARY KEY);
+    INSERT INTO n SELECT a.x*100 + b.x*10 + c.x + 1 FROM d a, d b, d c;
+    INSERT INTO n SELECT i + 1000 FROM n;
+}
+
+@setup gen2000
+test cume-dist-2000-rows-aggregate {
+    SELECT round(sum(r), 6), count(*)
+    FROM (SELECT cume_dist() OVER (ORDER BY i) r FROM n);
+}
+expect {
+    1000.5|2000
+}
+
+# 40 partitions of 50 rows each: every partition flush deletes its
+# rows before the next partition's inserts land on the freed pages.
+@setup gen2000
+test cume-dist-2000-rows-40-partitions {
+    SELECT round(sum(r), 6)
+    FROM (SELECT cume_dist() OVER (PARTITION BY i%40 ORDER BY i) r FROM n);
+}
+expect {
+    1020.0
+}
+expect @js {
+    1020
+}
+
+# 500 singleton partitions: insert one row, flush (emit + delete),
+# repeat — maximal churn on a near-empty buffer table.
+@setup gen2000
+test cume-dist-singleton-partition-churn {
+    SELECT round(sum(r), 6), count(*)
+    FROM (SELECT cume_dist() OVER (PARTITION BY i ORDER BY i) r FROM n
+          WHERE i <= 500);
+}
+expect {
+    500.0|500
+}
+expect @js {
+    500|500
+}
+
+# 64 rows with 5KB payloads: every buffered row's cell overflows, so
+# the streaming RETURN_ROW deletes walk overflow-page chains.
+setup overflow64 {
+    CREATE TABLE ovp(i INTEGER PRIMARY KEY, pad TEXT);
+    INSERT INTO ovp SELECT 1, printf('%.*c', 5000, 'y');
+    INSERT INTO ovp SELECT i + 1, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 2, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 4, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 8, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 16, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 32, pad FROM ovp;
+}
+
+@setup overflow64
+@cross-check-integrity
+test cume-dist-overflow-payload-streaming-delete {
+    SELECT round(sum(r), 6), sum(length(pad))
+    FROM (SELECT pad, cume_dist() OVER (ORDER BY i) r FROM ovp);
+}
+expect {
+    32.5|320000
+}
+
+# Mixed-affinity ORDER BY key: NULL < numerics < text < blob, with the
+# integer 1 / real 1.0 pair forming a cross-type peer group.
+setup mixed_affinity {
+    CREATE TABLE ma(v);
+    INSERT INTO ma VALUES (1),('1'),(1.0),('a'),(X'61'),(NULL),(2),('10');
+}
+
+@setup mixed_affinity
+test cume-dist-mixed-affinity-order-key {
+    SELECT typeof(v), cume_dist() OVER (ORDER BY v) FROM ma;
+}
+expect {
+    null|0.125
+    integer|0.375
+    real|0.375
+    integer|0.5
+    text|0.625
+    text|0.75
+    text|0.875
+    blob|1.0
+}
+expect @js {
+    null|0.125
+    integer|0.375
+    real|0.375
+    integer|0.5
+    text|0.625
+    text|0.75
+    text|0.875
+    blob|1
+}
+
+# BLOB order keys compare bytewise with length tiebreak; the two X'01'
+# rows are peers.
+setup blob_keys {
+    CREATE TABLE bl(v);
+    INSERT INTO bl VALUES (X'00'),(X'0000'),(X'01'),(X'01'),(X'FF');
+}
+
+@setup blob_keys
+test cume-dist-blob-order-key {
+    SELECT hex(v), cume_dist() OVER (ORDER BY v) FROM bl;
+}
+expect {
+    00|0.2
+    0000|0.4
+    01|0.8
+    01|0.8
+    FF|1.0
+}
+expect @js {
+    00|0.2
+    0000|0.4
+    01|0.8
+    01|0.8
+    FF|1
+}
+
+# Column-declared NOCASE collation makes 'a'/'A' and 'b'/'B' peers.
+setup nocase_col {
+    CREATE TABLE nc(v TEXT COLLATE NOCASE);
+    INSERT INTO nc VALUES ('a'),('A'),('b'),('B'),('c');
+}
+
+@setup nocase_col
+test cume-dist-nocase-column-ties {
+    SELECT v, cume_dist() OVER (ORDER BY v) FROM nc;
+}
+expect {
+    a|0.4
+    A|0.4
+    b|0.8
+    B|0.8
+    c|1.0
+}
+expect @js {
+    a|0.4
+    A|0.4
+    b|0.8
+    B|0.8
+    c|1
+}
+
+# An explicit COLLATE in the OVER clause overrides the column default.
+setup binary_col {
+    CREATE TABLE co(v TEXT);
+    INSERT INTO co VALUES ('a'),('A'),('b'),('B');
+}
+
+@setup binary_col
+test cume-dist-collate-in-over-clause {
+    SELECT v, cume_dist() OVER (ORDER BY v COLLATE NOCASE) FROM co;
+}
+expect {
+    a|0.5
+    A|0.5
+    b|1.0
+    B|1.0
+}
+expect @js {
+    a|0.5
+    A|0.5
+    b|1
+    B|1
+}
+
+# NULLS LAST moves the NULL peer group to the end of the ordering.
+setup nulls_mix {
+    CREATE TABLE nu(v);
+    INSERT INTO nu VALUES (NULL),(1),(NULL),(2),(3);
+}
+
+@setup nulls_mix
+test cume-dist-nulls-last {
+    SELECT v, cume_dist() OVER (ORDER BY v NULLS LAST) FROM nu;
+}
+expect {
+    1|0.2
+    2|0.4
+    3|0.6
+    |1.0
+    |1.0
+}
+expect @js {
+    1|0.2
+    2|0.4
+    3|0.6
+    |1
+    |1
+}
+
+# +0.0 and -0.0 compare equal, so they form one peer group.
+setup neg_zero {
+    CREATE TABLE nz(v REAL);
+    INSERT INTO nz VALUES (0.0),(-0.0),(1.0),(2.0);
+}
+
+@setup neg_zero
+test cume-dist-negative-zero-tie {
+    SELECT cume_dist() OVER (ORDER BY v) FROM nz;
+}
+expect {
+    0.5
+    0.5
+    0.75
+    1.0
+}
+expect @js {
+    0.5
+    0.5
+    0.75
+    1
+}
+
+# Integer 1 and real 1.0 are numerically equal → peers, despite
+# differing storage classes.
+setup cross_type {
+    CREATE TABLE xt(v);
+    INSERT INTO xt VALUES (1),(1.0),(2),(2.0),(3);
+}
+
+@setup cross_type
+test cume-dist-int-real-cross-type-ties {
+    SELECT v, cume_dist() OVER (ORDER BY v) FROM xt;
+}
+expect {
+    1|0.4
+    1.0|0.4
+    2|0.8
+    2.0|0.8
+    3|1.0
+}
+expect @js {
+    1|0.4
+    1|0.4
+    2|0.8
+    2|0.8
+    3|1
+}
+
+# NULL is a regular partition value: both NULL rows land in one
+# partition.
+setup part_null {
+    CREATE TABLE pn(p, v);
+    INSERT INTO pn VALUES (NULL,1),(NULL,2),(1,3),(1,4),(2,5);
+}
+
+@setup part_null
+test cume-dist-partition-by-null {
+    SELECT p, cume_dist() OVER (PARTITION BY p ORDER BY v) FROM pn;
+}
+expect {
+    |0.5
+    |1.0
+    1|0.5
+    1|1.0
+    2|1.0
+}
+expect @js {
+    |0.5
+    |1
+    1|0.5
+    1|1
+    2|1
+}
+
+# Sharing a window with lag() flips the buffering strategy: lag makes
+# the window cache the whole partition (csr_app), which suppresses the
+# streaming deletes cume_dist would otherwise trigger. Values must not
+# change.
+setup with_lag {
+    CREATE TABLE lg(v);
+    INSERT INTO lg VALUES (10),(20),(20),(30),(40);
+}
+
+@setup with_lag
+test cume-dist-with-lag-same-window {
+    SELECT v, cume_dist() OVER w, lag(v) OVER w FROM lg WINDOW w AS (ORDER BY v);
+}
+expect {
+    10|0.2|
+    20|0.6|10
+    20|0.6|20
+    30|0.8|20
+    40|1.0|30
+}
+expect @js {
+    10|0.2|
+    20|0.6|10
+    20|0.6|20
+    30|0.8|20
+    40|1|30
+}
+
+# cume_dist over cume_dist: the inner window's output feeds the outer
+# window's ORDER BY through a subquery.
+setup nested_vals {
+    CREATE TABLE ww(v);
+    INSERT INTO ww VALUES (1),(2),(2),(4),(5);
+}
+
+@setup nested_vals
+test cume-dist-window-over-window {
+    SELECT r, cume_dist() OVER (ORDER BY r)
+    FROM (SELECT cume_dist() OVER (ORDER BY v) r FROM ww);
+}
+expect {
+    0.2|0.2
+    0.6|0.6
+    0.6|0.6
+    0.8|0.8
+    1.0|1.0
+}
+expect @js {
+    0.2|0.2
+    0.6|0.6
+    0.6|0.6
+    0.8|0.8
+    1|1
+}
+
+# Referenced through a view with an outer WHERE on the window result.
+setup view_base {
+    CREATE TABLE tv(v);
+    INSERT INTO tv VALUES (1),(2),(2),(4);
+}
+
+@setup view_base
+test cume-dist-in-view {
+    CREATE VIEW vw AS SELECT v, cume_dist() OVER (ORDER BY v) r FROM tv;
+    SELECT * FROM vw WHERE r < 1;
+}
+expect {
+    1|0.25
+    2|0.75
+    2|0.75
+}
+
+# UPDATE reading cume_dist through a correlated scalar subquery.
+setup update_base {
+    CREATE TABLE up(v INTEGER, r REAL);
+    INSERT INTO up(v) VALUES (1),(2),(3),(4);
+}
+
+@setup update_base
+test cume-dist-in-update-subquery {
+    UPDATE up SET r = (SELECT rr FROM
+        (SELECT v vv, cume_dist() OVER (ORDER BY v) rr FROM up)
+        WHERE vv = up.v);
+    SELECT v, r FROM up ORDER BY v;
+}
+expect {
+    1|0.25
+    2|0.5
+    3|0.75
+    4|1.0
+}
+expect @js {
+    1|0.25
+    2|0.5
+    3|0.75
+    4|1
+}
+
+# FILTER is only legal on aggregate window functions; cume_dist must
+# reject it like SQLite does.
+@setup vals5
+test cume-dist-filter-rejected {
+    SELECT cume_dist() FILTER (WHERE x > 1) OVER (ORDER BY x) FROM t;
+}
+expect error {
+    FILTER clause may only be used with aggregate window functions
+}
+
+# A window function used only by the SELECT's ORDER BY still participates in
+# window planning and orders peers as a group.
+test cume-dist-used-only-in-order-by {
+    WITH t(x) AS (VALUES (3), (1), (2), (2))
+    SELECT x FROM t
+    ORDER BY cume_dist() OVER (ORDER BY x DESC), x DESC;
+}
+expect {
+    3
+    2
+    2
+    1
+}
+
+# An inline window extension inherits PARTITION BY from its base window.
+test cume-dist-inline-window-inherits-partition {
+    WITH t(g, x) AS (VALUES (1, 1), (1, 2), (2, 3), (2, 4))
+    SELECT g, x, cume_dist() OVER (base ORDER BY x)
+    FROM t
+    WINDOW base AS (PARTITION BY g);
+}
+expect {
+    1|1|0.5
+    1|2|1.0
+    2|3|0.5
+    2|4|1.0
+}
+expect @js {
+    1|1|0.5
+    1|2|1
+    2|3|0.5
+    2|4|1
+}

--- a/sqlite/conformance/sqlite-sqltests/window/percent_rank.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/percent_rank.sqltest
@@ -1,0 +1,675 @@
+@database :memory:
+
+# percent_rank() computes (rows in earlier peer groups) / (nTotal - 1).
+# Frame is GROUPS CURRENT ROW TO UNBOUNDED FOLLOWING — xStep counts every
+# row, xInverse increments nStep once per row of the leaving peer group,
+# xValue divides. Single-row partitions return 0.0.
+
+setup vals5 {
+    CREATE TABLE t(x INTEGER);
+    INSERT INTO t VALUES (1),(2),(3),(4),(5);
+}
+
+# 5 distinct rows: ranks 1..5; percent_rank = 0, 1/4, 2/4, 3/4, 1.
+# Picked 5 rows so denominators are 4 and every value has a clean f64.
+@setup vals5
+test percent-rank-no-peers {
+    SELECT x, percent_rank() OVER (ORDER BY x) FROM t;
+}
+expect {
+    1|0.0
+    2|0.25
+    3|0.5
+    4|0.75
+    5|1.0
+}
+expect @js {
+    1|0
+    2|0.25
+    3|0.5
+    4|0.75
+    5|1
+}
+
+# Peer groups share the same percent_rank value.
+setup peers {
+    CREATE TABLE p(x INTEGER);
+    INSERT INTO p VALUES (1),(1),(3),(3),(5);
+}
+
+@setup peers
+test percent-rank-with-peers {
+    SELECT x, percent_rank() OVER (ORDER BY x) FROM p;
+}
+expect {
+    1|0.0
+    1|0.0
+    3|0.5
+    3|0.5
+    5|1.0
+}
+expect @js {
+    1|0
+    1|0
+    3|0.5
+    3|0.5
+    5|1
+}
+
+# Single row → 0.0 (SQLite returns 0 when nTotal <= 1, avoiding the
+# divide-by-zero that the formula would otherwise produce).
+setup one_row {
+    CREATE TABLE r(x INTEGER);
+    INSERT INTO r VALUES (1);
+}
+
+@setup one_row
+test percent-rank-single-row {
+    SELECT percent_rank() OVER (ORDER BY x) FROM r;
+}
+expect {
+    0.0
+}
+expect @js {
+    0
+}
+
+# Empty table → no rows out.
+setup empty {
+    CREATE TABLE e(x INTEGER);
+}
+
+@setup empty
+test percent-rank-empty {
+    SELECT x, percent_rank() OVER (ORDER BY x) FROM e;
+}
+expect {
+}
+
+# All rows peers → all 0.0.
+setup all_peers {
+    CREATE TABLE ap(x INTEGER);
+    INSERT INTO ap VALUES (1),(1),(1);
+}
+
+@setup all_peers
+test percent-rank-all-peers {
+    SELECT percent_rank() OVER (ORDER BY x) FROM ap;
+}
+expect {
+    0.0
+    0.0
+    0.0
+}
+expect @js {
+    0
+    0
+    0
+}
+
+# PARTITION BY resets the rank within each partition.
+setup partitioned {
+    CREATE TABLE pa(g INTEGER, x INTEGER);
+    INSERT INTO pa VALUES (1,1),(1,2),(1,3),(1,4),(1,5),(2,10),(2,20);
+}
+
+@setup partitioned
+test percent-rank-with-partition {
+    SELECT g, x, percent_rank() OVER (PARTITION BY g ORDER BY x) FROM pa;
+}
+expect {
+    1|1|0.0
+    1|2|0.25
+    1|3|0.5
+    1|4|0.75
+    1|5|1.0
+    2|10|0.0
+    2|20|1.0
+}
+expect @js {
+    1|1|0
+    1|2|0.25
+    1|3|0.5
+    1|4|0.75
+    1|5|1
+    2|10|0
+    2|20|1
+}
+
+# DESC ordering — rows traverse in reverse, percent_rank assigns from
+# the largest x down.
+@setup vals5
+test percent-rank-order-desc {
+    SELECT x, percent_rank() OVER (ORDER BY x DESC) FROM t;
+}
+expect {
+    5|0.0
+    4|0.25
+    3|0.5
+    2|0.75
+    1|1.0
+}
+expect @js {
+    5|0
+    4|0.25
+    3|0.5
+    2|0.75
+    1|1
+}
+
+# Mixed with rank() in the same SELECT — different coerced frames
+# (rank's is RANGE UP→CURRENT, percent_rank's is GROUPS CURRENT→UF), so
+# the planner splits the window and each function gets its own pass.
+@setup vals5
+test percent-rank-mixed-with-rank {
+    SELECT x, rank() OVER (ORDER BY x), percent_rank() OVER (ORDER BY x) FROM t;
+}
+expect {
+    1|1|0.0
+    2|2|0.25
+    3|3|0.5
+    4|4|0.75
+    5|5|1.0
+}
+expect @js {
+    1|1|0
+    2|2|0.25
+    3|3|0.5
+    4|4|0.75
+    5|5|1
+}
+
+# OVER () — no PARTITION, no ORDER BY. With no ORDER BY every row is a
+# peer of every other row, so percent_rank is always 0.0.
+@setup vals5
+test percent-rank-over-empty {
+    SELECT percent_rank() OVER () FROM t;
+}
+expect {
+    0.0
+    0.0
+    0.0
+    0.0
+    0.0
+}
+expect @js {
+    0
+    0
+    0
+    0
+    0
+}
+
+# Format with printf to guarantee identical formatting against SQLite
+# for divisors that don't have a clean f64 representation (1/3, etc.).
+setup vals4 {
+    CREATE TABLE t4(x INTEGER);
+    INSERT INTO t4 VALUES (1),(2),(3),(4);
+}
+
+@setup vals4
+test percent-rank-printf-format {
+    SELECT printf('%.4f', percent_rank() OVER (ORDER BY x)) FROM t4;
+}
+expect {
+    0.0000
+    0.3333
+    0.6667
+    1.0000
+}
+
+# NULLs form their own peer group at the start of an ASC ordering.
+setup vals_nulls {
+    CREATE TABLE tn(v);
+    INSERT INTO tn VALUES (NULL),(1),(NULL),(2);
+}
+
+@setup vals_nulls
+test percent-rank-null-peers {
+    SELECT v, printf('%.4f', percent_rank() OVER (ORDER BY v)) FROM tn ORDER BY v;
+}
+expect {
+    |0.0000
+    |0.0000
+    1|0.6667
+    2|1.0000
+}
+
+# Regression companion to cume_dist's streaming-delete crash:
+# percent_rank's coerced frame starts at CURRENT ROW, so its buffered
+# rows are deleted at AGGINVERSE (SQLite's eDelete default arm,
+# window.c:2866-2868) — the start cursor trails the emit cursor, so
+# the delete-then-reinsert cycle across partition flushes must leave
+# the ephemeral btree consistent.
+setup stream_del {
+    CREATE TABLE sd(g INTEGER, x INTEGER);
+    INSERT INTO sd VALUES (1,10),(1,10),(1,20),(1,30),
+                          (2,5),(2,6),
+                          (3,1),(3,1),(3,2),(3,2);
+}
+
+@setup stream_del
+@cross-check-integrity
+test percent-rank-streaming-delete-multi-partition {
+    SELECT g, x, printf('%.4f', percent_rank() OVER (PARTITION BY g ORDER BY x))
+    FROM sd;
+}
+expect {
+    1|10|0.0000
+    1|10|0.0000
+    1|20|0.6667
+    1|30|1.0000
+    2|5|0.0000
+    2|6|1.0000
+    3|1|0.0000
+    3|1|0.0000
+    3|2|0.6667
+    3|2|0.6667
+}
+
+# 2000 rows spanning many ephemeral pages, deleted at AGGINVERSE as
+# the frame start advances. sum(percent_rank) over n distinct rows is
+# sum(k/(n-1) for k=0..n-1) = n/2 exactly.
+setup gen2000 {
+    CREATE TABLE d(x);
+    INSERT INTO d VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+    CREATE TABLE n(i INTEGER PRIMARY KEY);
+    INSERT INTO n SELECT a.x*100 + b.x*10 + c.x + 1 FROM d a, d b, d c;
+    INSERT INTO n SELECT i + 1000 FROM n;
+}
+
+@setup gen2000
+test percent-rank-2000-rows-aggregate {
+    SELECT round(sum(r), 6), count(*)
+    FROM (SELECT percent_rank() OVER (ORDER BY i) r FROM n);
+}
+expect {
+    1000.0|2000
+}
+expect @js {
+    1000|2000
+}
+
+# 40 partitions of 50 rows: each flush deletes the partition's rows,
+# the next partition reuses the freed pages.
+@setup gen2000
+test percent-rank-2000-rows-40-partitions {
+    SELECT round(sum(r), 6)
+    FROM (SELECT percent_rank() OVER (PARTITION BY i%40 ORDER BY i) r FROM n);
+}
+expect {
+    1000.0
+}
+expect @js {
+    1000
+}
+
+# 500 singleton partitions: nTotal-1 is 0 in every partition, so every
+# row is 0.0 — and the buffer churns through insert/flush/delete per row.
+@setup gen2000
+test percent-rank-singleton-partition-churn {
+    SELECT round(sum(r), 6), count(*)
+    FROM (SELECT percent_rank() OVER (PARTITION BY i ORDER BY i) r FROM n
+          WHERE i <= 500);
+}
+expect {
+    0.0|500
+}
+expect @js {
+    0|500
+}
+
+# 64 rows with 5KB payloads across 7 partitions: AGGINVERSE deletes
+# walk overflow-page chains, partition flushes recycle overflow pages.
+setup overflow64 {
+    CREATE TABLE ovp(i INTEGER PRIMARY KEY, pad TEXT);
+    INSERT INTO ovp SELECT 1, printf('%.*c', 5000, 'y');
+    INSERT INTO ovp SELECT i + 1, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 2, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 4, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 8, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 16, pad FROM ovp;
+    INSERT INTO ovp SELECT i + 32, pad FROM ovp;
+}
+
+@setup overflow64
+@cross-check-integrity
+test percent-rank-overflow-payload-partitioned {
+    SELECT round(sum(r), 6), sum(length(pad))
+    FROM (SELECT pad, percent_rank() OVER (PARTITION BY i%7 ORDER BY i) r
+          FROM ovp);
+}
+expect {
+    32.0|320000
+}
+expect @js {
+    32|320000
+}
+
+# Mixed-affinity ORDER BY key: NULL < numerics < text < blob, with the
+# integer 1 / real 1.0 pair forming a cross-type peer group.
+setup mixed_affinity {
+    CREATE TABLE ma(v);
+    INSERT INTO ma VALUES (1),('1'),(1.0),('a'),(X'61'),(NULL),(2),('10');
+}
+
+@setup mixed_affinity
+test percent-rank-mixed-affinity-order-key {
+    SELECT typeof(v), printf('%.4f', percent_rank() OVER (ORDER BY v)) FROM ma;
+}
+expect {
+    null|0.0000
+    integer|0.1429
+    real|0.1429
+    integer|0.4286
+    text|0.5714
+    text|0.7143
+    text|0.8571
+    blob|1.0000
+}
+
+# BLOB order keys compare bytewise with length tiebreak; the two X'01'
+# rows are peers.
+setup blob_keys {
+    CREATE TABLE bl(v);
+    INSERT INTO bl VALUES (X'00'),(X'0000'),(X'01'),(X'01'),(X'FF');
+}
+
+@setup blob_keys
+test percent-rank-blob-order-key {
+    SELECT hex(v), percent_rank() OVER (ORDER BY v) FROM bl;
+}
+expect {
+    00|0.0
+    0000|0.25
+    01|0.5
+    01|0.5
+    FF|1.0
+}
+expect @js {
+    00|0
+    0000|0.25
+    01|0.5
+    01|0.5
+    FF|1
+}
+
+# An explicit COLLATE in the OVER clause overrides the column default.
+setup binary_col {
+    CREATE TABLE co(v TEXT);
+    INSERT INTO co VALUES ('a'),('A'),('b'),('B');
+}
+
+@setup binary_col
+test percent-rank-collate-in-over-clause {
+    SELECT v, printf('%.4f', percent_rank() OVER (ORDER BY v COLLATE NOCASE))
+    FROM co;
+}
+expect {
+    a|0.0000
+    A|0.0000
+    b|0.6667
+    B|0.6667
+}
+
+# DESC with NULLS FIRST: the NULL peer group leads the ordering.
+setup nulls_mix {
+    CREATE TABLE nu(v);
+    INSERT INTO nu VALUES (NULL),(1),(NULL),(2),(3);
+}
+
+@setup nulls_mix
+test percent-rank-desc-nulls-first {
+    SELECT v, percent_rank() OVER (ORDER BY v DESC NULLS FIRST) FROM nu;
+}
+expect {
+    |0.0
+    |0.0
+    3|0.5
+    2|0.75
+    1|1.0
+}
+expect @js {
+    |0
+    |0
+    3|0.5
+    2|0.75
+    1|1
+}
+
+# +0.0 and -0.0 compare equal → one peer group; five rows keep the
+# n-1 divisor clean.
+setup neg_zero {
+    CREATE TABLE nz(v REAL);
+    INSERT INTO nz VALUES (0.0),(-0.0),(1.0),(2.0),(3.0);
+}
+
+@setup neg_zero
+test percent-rank-negative-zero-tie {
+    SELECT percent_rank() OVER (ORDER BY v) FROM nz;
+}
+expect {
+    0.0
+    0.0
+    0.5
+    0.75
+    1.0
+}
+expect @js {
+    0
+    0
+    0.5
+    0.75
+    1
+}
+
+# Integer 1 and real 1.0 are numerically equal → peers, despite
+# differing storage classes.
+setup cross_type {
+    CREATE TABLE xt(v);
+    INSERT INTO xt VALUES (1),(1.0),(2),(2.0),(3);
+}
+
+@setup cross_type
+test percent-rank-int-real-cross-type-ties {
+    SELECT v, percent_rank() OVER (ORDER BY v) FROM xt;
+}
+expect {
+    1|0.0
+    1.0|0.0
+    2|0.5
+    2.0|0.5
+    3|1.0
+}
+expect @js {
+    1|0
+    1|0
+    2|0.5
+    2|0.5
+    3|1
+}
+
+# NULL is a regular partition value: both NULL rows land in one
+# partition.
+setup part_null {
+    CREATE TABLE pn(p, v);
+    INSERT INTO pn VALUES (NULL,1),(NULL,2),(1,3),(1,4),(2,5);
+}
+
+@setup part_null
+test percent-rank-partition-by-null {
+    SELECT p, percent_rank() OVER (PARTITION BY p ORDER BY v) FROM pn;
+}
+expect {
+    |0.0
+    |1.0
+    1|0.0
+    1|1.0
+    2|0.0
+}
+expect @js {
+    |0
+    |1
+    1|0
+    1|1
+    2|0
+}
+
+# Sharing a window with first_value() flips the buffering strategy:
+# first_value makes the window cache the whole partition (csr_app),
+# which suppresses the AGGINVERSE deletes percent_rank would otherwise
+# trigger. Values must not change.
+setup with_fv {
+    CREATE TABLE lg(v);
+    INSERT INTO lg VALUES (10),(20),(20),(30),(40);
+}
+
+@setup with_fv
+test percent-rank-with-first-value-same-window {
+    SELECT v, percent_rank() OVER w, first_value(v) OVER w
+    FROM lg WINDOW w AS (ORDER BY v);
+}
+expect {
+    10|0.0|10
+    20|0.25|10
+    20|0.25|10
+    30|0.75|10
+    40|1.0|10
+}
+expect @js {
+    10|0|10
+    20|0.25|10
+    20|0.25|10
+    30|0.75|10
+    40|1|10
+}
+
+# percent_rank over percent_rank: the inner window's output feeds the
+# outer window's ORDER BY through a subquery.
+setup nested_vals {
+    CREATE TABLE ww(v);
+    INSERT INTO ww VALUES (1),(2),(2),(4),(5);
+}
+
+@setup nested_vals
+test percent-rank-window-over-window {
+    SELECT r, percent_rank() OVER (ORDER BY r)
+    FROM (SELECT percent_rank() OVER (ORDER BY v) r FROM ww);
+}
+expect {
+    0.0|0.0
+    0.25|0.25
+    0.25|0.25
+    0.75|0.75
+    1.0|1.0
+}
+expect @js {
+    0|0
+    0.25|0.25
+    0.25|0.25
+    0.75|0.75
+    1|1
+}
+
+# Referenced through a view with an outer WHERE on the window result;
+# five source rows keep the n-1 divisor clean.
+setup view_base {
+    CREATE TABLE tv(v);
+    INSERT INTO tv VALUES (1),(2),(2),(4),(5);
+}
+
+@setup view_base
+test percent-rank-in-view {
+    CREATE VIEW vw2 AS SELECT v, percent_rank() OVER (ORDER BY v) r FROM tv;
+    SELECT * FROM vw2 WHERE r > 0;
+}
+expect {
+    2|0.25
+    2|0.25
+    4|0.75
+    5|1.0
+}
+expect @js {
+    2|0.25
+    2|0.25
+    4|0.75
+    5|1
+}
+
+# UPDATE reading percent_rank through a correlated scalar subquery.
+setup update_base {
+    CREATE TABLE up(v INTEGER, r REAL);
+    INSERT INTO up(v) VALUES (1),(2),(3),(4),(5);
+}
+
+@setup update_base
+test percent-rank-in-update-subquery {
+    UPDATE up SET r = (SELECT rr FROM
+        (SELECT v vv, percent_rank() OVER (ORDER BY v) rr FROM up)
+        WHERE vv = up.v);
+    SELECT v, r FROM up ORDER BY v;
+}
+expect {
+    1|0.0
+    2|0.25
+    3|0.5
+    4|0.75
+    5|1.0
+}
+expect @js {
+    1|0
+    2|0.25
+    3|0.5
+    4|0.75
+    5|1
+}
+
+# FILTER is only legal on aggregate window functions; percent_rank
+# must reject it like SQLite does.
+@setup vals5
+test percent-rank-filter-rejected {
+    SELECT percent_rank() FILTER (WHERE x > 1) OVER (ORDER BY x) FROM t;
+}
+expect error {
+    FILTER clause may only be used with aggregate window functions
+}
+
+# Window functions run after grouping, so aggregate results form the input
+# rows and equal aggregate values form peer groups.
+test percent-rank-over-grouped-input {
+    WITH t(g, x) AS (
+        VALUES (1, 1), (2, 1), (2, 2), (3, 1), (3, 2)
+    )
+    SELECT g, count(*), percent_rank() OVER (ORDER BY count(*))
+    FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    1|1|0.0
+    2|2|0.5
+    3|2|0.5
+}
+expect @js {
+    1|1|0
+    2|2|0.5
+    3|2|0.5
+}
+
+# A derived named window inherits PARTITION BY from its base window.
+test percent-rank-derived-window-inherits-partition {
+    WITH t(g, x) AS (VALUES (1, 1), (1, 2), (2, 3), (2, 4))
+    SELECT g, x, percent_rank() OVER w
+    FROM t
+    WINDOW base AS (PARTITION BY g), w AS (base ORDER BY x);
+}
+expect {
+    1|1|0.0
+    1|2|1.0
+    2|3|0.0
+    2|4|1.0
+}
+expect @js {
+    1|1|0
+    1|2|1
+    2|3|0
+    2|4|1
+}

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -53,6 +53,13 @@ pub struct SqlGenBackend {
 
 impl SqlGenBackend {
     pub fn new(seed: u64) -> Self {
+        Self::new_with_window_weight(seed, 0.0)
+    }
+
+    /// Construct with a non-zero probability that each expression-list
+    /// result column is a window function. Used by the window-function-
+    /// focused fuzzing path.
+    pub fn new_with_window_weight(seed: u64, window_function_probability: f64) -> Self {
         let ctx = sql_gen::Context::new_with_seed(seed);
         let mut policy = Policy::default()
             .with_stmt_weights(sql_gen::StmtWeights {
@@ -63,6 +70,7 @@ impl SqlGenBackend {
                 sql_gen::FunctionConfig::deterministic().disable(&["LIKELY", "UNLIKELY"]),
             );
         policy.select_config.require_order_by_with_limit = true;
+        policy.select_config.window_function_probability = window_function_probability;
         // Disable expression values for inserts, enable conflict clauses for updates
         policy.insert_config.expression_value_probability = 0.0;
         policy.insert_config.or_replace_probability = 0.0;

--- a/testing/differential-oracle/fuzzer/main.rs
+++ b/testing/differential-oracle/fuzzer/main.rs
@@ -58,6 +58,12 @@ struct Args {
     /// Enable experimental MVCC mode.
     #[arg(long)]
     mvcc: bool,
+
+    /// Probability (0.0..=1.0) that each expression-list SELECT column
+    /// is generated as a window function. Set high (e.g. `0.6`) to
+    /// stress-test the window function emit pipeline.
+    #[arg(long, default_value_t = 0.0)]
+    window_function_probability: f64,
 }
 
 #[derive(Subcommand, Debug)]
@@ -240,6 +246,7 @@ fn run_single_inner(args: &Args) -> Result<differential_fuzzer::SimStats> {
             TreeMode::Simplified
         },
         mvcc: args.mvcc,
+        window_function_probability: args.window_function_probability.clamp(0.0, 1.0),
     };
 
     tracing::info!("Starting differential_fuzzer with config: {:?}", config);

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -52,6 +52,11 @@ pub struct SimConfig {
     pub tree_mode: TreeMode,
     /// Whether to enable MVCC mode.
     pub mvcc: bool,
+    /// Probability that each expression-list SELECT column is generated
+    /// as a window function. 0.0 disables window-function generation
+    /// entirely; values up to 1.0 weight the SELECT list heavily toward
+    /// `func(...) OVER (...)` projections.
+    pub window_function_probability: f64,
 }
 
 impl Default for SimConfig {
@@ -67,6 +72,7 @@ impl Default for SimConfig {
             coverage: false,
             tree_mode: TreeMode::default(),
             mvcc: false,
+            window_function_probability: 0.0,
         }
     }
 }
@@ -335,7 +341,10 @@ impl Fuzzer {
         let mut generator: Box<dyn SqlGenerator> = match self.config.generator {
             GeneratorKind::SqlGen => {
                 let seed: u64 = self.rng.borrow_mut().next_u64();
-                Box::new(SqlGenBackend::new(seed))
+                Box::new(SqlGenBackend::new_with_window_weight(
+                    seed,
+                    self.config.window_function_probability,
+                ))
             }
             GeneratorKind::SqlGenProp => {
                 let seed_bytes: [u8; 32] = {
@@ -648,6 +657,7 @@ mod tests {
             coverage: false,
             tree_mode: TreeMode::default(),
             mvcc: false,
+            window_function_probability: 0.0,
         };
         let sim = Fuzzer::new(config);
         assert!(sim.is_ok());

--- a/testing/differential-oracle/sql_gen/src/ast.rs
+++ b/testing/differential-oracle/sql_gen/src/ast.rs
@@ -1483,8 +1483,7 @@ pub enum Expr {
     ArrayLiteral(ArrayLiteralExpr),
     /// expr[n] — array subscript
     ArraySubscript(Box<ArraySubscriptExpr>),
-    // Stubs: not yet generated (weight 0), shown in coverage report
-    /// expr OVER (PARTITION BY ... ORDER BY ... ROWS/RANGE ...)
+    /// `func(args) OVER (PARTITION BY ... ORDER BY ...)`.
     WindowFunction(Box<WindowFunctionExpr>),
     /// expr COLLATE collation_name
     Collate(Box<CollateExpr>),
@@ -1511,8 +1510,8 @@ impl fmt::Display for Expr {
             Expr::Parenthesized(e) => write!(f, "({e})"),
             Expr::ArrayLiteral(a) => write!(f, "{a}"),
             Expr::ArraySubscript(a) => write!(f, "{a}"),
+            Expr::WindowFunction(w) => write!(f, "{w}"),
             // Stubs
-            Expr::WindowFunction(_) => todo!("window function generation"),
             Expr::Collate(_) => todo!("COLLATE expression generation"),
             Expr::Raise(_) => todo!("RAISE expression generation"),
         }
@@ -1645,10 +1644,21 @@ impl Expr {
         Expr::Parenthesized(Box::new(expr))
     }
 
-    /// Create a window function expression (stub — records to context).
-    pub fn window_function(ctx: &mut Context) -> Self {
+    /// Create a window function expression (records to context).
+    pub fn window_function(
+        ctx: &mut Context,
+        name: String,
+        args: Vec<Expr>,
+        partition_by: Vec<Expr>,
+        order_by: Vec<(Expr, OrderDirection)>,
+    ) -> Self {
         ctx.record(ExprKind::WindowFunction);
-        todo!("window function generation")
+        Expr::WindowFunction(Box::new(WindowFunctionExpr {
+            name,
+            args,
+            partition_by,
+            order_by,
+        }))
     }
 
     /// Create a COLLATE expression (stub — records to context).
@@ -2058,9 +2068,57 @@ pub struct InSubqueryExpr {
 // Stub expression types (not yet generated)
 // =============================================================================
 
-/// A window function expression (stub).
+/// A window function expression: `func(args) OVER (PARTITION BY ... ORDER BY ...)`.
+///
+/// Restricted to the planner-coerced frame set — no user-specified
+/// `ROWS`/`RANGE`/`GROUPS` clauses or `EXCLUDE` clauses, matching what
+/// the engine currently accepts.
 #[derive(Debug, Clone)]
-pub struct WindowFunctionExpr;
+pub struct WindowFunctionExpr {
+    pub name: String,
+    pub args: Vec<Expr>,
+    /// Optional list of partition expressions.
+    pub partition_by: Vec<Expr>,
+    /// Optional list of order-by expressions with direction.
+    pub order_by: Vec<(Expr, OrderDirection)>,
+}
+
+impl fmt::Display for WindowFunctionExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}(", self.name)?;
+        for (i, arg) in self.args.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{arg}")?;
+        }
+        write!(f, ") OVER (")?;
+        let mut first_clause = true;
+        if !self.partition_by.is_empty() {
+            write!(f, "PARTITION BY ")?;
+            for (i, e) in self.partition_by.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{e}")?;
+            }
+            first_clause = false;
+        }
+        if !self.order_by.is_empty() {
+            if !first_clause {
+                write!(f, " ")?;
+            }
+            write!(f, "ORDER BY ")?;
+            for (i, (e, dir)) in self.order_by.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{e} {dir}")?;
+            }
+        }
+        write!(f, ")")
+    }
+}
 
 /// A COLLATE expression (stub).
 #[derive(Debug, Clone)]

--- a/testing/differential-oracle/sql_gen/src/generate/select.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/select.rs
@@ -642,17 +642,25 @@ fn generate_select_columns<C: Capabilities>(
             let num_cols = ctx.gen_range_inclusive((*range.start()).max(1), *range.end());
             let mut columns = Vec::with_capacity(num_cols);
             let restrict = select_config.restrict_mixed_aggregates;
+            let window_prob = select_config.window_function_probability.clamp(0.0, 1.0);
 
             for i in 0..num_cols {
-                let expr = generate_expr(generator, ctx, 0)?;
-                // When restricting mixed aggregates and there is no GROUP BY,
-                // an expression that mixes aggregate calls with bare column
-                // refs (e.g. `COUNT(a) + b`) is invalid SQL.  Replace it with
-                // a plain column reference.
-                let expr = if restrict && expr.contains_aggregate() && expr.contains_column_ref() {
-                    pick_scoped_column_ref(ctx)?
+                // Window functions are only valid as a result-column expression
+                // (or in ORDER BY of the same SELECT). We don't recurse: the
+                // window function call itself is the projection.
+                let expr = if window_prob > 0.0 && ctx.gen_bool_with_prob(window_prob) {
+                    generate_window_function(ctx)?
                 } else {
-                    expr
+                    let e = generate_expr(generator, ctx, 0)?;
+                    // When restricting mixed aggregates and there is no GROUP BY,
+                    // an expression that mixes aggregate calls with bare column
+                    // refs (e.g. `COUNT(a) + b`) is invalid SQL. Replace it with
+                    // a plain column reference.
+                    if restrict && e.contains_aggregate() && e.contains_column_ref() {
+                        pick_scoped_column_ref(ctx)?
+                    } else {
+                        e
+                    }
                 };
                 columns.push(SelectColumn {
                     expr,
@@ -665,6 +673,113 @@ fn generate_select_columns<C: Capabilities>(
             }
             Ok(columns)
         }
+    }
+}
+
+/// The set of built-in window functions Turso supports. Mirrors
+/// SQLite's built-in list at `window.c:610-625`.
+const BUILTIN_WINDOW_FUNCS: &[(&str, WindowFnArity)] = &[
+    ("row_number", WindowFnArity::ZeroArg),
+    ("rank", WindowFnArity::ZeroArg),
+    ("dense_rank", WindowFnArity::ZeroArg),
+    ("percent_rank", WindowFnArity::ZeroArg),
+    ("cume_dist", WindowFnArity::ZeroArg),
+    ("ntile", WindowFnArity::Ntile),
+    ("lag", WindowFnArity::LagLead),
+    ("lead", WindowFnArity::LagLead),
+    ("first_value", WindowFnArity::OneArg),
+    ("last_value", WindowFnArity::OneArg),
+    ("nth_value", WindowFnArity::NthValue),
+];
+
+#[derive(Clone, Copy)]
+enum WindowFnArity {
+    ZeroArg,
+    OneArg,
+    Ntile,
+    NthValue,
+    LagLead,
+}
+
+/// Generate a `func(...) OVER (...)` projection. Mirrors the grammar at
+/// `window.c:600-708` — only built-in functions and the
+/// planner-coerced frames (no user `ROWS`/`RANGE`/`GROUPS` clauses,
+/// since the engine rejects those).
+fn generate_window_function(ctx: &mut Context) -> Result<Expr, GenError> {
+    // Pick a function.
+    let (name, arity) = *ctx
+        .choose(BUILTIN_WINDOW_FUNCS)
+        .expect("BUILTIN_WINDOW_FUNCS is non-empty");
+
+    // Pick a typed column for value args (lag/lead/first_value/etc).
+    // We restrict to columns the current scope sees; window functions
+    // are projection-only so the scope is the SELECT's FROM clause.
+    let arg_col = pick_scoped_column_ref(ctx)?;
+
+    let args: Vec<Expr> = match arity {
+        WindowFnArity::ZeroArg => Vec::new(),
+        WindowFnArity::OneArg => vec![arg_col],
+        WindowFnArity::Ntile => {
+            // ntile(N) — N must be a positive integer literal.
+            let n = ctx.gen_range_inclusive(1, 6) as i64;
+            vec![Expr::literal(ctx, Literal::Integer(n))]
+        }
+        WindowFnArity::NthValue => {
+            // nth_value(expr, N) — N must be a positive integer.
+            let n = ctx.gen_range_inclusive(1, 4) as i64;
+            vec![arg_col, Expr::literal(ctx, Literal::Integer(n))]
+        }
+        WindowFnArity::LagLead => {
+            // lag/lead take 1-3 args: expr[, offset[, default]].
+            let nargs = ctx.gen_range_inclusive(1, 3);
+            let mut a = vec![arg_col];
+            if nargs >= 2 {
+                // Negative offsets are legal and look in the opposite
+                // direction; for lag they exercise the streaming-frame
+                // miss behavior (forward lookups past the one buffered
+                // row return the default).
+                let offset = ctx.gen_range_inclusive(0, 8) as i64 - 4;
+                a.push(Expr::literal(ctx, Literal::Integer(offset)));
+            }
+            if nargs >= 3 {
+                let default = ctx.gen_range_inclusive(0, 200) as i64 - 100;
+                a.push(Expr::literal(ctx, Literal::Integer(default)));
+            }
+            a
+        }
+    };
+
+    // Build the OVER clause: 0-2 PARTITION BY exprs, 0-2 ORDER BY
+    // exprs with the same direction. Columns picked from the SELECT
+    // scope so they're always valid.
+    let n_part = ctx.gen_range_inclusive(0, 2);
+    let n_ord = ctx.gen_range_inclusive(0, 2);
+    let partition_by: Vec<Expr> = (0..n_part)
+        .map(|_| pick_scoped_column_ref(ctx))
+        .collect::<Result<_, _>>()?;
+    let dir = if ctx.gen_bool() {
+        OrderDirection::Asc
+    } else {
+        OrderDirection::Desc
+    };
+    let order_by: Vec<(Expr, OrderDirection)> = (0..n_ord)
+        .map(|_| pick_scoped_column_ref(ctx).map(|e| (e, dir)))
+        .collect::<Result<_, _>>()?;
+
+    // Some functions return floats whose default formatting differs
+    // between SQLite and Turso (e.g. percent_rank = 1/3). Wrap them in
+    // `printf('%.4f', ...)` so the textual comparison agrees while
+    // still exercising the same semantics.
+    let win = Expr::window_function(ctx, name.to_string(), args, partition_by, order_by);
+    if matches!(name, "percent_rank" | "cume_dist") {
+        let fmt_str = Expr::literal(ctx, Literal::Text("%.4f".to_string()));
+        Ok(Expr::function_call(
+            ctx,
+            "printf".to_string(),
+            vec![fmt_str, win],
+        ))
+    } else {
+        Ok(win)
     }
 }
 

--- a/testing/differential-oracle/sql_gen/src/policy.rs
+++ b/testing/differential-oracle/sql_gen/src/policy.rs
@@ -1175,6 +1175,14 @@ pub struct SelectConfig {
     /// Weights for compound operator selection.
     pub compound_operator_weights: CompoundOperatorWeights,
 
+    /// Probability that each expression-list result column is generated
+    /// as a window function (`func(...) OVER (...)`) rather than a
+    /// generic expression. 0.0 disables window-function generation in
+    /// the SELECT list. Window functions live outside the recursive
+    /// expression dispatch, so this gate keeps them out of WHERE /
+    /// HAVING / function args / subqueries.
+    pub window_function_probability: f64,
+
     // Stubs (not yet implemented, probability 0.0)
     /// Probability of generating a derived table (subquery in FROM).
     pub derived_table_probability: f64,
@@ -1220,6 +1228,10 @@ impl Default for SelectConfig {
             compound_operator_weights: CompoundOperatorWeights::default(),
             // Stubs
             derived_table_probability: 0.0,
+            // Off by default — the differential fuzzer's window_fuzzer
+            // mode and any explicit window-function test should set
+            // this themselves.
+            window_function_probability: 0.0,
         }
     }
 }


### PR DESCRIPTION
Implement `percent_rank()` and `cume_dist()` using the same peer-group and frame-based algorithm as SQLite:

```sql
WITH scores(name, score) AS (
  VALUES
    ('alice', 10),
    ('bob',   10),
    ('carol', 20),
    ('dave',  30)
)
SELECT
  name,
  score,
  printf('%.2f', percent_rank() OVER (ORDER BY score)) AS percent_rank,
  printf('%.2f', cume_dist() OVER (ORDER BY score)) AS cume_dist
FROM scores
ORDER BY score, name;
```

This produces:

```text
alice|10|0.00|0.50
bob|10|0.00|0.50
carol|20|0.67|0.75
dave|30|1.00|1.00
```

Rows with the same ordering value are peers and receive the same result.

`percent_rank()` measures how far the beginning of the current peer group is through the partition:

```text
rows in earlier peer groups / (total rows - 1)
```

For the two rows with score `10`, no rows belong to an earlier peer group, so both receive `0.0`. The row with score `20` has two earlier rows, giving `2 / 3`. A single-row partition returns `0.0`.

`cume_dist()` measures what fraction of the partition is less than or equal to the current peer group:

```text
rows in earlier or current peer groups / total rows
```

The two rows with score `10` therefore receive `2 / 4`. The row with score `20` receives `3 / 4`, and the final peer group always receives `1.0`.

### Window execution

Both functions use SQLite's accumulator model:

- `xStep` counts every row in the partition.
- `xInverse` counts rows as peer groups leave the start of the coerced frame.
- `xValue` divides those counters according to the function's formula.

`percent_rank()` uses a `GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING` frame. As each peer group leaves the frame, its rows become the numerator for the following group.

`cume_dist()` uses `GROUPS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING`. This means the current peer group must leave the frame before its value is read, so that group is included in the numerator.

The `1 FOLLOWING` start requires two pieces of window-emitter machinery:

- An `IfPos` countdown defers the first output until the first peer group has passed through `AggInverse`.
- A second flush loop continues emitting rows after the frame-start cursor reaches EOF, allowing the final peer group to observe the complete row count and return `1.0`.

The countdown is reinitialized at every partition boundary.

### Differential fuzzing

This also teaches the SQL generator to produce all supported built-in window functions:

- `row_number`, `rank`, `dense_rank`, `percent_rank`, and `cume_dist`
- `ntile`
- `lag` and `lead`
- `first_value`, `last_value`, and `nth_value`

Generated calls use valid argument shapes and randomized `OVER` clauses containing up to two `PARTITION BY` and two `ORDER BY` expressions.

Window functions are generated only as top-level SELECT result columns, keeping them out of invalid contexts such as `WHERE`, `HAVING`, nested function arguments, and grouped projections.

The differential fuzzer exposes this through:

```text
--window-function-probability <0.0..=1.0>
```

The option defaults to `0.0`, so existing fuzzing workloads are unchanged. Floating-point window results are formatted explicitly where necessary so SQLite and Turso can be compared textually without differences in default float rendering.

Dedicated conformance coverage includes peer groups, single-row and empty inputs, all-peer partitions, `PARTITION BY`, descending order, `OVER ()`, NULL peers, combinations with other window functions, and the streaming/flush paths used by both coerced frames.