### PR TITLE
bindings/python: Reject sqlite3.Row when used as a row_factory with an explicit TypeError

### DIFF
--- a/bindings/python/tests/test_database.py
+++ b/bindings/python/tests/test_database.py
@@ -406,6 +406,50 @@ def test_row_factory_keys(provider):
     conn.close()
 
 
+def test_stdlib_sqlite3_row_factory_rejected():
+    """sqlite3.Row cannot work with turso cursors (its C constructor requires a
+    real sqlite3.Cursor), so fetching raises an error that points at turso.Row
+    instead of the cryptic C-level TypeError."""
+    conn = turso.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+    conn.execute("INSERT INTO t VALUES (1, 'alice')")
+    with pytest.raises(TypeError, match="turso.Row"):
+        conn.execute("SELECT * FROM t").fetchone()
+    conn.close()
+
+
+def test_stdlib_sqlite3_row_subclass_rejected_on_cursor():
+    """Rejection also applies to per-cursor assignment and sqlite3.Row subclasses."""
+    conn = turso.connect(":memory:")
+
+    class SubRow(sqlite3.Row):
+        pass
+
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE t (id INTEGER)")
+    cur.execute("INSERT INTO t VALUES (1)")
+    cur.row_factory = SubRow
+    cur.execute("SELECT * FROM t")
+    with pytest.raises(TypeError, match="turso.Row"):
+        cur.fetchall()
+    conn.close()
+
+
+def test_turso_row_factory_works_where_stdlib_row_is_rejected():
+    """turso.Row is the supported replacement and provides the same interface."""
+    conn = turso.connect(":memory:")
+    conn.row_factory = turso.Row
+    conn.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+    conn.execute("INSERT INTO t VALUES (1, 'alice')")
+    row = conn.execute("SELECT * FROM t").fetchone()
+    assert row["id"] == 1
+    assert row["name"] == "alice"
+    assert row[0] == 1
+    assert row.keys() == ["id", "name"]
+    conn.close()
+
+
 @pytest.mark.parametrize("provider", ["sqlite3", "turso"])
 def test_parameterized_query(provider):
     conn = connect(provider, ":memory:")

--- a/bindings/python/turso/lib.py
+++ b/bindings/python/turso/lib.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3 as _stdlib_sqlite3
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from types import TracebackType
@@ -844,6 +845,8 @@ class Cursor:
         rf = self.row_factory
         if rf is None:
             return row_values
+        if isinstance(rf, type) and issubclass(rf, _stdlib_sqlite3.Row):
+            raise TypeError("sqlite3.Row is not supported as a row_factory on turso connections; use turso.Row instead")
         if isinstance(rf, type) and issubclass(rf, Row):
             return rf(self, Row(self, row_values))  # type: ignore[call-arg]
         if callable(rf):

--- a/bindings/python/turso/lib.py
+++ b/bindings/python/turso/lib.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sqlite3 as _stdlib_sqlite3
+import sys
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from types import TracebackType
@@ -205,6 +205,14 @@ def _step_once_with_io(stmt: PyTursoStatement, extra_io: Optional[Callable[[], N
                 extra_io()
             continue
         return status
+
+
+def _reject_stdlib_row_factory(rf: Any) -> None:
+    stdlib_sqlite3 = sys.modules.get("sqlite3")
+    if stdlib_sqlite3 is None:
+        return
+    if isinstance(rf, type) and issubclass(rf, stdlib_sqlite3.Row):
+        raise TypeError("sqlite3.Row is not supported as a row_factory on turso connections; use turso.Row instead")
 
 
 @dataclass
@@ -845,12 +853,14 @@ class Cursor:
         rf = self.row_factory
         if rf is None:
             return row_values
-        if isinstance(rf, type) and issubclass(rf, _stdlib_sqlite3.Row):
-            raise TypeError("sqlite3.Row is not supported as a row_factory on turso connections; use turso.Row instead")
         if isinstance(rf, type) and issubclass(rf, Row):
             return rf(self, Row(self, row_values))  # type: ignore[call-arg]
         if callable(rf):
-            return rf(self, Row(self, row_values))  # type: ignore[misc]
+            try:
+                return rf(self, Row(self, row_values))  # type: ignore[misc]
+            except TypeError:
+                _reject_stdlib_row_factory(rf)
+                raise
         # Fallback: return tuple
         return row_values
 


### PR DESCRIPTION
## Description
This PR addresses a user-reported bug on the Turso user Discord when using sqlite3.Row as a row factory:
```python
conn.row_factory = sqlite3.Row # assignment succeeds
conn.execute("SELECT * FROM t").fetchone() # Crashes with a TypeError
```

The issue is that Turso calls the configured row factory with a Turso Cursor, but `sqlite3.Row` only accepts a stdlib `sqlite3.Cursor`. We do not support mixing database libraries like this. The fix is straightforward. Detect when `sqlite3.Row` or a subclass is used as a Turso row factory, and raise an explicit TypeError when rows are fetched.

## Motivation and context
Defining a row_factory with `conn.row_factory = sqlite3.Row` is a common Python pattern users are accustomed to using with Python's standard library sqlite3 implementation. However, this will not work with pyturso.

Our _apply_row_factory() method in lib.py returns: 
```python
rf(self, Row(self, row_values))
```

If rf has been defined with sqlite3.Row, sqlite3.Row.__new__ performs an isinstance check on the arguments and discovers that *self* is a `turso.Cursor` object rather than a `sqlite3.Cursor` and rejects it with a TypeError. 

```bash 
>> TypeError: Row() argument 1 must be sqlite3.Cursor, not Cursor
```

This failure path misdiagnoses the real issue: the user is attempting to use `sqlite3.Row` to define a pyturso row factory. Turso's row class should be used to create the row_factory instead:

```python
conn.row_factory = turso.Row
```

By emitting our own TypeError instead, the user clearly understands the correct pattern to use:
```python
  if isinstance(rf, type) and issubclass(rf, _stdlib_sqlite3.Row):
    raise TypeError("sqlite3.Row is not supported as a row_factory on turso connections; use turso.Row instead")
```

## Description of AI Usage

Claude was used to verify the bug, research sqlite3 behavior, write tests and validate that the code change would not affect other callers.

## Files changed:
  - bindings/python/turso/lib.py:844: imports stdlib sqlite3 and rejects sqlite3.Row subclasses with the explicit TypeError.
  - bindings/python/tests/test_database.py:409: adds 3 regression tests.

## Validation:
targeted tests pass: 
```bash
uv run pytest bindings/python/tests/test_database.py -k "stdlib_sqlite3_row or turso_row_factory_works"
```

