### PR TITLE
WITH RECURSIVE

### DIFF
--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -100,6 +100,9 @@ cargo run --release -p memory-benchmark -- --mode mvcc --workload mixed -i 100 -
 # Run a final checkpoint after the workload
 cargo run --release -p memory-benchmark -- --mode wal --workload read-heavy --checkpoint
 
+# Exercise recursive queues at a 10k-row target cardinality
+cargo run --release -p memory-benchmark -- --mode wal --workload recursive-cte -i 20 -b 10000
+
 # Guarantee automatic MVCC checkpoints during the run by lowering the
 # logical-log threshold (default is ~4 MB, more than small workloads write)
 cargo run --release -p memory-benchmark -- --mode mvcc --workload insert-heavy --mvcc-checkpoint-threshold 16384
@@ -107,7 +110,7 @@ cargo run --release -p memory-benchmark -- --mode mvcc --workload insert-heavy -
 # All CLI options
 cargo run --release -p memory-benchmark -- \
   --mode wal|mvcc \
-  --workload insert-heavy|read-heavy|mixed|scan-heavy|series-blob|update-churn \
+  --workload insert-heavy|read-heavy|mixed|scan-heavy|recursive-cte|series-blob|update-churn \
   -i <iterations> \
   -b <batch-size> \
   --connections <N> \
@@ -135,6 +138,7 @@ Every run produces a `dhat-heap.json` in the current directory. This file contai
 | `read-heavy` | 90% SELECT by id / 10% INSERT | Seeds 10k rows |
 | `mixed` | 50% SELECT / 50% INSERT | Seeds 10k rows |
 | `scan-heavy` | Full table scans with LIKE | Seeds 10k rows |
+| `recursive-cte` | Repeated linear, priority-queue, UNION-distinct, and outer-LIMIT recursive CTE queries | No schema setup; `batch-size` is the target recursive result cardinality |
 | `series-blob` | `INSERT INTO bench(data) SELECT zeroblob(2048) FROM generate_series(1, ?)` | Creates `bench`; `batch-size` is the series length |
 | `update-churn` | Repeated UPDATEs to a fixed 10k-row set (key space partitioned per connection to avoid write-write conflicts) | Seeds 10k rows. Generates superseded versions — the MVCC GC accumulation case. |
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2724,6 +2724,17 @@ impl TryClone for FromClauseSubquery {
     }
 }
 
+impl TryClone for RecursiveCteInput {
+    type Error = TryReserveError;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(Self {
+            name: self.name.clone(),
+            columns: self.columns.try_clone()?,
+        })
+    }
+}
+
 impl TryClone for Table {
     type Error = TryReserveError;
 
@@ -2733,6 +2744,9 @@ impl TryClone for Table {
             Table::Virtual(table) => Table::Virtual(Arc::new(table.as_ref().try_clone()?)),
             Table::FromClauseSubquery(from_clause_subquery) => {
                 Table::FromClauseSubquery(Arc::new(from_clause_subquery.as_ref().try_clone()?))
+            }
+            Table::RecursiveCteInput(input) => {
+                Table::RecursiveCteInput(Arc::new(input.as_ref().try_clone()?))
             }
         })
     }
@@ -2860,6 +2874,9 @@ impl ColumnLayout {
             Table::FromClauseSubquery(subquery) => Ok(Self::Identity {
                 column_count: subquery.columns.len(),
             }),
+            Table::RecursiveCteInput(input) => Ok(Self::Identity {
+                column_count: input.columns.len(),
+            }),
         }
     }
 
@@ -2967,6 +2984,7 @@ pub enum Table {
     BTree(Arc<BTreeTable>),
     Virtual(Arc<VirtualTable>),
     FromClauseSubquery(Arc<FromClauseSubquery>),
+    RecursiveCteInput(Arc<RecursiveCteInput>),
 }
 
 impl Table {
@@ -2979,6 +2997,9 @@ impl Table {
             Table::FromClauseSubquery(_) => Err(crate::LimboError::InternalError(
                 "FROM clause subqueries do not have a root page".to_string(),
             )),
+            Table::RecursiveCteInput(_) => Err(crate::LimboError::InternalError(
+                "recursive CTE inputs do not have a root page".to_string(),
+            )),
         }
     }
 
@@ -2987,6 +3008,7 @@ impl Table {
             Self::BTree(table) => &table.name,
             Self::Virtual(table) => &table.name,
             Self::FromClauseSubquery(from_clause_subquery) => &from_clause_subquery.name,
+            Self::RecursiveCteInput(input) => &input.name,
         }
     }
 
@@ -2997,6 +3019,7 @@ impl Table {
             Self::FromClauseSubquery(from_clause_subquery) => {
                 from_clause_subquery.columns.get(index)
             }
+            Self::RecursiveCteInput(input) => input.columns.get(index),
         }
     }
 
@@ -3018,6 +3041,11 @@ impl Table {
                         .as_ref()
                         .is_some_and(|n| n.eq_ignore_ascii_case(name))
                 }),
+            Self::RecursiveCteInput(input) => input.columns.iter().enumerate().find(|(_, col)| {
+                col.name
+                    .as_ref()
+                    .is_some_and(|n| n.eq_ignore_ascii_case(name))
+            }),
         }
     }
 
@@ -3026,6 +3054,7 @@ impl Table {
             Self::BTree(table) => &table.columns,
             Self::Virtual(table) => &table.columns,
             Self::FromClauseSubquery(from_clause_subquery) => &from_clause_subquery.columns,
+            Self::RecursiveCteInput(input) => &input.columns,
         }
     }
 
@@ -3034,6 +3063,7 @@ impl Table {
             Self::BTree(table) => table.is_strict,
             Self::Virtual(_) => false,
             Self::FromClauseSubquery(_) => false,
+            Self::RecursiveCteInput(_) => false,
         }
     }
 
@@ -3042,6 +3072,7 @@ impl Table {
             Self::BTree(table) => Some(table.clone()),
             Self::Virtual(_) => None,
             Self::FromClauseSubquery(_) => None,
+            Self::RecursiveCteInput(_) => None,
         }
     }
 
@@ -3059,6 +3090,7 @@ impl Table {
             Self::BTree(table) => Some(table),
             Self::Virtual(_) => None,
             Self::FromClauseSubquery(_) => None,
+            Self::RecursiveCteInput(_) => None,
         }
     }
 
@@ -3957,6 +3989,13 @@ pub struct FromClauseSubquery {
     /// CTE-specific materialization metadata, when this FROM-subquery is a CTE
     /// reference rather than an inline derived table.
     pub cte: Option<FromClauseSubqueryCteMetadata>,
+}
+
+/// The one-row table read by the recursive part of a recursive CTE.
+#[derive(Debug, Clone)]
+pub struct RecursiveCteInput {
+    pub name: String,
+    pub columns: Vec<Column>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -28,7 +28,7 @@ use crate::{
     vdbe::{
         affinity::Affinity,
         builder::{CursorType, DmlColumnContext, ProgramBuilder},
-        insn::{to_u16, CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
+        insn::{to_u32, CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
     },
     vtab::VirtualTable,
     LimboError, Numeric, Result, Value, ValueRef,
@@ -243,9 +243,9 @@ fn emit_rename_autoincrement_backing_table_entry(
 
         let record_reg = program.alloc_register();
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(rec_start),
-            count: to_u16(5),
-            dest_reg: to_u16(record_reg),
+            start_reg: to_u32(rec_start),
+            count: to_u32(5),
+            dest_reg: to_u32(record_reg),
             index_name: None,
             affinity_str: None,
         });
@@ -336,9 +336,9 @@ fn emit_rename_sqlite_sequence_entry(
             extra_amount: 0,
         });
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(record_start_reg),
-            count: to_u16(2),
-            dest_reg: to_u16(record_reg),
+            start_reg: to_u32(record_start_reg),
+            count: to_u32(2),
+            dest_reg: to_u32(record_reg),
             index_name: None,
             affinity_str: Some(affinity_str.clone()),
         });
@@ -1647,9 +1647,9 @@ pub fn translate_alter_table(
                 let record = program.alloc_register();
 
                 program.emit_insn(Insn::MakeRecord {
-                    start_reg: to_u16(out),
-                    count: to_u16(sqlite_schema_column_len),
-                    dest_reg: to_u16(record),
+                    start_reg: to_u32(out),
+                    count: to_u32(sqlite_schema_column_len),
+                    dest_reg: to_u32(record),
                     index_name: None,
                     affinity_str: None,
                 });
@@ -2093,9 +2093,9 @@ pub fn translate_alter_table(
                 let record = program.alloc_register();
 
                 program.emit_insn(Insn::MakeRecord {
-                    start_reg: to_u16(out),
-                    count: to_u16(sqlite_schema_column_len),
-                    dest_reg: to_u16(record),
+                    start_reg: to_u32(out),
+                    count: to_u32(sqlite_schema_column_len),
+                    dest_reg: to_u32(record),
                     index_name: None,
                     affinity_str: None,
                 });
@@ -2322,9 +2322,9 @@ fn emit_rewrite_table_rows(
 
         let record = program.alloc_register();
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(base_dest_reg),
-            count: to_u16(non_virtual_column_count),
-            dest_reg: to_u16(record),
+            start_reg: to_u32(base_dest_reg),
+            count: to_u32(non_virtual_column_count),
+            dest_reg: to_u32(record),
             index_name: None,
             affinity_str: Some(affinity_str.clone()),
         });
@@ -2421,9 +2421,9 @@ fn translate_rename_virtual_table(
 
         let rec = program.alloc_register();
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(out),
-            count: to_u16(ncols),
-            dest_reg: to_u16(rec),
+            start_reg: to_u32(out),
+            count: to_u32(ncols),
+            dest_reg: to_u32(rec),
             index_name: None,
             affinity_str: None,
         });

--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -13,7 +13,7 @@ use crate::{
     vdbe::{
         affinity::Affinity,
         builder::{CursorType, ProgramBuilder},
-        insn::{to_u16, CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
+        insn::{to_u32, CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
     },
     Result,
 };
@@ -400,9 +400,9 @@ pub fn translate_analyze(
                 affinity: Affinity::Text,
             });
             program.emit_insn(Insn::MakeRecord {
-                start_reg: to_u16(tablename_reg),
-                count: to_u16(3),
-                dest_reg: to_u16(record_reg),
+                start_reg: to_u32(tablename_reg),
+                count: to_u32(3),
+                dest_reg: to_u32(record_reg),
                 index_name: None,
                 affinity_str: None,
             });
@@ -618,9 +618,9 @@ fn emit_index_stats(
 
     let idx_record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(record_start),
-        count: to_u16(3),
-        dest_reg: to_u16(idx_record_reg),
+        start_reg: to_u32(record_start),
+        count: to_u32(3),
+        dest_reg: to_u32(idx_record_reg),
         index_name: None,
         affinity_str: None,
     });

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -25,35 +25,26 @@ use tracing::Level;
 pub fn emit_program_for_compound_select(
     program: &mut ProgramBuilder,
     resolver: &Resolver,
-    plan: Plan,
+    plan: &mut Plan,
 ) -> crate::Result<Option<usize>> {
-    // Extract fields we need before plan is consumed by emit_compound_select.
-    let (has_order_by, order_by_owned, limit_owned, offset_owned, right_plan) = {
-        let Plan::CompoundSelect {
-            left: _,
-            right_most,
-            limit,
-            offset,
-            order_by,
-        } = &plan
-        else {
-            crate::bail_parse_error!("expected compound select plan");
-        };
-        (
-            order_by.is_some(),
-            order_by.clone(),
-            limit.clone(),
-            offset.clone(),
-            right_most.clone(),
-        )
+    let Plan::CompoundSelect {
+        left,
+        right_most,
+        limit,
+        offset,
+        order_by,
+    } = plan
+    else {
+        crate::bail_parse_error!("expected compound select plan");
     };
-    let Plan::CompoundSelect { ref left, .. } = plan else {
-        unreachable!()
-    };
+    let has_order_by = order_by.is_some();
+    let order_by_owned = order_by.clone();
+    let limit_owned = limit.clone();
+    let offset_owned = offset.clone();
     let right_most_ctx = Box::new(TranslateCtx::new(
         program,
         resolver.fork(),
-        right_plan.table_references.joined_tables().len(),
+        right_most.table_references.joined_tables().len(),
         false,
     ));
 
@@ -144,13 +135,13 @@ pub fn emit_program_for_compound_select(
             .transpose()?
     };
 
-    let real_query_destination = right_plan.query_destination.clone();
-    let num_result_cols = right_plan.result_columns.len();
+    let real_query_destination = right_most.query_destination.clone();
+    let num_result_cols = right_most.result_columns.len();
 
     // When ORDER BY is present, redirect compound output to a collection index,
     // then sort and emit to the real destination afterwards.
     let (query_destination, collection_cursor, collection_index) = if has_order_by {
-        let (cursor_id, index) = create_collection_index(program, &left[0].0, &right_plan)?;
+        let (cursor_id, index) = create_collection_index(program, &left[0].0, right_most)?;
         let dest = QueryDestination::EphemeralIndex {
             cursor_id,
             index: index.clone(),
@@ -188,24 +179,34 @@ pub fn emit_program_for_compound_select(
     // any tables are actually touched by the query. Previously this only used the rightmost subselect's
     // table references, but that breaks down with e.g. "SELECT * FROM t UNION VALUES(1)" where VALUES(1)
     // does not have any table references and we would erroneously not start a transaction.
-    for (plan, _) in left {
+    for (plan, _) in left.iter() {
         program
             .table_references
             .extend(plan.table_references.clone());
     }
-    program.table_references.extend(right_plan.table_references);
+    program
+        .table_references
+        .extend(right_most.table_references.clone());
 
     // When ORDER BY is present, update all subselect destinations in the Plan
     // to write to the collection index instead of ResultRows.
-    let mut plan = plan;
     if has_order_by {
-        set_select_plan_destination(&mut plan, &query_destination);
+        set_select_plan_destination(plan, &query_destination);
     }
+    let Plan::CompoundSelect {
+        left, right_most, ..
+    } = plan
+    else {
+        unreachable!()
+    };
 
     program.with_scoped_result_cols_start(|program| {
         emit_compound_select(
             program,
-            plan,
+            left,
+            right_most,
+            &limit_owned,
+            &offset_owned,
             &right_most_ctx.resolver,
             limit_ctx,
             offset_reg,
@@ -242,6 +243,15 @@ pub fn emit_program_for_compound_select(
         program.reg_result_cols_start = reg_result_cols_start;
     }
 
+    // Emission redirects subplan destinations to internal collection/dedupe
+    // indexes. The compound plan's externally visible destination is
+    // right_most's, and callers read it after emission (e.g. the scan opener
+    // locating a coroutine's yield register), so put the real one back.
+    let Plan::CompoundSelect { right_most, .. } = plan else {
+        unreachable!()
+    };
+    right_most.query_destination = real_query_destination;
+
     Ok(program.reg_result_cols_start)
 }
 
@@ -250,24 +260,16 @@ pub fn emit_program_for_compound_select(
 #[allow(clippy::too_many_arguments)]
 fn emit_compound_select(
     program: &mut ProgramBuilder,
-    plan: Plan,
+    left: &mut [(SelectPlan, CompoundOperator)],
+    right_most: &mut SelectPlan,
+    limit: &Option<Box<Expr>>,
+    offset: &Option<Box<Expr>>,
     resolver: &Resolver,
     limit_ctx: Option<LimitCtx>,
     offset_reg: Option<usize>,
     reg_result_cols_start: Option<usize>,
     query_destination: &QueryDestination,
 ) -> crate::Result<()> {
-    let Plan::CompoundSelect {
-        mut left,
-        mut right_most,
-        limit,
-        offset,
-        order_by,
-    } = plan
-    else {
-        unreachable!()
-    };
-
     let compound_select_end = program.allocate_label();
     if let Some(limit_ctx) = &limit_ctx {
         program.emit_insn(Insn::IfNot {
@@ -283,8 +285,8 @@ fn emit_compound_select(
         false,
     ));
     right_most_ctx.reg_result_cols_start = reg_result_cols_start;
-    match left.pop() {
-        Some((mut plan, operator)) => match operator {
+    match left.split_last_mut() {
+        Some(((plan, operator), left)) => match operator {
             CompoundOperator::UnionAll => {
                 if matches!(
                     right_most.query_destination,
@@ -295,16 +297,12 @@ fn emit_compound_select(
                 ) {
                     plan.query_destination = right_most.query_destination.clone();
                 }
-                let compound_select = Plan::CompoundSelect {
-                    left,
-                    right_most: Box::new(plan),
-                    limit: limit.clone(),
-                    offset: offset.clone(),
-                    order_by,
-                };
                 emit_compound_select(
                     program,
-                    compound_select,
+                    left,
+                    plan,
+                    limit,
+                    offset,
                     resolver,
                     limit_ctx,
                     offset_reg,
@@ -319,21 +317,18 @@ fn emit_compound_select(
                         target_pc: label_next_select,
                         jump_if_null: true,
                     });
-                    right_most.limit = limit;
+                    right_most.limit = limit.clone();
                     right_most_ctx.limit_ctx = Some(limit_ctx);
                 }
                 if offset_reg.is_some() {
-                    right_most.offset = offset;
+                    right_most.offset = offset.clone();
                     right_most_ctx.reg_offset = offset_reg;
                 }
 
                 emit_explain!(program, true, "UNION ALL".to_owned());
-                right_most_ctx.materialized_build_inputs = emit_materialized_build_inputs(
-                    program,
-                    &right_most_ctx.resolver,
-                    &mut right_most,
-                )?;
-                emit_query(program, &mut right_most, &mut right_most_ctx)?;
+                right_most_ctx.materialized_build_inputs =
+                    emit_materialized_build_inputs(program, &right_most_ctx.resolver, right_most)?;
+                emit_query(program, right_most, &mut right_most_ctx)?;
                 program.pop_current_parent_explain();
                 program.preassign_label_to_next_insn(label_next_select);
             }
@@ -349,7 +344,7 @@ fn emit_compound_select(
                     } if !index.has_rowid => (*cursor_id, index.clone()),
                     _ => {
                         new_dedupe_index = true;
-                        create_dedupe_index(program, &plan, &right_most)?
+                        create_dedupe_index(program, plan, right_most)?
                     }
                 };
                 plan.query_destination = QueryDestination::EphemeralIndex {
@@ -358,16 +353,12 @@ fn emit_compound_select(
                     affinity_str: affinity_str.clone(),
                     is_delete: false,
                 };
-                let compound_select = Plan::CompoundSelect {
-                    left,
-                    right_most: Box::new(plan),
-                    limit,
-                    offset,
-                    order_by,
-                };
                 emit_compound_select(
                     program,
-                    compound_select,
+                    left,
+                    plan,
+                    limit,
+                    offset,
                     resolver,
                     None,
                     None,
@@ -383,12 +374,9 @@ fn emit_compound_select(
                 };
 
                 emit_explain!(program, true, "UNION USING TEMP B-TREE".to_owned());
-                right_most_ctx.materialized_build_inputs = emit_materialized_build_inputs(
-                    program,
-                    &right_most_ctx.resolver,
-                    &mut right_most,
-                )?;
-                emit_query(program, &mut right_most, &mut right_most_ctx)?;
+                right_most_ctx.materialized_build_inputs =
+                    emit_materialized_build_inputs(program, &right_most_ctx.resolver, right_most)?;
+                emit_query(program, right_most, &mut right_most_ctx)?;
                 program.pop_current_parent_explain();
 
                 if new_dedupe_index {
@@ -409,8 +397,7 @@ fn emit_compound_select(
                 // this BEFORE we overwrite it with our own indexes for the intersection.
                 let intersect_destination = right_most.query_destination.clone();
 
-                let (left_cursor_id, left_index) =
-                    create_dedupe_index(program, &plan, &right_most)?;
+                let (left_cursor_id, left_index) = create_dedupe_index(program, plan, right_most)?;
                 plan.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id: left_cursor_id,
                     index: left_index.clone(),
@@ -419,23 +406,19 @@ fn emit_compound_select(
                 };
 
                 let (right_cursor_id, right_index) =
-                    create_dedupe_index(program, &plan, &right_most)?;
+                    create_dedupe_index(program, plan, right_most)?;
                 right_most.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id: right_cursor_id,
                     index: right_index,
                     affinity_str: None,
                     is_delete: false,
                 };
-                let compound_select = Plan::CompoundSelect {
-                    left,
-                    right_most: Box::new(plan),
-                    limit,
-                    offset,
-                    order_by,
-                };
                 emit_compound_select(
                     program,
-                    compound_select,
+                    left,
+                    plan,
+                    limit,
+                    offset,
                     resolver,
                     None,
                     None,
@@ -444,12 +427,9 @@ fn emit_compound_select(
                 )?;
 
                 emit_explain!(program, true, "INTERSECT USING TEMP B-TREE".to_owned());
-                right_most_ctx.materialized_build_inputs = emit_materialized_build_inputs(
-                    program,
-                    &right_most_ctx.resolver,
-                    &mut right_most,
-                )?;
-                emit_query(program, &mut right_most, &mut right_most_ctx)?;
+                right_most_ctx.materialized_build_inputs =
+                    emit_materialized_build_inputs(program, &right_most_ctx.resolver, right_most)?;
+                emit_query(program, right_most, &mut right_most_ctx)?;
                 program.pop_current_parent_explain();
                 read_intersect_rows(
                     program,
@@ -470,7 +450,7 @@ fn emit_compound_select(
                     } if !index.has_rowid => (*cursor_id, index.clone()),
                     _ => {
                         new_index = true;
-                        create_dedupe_index(program, &plan, &right_most)?
+                        create_dedupe_index(program, plan, right_most)?
                     }
                 };
                 plan.query_destination = QueryDestination::EphemeralIndex {
@@ -479,16 +459,12 @@ fn emit_compound_select(
                     affinity_str: None,
                     is_delete: false,
                 };
-                let compound_select = Plan::CompoundSelect {
-                    left,
-                    right_most: Box::new(plan),
-                    limit,
-                    offset,
-                    order_by,
-                };
                 emit_compound_select(
                     program,
-                    compound_select,
+                    left,
+                    plan,
+                    limit,
+                    offset,
                     resolver,
                     None,
                     None,
@@ -502,12 +478,9 @@ fn emit_compound_select(
                     is_delete: true,
                 };
                 emit_explain!(program, true, "EXCEPT USING TEMP B-TREE".to_owned());
-                right_most_ctx.materialized_build_inputs = emit_materialized_build_inputs(
-                    program,
-                    &right_most_ctx.resolver,
-                    &mut right_most,
-                )?;
-                emit_query(program, &mut right_most, &mut right_most_ctx)?;
+                right_most_ctx.materialized_build_inputs =
+                    emit_materialized_build_inputs(program, &right_most_ctx.resolver, right_most)?;
+                emit_query(program, right_most, &mut right_most_ctx)?;
                 program.pop_current_parent_explain();
                 if new_index {
                     read_deduplicated_union_or_except_rows(
@@ -525,16 +498,16 @@ fn emit_compound_select(
         None => {
             if let Some(limit_ctx) = limit_ctx {
                 right_most_ctx.limit_ctx = Some(limit_ctx);
-                right_most.limit = limit;
+                right_most.limit = limit.clone();
             }
             if offset_reg.is_some() {
-                right_most.offset = offset;
+                right_most.offset = offset.clone();
                 right_most_ctx.reg_offset = offset_reg;
             }
             emit_explain!(program, true, "LEFT-MOST SUBQUERY".to_owned());
             right_most_ctx.materialized_build_inputs =
-                emit_materialized_build_inputs(program, &right_most_ctx.resolver, &mut right_most)?;
-            emit_query(program, &mut right_most, &mut right_most_ctx)?;
+                emit_materialized_build_inputs(program, &right_most_ctx.resolver, right_most)?;
+            emit_query(program, right_most, &mut right_most_ctx)?;
             program.pop_current_parent_explain();
         }
     }

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -317,11 +317,11 @@ fn emit_compound_select(
                         target_pc: label_next_select,
                         jump_if_null: true,
                     });
-                    right_most.limit = limit.clone();
+                    right_most.limit.clone_from(limit);
                     right_most_ctx.limit_ctx = Some(limit_ctx);
                 }
                 if offset_reg.is_some() {
-                    right_most.offset = offset.clone();
+                    right_most.offset.clone_from(offset);
                     right_most_ctx.reg_offset = offset_reg;
                 }
 
@@ -498,10 +498,10 @@ fn emit_compound_select(
         None => {
             if let Some(limit_ctx) = limit_ctx {
                 right_most_ctx.limit_ctx = Some(limit_ctx);
-                right_most.limit = limit.clone();
+                right_most.limit.clone_from(limit);
             }
             if offset_reg.is_some() {
-                right_most.offset = offset.clone();
+                right_most.offset.clone_from(offset);
                 right_most_ctx.reg_offset = offset_reg;
             }
             emit_explain!(program, true, "LEFT-MOST SUBQUERY".to_owned());

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -166,6 +166,7 @@ pub fn emit_program_for_compound_select(
     let reg_result_cols_start = match &query_destination {
         QueryDestination::CoroutineYield { .. }
         | QueryDestination::EphemeralTable { .. }
+        | QueryDestination::RecursiveCteQueue { .. }
         | QueryDestination::EphemeralIndex { .. } => Some(program.alloc_registers(num_result_cols)),
         QueryDestination::ResultRows => None,
         other => {
@@ -198,7 +199,7 @@ pub fn emit_program_for_compound_select(
     // to write to the collection index instead of ResultRows.
     let mut plan = plan;
     if has_order_by {
-        set_compound_plan_destinations(&mut plan, &query_destination);
+        set_select_plan_destination(&mut plan, &query_destination);
     }
 
     program.with_scoped_result_cols_start(|program| {
@@ -290,6 +291,7 @@ fn emit_compound_select(
                     QueryDestination::EphemeralIndex { .. }
                         | QueryDestination::CoroutineYield { .. }
                         | QueryDestination::EphemeralTable { .. }
+                        | QueryDestination::RecursiveCteQueue { .. }
                 ) {
                     plan.query_destination = right_most.query_destination.clone();
                 }
@@ -740,22 +742,24 @@ fn read_intersect_rows(
     Ok(())
 }
 
-/// Recursively sets the query_destination of all SelectPlans within a CompoundSelect.
-/// This ensures UNION ALL subselects write to the collection index instead of ResultRows.
-fn set_compound_plan_destinations(plan: &mut Plan, dest: &QueryDestination) {
+/// Sets where a SELECT plan writes its rows, including each query in a compound SELECT.
+pub(crate) fn set_select_plan_destination(plan: &mut Plan, destination: &QueryDestination) {
     match plan {
         Plan::CompoundSelect {
             left, right_most, ..
         } => {
             for (subplan, _) in left.iter_mut() {
-                subplan.query_destination = dest.clone();
+                subplan.query_destination = destination.clone();
             }
-            right_most.query_destination = dest.clone();
+            right_most.query_destination = destination.clone();
         }
         Plan::Select(select_plan) => {
-            select_plan.query_destination = dest.clone();
+            select_plan.query_destination = destination.clone();
         }
-        _ => {}
+        Plan::RecursiveCte(plan) => plan.query_destination = destination.clone(),
+        Plan::Delete(_) | Plan::Update(_) => {
+            unreachable!("only SELECT plans have query destinations")
+        }
     }
 }
 

--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -61,7 +61,7 @@ pub(crate) fn format_eqp_detail(table: &JoinedTable) -> String {
                         format!("SCAN {table_name}")
                     }
                 }
-                Scan::VirtualTable { .. } | Scan::Subquery { .. } => {
+                Scan::VirtualTable { .. } | Scan::Subquery { .. } | Scan::RecursiveCteInput => {
                     format!("SCAN {table_name}")
                 }
             }
@@ -228,6 +228,13 @@ impl Display for Plan {
                 }
                 Ok(())
             }
+            Self::RecursiveCte(plan) => {
+                writeln!(f, "RECURSIVE CTE {}", plan.name)?;
+                writeln!(f, "INITIAL QUERY:")?;
+                plan.initial_query.fmt(f)?;
+                writeln!(f, "RECURSIVE QUERY:")?;
+                plan.recursive_query.fmt(f)
+            }
             Self::Delete(delete_plan) => delete_plan.fmt(f),
             Self::Update(update_plan) => update_plan.fmt(f),
         }
@@ -280,7 +287,9 @@ impl Display for SelectPlan {
                                 writeln!(f, "{indent}SCAN {table_name}")?;
                             }
                         }
-                        Scan::VirtualTable { .. } | Scan::Subquery { .. } => {
+                        Scan::VirtualTable { .. }
+                        | Scan::Subquery { .. }
+                        | Scan::RecursiveCteInput => {
                             writeln!(f, "{indent}SCAN {table_name}")?;
                         }
                     }
@@ -403,7 +412,9 @@ impl Display for DeletePlan {
                                 writeln!(f, "{indent}DELETE FROM {table_name}")?;
                             }
                         }
-                        Scan::VirtualTable { .. } | Scan::Subquery { .. } => {
+                        Scan::VirtualTable { .. }
+                        | Scan::Subquery { .. }
+                        | Scan::RecursiveCteInput => {
                             writeln!(f, "{indent}DELETE FROM {table_name}")?;
                         }
                     }
@@ -529,7 +540,9 @@ impl fmt::Display for UpdatePlan {
                                 writeln!(f, "{indent}{action} {table_name}")?;
                             }
                         }
-                        Scan::VirtualTable { .. } | Scan::Subquery { .. } => {
+                        Scan::VirtualTable { .. }
+                        | Scan::Subquery { .. }
+                        | Scan::RecursiveCteInput => {
                             if i == 0 {
                                 writeln!(f, "{indent}UPDATE {table_name}")?;
                             } else {
@@ -692,6 +705,15 @@ impl ToTokens for Plan {
                     s.append(TokenType::TK_FLOAT, Some(&offset.to_string()))?;
                 }
             }
+            Self::RecursiveCte(plan) => {
+                plan.initial_query.to_tokens(s, context)?;
+                if plan.union_all {
+                    ast::CompoundOperator::UnionAll.to_tokens(s, context)?;
+                } else {
+                    ast::CompoundOperator::Union.to_tokens(s, context)?;
+                }
+                plan.recursive_query.to_tokens(s, context)?;
+            }
             Self::Delete(delete) => delete.to_tokens(s, context)?,
             Self::Update(update) => update.to_tokens(s, context)?,
         }
@@ -713,7 +735,7 @@ impl ToTokens for JoinedTable {
         _context: &C,
     ) -> Result<(), S::Error> {
         match &self.table {
-            Table::BTree(..) | Table::Virtual(..) => {
+            Table::BTree(..) | Table::Virtual(..) | Table::RecursiveCteInput(..) => {
                 let name = self.table.get_name();
                 s.append(TokenType::TK_ID, Some(name))?;
                 if self.identifier != name {

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1071,6 +1071,10 @@ pub fn emit_program(
         Plan::CompoundSelect { .. } => {
             emit_program_for_compound_select(program, resolver, plan).map(|_| ())
         }
+        Plan::RecursiveCte(mut recursive_cte) => {
+            super::recursive_cte::emit_recursive_cte(program, resolver, &mut recursive_cte)
+                .map(|_| ())
+        }
     }
 }
 

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -33,7 +33,7 @@ use crate::translate::plan::ColumnMask;
 use crate::vdbe::{
     affinity::Affinity,
     builder::{CursorType, DmlColumnContext, ProgramBuilder, SelfTableContext},
-    insn::{to_u16, InsertFlags, Insn},
+    insn::{to_u32, InsertFlags, Insn},
     BranchOffset, CursorID,
 };
 use crate::{
@@ -1144,9 +1144,9 @@ pub fn emit_cdc_patch_record(
             .collect::<String>();
 
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(columns_reg),
-            count: to_u16(storable_count),
-            dest_reg: to_u16(record_reg),
+            start_reg: to_u32(columns_reg),
+            count: to_u32(storable_count),
+            dest_reg: to_u32(record_reg),
             index_name: None,
             affinity_str: Some(affinity_str),
         });
@@ -1175,9 +1175,9 @@ pub(super) fn emit_make_record<'a>(
         .collect();
 
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(start_reg),
-        count: to_u16(storable_count),
-        dest_reg: to_u16(dest_reg),
+        start_reg: to_u32(start_reg),
+        count: to_u32(storable_count),
+        dest_reg: to_u32(dest_reg),
         index_name: None,
         affinity_str: Some(affinity_str),
     });
@@ -1215,9 +1215,9 @@ pub fn emit_cdc_full_record(
         .collect::<String>();
 
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(columns_reg + 1),
-        count: to_u16(storable_count),
-        dest_reg: to_u16(columns_reg),
+        start_reg: to_u32(columns_reg + 1),
+        count: to_u32(storable_count),
+        dest_reg: to_u32(columns_reg),
         index_name: None,
         affinity_str: Some(affinity_str),
     });
@@ -1410,9 +1410,9 @@ fn emit_cdc_insns_v1(
 
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(turso_cdc_registers),
-        count: to_u16(8),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(turso_cdc_registers),
+        count: to_u32(8),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });
@@ -1537,9 +1537,9 @@ fn emit_cdc_insns_v2(
 
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(turso_cdc_registers),
-        count: to_u16(9),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(turso_cdc_registers),
+        count: to_u32(9),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });
@@ -1618,9 +1618,9 @@ pub fn emit_cdc_commit_insns(
 
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(regs),
-        count: to_u16(9),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(regs),
+        count: to_u32(9),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1068,8 +1068,8 @@ pub fn emit_program(
         Plan::Select(plan) => emit_program_for_select(program, resolver, *plan),
         Plan::Delete(plan) => emit_program_for_delete(connection, resolver, program, *plan),
         Plan::Update(plan) => emit_program_for_update(connection, resolver, program, *plan, after),
-        Plan::CompoundSelect { .. } => {
-            emit_program_for_compound_select(program, resolver, plan).map(|_| ())
+        mut plan @ Plan::CompoundSelect { .. } => {
+            emit_program_for_compound_select(program, resolver, &mut plan).map(|_| ())
         }
         Plan::RecursiveCte(mut recursive_cte) => {
             super::recursive_cte::emit_recursive_cte(program, resolver, &mut recursive_cte)

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -51,7 +51,7 @@ use crate::{
     vdbe::{
         affinity::Affinity,
         builder::{CursorKey, CursorType, DmlColumnContext},
-        insn::{to_u16, CmpInsFlags, IdxInsertFlags, InsertFlags, Insn, RegisterOrLiteral},
+        insn::{to_u32, CmpInsFlags, IdxInsertFlags, InsertFlags, Insn, RegisterOrLiteral},
         BranchOffset,
     },
     CaptureDataChangesExt, Connection, HashSet, Result, MAIN_DB_ID,
@@ -1887,9 +1887,9 @@ fn emit_update_insns<'a>(
         });
 
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(idx_start_reg),
-            count: to_u16(num_cols + 1),
-            dest_reg: to_u16(*record_reg),
+            start_reg: to_u32(idx_start_reg),
+            count: to_u32(num_cols + 1),
+            dest_reg: to_u32(*record_reg),
             index_name: Some(index.name.clone()),
             affinity_str: None,
         });
@@ -2229,7 +2229,7 @@ fn emit_update_insns<'a>(
             cursor_id: ctx.idx_cursor_id,
             record_reg: ctx.record_reg,
             unpacked_start: Some(ctx.idx_start_reg),
-            unpacked_count: Some((ctx.num_cols + 1) as u16),
+            unpacked_count: Some((ctx.num_cols + 1) as u32),
             flags: IdxInsertFlags::new().nchange(true),
         });
 
@@ -2547,9 +2547,9 @@ fn emit_update_insns<'a>(
             let cdc_updates_record = if let Some(cdc_updates_register) = cdc_updates_register {
                 let record_reg = program.alloc_register();
                 program.emit_insn(Insn::MakeRecord {
-                    start_reg: to_u16(cdc_updates_register),
-                    count: to_u16(2 * col_len),
-                    dest_reg: to_u16(record_reg),
+                    start_reg: to_u32(cdc_updates_register),
+                    count: to_u32(2 * col_len),
+                    dest_reg: to_u32(record_reg),
                     index_name: None,
                     affinity_str: None,
                 });

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -175,11 +175,12 @@ pub fn bind_and_rewrite_expr<'a>(
                     if match_result.is_none() {
                         let mut matched_scope_depth = None;
                         for outer_ref in referenced_tables.outer_query_refs().iter() {
-                            // CTEs (FromClauseSubquery) in outer_query_refs are only for table
-                            // lookup (e.g., FROM cte1), not for column resolution. Columns from
-                            // CTEs should only be accessible when the CTE is explicitly in the
-                            // FROM clause, not as implicit outer references.
-                            if matches!(outer_ref.table, Table::FromClauseSubquery(_)) {
+                            // These entries let a FROM clause find a CTE by name. The CTE's
+                            // columns are visible only after that FROM clause adds the table.
+                            if matches!(
+                                outer_ref.table,
+                                Table::FromClauseSubquery(_) | Table::RecursiveCteInput(_)
+                            ) {
                                 continue;
                             }
                             // Skip refs from deeper scopes once we found a match

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -175,12 +175,13 @@ pub fn bind_and_rewrite_expr<'a>(
                     if match_result.is_none() {
                         let mut matched_scope_depth = None;
                         for outer_ref in referenced_tables.outer_query_refs().iter() {
-                            // These entries let a FROM clause find a CTE by name. The CTE's
-                            // columns are visible only after that FROM clause adds the table.
-                            if matches!(
-                                outer_ref.table,
-                                Table::FromClauseSubquery(_) | Table::RecursiveCteInput(_)
-                            ) {
+                            // Definition-only entries let a FROM clause find a CTE by
+                            // name; the CTE's columns are visible only after a FROM
+                            // clause actually adds the table. Every other outer ref is
+                            // a real table in an enclosing scope, including CTEs and
+                            // the recursive self-reference, and its columns can be
+                            // referenced without qualification.
+                            if outer_ref.cte_definition_only {
                                 continue;
                             }
                             // Skip refs from deeper scopes once we found a match

--- a/core/translate/expr/emission.rs
+++ b/core/translate/expr/emission.rs
@@ -307,9 +307,9 @@ pub(crate) fn emit_returning_results<'a>(
             let record_reg = program.alloc_register();
             let eph_rowid_reg = program.alloc_register();
             program.emit_insn(Insn::MakeRecord {
-                start_reg: crate::vdbe::insn::to_u16(result_start_reg),
-                count: crate::vdbe::insn::to_u16(result_columns.len()),
-                dest_reg: crate::vdbe::insn::to_u16(record_reg),
+                start_reg: crate::vdbe::insn::to_u32(result_start_reg),
+                count: crate::vdbe::insn::to_u32(result_columns.len()),
+                dest_reg: crate::vdbe::insn::to_u32(record_reg),
                 index_name: None,
                 affinity_str: None,
             });

--- a/core/translate/expr/functions.rs
+++ b/core/translate/expr/functions.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::translate::sequence::emit_sequence_descriptor_literals;
 use crate::vdbe::builder::CursorType;
-use crate::vdbe::insn::{to_u16, InsertFlags, RegisterOrLiteral};
+use crate::vdbe::insn::{to_u32, InsertFlags, RegisterOrLiteral};
 
 /// The base logic for translating LIKE and GLOB expressions.
 /// The logic for handling "NOT LIKE" is different depending on whether the expression
@@ -345,9 +345,9 @@ pub(super) fn translate_sequence_function(
 
         let record_reg = program.alloc_register();
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(col_base),
+            start_reg: to_u32(col_base),
             count: 7,
-            dest_reg: to_u16(record_reg),
+            dest_reg: to_u32(record_reg),
             index_name: None,
             affinity_str: None,
         });

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2657,6 +2657,16 @@ pub fn translate_expr(
                     });
                     Ok(target_register)
                 }
+                Table::RecursiveCteInput(_) => {
+                    let cursor_id = program.resolve_cursor_id(&CursorKey::table(*table_ref_id));
+                    program.emit_insn(Insn::Column {
+                        cursor_id,
+                        column: *column,
+                        dest: target_register,
+                        default: None,
+                    });
+                    Ok(target_register)
+                }
                 Table::Virtual(_) => {
                     let cursor_id = program.resolve_cursor_id(&CursorKey::table(*table_ref_id));
                     program.emit_insn(Insn::VColumn {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -19,7 +19,7 @@ use crate::translate::{
     plan::{ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReferences},
 };
 use crate::vdbe::builder::{CursorKey, ProgramBuilderOpts, SelfTableContext};
-use crate::vdbe::insn::{to_u16, CmpInsFlags, Cookie};
+use crate::vdbe::insn::{to_u32, CmpInsFlags, Cookie};
 use crate::{bail_parse_error, CaptureDataChangesExt, LimboError, MAIN_DB_ID, TEMP_DB_ID};
 use crate::{
     schema::{
@@ -416,9 +416,9 @@ fn emit_refill_index(
         });
         let record_reg = program.alloc_register();
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(start_reg),
-            count: to_u16(columns.len() + 1),
-            dest_reg: to_u16(record_reg),
+            start_reg: to_u32(start_reg),
+            count: to_u32(columns.len() + 1),
+            dest_reg: to_u32(record_reg),
             index_name: Some(idx.name.clone()),
             affinity_str: None,
         });
@@ -427,7 +427,7 @@ fn emit_refill_index(
             cursor_id: index_cursor_id,
             record_reg,
             unpacked_start: Some(start_reg),
-            unpacked_count: Some((columns.len() + 1) as u16),
+            unpacked_count: Some((columns.len() + 1) as u32),
             flags: IdxInsertFlags::new().use_seek(false),
         });
 
@@ -513,9 +513,9 @@ fn emit_refill_index(
         });
         let record_reg = program.alloc_register();
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(start_reg),
-            count: to_u16(columns.len() + 1),
-            dest_reg: to_u16(record_reg),
+            start_reg: to_u32(start_reg),
+            count: to_u32(columns.len() + 1),
+            dest_reg: to_u32(record_reg),
             index_name: Some(idx.name.clone()),
             affinity_str: None,
         });

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -48,7 +48,7 @@ use crate::{
     vdbe::{
         affinity::Affinity,
         builder::{CursorKey, CursorType, DmlColumnContext, ProgramBuilder, ProgramBuilderOpts},
-        insn::{to_u16, CmpInsFlags, IdxInsertFlags, InsertFlags, Insn, RegisterOrLiteral},
+        insn::{to_u32, CmpInsFlags, IdxInsertFlags, InsertFlags, Insn, RegisterOrLiteral},
         BranchOffset,
     },
     CaptureDataChangesExt, Connection, LimboError, Result, VirtualTable,
@@ -1395,9 +1395,9 @@ fn emit_commit_phase(
 
         let record_reg = program.alloc_register();
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(idx_start_reg),
-            count: to_u16(num_cols + 1),
-            dest_reg: to_u16(record_reg),
+            start_reg: to_u32(idx_start_reg),
+            count: to_u32(num_cols + 1),
+            dest_reg: to_u32(record_reg),
             index_name: Some(index.name.clone()),
             affinity_str: None,
         });
@@ -1405,7 +1405,7 @@ fn emit_commit_phase(
             cursor_id: idx_cursor_id,
             record_reg,
             unpacked_start: Some(idx_start_reg),
-            unpacked_count: Some((num_cols + 1) as u16),
+            unpacked_count: Some((num_cols + 1) as u32),
             flags: IdxInsertFlags::new().nchange(true),
         });
 
@@ -2279,9 +2279,9 @@ fn init_source_emission<'a>(
                     };
 
                     program.emit_insn(Insn::MakeRecord {
-                        start_reg: to_u16(program.reg_result_cols_start.unwrap_or(yield_reg + 1)),
-                        count: to_u16(num_result_cols),
-                        dest_reg: to_u16(record_reg),
+                        start_reg: to_u32(program.reg_result_cols_start.unwrap_or(yield_reg + 1)),
+                        count: to_u32(num_result_cols),
+                        dest_reg: to_u32(record_reg),
                         index_name: None,
                         affinity_str: Some(affinity_str),
                     });
@@ -3037,9 +3037,9 @@ fn emit_index_uniqueness_check(
         if preflight.on_replace {
             let record_reg = program.alloc_register();
             program.emit_insn(Insn::MakeRecord {
-                start_reg: to_u16(idx_start_reg),
-                count: to_u16(num_cols + 1),
-                dest_reg: to_u16(record_reg),
+                start_reg: to_u32(idx_start_reg),
+                count: to_u32(num_cols + 1),
+                dest_reg: to_u32(record_reg),
                 index_name: Some(index.name.clone()),
                 affinity_str: None,
             });
@@ -3047,7 +3047,7 @@ fn emit_index_uniqueness_check(
                 cursor_id: idx_cursor_id,
                 record_reg,
                 unpacked_start: Some(idx_start_reg),
-                unpacked_count: Some((num_cols + 1) as u16),
+                unpacked_count: Some((num_cols + 1) as u32),
                 flags: IdxInsertFlags::new().nchange(true),
             });
         }
@@ -3189,9 +3189,9 @@ fn emit_unique_index_check(
             // IdxDelete repositions the cursor, so we must NOT use USE_SEEK.
             let record_reg = program.alloc_register();
             program.emit_insn(Insn::MakeRecord {
-                start_reg: to_u16(idx_start_reg),
-                count: to_u16(num_cols + 1),
-                dest_reg: to_u16(record_reg),
+                start_reg: to_u32(idx_start_reg),
+                count: to_u32(num_cols + 1),
+                dest_reg: to_u32(record_reg),
                 index_name: Some(index.name.clone()),
                 affinity_str: None,
             });
@@ -3199,7 +3199,7 @@ fn emit_unique_index_check(
                 cursor_id: idx_cursor_id,
                 record_reg,
                 unpacked_start: Some(idx_start_reg),
-                unpacked_count: Some((num_cols + 1) as u16),
+                unpacked_count: Some((num_cols + 1) as u32),
                 flags: IdxInsertFlags::new().nchange(true),
             });
         }
@@ -3442,9 +3442,9 @@ fn ensure_sequence_initialized(
         .collect();
 
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(record_start_reg),
-        count: to_u16(2),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(record_start_reg),
+        count: to_u32(2),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: Some(affinity_str),
     });
@@ -3732,9 +3732,9 @@ fn emit_update_sqlite_sequence(
         .map(|col| col.affinity().aff_mask())
         .collect::<String>();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(record_start_reg),
-        count: to_u16(2),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(record_start_reg),
+        count: to_u32(2),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: Some(affinity_str),
     });

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -141,6 +141,7 @@ impl CloseLoop {
                                 });
                             }
                         }
+                        Scan::RecursiveCteInput => {}
                     }
                     program.preassign_label_to_next_insn(loop_labels.loop_end);
                 }

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -527,9 +527,9 @@ pub(super) fn emit_autoindex(
     }
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(ephemeral_cols_start_reg),
-        count: to_u16(num_regs_to_reserve),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(ephemeral_cols_start_reg),
+        count: to_u32(num_regs_to_reserve),
+        dest_reg: to_u32(record_reg),
         index_name: Some(index.name.clone()),
         affinity_str: affinity_str.map(|s| (**s).clone()),
     });
@@ -549,7 +549,7 @@ pub(super) fn emit_autoindex(
         cursor_id: index_cursor_id,
         record_reg,
         unpacked_start: Some(ephemeral_cols_start_reg),
-        unpacked_count: Some(num_regs_to_reserve as u16),
+        unpacked_count: Some(num_regs_to_reserve as u32),
         flags: IdxInsertFlags::new().use_seek(false),
     });
     program.emit_insn(Insn::Next {

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -753,16 +753,16 @@ impl<'a, 'plan> HashProbeSetupEmitter<'a, 'plan> {
 
         let match_reg = self.program.alloc_register();
         self.program.emit_insn(Insn::HashProbe {
-            hash_table_id: to_u16(hash_table_id),
-            key_start_reg: to_u16(probe_key_start_reg),
-            num_keys: to_u16(num_keys),
-            dest_reg: to_u16(match_reg),
+            hash_table_id: to_u32(hash_table_id),
+            key_start_reg: to_u32(probe_key_start_reg),
+            num_keys: to_u32(num_keys),
+            dest_reg: to_u32(match_reg),
             target_pc: hash_probe_miss_label,
-            payload_dest_reg: payload_dest_reg.map(to_u16),
-            num_payload: to_u16(num_payload),
+            payload_dest_reg: payload_dest_reg.map(to_u32),
+            num_payload: to_u32(num_payload),
             // Main probe loop always carries the probe rowid so spilled build
             // partitions are deferred to grace processing instead of loaded here.
-            probe_rowid_reg: probe_rowid_reg.map(to_u16),
+            probe_rowid_reg: probe_rowid_reg.map(to_u32),
         });
 
         let match_found_label = self.program.allocate_label();
@@ -1229,7 +1229,7 @@ impl GraceHashLoop {
 
         // HashGraceInit: finalize probe spill + grace_begin
         program.emit_insn(Insn::HashGraceInit {
-            hash_table_id: to_u16(hash_table_reg),
+            hash_table_id: to_u32(hash_table_reg),
             target_pc: grace_done,
         });
 
@@ -1242,7 +1242,7 @@ impl GraceHashLoop {
         // grace_partition_top: load build partition + first probe chunk
         program.preassign_label_to_next_insn(grace_partition_top);
         program.emit_insn(Insn::HashGraceLoadPartition {
-            hash_table_id: to_u16(hash_table_reg),
+            hash_table_id: to_u32(hash_table_reg),
             target_pc: grace_cleanup,
         });
 
@@ -1261,10 +1261,10 @@ impl GraceHashLoop {
         }
 
         program.emit_insn(Insn::HashGraceNextProbe {
-            hash_table_id: to_u16(hash_table_reg),
-            key_start_reg: to_u16(hash_ctx.key_start_reg),
-            num_keys: to_u16(hash_ctx.num_keys),
-            probe_rowid_dest: to_u16(probe_rowid_reg),
+            hash_table_id: to_u32(hash_table_reg),
+            key_start_reg: to_u32(hash_ctx.key_start_reg),
+            num_keys: to_u32(hash_ctx.num_keys),
+            probe_rowid_dest: to_u32(probe_rowid_reg),
             target_pc: grace_advance,
         });
 
@@ -1286,13 +1286,13 @@ impl GraceHashLoop {
 
         // HashProbe the loaded build partition with the probe keys
         program.emit_insn(Insn::HashProbe {
-            hash_table_id: to_u16(hash_table_reg),
-            key_start_reg: to_u16(hash_ctx.key_start_reg),
-            num_keys: to_u16(hash_ctx.num_keys),
-            dest_reg: to_u16(match_reg),
+            hash_table_id: to_u32(hash_table_reg),
+            key_start_reg: to_u32(hash_ctx.key_start_reg),
+            num_keys: to_u32(hash_ctx.num_keys),
+            dest_reg: to_u32(match_reg),
             target_pc: grace_outer_check,
-            payload_dest_reg: payload_dest_reg.map(to_u16),
-            num_payload: to_u16(num_payload),
+            payload_dest_reg: payload_dest_reg.map(to_u32),
+            num_payload: to_u32(num_payload),
             probe_rowid_reg: None, // grace-only: HashGraceLoadPartition already loaded this partition
         });
 
@@ -1440,7 +1440,7 @@ impl GraceHashLoop {
 
         // Evict current partition, advance to next
         program.emit_insn(Insn::HashGraceAdvancePartition {
-            hash_table_id: to_u16(hash_table_reg),
+            hash_table_id: to_u32(hash_table_reg),
             target_pc: grace_cleanup,
         });
         program.emit_insn(Insn::Goto {

--- a/core/translate/main_loop/in_seek.rs
+++ b/core/translate/main_loop/in_seek.rs
@@ -60,9 +60,9 @@ pub(super) fn open_in_seek_source_cursor(
                     NoConstantOptReason::InListEphemeral,
                 )?;
                 program.emit_insn(Insn::MakeRecord {
-                    start_reg: to_u16(val_reg),
+                    start_reg: to_u32(val_reg),
                     count: 1,
-                    dest_reg: to_u16(record_reg),
+                    dest_reg: to_u32(record_reg),
                     index_name: None,
                     affinity_str: Some(affinity_str.clone()),
                 });

--- a/core/translate/main_loop/mod.rs
+++ b/core/translate/main_loop/mod.rs
@@ -43,7 +43,7 @@ use crate::{
             CursorKey, CursorType, HashBuildSignature, MaterializedBuildInputModeTag,
             ProgramBuilder,
         },
-        insn::{to_u16, CmpInsFlags, HashBuildData, IdxInsertFlags, Insn},
+        insn::{to_u32, CmpInsFlags, HashBuildData, IdxInsertFlags, Insn},
         BranchOffset, CursorID,
     },
     Result,

--- a/core/translate/main_loop/open.rs
+++ b/core/translate/main_loop/open.rs
@@ -236,6 +236,9 @@ impl OpenLoop {
                                 }
                             }
                         }
+                        (Scan::RecursiveCteInput, Table::RecursiveCteInput(_)) => {
+                            program.preassign_label_to_next_insn(loop_start);
+                        }
                         _ => unreachable!(
                             "{:?} scan cannot be used with {:?} table",
                             scan, table.table

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod order_by;
 pub(crate) mod plan;
 pub(crate) mod planner;
 pub(crate) mod pragma;
+pub(crate) mod recursive_cte;
 pub(crate) mod result_row;
 pub(crate) mod rollback;
 pub(crate) mod schema;

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -109,6 +109,8 @@ pub enum AccessMethodParams {
     /// subqueries may also be scanned backwards when their intrinsic order
     /// matches the requested extremum order.
     Subquery { iter_dir: IterationDirection },
+    /// The single row currently being expanded by a recursive CTE.
+    RecursiveCteInput,
     /// Materialized subquery with an ephemeral index for seeking.
     /// The subquery results are materialized once into an ephemeral index,
     /// which can then be seeked using join conditions.
@@ -757,6 +759,22 @@ pub fn find_best_access_method_for_join_order(
             base_row_count,
             params,
         ),
+        Table::RecursiveCteInput(_) => Ok(Some(AccessMethod {
+            cost: estimate_cost_for_scan_or_seek(
+                None,
+                &[],
+                &[],
+                input_cardinality,
+                RowCountEstimate::HardcodedFallback(1.0),
+                false,
+                params,
+                None,
+            ),
+            estimated_rows_per_outer_row: 1.0,
+            residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
+            consumed_where_terms: SmallVec::new(),
+            params: AccessMethodParams::RecursiveCteInput,
+        })),
     }
 }
 
@@ -1430,8 +1448,6 @@ fn find_best_access_method_for_subquery(
     use super::constraints::ConstraintRef;
     let maybe_order_target = planning_context.maybe_order_target;
 
-    let table_materialization_required = subquery.requires_table_materialization();
-    let can_direct_materialize_index = subquery.supports_direct_index_materialization();
     let coroutine_scan_cost = estimate_cost_for_scan_or_seek(
         None,
         &[],
@@ -1445,6 +1461,8 @@ fn find_best_access_method_for_subquery(
     let coroutine_reexecution_overhead =
         Cost((input_cardinality - 1.0).max(0.0) * *base_row_count * params.cpu_cost_per_seek);
     let coroutine_cost = coroutine_scan_cost + coroutine_reexecution_overhead;
+    let table_materialization_required = subquery.requires_table_materialization();
+    let can_direct_materialize_index = subquery.supports_direct_index_materialization();
     let scan_cost = if table_materialization_required {
         // Explicit MATERIALIZED hints and shared CTEs already produce a table-backed
         // row source. Scanning them behaves like rescanning cached rows, not rerunning

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1354,9 +1354,17 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                             && other.join_info.as_ref().is_some_and(|ji| ji.is_outer())
                     })
                 });
+                // A recursive CTE input cannot be the build side of the hash
+                // join that FULL OUTER requires, so no plan exists for
+                // `recursive_table FULL JOIN other`.
+                let has_recursive_input = joined_tables
+                    .iter()
+                    .any(|t| matches!(t.table, crate::schema::Table::RecursiveCteInput(_)));
                 let has_correlated_subquery = subqueries.iter().any(|sq| sq.correlated);
                 let msg = if build_is_outer {
                     "FULL OUTER JOIN chaining is not yet supported"
+                } else if has_recursive_input {
+                    "FULL OUTER JOIN with a recursive reference is not yet supported"
                 } else if has_correlated_subquery {
                     "FULL OUTER JOIN is not supported with correlated subqueries that reference the joined tables"
                 } else {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -553,10 +553,31 @@ pub fn optimize_plan(
                 optimize_select_plan(plan, resolver)?;
             }
         }
+        Plan::RecursiveCte(recursive_cte) => {
+            optimize_recursive_cte_query(&mut recursive_cte.initial_query, resolver)?;
+            optimize_recursive_cte_query(&mut recursive_cte.recursive_query, resolver)?;
+        }
     }
     // When debug tracing is enabled, print the optimized plan as a SQL string for debugging
     tracing::debug!(plan_sql = plan.to_string());
     Ok(())
+}
+
+fn optimize_recursive_cte_query(query: &mut Plan, resolver: &Resolver) -> Result<()> {
+    match query {
+        Plan::Select(select) => optimize_select_plan(select, resolver),
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => {
+            for (select, _) in left {
+                optimize_select_plan(select, resolver)?;
+            }
+            optimize_select_plan(right_most, resolver)
+        }
+        Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => Err(
+            LimboError::InternalError("recursive CTE query is not a SELECT".to_string()),
+        ),
+    }
 }
 
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
@@ -1328,6 +1349,10 @@ fn optimize_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()>
                         optimize_select_plan(select_plan, resolver)?;
                     }
                 }
+                Plan::RecursiveCte(recursive_cte) => {
+                    optimize_recursive_cte_query(&mut recursive_cte.initial_query, resolver)?;
+                    optimize_recursive_cte_query(&mut recursive_cte.recursive_query, resolver)?;
+                }
                 Plan::Delete(_) | Plan::Update(_) => {
                     turso_soft_unreachable!(
                         "DELETE/UPDATE plans should not appear in FROM clause subqueries"
@@ -1413,6 +1438,7 @@ fn select_plan_contains_cte_from_clause_subquery(plan: &SelectPlan) -> bool {
                                 select_plan_contains_cte_from_clause_subquery(select_plan)
                             }) || select_plan_contains_cte_from_clause_subquery(right_most)
                         }
+                        Plan::RecursiveCte(_) => false,
                         Plan::Delete(_) | Plan::Update(_) => false,
                     }
             }
@@ -2453,6 +2479,10 @@ fn optimize_table_access(
                     Operation::Scan(Scan::Subquery {
                         iter_dir: *iter_dir,
                     });
+            }
+            AccessMethodParams::RecursiveCteInput => {
+                table_references.joined_tables_mut()[table_idx].op =
+                    Operation::Scan(Scan::RecursiveCteInput);
             }
             AccessMethodParams::MaterializedSubquery {
                 index,

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -373,6 +373,7 @@ fn access_method_emits_unique_order_prefix(
             consumed_order_terms,
         ),
         AccessMethodParams::Subquery { .. }
+        | AccessMethodParams::RecursiveCteInput
         | AccessMethodParams::HashJoin { .. }
         | AccessMethodParams::VirtualTable { .. }
         | AccessMethodParams::IndexMethod { .. }

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -14,7 +14,7 @@ use crate::{
     util::exprs_are_equivalent,
     vdbe::{
         builder::{CursorType, ProgramBuilder},
-        insn::{to_u16, IdxInsertFlags, Insn},
+        insn::{to_u32, IdxInsertFlags, Insn},
     },
     Result,
 };
@@ -661,9 +661,9 @@ impl EmitOrderBy {
 
         if *use_heap_sort {
             program.emit_insn(Insn::MakeRecord {
-                start_reg: to_u16(start_reg),
-                count: to_u16(orderby_sorter_column_count),
-                dest_reg: to_u16(*reg_sorter_data),
+                start_reg: to_u32(start_reg),
+                count: to_u32(orderby_sorter_column_count),
+                dest_reg: to_u32(*reg_sorter_data),
                 index_name: None,
                 affinity_str: None,
             });
@@ -698,9 +698,9 @@ pub fn sorter_insert(
     record_reg: usize,
 ) {
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(start_reg),
-        count: to_u16(column_count),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(start_reg),
+        count: to_u32(column_count),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -622,9 +622,9 @@ pub enum QueryDestination {
 /// One result column used to order the recursive CTE work queue.
 pub struct RecursiveCteQueueKey {
     pub result_column_index: usize,
-    /// `Some(true)` for NULLS LAST, `Some(false)` for NULLS FIRST, and `None`
-    /// when the index sort order already puts NULLs in the requested position.
-    pub nulls_last_override: Option<bool>,
+    /// `None` when the index sort order already puts NULLs in the requested
+    /// position.
+    pub nulls_override: Option<ast::NullsOrder>,
 }
 
 impl QueryDestination {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -592,7 +592,7 @@ pub enum QueryDestination {
         cursor_id: CursorID,
         index: Arc<Index>,
         /// Result columns that determine which queued row is read next.
-        sort_keys: Vec<RecursiveCteQueueKey>,
+        sort_keys: alloc::Vec<RecursiveCteQueueKey>,
         /// Index of rows already produced by a recursive `UNION`.
         seen_rows: Option<(CursorID, Arc<Index>)>,
     },

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2531,7 +2531,14 @@ impl JoinedTable {
         internal_id: TableInternalId,
         explicit_columns: Option<&[String]>,
     ) -> Result<Self> {
-        let columns = query_output_columns(query, explicit_columns)?;
+        let mut columns = query_output_columns(query, explicit_columns)?;
+        // The recursive self-reference reads SQLite's queue table, whose
+        // columns have no declared type: comparisons in the recursive term
+        // see the stored value without the anchor query's affinity. Only the
+        // outer read of the CTE keeps the derived affinity.
+        for column in columns.iter_mut() {
+            column.set_base_affinity(Affinity::Blob);
+        }
         let table = Table::RecursiveCteInput(Arc::new(RecursiveCteInput {
             name: identifier.clone(),
             columns,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1,8 +1,9 @@
 use crate::{
-    alloc::{self, TursoIteratorExt},
+    alloc::{self, TursoIteratorExt, TursoVecExt},
     function::{AccumulatorFunc, AggFunc},
     schema::{
-        BTreeTable, ColDef, Column, FromClauseSubquery, Index, Schema, Table, Type, ROWID_SENTINEL,
+        BTreeTable, ColDef, Column, FromClauseSubquery, Index, PseudoCursorType, RecursiveCteInput,
+        Schema, Table, Type, ROWID_SENTINEL,
     },
     translate::{
         collate::{get_collseq_from_expr, CollationSeq},
@@ -384,8 +385,24 @@ pub enum Plan {
         /// ORDER BY for compound selects, or `None` when the query has none.
         order_by: Option<Vec<CompoundOrderByKey>>,
     },
+    /// Runs the initial query once, then runs the recursive query for each queued row.
+    RecursiveCte(Box<RecursiveCtePlan>),
     Delete(Box<DeletePlan>),
     Update(Box<UpdatePlan>),
+}
+
+#[derive(Debug, Clone)]
+/// Everything needed to emit one self-referencing CTE.
+pub struct RecursiveCtePlan {
+    pub name: String,
+    pub initial_query: Box<Plan>,
+    pub recursive_query: Box<Plan>,
+    pub input_table_id: TableInternalId,
+    pub union_all: bool,
+    pub limit: Option<Box<Expr>>,
+    pub offset: Option<Box<Expr>>,
+    pub queue_order: Option<Vec<CompoundOrderByKey>>,
+    pub query_destination: QueryDestination,
 }
 
 impl Plan {
@@ -403,6 +420,10 @@ impl Plan {
                         .iter()
                         .any(|(plan, _)| plan.table_references.contains_table(table))
             }
+            Plan::RecursiveCte(plan) => {
+                plan.initial_query.select_contains_table(table)
+                    || plan.recursive_query.select_contains_table(table)
+            }
             Plan::Delete(_) | Plan::Update(_) => false,
         }
     }
@@ -413,6 +434,7 @@ impl Plan {
         match self {
             Plan::Select(select_plan) => Some(&select_plan.query_destination),
             Plan::CompoundSelect { right_most, .. } => Some(&right_most.query_destination),
+            Plan::RecursiveCte(plan) => Some(&plan.query_destination),
             Plan::Delete(_) | Plan::Update(_) => None,
         }
     }
@@ -423,6 +445,7 @@ impl Plan {
         match self {
             Plan::Select(select_plan) => Some(&mut select_plan.query_destination),
             Plan::CompoundSelect { right_most, .. } => Some(&mut right_most.query_destination),
+            Plan::RecursiveCte(plan) => Some(&mut plan.query_destination),
             Plan::Delete(_) | Plan::Update(_) => None,
         }
     }
@@ -439,6 +462,7 @@ impl Plan {
         match self {
             Plan::Select(select_plan) => &select_plan.result_columns,
             Plan::CompoundSelect { right_most, .. } => &right_most.result_columns,
+            Plan::RecursiveCte(plan) => plan.initial_query.select_result_columns(),
             Plan::Delete(_) | Plan::Update(_) => {
                 panic!("select_result_columns called on a non-SELECT plan")
             }
@@ -456,6 +480,7 @@ impl Plan {
         match self {
             Plan::Select(select_plan) => &select_plan.table_references,
             Plan::CompoundSelect { right_most, .. } => &right_most.table_references,
+            Plan::RecursiveCte(plan) => plan.initial_query.select_table_references(),
             Plan::Delete(_) | Plan::Update(_) => {
                 panic!("select_table_references called on a non-SELECT plan")
             }
@@ -485,6 +510,10 @@ impl Plan {
                 }
                 collect_from_select(right_most, &mut ids);
             }
+            Plan::RecursiveCte(plan) => {
+                ids.extend(plan.initial_query.used_outer_query_ref_ids());
+                ids.extend(plan.recursive_query.used_outer_query_ref_ids());
+            }
             Plan::Delete(_) | Plan::Update(_) => {}
         }
         ids
@@ -501,6 +530,10 @@ impl Plan {
                 left.iter()
                     .any(|(select_plan, _)| select_plan.reads_table(database_id, table_name))
                     || right_most.reads_table(database_id, table_name)
+            }
+            Plan::RecursiveCte(plan) => {
+                plan.initial_query.reads_table(database_id, table_name)
+                    || plan.recursive_query.reads_table(database_id, table_name)
             }
             Plan::Delete(_) | Plan::Update(_) => false,
         }
@@ -554,6 +587,15 @@ pub enum QueryDestination {
         /// How to determine the rowid key for inserts.
         rowid_mode: EphemeralRowidMode,
     },
+    /// Insert rows produced by a recursive CTE into its work queue.
+    RecursiveCteQueue {
+        cursor_id: CursorID,
+        index: Arc<Index>,
+        /// Result columns that determine which queued row is read next.
+        sort_keys: Vec<RecursiveCteQueueKey>,
+        /// Index of rows already produced by a recursive `UNION`.
+        seen_rows: Option<(CursorID, Arc<Index>)>,
+    },
     /// The result of an EXISTS subquery are stored in a single register.
     ExistsSubqueryResult {
         /// The register that holds the result of the EXISTS subquery.
@@ -574,6 +616,15 @@ pub enum QueryDestination {
     },
     /// Decision made at some point after query plan construction.
     Unset,
+}
+
+#[derive(Debug, Clone, Copy)]
+/// One result column used to order the recursive CTE work queue.
+pub struct RecursiveCteQueueKey {
+    pub result_column_index: usize,
+    /// `Some(true)` for NULLS LAST, `Some(false)` for NULLS FIRST, and `None`
+    /// when the index sort order already puts NULLs in the requested position.
+    pub nulls_last_override: Option<bool>,
 }
 
 impl QueryDestination {
@@ -760,7 +811,7 @@ impl SelectPlan {
                     Table::FromClauseSubquery(subquery) => {
                         subquery.plan.reads_table(database_id, table_name)
                     }
-                    Table::BTree(_) | Table::Virtual(_) => false,
+                    Table::BTree(_) | Table::Virtual(_) | Table::RecursiveCteInput(_) => false,
                 }
         }) || self
             .non_from_clause_subqueries
@@ -2226,6 +2277,7 @@ impl Operation {
             Table::FromClauseSubquery(_) => Operation::Scan(Scan::Subquery {
                 iter_dir: IterationDirection::Forwards,
             }),
+            Table::RecursiveCteInput(_) => Operation::Scan(Scan::RecursiveCteInput),
         }
     }
 
@@ -2274,6 +2326,76 @@ impl Operation {
             _ => false,
         }
     }
+}
+
+fn query_output_columns(
+    plan: &Plan,
+    explicit_columns: Option<&[String]>,
+) -> Result<alloc::Vec<Column>> {
+    let (result_columns, table_references): (&[ResultSetColumn], &TableReferences) = match plan {
+        Plan::Select(select_plan) => (&select_plan.result_columns, &select_plan.table_references),
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => left
+            .first()
+            .map(|(select, _)| (&select.result_columns[..], &select.table_references))
+            .unwrap_or((&right_most.result_columns, &right_most.table_references)),
+        Plan::RecursiveCte(recursive_cte) => (
+            recursive_cte.initial_query.select_result_columns(),
+            recursive_cte.initial_query.select_table_references(),
+        ),
+        Plan::Delete(_) | Plan::Update(_) => {
+            unreachable!("DELETE/UPDATE plans cannot define query output columns")
+        }
+    };
+
+    let compound_arms = match plan {
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => {
+            let mut arms = left
+                .iter()
+                .map(|(select, _)| select)
+                .try_collect::<alloc::Vec<_>>()?;
+            arms.try_push(right_most)?;
+            Some(arms)
+        }
+        _ => None,
+    };
+
+    let mut columns = result_columns
+        .iter()
+        .enumerate()
+        .map(|(column_index, result_column)| {
+            let name = explicit_columns
+                .and_then(|names| names.get(column_index).cloned())
+                .or_else(|| result_column.name(table_references).map(String::from));
+            let column_type = compound_arms
+                .as_ref()
+                .map(|arms| compound_column_affinity(arms, column_index).to_type())
+                .unwrap_or_else(|| {
+                    infer_type_from_expr(&result_column.expr, Some(table_references))
+                });
+            Column::new(
+                name,
+                column_type.to_string(),
+                None,
+                None,
+                column_type,
+                None,
+                ColDef::default(),
+            )
+        })
+        .try_collect::<alloc::Vec<_>>()?;
+
+    for (column_index, column) in columns.iter_mut().enumerate() {
+        let result_expr = &result_columns[column_index].expr;
+        if super::expr::expr_is_array(result_expr, Some(table_references)) {
+            column.set_array_dimensions(1);
+        }
+        column.set_collation(get_collseq_from_expr(result_expr, table_references)?);
+    }
+    Ok(columns)
 }
 
 impl JoinedTable {
@@ -2371,80 +2493,8 @@ impl JoinedTable {
         cte_id: Option<usize>,
         materialize_hint: bool,
     ) -> Result<Self> {
+        let columns = query_output_columns(&plan, explicit_columns)?;
         // Get result columns and table references from the plan
-        let (result_columns, table_references) = match &plan {
-            Plan::Select(select_plan) => {
-                (&select_plan.result_columns, &select_plan.table_references)
-            }
-            Plan::CompoundSelect {
-                left, right_most, ..
-            } => {
-                // For compound selects, SQLite uses the leftmost select's column names.
-                // The leftmost select is left[0] if the vec is not empty, otherwise right_most.
-                if !left.is_empty() {
-                    (&left[0].0.result_columns, &left[0].0.table_references)
-                } else {
-                    (&right_most.result_columns, &right_most.table_references)
-                }
-            }
-            Plan::Delete(_) | Plan::Update(_) => {
-                unreachable!("DELETE/UPDATE plans cannot be subqueries")
-            }
-        };
-
-        // Note: column count validation (explicit_columns.len() vs result_columns.len())
-        // is intentionally NOT done here. SQLite defers this check until the CTE is
-        // actually referenced. Callers that represent actual CTE references should
-        // validate the count before calling this method.
-
-        // For a compound select, a column's affinity is combined across every arm
-        // (not just the leftmost one), so collect the arms to fold over.
-        let compound_arms: Option<Vec<&SelectPlan>> = match &plan {
-            Plan::CompoundSelect {
-                left, right_most, ..
-            } => {
-                let mut arms: Vec<&SelectPlan> = left.iter().map(|(p, _)| p).collect();
-                arms.push(right_most);
-                Some(arms)
-            }
-            _ => None,
-        };
-
-        let mut columns = result_columns
-            .iter()
-            .enumerate()
-            .map(|(i, rc)| {
-                // Use explicit column name if provided, otherwise derive from result column
-                let col_name = explicit_columns
-                    .and_then(|cols| cols.get(i).cloned())
-                    .or_else(|| rc.name(table_references).map(String::from));
-                let col_type = match &compound_arms {
-                    Some(arms) => compound_column_affinity(arms, i).to_type(),
-                    None => infer_type_from_expr(&rc.expr, Some(table_references)),
-                };
-                let type_name = col_type.to_string();
-                Column::new(
-                    col_name,
-                    type_name,
-                    None,
-                    None,
-                    col_type,
-                    None,
-                    ColDef::default(),
-                )
-            })
-            .try_collect::<alloc::Vec<_>>()?;
-
-        for (i, column) in columns.iter_mut().enumerate() {
-            if super::expr::expr_is_array(&result_columns[i].expr, Some(table_references)) {
-                column.set_array_dimensions(1);
-            }
-            column.set_collation(get_collseq_from_expr(
-                &result_columns[i].expr,
-                table_references,
-            )?);
-        }
-
         // materialize_hint is set true for explicit WITH ... AS MATERIALIZED hint.
         // Multi-reference CTEs are also detected at emission time via reference counting,
         // and they may be materialized regardless of explicit keyword usage.
@@ -2467,6 +2517,31 @@ impl JoinedTable {
             identifier,
             internal_id,
             join_info,
+            col_used_mask: ColumnUsedMask::default(),
+            column_use_counts: Vec::new(),
+            expression_index_usages: Vec::new(),
+            database_id: MAIN_DB_ID,
+            indexed: None,
+        })
+    }
+
+    pub fn new_recursive_cte_input(
+        identifier: String,
+        query: &Plan,
+        internal_id: TableInternalId,
+        explicit_columns: Option<&[String]>,
+    ) -> Result<Self> {
+        let columns = query_output_columns(query, explicit_columns)?;
+        let table = Table::RecursiveCteInput(Arc::new(RecursiveCteInput {
+            name: identifier.clone(),
+            columns,
+        }));
+        Ok(Self {
+            op: Operation::default_scan_for(&table),
+            table,
+            identifier,
+            internal_id,
+            join_info: None,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
@@ -2644,6 +2719,13 @@ impl JoinedTable {
                     })
                     .transpose()?;
                 Ok((None, index_cursor_id))
+            }
+            Table::RecursiveCteInput(input) => {
+                let cursor_id = program.alloc_cursor_id_keyed_if_not_exists(
+                    CursorKey::table(self.internal_id),
+                    CursorType::Pseudo(PseudoCursorType::new_with_columns(&input.columns)),
+                );
+                Ok((Some(cursor_id), None))
             }
         }
     }
@@ -2939,6 +3021,8 @@ pub enum Scan {
         /// subquery order for an extremum fast path.
         iter_dir: IterationDirection,
     },
+    /// The one-row input consumed by the recursive part of a recursive CTE.
+    RecursiveCteInput,
 }
 
 /// An enum that represents a search operation that can be used to search for a row in a table using an index
@@ -3461,6 +3545,13 @@ fn eval_at_for_plan(
             )?);
             Ok(eval_at)
         }
+        Plan::RecursiveCte(recursive_cte) => {
+            let initial_query =
+                eval_at_for_plan(&recursive_cte.initial_query, join_order, table_references)?;
+            let recursive_query =
+                eval_at_for_plan(&recursive_cte.recursive_query, join_order, table_references)?;
+            Ok(initial_query.max(recursive_query))
+        }
         Plan::Delete(_) | Plan::Update(_) => Ok(EvalAt::BeforeLoop),
     }
 }
@@ -3472,6 +3563,10 @@ pub fn plan_is_correlated(plan: &Plan) -> bool {
         Plan::CompoundSelect {
             left, right_most, ..
         } => left.iter().any(|(plan, _)| plan.is_correlated()) || right_most.is_correlated(),
+        Plan::RecursiveCte(recursive_cte) => {
+            plan_is_correlated(&recursive_cte.initial_query)
+                || plan_is_correlated(&recursive_cte.recursive_query)
+        }
         Plan::Delete(_) | Plan::Update(_) => false,
     }
 }
@@ -3546,6 +3641,15 @@ fn plan_has_outer_scope_dependency_with_tables(
                 )
             }) || select_plan_has_outer_scope_dependency_with_tables(
                 right_most,
+                accessible_table_ids,
+            )
+        }
+        Plan::RecursiveCte(recursive_cte) => {
+            plan_has_outer_scope_dependency_with_tables(
+                &recursive_cte.initial_query,
+                accessible_table_ids,
+            ) || plan_has_outer_scope_dependency_with_tables(
+                &recursive_cte.recursive_query,
                 accessible_table_ids,
             )
         }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -7,9 +7,9 @@ use super::{
     plan::{
         Aggregate, ColumnMask, ColumnUsedMask, Distinctness, EvalAt, IterationDirection, JoinInfo,
         JoinOrderMember, JoinType as PlanJoinType, JoinedTable, Operation, OuterQueryReference,
-        Plan, QueryDestination, ResultSetColumn, Scan, TableReferences, WhereTerm,
+        Plan, QueryDestination, ResultSetColumn, Scan, SelectPlan, TableReferences, WhereTerm,
     },
-    select::prepare_select_plan,
+    select::{prepare_select_plan, prepare_select_plan_from_arms},
 };
 use crate::translate::plan::BitSet;
 use crate::translate::{
@@ -42,26 +42,70 @@ use turso_parser::ast::{
     TableInternalId, With,
 };
 
-/// A CTE definition stored for deferred planning.
-/// Instead of planning CTEs once and cloning the result, we store the AST and
-/// re-plan each time the CTE is referenced. This ensures each reference gets
-/// truly unique internal_ids and cursor IDs.
+/// Data needed to plan each reference to a CTE separately.
+///
+/// Separate plans prevent two references from accidentally sharing table IDs
+/// or cursor IDs unless the CTE is deliberately materialized once.
 struct CteDefinition {
-    /// Globally unique CTE identity for sharing materialized data.
-    /// Multiple references to this CTE will use this ID to look up shared cursors.
+    /// Identifies materialized results shared by references to this CTE.
     cte_id: usize,
-    /// Normalized CTE name
+    /// Normalized CTE name.
     name: String,
-    /// The original AST SELECT statement (cloned for each reference)
+    /// SELECT syntax used to build a plan for each reference.
     select: Select,
-    /// Explicit column names from WITH t(a, b) AS (...) syntax
+    /// Explicit column names from `WITH t(a, b) AS (...)`.
     explicit_columns: Vec<String>,
-    /// Indexes of CTEs that this CTE directly references.
-    /// Only includes CTEs that appear in this CTE's FROM clause,
-    /// avoiding exponential re-planning when CTEs have transitive dependencies.
+    /// Other CTE definitions referenced by this CTE.
     referenced_cte_indices: SmallVec<[usize; 2]>,
-    /// True if WITH ... AS MATERIALIZED was specified, forcing materialization
+    /// True when `AS MATERIALIZED` requires one stored result.
     materialize_hint: bool,
+    /// The CTE body contains a reference to its own name.
+    references_itself: bool,
+}
+
+fn collect_cte_definitions(with: With, program: &mut ProgramBuilder) -> Result<Vec<CteDefinition>> {
+    let mut definitions = Vec::with_capacity(with.ctes.len());
+    let mut referenced_table_names_by_cte = Vec::with_capacity(with.ctes.len());
+
+    for cte in with.ctes {
+        let name = normalize_ident(cte.tbl_name.as_str());
+        if definitions
+            .iter()
+            .any(|definition: &CteDefinition| definition.name == name)
+        {
+            crate::bail_parse_error!("duplicate WITH table name: {}", cte.tbl_name.as_str());
+        }
+
+        let mut referenced_table_names = Vec::new();
+        collect_from_clause_table_refs(&cte.select, &mut referenced_table_names);
+        let references_itself = referenced_table_names.contains(&name);
+        referenced_table_names_by_cte.push(referenced_table_names);
+        definitions.push(CteDefinition {
+            cte_id: program.alloc_cte_id(),
+            name,
+            select: cte.select,
+            explicit_columns: cte
+                .columns
+                .iter()
+                .map(|column| normalize_ident(column.col_name.as_str()))
+                .collect(),
+            referenced_cte_indices: SmallVec::new(),
+            materialize_hint: cte.materialized == Materialized::Yes,
+            references_itself,
+        });
+    }
+
+    for (cte_index, referenced_table_names) in referenced_table_names_by_cte.iter().enumerate() {
+        definitions[cte_index].referenced_cte_indices = definitions
+            .iter()
+            .enumerate()
+            .filter(|(candidate_index, definition)| {
+                *candidate_index != cte_index && referenced_table_names.contains(&definition.name)
+            })
+            .map(|(candidate_index, _)| candidate_index)
+            .collect();
+    }
+    Ok(definitions)
 }
 
 /// Collect all table names referenced in a SELECT's FROM clause.
@@ -92,11 +136,63 @@ fn collect_from_one_select(one: &ast::OneSelect, out: &mut Vec<String>) {
     }
 }
 
+fn count_cte_self_references(one: &ast::OneSelect, cte_name: &str) -> (usize, usize) {
+    fn count_in_from_table(table: &ast::SelectTable, cte_name: &str) -> usize {
+        match table {
+            ast::SelectTable::Table(name, _, _) | ast::SelectTable::TableCall(name, _, _) => {
+                usize::from(
+                    name.db_name.is_none() && normalize_ident(name.name.as_str()) == cte_name,
+                )
+            }
+            ast::SelectTable::Select(_, _) => 0,
+            ast::SelectTable::Sub(from, _) => {
+                count_in_from_table(&from.select, cte_name)
+                    + from
+                        .joins
+                        .iter()
+                        .map(|join| count_in_from_table(&join.table, cte_name))
+                        .sum::<usize>()
+            }
+        }
+    }
+
+    let top_level_from_count = if let ast::OneSelect::Select {
+        from: Some(from), ..
+    } = one
+    {
+        count_in_from_table(&from.select, cte_name)
+            + from
+                .joins
+                .iter()
+                .map(|join| count_in_from_table(&join.table, cte_name))
+                .sum::<usize>()
+    } else {
+        0
+    };
+    let mut referenced_table_names = Vec::new();
+    collect_from_one_select(one, &mut referenced_table_names);
+    collect_subquery_table_refs_in_one_select(one, &mut referenced_table_names);
+    let total_count = referenced_table_names
+        .iter()
+        .filter(|name| name.as_str() == cte_name)
+        .count();
+    (top_level_from_count, total_count)
+}
+
 fn collect_from_select_table(table: &ast::SelectTable, out: &mut Vec<String>) {
     match table {
-        ast::SelectTable::Table(qualified_name, _, _)
-        | ast::SelectTable::TableCall(qualified_name, _, _) => {
-            out.push(normalize_ident(qualified_name.name.as_str()));
+        ast::SelectTable::Table(qualified_name, _, _) => {
+            if qualified_name.db_name.is_none() {
+                out.push(normalize_ident(qualified_name.name.as_str()));
+            }
+        }
+        ast::SelectTable::TableCall(qualified_name, args, _) => {
+            if qualified_name.db_name.is_none() {
+                out.push(normalize_ident(qualified_name.name.as_str()));
+            }
+            for arg in args {
+                collect_subquery_table_refs_in_expr(arg, out);
+            }
         }
         ast::SelectTable::Select(subselect, _) => {
             collect_from_clause_table_refs(subselect, out);
@@ -105,6 +201,9 @@ fn collect_from_select_table(table: &ast::SelectTable, out: &mut Vec<String>) {
             collect_from_select_table(&from_clause.select, out);
             for join in &from_clause.joins {
                 collect_from_select_table(&join.table, out);
+                if let Some(ast::JoinConstraint::On(expr)) = &join.constraint {
+                    collect_subquery_table_refs_in_expr(expr, out);
+                }
             }
         }
     }
@@ -151,6 +250,16 @@ fn collect_subquery_table_refs_in_one_select(one: &ast::OneSelect, out: &mut Vec
                 }
                 if let Some(having) = &group_by.having {
                     collect_subquery_table_refs_in_expr(having, out);
+                }
+            }
+            if let ast::OneSelect::Select {
+                from: Some(from), ..
+            } = one
+            {
+                for join in &from.joins {
+                    if let Some(ast::JoinConstraint::On(expr)) = &join.constraint {
+                        collect_subquery_table_refs_in_expr(expr, out);
+                    }
                 }
             }
         }
@@ -744,120 +853,397 @@ fn build_ordered_set_aggregate(
     })
 }
 
-/// Plan a CTE when it's referenced in a query.
-/// Each call produces a fresh plan with unique internal_ids, ensuring that
-/// multiple references to the same CTE get independent cursor IDs,
-/// yield registers and so on.
+/// Plans one use of a CTE.
 ///
+/// Each use gets separate table and cursor IDs unless it shares materialized rows.
 #[allow(clippy::too_many_arguments)]
 fn plan_cte(
-    cte_idx: usize,
+    cte_definition_index: usize,
     cte_definitions: &[CteDefinition],
     base_outer_query_refs: &[OuterQueryReference],
     resolver: &Resolver,
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
-    actual_reference: bool,
+    validate_explicit_column_count: bool,
 ) -> Result<JoinedTable> {
-    let cte_def = &cte_definitions[cte_idx];
-
-    // Build outer_query_refs including only the CTEs this one directly references.
-    // By tracking direct dependencies instead of all preceding CTEs, we avoid
-    // exponential re-planning when CTEs have transitive dependencies.
-    let mut outer_query_refs = base_outer_query_refs.to_vec();
-    for &ref_idx in &cte_def.referenced_cte_indices {
-        let ref_cte_name = &cte_definitions[ref_idx].name;
-        // Check if this CTE has already been planned and is in outer_query_refs.
-        // This avoids exponential re-planning when CTEs have transitive dependencies.
-        if outer_query_refs
-            .iter()
-            .any(|r| &r.identifier == ref_cte_name)
-        {
-            continue;
-        }
-        // Recursively plan the referenced CTE so it's visible within this CTE's body.
-        // Example: WITH a AS (...), b AS (SELECT * FROM a) - when planning b, we need
-        // a to be in scope. This visibility-only copy is not itself a read that can
-        // share a materialized result, so it must not be treated as one here.
-        let referenced_table = plan_cte(
-            ref_idx,
-            cte_definitions,
-            base_outer_query_refs,
-            resolver,
-            program,
-            connection,
-            false,
-        )?;
-        outer_query_refs.push(OuterQueryReference {
-            identifier: referenced_table.identifier.clone(),
-            internal_id: referenced_table.internal_id,
-            table: referenced_table.table.clone(),
-            using_dedup_hidden_cols: referenced_table.using_dedup_hidden_cols()?,
-            col_used_mask: ColumnUsedMask::default(),
-            cte_select: None,
-            cte_explicit_columns: vec![],
-            cte_id: Some(cte_definitions[ref_idx].cte_id),
-            cte_definition_only: false,
-            rowid_referenced: false,
-            scope_depth: 0,
-        });
+    let cte_definition = &cte_definitions[cte_definition_index];
+    if program.is_cte_being_defined(&cte_definition.name) {
+        crate::bail_parse_error!("circular reference: {}", cte_definition.name);
     }
 
-    // Block the CTE's own name from resolving to a schema object during
-    // planning of its body. Without this, a same-named view would be expanded
-    // recursively (stack overflow) and a same-named table would give wrong
-    // results. `parse_table` checks this and produces "circular reference".
-    program.push_cte_being_defined(cte_def.name.clone());
-
-    // Plan this CTE with fresh IDs
-    let cte_plan = prepare_select_plan(
-        cte_def.select.clone(),
-        resolver,
-        program,
-        &outer_query_refs,
-        QueryDestination::placeholder_for_subquery(),
-        connection,
-    );
+    // Plan only the other CTEs this definition names. Planning every preceding
+    // CTE here would repeatedly plan the same transitive dependencies.
+    program.push_cte_being_defined(cte_definition.name.clone());
+    let outer_query_refs: Result<Vec<OuterQueryReference>> = (|| {
+        let mut outer_query_refs = base_outer_query_refs.to_vec();
+        for &referenced_cte_index in &cte_definition.referenced_cte_indices {
+            let referenced_cte_name = &cte_definitions[referenced_cte_index].name;
+            if outer_query_refs
+                .iter()
+                .any(|reference| &reference.identifier == referenced_cte_name)
+            {
+                continue;
+            }
+            let referenced_cte_table = plan_cte(
+                referenced_cte_index,
+                cte_definitions,
+                base_outer_query_refs,
+                resolver,
+                program,
+                connection,
+                false,
+            )?;
+            outer_query_refs.push(OuterQueryReference {
+                identifier: referenced_cte_table.identifier.clone(),
+                internal_id: referenced_cte_table.internal_id,
+                table: referenced_cte_table.table.clone(),
+                using_dedup_hidden_cols: referenced_cte_table.using_dedup_hidden_cols()?,
+                col_used_mask: ColumnUsedMask::default(),
+                cte_select: None,
+                cte_explicit_columns: vec![],
+                cte_id: Some(cte_definitions[referenced_cte_index].cte_id),
+                cte_definition_only: false,
+                rowid_referenced: false,
+                scope_depth: 0,
+            });
+        }
+        Ok(outer_query_refs)
+    })();
     program.pop_cte_being_defined();
-    let cte_plan = cte_plan?;
+    let outer_query_refs = outer_query_refs?;
 
-    // CTEs can be either simple SELECT or compound SELECT (UNION/INTERSECT/EXCEPT)
-    let explicit_cols = if cte_def.explicit_columns.is_empty() {
+    let cte_query_plan = if cte_definition.references_itself {
+        prepare_recursive_cte_plan(
+            cte_definition,
+            resolver,
+            program,
+            &outer_query_refs,
+            connection,
+        )?
+    } else {
+        // A non-recursive CTE cannot read a table or view with the same name.
+        // Keep that name hidden while planning so the lookup reports a circular reference.
+        program.push_cte_being_defined(cte_definition.name.clone());
+        let plan = prepare_select_plan(
+            cte_definition.select.clone(),
+            resolver,
+            program,
+            &outer_query_refs,
+            QueryDestination::placeholder_for_subquery(),
+            connection,
+        );
+        program.pop_cte_being_defined();
+        plan?
+    };
+
+    let explicit_columns = if cte_definition.explicit_columns.is_empty() {
         None
     } else {
-        Some(cte_def.explicit_columns.as_slice())
+        Some(cte_definition.explicit_columns.as_slice())
     };
 
     // SQLite defers explicit column-count validation until the CTE is actually
     // referenced, so preplanned visibility-only copies must not raise here.
-    if actual_reference {
-        if let Some(cols) = explicit_cols {
-            let result_col_count = cte_plan.select_result_columns().len();
-            if cols.len() != result_col_count {
+    if validate_explicit_column_count {
+        if let Some(columns) = explicit_columns {
+            let result_column_count = cte_query_plan.select_result_columns().len();
+            if columns.len() != result_column_count {
                 crate::bail_parse_error!(
                     "table {} has {} columns but {} column names were provided",
-                    cte_def.name,
-                    result_col_count,
-                    cols.len()
+                    cte_definition.name,
+                    result_column_count,
+                    columns.len()
                 );
             }
         }
     }
 
-    match cte_plan {
-        Plan::Select(_) | Plan::CompoundSelect { .. } => JoinedTable::new_subquery_from_plan(
-            cte_def.name.clone(),
-            cte_plan,
-            None,
-            program.table_reference_counter.next(),
-            explicit_cols,
-            Some(cte_def.cte_id), // Pass the CTE identity for sharing materialized data
-            cte_def.materialize_hint,
-        ),
+    match cte_query_plan {
+        Plan::Select(_) | Plan::CompoundSelect { .. } | Plan::RecursiveCte(_) => {
+            JoinedTable::new_subquery_from_plan(
+                cte_definition.name.clone(),
+                cte_query_plan,
+                None,
+                program.table_reference_counter.next(),
+                explicit_columns,
+                Some(cte_definition.cte_id),
+                cte_definition.materialize_hint,
+            )
+        }
         Plan::Delete(_) | Plan::Update(_) => {
             crate::bail_parse_error!("DELETE/UPDATE queries are not supported in CTEs")
         }
     }
+}
+
+fn prepare_recursive_cte_plan(
+    cte_definition: &CteDefinition,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+    outer_query_refs: &[OuterQueryReference],
+    connection: &Arc<crate::Connection>,
+) -> Result<Plan> {
+    let select = &cte_definition.select;
+    let mut first_recursive_query_index = None;
+    for (query_index, query) in std::iter::once(&select.body.select)
+        .chain(
+            select
+                .body
+                .compounds
+                .iter()
+                .map(|compound| &compound.select),
+        )
+        .enumerate()
+    {
+        let (top_level_from_count, total_count) =
+            count_cte_self_references(query, &cte_definition.name);
+        if first_recursive_query_index.is_none() && total_count == 0 {
+            continue;
+        }
+        if query_index == 0 {
+            crate::bail_parse_error!("circular reference: {}", cte_definition.name);
+        }
+        first_recursive_query_index.get_or_insert(query_index);
+        if top_level_from_count == 0 {
+            crate::bail_parse_error!("circular reference: {}", cte_definition.name);
+        }
+        if top_level_from_count > 1 {
+            crate::bail_parse_error!(
+                "multiple references to recursive table: {}",
+                cte_definition.name
+            );
+        }
+        if total_count > top_level_from_count {
+            crate::bail_parse_error!("multiple recursive references: {}", cte_definition.name);
+        }
+    }
+    let Some(first_recursive_query_index) = first_recursive_query_index else {
+        return Err(crate::LimboError::InternalError(format!(
+            "recursive CTE {} has no recursive query",
+            cte_definition.name
+        )));
+    };
+
+    let recursive_compound_operator =
+        select.body.compounds[first_recursive_query_index - 1].operator;
+    let union_all = match recursive_compound_operator {
+        ast::CompoundOperator::UnionAll => true,
+        ast::CompoundOperator::Union => false,
+        ast::CompoundOperator::Except | ast::CompoundOperator::Intersect => {
+            crate::bail_parse_error!(
+                "recursive CTEs must use UNION ALL or UNION between the initial and recursive queries"
+            );
+        }
+    };
+    for compound in select
+        .body
+        .compounds
+        .iter()
+        .skip(first_recursive_query_index)
+    {
+        if compound.operator != recursive_compound_operator {
+            crate::bail_parse_error!("recursive CTE queries must use the same UNION operator");
+        }
+    }
+
+    let initial_query = prepare_select_plan_from_arms(
+        select.body.select.clone(),
+        select.body.compounds[..first_recursive_query_index - 1]
+            .iter()
+            .cloned(),
+        select.with.clone(),
+        vec![],
+        None,
+        resolver,
+        program,
+        outer_query_refs,
+        QueryDestination::placeholder_for_subquery(),
+        connection,
+    )?;
+
+    let explicit_columns = (!cte_definition.explicit_columns.is_empty())
+        .then_some(cte_definition.explicit_columns.as_slice());
+    if let Some(columns) = explicit_columns {
+        let result_column_count = initial_query.select_result_columns().len();
+        if columns.len() != result_column_count {
+            crate::bail_parse_error!(
+                "table {} has {} values for {} columns",
+                cte_definition.name,
+                result_column_count,
+                columns.len()
+            );
+        }
+    }
+
+    let input_table = JoinedTable::new_recursive_cte_input(
+        cte_definition.name.clone(),
+        &initial_query,
+        program.table_reference_counter.next(),
+        explicit_columns,
+    )?;
+    let input_table_id = input_table.internal_id;
+
+    let mut recursive_query_outer_refs = outer_query_refs.to_vec();
+    recursive_query_outer_refs.push(OuterQueryReference {
+        identifier: cte_definition.name.clone(),
+        internal_id: input_table.internal_id,
+        table: input_table.table,
+        using_dedup_hidden_cols: ColumnMask::default(),
+        col_used_mask: ColumnUsedMask::default(),
+        cte_select: None,
+        cte_explicit_columns: cte_definition.explicit_columns.clone(),
+        cte_id: None,
+        cte_definition_only: false,
+        rowid_referenced: false,
+        scope_depth: 0,
+    });
+
+    let recursive_query = prepare_select_plan_from_arms(
+        select.body.compounds[first_recursive_query_index - 1]
+            .select
+            .clone(),
+        select.body.compounds[first_recursive_query_index..]
+            .iter()
+            .map(|compound| ast::CompoundSelect {
+                operator: ast::CompoundOperator::UnionAll,
+                select: compound.select.clone(),
+            }),
+        select.with.clone(),
+        vec![],
+        None,
+        resolver,
+        program,
+        &recursive_query_outer_refs,
+        QueryDestination::placeholder_for_subquery(),
+        connection,
+    )?;
+
+    if initial_query.select_result_columns().len() != recursive_query.select_result_columns().len()
+    {
+        crate::bail_parse_error!(
+            "SELECTs to the left and right of {} do not have the same number of result columns",
+            recursive_compound_operator
+        );
+    }
+    reject_aggregates_and_windows_in_recursive_query(&recursive_query)?;
+    reject_outer_join_on_clause_reading_past_recursive_input(&recursive_query, input_table_id)?;
+
+    let queue_order = super::select::resolve_recursive_cte_queue_order(
+        &select.order_by,
+        &initial_query,
+        &recursive_query,
+    )?;
+    let (limit, offset) = select
+        .limit
+        .clone()
+        .map_or(Ok((None, None)), |limit| parse_limit(limit, resolver))?;
+
+    Ok(Plan::RecursiveCte(Box::new(
+        super::plan::RecursiveCtePlan {
+            name: cte_definition.name.clone(),
+            initial_query: Box::new(initial_query),
+            recursive_query: Box::new(recursive_query),
+            input_table_id,
+            union_all,
+            limit,
+            offset,
+            queue_order,
+            query_destination: QueryDestination::placeholder_for_subquery(),
+        },
+    )))
+}
+
+fn reject_aggregates_and_windows_in_recursive_query(query: &Plan) -> Result<()> {
+    match query {
+        Plan::Select(select) => {
+            if !select.aggregates.is_empty() {
+                crate::bail_parse_error!("recursive aggregate queries not supported");
+            }
+            if select.window.is_some() {
+                crate::bail_parse_error!("cannot use window functions in recursive queries");
+            }
+        }
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => {
+            if left.iter().any(|(select, _)| !select.aggregates.is_empty())
+                || !right_most.aggregates.is_empty()
+            {
+                crate::bail_parse_error!("recursive aggregate queries not supported");
+            }
+            if left.iter().any(|(select, _)| select.window.is_some()) || right_most.window.is_some()
+            {
+                crate::bail_parse_error!("cannot use window functions in recursive queries");
+            }
+        }
+        Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => {
+            return Err(crate::LimboError::InternalError(
+                "recursive CTE query is not a SELECT".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// SQLite scans the recursive input as the outermost loop of the recursive
+/// step, so when the input is the right operand of a LEFT or FULL join, any
+/// ON term that also reads another table in the FROM clause would depend on
+/// loops that have not started yet. SQLite rejects this with "ON clause
+/// references tables to its right" (whereexpr.c), and we mirror that.
+///
+/// A recursive input written on the left of a RIGHT JOIN ends up as the
+/// rightmost outer-joined table after the planner's swap; SQLite accepts that
+/// form, so swapped joins are skipped.
+fn reject_outer_join_on_clause_reading_past_recursive_input(
+    query: &Plan,
+    input_table_id: TableInternalId,
+) -> Result<()> {
+    let selects: Vec<&SelectPlan> = match query {
+        Plan::Select(select) => vec![select],
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => left
+            .iter()
+            .map(|(select, _)| select)
+            .chain(std::iter::once(right_most.as_ref()))
+            .collect(),
+        Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => {
+            return Err(crate::LimboError::InternalError(
+                "recursive CTE query is not a SELECT".to_string(),
+            ));
+        }
+    };
+    for select in selects {
+        if select.table_references.right_join_swapped() {
+            continue;
+        }
+        for term in &select.where_clause {
+            if term.from_outer_join != Some(input_table_id) {
+                continue;
+            }
+            let Some(input_table_idx) = select
+                .table_references
+                .joined_tables()
+                .iter()
+                .position(|table| table.internal_id == input_table_id)
+            else {
+                return Err(crate::LimboError::InternalError(
+                    "outer-join ON term references a table that is not in the FROM clause"
+                        .to_string(),
+                ));
+            };
+            let mut mask = table_mask_from_expr(
+                &term.expr,
+                &select.table_references,
+                &select.non_from_clause_subqueries,
+            )?;
+            mask.clear(input_table_idx);
+            if !mask.is_empty() {
+                crate::bail_parse_error!("ON clause references tables to its right");
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Plan CTEs from a WITH clause and add them as outer query references.
@@ -875,84 +1261,29 @@ pub fn plan_ctes_as_outer_refs(
         return Ok(());
     };
 
-    if with.recursive {
-        crate::bail_parse_error!("Recursive CTEs are not yet supported");
-    }
+    let cte_definitions = collect_cte_definitions(with, program)?;
 
-    for cte in with.ctes {
-        // Normalize explicit column names
-        let explicit_columns: Vec<String> = cte
-            .columns
-            .iter()
-            .map(|c| normalize_ident(c.col_name.as_str()))
-            .collect();
-
-        let cte_name = normalize_ident(cte.tbl_name.as_str());
-
-        // Check for duplicate CTE names
-        if table_references
-            .outer_query_refs()
-            .iter()
-            .any(|r| r.identifier == cte_name)
-        {
-            crate::bail_parse_error!("duplicate WITH table name: {}", cte.tbl_name.as_str());
-        }
-
-        // Clone the CTE select AST before planning, so we can store it for re-planning
-        let cte_select_ast = cte.select.clone();
-        // AS MATERIALIZED forces materialization
-        let materialize_hint = cte.materialized == Materialized::Yes;
-        // Block the CTE's own name from resolving to a schema object during
-        // planning of its body (see push_cte_being_defined).
-        program.push_cte_being_defined(cte_name.clone());
-
-        // Plan the CTE SELECT
-        let cte_plan = prepare_select_plan(
-            cte.select,
+    let base_outer_query_refs =
+        base_outer_refs_for_cte_planning(table_references.outer_query_refs(), &cte_definitions);
+    for (cte_definition_index, cte_definition) in cte_definitions.iter().enumerate() {
+        let joined_table = plan_cte(
+            cte_definition_index,
+            &cte_definitions,
+            &base_outer_query_refs,
             resolver,
             program,
-            table_references.outer_query_refs(),
-            QueryDestination::placeholder_for_subquery(),
             connection,
-        );
-        program.pop_cte_being_defined();
-        let cte_plan = cte_plan?;
-
-        // Convert plan to JoinedTable to extract column info
-        let explicit_cols = if explicit_columns.is_empty() {
-            None
-        } else {
-            Some(explicit_columns.as_slice())
-        };
-        let joined_table = match cte_plan {
-            Plan::Select(_) | Plan::CompoundSelect { .. } => JoinedTable::new_subquery_from_plan(
-                cte_name.clone(),
-                cte_plan,
-                None,
-                program.table_reference_counter.next(),
-                explicit_cols,
-                None, // DML CTEs don't share materialized data (TODO: implement if needed)
-                materialize_hint,
-            )?,
-            Plan::Delete(_) | Plan::Update(_) => {
-                crate::bail_parse_error!("Only SELECT queries are supported in CTEs")
-            }
-        };
-
-        // Add CTE as outer query reference so it's available to subqueries.
-        // cte_definition_only = true: the CTE is only for subquery FROM lookup
-        // (e.g. UPDATE t SET b = (SELECT v FROM c)), not for direct column
-        // resolution (e.g. UPDATE t SET b = c.v which SQLite rejects as
-        // "no such column").
+            false,
+        )?;
         table_references.add_outer_query_reference(OuterQueryReference {
-            identifier: cte_name,
+            identifier: cte_definition.name.clone(),
             internal_id: joined_table.internal_id,
             table: joined_table.table,
             using_dedup_hidden_cols: ColumnMask::default(),
             col_used_mask: ColumnUsedMask::default(),
-            cte_select: Some(cte_select_ast),
-            cte_explicit_columns: explicit_columns,
-            cte_id: None, // DML CTEs don't track CTE sharing (TODO: implement if needed)
+            cte_select: (!cte_definition.references_itself).then(|| cte_definition.select.clone()),
+            cte_explicit_columns: cte_definition.explicit_columns.clone(),
+            cte_id: Some(cte_definition.cte_id),
             cte_definition_only: true,
             rowid_referenced: false,
             scope_depth: 0,
@@ -985,29 +1316,23 @@ fn parse_from_clause_table(
             connection,
         ),
         ast::SelectTable::Select(subselect, maybe_alias) => {
-            // For inline subqueries, we plan all CTEs once and pass them as outer_query_refs.
-            // This allows the subquery to reference CTEs defined in the parent's WITH clause.
+            // Make the parent's CTEs visible while planning this inline subquery.
             let mut outer_query_refs_for_subquery = table_references.outer_query_refs().to_vec();
             let base_outer_query_refs_for_subquery = base_outer_refs_for_cte_planning(
                 table_references.outer_query_refs(),
                 cte_definitions,
             );
-            for (idx, cte_def) in cte_definitions.iter().enumerate() {
-                // Check if this CTE has already been planned and is in outer_query_refs.
-                // This avoids exponential re-planning when CTEs have transitive dependencies.
+            for (cte_definition_index, cte_definition) in cte_definitions.iter().enumerate() {
                 if outer_query_refs_for_subquery
                     .iter()
-                    .any(|r| r.identifier == cte_def.name)
+                    .any(|reference| reference.identifier == cte_definition.name)
                 {
                     continue;
                 }
-                // Plan each CTE so it's visible to this inline subquery's FROM clause.
-                // Example: WITH cte AS (...) SELECT * FROM (SELECT * FROM cte) sub
-                // The inline subquery "(SELECT * FROM cte)" needs cte in scope, but
-                // planning this visibility isn't a reference - the actual reference
-                // happens when the inline subquery's FROM clause resolves "cte".
+                // This plan only makes the name visible. A later FROM lookup performs
+                // the real CTE use and validates its explicit column list.
                 let cte_table = plan_cte(
-                    idx,
+                    cte_definition_index,
                     cte_definitions,
                     &base_outer_query_refs_for_subquery,
                     resolver,
@@ -1016,14 +1341,15 @@ fn parse_from_clause_table(
                     false,
                 )?;
                 outer_query_refs_for_subquery.push(OuterQueryReference {
-                    identifier: cte_def.name.clone(),
+                    identifier: cte_definition.name.clone(),
                     internal_id: cte_table.internal_id,
                     table: cte_table.table,
                     using_dedup_hidden_cols: ColumnMask::default(),
                     col_used_mask: ColumnUsedMask::default(),
-                    cte_select: Some(cte_def.select.clone()),
-                    cte_explicit_columns: cte_def.explicit_columns.clone(),
-                    cte_id: Some(cte_def.cte_id),
+                    cte_select: (!cte_definition.references_itself)
+                        .then(|| cte_definition.select.clone()),
+                    cte_explicit_columns: cte_definition.explicit_columns.clone(),
+                    cte_id: Some(cte_definition.cte_id),
                     cte_definition_only: false,
                     rowid_referenced: false,
                     scope_depth: 0,
@@ -1039,7 +1365,7 @@ fn parse_from_clause_table(
                 connection,
             )?;
             match &subplan {
-                Plan::Select(_) | Plan::CompoundSelect { .. } => {}
+                Plan::Select(_) | Plan::CompoundSelect { .. } | Plan::RecursiveCte(_) => {}
                 Plan::Delete(_) | Plan::Update(_) => {
                     crate::bail_parse_error!(
                         "DELETE/UPDATE queries are not supported in FROM clause subqueries"
@@ -1097,25 +1423,24 @@ fn parse_table(
     let table_name = &qualified_name.name;
 
     if qualified_name.db_name.is_none() {
-        // Check if the FROM clause table is referring to a CTE in the current scope.
-        // Each reference gets a freshly planned CTE to ensure unique internal_ids and cursor IDs.
-        if let Some(cte_idx) = cte_definitions
+        // Each CTE use gets its own table and cursor IDs unless it shares materialized rows.
+        if let Some(cte_definition_index) = cte_definitions
             .iter()
-            .position(|cte| cte.name == normalized_qualified_name)
+            .position(|definition| definition.name == normalized_qualified_name)
         {
             let planning_outer_query_refs = base_outer_refs_for_cte_planning(
                 table_references.outer_query_refs(),
                 cte_definitions,
             );
-            // This is an actual CTE reference in the FROM/JOIN clause - count it
+            // Only a real FROM/JOIN use should report an explicit column-count mismatch.
             let mut cte_table = plan_cte(
-                cte_idx,
+                cte_definition_index,
                 cte_definitions,
                 &planning_outer_query_refs,
                 resolver,
                 program,
                 connection,
-                true, // Actual FROM/JOIN reference - count it
+                true,
             )?;
 
             // If there's an alias provided, update the identifier to use that alias
@@ -1134,21 +1459,18 @@ fn parse_table(
             return Ok(());
         }
 
-        // A non-recursive CTE's body cannot reference its own name. The CTE name
-        // shadows any same-named schema object, but without RECURSIVE it's circular.
+        // A non-recursive CTE cannot read its own name, even when a table or view
+        // with that name exists.
         if program.is_cte_being_defined(&normalized_qualified_name) {
             crate::bail_parse_error!("circular reference: {}", table_name.as_str());
         }
 
-        // Check if the table is a CTE from an outer scope (e.g., a CTE referencing another CTE).
-        // This handles cases like: WITH a AS (...), b AS (SELECT ... FROM a) SELECT * FROM b;
-        // When planning b's body, 'a' is in outer_query_refs.
+        // A CTE can read another CTE defined by the surrounding WITH clause.
         if let Some(outer_ref) =
             table_references.find_outer_query_ref_by_identifier(&normalized_qualified_name)
         {
             let alias = maybe_alias.map(|a| normalize_ident(a.name().as_str()));
-            // Clone fields we need before dropping the borrow on table_references.
-            let cte_select = outer_ref.cte_select.clone();
+            let cte_select_syntax = outer_ref.cte_select.clone();
             let cte_explicit_columns = outer_ref.cte_explicit_columns.clone();
             let cte_id = outer_ref.cte_id;
             let outer_table = outer_ref.table.clone();
@@ -1157,54 +1479,55 @@ fn parse_table(
                 _ => false,
             };
 
-            if let Some(cte_ast) = cte_select {
-                // Re-plan the CTE from its original AST to get fresh internal_ids.
-                // This prevents cursor key collisions when the same CTE is
-                // referenced multiple times in the same scope.
-                let cte_plan = prepare_select_plan(
-                    cte_ast,
+            if let Some(cte_select) = cte_select_syntax {
+                // Plan each use separately so two uses do not receive the same
+                // table or cursor IDs.
+                let cte_query_plan = prepare_select_plan(
+                    cte_select,
                     resolver,
                     program,
                     table_references.outer_query_refs(),
                     QueryDestination::placeholder_for_subquery(),
                     connection,
                 )?;
-                let explicit_cols = if cte_explicit_columns.is_empty() {
+                let explicit_columns = if cte_explicit_columns.is_empty() {
                     None
                 } else {
                     Some(cte_explicit_columns.as_slice())
                 };
-                // Validate explicit column count on actual CTE reference (matching SQLite
-                // behavior, which defers this check until the CTE is used).
-                if let Some(cols) = explicit_cols {
-                    let result_col_count = cte_plan.select_result_columns().len();
-                    if cols.len() != result_col_count {
+                // SQLite reports an explicit column-count mismatch only when the CTE is used.
+                if let Some(columns) = explicit_columns {
+                    let result_column_count = cte_query_plan.select_result_columns().len();
+                    if columns.len() != result_column_count {
                         crate::bail_parse_error!(
                             "table {} has {} columns but {} column names were provided",
                             normalized_qualified_name,
-                            result_col_count,
-                            cols.len()
+                            result_column_count,
+                            columns.len()
                         );
                     }
                 }
-                // Use the CTE name for the subquery name so query plans show
-                // "SCAN cte_name AS alias" instead of just "SCAN alias".
-                let mut jt = JoinedTable::new_subquery_from_plan(
+                let mut joined_table = JoinedTable::new_subquery_from_plan(
                     normalized_qualified_name.clone(),
-                    cte_plan,
+                    cte_query_plan,
                     None,
                     program.table_reference_counter.next(),
-                    explicit_cols,
+                    explicit_columns,
                     cte_id,
                     materialize_hint,
                 )?;
                 if let Some(alias) = alias {
-                    jt.identifier = alias;
+                    joined_table.identifier = alias;
                 }
-                jt.database_id = database_id;
-                table_references.add_joined_table(jt);
+                joined_table.database_id = database_id;
+                table_references.add_joined_table(joined_table);
             } else {
-                let internal_id = program.table_reference_counter.next();
+                // All recursive arms read the same one-row pseudo-cursor.
+                let internal_id = if matches!(outer_table, Table::RecursiveCteInput(_)) {
+                    outer_ref.internal_id
+                } else {
+                    program.table_reference_counter.next()
+                };
                 table_references.add_joined_table(JoinedTable {
                     op: Operation::default_scan_for(&outer_table),
                     table: outer_table,
@@ -1363,10 +1686,7 @@ fn parse_table(
         return Ok(());
     }
 
-    // CTEs are transformed into FROM clause subqueries.
-    // If we find a CTE with this name in our outer query references,
-    // we can use it as a joined table, but we must clone it since it's not MATERIALIZED.
-    //
+    // Query-backed CTEs become FROM-clause subqueries.
     // For other types of tables in the outer query references, we do not add them as joined tables,
     // because the query can simply _reference_ them in e.g. the SELECT columns or the WHERE clause,
     // but it's not part of the join order.
@@ -1502,64 +1822,20 @@ pub fn parse_from(
     table_references: &mut TableReferences,
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
-    // Collect CTE definitions instead of planning them immediately.
-    // Each CTE reference will be planned fresh when encountered, ensuring unique internal_ids.
-    let mut cte_definitions: Vec<CteDefinition> = vec![];
+    let mut cte_definitions = Vec::new();
 
     if let Some(with) = with {
-        if with.recursive {
-            crate::bail_parse_error!("Recursive CTEs are not yet supported");
-        }
-
-        for (idx, cte) in with.ctes.into_iter().enumerate() {
-            // Normalize explicit column names
-            let explicit_columns: Vec<String> = cte
-                .columns
-                .iter()
-                .map(|c| normalize_ident(c.col_name.as_str()))
-                .collect();
-
-            let cte_name_normalized = normalize_ident(cte.tbl_name.as_str());
-            if cte_definitions
-                .iter()
-                .any(|d| d.name == cte_name_normalized)
-            {
-                crate::bail_parse_error!("duplicate WITH table name: {}", cte.tbl_name.as_str());
-            }
-            // Collect table names referenced in this CTE's FROM clause.
-            let mut referenced_tables = Vec::new();
-            collect_from_clause_table_refs(&cte.select, &mut referenced_tables);
-
-            // Find which preceding CTEs are directly referenced by this CTE.
-            // This avoids exponential re-planning when CTEs have transitive dependencies.
-            let referenced_cte_indices: SmallVec<[usize; 2]> = (0..idx)
-                .filter(|&i| referenced_tables.contains(&cte_definitions[i].name))
-                .collect();
-
-            // AS MATERIALIZED forces materialization; AS NOT MATERIALIZED prevents it
-            let materialize_hint = cte.materialized == Materialized::Yes;
-
-            cte_definitions.push(CteDefinition {
-                cte_id: program.alloc_cte_id(),
-                name: cte_name_normalized,
-                select: cte.select,
-                explicit_columns,
-                referenced_cte_indices,
-                materialize_hint,
-            });
-        }
+        cte_definitions = collect_cte_definitions(with, program)?;
 
         if preplan_ctes_for_non_from_subqueries {
-            // Pre-plan all CTEs and add them to outer_query_refs for visibility.
-            // This is needed when non-FROM expressions contain subqueries that may reference
-            // CTEs from this WITH scope.
+            // Make these CTE names available to subqueries outside the FROM clause.
             let base_outer_query_refs = base_outer_refs_for_cte_planning(
                 table_references.outer_query_refs(),
                 &cte_definitions,
             );
-            for (idx, cte_def) in cte_definitions.iter().enumerate() {
+            for (cte_definition_index, cte_definition) in cte_definitions.iter().enumerate() {
                 let cte_table = plan_cte(
-                    idx,
+                    cte_definition_index,
                     &cte_definitions,
                     &base_outer_query_refs,
                     resolver,
@@ -1568,17 +1844,16 @@ pub fn parse_from(
                     false,
                 )?;
                 table_references.add_outer_query_reference(OuterQueryReference {
-                    identifier: cte_def.name.clone(),
+                    identifier: cte_definition.name.clone(),
                     internal_id: cte_table.internal_id,
                     table: cte_table.table,
                     using_dedup_hidden_cols: ColumnMask::default(),
                     col_used_mask: ColumnUsedMask::default(),
-                    cte_select: Some(cte_def.select.clone()),
-                    cte_explicit_columns: cte_def.explicit_columns.clone(),
-                    cte_id: Some(cte_def.cte_id),
-                    // Preplanned CTE refs are for subquery FROM lookup only. They are not
-                    // visible as column sources unless the CTE is explicitly referenced in
-                    // this scope's FROM/JOIN clause.
+                    cte_select: (!cte_definition.references_itself)
+                        .then(|| cte_definition.select.clone()),
+                    cte_explicit_columns: cte_definition.explicit_columns.clone(),
+                    cte_id: Some(cte_definition.cte_id),
+                    // This entry only lets a nested FROM clause find the CTE name.
                     cte_definition_only: true,
                     rowid_referenced: false,
                     scope_depth: 0,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1359,7 +1359,7 @@ fn prepare_recursive_cte_plan(
 fn reject_aggregates_and_windows_in_recursive_query(query: &Plan) -> Result<()> {
     match query {
         Plan::Select(select) => {
-            if !select.aggregates.is_empty() {
+            if !select.aggregates.is_empty() || select.group_by.is_some() {
                 crate::bail_parse_error!("recursive aggregate queries not supported");
             }
             if select.window.is_some() {
@@ -1369,8 +1369,11 @@ fn reject_aggregates_and_windows_in_recursive_query(query: &Plan) -> Result<()> 
         Plan::CompoundSelect {
             left, right_most, ..
         } => {
-            if left.iter().any(|(select, _)| !select.aggregates.is_empty())
+            if left
+                .iter()
+                .any(|(select, _)| !select.aggregates.is_empty() || select.group_by.is_some())
                 || !right_most.aggregates.is_empty()
+                || right_most.group_by.is_some()
             {
                 crate::bail_parse_error!("recursive aggregate queries not supported");
             }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -7,7 +7,7 @@ use super::{
     plan::{
         Aggregate, ColumnMask, ColumnUsedMask, Distinctness, EvalAt, IterationDirection, JoinInfo,
         JoinOrderMember, JoinType as PlanJoinType, JoinedTable, Operation, OuterQueryReference,
-        Plan, QueryDestination, ResultSetColumn, Scan, SelectPlan, TableReferences, WhereTerm,
+        Plan, QueryDestination, ResultSetColumn, Scan, TableReferences, WhereTerm,
     },
     select::{prepare_select_plan, prepare_select_plan_from_arms},
 };
@@ -1329,7 +1329,6 @@ fn prepare_recursive_cte_plan(
         );
     }
     reject_aggregates_and_windows_in_recursive_query(&recursive_query)?;
-    reject_outer_join_on_clause_reading_past_recursive_input(&recursive_query, input_table_id)?;
 
     let queue_order = super::select::resolve_recursive_cte_queue_order(
         &select.order_by,
@@ -1386,67 +1385,6 @@ fn reject_aggregates_and_windows_in_recursive_query(query: &Plan) -> Result<()> 
             return Err(crate::LimboError::InternalError(
                 "recursive CTE query is not a SELECT".to_string(),
             ));
-        }
-    }
-    Ok(())
-}
-
-/// SQLite scans the recursive input as the outermost loop of the recursive
-/// step, so when the input is the right operand of a LEFT or FULL join, any
-/// ON term that also reads another table in the FROM clause would depend on
-/// loops that have not started yet. SQLite rejects this with "ON clause
-/// references tables to its right" (whereexpr.c), and we mirror that.
-///
-/// A recursive input written on the left of a RIGHT JOIN ends up as the
-/// rightmost outer-joined table after the planner's swap; SQLite accepts that
-/// form, so swapped joins are skipped.
-fn reject_outer_join_on_clause_reading_past_recursive_input(
-    query: &Plan,
-    input_table_id: TableInternalId,
-) -> Result<()> {
-    let selects: Vec<&SelectPlan> = match query {
-        Plan::Select(select) => vec![select],
-        Plan::CompoundSelect {
-            left, right_most, ..
-        } => left
-            .iter()
-            .map(|(select, _)| select)
-            .chain(std::iter::once(right_most.as_ref()))
-            .collect(),
-        Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => {
-            return Err(crate::LimboError::InternalError(
-                "recursive CTE query is not a SELECT".to_string(),
-            ));
-        }
-    };
-    for select in selects {
-        if select.table_references.right_join_swapped() {
-            continue;
-        }
-        for term in &select.where_clause {
-            if term.from_outer_join != Some(input_table_id) {
-                continue;
-            }
-            let Some(input_table_idx) = select
-                .table_references
-                .joined_tables()
-                .iter()
-                .position(|table| table.internal_id == input_table_id)
-            else {
-                return Err(crate::LimboError::InternalError(
-                    "outer-join ON term references a table that is not in the FROM clause"
-                        .to_string(),
-                ));
-            };
-            let mut mask = table_mask_from_expr(
-                &term.expr,
-                &select.table_references,
-                &select.non_from_clause_subqueries,
-            )?;
-            mask.clear(input_table_idx);
-            if !mask.is_empty() {
-                crate::bail_parse_error!("ON clause references tables to its right");
-            }
         }
     }
     Ok(())

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1631,6 +1631,9 @@ fn parse_table(
             .iter()
             .position(|definition| definition.name == normalized_qualified_name)
         {
+            if !args.is_empty() {
+                crate::bail_parse_error!("'{}' is not a function", table_name.as_str());
+            }
             let planning_outer_query_refs = base_outer_refs_for_cte_planning(
                 table_references.outer_query_refs(),
                 cte_definitions,
@@ -1672,6 +1675,17 @@ fn parse_table(
         if let Some(outer_ref) =
             table_references.find_outer_query_ref_by_identifier(&normalized_qualified_name)
         {
+            if !args.is_empty() {
+                if matches!(outer_ref.table, Table::RecursiveCteInput(_)) {
+                    // SQLite resolves the recursive self-reference as a plain
+                    // table with zero table-valued-function parameters.
+                    crate::bail_parse_error!(
+                        "too many arguments on {}() - max 0",
+                        table_name.as_str()
+                    );
+                }
+                crate::bail_parse_error!("'{}' is not a function", table_name.as_str());
+            }
             let alias = maybe_alias.map(|a| normalize_ident(a.name().as_str()));
             let cte_select_syntax = outer_ref.cte_select.clone();
             let cte_explicit_columns = outer_ref.cte_explicit_columns.clone();
@@ -1758,6 +1772,9 @@ fn parse_table(
             transform_args_into_where_terms(args, internal_id, vtab_predicates, table.as_ref())?;
             Table::Virtual(tbl.clone())
         } else if let Table::BTree(table) = table.as_ref() {
+            if !args.is_empty() {
+                crate::bail_parse_error!("'{}' is not a function", table_name.as_str());
+            }
             Table::BTree(table.clone())
         } else {
             return Err(crate::LimboError::InvalidArgument(

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -78,7 +78,9 @@ fn collect_cte_definitions(with: With, program: &mut ProgramBuilder) -> Result<V
 
         let mut referenced_table_names = Vec::new();
         collect_from_clause_table_refs(&cte.select, &mut referenced_table_names);
-        let references_itself = referenced_table_names.contains(&name);
+        let references_itself = RecursiveRefCounter { cte_name: &name }
+            .count_select(&cte.select, &mut RecursiveRefScope::new())
+            > 0;
         referenced_table_names_by_cte.push(referenced_table_names);
         definitions.push(CteDefinition {
             cte_id: program.alloc_cte_id(),
@@ -136,47 +138,241 @@ fn collect_from_one_select(one: &ast::OneSelect, out: &mut Vec<String>) {
     }
 }
 
-fn count_cte_self_references(one: &ast::OneSelect, cte_name: &str) -> (usize, usize) {
-    fn count_in_from_table(table: &ast::SelectTable, cte_name: &str) -> usize {
-        match table {
-            ast::SelectTable::Table(name, _, _) | ast::SelectTable::TableCall(name, _, _) => {
-                usize::from(
-                    name.db_name.is_none() && normalize_ident(name.name.as_str()) == cte_name,
-                )
+/// Counts references to a recursive CTE's own name the way SQLite's name
+/// resolution does:
+/// - a nested `WITH` that redefines the name shadows it for that subtree, and
+/// - references inside a nested CTE body only count when that CTE is itself
+///   referenced (an unused nested CTE that mentions the recursive table does
+///   not make the query recursive), weighted by how many references its body
+///   contains.
+struct RecursiveRefCounter<'a> {
+    cte_name: &'a str,
+}
+
+/// Names visible at the current point, innermost last. Each entry carries the
+/// number of recursive references that using the name implies: 0 for a name
+/// that shadows the recursive table, and the body's own reference count for
+/// any other nested CTE.
+type RecursiveRefScope = Vec<(String, usize)>;
+
+impl RecursiveRefCounter<'_> {
+    /// The number of recursive references implied by referring to `name`.
+    fn name_weight(&self, name: &str, scope: &RecursiveRefScope) -> usize {
+        for (scope_name, weight) in scope.iter().rev() {
+            if scope_name == name {
+                return *weight;
             }
-            ast::SelectTable::Select(_, _) => 0,
+        }
+        usize::from(name == self.cte_name)
+    }
+
+    /// Brings the CTEs of a nested `WITH` into scope with their reference
+    /// weights. The caller is responsible for truncating `scope` afterwards.
+    fn push_nested_ctes(&self, with: Option<&With>, scope: &mut RecursiveRefScope) {
+        let Some(with) = with else {
+            return;
+        };
+        for cte in &with.ctes {
+            let name = normalize_ident(cte.tbl_name.as_str());
+            // The CTE's own name is visible inside its body, where it refers
+            // to the nested CTE itself rather than the recursive table.
+            scope.push((name, 0));
+            let weight = self.count_select(&cte.select, scope);
+            scope.last_mut().expect("scope entry pushed above").1 = weight;
+        }
+    }
+
+    fn count_select(&self, select: &Select, scope: &mut RecursiveRefScope) -> usize {
+        let scope_base = scope.len();
+        self.push_nested_ctes(select.with.as_ref(), scope);
+        let mut count = self.count_one_select(&select.body.select, scope);
+        for compound in &select.body.compounds {
+            count += self.count_one_select(&compound.select, scope);
+        }
+        for sorted in &select.order_by {
+            count += self.count_expr(&sorted.expr, scope);
+        }
+        if let Some(limit) = &select.limit {
+            count += self.count_expr(&limit.expr, scope);
+            if let Some(offset) = &limit.offset {
+                count += self.count_expr(offset, scope);
+            }
+        }
+        scope.truncate(scope_base);
+        count
+    }
+
+    fn count_one_select(&self, one: &ast::OneSelect, scope: &mut RecursiveRefScope) -> usize {
+        match one {
+            ast::OneSelect::Select {
+                columns,
+                from,
+                where_clause,
+                group_by,
+                window_clause,
+                ..
+            } => {
+                let mut count = 0;
+                if let Some(from) = from {
+                    count += self.count_from_table(&from.select, scope);
+                    for join in &from.joins {
+                        count += self.count_from_table(&join.table, scope);
+                        if let Some(ast::JoinConstraint::On(expr)) = &join.constraint {
+                            count += self.count_expr(expr, scope);
+                        }
+                    }
+                }
+                for column in columns {
+                    if let ast::ResultColumn::Expr(expr, _) = column {
+                        count += self.count_expr(expr, scope);
+                    }
+                }
+                if let Some(expr) = where_clause {
+                    count += self.count_expr(expr, scope);
+                }
+                if let Some(group_by) = group_by {
+                    for expr in &group_by.exprs {
+                        count += self.count_expr(expr, scope);
+                    }
+                    if let Some(having) = &group_by.having {
+                        count += self.count_expr(having, scope);
+                    }
+                }
+                for window_def in window_clause {
+                    count += self.count_window(&window_def.window, scope);
+                }
+                count
+            }
+            ast::OneSelect::Values(rows) => rows
+                .iter()
+                .flatten()
+                .map(|expr| self.count_expr(expr, scope))
+                .sum(),
+        }
+    }
+
+    fn count_from_table(&self, table: &ast::SelectTable, scope: &mut RecursiveRefScope) -> usize {
+        match table {
+            ast::SelectTable::Table(name, _, _) => {
+                if name.db_name.is_none() {
+                    self.name_weight(&normalize_ident(name.name.as_str()), scope)
+                } else {
+                    0
+                }
+            }
+            ast::SelectTable::TableCall(name, args, _) => {
+                let mut count = if name.db_name.is_none() {
+                    self.name_weight(&normalize_ident(name.name.as_str()), scope)
+                } else {
+                    0
+                };
+                for arg in args {
+                    count += self.count_expr(arg, scope);
+                }
+                count
+            }
+            ast::SelectTable::Select(subselect, _) => self.count_select(subselect, scope),
             ast::SelectTable::Sub(from, _) => {
-                count_in_from_table(&from.select, cte_name)
-                    + from
-                        .joins
-                        .iter()
-                        .map(|join| count_in_from_table(&join.table, cte_name))
-                        .sum::<usize>()
+                let mut count = self.count_from_table(&from.select, scope);
+                for join in &from.joins {
+                    count += self.count_from_table(&join.table, scope);
+                    if let Some(ast::JoinConstraint::On(expr)) = &join.constraint {
+                        count += self.count_expr(expr, scope);
+                    }
+                }
+                count
             }
         }
     }
 
-    let top_level_from_count = if let ast::OneSelect::Select {
-        from: Some(from), ..
-    } = one
-    {
-        count_in_from_table(&from.select, cte_name)
-            + from
-                .joins
-                .iter()
-                .map(|join| count_in_from_table(&join.table, cte_name))
-                .sum::<usize>()
-    } else {
-        0
-    };
-    let mut referenced_table_names = Vec::new();
-    collect_from_one_select(one, &mut referenced_table_names);
-    collect_subquery_table_refs_in_one_select(one, &mut referenced_table_names);
-    let total_count = referenced_table_names
-        .iter()
-        .filter(|name| name.as_str() == cte_name)
-        .count();
-    (top_level_from_count, total_count)
+    fn count_window(&self, window: &ast::Window, scope: &mut RecursiveRefScope) -> usize {
+        let mut count = 0;
+        for expr in &window.partition_by {
+            count += self.count_expr(expr, scope);
+        }
+        for sorted in &window.order_by {
+            count += self.count_expr(&sorted.expr, scope);
+        }
+        if let Some(frame_clause) = &window.frame_clause {
+            for bound in std::iter::once(&frame_clause.start).chain(frame_clause.end.as_ref()) {
+                if let ast::FrameBound::Following(expr) | ast::FrameBound::Preceding(expr) = bound {
+                    count += self.count_expr(expr, scope);
+                }
+            }
+        }
+        count
+    }
+
+    fn count_expr(&self, expr: &Expr, scope: &mut RecursiveRefScope) -> usize {
+        let mut count = 0;
+        let _ = walk_expr(expr, &mut |node: &Expr| -> Result<WalkControl> {
+            match node {
+                Expr::Exists(select) | Expr::Subquery(select) => {
+                    count += self.count_select(select, scope);
+                    Ok(WalkControl::SkipChildren)
+                }
+                Expr::InSelect { rhs, .. } => {
+                    count += self.count_select(rhs, scope);
+                    // The walker does not descend into the subquery, only the
+                    // left-hand side expression.
+                    Ok(WalkControl::Continue)
+                }
+                _ => Ok(WalkControl::Continue),
+            }
+        });
+        count
+    }
+
+    /// Returns `(top_level_from_count, total_count)` for one arm of a
+    /// recursive CTE body: direct references to the recursive table in the
+    /// arm's FROM clause, and all references reachable from the arm.
+    fn count_arm(&self, one: &ast::OneSelect, scope: &mut RecursiveRefScope) -> (usize, usize) {
+        fn count_direct_in_from_table(
+            counter: &RecursiveRefCounter,
+            table: &ast::SelectTable,
+            scope: &RecursiveRefScope,
+        ) -> usize {
+            match table {
+                ast::SelectTable::Table(name, _, _) | ast::SelectTable::TableCall(name, _, _) => {
+                    if name.db_name.is_some() {
+                        return 0;
+                    }
+                    let name = normalize_ident(name.name.as_str());
+                    // A direct reference only counts when nothing shadows the
+                    // recursive table's name.
+                    usize::from(
+                        name == counter.cte_name
+                            && !scope.iter().any(|(scope_name, _)| *scope_name == name),
+                    )
+                }
+                ast::SelectTable::Select(_, _) => 0,
+                ast::SelectTable::Sub(from, _) => {
+                    count_direct_in_from_table(counter, &from.select, scope)
+                        + from
+                            .joins
+                            .iter()
+                            .map(|join| count_direct_in_from_table(counter, &join.table, scope))
+                            .sum::<usize>()
+                }
+            }
+        }
+
+        let top_level_from_count = if let ast::OneSelect::Select {
+            from: Some(from), ..
+        } = one
+        {
+            count_direct_in_from_table(self, &from.select, scope)
+                + from
+                    .joins
+                    .iter()
+                    .map(|join| count_direct_in_from_table(self, &join.table, scope))
+                    .sum::<usize>()
+        } else {
+            0
+        };
+        let total_count = self.count_one_select(one, scope);
+        (top_level_from_count, total_count)
+    }
 }
 
 fn collect_from_select_table(table: &ast::SelectTable, out: &mut Vec<String>) {
@@ -985,6 +1181,14 @@ fn prepare_recursive_cte_plan(
 ) -> Result<Plan> {
     let select = &cte_definition.select;
     let mut first_recursive_query_index = None;
+    let ref_counter = RecursiveRefCounter {
+        cte_name: &cte_definition.name,
+    };
+    // Nested CTEs defined at the body level are visible in every arm; bring
+    // them into scope so shadowing and use-through-nested-CTE references are
+    // counted the way name resolution will see them.
+    let mut ref_scope = RecursiveRefScope::new();
+    ref_counter.push_nested_ctes(select.with.as_ref(), &mut ref_scope);
     for (query_index, query) in std::iter::once(&select.body.select)
         .chain(
             select
@@ -995,8 +1199,7 @@ fn prepare_recursive_cte_plan(
         )
         .enumerate()
     {
-        let (top_level_from_count, total_count) =
-            count_cte_self_references(query, &cte_definition.name);
+        let (top_level_from_count, total_count) = ref_counter.count_arm(query, &mut ref_scope);
         if first_recursive_query_index.is_none() && total_count == 0 {
             continue;
         }
@@ -1823,9 +2026,19 @@ pub fn parse_from(
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
     let mut cte_definitions = Vec::new();
+    let mut shadowed_outer_ctes = Vec::new();
 
     if let Some(with) = with {
         cte_definitions = collect_cte_definitions(with, program)?;
+
+        // This WITH clause's definitions shadow same-named CTEs from outer
+        // scopes that are still being planned, so references to those names
+        // here are not circular.
+        let shadowing_names = cte_definitions
+            .iter()
+            .map(|definition| definition.name.clone())
+            .collect::<Vec<_>>();
+        shadowed_outer_ctes = program.mask_shadowed_ctes_being_defined(&shadowing_names);
 
         if preplan_ctes_for_non_from_subqueries {
             // Make these CTE names available to subqueries outside the FROM clause.
@@ -1890,6 +2103,7 @@ pub fn parse_from(
         }
     }
 
+    program.unmask_shadowed_ctes_being_defined(shadowed_outer_ctes);
     Ok(())
 }
 

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1098,7 +1098,10 @@ fn plan_cte(
                 cte_select: None,
                 cte_explicit_columns: vec![],
                 cte_id: Some(cte_definitions[referenced_cte_index].cte_id),
-                cte_definition_only: false,
+                // This entry only lets the body's FROM clause find the sibling
+                // CTE by name; its columns become visible when a FROM clause
+                // actually adds the table.
+                cte_definition_only: true,
                 rowid_referenced: false,
                 scope_depth: 0,
             });

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1919,6 +1919,9 @@ fn is_database_empty(schema: &Schema, pager: &Arc<Pager>) -> crate::Result<bool>
             Table::BTree(tbl) => &tbl.name,
             Table::Virtual(tbl) => &tbl.name,
             Table::FromClauseSubquery(tbl) => &tbl.name,
+            Table::RecursiveCteInput(_) => {
+                unreachable!("recursive CTE inputs are not stored in the schema")
+            }
         };
 
         if table_name != "sqlite_schema" {

--- a/core/translate/recursive_cte.rs
+++ b/core/translate/recursive_cte.rs
@@ -67,10 +67,10 @@ pub(crate) fn emit_recursive_cte(
                 default: None,
                 expr: None,
             })?;
-            queue_sort_keys.push(RecursiveCteQueueKey {
+            queue_sort_keys.try_push(RecursiveCteQueueKey {
                 result_column_index: *result_column_index,
                 nulls_override,
-            });
+            })?;
         }
     }
     let queue_sort_column_count = queue_index_columns.len();

--- a/core/translate/recursive_cte.rs
+++ b/core/translate/recursive_cte.rs
@@ -14,7 +14,7 @@ use crate::translate::plan::{Plan, QueryDestination, RecursiveCtePlan, Recursive
 use crate::translate::result_row::{emit_columns_to_destination, emit_offset};
 use crate::vdbe::builder::{CursorKey, CursorType, ProgramBuilder};
 use crate::vdbe::insn::{to_u16, Insn};
-use crate::{LimboError, Result};
+use crate::{emit_explain, LimboError, Result};
 use turso_parser::ast::{NullsOrder, SortOrder};
 
 pub(crate) fn emit_recursive_cte(
@@ -158,7 +158,9 @@ pub(crate) fn emit_recursive_cte(
         &recursive_cte.offset,
     )?;
 
+    emit_explain!(program, true, "SETUP".to_owned());
     emit_recursive_cte_query(program, resolver, &mut recursive_cte.initial_query)?;
+    program.pop_current_parent_explain();
 
     program.preassign_label_to_next_insn(dequeue_next_row);
     program.emit_insn(Insn::Rewind {
@@ -211,7 +213,9 @@ pub(crate) fn emit_recursive_cte(
     }
 
     program.preassign_label_to_next_insn(run_recursive_query);
+    emit_explain!(program, true, "RECURSIVE STEP".to_owned());
     emit_recursive_cte_query(program, resolver, &mut recursive_cte.recursive_query)?;
+    program.pop_current_parent_explain();
     program.emit_insn(Insn::Goto {
         target_pc: dequeue_next_row,
     });

--- a/core/translate/recursive_cte.rs
+++ b/core/translate/recursive_cte.rs
@@ -1,0 +1,319 @@
+use crate::alloc::TursoVecExt;
+use crate::schema::{Index, IndexColumn, PseudoCursorType};
+use crate::sync::Arc;
+use crate::translate::collate::{get_collseq_from_expr, CollationSeq};
+use crate::translate::compound_select::{
+    emit_program_for_compound_select, set_select_plan_destination,
+};
+use crate::translate::emitter::{
+    init_limit,
+    select::{emit_materialized_build_inputs, emit_query},
+    Resolver, TranslateCtx,
+};
+use crate::translate::plan::{Plan, QueryDestination, RecursiveCtePlan, RecursiveCteQueueKey};
+use crate::translate::result_row::{emit_columns_to_destination, emit_offset};
+use crate::vdbe::builder::{CursorKey, CursorType, ProgramBuilder};
+use crate::vdbe::insn::{to_u16, Insn};
+use crate::{LimboError, Result};
+use turso_parser::ast::{NullsOrder, SortOrder};
+
+pub(crate) fn emit_recursive_cte(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    recursive_cte: &mut RecursiveCtePlan,
+) -> Result<usize> {
+    let num_result_columns = recursive_cte.initial_query.select_result_columns().len();
+    let input_record_reg = program.alloc_register();
+    let input_cursor_id = program.alloc_cursor_id_keyed_if_not_exists(
+        CursorKey::table(recursive_cte.input_table_id),
+        CursorType::Pseudo(PseudoCursorType {
+            column_count: num_result_columns,
+        }),
+    );
+    program.emit_insn(Insn::OpenPseudo {
+        cursor_id: input_cursor_id,
+        content_reg: input_record_reg,
+        num_fields: num_result_columns,
+    });
+
+    let mut queue_index_columns = crate::alloc::try_vec![]?;
+    let mut queue_sort_keys = Vec::new();
+    if let Some(queue_order) = &recursive_cte.queue_order {
+        for (result_column_index, order, nulls, explicit_collation) in queue_order {
+            let default_nulls = match order {
+                SortOrder::Asc => NullsOrder::First,
+                SortOrder::Desc => NullsOrder::Last,
+            };
+            let nulls_last_override = nulls
+                .filter(|nulls| *nulls != default_nulls)
+                .map(|nulls| matches!(nulls, NullsOrder::Last));
+            if nulls_last_override.is_some() {
+                queue_index_columns.try_push(IndexColumn {
+                    name: format!("null-rank-{}", queue_sort_keys.len()),
+                    order: SortOrder::Asc,
+                    pos_in_table: queue_index_columns.len(),
+                    collation: None,
+                    default: None,
+                    expr: None,
+                })?;
+            }
+            let collation = explicit_collation.or(recursive_cte_result_column_collation(
+                recursive_cte,
+                *result_column_index,
+            )?);
+            queue_index_columns.try_push(IndexColumn {
+                name: format!("priority-{}", queue_sort_keys.len()),
+                order: *order,
+                pos_in_table: queue_index_columns.len(),
+                collation,
+                default: None,
+                expr: None,
+            })?;
+            queue_sort_keys.push(RecursiveCteQueueKey {
+                result_column_index: *result_column_index,
+                nulls_last_override,
+            });
+        }
+    }
+    let queue_sort_column_count = queue_index_columns.len();
+    queue_index_columns.try_push(IndexColumn::new("sequence", queue_index_columns.len()))?;
+    for result_column_index in 0..num_result_columns {
+        queue_index_columns.try_push(IndexColumn::new(
+            format!("result-{result_column_index}"),
+            queue_index_columns.len(),
+        ))?;
+    }
+
+    let queue_index = Arc::new(Index {
+        name: format!("recursive-queue-{}", recursive_cte.name),
+        table_name: String::new(),
+        root_page: 0,
+        columns: queue_index_columns,
+        unique: true,
+        ephemeral: true,
+        has_rowid: false,
+        where_clause: None,
+        index_method: None,
+        on_conflict: None,
+    });
+    let queue_cursor_id = program.alloc_cursor_id(CursorType::BTreeIndex(queue_index.clone()));
+    program.emit_insn(Insn::OpenEphemeral {
+        cursor_id: queue_cursor_id,
+        is_table: false,
+    });
+    let seen_rows = if recursive_cte.union_all {
+        None
+    } else {
+        let mut seen_row_index_columns = crate::alloc::try_vec![]?;
+        for result_column_index in 0..num_result_columns {
+            seen_row_index_columns.try_push(IndexColumn {
+                name: format!("distinct-{result_column_index}"),
+                order: SortOrder::Asc,
+                pos_in_table: result_column_index,
+                collation: recursive_cte_result_column_collation(
+                    recursive_cte,
+                    result_column_index,
+                )?,
+                default: None,
+                expr: None,
+            })?;
+        }
+        let seen_row_index = Arc::new(Index {
+            name: format!("recursive-distinct-{}", recursive_cte.name),
+            table_name: String::new(),
+            root_page: 0,
+            columns: seen_row_index_columns,
+            unique: false,
+            ephemeral: true,
+            has_rowid: false,
+            where_clause: None,
+            index_method: None,
+            on_conflict: None,
+        });
+        let cursor_id = program.alloc_cursor_id(CursorType::BTreeIndex(seen_row_index.clone()));
+        program.emit_insn(Insn::OpenEphemeral {
+            cursor_id,
+            is_table: false,
+        });
+        Some((cursor_id, seen_row_index))
+    };
+    let seen_rows_cursor_id = seen_rows.as_ref().map(|(cursor_id, _)| *cursor_id);
+    let queue_destination = QueryDestination::RecursiveCteQueue {
+        cursor_id: queue_cursor_id,
+        index: queue_index,
+        sort_keys: queue_sort_keys,
+        seen_rows,
+    };
+
+    set_select_plan_destination(&mut recursive_cte.initial_query, &queue_destination);
+    set_select_plan_destination(&mut recursive_cte.recursive_query, &queue_destination);
+
+    let recursive_cte_end = program.allocate_label();
+    let dequeue_next_row = program.allocate_label();
+    let run_recursive_query = program.allocate_label();
+    let mut output_limit_context = TranslateCtx::new(program, resolver.fork(), 0, false);
+    output_limit_context.label_main_loop_end = Some(recursive_cte_end);
+    init_limit(
+        program,
+        &mut output_limit_context,
+        &recursive_cte.limit,
+        &recursive_cte.offset,
+    )?;
+
+    emit_recursive_cte_query(program, resolver, &mut recursive_cte.initial_query)?;
+
+    program.preassign_label_to_next_insn(dequeue_next_row);
+    program.emit_insn(Insn::Rewind {
+        cursor_id: queue_cursor_id,
+        pc_if_empty: recursive_cte_end,
+    });
+
+    let queue_column_count = queue_sort_column_count + 1 + num_result_columns;
+    let queue_row_regs = program.alloc_registers(queue_column_count);
+    for queue_column_index in 0..queue_column_count {
+        program.emit_insn(Insn::Column {
+            cursor_id: queue_cursor_id,
+            column: queue_column_index,
+            dest: queue_row_regs + queue_column_index,
+            default: None,
+        });
+    }
+    let result_row_regs = queue_row_regs + queue_sort_column_count + 1;
+    program.emit_insn(Insn::IdxDelete {
+        start_reg: queue_row_regs,
+        num_regs: queue_column_count,
+        cursor_id: queue_cursor_id,
+        raise_error_if_no_matching_entry: false,
+    });
+
+    program.emit_insn(Insn::MakeRecord {
+        start_reg: to_u16(result_row_regs),
+        count: to_u16(num_result_columns),
+        dest_reg: to_u16(input_record_reg),
+        index_name: None,
+        affinity_str: None,
+    });
+
+    emit_offset(
+        program,
+        run_recursive_query,
+        output_limit_context.reg_offset,
+    );
+    emit_columns_to_destination(
+        program,
+        &recursive_cte.query_destination,
+        result_row_regs,
+        num_result_columns,
+    )?;
+    if let Some(limit) = output_limit_context.limit_ctx {
+        program.emit_insn(Insn::DecrJumpZero {
+            reg: limit.reg_limit,
+            target_pc: recursive_cte_end,
+        });
+    }
+
+    program.preassign_label_to_next_insn(run_recursive_query);
+    emit_recursive_cte_query(program, resolver, &mut recursive_cte.recursive_query)?;
+    program.emit_insn(Insn::Goto {
+        target_pc: dequeue_next_row,
+    });
+
+    program.preassign_label_to_next_insn(recursive_cte_end);
+    program.emit_insn(Insn::Close {
+        cursor_id: queue_cursor_id,
+    });
+    if let Some(cursor_id) = seen_rows_cursor_id {
+        program.emit_insn(Insn::Close { cursor_id });
+    }
+    program.emit_insn(Insn::Close {
+        cursor_id: input_cursor_id,
+    });
+    program.result_columns = recursive_cte.initial_query.select_result_columns().to_vec();
+    program.reg_result_cols_start = Some(result_row_regs);
+    Ok(result_row_regs)
+}
+
+fn recursive_cte_result_column_collation(
+    recursive_cte: &RecursiveCtePlan,
+    result_column_index: usize,
+) -> Result<Option<CollationSeq>> {
+    let initial_query_collation = recursive_cte_query_result_column_collation(
+        &recursive_cte.initial_query,
+        result_column_index,
+    )?;
+    if initial_query_collation.is_some() {
+        Ok(initial_query_collation)
+    } else {
+        recursive_cte_query_result_column_collation(
+            &recursive_cte.recursive_query,
+            result_column_index,
+        )
+    }
+}
+
+fn recursive_cte_query_result_column_collation(
+    query: &Plan,
+    result_column_index: usize,
+) -> Result<Option<CollationSeq>> {
+    match query {
+        Plan::Select(select) => {
+            let expr = select
+                .values
+                .first()
+                .and_then(|row| row.get(result_column_index))
+                .unwrap_or(&select.result_columns[result_column_index].expr);
+            get_collseq_from_expr(expr, &select.table_references)
+        }
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => {
+            for (select, _) in left {
+                let expr = select
+                    .values
+                    .first()
+                    .and_then(|row| row.get(result_column_index))
+                    .unwrap_or(&select.result_columns[result_column_index].expr);
+                let collation = get_collseq_from_expr(expr, &select.table_references)?;
+                if collation.is_some() {
+                    return Ok(collation);
+                }
+            }
+            let expr = right_most
+                .values
+                .first()
+                .and_then(|row| row.get(result_column_index))
+                .unwrap_or(&right_most.result_columns[result_column_index].expr);
+            get_collseq_from_expr(expr, &right_most.table_references)
+        }
+        Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => Err(
+            LimboError::InternalError("recursive CTE query is not a SELECT".to_string()),
+        ),
+    }
+}
+
+fn emit_recursive_cte_query(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    query: &mut Plan,
+) -> Result<()> {
+    match query {
+        Plan::Select(select_plan) => {
+            let mut context = TranslateCtx::new(
+                program,
+                resolver.fork(),
+                select_plan.joined_tables().len(),
+                false,
+            );
+            context.materialized_build_inputs =
+                emit_materialized_build_inputs(program, &context.resolver, select_plan)?;
+            emit_query(program, select_plan, &mut context)?;
+            Ok(())
+        }
+        Plan::CompoundSelect { .. } => {
+            emit_program_for_compound_select(program, resolver, query.clone()).map(|_| ())
+        }
+        Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => Err(
+            LimboError::InternalError("recursive CTE query is not a SELECT".to_string()),
+        ),
+    }
+}

--- a/core/translate/recursive_cte.rs
+++ b/core/translate/recursive_cte.rs
@@ -37,17 +37,15 @@ pub(crate) fn emit_recursive_cte(
     });
 
     let mut queue_index_columns = crate::alloc::try_vec![]?;
-    let mut queue_sort_keys = Vec::new();
+    let mut queue_sort_keys = crate::alloc::try_vec![]?;
     if let Some(queue_order) = &recursive_cte.queue_order {
         for (result_column_index, order, nulls, explicit_collation) in queue_order {
             let default_nulls = match order {
                 SortOrder::Asc => NullsOrder::First,
                 SortOrder::Desc => NullsOrder::Last,
             };
-            let nulls_last_override = nulls
-                .filter(|nulls| *nulls != default_nulls)
-                .map(|nulls| matches!(nulls, NullsOrder::Last));
-            if nulls_last_override.is_some() {
+            let nulls_override = nulls.filter(|nulls| *nulls != default_nulls);
+            if nulls_override.is_some() {
                 queue_index_columns.try_push(IndexColumn {
                     name: format!("null-rank-{}", queue_sort_keys.len()),
                     order: SortOrder::Asc,
@@ -71,7 +69,7 @@ pub(crate) fn emit_recursive_cte(
             })?;
             queue_sort_keys.push(RecursiveCteQueueKey {
                 result_column_index: *result_column_index,
-                nulls_last_override,
+                nulls_override,
             });
         }
     }

--- a/core/translate/recursive_cte.rs
+++ b/core/translate/recursive_cte.rs
@@ -312,7 +312,7 @@ fn emit_recursive_cte_query(
             Ok(())
         }
         Plan::CompoundSelect { .. } => {
-            emit_program_for_compound_select(program, resolver, query.clone()).map(|_| ())
+            emit_program_for_compound_select(program, resolver, query).map(|_| ())
         }
         Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => Err(
             LimboError::InternalError("recursive CTE query is not a SELECT".to_string()),

--- a/core/translate/recursive_cte.rs
+++ b/core/translate/recursive_cte.rs
@@ -13,7 +13,7 @@ use crate::translate::emitter::{
 use crate::translate::plan::{Plan, QueryDestination, RecursiveCtePlan, RecursiveCteQueueKey};
 use crate::translate::result_row::{emit_columns_to_destination, emit_offset};
 use crate::vdbe::builder::{CursorKey, CursorType, ProgramBuilder};
-use crate::vdbe::insn::{to_u16, Insn};
+use crate::vdbe::insn::{to_u32, Insn};
 use crate::{emit_explain, LimboError, Result};
 use turso_parser::ast::{NullsOrder, SortOrder};
 
@@ -187,9 +187,9 @@ pub(crate) fn emit_recursive_cte(
     });
 
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(result_row_regs),
-        count: to_u16(num_result_columns),
-        dest_reg: to_u16(input_record_reg),
+        start_reg: to_u32(result_row_regs),
+        count: to_u32(num_result_columns),
+        dest_reg: to_u32(input_record_reg),
         index_name: None,
         affinity_str: None,
     });

--- a/core/translate/result_row.rs
+++ b/core/translate/result_row.rs
@@ -354,13 +354,14 @@ pub fn emit_columns_to_destination(
 
             let sort_key_column_count = sort_keys
                 .iter()
-                .map(|key| 1 + usize::from(key.nulls_last_override.is_some()))
+                .map(|key| 1 + usize::from(key.nulls_override.is_some()))
                 .sum::<usize>();
             let queue_row_start_reg =
                 program.alloc_registers(sort_key_column_count + 1 + num_columns);
             let mut queue_key_reg = queue_row_start_reg;
             for key in sort_keys {
-                if let Some(nulls_last) = key.nulls_last_override {
+                if let Some(nulls) = key.nulls_override {
+                    let nulls_last = matches!(nulls, ast::NullsOrder::Last);
                     let null_rank_ready = program.allocate_label();
                     program.emit_insn(Insn::Integer {
                         value: i64::from(nulls_last),

--- a/core/translate/result_row.rs
+++ b/core/translate/result_row.rs
@@ -2,7 +2,7 @@ use crate::turso_assert_eq;
 use crate::{
     vdbe::{
         builder::ProgramBuilder,
-        insn::{to_u16, IdxInsertFlags, InsertFlags, Insn},
+        insn::{to_u32, IdxInsertFlags, InsertFlags, Insn},
         BranchOffset,
     },
     Result,
@@ -239,9 +239,9 @@ pub fn emit_columns_to_destination(
                     };
 
                 program.emit_insn(Insn::MakeRecord {
-                    start_reg: to_u16(record_start),
-                    count: to_u16(record_count),
-                    dest_reg: to_u16(record_reg),
+                    start_reg: to_u32(record_start),
+                    count: to_u32(record_count),
+                    dest_reg: to_u32(record_reg),
                     index_name: Some(dedupe_index.name.clone()),
                     affinity_str: affinity_str.as_ref().map(|s| (**s).clone()),
                 });
@@ -269,17 +269,17 @@ pub fn emit_columns_to_destination(
                     // create a record containing the rowid so it can be read back later.
                     if num_columns == 1 {
                         program.emit_insn(Insn::MakeRecord {
-                            start_reg: to_u16(start_reg),
-                            count: to_u16(1),
-                            dest_reg: to_u16(record_reg),
+                            start_reg: to_u32(start_reg),
+                            count: to_u32(1),
+                            dest_reg: to_u32(record_reg),
                             index_name: Some(table.name.clone()),
                             affinity_str: None,
                         });
                     } else if num_columns > 1 {
                         program.emit_insn(Insn::MakeRecord {
-                            start_reg: to_u16(start_reg),
-                            count: to_u16(num_columns - 1),
-                            dest_reg: to_u16(record_reg),
+                            start_reg: to_u32(start_reg),
+                            count: to_u32(num_columns - 1),
+                            dest_reg: to_u32(record_reg),
                             index_name: Some(table.name.clone()),
                             affinity_str: None,
                         });
@@ -297,9 +297,9 @@ pub fn emit_columns_to_destination(
                 super::plan::EphemeralRowidMode::Auto => {
                     if num_columns > 0 {
                         program.emit_insn(Insn::MakeRecord {
-                            start_reg: to_u16(start_reg),
-                            count: to_u16(num_columns),
-                            dest_reg: to_u16(record_reg),
+                            start_reg: to_u32(start_reg),
+                            count: to_u32(num_columns),
+                            dest_reg: to_u32(record_reg),
                             index_name: Some(table.name.clone()),
                             affinity_str: None,
                         });
@@ -336,9 +336,9 @@ pub fn emit_columns_to_destination(
                 });
                 let record_reg = program.alloc_register();
                 program.emit_insn(Insn::MakeRecord {
-                    start_reg: to_u16(start_reg),
-                    count: to_u16(num_columns),
-                    dest_reg: to_u16(record_reg),
+                    start_reg: to_u32(start_reg),
+                    count: to_u32(num_columns),
+                    dest_reg: to_u32(record_reg),
                     index_name: Some(index.name.clone()),
                     affinity_str: None,
                 });
@@ -346,7 +346,7 @@ pub fn emit_columns_to_destination(
                     cursor_id: *cursor_id,
                     record_reg,
                     unpacked_start: Some(start_reg),
-                    unpacked_count: Some(to_u16(num_columns)),
+                    unpacked_count: Some(to_u32(num_columns)),
                     flags: IdxInsertFlags::new().no_op_duplicate(),
                 });
                 skip_seen_row
@@ -396,9 +396,9 @@ pub fn emit_columns_to_destination(
             });
             let record_reg = program.alloc_register();
             program.emit_insn(Insn::MakeRecord {
-                start_reg: to_u16(queue_row_start_reg),
-                count: to_u16(sort_key_column_count + 1 + num_columns),
-                dest_reg: to_u16(record_reg),
+                start_reg: to_u32(queue_row_start_reg),
+                count: to_u32(sort_key_column_count + 1 + num_columns),
+                dest_reg: to_u32(record_reg),
                 index_name: Some(index.name.clone()),
                 affinity_str: None,
             });

--- a/core/translate/result_row.rs
+++ b/core/translate/result_row.rs
@@ -69,6 +69,7 @@ pub fn emit_select_result(
         QueryDestination::EphemeralIndex { .. }
             | QueryDestination::CoroutineYield { .. }
             | QueryDestination::EphemeralTable { .. }
+            | QueryDestination::RecursiveCteQueue { .. }
     );
 
     if !skip_column_eval {
@@ -317,6 +318,99 @@ pub fn emit_columns_to_destination(
                         table_name: table.name.clone(),
                     });
                 }
+            }
+        }
+        QueryDestination::RecursiveCteQueue {
+            cursor_id,
+            index,
+            sort_keys,
+            seen_rows,
+        } => {
+            let skip_seen_row = seen_rows.as_ref().map(|(cursor_id, index)| {
+                let skip_seen_row = program.allocate_label();
+                program.emit_insn(Insn::Found {
+                    cursor_id: *cursor_id,
+                    target_pc: skip_seen_row,
+                    record_reg: start_reg,
+                    num_regs: num_columns,
+                });
+                let record_reg = program.alloc_register();
+                program.emit_insn(Insn::MakeRecord {
+                    start_reg: to_u16(start_reg),
+                    count: to_u16(num_columns),
+                    dest_reg: to_u16(record_reg),
+                    index_name: Some(index.name.clone()),
+                    affinity_str: None,
+                });
+                program.emit_insn(Insn::IdxInsert {
+                    cursor_id: *cursor_id,
+                    record_reg,
+                    unpacked_start: Some(start_reg),
+                    unpacked_count: Some(to_u16(num_columns)),
+                    flags: IdxInsertFlags::new().no_op_duplicate(),
+                });
+                skip_seen_row
+            });
+
+            let sort_key_column_count = sort_keys
+                .iter()
+                .map(|key| 1 + usize::from(key.nulls_last_override.is_some()))
+                .sum::<usize>();
+            let queue_row_start_reg =
+                program.alloc_registers(sort_key_column_count + 1 + num_columns);
+            let mut queue_key_reg = queue_row_start_reg;
+            for key in sort_keys {
+                if let Some(nulls_last) = key.nulls_last_override {
+                    let null_rank_ready = program.allocate_label();
+                    program.emit_insn(Insn::Integer {
+                        value: i64::from(nulls_last),
+                        dest: queue_key_reg,
+                    });
+                    program.emit_insn(Insn::IsNull {
+                        reg: start_reg + key.result_column_index,
+                        target_pc: null_rank_ready,
+                    });
+                    program.emit_insn(Insn::Integer {
+                        value: i64::from(!nulls_last),
+                        dest: queue_key_reg,
+                    });
+                    program.preassign_label_to_next_insn(null_rank_ready);
+                    queue_key_reg += 1;
+                }
+                program.emit_insn(Insn::Copy {
+                    src_reg: start_reg + key.result_column_index,
+                    dst_reg: queue_key_reg,
+                    extra_amount: 0,
+                });
+                queue_key_reg += 1;
+            }
+            program.emit_insn(Insn::Sequence {
+                cursor_id: *cursor_id,
+                target_reg: queue_row_start_reg + sort_key_column_count,
+            });
+            program.emit_insn(Insn::Copy {
+                src_reg: start_reg,
+                dst_reg: queue_row_start_reg + sort_key_column_count + 1,
+                extra_amount: num_columns - 1,
+            });
+            let record_reg = program.alloc_register();
+            program.emit_insn(Insn::MakeRecord {
+                start_reg: to_u16(queue_row_start_reg),
+                count: to_u16(sort_key_column_count + 1 + num_columns),
+                dest_reg: to_u16(record_reg),
+                index_name: Some(index.name.clone()),
+                affinity_str: None,
+            });
+            program.emit_insn(Insn::IdxInsert {
+                cursor_id: *cursor_id,
+                record_reg,
+                unpacked_start: None,
+                unpacked_count: None,
+                flags: IdxInsertFlags::new().no_op_duplicate(),
+            });
+
+            if let Some(skip_seen_row) = skip_seen_row {
+                program.preassign_label_to_next_insn(skip_seen_row);
             }
         }
         QueryDestination::CoroutineYield { yield_reg, .. } => {

--- a/core/translate/result_row.rs
+++ b/core/translate/result_row.rs
@@ -328,12 +328,10 @@ pub fn emit_columns_to_destination(
         } => {
             let skip_seen_row = seen_rows.as_ref().map(|(cursor_id, index)| {
                 let skip_seen_row = program.allocate_label();
-                program.emit_insn(Insn::Found {
-                    cursor_id: *cursor_id,
-                    target_pc: skip_seen_row,
-                    record_reg: start_reg,
-                    num_regs: num_columns,
-                });
+                // Build the probe record once and reuse it for the insert.
+                // The failed Found leaves the cursor at the insertion point
+                // (both run the same eq-only GE seek), so the insert can skip
+                // its own descent via USE_SEEK, as SQLite does.
                 let record_reg = program.alloc_register();
                 program.emit_insn(Insn::MakeRecord {
                     start_reg: to_u32(start_reg),
@@ -342,12 +340,18 @@ pub fn emit_columns_to_destination(
                     index_name: Some(index.name.clone()),
                     affinity_str: None,
                 });
+                program.emit_insn(Insn::Found {
+                    cursor_id: *cursor_id,
+                    target_pc: skip_seen_row,
+                    record_reg,
+                    num_regs: 0,
+                });
                 program.emit_insn(Insn::IdxInsert {
                     cursor_id: *cursor_id,
                     record_reg,
                     unpacked_start: Some(start_reg),
                     unpacked_count: Some(to_u32(num_columns)),
-                    flags: IdxInsertFlags::new().no_op_duplicate(),
+                    flags: IdxInsertFlags::new().no_op_duplicate().use_seek(true),
                 });
                 skip_seen_row
             });

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -26,7 +26,7 @@ use crate::util::{
 };
 use crate::vdbe::builder::CursorType;
 use crate::vdbe::insn::{
-    to_u16, {CmpInsFlags, Cookie, InsertFlags, Insn, RegisterOrLiteral},
+    to_u32, {CmpInsFlags, Cookie, InsertFlags, Insn, RegisterOrLiteral},
 };
 use crate::{bail_parse_error, turso_assert, turso_assert_eq, CaptureDataChangesExt, Result};
 use crate::{Connection, MAIN_DB_ID};
@@ -1062,9 +1062,9 @@ fn emit_ctas_insert(
     })?;
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(result_start_reg),
-        count: to_u16(col_count),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(result_start_reg),
+        count: to_u32(col_count),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });
@@ -1541,9 +1541,9 @@ pub fn emit_schema_entry(
 
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(type_reg),
-        count: to_u16(5),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(type_reg),
+        count: to_u32(5),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });
@@ -1720,9 +1720,9 @@ pub fn translate_create_virtual_table(
 
         // VCreate expects an array of args as a record
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(args_start),
-            count: to_u16(args_vec.len()),
-            dest_reg: to_u16(args_record_reg),
+            start_reg: to_u32(args_start),
+            count: to_u32(args_vec.len()),
+            dest_reg: to_u32(args_record_reg),
             index_name: None,
             affinity_str: None,
         });
@@ -2231,9 +2231,9 @@ pub fn translate_drop_table(
         });
         program.emit_column_or_rowid(sqlite_schema_cursor_id_1, 4, schema_column_4_register);
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(schema_column_0_register),
-            count: to_u16(5),
-            dest_reg: to_u16(new_record_register),
+            start_reg: to_u32(schema_column_0_register),
+            count: to_u32(5),
+            dest_reg: to_u32(new_record_register),
             index_name: None,
             affinity_str: None,
         });
@@ -2586,9 +2586,9 @@ fn persist_type_definition(
     program.emit_string8_new_reg(sql.clone());
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(name_reg),
-        count: to_u16(2),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(name_reg),
+        count: to_u32(2),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -2092,6 +2092,7 @@ pub fn translate_drop_table(
             });
         }
         Table::FromClauseSubquery(..) => panic!("FromClauseSubquery can't be dropped"),
+        Table::RecursiveCteInput(..) => panic!("recursive CTE inputs cannot be dropped"),
     };
 
     let schema_data_register = program.alloc_register();

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1197,7 +1197,7 @@ fn replace_column_number_with_copy_of_column_expr(
         }
         ast::Expr::Unary(ast::UnaryOperator::Negative, inner) => {
             if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner.as_ref() {
-                if num.parse::<usize>().is_ok() {
+                if num.parse::<i32>().is_ok() {
                     crate::bail_parse_error!(
                         "1st {} term out of range - should be between 1 and {}",
                         clause_name,
@@ -1210,17 +1210,19 @@ fn replace_column_number_with_copy_of_column_expr(
         _ => None,
     };
     if let Some(num) = num_str {
-        // Only treat as column reference if it parses as a positive integer.
-        // Float literals like "0.5" or "1.0" are valid constant expressions, not column references.
-        if let Ok(column_number) = num.parse::<usize>() {
-            if column_number == 0 || column_number > columns.len() {
+        // Only treat as column reference if it parses as an integer that fits
+        // a 32-bit int, mirroring SQLite's sqlite3ExprIsInteger. Float
+        // literals like "0.5" and integers past the 32-bit range are valid
+        // constant expressions, not column references.
+        if let Ok(column_number) = num.parse::<i32>() {
+            if column_number <= 0 || column_number as usize > columns.len() {
                 crate::bail_parse_error!(
                     "1st {} term out of range - should be between 1 and {}",
                     clause_name,
                     columns.len()
                 );
             }
-            let ResultSetColumn { expr, .. } = &columns[column_number - 1];
+            let ResultSetColumn { expr, .. } = &columns[column_number as usize - 1];
             *order_by_or_group_by_expr = expr.clone();
         }
         // Otherwise, leave the expression as-is (constant expression, case 3 per SQLite docs)
@@ -1246,17 +1248,19 @@ fn resolve_compound_order_by_expr(
             let (col_idx, _) = resolve_compound_order_by_expr(inner, all_plans, term_number)?;
             Ok((col_idx, Some(CollationSeq::new(collation_name.as_str())?)))
         }
-        // Case 1: Numeric column reference (e.g., ORDER BY 1)
+        // Case 1: Numeric column reference (e.g., ORDER BY 1). As in SQLite's
+        // sqlite3ExprIsInteger, only literals that fit a 32-bit int count as
+        // column positions.
         ast::Expr::Literal(ast::Literal::Numeric(num)) => {
-            if let Ok(column_number) = num.parse::<usize>() {
-                if column_number == 0 || column_number > num_result_columns {
+            if let Ok(column_number) = num.parse::<i32>() {
+                if column_number <= 0 || column_number as usize > num_result_columns {
                     crate::bail_parse_error!(
                         "{} ORDER BY term out of range - should be between 1 and {}",
                         column_number,
                         num_result_columns
                     );
                 }
-                Ok((column_number - 1, None))
+                Ok((column_number as usize - 1, None))
             } else {
                 crate::bail_parse_error!(
                     "{} ORDER BY term does not match any column in the result set",

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -101,6 +101,14 @@ pub fn emit_select_plan(
                         .sum::<usize>(),
             }
         }
+        Plan::RecursiveCte(recursive_cte) => {
+            num_result_cols = recursive_cte.initial_query.select_result_columns().len();
+            ProgramBuilderOpts {
+                num_cursors: count_required_cursors_for_plan(&plan),
+                approx_num_insns: estimate_num_instructions_for_plan(&plan),
+                approx_num_labels: estimate_num_labels_for_plan(&plan),
+            }
+        }
         _ => crate::bail_parse_error!("emit_select_plan called with non-SELECT plan"),
     };
 
@@ -118,6 +126,10 @@ fn plan_first_virtual_table_name(plan: &Plan) -> Option<String> {
             left.iter()
                 .find_map(|(plan, _)| select_plan_first_virtual_table_name(plan))
         }),
+        Plan::RecursiveCte(recursive_cte) => {
+            plan_first_virtual_table_name(&recursive_cte.initial_query)
+                .or_else(|| plan_first_virtual_table_name(&recursive_cte.recursive_query))
+        }
         Plan::Delete(_) | Plan::Update(_) => None,
     }
 }
@@ -148,7 +160,6 @@ fn select_plan_first_virtual_table_name(select_plan: &SelectPlan) -> Option<Stri
     None
 }
 
-#[turso_macros::trace_stack]
 pub fn prepare_select_plan(
     select: ast::Select,
     resolver: &Resolver,
@@ -157,105 +168,113 @@ pub fn prepare_select_plan(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<Plan> {
-    let compounds = select.body.compounds;
-    match compounds.is_empty() {
-        true => Ok(Plan::Select(Box::new(prepare_one_select_plan(
-            select.body.select,
+    prepare_select_plan_from_arms(
+        select.body.select,
+        select.body.compounds,
+        select.with,
+        select.order_by,
+        select.limit,
+        resolver,
+        program,
+        outer_query_refs,
+        query_destination,
+        connection,
+    )
+}
+
+/// Plans a first SELECT arm followed by zero or more compound arms.
+///
+/// Accepting the arms directly lets recursive CTE planning divide a stored
+/// SELECT without allocating temporary compound-arm vectors.
+#[allow(clippy::too_many_arguments)]
+#[turso_macros::trace_stack]
+pub(crate) fn prepare_select_plan_from_arms(
+    first_arm: ast::OneSelect,
+    compound_arms: impl IntoIterator<Item = CompoundSelect>,
+    with: Option<ast::With>,
+    order_by: Vec<ast::SortedColumn>,
+    limit: Option<ast::Limit>,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+    outer_query_refs: &[OuterQueryReference],
+    query_destination: QueryDestination,
+    connection: &Arc<crate::Connection>,
+) -> Result<Plan> {
+    let mut compound_arms = compound_arms.into_iter().peekable();
+    if compound_arms.peek().is_none() {
+        return Ok(Plan::Select(Box::new(prepare_one_select_plan(
+            first_arm,
             resolver,
             program,
-            select.limit,
-            select.order_by,
-            select.with,
+            limit,
+            order_by,
+            with,
             outer_query_refs,
             query_destination,
             connection,
-        )?))),
-        false => {
-            // For compound SELECTs, the WITH clause applies to all parts.
-            // We clone the WITH clause for each SELECT in the compound so that
-            // each one can resolve CTE references independently.
-            let with = select.with;
+        )?)));
+    }
 
-            let mut last = prepare_one_select_plan(
-                select.body.select,
-                resolver,
-                program,
-                None,
-                vec![],
-                with.clone(),
-                outer_query_refs,
-                query_destination.clone(),
-                connection,
-            )?;
+    // The WITH clause applies to every arm, so each arm needs its own copy
+    // while names are resolved.
+    let mut last = prepare_one_select_plan(
+        first_arm,
+        resolver,
+        program,
+        None,
+        vec![],
+        with.clone(),
+        outer_query_refs,
+        query_destination.clone(),
+        connection,
+    )?;
 
-            let mut left = Vec::with_capacity(compounds.len());
-            for CompoundSelect {
-                select: compound_select,
-                operator,
-            } in compounds
-            {
-                left.push((last, operator));
-                last = prepare_one_select_plan(
-                    compound_select,
-                    resolver,
-                    program,
-                    None,
-                    vec![],
-                    with.clone(),
-                    outer_query_refs,
-                    query_destination.clone(),
-                    connection,
-                )?;
-            }
+    let mut left = Vec::with_capacity(compound_arms.size_hint().0);
+    for CompoundSelect {
+        select: compound_select,
+        operator,
+    } in compound_arms
+    {
+        left.push((last, operator));
+        last = prepare_one_select_plan(
+            compound_select,
+            resolver,
+            program,
+            None,
+            vec![],
+            with.clone(),
+            outer_query_refs,
+            query_destination.clone(),
+            connection,
+        )?;
+    }
 
-            // Ensure all subplans have the same number of result columns
-            let right_most_num_result_columns = last.result_columns.len();
-            for (plan, operator) in left.iter() {
-                if plan.result_columns.len() != right_most_num_result_columns {
-                    crate::bail_parse_error!(
-                        "SELECTs to the left and right of {} do not have the same number of result columns",
-                        operator
-                    );
-                }
-            }
-            let (limit, offset) = select
-                .limit
-                .map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
-
-            // Parse ORDER BY for compound selects.
-            // ORDER BY can reference columns by number (1-based) or by name/alias
-            // from any constituent SELECT's result columns.
-            let all_plans: Vec<&SelectPlan> = left
-                .iter()
-                .map(|(plan, _)| plan)
-                .chain(std::iter::once(&last))
-                .collect();
-            let order_by = if select.order_by.is_empty() {
-                None
-            } else {
-                let mut key = Vec::with_capacity(select.order_by.len());
-                for (i, o) in select.order_by.iter().enumerate() {
-                    let (col_idx, collation) =
-                        resolve_compound_order_by_expr(&o.expr, &all_plans, i + 1)?;
-                    key.push((
-                        col_idx,
-                        o.order.unwrap_or(ast::SortOrder::Asc),
-                        o.nulls,
-                        collation,
-                    ));
-                }
-                Some(key)
-            };
-
-            Ok(Plan::CompoundSelect {
-                left,
-                right_most: Box::new(last),
-                limit,
-                offset,
-                order_by,
-            })
+    let right_most_num_result_columns = last.result_columns.len();
+    for (plan, operator) in &left {
+        if plan.result_columns.len() != right_most_num_result_columns {
+            crate::bail_parse_error!(
+                "SELECTs to the left and right of {} do not have the same number of result columns",
+                operator
+            );
         }
     }
+    let (limit, offset) = limit.map_or(Ok((None, None)), |limit| parse_limit(limit, resolver))?;
+
+    // ORDER BY names can come from any arm of a compound SELECT.
+    let all_plans: Vec<&SelectPlan> = left
+        .iter()
+        .map(|(plan, _)| plan)
+        .chain(std::iter::once(&last))
+        .collect();
+    let order_by = resolve_compound_order_by(&order_by, &all_plans)?;
+
+    Ok(Plan::CompoundSelect {
+        left,
+        right_most: Box::new(last),
+        limit,
+        offset,
+        order_by,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1054,6 +1073,16 @@ fn reject_outer_scope_refs_inside_plan_tree(
             }
             reject_outer_scope_refs_inside_select_plan(right_most, current_scope_table_refs)
         }
+        Plan::RecursiveCte(recursive_cte) => {
+            reject_outer_scope_refs_inside_plan_tree(
+                &recursive_cte.initial_query,
+                current_scope_table_refs,
+            )?;
+            reject_outer_scope_refs_inside_plan_tree(
+                &recursive_cte.recursive_query,
+                current_scope_table_refs,
+            )
+        }
         Plan::Delete(_) | Plan::Update(_) => Ok(()),
     }
 }
@@ -1273,6 +1302,55 @@ fn resolve_compound_order_by_expr(
     }
 }
 
+fn resolve_compound_order_by(
+    order_by: &[ast::SortedColumn],
+    plans: &[&SelectPlan],
+) -> Result<Option<Vec<super::plan::CompoundOrderByKey>>> {
+    if order_by.is_empty() {
+        return Ok(None);
+    }
+    order_by
+        .iter()
+        .enumerate()
+        .map(|(index, term)| {
+            let (column, collation) = resolve_compound_order_by_expr(&term.expr, plans, index + 1)?;
+            Ok((
+                column,
+                term.order.unwrap_or(ast::SortOrder::Asc),
+                term.nulls,
+                collation,
+            ))
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(Some)
+}
+
+pub(crate) fn resolve_recursive_cte_queue_order(
+    order_by: &[ast::SortedColumn],
+    initial_query: &Plan,
+    recursive_query: &Plan,
+) -> Result<Option<Vec<super::plan::CompoundOrderByKey>>> {
+    fn collect_selects<'a>(plan: &'a Plan, out: &mut Vec<&'a SelectPlan>) {
+        match plan {
+            Plan::Select(plan) => out.push(plan),
+            Plan::CompoundSelect {
+                left, right_most, ..
+            } => {
+                out.extend(left.iter().map(|(plan, _)| plan));
+                out.push(right_most);
+            }
+            Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => {
+                unreachable!("recursive CTE queries must be SELECT plans")
+            }
+        }
+    }
+
+    let mut plans = Vec::new();
+    collect_selects(initial_query, &mut plans);
+    collect_selects(recursive_query, &mut plans);
+    resolve_compound_order_by(order_by, &plans)
+}
+
 fn ordinal(n: usize) -> String {
     let suffix = match (n % 10, n % 100) {
         (1, 11) | (2, 12) | (3, 13) => "th",
@@ -1284,8 +1362,8 @@ fn ordinal(n: usize) -> String {
     format!("{n}{suffix}")
 }
 
-/// Count required cursors for a Plan (either Select or CompoundSelect)
-fn count_required_cursors_for_simple_or_compound_select(plan: &Plan) -> usize {
+/// Counts cursors needed to emit a query plan.
+fn count_required_cursors_for_plan(plan: &Plan) -> usize {
     match plan {
         Plan::Select(select_plan) => count_required_cursors_for_simple_select(select_plan),
         Plan::CompoundSelect {
@@ -1296,6 +1374,11 @@ fn count_required_cursors_for_simple_or_compound_select(plan: &Plan) -> usize {
                     .iter()
                     .map(|(p, _)| count_required_cursors_for_simple_select(p))
                     .sum::<usize>()
+        }
+        Plan::RecursiveCte(recursive_cte) => {
+            count_required_cursors_for_plan(&recursive_cte.initial_query)
+                + count_required_cursors_for_plan(&recursive_cte.recursive_query)
+                + 2
         }
         Plan::Delete(_) | Plan::Update(_) => 0,
     }
@@ -1322,7 +1405,7 @@ fn count_required_cursors_for_simple_select(plan: &SelectPlan) -> usize {
             // One table cursor + one cursor per index branch
             Operation::MultiIndexScan(multi_idx) => 1 + multi_idx.branches.len(),
         } + if let Table::FromClauseSubquery(from_clause_subquery) = &t.table {
-            count_required_cursors_for_simple_or_compound_select(&from_clause_subquery.plan)
+            count_required_cursors_for_plan(&from_clause_subquery.plan)
         } else {
             0
         })
@@ -1337,8 +1420,8 @@ fn count_required_cursors_for_simple_select(plan: &SelectPlan) -> usize {
     num_table_cursors + num_sorter_cursors + num_pseudo_cursors
 }
 
-/// Estimate number of instructions for a Plan (either Select or CompoundSelect)
-fn estimate_num_instructions_for_simple_or_compound_select(plan: &Plan) -> usize {
+/// Estimates bytecode instructions needed to emit a query plan.
+fn estimate_num_instructions_for_plan(plan: &Plan) -> usize {
     match plan {
         Plan::Select(select_plan) => estimate_num_instructions_for_simple_select(select_plan),
         Plan::CompoundSelect {
@@ -1350,6 +1433,11 @@ fn estimate_num_instructions_for_simple_or_compound_select(plan: &Plan) -> usize
                     .map(|(p, _)| estimate_num_instructions_for_simple_select(p))
                     .sum::<usize>()
                 + 20 // overhead for compound select operations
+        }
+        Plan::RecursiveCte(recursive_cte) => {
+            estimate_num_instructions_for_plan(&recursive_cte.initial_query)
+                + estimate_num_instructions_for_plan(&recursive_cte.recursive_query)
+                + 32
         }
         Plan::Delete(_) | Plan::Update(_) => 0,
     }
@@ -1367,7 +1455,7 @@ fn estimate_num_instructions_for_simple_select(select: &SelectPlan) -> usize {
             // Multi-index scan: scan overhead per branch + deduplication + final rowid fetch
             Operation::MultiIndexScan(multi_idx) => 15 * multi_idx.branches.len() + 10,
         } + if let Table::FromClauseSubquery(from_clause_subquery) = &t.table {
-            10 + estimate_num_instructions_for_simple_or_compound_select(&from_clause_subquery.plan)
+            10 + estimate_num_instructions_for_plan(&from_clause_subquery.plan)
         } else {
             0
         })
@@ -1581,8 +1669,8 @@ fn select_has_non_from_subqueries(
     false
 }
 
-/// Estimate number of labels for a Plan (either Select or CompoundSelect)
-fn estimate_num_labels_for_simple_or_compound_select(plan: &Plan) -> usize {
+/// Estimates jump labels needed to emit a query plan.
+fn estimate_num_labels_for_plan(plan: &Plan) -> usize {
     match plan {
         Plan::Select(select_plan) => estimate_num_labels_for_simple_select(select_plan),
         Plan::CompoundSelect {
@@ -1594,6 +1682,11 @@ fn estimate_num_labels_for_simple_or_compound_select(plan: &Plan) -> usize {
                     .map(|(p, _)| estimate_num_labels_for_simple_select(p))
                     .sum::<usize>()
                 + 10 // overhead for compound select operations
+        }
+        Plan::RecursiveCte(recursive_cte) => {
+            estimate_num_labels_for_plan(&recursive_cte.initial_query)
+                + estimate_num_labels_for_plan(&recursive_cte.recursive_query)
+                + 4
         }
         Plan::Delete(_) | Plan::Update(_) => 0,
     }
@@ -1613,7 +1706,7 @@ fn estimate_num_labels_for_simple_select(select: &SelectPlan) -> usize {
             // Multi-index scan needs extra labels for each branch + rowset loop
             Operation::MultiIndexScan(multi_idx) => 3 + multi_idx.branches.len() * 2,
         } + if let Table::FromClauseSubquery(from_clause_subquery) = &t.table {
-            3 + estimate_num_labels_for_simple_or_compound_select(&from_clause_subquery.plan)
+            3 + estimate_num_labels_for_plan(&from_clause_subquery.plan)
         } else {
             0
         })

--- a/core/translate/sequence.rs
+++ b/core/translate/sequence.rs
@@ -23,7 +23,7 @@ use crate::translate::emitter::Resolver;
 use crate::translate::schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID};
 use crate::util::{escape_sql_string_literal, normalize_ident};
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
-use crate::vdbe::insn::{to_u16, CmpInsFlags, Cookie, InsertFlags, Insn, RegisterOrLiteral};
+use crate::vdbe::insn::{to_u32, CmpInsFlags, Cookie, InsertFlags, Insn, RegisterOrLiteral};
 use crate::Result;
 use turso_parser::ast;
 
@@ -128,9 +128,9 @@ pub fn emit_sequence_backing_table(
 
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(base_reg),
+        start_reg: to_u32(base_reg),
         count: 7,
-        dest_reg: to_u16(record_reg),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });
@@ -276,9 +276,9 @@ pub fn emit_disk_read_nextval(
 
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(col_base),
+        start_reg: to_u32(col_base),
         count: 7,
-        dest_reg: to_u16(record_reg),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });
@@ -509,9 +509,9 @@ pub fn emit_disk_advance_past(
 
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(col_base),
+        start_reg: to_u32(col_base),
         count: 7,
-        dest_reg: to_u16(record_reg),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });
@@ -720,9 +720,9 @@ pub(crate) fn emit_sqlite_sequence_sync(
     });
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(col_base),
-        count: to_u16(2),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(col_base),
+        count: to_u32(2),
+        dest_reg: to_u32(record_reg),
         index_name: None,
         affinity_str: None,
     });

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1699,12 +1699,10 @@ pub fn emit_from_clause_subquery(
                 emit_query(program, select_plan, &mut metadata)?
             }
             Plan::CompoundSelect { .. } => {
-                // Clone the plan to pass to emit_program_for_compound_select (it takes ownership)
-                let plan_clone = plan.clone();
                 let resolver = t_ctx.resolver.fork();
                 // emit_program_for_compound_select returns the result column start register
                 // for coroutine mode, which is needed by the outer query.
-                emit_program_for_compound_select(program, &resolver, plan_clone)?
+                emit_program_for_compound_select(program, &resolver, plan)?
                     .expect("compound CTE in coroutine mode must have result register")
             }
             Plan::RecursiveCte(recursive_cte) => {
@@ -1791,9 +1789,8 @@ fn emit_indexed_materialized_subquery(
             emit_query(program, select_plan, &mut metadata)?;
         }
         Plan::CompoundSelect { .. } => {
-            let plan_clone = plan.clone();
             let resolver = t_ctx.resolver.fork();
-            emit_program_for_compound_select(program, &resolver, plan_clone)?;
+            emit_program_for_compound_select(program, &resolver, plan)?;
         }
         Plan::RecursiveCte(_) => {
             unreachable!("recursive CTEs require table-backed materialization for indexed access")
@@ -1889,10 +1886,8 @@ fn emit_materialized_subquery_table(
             emit_query(program, select_plan, &mut metadata)?;
         }
         Plan::CompoundSelect { .. } => {
-            // Clone the plan to pass to emit_program_for_compound_select (it takes ownership)
-            let plan_clone = plan.clone();
             let resolver = t_ctx.resolver.fork();
-            emit_program_for_compound_select(program, &resolver, plan_clone)?;
+            emit_program_for_compound_select(program, &resolver, plan)?;
         }
         Plan::RecursiveCte(recursive_cte) => {
             super::recursive_cte::emit_recursive_cte(program, &t_ctx.resolver, recursive_cte)?;
@@ -1977,8 +1972,8 @@ pub fn emit_non_from_clause_subquery(
                         emit_program_for_select(program, resolver, *select_plan)
                     }
                 }
-                compound @ Plan::CompoundSelect { .. } => {
-                    emit_program_for_compound_select(program, resolver, compound)?;
+                mut compound @ Plan::CompoundSelect { .. } => {
+                    emit_program_for_compound_select(program, resolver, &mut compound)?;
                     Ok(())
                 }
                 _ => unreachable!("DML plans cannot be subqueries"),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -139,6 +139,10 @@ fn count_shared_cte_references_in_plan(counts: &mut HashMap<usize, usize>, plan:
                 &right_most.non_from_clause_subqueries,
             );
         }
+        Plan::RecursiveCte(recursive_cte) => {
+            count_shared_cte_references_in_plan(counts, &recursive_cte.initial_query);
+            count_shared_cte_references_in_plan(counts, &recursive_cte.recursive_query);
+        }
         Plan::Delete(_) | Plan::Update(_) => {}
     }
 }
@@ -168,6 +172,10 @@ pub(crate) fn mark_shared_cte_materialization_requirements(
                     &mut right_most.table_references,
                     &mut right_most.non_from_clause_subqueries,
                 );
+            }
+            Plan::RecursiveCte(recursive_cte) => {
+                annotate_plan(&mut recursive_cte.initial_query);
+                annotate_plan(&mut recursive_cte.recursive_query);
             }
             Plan::Delete(_) | Plan::Update(_) => {}
         }
@@ -1144,6 +1152,10 @@ fn update_column_used_masks(
                 }
                 propagate_outer_refs_from_select_plan(table_refs, right_most)?;
             }
+            Plan::RecursiveCte(recursive_cte) => {
+                propagate_outer_refs_from_plan(table_refs, &recursive_cte.initial_query)?;
+                propagate_outer_refs_from_plan(table_refs, &recursive_cte.recursive_query)?;
+            }
             Plan::Delete(_) | Plan::Update(_) => {
                 return Err(crate::LimboError::InternalError(
                     "DELETE/UPDATE plans should not appear in FROM clause subqueries".into(),
@@ -1206,6 +1218,10 @@ fn pre_materialize_multi_ref_ctes(
                 pre_materialize_multi_ref_ctes_in_select_plan(program, select_plan, t_ctx)?;
             }
             pre_materialize_multi_ref_ctes_in_select_plan(program, right_most, t_ctx)?;
+        }
+        Plan::RecursiveCte(recursive_cte) => {
+            pre_materialize_multi_ref_ctes(program, &mut recursive_cte.initial_query, t_ctx)?;
+            pre_materialize_multi_ref_ctes(program, &mut recursive_cte.recursive_query, t_ctx)?;
         }
         Plan::Delete(_) | Plan::Update(_) => {}
     }
@@ -1401,7 +1417,9 @@ pub fn emit_from_clause_subqueries(
                                 format!("SCAN {table_name}")
                             }
                         }
-                        Scan::VirtualTable { .. } | Scan::Subquery { .. } => {
+                        Scan::VirtualTable { .. }
+                        | Scan::Subquery { .. }
+                        | Scan::RecursiveCteInput => {
                             format!("SCAN {table_name}")
                         }
                     }
@@ -1689,6 +1707,9 @@ pub fn emit_from_clause_subquery(
                 emit_program_for_compound_select(program, &resolver, plan_clone)?
                     .expect("compound CTE in coroutine mode must have result register")
             }
+            Plan::RecursiveCte(recursive_cte) => {
+                super::recursive_cte::emit_recursive_cte(program, &t_ctx.resolver, recursive_cte)?
+            }
             Plan::Delete(_) | Plan::Update(_) => {
                 unreachable!("DELETE/UPDATE plans cannot be FROM clause subqueries")
             }
@@ -1773,6 +1794,9 @@ fn emit_indexed_materialized_subquery(
             let plan_clone = plan.clone();
             let resolver = t_ctx.resolver.fork();
             emit_program_for_compound_select(program, &resolver, plan_clone)?;
+        }
+        Plan::RecursiveCte(_) => {
+            unreachable!("recursive CTEs require table-backed materialization for indexed access")
         }
         Plan::Delete(_) | Plan::Update(_) => {
             unreachable!("DELETE/UPDATE plans cannot be FROM clause subqueries")
@@ -1869,6 +1893,9 @@ fn emit_materialized_subquery_table(
             let plan_clone = plan.clone();
             let resolver = t_ctx.resolver.fork();
             emit_program_for_compound_select(program, &resolver, plan_clone)?;
+        }
+        Plan::RecursiveCte(recursive_cte) => {
+            super::recursive_cte::emit_recursive_cte(program, &t_ctx.resolver, recursive_cte)?;
         }
         Plan::Delete(_) | Plan::Update(_) => {
             unreachable!("DELETE/UPDATE plans cannot be FROM clause subqueries")

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -20,7 +20,7 @@ use crate::translate::planner::ROWID_STRS;
 use crate::translate::trigger_exec::{
     fire_trigger, get_triggers_including_temp, has_triggers_including_temp, TriggerContext,
 };
-use crate::vdbe::insn::{to_u16, CmpInsFlags};
+use crate::vdbe::insn::{to_u32, CmpInsFlags};
 use crate::{
     bail_parse_error,
     error::SQLITE_CONSTRAINT_NOTNULL,
@@ -1097,9 +1097,9 @@ pub fn emit_upsert(
 
             let rec = program.alloc_register();
             program.emit_insn(Insn::MakeRecord {
-                start_reg: to_u16(ins),
-                count: to_u16(k + 1),
-                dest_reg: to_u16(rec),
+                start_reg: to_u32(ins),
+                count: to_u32(k + 1),
+                dest_reg: to_u32(rec),
                 index_name: Some((*idx_name).clone()),
                 affinity_str: None,
             });
@@ -1245,7 +1245,7 @@ pub fn emit_upsert(
                 cursor_id: pending.idx_cid,
                 record_reg: pending.record_reg,
                 unpacked_start: Some(pending.ins_start),
-                unpacked_count: Some((k + 1) as u16),
+                unpacked_count: Some((k + 1) as u32),
                 flags: IdxInsertFlags::new().nchange(true),
             });
 

--- a/core/translate/values.rs
+++ b/core/translate/values.rs
@@ -1,7 +1,7 @@
 use crate::translate::emitter::TranslateCtx;
 use crate::translate::expr::{translate_expr_no_constant_opt, NoConstantOptReason};
 use crate::translate::plan::{QueryDestination, SelectPlan};
-use crate::translate::result_row::emit_offset;
+use crate::translate::result_row::{emit_columns_to_destination, emit_offset};
 use crate::turso_assert_eq;
 use crate::vdbe::builder::ProgramBuilder;
 use crate::vdbe::insn::{to_u16, IdxInsertFlags, InsertFlags, Insn};
@@ -25,6 +25,7 @@ pub fn emit_values(
         }
         QueryDestination::EphemeralIndex { .. } => emit_toplevel_values(program, plan, t_ctx)?,
         QueryDestination::EphemeralTable { .. } => emit_toplevel_values(program, plan, t_ctx)?,
+        QueryDestination::RecursiveCteQueue { .. } => emit_toplevel_values(program, plan, t_ctx)?,
         QueryDestination::ExistsSubqueryResult { result_reg } => {
             program.emit_insn(Insn::Integer {
                 value: 1,
@@ -206,6 +207,9 @@ fn emit_values_to_destination(
         }
         QueryDestination::EphemeralTable { .. } => {
             emit_values_to_table(program, plan, start_reg, row_len);
+        }
+        destination @ QueryDestination::RecursiveCteQueue { .. } => {
+            emit_columns_to_destination(program, destination, start_reg, row_len)?;
         }
         QueryDestination::ExistsSubqueryResult { result_reg } => {
             program.emit_insn(Insn::Integer {

--- a/core/translate/values.rs
+++ b/core/translate/values.rs
@@ -4,7 +4,7 @@ use crate::translate::plan::{QueryDestination, SelectPlan};
 use crate::translate::result_row::{emit_columns_to_destination, emit_offset};
 use crate::turso_assert_eq;
 use crate::vdbe::builder::ProgramBuilder;
-use crate::vdbe::insn::{to_u16, IdxInsertFlags, InsertFlags, Insn};
+use crate::vdbe::insn::{to_u32, IdxInsertFlags, InsertFlags, Insn};
 use crate::vdbe::BranchOffset;
 use crate::Result;
 
@@ -319,9 +319,9 @@ fn emit_values_to_index(
         };
 
         program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(record_start),
-            count: to_u16(record_count),
-            dest_reg: to_u16(record_reg),
+            start_reg: to_u32(record_start),
+            count: to_u32(record_count),
+            dest_reg: to_u32(record_reg),
             index_name: Some(index.name.clone()),
             affinity_str: affinity_str.as_ref().map(|s| (**s).clone()),
         });
@@ -351,9 +351,9 @@ fn emit_values_to_table(
     let record_reg = program.alloc_register();
     let rowid_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(start_reg),
-        count: to_u16(row_len),
-        dest_reg: to_u16(record_reg),
+        start_reg: to_u32(start_reg),
+        count: to_u32(row_len),
+        dest_reg: to_u32(record_reg),
         index_name: Some(table.name.clone()),
         affinity_str: None,
     });

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -21,7 +21,7 @@ use crate::types::KeyInfo;
 use crate::util::exprs_are_equivalent;
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
 use crate::vdbe::insn::{
-    to_u16, {InsertFlags, Insn},
+    to_u32, {InsertFlags, Insn},
 };
 use crate::vdbe::{BranchOffset, CursorID};
 use crate::Connection;
@@ -1296,9 +1296,9 @@ fn emit_insert_row_into_buffer(
     let reg_record = program.alloc_register();
 
     program.emit_insn(Insn::MakeRecord {
-        start_reg: to_u16(registers.src_columns_start),
-        count: to_u16(*input_column_count),
-        dest_reg: to_u16(reg_record),
+        start_reg: to_u32(registers.src_columns_start),
+        count: to_u32(*input_column_count),
+        dest_reg: to_u32(reg_record),
         index_name: None,
         affinity_str: None,
     });

--- a/core/types.rs
+++ b/core/types.rs
@@ -3341,6 +3341,11 @@ impl Cursor {
         match self {
             Self::BTree(cursor) => cursor.set_null_flag(flag),
             Self::Virtual(cursor) => cursor.set_null_flag(flag),
+            // A pseudo cursor always decodes columns from its content
+            // register. SQLite's OP_NullRow likewise leaves pseudo-cursor
+            // column reads untouched: nullRow is the steady state for pseudo
+            // cursors there, and OP_Column keeps routing to the register.
+            Self::Pseudo(_) => {}
             _ => {
                 mark_unlikely();
                 panic!("set_null_flag on unexpected cursor type");

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -750,6 +750,30 @@ impl ProgramBuilder {
         self.ctes_being_defined.iter().any(|n| n == name)
     }
 
+    /// Hide CTEs being defined whose names an inner WITH clause redefines:
+    /// the inner definitions shadow the outer names for that lexical scope,
+    /// so references to them are not circular. Returns the hidden names for
+    /// [Self::unmask_shadowed_ctes_being_defined].
+    pub fn mask_shadowed_ctes_being_defined(&mut self, shadowing_names: &[String]) -> Vec<String> {
+        let mut masked = Vec::new();
+        self.ctes_being_defined.retain(|name| {
+            if shadowing_names.contains(name) {
+                masked.push(name.clone());
+                false
+            } else {
+                true
+            }
+        });
+        masked
+    }
+
+    /// Restore names hidden by [Self::mask_shadowed_ctes_being_defined] when
+    /// their shadowing scope ends. Membership is all that matters for the
+    /// circular-reference check, so restore order is irrelevant.
+    pub fn unmask_shadowed_ctes_being_defined(&mut self, masked: Vec<String>) {
+        self.ctes_being_defined.extend(masked);
+    }
+
     /// Temporarily take the CTE-being-defined stack (e.g. during view
     /// expansion, which should not see CTE context from the caller).
     pub fn take_ctes_being_defined(&mut self) -> Vec<String> {

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1,10 +1,12 @@
 use std::num::{NonZero, NonZeroUsize};
 
-/// Convert a usize to u16 for instruction fields (registers, counts).
-/// Panics if the value exceeds u16::MAX.
+/// Convert a usize to u32 for instruction fields (registers, counts).
+/// Panics if the value exceeds u32::MAX, which would require an impossible
+/// four-billion-register program; u16 was too small for real queries (e.g. a
+/// handful of CTEs at the 2000-column limit already exceed 65535 registers).
 #[inline]
-pub fn to_u16(v: usize) -> u16 {
-    v.try_into().expect("value exceeds u16::MAX")
+pub fn to_u32(v: usize) -> u32 {
+    v.try_into().expect("value exceeds u32::MAX")
 }
 
 use super::{execute, BranchOffset, CursorID, FuncCtx, InsnFunction, PageIdx};
@@ -803,9 +805,9 @@ pub enum Insn {
 
     // Make a record and write it to destination register.
     MakeRecord {
-        start_reg: u16, // P1
-        count: u16,     // P2
-        dest_reg: u16,  // P3
+        start_reg: u32, // P1
+        count: u32,     // P2
+        dest_reg: u32,  // P3
         index_name: Option<String>,
         affinity_str: Option<String>,
     },
@@ -1000,7 +1002,7 @@ pub enum Insn {
         cursor_id: CursorID,
         record_reg: usize, // P2 the register containing the record to insert
         unpacked_start: Option<usize>, // P3 the index of the first register for the unpacked key
-        unpacked_count: Option<u16>, // P4 # of unpacked values in the key in P2
+        unpacked_count: Option<u32>, // P4 # of unpacked values in the key in P2
         flags: IdxInsertFlags, // TODO: optimization
     },
 
@@ -1853,21 +1855,21 @@ pub enum Insn {
     /// payload_dest_reg..payload_dest_reg+num_payload-1.
     /// If no matches, jump to target_pc.
     HashProbe {
-        hash_table_id: u16,
-        key_start_reg: u16,
-        num_keys: u16,
-        dest_reg: u16,
+        hash_table_id: u32,
+        key_start_reg: u32,
+        num_keys: u32,
+        dest_reg: u32,
         target_pc: BranchOffset,
         /// Starting register to write payload columns from hash entry.
-        payload_dest_reg: Option<u16>,
+        payload_dest_reg: Option<u32>,
         /// Number of payload columns expected
-        num_payload: u16,
+        num_payload: u32,
         /// Register containing probe-side rowid for grace hash join buffering.
         /// When Some and target partition is on disk, buffer the probe row
         /// instead of loading the partition on demand.
         /// When None, this instruction is running inside grace processing and
         /// the build partition must already be loaded.
-        probe_rowid_reg: Option<u16>,
+        probe_rowid_reg: Option<u32>,
     },
 
     /// Advance to next matching row in hash table bucket.
@@ -1933,14 +1935,14 @@ pub enum Insn {
     /// Finalizes probe-side spills and calls grace_begin.
     /// Jumps to target_pc if no spilling occurred or no partitions to process.
     HashGraceInit {
-        hash_table_id: u16,
+        hash_table_id: u32,
         target_pc: BranchOffset,
     },
 
     /// Load the current grace partition's build side from disk.
     /// Also loads the first probe chunk. Jumps to target_pc when all partitions done.
     HashGraceLoadPartition {
-        hash_table_id: u16,
+        hash_table_id: u32,
         target_pc: BranchOffset,
     },
 
@@ -1948,17 +1950,17 @@ pub enum Insn {
     /// Writes probe keys to key_start_reg..key_start_reg+num_keys-1 and probe rowid to probe_rowid_dest.
     /// Jumps to target_pc when probe entries exhausted.
     HashGraceNextProbe {
-        hash_table_id: u16,
-        key_start_reg: u16,
-        num_keys: u16,
-        probe_rowid_dest: u16,
+        hash_table_id: u32,
+        key_start_reg: u32,
+        num_keys: u32,
+        probe_rowid_dest: u32,
         target_pc: BranchOffset,
     },
 
     /// Evict current grace partition and advance to the next one.
     /// Jumps to target_pc when all partitions are processed.
     HashGraceAdvancePartition {
-        hash_table_id: u16,
+        hash_table_id: u32,
         target_pc: BranchOffset,
     },
 
@@ -2342,5 +2344,17 @@ mod tests {
                 variant, *variant as usize
             );
         }
+    }
+
+    #[test]
+    fn test_insn_size_does_not_grow() {
+        // Interpreter dispatch is sensitive to instruction size. Widening a
+        // variant past the current largest one silently degrades every query;
+        // grow this bound only deliberately.
+        assert!(
+            std::mem::size_of::<super::Insn>() <= 96,
+            "Insn grew to {} bytes",
+            std::mem::size_of::<super::Insn>()
+        );
     }
 }

--- a/perf/memory/codspeed/benches/memory_profiles.rs
+++ b/perf/memory/codspeed/benches/memory_profiles.rs
@@ -28,11 +28,12 @@ use memory_benchmark::workload::{
 
 const MODES: [JournalMode; 2] = [JournalMode::Wal, JournalMode::Mvcc];
 
-const WORKLOADS: [WorkloadProfile; 6] = [
+const WORKLOADS: [WorkloadProfile; 7] = [
     WorkloadProfile::InsertHeavy,
     WorkloadProfile::ReadHeavy,
     WorkloadProfile::Mixed,
     WorkloadProfile::ScanHeavy,
+    WorkloadProfile::RecursiveCte,
     WorkloadProfile::SeriesBlob,
     WorkloadProfile::UpdateChurn,
 ];
@@ -59,6 +60,7 @@ const MVCC_CHECKPOINT_THRESHOLD_BYTES: i64 = 16 * 1024;
 fn base_workload_size(workload: WorkloadProfile) -> (usize, usize) {
     match workload {
         WorkloadProfile::ScanHeavy => (5, 2),
+        WorkloadProfile::RecursiveCte => (2, 100),
         _ => (10, 50),
     }
 }

--- a/perf/memory/src/profile/mod.rs
+++ b/perf/memory/src/profile/mod.rs
@@ -2,6 +2,7 @@ pub mod checkpoint;
 pub mod insert;
 pub mod mixed;
 pub mod read;
+pub mod recursive_cte;
 pub mod scan;
 pub mod series_blob;
 pub mod update_churn;

--- a/perf/memory/src/profile/recursive_cte.rs
+++ b/perf/memory/src/profile/recursive_cte.rs
@@ -1,0 +1,99 @@
+use super::{Phase, Profile, WorkItem};
+
+/// Recursive-CTE workload covering the queue shapes with distinct memory
+/// behavior: a constant-width linear queue, a priority queue, a global UNION
+/// distinct set, and an infinite producer stopped by an outer LIMIT.
+pub struct RecursiveCte {
+    iterations: usize,
+    output_rows: usize,
+    current_iteration: usize,
+}
+
+impl RecursiveCte {
+    pub fn new(iterations: usize, output_rows: usize) -> Self {
+        Self {
+            iterations,
+            output_rows: output_rows.max(1),
+            current_iteration: 0,
+        }
+    }
+}
+
+impl Profile for RecursiveCte {
+    fn name(&self) -> &str {
+        "recursive-cte"
+    }
+
+    fn next_batch(&mut self, connections: usize) -> (Phase, Vec<Vec<WorkItem>>) {
+        if self.current_iteration >= self.iterations {
+            return (Phase::Done, vec![]);
+        }
+
+        let rows = self.output_rows as i64;
+        let mut batches = Vec::with_capacity(connections);
+        for _ in 0..connections {
+            batches.push(vec![
+                WorkItem {
+                    sql: "SELECT (WITH RECURSIVE seq(x) AS (VALUES(1) UNION ALL SELECT x + 1 FROM seq WHERE x < ?) SELECT count(*) FROM seq)".to_string(),
+                    params: vec![turso::Value::Integer(rows)],
+                },
+                WorkItem {
+                    sql: "SELECT (WITH RECURSIVE tree(x, depth) AS (VALUES(1, 0) UNION ALL SELECT x * 2, depth + 1 FROM tree WHERE depth < 20 UNION ALL SELECT x * 2 + 1, depth + 1 FROM tree WHERE depth < 20 ORDER BY 2, 1 LIMIT ?) SELECT count(*) FROM tree)".to_string(),
+                    params: vec![turso::Value::Integer(rows)],
+                },
+                WorkItem {
+                    sql: "SELECT (WITH RECURSIVE cycle(x) AS (VALUES(0) UNION SELECT (x + 1) % ? FROM cycle) SELECT count(*) FROM cycle)".to_string(),
+                    params: vec![turso::Value::Integer(rows)],
+                },
+                WorkItem {
+                    sql: "SELECT count(*) FROM (WITH RECURSIVE infinite(x) AS (VALUES(1) UNION ALL SELECT x + 1 FROM infinite) SELECT x FROM infinite LIMIT ?)".to_string(),
+                    params: vec![turso::Value::Integer(rows)],
+                },
+            ]);
+        }
+
+        self.current_iteration += 1;
+        (Phase::Run, batches)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recursive_cte_profile_emits_all_queue_shapes_per_connection() {
+        let mut profile = RecursiveCte::new(1, 128);
+        let (phase, batches) = profile.next_batch(3);
+
+        assert_eq!(phase, Phase::Run);
+        assert_eq!(batches.len(), 3);
+        for batch in batches {
+            assert_eq!(batch.len(), 4);
+            assert!(batch[0].sql.contains("UNION ALL"));
+            assert!(batch[1].sql.contains("ORDER BY 2, 1 LIMIT ?"));
+            assert!(batch[2].sql.contains("UNION SELECT"));
+            assert!(batch[3].sql.contains("infinite"));
+            assert!(
+                batch
+                    .iter()
+                    .all(|item| { item.params == vec![turso::Value::Integer(128)] })
+            );
+        }
+
+        let (phase, batches) = profile.next_batch(3);
+        assert_eq!(phase, Phase::Done);
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn recursive_cte_profile_never_generates_zero_cardinality() {
+        let mut profile = RecursiveCte::new(1, 0);
+        let (_, batches) = profile.next_batch(1);
+        assert!(
+            batches[0]
+                .iter()
+                .all(|item| item.params == vec![turso::Value::Integer(1)])
+        );
+    }
+}

--- a/perf/memory/src/workload.rs
+++ b/perf/memory/src/workload.rs
@@ -7,7 +7,8 @@ use turso::params::Params;
 
 use super::profile::{
     Phase, Profile, WorkItem, checkpoint::Checkpoint, insert::InsertHeavy, mixed::Mixed,
-    read::ReadHeavy, scan::ScanHeavy, series_blob::SeriesBlob, update_churn::UpdateChurn,
+    read::ReadHeavy, recursive_cte::RecursiveCte, scan::ScanHeavy, series_blob::SeriesBlob,
+    update_churn::UpdateChurn,
 };
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -31,6 +32,7 @@ pub enum WorkloadProfile {
     ReadHeavy,
     Mixed,
     ScanHeavy,
+    RecursiveCte,
     SeriesBlob,
     UpdateChurn,
 }
@@ -42,6 +44,7 @@ impl std::fmt::Display for WorkloadProfile {
             WorkloadProfile::ReadHeavy => write!(f, "read-heavy"),
             WorkloadProfile::Mixed => write!(f, "mixed"),
             WorkloadProfile::ScanHeavy => write!(f, "scan-heavy"),
+            WorkloadProfile::RecursiveCte => write!(f, "recursive-cte"),
             WorkloadProfile::SeriesBlob => write!(f, "series-blob"),
             WorkloadProfile::UpdateChurn => write!(f, "update-churn"),
         }
@@ -91,6 +94,7 @@ pub fn create_profile(
         WorkloadProfile::ReadHeavy => Box::new(ReadHeavy::new(iterations, batch_size)),
         WorkloadProfile::Mixed => Box::new(Mixed::new(iterations, batch_size)),
         WorkloadProfile::ScanHeavy => Box::new(ScanHeavy::new(iterations, batch_size)),
+        WorkloadProfile::RecursiveCte => Box::new(RecursiveCte::new(iterations, batch_size)),
         WorkloadProfile::SeriesBlob => Box::new(SeriesBlob::new(iterations, batch_size)),
         WorkloadProfile::UpdateChurn => Box::new(UpdateChurn::new(iterations, batch_size)),
     };

--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -179,7 +179,7 @@ INTEGER. Unknown type names pass through as custom types.
 | Non-decimal integer literals | ✅ Supported | `0x`, `0o`, `0b` |
 | ORDER BY NULLS FIRST/LAST | ✅ Supported | Honored in SELECT, window, and compound SELECT ORDER BY; rejected (matching SQLite) in CREATE INDEX |
 | range_agg range type aggregation function | ❌ Not supported | |
-| Recursive queries | ❌ Not supported | WITH RECURSIVE translates but the engine rejects it ("Recursive CTEs are not yet supported") |
+| Recursive queries | 🟡 Partial | WITH RECURSIVE works with SQLite semantics (row-at-a-time recursive term, so e.g. DISTINCT in the recursive term over a multi-row anchor can differ from PG); SEARCH/CYCLE clauses are rejected |
 | regexp_count, regexp_instr, regexp_like | ❌ Not supported | Regex *operators* (`~`, `~*`, SIMILAR TO) work |
 | Return OLD and NEW values from modified rows | ❌ Not supported | |
 | Row-wise comparison | ❌ Not supported | Row constructors `(a,b) < (c,d)` fail to translate |
@@ -194,7 +194,7 @@ INTEGER. Unknown type names pass through as custom types.
 | Window functions | 🟡 Partial | Aggregate window functions (COUNT/SUM/AVG/MIN/MAX OVER), row_number, PARTITION BY/ORDER BY, frame clauses, and named WINDOW clauses work; rank, dense_rank, lag, lead, etc. are not implemented |
 | WITHIN GROUP clause | ❌ Not supported | Silently dropped; ordered-set aggregates (percentile_cont) missing |
 | WITH ORDINALITY clause | ❌ Not supported | |
-| WITH queries (Common Table Expressions) | ✅ Supported | Non-recursive only; MATERIALIZED hints accepted |
+| WITH queries (Common Table Expressions) | ✅ Supported | Including WITH RECURSIVE; MATERIALIZED hints accepted |
 | Writable WITH queries (Common Table Expressions) | ❌ Not supported | "CTE query is not a SELECT statement" |
 
 ## Data Definition Language (DDL)

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -3356,6 +3356,20 @@ impl PostgreSQLTranslator {
 
             let tbl_name = ast::Name::from_string(&cte.ctename);
 
+            // PostgreSQL evaluates SEARCH/CYCLE by adding computed columns to
+            // the recursion; silently dropping them would change results (and
+            // a CYCLE clause is often what makes the query terminate at all).
+            if cte.search_clause.is_some() {
+                return Err(ParseError::ParseError(
+                    "SEARCH clause on a common table expression is not supported".into(),
+                ));
+            }
+            if cte.cycle_clause.is_some() {
+                return Err(ParseError::ParseError(
+                    "CYCLE clause on a common table expression is not supported".into(),
+                ));
+            }
+
             // Translate column aliases if specified
             let columns: Vec<ast::IndexedColumn> = cte
                 .aliascolnames
@@ -6918,5 +6932,35 @@ mod tests {
             }
             other => panic!("Expected CreateSequence, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_recursive_cte_cycle_clause_rejected() {
+        let translator = PostgreSQLTranslator::new();
+        let sql = "WITH RECURSIVE walk(dst) AS (
+            SELECT 1 UNION ALL SELECT w.dst + 1 FROM walk w WHERE w.dst < 3
+        ) CYCLE dst SET is_cycle USING path
+        SELECT * FROM walk";
+        let parse_result = crate::parse(sql).unwrap();
+        let err = translator.translate(&parse_result).unwrap_err();
+        assert!(
+            err.to_string().contains("CYCLE clause"),
+            "expected CYCLE clause rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_recursive_cte_search_clause_rejected() {
+        let translator = PostgreSQLTranslator::new();
+        let sql = "WITH RECURSIVE walk(dst) AS (
+            SELECT 1 UNION ALL SELECT w.dst + 1 FROM walk w WHERE w.dst < 3
+        ) SEARCH DEPTH FIRST BY dst SET ordercol
+        SELECT * FROM walk";
+        let parse_result = crate::parse(sql).unwrap();
+        let err = translator.translate(&parse_result).unwrap_err();
+        assert!(
+            err.to_string().contains("SEARCH clause"),
+            "expected SEARCH clause rejection, got: {err}"
+        );
     }
 }

--- a/sqlite/conformance/sqlite-sqltests/compound-select-orderby.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/compound-select-orderby.sqltest
@@ -1,5 +1,14 @@
 @database :memory:
 
+# Integer literals past the 32-bit range are not column positions; in a
+# compound ORDER BY they fail to match a result column (SQLite semantics).
+test compound-order-by-integer-beyond-i32-does-not-match {
+    SELECT 1 UNION SELECT 2 ORDER BY 6641019685895816357;
+}
+expect error {
+    1st ORDER BY term does not match any column in the result set
+}
+
 setup schema {
     CREATE TABLE t1 (a INTEGER, b TEXT, c INTEGER);
     INSERT INTO t1 VALUES (3, 'cherry', 30);

--- a/sqlite/conformance/sqlite-sqltests/cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/cte.sqltest
@@ -1463,3 +1463,20 @@ expect {
     1
     2
 }
+
+# A CTE is not a table-valued function; calling it with arguments is an error.
+test cte-referenced-with-call-arguments-rejected {
+    WITH cte1(x) AS (VALUES(1)) SELECT * FROM cte1(7);
+}
+expect error {
+    'cte1' is not a function
+}
+
+# Neither is a regular table.
+test table-referenced-with-call-arguments-rejected {
+    CREATE TABLE not_a_function(a);
+    SELECT * FROM not_a_function(5);
+}
+expect error {
+    'not_a_function' is not a function
+}

--- a/sqlite/conformance/sqlite-sqltests/cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/cte.sqltest
@@ -1464,6 +1464,32 @@ expect {
     2
 }
 
+# An unqualified column in a correlated subquery resolves against a CTE joined
+# in the outer FROM clause, same as a plain table.
+test cte-unqualified-correlated-ref-in-exists {
+    WITH c(x) AS (SELECT 1)
+    SELECT * FROM c WHERE EXISTS (SELECT 1 WHERE x > 0);
+}
+expect {
+    1
+}
+
+# A sibling CTE's columns are not visible in another CTE's body unless the
+# body's FROM clause adds the table.
+test cte-sibling-columns-not-visible-without-from {
+    WITH a(y) AS (SELECT 1), b AS (SELECT y) SELECT * FROM b;
+}
+expect error {
+    no such column: y
+}
+
+test cte-sibling-columns-not-visible-in-subquery-without-from {
+    WITH a(y) AS (SELECT 1), b AS (SELECT (SELECT y)) SELECT * FROM b;
+}
+expect error {
+    no such column: y
+}
+
 # A CTE is not a table-valued function; calling it with arguments is an error.
 test cte-referenced-with-call-arguments-rejected {
     WITH cte1(x) AS (VALUES(1)) SELECT * FROM cte1(7);

--- a/sqlite/conformance/sqlite-sqltests/orderby/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/orderby/memory.sqltest
@@ -230,3 +230,43 @@ expect error {
     1st ORDER BY term out of range - should be between 1 and 2
 }
 
+# Only integer literals that fit a 32-bit int are column positions
+# (SQLite's sqlite3ExprIsInteger); larger ones are constant expressions.
+test order-by-integer-beyond-i32-is-constant {
+    CREATE TABLE t16(a);
+    INSERT INTO t16 VALUES(1),(2);
+    SELECT a FROM t16 ORDER BY 6641019685895816357, a DESC;
+}
+expect {
+    2
+    1
+}
+
+test order-by-i32-max-is-positional {
+    CREATE TABLE t17(a);
+    INSERT INTO t17 VALUES(1);
+    SELECT a FROM t17 ORDER BY 2147483647;
+}
+expect error {
+    1st ORDER BY term out of range - should be between 1 and 1
+}
+
+test order-by-negative-integer-beyond-i32-is-constant {
+    CREATE TABLE t18(a);
+    INSERT INTO t18 VALUES(1),(2);
+    SELECT a FROM t18 ORDER BY -6641019685895816357, a DESC;
+}
+expect {
+    2
+    1
+}
+
+test group-by-integer-beyond-i32-is-constant {
+    CREATE TABLE t19(a);
+    INSERT INTO t19 VALUES(1);
+    SELECT a FROM t19 GROUP BY 6641019685895816357;
+}
+expect {
+    1
+}
+

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -1733,3 +1733,19 @@ expect {
     2|1,3
     3|1,3
 }
+
+test recursive-cte-left-join-recursive-ref-on-inner-side {
+    CREATE TABLE lj(a);
+    INSERT INTO lj VALUES(1),(2),(3);
+    WITH RECURSIVE c(x) AS (
+        SELECT 1
+        UNION
+        SELECT lj.a FROM lj LEFT JOIN c ON 0
+    )
+    SELECT * FROM c;
+}
+expect {
+    1
+    2
+    3
+}

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -1855,6 +1855,22 @@ expect error {
     multiple recursive references: w
 }
 
+# An unqualified column in a correlated subquery resolves against the
+# recursive self-reference like any other outer table.
+test recursive-cte-unqualified-correlated-ref-in-exists {
+    WITH RECURSIVE c(x) AS (
+        SELECT 1
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 3 AND EXISTS (SELECT 1 WHERE x > 0)
+    )
+    SELECT * FROM c;
+}
+expect {
+    1
+    2
+    3
+}
+
 # GROUP BY makes the recursive term an aggregate query even without aggregate
 # functions; SQLite rejects it rather than producing non-monotonic results.
 test recursive-cte-group-by-in-recursive-term-rejected {

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -1749,3 +1749,82 @@ expect {
     2
     3
 }
+
+test recursive-cte-nested-with-shadows-outer-name {
+    WITH RECURSIVE t21(a, b) AS (
+        WITH t21(x) AS (VALUES (1))
+        SELECT x, x FROM t21 ORDER BY 1 LIMIT 5
+    )
+    SELECT * FROM t21 AS tA, t21 AS tB;
+}
+expect {
+    1|1|1|1
+}
+
+test recursive-cte-unused-nested-cte-self-ref-is-not-a-recursive-ref {
+    WITH RECURSIVE c(x) AS (
+        WITH t(y) AS (SELECT x FROM c)
+        SELECT 1
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 3
+    )
+    SELECT * FROM c;
+}
+expect {
+    1
+    2
+    3
+}
+
+test recursive-cte-unused-nested-cte-self-ref-keeps-cte-non-recursive {
+    WITH RECURSIVE c AS (
+        WITH t AS (SELECT * FROM c)
+        SELECT 1
+    )
+    SELECT * FROM c;
+}
+expect {
+    1
+}
+
+test recursive-cte-used-nested-cte-self-ref-rejected {
+    WITH RECURSIVE c(x, m) AS (
+        WITH t AS (SELECT max(x) AS m FROM c)
+        SELECT 1, 0
+        UNION ALL
+        SELECT x + 1, (SELECT m FROM t) FROM c WHERE x < 4
+    )
+    SELECT * FROM c;
+}
+expect error {
+    multiple recursive references: c
+}
+
+test recursive-cte-visited-set-via-nested-cte-rejected {
+    CREATE TABLE visited_edge(a, b);
+    INSERT INTO visited_edge VALUES(1, 2), (2, 3), (3, 2);
+    WITH RECURSIVE reach(n) AS (
+        WITH seen AS (SELECT n FROM reach)
+        SELECT 1
+        UNION ALL
+        SELECT e.b FROM reach r JOIN visited_edge e ON e.a = r.n
+        WHERE e.b NOT IN (SELECT n FROM seen)
+    )
+    SELECT count(*) FROM reach;
+}
+expect error {
+    multiple recursive references: reach
+}
+
+test recursive-cte-window-clause-self-ref-rejected {
+    WITH RECURSIVE w(x) AS (
+        SELECT 1
+        UNION ALL
+        SELECT x + 1 FROM w WHERE x < 3
+        WINDOW win AS (PARTITION BY (SELECT max(x) FROM w))
+    )
+    SELECT * FROM w;
+}
+expect error {
+    multiple recursive references: w
+}

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -1,0 +1,1735 @@
+# Recursive CTE conformance and regression coverage.
+#
+# These cases intentionally exercise the queue semantics described by SQLite's
+# select.c: anchors fill the queue, one row becomes the current recursive row,
+# and the recursive terms append work until the queue is empty.
+
+@database :memory:
+
+test recursive-cte-series-with-keyword {
+    WITH RECURSIVE seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 10
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+}
+
+test recursive-cte-series-keyword-optional {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 5
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+}
+
+test recursive-cte-multiple-anchor-rows {
+    WITH seq(x) AS (
+        VALUES(1), (10)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 3
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    10
+    2
+    3
+}
+
+test recursive-cte-multiple-anchor-arms {
+    WITH seq(x) AS (
+        SELECT 1
+        UNION ALL
+        SELECT 10
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 3
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    10
+    2
+    3
+}
+
+test recursive-cte-multiple-recursive-arms {
+    WITH seq(x) AS (
+        VALUES(0)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 2
+        UNION ALL
+        SELECT x + 10 FROM seq WHERE x < 20
+    )
+    SELECT x FROM seq LIMIT 12;
+}
+expect {
+    0
+    1
+    10
+    2
+    11
+    20
+    12
+    21
+    22
+}
+
+test recursive-cte-union-stops-cycle {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION
+        SELECT (x + 1) % 10 FROM seq
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    0
+}
+
+test recursive-cte-union-null-equality {
+    WITH seq(x) AS (
+        VALUES(NULL)
+        UNION
+        SELECT NULL FROM seq
+    )
+    SELECT quote(x) FROM seq;
+}
+expect {
+    NULL
+}
+
+test recursive-cte-union-numeric-equality {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION
+        SELECT 1.0 FROM seq
+    )
+    SELECT typeof(x), quote(x) FROM seq;
+}
+expect {
+    integer|1
+}
+
+test recursive-cte-union-anchor-collation {
+    WITH seq(x) AS (
+        VALUES('a' COLLATE nocase)
+        UNION
+        SELECT upper(x) FROM seq
+    )
+    SELECT x FROM seq;
+}
+expect {
+    a
+}
+
+test recursive-cte-union-recursive-collation {
+    WITH seq(x) AS (
+        VALUES('a')
+        UNION
+        SELECT upper(x) COLLATE nocase FROM seq
+    )
+    SELECT x FROM seq;
+}
+expect {
+    a
+}
+
+test recursive-cte-limit {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq
+        LIMIT 5
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+}
+
+test recursive-cte-limit-offset {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq
+        LIMIT 5 OFFSET 5
+    )
+    SELECT x FROM seq;
+}
+expect {
+    6
+    7
+    8
+    9
+    10
+}
+
+test recursive-cte-zero-limit-does-not-recurse {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT 1 / 0 FROM seq
+        LIMIT 0
+    )
+    SELECT x FROM seq;
+}
+expect {
+}
+
+test recursive-cte-zero-limit-skips-initial-query {
+    WITH seq(x) AS (
+        SELECT json_extract('not-json', '$')
+        UNION ALL
+        SELECT x FROM seq
+        LIMIT 0
+    )
+    SELECT x FROM seq;
+}
+expect {
+}
+
+test recursive-cte-outer-limit-short-circuits-infinite-sequence {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq
+    )
+    SELECT x FROM seq LIMIT 5;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+}
+
+test recursive-cte-large-linear-count {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 10000
+    )
+    SELECT count(*), min(x), max(x), sum(x) FROM seq;
+}
+expect {
+    10000|1|10000|50005000
+}
+
+test recursive-cte-large-union-cycle-uses-global-distinct-index {
+    WITH cycle(x) AS (
+        VALUES(0)
+        UNION
+        SELECT (x + 1) % 20000 FROM cycle
+    )
+    SELECT count(*), min(x), max(x), sum(x) FROM cycle;
+}
+expect {
+    20000|0|19999|199990000
+}
+
+@cross-check-integrity
+test recursive-cte-graph-breadth-first {
+    CREATE TABLE edge(parent INTEGER, child INTEGER);
+    CREATE INDEX edge_parent ON edge(parent);
+    INSERT INTO edge VALUES
+        (1,2), (1,3), (2,4), (2,5), (3,6), (5,7);
+    WITH path(node, depth) AS (
+        VALUES(1, 0)
+        UNION ALL
+        SELECT child, depth + 1
+          FROM edge JOIN path ON edge.parent = path.node
+        ORDER BY 2, 1
+    )
+    SELECT node, depth FROM path;
+}
+expect {
+    1|0
+    2|1
+    3|1
+    4|2
+    5|2
+    6|2
+    7|3
+}
+
+# Minimized from differential-fuzzer seed 120717, statement 481. Older SQLite
+# releases incorrectly elide the outer ORDER BY for this shape; Turso must sort
+# before applying the outer OFFSET.
+@skip-if sqlite "SQLite 3.49.1 elides the outer ORDER BY for this recursive CTE shape"
+test recursive-cte-fuzz-120717-outer-order-after-priority-queue {
+    WITH RECURSIVE c(x) AS MATERIALIZED (
+        VALUES(8)
+        UNION
+        SELECT (x + 3) % 10 FROM c
+        ORDER BY 1
+        LIMIT 20 OFFSET 2
+    )
+    SELECT x FROM c ORDER BY x LIMIT 20 OFFSET 2;
+}
+expect {
+    3
+    4
+    5
+    6
+    7
+    9
+}
+
+test recursive-cte-anchor-only-when-step-filter-is-false {
+    WITH RECURSIVE c(x) AS (
+        VALUES(7)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE 0
+    )
+    SELECT x FROM c;
+}
+expect {
+    7
+}
+
+test recursive-cte-negative-limit-means-unlimited {
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 4
+        LIMIT -1
+    )
+    SELECT x FROM c;
+}
+expect {
+    1
+    2
+    3
+    4
+}
+
+test recursive-cte-expression-limit-and-offset {
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 20
+        LIMIT 2 + 3 OFFSET 1 + 1
+    )
+    SELECT x FROM c;
+}
+expect {
+    3
+    4
+    5
+    6
+    7
+}
+
+test recursive-cte-multicolumn-union-distinct {
+    WITH RECURSIVE c(x, label) AS (
+        VALUES(0, 'A')
+        UNION
+        SELECT (x + 1) % 3, lower(label) FROM c
+    )
+    SELECT x, label FROM c;
+}
+expect {
+    0|A
+    1|a
+    2|a
+    0|a
+}
+
+@cross-check-integrity
+test recursive-cte-recursive-step-joins-indexed-table {
+    CREATE TABLE edge(parent INTEGER, child INTEGER);
+    CREATE INDEX edge_parent_idx ON edge(parent);
+    INSERT INTO edge VALUES (1,2), (1,3), (2,4), (3,5);
+    WITH RECURSIVE walk(node) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT child
+          FROM walk JOIN edge ON edge.parent = walk.node
+        ORDER BY 1
+    )
+    SELECT node FROM walk;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+}
+
+@cross-check-integrity
+test recursive-cte-step-uses-scalar-subquery {
+    CREATE TABLE config(delta INTEGER);
+    INSERT INTO config VALUES(2);
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + (SELECT delta FROM config) FROM c WHERE x < 5
+    )
+    SELECT x FROM c;
+}
+expect {
+    1
+    3
+    5
+}
+
+test recursive-cte-text-values-grow-dynamically {
+    WITH RECURSIVE c(value) AS (
+        VALUES('a')
+        UNION ALL
+        SELECT value || 'x' FROM c WHERE length(value) < 4
+    )
+    SELECT value, typeof(value) FROM c;
+}
+expect {
+    a|text
+    ax|text
+    axx|text
+    axxx|text
+}
+
+test recursive-cte-consumed-by-in-and-scalar-aggregate {
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 5
+    )
+    SELECT 4 IN (SELECT x FROM c),
+           (SELECT sum(x) FROM c);
+}
+expect {
+    1|15
+}
+
+test recursive-cte-outer-distinct-collapses-union-all {
+    WITH RECURSIVE c(x, depth) AS (
+        VALUES(1, 0)
+        UNION ALL
+        SELECT 1, depth + 1 FROM c WHERE depth < 4
+    )
+    SELECT DISTINCT x FROM c;
+}
+expect {
+    1
+}
+
+test recursive-cte-name-shadows-base-table {
+    CREATE TABLE c(x);
+    INSERT INTO c VALUES(99);
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 3
+    )
+    SELECT x FROM c;
+}
+expect {
+    1
+    2
+    3
+}
+
+test recursive-cte-quoted-identifiers {
+    WITH RECURSIVE "odd name"("odd column") AS (
+        VALUES(1)
+        UNION ALL
+        SELECT "odd column" + 2 FROM "odd name" WHERE "odd column" < 5
+    )
+    SELECT "odd column" FROM "odd name";
+}
+expect {
+    1
+    3
+    5
+}
+
+test recursive-cte-inside-view {
+    CREATE VIEW sequence_view AS
+        WITH RECURSIVE c(x) AS (
+            VALUES(2)
+            UNION ALL
+            SELECT x + 2 FROM c WHERE x < 6
+        )
+        SELECT x FROM c;
+    SELECT x FROM sequence_view;
+}
+expect {
+    2
+    4
+    6
+}
+
+@cross-check-integrity
+test recursive-cte-update-with-in-consumer {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, value INTEGER);
+    INSERT INTO target VALUES (1,10), (2,20), (3,30), (4,40);
+    WITH RECURSIVE ids(id) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT id + 1 FROM ids WHERE id < 3
+    )
+    UPDATE target SET value = value + 5
+     WHERE id IN (SELECT id FROM ids);
+    SELECT id, value FROM target ORDER BY id;
+}
+expect {
+    1|15
+    2|25
+    3|35
+    4|40
+}
+
+@cross-check-integrity
+test recursive-cte-create-table-as-select {
+    CREATE TABLE generated AS
+        WITH RECURSIVE c(x) AS (
+            VALUES(3)
+            UNION ALL
+            SELECT x + 3 FROM c WHERE x < 9
+        )
+        SELECT x, x * x AS square FROM c;
+    SELECT x, square FROM generated;
+}
+expect {
+    3|9
+    6|36
+    9|81
+}
+
+test recursive-cte-dependent-recursive-producers {
+    WITH RECURSIVE
+      first(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM first WHERE x < 3
+      ),
+      second(x) AS (
+        SELECT x FROM first
+        UNION ALL
+        SELECT x + 10 FROM second WHERE x < 3
+      )
+    SELECT x FROM second;
+}
+expect {
+    1
+    2
+    3
+    11
+    12
+}
+
+@cross-check-integrity
+test recursive-cte-graph-depth-first {
+    CREATE TABLE edge(parent INTEGER, child INTEGER);
+    INSERT INTO edge VALUES
+        (1,2), (1,3), (2,4), (2,5), (3,6), (5,7);
+    WITH path(node, depth) AS (
+        VALUES(1, 0)
+        UNION ALL
+        SELECT child, depth + 1
+          FROM edge JOIN path ON edge.parent = path.node
+        ORDER BY 2 DESC, 1
+    )
+    SELECT node, depth FROM path;
+}
+expect {
+    1|0
+    2|1
+    4|2
+    5|2
+    7|3
+    3|1
+    6|2
+}
+
+@cross-check-integrity
+test recursive-cte-graph-union-deduplicates-diamonds {
+    CREATE TABLE edge(parent INTEGER, child INTEGER);
+    INSERT INTO edge VALUES
+        (1,2), (1,3), (2,4), (3,4), (4,5), (5,1);
+    WITH path(node) AS (
+        VALUES(1)
+        UNION
+        SELECT child FROM edge JOIN path ON edge.parent = path.node
+    )
+    SELECT node FROM path;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+}
+
+test recursive-cte-order-null-modes {
+    WITH seq(label, priority) AS (
+        VALUES('null', NULL), ('one', 1), ('zero', 0)
+        UNION ALL
+        SELECT label, priority FROM seq WHERE 0
+        ORDER BY 2 DESC NULLS FIRST
+    )
+    SELECT label FROM seq;
+}
+expect {
+    null
+    one
+    zero
+}
+
+test recursive-cte-order-inherits-recursive-collation {
+    WITH seq(x) AS (
+        VALUES('b'), ('A')
+        UNION ALL
+        SELECT 'c' COLLATE nocase FROM seq WHERE 0
+        ORDER BY 1
+    )
+    SELECT x FROM seq;
+}
+expect {
+    A
+    b
+}
+
+test recursive-cte-order-alias-from-anchor {
+    WITH seq(x) AS (
+        SELECT 1 AS anchor_name
+        UNION ALL
+        SELECT x + 1 AS recursive_name FROM seq WHERE x < 4
+        ORDER BY anchor_name DESC
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+    4
+}
+
+test recursive-cte-order-alias-from-recursive-term {
+    WITH seq(x) AS (
+        SELECT 1 AS anchor_name
+        UNION ALL
+        SELECT x + 1 AS recursive_name FROM seq WHERE x < 4
+        ORDER BY recursive_name
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+    4
+}
+
+test recursive-cte-two-independent-producers {
+    WITH RECURSIVE
+      a(x) AS (VALUES(1) UNION ALL SELECT x + 1 FROM a WHERE x < 3),
+      b(y) AS (VALUES(7) UNION ALL SELECT y + 1 FROM b WHERE y < 9)
+    SELECT x, y FROM a, b ORDER BY x, y;
+}
+expect {
+    1|7
+    1|8
+    1|9
+    2|7
+    2|8
+    2|9
+    3|7
+    3|8
+    3|9
+}
+
+test recursive-cte-dependency-chain {
+    WITH RECURSIVE
+      seq(x) AS (VALUES(1) UNION ALL SELECT x + 1 FROM seq WHERE x < 3),
+      scaled(y) AS (SELECT x * 10 FROM seq),
+      labeled(z) AS (SELECT printf('v=%d', y) FROM scaled)
+    SELECT z FROM labeled;
+}
+expect {
+    v=10
+    v=20
+    v=30
+}
+
+test recursive-cte-forward-dependency {
+    WITH RECURSIVE
+      scaled(y) AS (SELECT x * 10 FROM seq),
+      seq(x) AS (VALUES(1) UNION ALL SELECT x + 1 FROM seq WHERE x < 3)
+    SELECT y FROM scaled;
+}
+expect {
+    10
+    20
+    30
+}
+
+test recursive-cte-multiple-references-materialized {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 3
+    )
+    SELECT a.x, b.x FROM seq AS a, seq AS b ORDER BY a.x, b.x;
+}
+expect {
+    1|1
+    1|2
+    1|3
+    2|1
+    2|2
+    2|3
+    3|1
+    3|2
+    3|3
+}
+
+test recursive-cte-multiple-scalar-subquery-references {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 4
+    )
+    SELECT (SELECT sum(x) FROM seq), (SELECT count(*) FROM seq);
+}
+expect {
+    10|4
+}
+
+test recursive-cte-inline-subquery-reference {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 3
+    )
+    SELECT x FROM (SELECT x FROM seq);
+}
+expect {
+    1
+    2
+    3
+}
+
+@cross-check-integrity
+test recursive-cte-insert-select {
+    CREATE TABLE output(x INTEGER);
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 4
+    )
+    INSERT INTO output SELECT x FROM seq;
+    SELECT x FROM output;
+}
+expect {
+    1
+    2
+    3
+    4
+}
+
+@cross-check-integrity
+test recursive-cte-delete-subquery {
+    CREATE TABLE output(x INTEGER);
+    INSERT INTO output VALUES(1),(2),(3),(4),(5);
+    WITH seq(x) AS (
+        VALUES(2)
+        UNION ALL
+        SELECT x + 2 FROM seq WHERE x < 4
+    )
+    DELETE FROM output WHERE x IN (SELECT x FROM seq);
+    SELECT x FROM output;
+}
+expect {
+    1
+    3
+    5
+}
+
+@cross-check-integrity
+test recursive-cte-update-correlated-subquery {
+    CREATE TABLE output(x INTEGER, y INTEGER);
+    INSERT INTO output VALUES(1,0),(2,0),(3,0);
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 3
+    )
+    UPDATE output
+       SET y = (SELECT x * 10 FROM seq WHERE seq.x = output.x);
+    SELECT x, y FROM output;
+}
+expect {
+    1|10
+    2|20
+    3|30
+}
+
+@cross-check-integrity
+test recursive-cte-forward-insert-select {
+    CREATE TABLE output(x INTEGER);
+    WITH
+      projected AS (SELECT x FROM seq),
+      seq(x) AS (VALUES(1) UNION ALL SELECT x + 1 FROM seq WHERE x < 3)
+    INSERT INTO output SELECT x FROM projected;
+    SELECT x FROM output;
+}
+expect {
+    1
+    2
+    3
+}
+
+test recursive-cte-dynamic-types {
+    WITH seq(n, value) AS (
+        VALUES(0, NULL)
+        UNION ALL
+        SELECT n + 1,
+               CASE n
+                 WHEN 0 THEN 42
+                 WHEN 1 THEN 3.5
+                 WHEN 2 THEN 'text'
+                 ELSE x'0102'
+               END
+          FROM seq
+         WHERE n < 4
+    )
+    SELECT n, typeof(value), quote(value) FROM seq;
+}
+expect {
+    0|null|NULL
+    1|integer|42
+    2|real|3.5
+    3|text|'text'
+    4|blob|X'0102'
+}
+
+test recursive-cte-explicit-columns-used-in-step {
+    WITH seq(number, doubled) AS (
+        VALUES(1, 2)
+        UNION ALL
+        SELECT number + 1, doubled + 2 FROM seq WHERE number < 4
+    )
+    SELECT number, doubled FROM seq;
+}
+expect {
+    1|2
+    2|4
+    3|6
+    4|8
+}
+
+test recursive-cte-anchor-compound-except {
+    WITH seq(x) AS (
+        SELECT 1
+        UNION
+        SELECT 2
+        EXCEPT
+        SELECT 2
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 4
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+    4
+}
+
+test recursive-cte-anchor-compound-intersect {
+    WITH seq(x) AS (
+        SELECT 1
+        INTERSECT
+        SELECT 1
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 3
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+}
+
+test recursive-cte-aliased-self-reference {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT s.x + 1 FROM seq AS s WHERE s.x < 3
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+}
+
+test recursive-cte-left-join-keeps-current-row-on-left {
+    CREATE TABLE edge(parent INTEGER, child INTEGER);
+    INSERT INTO edge VALUES(1,2),(2,3);
+    WITH path(node) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT edge.child
+          FROM path LEFT JOIN edge ON edge.parent = path.node
+         WHERE edge.child IS NOT NULL
+    )
+    SELECT node FROM path;
+}
+expect {
+    1
+    2
+    3
+}
+
+test recursive-cte-left-join-allows-on-clause-reading-only-current-row {
+    CREATE TABLE edge_for_recursive_right(parent INTEGER, child INTEGER);
+    INSERT INTO edge_for_recursive_right VALUES(1,2);
+    WITH path(node) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT edge_for_recursive_right.child
+          FROM edge_for_recursive_right LEFT JOIN path ON path.node = 1
+         WHERE path.node < 2
+        LIMIT 2
+    )
+    SELECT node FROM path;
+}
+expect {
+    1
+    2
+}
+
+test recursive-cte-right-join-allows-current-row-on-left {
+    CREATE TABLE edge_for_recursive_left(parent INTEGER, child INTEGER);
+    INSERT INTO edge_for_recursive_left VALUES(1,2);
+    WITH path(node) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT edge_for_recursive_left.child
+          FROM path RIGHT JOIN edge_for_recursive_left
+            ON edge_for_recursive_left.parent = path.node
+         WHERE path.node < 2
+        LIMIT 2
+    )
+    SELECT node FROM path;
+}
+expect {
+    1
+    2
+}
+
+@skip-if sqlite "only newer SQLite rejects an outer-join ON clause reading past the recursive table (3.53 errors, 3.43 and 3.50 accept)"
+test recursive-cte-left-join-rejects-on-clause-reading-left-table {
+    CREATE TABLE edge_for_invalid_recursive_right(parent INTEGER, child INTEGER);
+    INSERT INTO edge_for_invalid_recursive_right VALUES(1, 2);
+    WITH RECURSIVE path(node) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT edge_for_invalid_recursive_right.child
+          FROM edge_for_invalid_recursive_right LEFT JOIN path
+            ON edge_for_invalid_recursive_right.parent = path.node
+        LIMIT 2
+    )
+    SELECT node FROM path;
+}
+expect error {
+    ON clause references tables to its right
+}
+
+# SQLite supports FULL JOIN with the recursive table on the left, but our
+# FULL OUTER implementation requires a hash join and the recursive input
+# cannot be its build side. Verify we return a useful error.
+@skip-if sqlite "supported in sqlite"
+test recursive-cte-full-join-recursive-on-left-not-supported {
+    CREATE TABLE edge_for_recursive_full(parent INTEGER, child INTEGER);
+    INSERT INTO edge_for_recursive_full VALUES(1, 2);
+    WITH RECURSIVE path(node) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT edge_for_recursive_full.child
+          FROM path FULL JOIN edge_for_recursive_full
+            ON edge_for_recursive_full.parent = path.node
+         WHERE path.node < 2
+        LIMIT 2
+    )
+    SELECT node FROM path;
+}
+expect error {
+    FULL OUTER JOIN with a recursive reference is not yet supported
+}
+
+@skip-if sqlite "only newer SQLite rejects an outer-join ON clause reading past the recursive table (3.53 errors, 3.43 and 3.50 accept)"
+test recursive-cte-full-join-rejects-on-clause-reading-left-table {
+    CREATE TABLE edge_for_invalid_recursive_full(parent INTEGER, child INTEGER);
+    INSERT INTO edge_for_invalid_recursive_full VALUES(1, 2);
+    WITH RECURSIVE path(node) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT edge_for_invalid_recursive_full.child
+          FROM edge_for_invalid_recursive_full FULL JOIN path
+            ON edge_for_invalid_recursive_full.parent = path.node
+        LIMIT 2
+    )
+    SELECT node FROM path;
+}
+expect error {
+    ON clause references tables to its right
+}
+
+@skip-if sqlite "only newer SQLite rejects an outer-join ON clause reading past the recursive table (3.53 errors, 3.43 and 3.50 accept)"
+test recursive-cte-left-join-rejects-on-clause-subquery-reading-left-table {
+    CREATE TABLE edge_for_recursive_on_subquery(parent INTEGER, child INTEGER);
+    INSERT INTO edge_for_recursive_on_subquery VALUES(1, 2);
+    WITH RECURSIVE path(node) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT edge_for_recursive_on_subquery.child
+          FROM edge_for_recursive_on_subquery LEFT JOIN path
+            ON path.node = (SELECT edge_for_recursive_on_subquery.parent)
+        LIMIT 2
+    )
+    SELECT node FROM path;
+}
+expect error {
+    ON clause references tables to its right
+}
+
+test recursive-cte-cross-join-current-row-inner {
+    CREATE TABLE edge(parent INTEGER, child INTEGER);
+    INSERT INTO edge VALUES(1,2),(2,3);
+    WITH path(node) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT edge.child FROM edge CROSS JOIN path WHERE edge.parent = path.node
+    )
+    SELECT node FROM path;
+}
+expect {
+    1
+    2
+    3
+}
+
+test recursive-cte-distinct-in-recursive-step {
+    WITH seq(x) AS (
+        VALUES(1),(1)
+        UNION ALL
+        SELECT DISTINCT x + 1 FROM seq WHERE x < 3
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    1
+    2
+    2
+    3
+    3
+}
+
+test recursive-cte-aggregate-in-anchor {
+    CREATE TABLE t(a INTEGER);
+    INSERT INTO t VALUES(5),(6);
+    WITH seq(x) AS (
+        SELECT count(*) FROM t
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 4
+    )
+    SELECT x FROM seq;
+}
+expect {
+    2
+    3
+    4
+}
+
+test recursive-cte-nested-with-in-body {
+    WITH RECURSIVE outer_seq(x) AS (
+        WITH inner_seq(y) AS (SELECT 2)
+        SELECT y FROM inner_seq
+        UNION ALL
+        SELECT x * 2 FROM outer_seq WHERE x < 20
+    )
+    SELECT x FROM outer_seq;
+}
+expect {
+    2
+    4
+    8
+    16
+    32
+}
+
+test recursive-cte-correlated-subquery-consumer {
+    CREATE TABLE t(a INTEGER);
+    INSERT INTO t VALUES(2),(4);
+    SELECT (
+        SELECT count(*) FROM (
+            WITH RECURSIVE r(i) AS (
+                SELECT 1
+                UNION ALL
+                SELECT i + 1 FROM r WHERE i < t.a
+            )
+            SELECT i FROM r
+        )
+    ) FROM t;
+}
+expect {
+    2
+    4
+}
+
+test recursive-cte-union-dedups-anchor-duplicates {
+    WITH seq(x) AS (
+        VALUES(1),(1),(2)
+        UNION
+        SELECT x FROM seq
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+}
+
+test recursive-cte-union-distinct-cross-type {
+    WITH seq(x) AS (
+        SELECT '1'
+        UNION
+        SELECT 1 FROM seq
+        UNION
+        SELECT NULL FROM seq
+    )
+    SELECT quote(x), typeof(x) FROM seq;
+}
+expect {
+    '1'|text
+    1|integer
+    NULL|null
+}
+
+test recursive-cte-order-by-ordinals {
+    WITH seq(a, b) AS (
+        VALUES(1,3),(1,1),(2,0)
+        UNION ALL
+        SELECT a + 1, b FROM seq WHERE a < 3
+        ORDER BY 2, 1 DESC
+    )
+    SELECT a, b FROM seq;
+}
+expect {
+    2|0
+    3|0
+    1|1
+    2|1
+    3|1
+    1|3
+    2|3
+    3|3
+}
+
+# The ORDER BY drives queue extraction, not a final sort: rows produced after
+# the queue has moved past their key are emitted out of global order.
+test recursive-cte-order-is-priority-queue-not-final-sort {
+    WITH seq(x) AS (
+        SELECT 5 AS x
+        UNION ALL
+        SELECT 1
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 7
+        ORDER BY x DESC
+    )
+    SELECT x FROM seq;
+}
+expect {
+    5
+    6
+    7
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+}
+
+test recursive-cte-order-multi-arm-depth-first {
+    WITH seq(x, d) AS (
+        SELECT 1 AS x, 0 AS d
+        UNION ALL
+        SELECT x * 2, d + 1 FROM seq WHERE d < 3
+        UNION ALL
+        SELECT x * 3, d + 1 FROM seq WHERE d < 3
+        ORDER BY d DESC, x ASC
+    )
+    SELECT x, d FROM seq;
+}
+expect {
+    1|0
+    2|1
+    4|2
+    8|3
+    12|3
+    6|2
+    12|3
+    18|3
+    3|1
+    6|2
+    12|3
+    18|3
+    9|2
+    18|3
+    27|3
+}
+
+test recursive-cte-order-ties-preserve-fifo {
+    WITH seq(x, s) AS (
+        SELECT 1 AS x, 'a' AS s
+        UNION ALL
+        SELECT 1, 'b'
+        UNION ALL
+        SELECT x + 1, s FROM seq WHERE x < 3
+        ORDER BY x
+    )
+    SELECT x, s FROM seq;
+}
+expect {
+    1|a
+    1|b
+    2|a
+    2|b
+    3|a
+    3|b
+}
+
+test recursive-cte-order-with-limit-stops-infinite {
+    WITH seq(x) AS (
+        SELECT 1 AS x
+        UNION ALL
+        SELECT x + 1 FROM seq
+        ORDER BY x
+        LIMIT 6
+    )
+    SELECT x FROM seq;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+    6
+}
+
+test recursive-cte-circular-reference-in-subquery {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT (SELECT x FROM seq)
+    )
+    SELECT x FROM seq;
+}
+expect error {
+    circular reference: seq
+}
+
+test recursive-cte-multiple-direct-references {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT a.x + b.x FROM seq AS a, seq AS b
+    )
+    SELECT x FROM seq;
+}
+expect error {
+    multiple references to recursive table: seq
+}
+
+test recursive-cte-multiple-nested-references {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x FROM seq WHERE x IN (SELECT x FROM seq)
+    )
+    SELECT x FROM seq;
+}
+expect error {
+    multiple recursive references: seq
+}
+
+test recursive-cte-aggregate-rejected {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT max(x) FROM seq
+    )
+    SELECT x FROM seq;
+}
+expect error {
+    recursive aggregate queries not supported
+}
+
+test recursive-cte-window-rejected {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT row_number() OVER () FROM seq
+    )
+    SELECT x FROM seq;
+}
+expect error {
+    cannot use window functions in recursive queries
+}
+
+test recursive-cte-column-count-rejected {
+    WITH seq(x, y) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq
+    )
+    SELECT * FROM seq;
+}
+expect error {
+    table seq has 1 values for 2 columns
+}
+
+test recursive-cte-arm-column-count-rejected {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1, x + 2 FROM seq
+    )
+    SELECT * FROM seq;
+}
+expect error {
+    SELECTs to the left and right of UNION ALL do not have the same number of result columns
+}
+
+test recursive-cte-order-expression-must-match-output {
+    WITH seq(x) AS (
+        SELECT 1 AS anchor_name
+        UNION ALL
+        SELECT x + 1 AS recursive_name FROM seq WHERE x < 4
+        ORDER BY x
+    )
+    SELECT x FROM seq;
+}
+expect error {
+    1st ORDER BY term does not match any column in the result set
+}
+
+test recursive-cte-mutual-cycle-rejected {
+    WITH RECURSIVE
+      a(x) AS (SELECT x FROM b),
+      b(x) AS (SELECT x FROM a)
+    SELECT x FROM a;
+}
+expect error {
+    circular reference: a
+}
+
+test recursive-cte-rowid-not-visible {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 3
+    )
+    SELECT rowid FROM seq;
+}
+expect error {
+    no such column: rowid
+}
+
+test recursive-cte-first-term-self-reference-rejected {
+    WITH RECURSIVE seq(x) AS (
+        SELECT x FROM seq
+        UNION ALL
+        SELECT 1
+    )
+    SELECT x FROM seq;
+}
+expect error {
+    circular reference: seq
+}
+
+test recursive-cte-non-recursive-term-after-recursive-rejected {
+    WITH seq(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM seq WHERE x < 3
+        UNION ALL
+        SELECT 100
+    )
+    SELECT x FROM seq;
+}
+expect error {
+    circular reference: seq
+}
+
+test recursive-cte-correlated-union-resets-seen-rows-per-invocation {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(2),(4);
+    SELECT n, (
+        WITH RECURSIVE r(x) AS (
+            VALUES(1)
+            UNION
+            SELECT x + 1 FROM r WHERE x < bounds.n
+        )
+        SELECT count(*) FROM r
+    )
+    FROM bounds;
+}
+expect {
+    2|2
+    4|4
+}
+
+test recursive-cte-correlated-resets-limit-and-offset-per-invocation {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(3),(5),(2);
+    SELECT n, (
+        WITH RECURSIVE r(x) AS (
+            VALUES(1)
+            UNION ALL
+            SELECT x + 1 FROM r WHERE x < bounds.n
+            LIMIT 3 OFFSET 1
+        )
+        SELECT group_concat(x) FROM r
+    )
+    FROM bounds;
+}
+expect {
+    3|2,3
+    5|2,3,4
+    2|2
+}
+
+test recursive-cte-correlated-anchor-feeds-priority-queue {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(4),(2),(6);
+    SELECT n, (
+        WITH RECURSIVE r(x) AS (
+            VALUES(bounds.n)
+            UNION
+            SELECT x - 1 FROM r WHERE x > 0
+            ORDER BY 1 DESC
+        )
+        SELECT group_concat(x) FROM r
+    )
+    FROM bounds;
+}
+expect {
+    4|4,3,2,1,0
+    2|2,1,0
+    6|6,5,4,3,2,1,0
+}
+
+test recursive-cte-correlated-same-cte-twice-per-outer-row {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(2),(4);
+    SELECT n,
+        (WITH RECURSIVE r(x) AS (VALUES(1) UNION SELECT x + 1 FROM r WHERE x < bounds.n)
+         SELECT count(*) FROM r),
+        (WITH RECURSIVE r(x) AS (VALUES(1) UNION SELECT x + 1 FROM r WHERE x < bounds.n)
+         SELECT sum(x) FROM r)
+    FROM bounds;
+}
+expect {
+    2|2|3
+    4|4|10
+}
+
+test recursive-cte-correlated-in-where-clause {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(1),(3),(5);
+    SELECT n FROM bounds
+    WHERE n = (
+        WITH RECURSIVE r(x) AS (
+            VALUES(1)
+            UNION ALL
+            SELECT x + 2 FROM r WHERE x < bounds.n
+        )
+        SELECT max(x) FROM r
+    );
+}
+expect {
+    1
+    3
+    5
+}
+
+test recursive-cte-correlated-graph-traversal-per-root {
+    CREATE TABLE edge(parent INTEGER, child INTEGER);
+    INSERT INTO edge VALUES(1,2),(2,3),(3,4),(1,5);
+    CREATE TABLE roots(root INTEGER);
+    INSERT INTO roots VALUES(1),(2),(3);
+    SELECT root, (
+        WITH RECURSIVE reach(node) AS (
+            VALUES(roots.root)
+            UNION
+            SELECT edge.child FROM reach JOIN edge ON edge.parent = reach.node
+        )
+        SELECT group_concat(node) FROM reach
+    )
+    FROM roots;
+}
+expect {
+    1|1,2,5,3,4
+    2|2,3,4
+    3|3,4
+}
+
+test recursive-cte-correlated-multi-arm-recursion {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(2),(3);
+    SELECT n, (
+        WITH RECURSIVE r(x, depth) AS (
+            VALUES(1, 0)
+            UNION
+            SELECT x * 2, depth + 1 FROM r WHERE depth < bounds.n
+            UNION
+            SELECT x * 2 + 1, depth + 1 FROM r WHERE depth < bounds.n
+        )
+        SELECT count(*) FROM r
+    )
+    FROM bounds;
+}
+expect {
+    2|7
+    3|15
+}
+
+test recursive-cte-correlated-with-two-outer-tables {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(3),(1),(4);
+    SELECT lo.n, hi.n, (
+        WITH RECURSIVE r(x) AS (
+            VALUES(lo.n)
+            UNION
+            SELECT x + 1 FROM r WHERE x < hi.n
+        )
+        SELECT group_concat(x) FROM r
+    )
+    FROM bounds lo JOIN bounds hi ON lo.n < hi.n;
+}
+expect {
+    3|4|3,4
+    1|3|1,2,3
+    1|4|1,2,3,4
+}
+
+test recursive-cte-self-join-consumer {
+    WITH RECURSIVE r(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM r WHERE x < 3
+    )
+    SELECT a.x, b.x FROM r a JOIN r b ON a.x <= b.x ORDER BY 1, 2;
+}
+expect {
+    1|1
+    1|2
+    1|3
+    2|2
+    2|3
+    3|3
+}
+
+test recursive-cte-correlated-order-by-desc-with-limit {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(5),(2),(7);
+    SELECT n, (
+        WITH RECURSIVE r(x) AS (
+            VALUES(1)
+            UNION ALL
+            SELECT x + 1 FROM r WHERE x < bounds.n
+            ORDER BY 1 DESC
+            LIMIT 3
+        )
+        SELECT group_concat(x) FROM r
+    )
+    FROM bounds;
+}
+expect {
+    5|1,2,3
+    2|1,2
+    7|1,2,3
+}
+
+test recursive-cte-correlated-nocase-priority-queue {
+    CREATE TABLE words(w TEXT);
+    INSERT INTO words VALUES('b'),('D');
+    SELECT w, (
+        WITH RECURSIVE r(s) AS (
+            SELECT words.w
+            UNION
+            SELECT s || 'x' FROM r WHERE length(s) < 3
+            ORDER BY 1 COLLATE NOCASE DESC
+        )
+        SELECT group_concat(s) FROM r
+    )
+    FROM words;
+}
+expect {
+    b|b,bx,bxx
+    D|D,Dx,Dxx
+}
+
+test recursive-cte-correlated-limit-zero-and-offset-past-end {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(3),(0),(2);
+    SELECT n, (
+        WITH RECURSIVE r(x) AS (
+            VALUES(1)
+            UNION ALL
+            SELECT x + 1 FROM r WHERE x < 5
+            LIMIT 10 OFFSET 20
+        )
+        SELECT count(*) FROM r
+    ), (
+        WITH RECURSIVE r2(x) AS (
+            VALUES(1)
+            UNION ALL
+            SELECT x + 1 FROM r2 WHERE x < 5
+            LIMIT 0
+        )
+        SELECT count(*) FROM r2
+    )
+    FROM bounds;
+}
+expect {
+    3|0|0
+    0|0|0
+    2|0|0
+}
+
+test recursive-cte-in-insert-update-delete {
+    CREATE TABLE target(v INTEGER);
+    INSERT INTO target
+    WITH RECURSIVE r(x) AS (VALUES(1) UNION ALL SELECT x + 1 FROM r WHERE x < 4)
+    SELECT x FROM r;
+    SELECT v FROM target ORDER BY v;
+    UPDATE target SET v = v * 10
+    WHERE v IN (
+        WITH RECURSIVE s(x) AS (VALUES(2) UNION ALL SELECT x + 2 FROM s WHERE x < 4)
+        SELECT x FROM s
+    );
+    SELECT v FROM target ORDER BY v;
+    DELETE FROM target
+    WHERE v IN (
+        WITH RECURSIVE d(x) AS (VALUES(1) UNION ALL SELECT x + 2 FROM d WHERE x < 3)
+        SELECT x FROM d
+    );
+    SELECT v FROM target ORDER BY v;
+}
+expect {
+    1
+    2
+    3
+    4
+    1
+    3
+    20
+    40
+    20
+    40
+}
+
+@skip-if sqlite "SQLite 3.50 drops rows from a recursive CTE that combines ORDER BY with scalar-subquery placement; 3.43 and 3.53 return the correct result"
+test recursive-cte-order-by-inside-scalar-subquery-keeps-all-rows {
+    CREATE TABLE t(a INTEGER);
+    INSERT INTO t VALUES(15);
+    SELECT (
+        WITH RECURSIVE c(x) AS (
+            VALUES(-8)
+            UNION
+            SELECT x + 1 FROM c WHERE x < min(t.a, -7)
+            ORDER BY 1 DESC
+        )
+        SELECT max(x) FROM c
+    ), (
+        WITH RECURSIVE c(x) AS (
+            VALUES(-8)
+            UNION ALL
+            SELECT x + 1 FROM c WHERE x < min(15, -7)
+            ORDER BY 1 DESC
+        )
+        SELECT max(x) FROM c
+    )
+    FROM t;
+}
+expect {
+    -7|-7
+}
+
+test recursive-cte-correlated-nested-recursion-in-recursive-step {
+    CREATE TABLE bounds(n INTEGER);
+    INSERT INTO bounds VALUES(2),(3);
+    SELECT n, (
+        WITH RECURSIVE outer_r(x) AS (
+            VALUES(1)
+            UNION ALL
+            SELECT x + (
+                WITH RECURSIVE inner_r(y) AS (
+                    VALUES(1)
+                    UNION ALL
+                    SELECT y + 1 FROM inner_r WHERE y < 2
+                )
+                SELECT max(y) FROM inner_r
+            )
+            FROM outer_r WHERE x < bounds.n
+        )
+        SELECT group_concat(x) FROM outer_r
+    )
+    FROM bounds;
+}
+expect {
+    2|1,3
+    3|1,3
+}

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -1829,6 +1829,38 @@ expect error {
     multiple recursive references: w
 }
 
+# The recursive self-reference reads the queue table, whose columns have no
+# declared type: text '2' compares after numeric 3, stopping the recursion.
+test recursive-cte-self-reference-has-no-affinity {
+    CREATE TABLE aff_anchor(a INT);
+    INSERT INTO aff_anchor VALUES(1);
+    WITH RECURSIVE c(x) AS (
+        SELECT a FROM aff_anchor
+        UNION ALL
+        SELECT '2' FROM c WHERE x < 3
+    )
+    SELECT count(*) FROM c;
+}
+expect {
+    2
+}
+
+# The outer read of the CTE keeps the affinity derived from the anchor query,
+# so comparing against text '1' still coerces.
+test recursive-cte-outer-read-keeps-anchor-affinity {
+    CREATE TABLE aff_anchor_outer(a INT);
+    INSERT INTO aff_anchor_outer VALUES(1);
+    WITH RECURSIVE c(x) AS (
+        SELECT a FROM aff_anchor_outer
+        UNION ALL
+        SELECT x FROM c WHERE 0
+    )
+    SELECT x = '1' FROM c;
+}
+expect {
+    1
+}
+
 # Seven recursive CTEs at the 2000-column limit need well over 65535 registers
 # in one program; register-carrying instruction fields must not overflow.
 test recursive-cte-many-max-width-ctes-no-register-overflow {

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -963,22 +963,45 @@ expect {
     2
 }
 
-@skip-if sqlite "only newer SQLite rejects an outer-join ON clause reading past the recursive table (3.53 errors, 3.43 and 3.50 accept)"
-test recursive-cte-left-join-rejects-on-clause-reading-left-table {
-    CREATE TABLE edge_for_invalid_recursive_right(parent INTEGER, child INTEGER);
-    INSERT INTO edge_for_invalid_recursive_right VALUES(1, 2);
+# SQLite 3.53 rejects an outer-join ON clause reading tables left of the
+# recursive table ("ON clause references tables to its right") because the
+# recursive table is scanned outermost; 3.43-3.50 accept and evaluate it, and
+# the rejection was reported upstream as a regression. We accept.
+@skip-if sqlite "SQLite 3.53 rejects this form due to an upstream regression; 3.43-3.50 accept"
+test recursive-cte-left-join-on-clause-reading-left-table {
+    CREATE TABLE edge_for_recursive_right(parent INTEGER, child INTEGER);
+    INSERT INTO edge_for_recursive_right VALUES(1, 2);
     WITH RECURSIVE path(node) AS (
         VALUES(1)
         UNION ALL
-        SELECT edge_for_invalid_recursive_right.child
-          FROM edge_for_invalid_recursive_right LEFT JOIN path
-            ON edge_for_invalid_recursive_right.parent = path.node
+        SELECT edge_for_recursive_right.child
+          FROM edge_for_recursive_right LEFT JOIN path
+            ON edge_for_recursive_right.parent = path.node
         LIMIT 2
     )
     SELECT node FROM path;
 }
-expect error {
-    ON clause references tables to its right
+expect {
+    1
+    2
+}
+
+@skip-if sqlite "SQLite 3.53 rejects this form due to an upstream regression; 3.43-3.50 accept"
+test recursive-cte-left-join-on-clause-reading-only-left-table {
+    CREATE TABLE lj_const_on(a);
+    INSERT INTO lj_const_on VALUES(5),(6);
+    WITH RECURSIVE c(x) AS (
+        SELECT 1
+        UNION ALL
+        SELECT c.x + 1 FROM lj_const_on LEFT JOIN c ON lj_const_on.a = 5
+        WHERE c.x < 3
+    )
+    SELECT * FROM c;
+}
+expect {
+    1
+    2
+    3
 }
 
 # SQLite supports FULL JOIN with the recursive table on the left, but our
@@ -1003,8 +1026,10 @@ expect error {
     FULL OUTER JOIN with a recursive reference is not yet supported
 }
 
-@skip-if sqlite "only newer SQLite rejects an outer-join ON clause reading past the recursive table (3.53 errors, 3.43 and 3.50 accept)"
-test recursive-cte-full-join-rejects-on-clause-reading-left-table {
+# Like recursive-on-left FULL JOIN above, this needs a hash join with the
+# recursive input as a build side, which is not supported yet.
+@skip-if sqlite "supported in sqlite"
+test recursive-cte-full-join-recursive-on-right-not-supported {
     CREATE TABLE edge_for_invalid_recursive_full(parent INTEGER, child INTEGER);
     INSERT INTO edge_for_invalid_recursive_full VALUES(1, 2);
     WITH RECURSIVE path(node) AS (
@@ -1018,11 +1043,11 @@ test recursive-cte-full-join-rejects-on-clause-reading-left-table {
     SELECT node FROM path;
 }
 expect error {
-    ON clause references tables to its right
+    FULL OUTER JOIN with a recursive reference is not yet supported
 }
 
-@skip-if sqlite "only newer SQLite rejects an outer-join ON clause reading past the recursive table (3.53 errors, 3.43 and 3.50 accept)"
-test recursive-cte-left-join-rejects-on-clause-subquery-reading-left-table {
+@skip-if sqlite "SQLite 3.53 rejects this form due to an upstream regression; 3.43-3.50 accept"
+test recursive-cte-left-join-on-clause-subquery-reading-left-table {
     CREATE TABLE edge_for_recursive_on_subquery(parent INTEGER, child INTEGER);
     INSERT INTO edge_for_recursive_on_subquery VALUES(1, 2);
     WITH RECURSIVE path(node) AS (
@@ -1035,8 +1060,9 @@ test recursive-cte-left-join-rejects-on-clause-subquery-reading-left-table {
     )
     SELECT node FROM path;
 }
-expect error {
-    ON clause references tables to its right
+expect {
+    1
+    2
 }
 
 test recursive-cte-cross-join-current-row-inner {

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -1829,6 +1829,23 @@ expect error {
     multiple recursive references: w
 }
 
+# Seven recursive CTEs at the 2000-column limit need well over 65535 registers
+# in one program; register-carrying instruction fields must not overflow.
+test recursive-cte-many-max-width-ctes-no-register-overflow {
+    WITH RECURSIVE
+    c0 AS (VALUES(0{{repeat:1999:,0}}) UNION ALL SELECT * FROM c0 WHERE 0),
+    c1 AS (VALUES(0{{repeat:1999:,0}}) UNION ALL SELECT * FROM c1 WHERE 0),
+    c2 AS (VALUES(0{{repeat:1999:,0}}) UNION ALL SELECT * FROM c2 WHERE 0),
+    c3 AS (VALUES(0{{repeat:1999:,0}}) UNION ALL SELECT * FROM c3 WHERE 0),
+    c4 AS (VALUES(0{{repeat:1999:,0}}) UNION ALL SELECT * FROM c4 WHERE 0),
+    c5 AS (VALUES(0{{repeat:1999:,0}}) UNION ALL SELECT * FROM c5 WHERE 0),
+    c6 AS (VALUES(0{{repeat:1999:,0}}) UNION ALL SELECT * FROM c6 WHERE 0)
+    SELECT 1 FROM c0, c1, c2, c3, c4, c5, c6 LIMIT 1;
+}
+expect {
+    1
+}
+
 test recursive-cte-self-ref-with-call-arguments-rejected {
     CREATE TABLE tvf_probe(a);
     WITH RECURSIVE cte1(x, y, z) AS (

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -1829,6 +1829,41 @@ expect error {
     multiple recursive references: w
 }
 
+# GROUP BY makes the recursive term an aggregate query even without aggregate
+# functions; SQLite rejects it rather than producing non-monotonic results.
+test recursive-cte-group-by-in-recursive-term-rejected {
+    CREATE TABLE gb_edge(p, c);
+    INSERT INTO gb_edge VALUES (1, 2), (1, 3), (2, 4);
+    WITH RECURSIVE w(n, d) AS (
+        VALUES (1, 0)
+        UNION ALL
+        SELECT gb_edge.c, d + 1
+        FROM w JOIN gb_edge ON gb_edge.p = w.n
+        WHERE d < 2
+        GROUP BY 'k'
+    )
+    SELECT n, d FROM w;
+}
+expect error {
+    recursive aggregate queries not supported
+}
+
+# Aggregates in the anchor query are fine; only the recursive term is restricted.
+test recursive-cte-aggregate-in-anchor-allowed {
+    CREATE TABLE agg_anchor(p);
+    INSERT INTO agg_anchor VALUES (1), (2);
+    WITH RECURSIVE w(n) AS (
+        SELECT max(p) FROM agg_anchor
+        UNION ALL
+        SELECT n + 1 FROM w WHERE n < 3
+    )
+    SELECT n FROM w;
+}
+expect {
+    2
+    3
+}
+
 # The recursive self-reference reads the queue table, whose columns have no
 # declared type: text '2' compares after numeric 3, stopping the recursion.
 test recursive-cte-self-reference-has-no-affinity {

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -1828,3 +1828,16 @@ test recursive-cte-window-clause-self-ref-rejected {
 expect error {
     multiple recursive references: w
 }
+
+test recursive-cte-self-ref-with-call-arguments-rejected {
+    CREATE TABLE tvf_probe(a);
+    WITH RECURSIVE cte1(x, y, z) AS (
+        VALUES(1, 2, 3)
+        UNION ALL
+        SELECT x, 4, 5 FROM tvf_probe RIGHT JOIN cte1(x)
+    )
+    SELECT * FROM cte1;
+}
+expect error {
+    too many arguments on cte1\(\) - max 0
+}

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -127,10 +127,11 @@ impl SqlGenerator for SqlGenBackend {
 pub struct PropTestBackend {
     test_runner: TestRunner,
     profile: sql_gen_prop::StatementProfile,
+    recursive_cte_focus: bool,
 }
 
 impl PropTestBackend {
-    pub fn new(seed_bytes: [u8; 32]) -> Self {
+    pub fn new(seed_bytes: [u8; 32], recursive_cte_focus: bool) -> Self {
         let test_runner = TestRunner::new_with_rng(
             proptest::test_runner::Config::default(),
             proptest::test_runner::TestRng::from_seed(
@@ -144,9 +145,21 @@ impl PropTestBackend {
             .expression
             .base
             .order_by_allow_integer_positions = false;
+        if recursive_cte_focus {
+            profile = profile.read_only();
+            profile.generation.expression = profile.generation.expression.clone().simple();
+            profile.select.extra.allow_aggregates = false;
+            let cte = &mut profile.select.extra.cte_profile;
+            cte.cte_weight = 100;
+            cte.no_cte_weight = 0;
+            cte.cte_count_range = 1..=3;
+            cte.recursive_weight = 100;
+            cte.non_recursive_weight = 0;
+        }
         Self {
             test_runner,
             profile,
+            recursive_cte_focus,
         }
     }
 }
@@ -154,11 +167,30 @@ impl PropTestBackend {
 impl SqlGenerator for PropTestBackend {
     fn generate(&mut self, schema: &sql_gen::Schema) -> Result<GeneratedStatement> {
         let prop_schema = to_prop_schema(schema);
-        let strategy = sql_gen_prop::strategies::statement_for_schema(&prop_schema, &self.profile);
+        let bootstrap_profile;
+        let profile = if self.recursive_cte_focus && prop_schema.tables.is_empty() {
+            bootstrap_profile = sql_gen_prop::StatementProfile::default();
+            &bootstrap_profile
+        } else {
+            &self.profile
+        };
+        let strategy = sql_gen_prop::strategies::statement_for_schema(&prop_schema, profile);
         let value_tree = strategy
             .new_tree(&mut self.test_runner)
             .map_err(|e| anyhow::anyhow!("Failed to generate statement: {e}"))?;
-        let stmt = value_tree.current();
+        let mut stmt = value_tree.current();
+        // SQLite 3.50.2, currently bundled by rusqlite in this workspace,
+        // has an ORDER BY elision regression for recursive CTEs that was
+        // fixed in later SQLite versions. In focused mode, avoid an outer
+        // LIMIT/OFFSET so that this oracle bug cannot change the compared
+        // row set. Recursive LIMIT/OFFSET and priority ordering remain fully
+        // generated inside the CTE.
+        if self.recursive_cte_focus {
+            if let sql_gen_prop::SqlStatement::Select(select) = &mut stmt {
+                select.limit = None;
+                select.offset = None;
+            }
+        }
         let sql = stmt.to_string();
         let stmt_kind = sql_gen_prop::StatementKind::from(&stmt);
         let is_ddl = stmt_kind.is_ddl();

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -181,12 +181,13 @@ impl SqlGenerator for PropTestBackend {
         let mut stmt = value_tree.current();
         // SQLite 3.50.2, currently bundled by rusqlite in this workspace,
         // has an ORDER BY elision regression for recursive CTEs that was
-        // fixed in later SQLite versions. In focused mode, avoid an outer
-        // LIMIT/OFFSET so that this oracle bug cannot change the compared
-        // row set. Recursive LIMIT/OFFSET and priority ordering remain fully
-        // generated inside the CTE.
-        if self.recursive_cte_focus {
-            if let sql_gen_prop::SqlStatement::Select(select) = &mut stmt {
+        // fixed in later SQLite versions. Avoid an outer LIMIT/OFFSET on any
+        // statement with a recursive CTE - the default profile generates them
+        // too - so that this oracle bug cannot change the compared row set.
+        // Recursive LIMIT/OFFSET and priority ordering remain fully generated
+        // inside the CTE.
+        if let sql_gen_prop::SqlStatement::Select(select) = &mut stmt {
+            if select.has_recursive_cte() {
                 select.limit = None;
                 select.offset = None;
             }

--- a/testing/differential-oracle/fuzzer/main.rs
+++ b/testing/differential-oracle/fuzzer/main.rs
@@ -64,6 +64,10 @@ struct Args {
     /// stress-test the window function emit pipeline.
     #[arg(long, default_value_t = 0.0)]
     window_function_probability: f64,
+
+    /// Focus sql-gen-prop on bounded recursive CTE SELECT workloads.
+    #[arg(long, requires = "generator")]
+    recursive_cte_focus: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -100,6 +104,7 @@ struct ConfigRecord {
     num_statements: usize,
     generator: String,
     mvcc: bool,
+    recursive_cte_focus: bool,
 }
 
 /// Summary written to the JSON report file.
@@ -118,6 +123,7 @@ impl ConfigRecord {
             num_statements: args.num_statements,
             generator: format!("{:?}", args.generator),
             mvcc: args.mvcc,
+            recursive_cte_focus: args.recursive_cte_focus,
         }
     }
 }
@@ -231,6 +237,9 @@ fn main() -> Result<()> {
 /// Run a single fuzzer iteration, returning stats on success.
 /// Does NOT call `process::exit` — the caller decides what to do with failures.
 fn run_single_inner(args: &Args) -> Result<differential_fuzzer::SimStats> {
+    if args.recursive_cte_focus && !matches!(args.generator, GeneratorKind::SqlGenProp) {
+        anyhow::bail!("--recursive-cte-focus requires --generator sql-gen-prop");
+    }
     let config = SimConfig {
         seed: args.seed,
         num_tables: args.num_tables,
@@ -247,6 +256,7 @@ fn run_single_inner(args: &Args) -> Result<differential_fuzzer::SimStats> {
         },
         mvcc: args.mvcc,
         window_function_probability: args.window_function_probability.clamp(0.0, 1.0),
+        recursive_cte_focus: args.recursive_cte_focus,
     };
 
     tracing::info!("Starting differential_fuzzer with config: {:?}", config);

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -57,6 +57,8 @@ pub struct SimConfig {
     /// entirely; values up to 1.0 weight the SELECT list heavily toward
     /// `func(...) OVER (...)` projections.
     pub window_function_probability: f64,
+    /// Generate SELECT-only workloads whose CTE definitions are all recursive.
+    pub recursive_cte_focus: bool,
 }
 
 impl Default for SimConfig {
@@ -73,6 +75,7 @@ impl Default for SimConfig {
             tree_mode: TreeMode::default(),
             mvcc: false,
             window_function_probability: 0.0,
+            recursive_cte_focus: false,
         }
     }
 }
@@ -352,7 +355,10 @@ impl Fuzzer {
                     self.rng.borrow_mut().fill_bytes(&mut bytes);
                     bytes
                 };
-                Box::new(PropTestBackend::new(seed_bytes))
+                Box::new(PropTestBackend::new(
+                    seed_bytes,
+                    self.config.recursive_cte_focus,
+                ))
             }
         };
 
@@ -658,6 +664,7 @@ mod tests {
             tree_mode: TreeMode::default(),
             mvcc: false,
             window_function_probability: 0.0,
+            recursive_cte_focus: false,
         };
         let sim = Fuzzer::new(config);
         assert!(sim.is_ok());

--- a/testing/differential-oracle/sql_gen_prop/cte.rs
+++ b/testing/differential-oracle/sql_gen_prop/cte.rs
@@ -171,6 +171,17 @@ pub struct WithClause {
     pub ctes: Vec<CteDefinition>,
 }
 
+impl WithClause {
+    /// True when any CTE in this clause (or nested in one of its bodies) is
+    /// recursive.
+    pub fn has_recursive_cte(&self) -> bool {
+        self.ctes.iter().any(|cte| match &cte.query {
+            CteQuery::Recursive(_) => true,
+            CteQuery::Select(select) => select.has_recursive_cte(),
+        })
+    }
+}
+
 impl fmt::Display for WithClause {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.ctes.iter().any(|cte| cte.query.is_recursive()) {

--- a/testing/differential-oracle/sql_gen_prop/cte.rs
+++ b/testing/differential-oracle/sql_gen_prop/cte.rs
@@ -1,15 +1,37 @@
 //! Common Table Expression (CTE) generation.
 //!
-//! This module provides types and strategies for generating CTEs (WITH clauses).
-//! Only non-recursive CTEs are supported.
+//! This module generates both ordinary CTEs and bounded recursive CTEs. The
+//! recursive shapes are intentionally self-terminating so differential fuzzing
+//! can exercise queue semantics without relying on timeouts.
 
 use proptest::prelude::*;
 use std::fmt;
 use std::ops::RangeInclusive;
 
 use crate::profile::StatementProfile;
-use crate::schema::Schema;
+use crate::schema::{ColumnDef, DataType, Schema};
 use crate::select::SelectStatement;
+
+#[derive(Debug, Clone)]
+pub enum CteQuery {
+    Select(SelectStatement),
+    Recursive(String),
+}
+
+impl CteQuery {
+    pub(crate) fn is_recursive(&self) -> bool {
+        matches!(self, Self::Recursive(_))
+    }
+}
+
+impl fmt::Display for CteQuery {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Select(select) => write!(f, "{select}"),
+            Self::Recursive(sql) => f.write_str(sql),
+        }
+    }
+}
 
 /// Materialization hint for a CTE.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,7 +64,7 @@ pub struct CteDefinition {
     /// Materialization hint.
     pub materialization: CteMaterialization,
     /// The SELECT statement defining the CTE.
-    pub query: SelectStatement,
+    pub query: CteQuery,
     /// The effective columns this CTE exposes (derived from aliases or query).
     pub effective_columns: Vec<crate::schema::ColumnDef>,
 }
@@ -151,7 +173,11 @@ pub struct WithClause {
 
 impl fmt::Display for WithClause {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "WITH ")?;
+        if self.ctes.iter().any(|cte| cte.query.is_recursive()) {
+            write!(f, "WITH RECURSIVE ")?;
+        } else {
+            write!(f, "WITH ")?;
+        }
         for (i, cte) in self.ctes.iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;
@@ -181,6 +207,10 @@ pub struct CteProfile {
     pub column_aliases_weight: u32,
     /// Weight for no column aliases.
     pub no_column_aliases_weight: u32,
+    /// Weight for recursive definitions among generated CTEs.
+    pub recursive_weight: u32,
+    /// Weight for ordinary definitions among generated CTEs.
+    pub non_recursive_weight: u32,
 }
 
 impl Default for CteProfile {
@@ -194,6 +224,8 @@ impl Default for CteProfile {
             not_materialized_weight: 25,
             column_aliases_weight: 20,
             no_column_aliases_weight: 80,
+            recursive_weight: 20,
+            non_recursive_weight: 80,
         }
     }
 }
@@ -294,7 +326,7 @@ fn column_aliases(num_columns: usize, profile: &CteProfile) -> BoxedStrategy<Opt
 }
 
 /// Generate a single CTE definition.
-pub fn cte_definition(
+fn non_recursive_cte_definition(
     schema: &Schema,
     existing_cte_names: &[String],
     profile: &StatementProfile,
@@ -354,7 +386,7 @@ pub fn cte_definition(
                                 name,
                                 column_aliases: aliases,
                                 materialization: mat,
-                                query: query_clone.clone(),
+                                query: CteQuery::Select(query_clone.clone()),
                                 effective_columns,
                             }
                         })
@@ -362,6 +394,276 @@ pub fn cte_definition(
             )
         })
         .boxed()
+}
+
+fn recursive_cte_definition(
+    schema: &Schema,
+    existing_cte_names: &[String],
+    profile: &StatementProfile,
+) -> BoxedStrategy<CteDefinition> {
+    let cte_profile = profile.select_profile().cte_profile.clone();
+    let existing = existing_cte_names.to_vec();
+    let schema = schema.clone();
+    let tables = schema.tables.clone();
+
+    (
+        cte_name(&schema, &existing),
+        proptest::sample::select((*tables).clone()),
+        0u8..5,
+        -32i64..=32,
+        1i64..=7,
+        0i64..=64,
+        any::<bool>(),
+        0u8..5,
+        any::<bool>(),
+        0u32..=128,
+        0u32..=32,
+        materialization(&cte_profile),
+    )
+        .prop_map(
+            |(
+                name,
+                table,
+                shape,
+                seed,
+                magnitude,
+                span,
+                descending,
+                order_mode,
+                has_limit,
+                limit,
+                offset,
+                materialization,
+            )| {
+                let order_suffix = match order_mode {
+                    0 => String::new(),
+                    1 => " ORDER BY 1 ASC".to_string(),
+                    2 => " ORDER BY 1 DESC".to_string(),
+                    3 => " ORDER BY 1 ASC NULLS LAST".to_string(),
+                    _ => " ORDER BY 1 DESC NULLS FIRST".to_string(),
+                };
+                let limit_suffix = if has_limit {
+                    format!(" LIMIT {limit} OFFSET {offset}")
+                } else {
+                    String::new()
+                };
+                let bounded_limit_suffix = if has_limit {
+                    format!(" LIMIT {} OFFSET {}", limit.min(64), offset.min(32))
+                } else {
+                    " LIMIT 64".to_string()
+                };
+
+                let (column_aliases, sql) = match shape {
+                    0 => {
+                        let step = if descending { -magnitude } else { magnitude };
+                        let bound = seed.saturating_add(step.saturating_mul(span));
+                        let comparison = if step > 0 { "<" } else { ">" };
+                        let union = if span % 3 == 0 { "UNION" } else { "UNION ALL" };
+                        (
+                            vec!["x".to_string()],
+                            format!(
+                                "VALUES({seed}) {union} SELECT x + ({step}) FROM {name} \
+                                 WHERE x {comparison} {bound}{order_suffix}{limit_suffix}"
+                            ),
+                        )
+                    }
+                    1 => {
+                        let modulus = magnitude + span.max(1);
+                        let start = seed.rem_euclid(modulus);
+                        (
+                            vec!["x".to_string()],
+                            format!(
+                                "VALUES({start}) UNION SELECT (x + {magnitude}) % {modulus} \
+                                 FROM {name}{order_suffix}{limit_suffix}"
+                            ),
+                        )
+                    }
+                    2 => {
+                        let max_depth = span.min(7);
+                        let branch_order = match order_mode {
+                            0 => String::new(),
+                            1 | 3 => " ORDER BY 2 ASC, 1 ASC".to_string(),
+                            _ => " ORDER BY 2 DESC, 1 ASC".to_string(),
+                        };
+                        (
+                            vec!["x".to_string(), "depth".to_string()],
+                            format!(
+                                "VALUES({seed}, 0) \
+                                 UNION ALL SELECT x * 2, depth + 1 FROM {name} \
+                                 WHERE depth < {max_depth} \
+                                 UNION ALL SELECT x * 2 + 1, depth + 1 FROM {name} \
+                                WHERE depth < {max_depth}{branch_order}{limit_suffix}"
+                            ),
+                        )
+                    }
+                    3 => {
+                        let bound = seed.saturating_add(span.clamp(1, 4));
+                        let table_name = table.qualified_name();
+                        let column_name = &table
+                            .columns
+                            .first()
+                            .expect("generated tables must have at least one column")
+                            .name;
+                        (
+                            vec!["x".to_string()],
+                            format!(
+                                "VALUES({seed}) \
+                                 UNION ALL SELECT x + 1 FROM {name} \
+                                 JOIN {table_name} AS recursive_source \
+                                   ON recursive_source.{column_name} IS NOT NULL \
+                                 WHERE x < {bound}{order_suffix}{bounded_limit_suffix}"
+                            ),
+                        )
+                    }
+                    4 => {
+                        let bound = seed.saturating_add(span.clamp(1, 4));
+                        let table_name = table.qualified_name();
+                        let column_name = &table
+                            .columns
+                            .first()
+                            .expect("generated tables must have at least one column")
+                            .name;
+                        (
+                            vec!["x".to_string()],
+                            format!(
+                                "VALUES({seed}) \
+                                 UNION ALL SELECT {name}.x + 1 FROM {name} \
+                                 LEFT JOIN {table_name} AS recursive_source \
+                                   ON recursive_source.{column_name} = {name}.x \
+                                 WHERE {name}.x < {bound}{order_suffix}{bounded_limit_suffix}"
+                            ),
+                        )
+                    }
+                    _ => unreachable!("recursive CTE generator produced unknown shape {shape}"),
+                };
+                let effective_columns = column_aliases
+                    .iter()
+                    .map(|name| ColumnDef::new(name.clone(), DataType::Integer))
+                    .collect();
+                CteDefinition {
+                    name,
+                    column_aliases: Some(column_aliases),
+                    materialization,
+                    query: CteQuery::Recursive(sql),
+                    effective_columns,
+                }
+            },
+        )
+        .boxed()
+}
+
+/// Generate a scalar subquery whose recursive CTE bound is correlated with a
+/// column of the outer query's source table.
+///
+/// The recursion bound is clamped through `min(<outer column>, <small
+/// constant>)`, which is never larger than the constant regardless of the
+/// outer column's type or value, so every invocation terminates. Aggregating
+/// the CTE inside the subquery keeps the result a single value while still
+/// depending on the full per-invocation row set, so stale queue, distinct, or
+/// LIMIT state from a previous outer row changes the compared output.
+fn correlated_recursive_subquery(
+    outer: &crate::schema::Table,
+    schema: &Schema,
+    excluded_cte_names: &[String],
+) -> BoxedStrategy<crate::expression::Expression> {
+    use crate::expression::Expression;
+
+    let outer_name = outer.qualified_name();
+    let column_names: Vec<String> = outer.columns.iter().map(|c| c.name.clone()).collect();
+    assert!(
+        !column_names.is_empty(),
+        "correlated recursive subquery requires an outer table with columns"
+    );
+
+    // SQLite 3.50.2, currently bundled by rusqlite in this workspace, drops
+    // rows from a recursive CTE that combines ORDER BY with placement inside
+    // a scalar subquery (fixed in later SQLite versions), so no ORDER BY is
+    // generated here. recursive-cte.sqltest covers that combination against
+    // current SQLite instead.
+    (
+        cte_name(schema, excluded_cte_names),
+        proptest::sample::select(column_names),
+        -8i64..=8,
+        1i64..=8,
+        any::<bool>(),
+        proptest::option::of((0u32..=16, 0u32..=4)),
+        proptest::sample::select(vec!["count", "sum", "max", "min", "total"]),
+    )
+        .prop_map(
+            move |(name, column, seed, span, union_all, limit, aggregate)| {
+                let union = if union_all { "UNION ALL" } else { "UNION" };
+                let bound = seed + span;
+                let limit_suffix = limit
+                    .map(|(limit, offset)| format!(" LIMIT {limit} OFFSET {offset}"))
+                    .unwrap_or_default();
+                let body = format!(
+                    "VALUES({seed}) {union} SELECT x + 1 FROM {name} \
+                     WHERE x < min({outer_name}.{column}, {bound}){limit_suffix}"
+                );
+                let cte = CteDefinition {
+                    name: name.clone(),
+                    column_aliases: Some(vec!["x".to_string()]),
+                    materialization: CteMaterialization::Default,
+                    query: CteQuery::Recursive(body),
+                    effective_columns: vec![ColumnDef::new("x", DataType::Integer)],
+                };
+                Expression::Subquery(Box::new(SelectStatement {
+                    with_clause: Some(WithClause { ctes: vec![cte] }),
+                    table: name,
+                    columns: vec![Expression::FunctionCall {
+                        name: aggregate.to_string(),
+                        args: vec![Expression::Column("x".to_string())],
+                        filter: None,
+                    }],
+                    where_clause: None,
+                    order_by: vec![],
+                    limit: None,
+                    offset: None,
+                }))
+            },
+        )
+        .boxed()
+}
+
+/// Generate extra SELECT-list columns holding correlated recursive scalar
+/// subqueries, scaled by how strongly the profile favors recursive CTEs.
+/// Generating up to two per statement exercises repeated re-entry of separate
+/// recursive CTEs for each outer row.
+pub fn correlated_recursive_subquery_columns(
+    outer: &crate::schema::Table,
+    schema: &Schema,
+    excluded_cte_names: &[String],
+    profile: &StatementProfile,
+) -> BoxedStrategy<Vec<crate::expression::Expression>> {
+    let cte_profile = &profile.select_profile().cte_profile;
+    let weight = (cte_profile.cte_weight * cte_profile.recursive_weight / 100).min(50);
+    if weight == 0 {
+        return Just(Vec::new()).boxed();
+    }
+    prop_oneof![
+        (100 - weight) => Just(Vec::new()),
+        weight => proptest::collection::vec(
+            correlated_recursive_subquery(outer, schema, excluded_cte_names),
+            1..=2,
+        ),
+    ]
+    .boxed()
+}
+
+/// Generate a single ordinary or recursive CTE definition.
+pub fn cte_definition(
+    schema: &Schema,
+    existing_cte_names: &[String],
+    profile: &StatementProfile,
+) -> BoxedStrategy<CteDefinition> {
+    let recursive_weight = profile.select_profile().cte_profile.recursive_weight;
+    let non_recursive_weight = profile.select_profile().cte_profile.non_recursive_weight;
+    prop_oneof![
+        non_recursive_weight =>
+            non_recursive_cte_definition(schema, existing_cte_names, profile),
+        recursive_weight => recursive_cte_definition(schema, existing_cte_names, profile),
+    ]
+    .boxed()
 }
 
 /// Generate a WITH clause with one or more CTEs.
@@ -428,6 +730,8 @@ pub fn optional_with_clause(
 mod tests {
     use super::*;
     use crate::schema::{ColumnDef, DataType, SchemaBuilder, Table};
+    use proptest::strategy::ValueTree;
+    use proptest::test_runner::TestRunner;
 
     fn test_schema() -> Schema {
         SchemaBuilder::new()
@@ -469,7 +773,7 @@ mod tests {
             name: "my_cte".to_string(),
             column_aliases: None,
             materialization: CteMaterialization::Default,
-            query: SelectStatement {
+            query: CteQuery::Select(SelectStatement {
                 with_clause: None,
                 table: "users".to_string(),
                 columns: vec![Expression::Column("id".to_string())],
@@ -477,7 +781,7 @@ mod tests {
                 order_by: vec![],
                 limit: None,
                 offset: None,
-            },
+            }),
             effective_columns: vec![ColumnDef::new("id", DataType::Integer)],
         };
 
@@ -487,7 +791,7 @@ mod tests {
             name: "my_cte".to_string(),
             column_aliases: Some(vec!["a".to_string(), "b".to_string()]),
             materialization: CteMaterialization::Materialized,
-            query: SelectStatement {
+            query: CteQuery::Select(SelectStatement {
                 with_clause: None,
                 table: "users".to_string(),
                 columns: vec![
@@ -498,7 +802,7 @@ mod tests {
                 order_by: vec![],
                 limit: None,
                 offset: None,
-            },
+            }),
             effective_columns: vec![
                 ColumnDef::new("a", DataType::Integer),
                 ColumnDef::new("b", DataType::Text),
@@ -521,7 +825,7 @@ mod tests {
                     name: "cte1".to_string(),
                     column_aliases: None,
                     materialization: CteMaterialization::Default,
-                    query: SelectStatement {
+                    query: CteQuery::Select(SelectStatement {
                         with_clause: None,
                         table: "users".to_string(),
                         columns: vec![Expression::Column("id".to_string())],
@@ -529,14 +833,14 @@ mod tests {
                         order_by: vec![],
                         limit: None,
                         offset: None,
-                    },
+                    }),
                     effective_columns: vec![ColumnDef::new("id", DataType::Integer)],
                 },
                 CteDefinition {
                     name: "cte2".to_string(),
                     column_aliases: None,
                     materialization: CteMaterialization::NotMaterialized,
-                    query: SelectStatement {
+                    query: CteQuery::Select(SelectStatement {
                         with_clause: None,
                         table: "orders".to_string(),
                         columns: vec![Expression::Column("user_id".to_string())],
@@ -544,7 +848,7 @@ mod tests {
                         order_by: vec![],
                         limit: None,
                         offset: None,
-                    },
+                    }),
                     effective_columns: vec![ColumnDef::new("user_id", DataType::Integer)],
                 },
             ],
@@ -553,6 +857,125 @@ mod tests {
         assert_eq!(
             with.to_string(),
             "WITH cte1 AS (SELECT id FROM users), cte2 AS NOT MATERIALIZED (SELECT user_id FROM orders)"
+        );
+    }
+
+    #[test]
+    fn recursive_definition_display_enables_recursive_keyword() {
+        let with = WithClause {
+            ctes: vec![CteDefinition {
+                name: "seq".to_string(),
+                column_aliases: Some(vec!["x".to_string()]),
+                materialization: CteMaterialization::NotMaterialized,
+                query: CteQuery::Recursive(
+                    "VALUES(1) UNION ALL SELECT x + 1 FROM seq WHERE x < 3".to_string(),
+                ),
+                effective_columns: vec![ColumnDef::new("x", DataType::Integer)],
+            }],
+        };
+
+        assert_eq!(
+            with.to_string(),
+            "WITH RECURSIVE seq(x) AS NOT MATERIALIZED (VALUES(1) UNION ALL SELECT x + 1 FROM seq WHERE x < 3)"
+        );
+    }
+
+    #[test]
+    fn recursive_generator_produces_bounded_well_formed_definitions() {
+        let schema = test_schema();
+        let mut profile = StatementProfile::default();
+        profile.select.extra.cte_profile = CteProfile {
+            cte_weight: 100,
+            no_cte_weight: 0,
+            cte_count_range: 1..=4,
+            recursive_weight: 100,
+            non_recursive_weight: 0,
+            ..CteProfile::default()
+        };
+        let strategy = with_clause(&schema, &profile);
+        let mut runner = TestRunner::deterministic();
+
+        for _ in 0..512 {
+            let with = strategy
+                .new_tree(&mut runner)
+                .expect("recursive CTE strategy must produce a value")
+                .current();
+            let sql = with.to_string();
+            assert!(sql.starts_with("WITH RECURSIVE "));
+
+            let mut names = std::collections::HashSet::new();
+            for cte in &with.ctes {
+                assert!(names.insert(cte.name.clone()), "duplicate CTE name: {sql}");
+                assert_eq!(
+                    cte.column_aliases.as_ref().map(Vec::len),
+                    Some(cte.effective_columns.len())
+                );
+                assert!(
+                    cte.effective_columns
+                        .iter()
+                        .all(|column| column.data_type == DataType::Integer)
+                );
+
+                let CteQuery::Recursive(body) = &cte.query else {
+                    panic!("recursive-only profile generated an ordinary CTE: {sql}");
+                };
+                assert!(
+                    body.contains(&format!("FROM {}", cte.name))
+                        || body.contains(&format!("JOIN {}", cte.name))
+                );
+                assert!(
+                    body.contains(" WHERE ") || body.contains(" UNION SELECT "),
+                    "recursive body is not structurally bounded: {body}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn correlated_recursive_subquery_is_clamped_to_the_outer_source() {
+        let schema = test_schema();
+        let outer = schema
+            .tables
+            .iter()
+            .find(|table| table.unqualified_name() == "users")
+            .expect("test schema must contain users")
+            .clone();
+        let mut profile = StatementProfile::default();
+        profile.select.extra.cte_profile = CteProfile {
+            cte_weight: 100,
+            no_cte_weight: 0,
+            recursive_weight: 100,
+            non_recursive_weight: 0,
+            ..CteProfile::default()
+        };
+        let strategy = correlated_recursive_subquery_columns(
+            &outer,
+            &schema,
+            &["cte_0".to_string()],
+            &profile,
+        );
+        let mut runner = TestRunner::deterministic();
+
+        let mut saw_subquery = false;
+        for _ in 0..256 {
+            let columns = strategy
+                .new_tree(&mut runner)
+                .expect("correlated subquery strategy must produce a value")
+                .current();
+            for column in &columns {
+                saw_subquery = true;
+                let sql = column.to_string();
+                assert!(sql.contains("WITH RECURSIVE "), "not recursive: {sql}");
+                assert!(
+                    sql.contains(" WHERE x < min(users."),
+                    "recursion bound is not clamped to the outer source: {sql}"
+                );
+                assert!(!sql.contains("cte_0"), "excluded CTE name reused: {sql}");
+            }
+        }
+        assert!(
+            saw_subquery,
+            "strategy never produced a correlated subquery"
         );
     }
 

--- a/testing/differential-oracle/sql_gen_prop/lib.rs
+++ b/testing/differential-oracle/sql_gen_prop/lib.rs
@@ -48,7 +48,7 @@ pub use create_trigger::{
     CreateTriggerContext, CreateTriggerKind, CreateTriggerOpWeights, CreateTriggerStatement,
     TriggerEvent, TriggerTiming,
 };
-pub use cte::{CteDefinition, CteMaterialization, CteProfile, WithClause};
+pub use cte::{CteDefinition, CteMaterialization, CteProfile, CteQuery, WithClause};
 pub use delete::DeleteStatement;
 pub use drop_index::DropIndexStatement;
 pub use drop_table::DropTableStatement;

--- a/testing/differential-oracle/sql_gen_prop/select.rs
+++ b/testing/differential-oracle/sql_gen_prop/select.rs
@@ -456,8 +456,14 @@ pub fn select_for_table(
             let profile = profile_clone.clone();
             let original_table = table_clone.clone();
 
-            // Build list of available sources: original table + any CTEs
-            let mut sources: Vec<TableRef> = vec![original_table];
+            let recursive_only = with_clause
+                .as_ref()
+                .is_some_and(|with| with.ctes.iter().all(|cte| cte.query.is_recursive()));
+            let mut sources: Vec<TableRef> = if recursive_only {
+                Vec::new()
+            } else {
+                vec![original_table]
+            };
             if let Some(ref with) = with_clause {
                 for cte in &with.ctes {
                     sources.push(std::rc::Rc::new(cte.as_table()));
@@ -470,18 +476,38 @@ pub fn select_for_table(
             proptest::sample::select(sources).prop_flat_map(move |source| {
                 let with_clause = with_for_closure.clone();
                 let source_name = source.qualified_name();
+                let outer_cte_names: Vec<String> = with_clause
+                    .as_ref()
+                    .map(|with| with.ctes.iter().map(|cte| cte.name.clone()).collect())
+                    .unwrap_or_default();
 
-                select_body_for_source(&source, &schema, &profile).prop_map(
-                    move |(columns, where_clause, order_by, limit, offset)| SelectStatement {
-                        with_clause: with_clause.clone(),
-                        table: source_name.clone(),
-                        columns,
-                        where_clause,
-                        order_by,
-                        limit,
-                        offset,
-                    },
+                (
+                    select_body_for_source(&source, &schema, &profile),
+                    crate::cte::correlated_recursive_subquery_columns(
+                        &source,
+                        &schema,
+                        &outer_cte_names,
+                        &profile,
+                    ),
                 )
+                    .prop_map(
+                        move |(
+                            (columns, where_clause, order_by, limit, offset),
+                            correlated_columns,
+                        )| {
+                            let mut columns = columns;
+                            columns.extend(correlated_columns);
+                            SelectStatement {
+                                with_clause: with_clause.clone(),
+                                table: source_name.clone(),
+                                columns,
+                                where_clause,
+                                order_by,
+                                limit,
+                                offset,
+                            }
+                        },
+                    )
             })
         })
         .boxed()
@@ -837,5 +863,53 @@ mod tests {
             found_function,
             "Expected to generate at least one SELECT with function calls in 50 attempts"
         );
+    }
+
+    #[test]
+    fn recursive_only_selects_query_a_recursive_cte() {
+        use proptest::strategy::Strategy;
+        use proptest::test_runner::TestRunner;
+
+        let table = crate::schema::Table::new(
+            "test",
+            vec![crate::schema::ColumnDef::new(
+                "id",
+                crate::schema::DataType::Integer,
+            )],
+        );
+        let schema = crate::schema::SchemaBuilder::new()
+            .add_table(table.clone())
+            .build();
+        let table_ref: crate::schema::TableRef = table.into();
+        let mut profile = StatementProfile::default();
+        profile.select.extra.cte_profile = crate::cte::CteProfile {
+            cte_weight: 100,
+            no_cte_weight: 0,
+            cte_count_range: 1..=3,
+            recursive_weight: 100,
+            non_recursive_weight: 0,
+            ..crate::cte::CteProfile::default()
+        };
+        let strategy = select_for_table(&table_ref, &schema, &profile);
+        let mut runner = TestRunner::deterministic();
+
+        for _ in 0..128 {
+            let stmt = strategy
+                .new_tree(&mut runner)
+                .expect("recursive SELECT strategy must produce a value")
+                .current();
+            let with = stmt
+                .with_clause
+                .as_ref()
+                .expect("recursive-only profile must generate a WITH clause");
+            assert!(
+                with.ctes.iter().all(|cte| cte.query.is_recursive()),
+                "recursive-only profile generated an ordinary CTE: {stmt}"
+            );
+            assert!(
+                with.ctes.iter().any(|cte| cte.name == stmt.table),
+                "recursive-only SELECT queried the base table: {stmt}"
+            );
+        }
     }
 }

--- a/testing/differential-oracle/sql_gen_prop/select.rs
+++ b/testing/differential-oracle/sql_gen_prop/select.rs
@@ -299,6 +299,14 @@ impl SelectStatement {
         }
         false
     }
+
+    /// True when this SELECT's WITH clause defines a recursive CTE, directly
+    /// or nested inside another CTE body.
+    pub fn has_recursive_cte(&self) -> bool {
+        self.with_clause
+            .as_ref()
+            .is_some_and(crate::cte::WithClause::has_recursive_cte)
+    }
 }
 
 impl fmt::Display for SelectStatement {

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -56,6 +56,32 @@ fn recursive_cte_with_bound_termination_predicate(tmp_db: TempDatabase) -> anyho
     Ok(())
 }
 
+#[turso_macros::test]
+fn recursive_cte_explain_query_plan_shows_setup_and_recursive_step(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    let eqp_rows = limbo_exec_rows(
+        &conn,
+        "EXPLAIN QUERY PLAN
+         WITH RECURSIVE t(a) AS (SELECT 1 UNION ALL SELECT a + 1 FROM t WHERE a < 3)
+         SELECT * FROM t",
+    );
+    let plan = eqp_rows
+        .iter()
+        .filter_map(|row| match row.get(3) {
+            Some(rusqlite::types::Value::Text(detail)) => Some(detail.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        plan.contains("SETUP") && plan.contains("RECURSIVE STEP"),
+        "expected recursive CTE structure in query plan, got:\n{plan}"
+    );
+    Ok(())
+}
+
 #[turso_macros::test(mvcc, init_sql = "create table test (i integer);")]
 fn test_statement_bind(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -35,6 +35,27 @@ fn test_statement_reset_bind(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[turso_macros::test]
+fn recursive_cte_with_bound_termination_predicate(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    let mut stmt = conn.prepare(
+        "SELECT (
+            WITH RECURSIVE seq(x) AS (
+                VALUES(1)
+                UNION ALL
+                SELECT x + 1 FROM seq WHERE x < ?
+            )
+            SELECT count(*) FROM seq
+        )",
+    )?;
+    stmt.bind_at(1.try_into()?, Value::from_i64(100))?;
+    stmt.run_with_row_callback(|row| {
+        assert_eq!(*row.get::<&Value>(0).unwrap(), Value::from_i64(100));
+        Ok(())
+    })?;
+    Ok(())
+}
+
 #[turso_macros::test(mvcc, init_sql = "create table test (i integer);")]
 fn test_statement_bind(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();


### PR DESCRIPTION
Implement `WITH RECURSIVE` using the same iterative queue algorithm as SQLite:

```sql
WITH seq(x) AS (
  VALUES (1) -- initial query
  UNION ALL
  SELECT x + 1 FROM seq WHERE x < 3 -- recursive query
)
SELECT x FROM seq;
```

The algorithm is essentially:

- Run the initial query `VALUES (1)` once and put `1` in a work queue.
- Remove `1` from the queue and return it.
- Make `1` visible to the recursive query as the single row of `seq`.
- Run the recursive query, producing `2`, and add it to the queue.
- Repeat for `2` and `3`.
- Stop when the queue is empty.

A CTE may contain multiple recursive queries:

```sql
WITH seq(x) AS (
  VALUES (1)
  UNION ALL
  SELECT x + 1 FROM seq WHERE x < 3
  UNION ALL
  SELECT x + 10 FROM seq WHERE x < 3
)
SELECT x FROM seq;
```

Each time a row is removed from the queue, every recursive query runs against that same single row. When `1` is removed, the two recursive queries produce `2` and `11`, and both are added to the queue.

With `UNION`, the engine also remembers (via an ephemeral index) every row that has ever been added to the queue:

```sql
WITH cycle(x) AS (
  VALUES (1)
  UNION
  SELECT CASE x WHEN 1 THEN 2 ELSE 1 END FROM cycle
)
SELECT x FROM cycle;
```

Processing `1` produces `2`. Processing `2` produces `1` again, but that row is discarded because it has already been seen, so the queue becomes empty and execution stops.

`UNION ALL` does not perform this duplicate check. It adds every generated row to the queue, so a cycle continues indefinitely unless stopped by a condition or `LIMIT`.

### Joining the recursive row with other tables

The recursive query can join the current recursive row with ordinary tables:

```sql
WITH seq(x) AS (
  VALUES (1)
  UNION ALL
  SELECT seq.x + 1
  FROM seq
  JOIN users ON users.id = seq.x
  WHERE seq.x < 3
)
SELECT x FROM seq;
```

For each row removed from the queue, `seq` behaves as a one-row table containing that row. The recursive query then runs the join normally:

- Remove `1` from the queue and expose it as the single row of `seq`.
- Look up the matching `users` row and run the recursive query.
- Add the produced row to the queue.
- Repeat with the next queued row.

The real-table access is repeated for every queued row. If the join uses an index, such as the primary key on `users.id`, this normally means one index probe per recursive step. Without a usable index, it may mean scanning the table again for every step.