### PR TITLE
sync: auto-detect the remote pull protocol

### DIFF
--- a/bindings/go/bindings_sync.go
+++ b/bindings/go/bindings_sync.go
@@ -82,6 +82,10 @@ type TursoSyncDatabaseConfig struct {
 	// in chunks. 0 (default) bootstraps in a single round-trip. no-op when partial-sync uses the
 	// query bootstrap strategy.
 	PullBytesThreshold int
+	// when true, forces incremental pulls to use the MVCC logical-log stream.
+	// false (default) auto-detects the remote's protocol from the first pull
+	// response and persists it, so this only needs to be set as an escape hatch.
+	LogicalMvccPull bool
 }
 
 // TursoSyncStats holds sync engine stats.
@@ -139,6 +143,7 @@ type turso_sync_database_config_t struct {
 	remote_encryption_cipher          uintptr // const char*
 	push_operations_threshold         uintptr // size_t
 	pull_bytes_threshold              uintptr // size_t
+	logical_mvcc_pull                 bool
 }
 
 type turso_sync_io_http_request_t struct {
@@ -428,6 +433,7 @@ func turso_sync_database_new(dbConfig TursoDatabaseConfig, syncConfig TursoSyncD
 	}
 	csync.push_operations_threshold = uintptr(syncConfig.PushOperationsThreshold)
 	csync.pull_bytes_threshold = uintptr(syncConfig.PullBytesThreshold)
+	csync.logical_mvcc_pull = syncConfig.LogicalMvccPull
 
 	var db *turso_sync_database_t
 	var errPtr *byte

--- a/bindings/go/driver_sync.go
+++ b/bindings/go/driver_sync.go
@@ -86,6 +86,11 @@ type TursoSyncDbConfig struct {
 	// in chunks. 0 (default) bootstraps in a single round-trip. no-op when partial sync uses the
 	// query bootstrap strategy.
 	PullBytesThreshold int
+
+	// when true, forces incremental pulls to use the MVCC logical-log stream.
+	// false (default) auto-detects the remote's protocol from the first pull
+	// response and persists it, so this only needs to be set as an escape hatch.
+	LogicalMvccPull bool
 }
 
 // statistics for the synced database.
@@ -172,6 +177,7 @@ func NewTursoSyncDb(ctx context.Context, config TursoSyncDbConfig) (*TursoSyncDb
 		PartialBootstrapPrefetch:       config.PartialSyncExperimental.Prefetch,
 		PushOperationsThreshold:        config.PushOperationsThreshold,
 		PullBytesThreshold:             config.PullBytesThreshold,
+		LogicalMvccPull:                config.LogicalMvccPull,
 	}
 	sdb, err := turso_sync_database_new(dbCfg, syncCfg)
 	if err != nil {

--- a/bindings/javascript/sync/packages/common/types.ts
+++ b/bindings/javascript/sync/packages/common/types.ts
@@ -141,6 +141,15 @@ export interface DatabaseOpts {
      */
     pullBytesThreshold?: number,
     /**
+     * sync-protocol override for incremental pulls.
+     * unset (default) auto-detects the remote's protocol (WAL page streams vs
+     * MVCC logical-log streams) from the first pull response and persists it —
+     * no configuration is needed to sync with MVCC-mode remotes.
+     * true forces MVCC logical-log streams; false forces page streams.
+     * only needed for tests or as an escape hatch.
+     */
+    logicalMvccPull?: boolean,
+    /**
      * optional fetch override used for every HTTP request made by the sync engine
      * (push, pull, wait-for-changes). drop-in replacement for `globalThis.fetch`.
      * use cases:

--- a/bindings/javascript/sync/packages/native/index.d.ts
+++ b/bindings/javascript/sync/packages/native/index.d.ts
@@ -330,7 +330,11 @@ export interface SyncEngineOpts {
    * partial-sync uses the query bootstrap strategy.
    */
   pullBytesThreshold?: number
-  /** Use MVCC logical-log stream for incremental V1 pulls. */
+  /**
+   * Sync-protocol override for incremental pulls. Unset (default)
+   * auto-detects the remote protocol from the first pull-updates response;
+   * `true` forces MVCC logical-log streams; `false` forces page streams.
+   */
   logicalMvccPull?: boolean
 }
 

--- a/bindings/javascript/sync/packages/native/promise.ts
+++ b/bindings/javascript/sync/packages/native/promise.ts
@@ -100,6 +100,7 @@ class Database extends DatabasePromise {
             partialSyncOpts: partialSyncOpts as any,
             pushOperationsThreshold: opts.pushOperationsThreshold,
             pullBytesThreshold: opts.pullBytesThreshold,
+            logicalMvccPull: opts.logicalMvccPull,
         });
 
         let headers: { [K: string]: string } | (() => Promise<{ [K: string]: string }>);

--- a/bindings/javascript/sync/packages/wasm/promise-bundle.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-bundle.ts
@@ -101,6 +101,7 @@ class Database extends DatabasePromise {
             partialSyncOpts: partialSyncOpts,
             pushOperationsThreshold: opts.pushOperationsThreshold,
             pullBytesThreshold: opts.pullBytesThreshold,
+            logicalMvccPull: opts.logicalMvccPull,
         });
 
         let headers: { [K: string]: string } | (() => Promise<{ [K: string]: string }>);

--- a/bindings/javascript/sync/packages/wasm/promise-default.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-default.ts
@@ -101,6 +101,7 @@ class Database extends DatabasePromise {
             partialSyncOpts: partialSyncOpts,
             pushOperationsThreshold: opts.pushOperationsThreshold,
             pullBytesThreshold: opts.pullBytesThreshold,
+            logicalMvccPull: opts.logicalMvccPull,
         });
 
         let headers: { [K: string]: string } | (() => Promise<{ [K: string]: string }>);

--- a/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
@@ -101,6 +101,7 @@ class Database extends DatabasePromise {
             partialSyncOpts: partialSyncOpts,
             pushOperationsThreshold: opts.pushOperationsThreshold,
             pullBytesThreshold: opts.pullBytesThreshold,
+            logicalMvccPull: opts.logicalMvccPull,
         });
 
         let headers: { [K: string]: string } | (() => Promise<{ [K: string]: string }>);

--- a/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
@@ -101,6 +101,7 @@ class Database extends DatabasePromise {
             partialSyncOpts: partialSyncOpts,
             pushOperationsThreshold: opts.pushOperationsThreshold,
             pullBytesThreshold: opts.pullBytesThreshold,
+            logicalMvccPull: opts.logicalMvccPull,
         });
 
         let headers: { [K: string]: string } | (() => Promise<{ [K: string]: string }>);

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -163,7 +163,9 @@ pub struct SyncEngineOpts {
     /// `None` (default) bootstraps in a single round-trip. No-op when
     /// partial-sync uses the query bootstrap strategy.
     pub pull_bytes_threshold: Option<u32>,
-    /// Use MVCC logical-log stream for incremental V1 pulls.
+    /// Sync-protocol override for incremental pulls. Unset (default)
+    /// auto-detects the remote protocol from the first pull-updates response;
+    /// `true` forces MVCC logical-log streams; `false` forces page streams.
     pub logical_mvcc_pull: Option<bool>,
 }
 
@@ -183,7 +185,7 @@ struct SyncEngineOptsFilled {
     pub partial_sync_opts: Option<PartialSyncOpts>,
     pub push_operations_threshold: Option<usize>,
     pub pull_bytes_threshold: Option<usize>,
-    pub logical_mvcc_pull: bool,
+    pub logical_mvcc_pull: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -336,7 +338,7 @@ impl SyncEngine {
             remote_encryption_key: opts.remote_encryption_key.clone(),
             push_operations_threshold: opts.push_operations_threshold.map(|x| x as usize),
             pull_bytes_threshold: opts.pull_bytes_threshold.map(|x| x as usize),
-            logical_mvcc_pull: opts.logical_mvcc_pull.unwrap_or(false),
+            logical_mvcc_pull: opts.logical_mvcc_pull,
         };
         Ok(SyncEngine {
             opts: opts_filled,

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -113,8 +113,10 @@ pub struct PyTursoSyncDatabaseConfig {
     // /pull-updates HTTP requests of >= this many bytes each. None (default) bootstraps
     // in a single round-trip. no-op when partial-sync uses the query bootstrap strategy.
     pub pull_bytes_threshold: Option<usize>,
-    // use MVCC logical-log stream for incremental V1 pulls
-    pub logical_mvcc_pull: bool,
+    // sync-protocol override: None (default) auto-detects the remote protocol
+    // from the first pull-updates response; Some(true) forces MVCC logical-log
+    // streams; Some(false) forces page streams
+    pub logical_mvcc_pull: Option<bool>,
 }
 
 #[pymethods]
@@ -132,7 +134,7 @@ impl PyTursoSyncDatabaseConfig {
         remote_encryption_cipher=None,
         push_operations_threshold=None,
         pull_bytes_threshold=None,
-        logical_mvcc_pull=false,
+        logical_mvcc_pull=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -147,7 +149,7 @@ impl PyTursoSyncDatabaseConfig {
         remote_encryption_cipher: Option<PyRemoteEncryptionCipher>,
         push_operations_threshold: Option<usize>,
         pull_bytes_threshold: Option<usize>,
-        logical_mvcc_pull: bool,
+        logical_mvcc_pull: Option<bool>,
     ) -> Self {
         Self {
             path,

--- a/bindings/python/turso/lib_sync.py
+++ b/bindings/python/turso/lib_sync.py
@@ -432,6 +432,7 @@ def connect_sync(
     remote_encryption_cipher: Optional[RemoteEncryptionCipher] = None,
     push_operations_threshold: Optional[int] = None,
     pull_bytes_threshold: Optional[int] = None,
+    logical_mvcc_pull: Optional[bool] = None,
 ) -> ConnectionSync:
     """
     Create and open a synchronized database connection.
@@ -453,6 +454,9 @@ def connect_sync(
     - pull_bytes_threshold: optional hint, in bytes, that splits the bootstrap download into multiple
       pull-updates HTTP requests of >= this many bytes each. None (default) bootstraps in a single
       round-trip; no-op when partial sync uses the query bootstrap strategy
+    - logical_mvcc_pull: sync-protocol override. None (default) auto-detects the remote protocol
+      from the first pull-updates response and persists it; True forces the MVCC logical-log
+      stream; False forces page streams. Only needed for tests or as an escape hatch
     """
     # Resolve client name
     cname = client_name or "turso-sync-py"
@@ -497,6 +501,7 @@ def connect_sync(
         remote_encryption_cipher=remote_encryption_cipher,
         push_operations_threshold=push_operations_threshold,
         pull_bytes_threshold=pull_bytes_threshold,
+        logical_mvcc_pull=logical_mvcc_pull,
     )
 
     # Create sync database holder

--- a/bindings/python/turso/lib_sync_aio.py
+++ b/bindings/python/turso/lib_sync_aio.py
@@ -76,6 +76,7 @@ def connect_sync(
     isolation_level: Optional[str] = "DEFERRED",
     push_operations_threshold: Optional[int] = None,
     pull_bytes_threshold: Optional[int] = None,
+    logical_mvcc_pull: Optional[bool] = None,
 ) -> ConnectionSync:
     # Connector creating the blocking synchronized connection in the worker thread
     def _connector() -> BlockingConnectionSync:
@@ -91,6 +92,7 @@ def connect_sync(
             isolation_level=isolation_level,
             push_operations_threshold=push_operations_threshold,
             pull_bytes_threshold=pull_bytes_threshold,
+            logical_mvcc_pull=logical_mvcc_pull,
         )
 
     # Return awaitable async wrapper with sync extras

--- a/bindings/react-native/cpp/TursoHostObject.cpp
+++ b/bindings/react-native/cpp/TursoHostObject.cpp
@@ -494,6 +494,24 @@ namespace turso
                     sync_config.pull_bytes_threshold = 0;
                 }
 
+                // logicalMvccPull (required for MVCC-mode remotes, see C ABI docs)
+                if (syncConfigObj.hasProperty(rt, "logicalMvccPull"))
+                {
+                    jsi::Value logicalMvccPullVal = syncConfigObj.getProperty(rt, "logicalMvccPull");
+                    if (logicalMvccPullVal.isBool())
+                    {
+                        sync_config.logical_mvcc_pull = logicalMvccPullVal.getBool();
+                    }
+                    else
+                    {
+                        sync_config.logical_mvcc_pull = false;
+                    }
+                }
+                else
+                {
+                    sync_config.logical_mvcc_pull = false;
+                }
+
                 // Create sync database instance
                 const turso_sync_database_t* database = nullptr;
                 const char* error = nullptr;

--- a/bindings/react-native/src/Database.ts
+++ b/bindings/react-native/src/Database.ts
@@ -174,6 +174,7 @@ export class Database {
       remoteEncryptionCipher: this._opts.remoteEncryption?.cipher,
       pushOperationsThreshold: this._opts.pushOperationsThreshold,
       pullBytesThreshold: this._opts.pullBytesThreshold,
+      logicalMvccPull: this._opts.logicalMvccPull ?? false,
     };
 
     // Add partial sync options if present

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -332,6 +332,14 @@ export interface DatabaseOpts {
   pullBytesThreshold?: number;
 
   /**
+   * When true, forces incremental pulls to use the MVCC logical-log stream.
+   * Unset/false (default) auto-detects the remote's protocol from the first
+   * pull response and persists it, so this only needs to be set as an
+   * escape hatch.
+   */
+  logicalMvccPull?: boolean;
+
+  /**
    * Optional parameter to enable partial sync for the database
    * WARNING: This feature is EXPERIMENTAL
    */

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -107,8 +107,10 @@ pub struct Builder {
     remote_encryption_key: Option<String>,
     // Encryption cipher for the Turso Cloud database
     remote_encryption_cipher: Option<RemoteEncryptionCipher>,
-    // Use MVCC logical-log incremental pulls instead of page-stream pulls.
-    logical_mvcc_pull: bool,
+    // Sync-protocol override: None (default) auto-detects the remote protocol
+    // from the first pull-updates response; Some(true) forces MVCC logical-log
+    // pulls; Some(false) forces page-stream pulls.
+    logical_mvcc_pull: Option<bool>,
     // Experimental engine features to enable on the local synced database.
     // These mirror the local [`crate::Builder`] flags so synced databases
     // expose the same SQL surface as their local-only counterparts. Local
@@ -138,7 +140,7 @@ impl Builder {
             partial_sync_config_experimental: None,
             remote_encryption_key: None,
             remote_encryption_cipher: None,
-            logical_mvcc_pull: false,
+            logical_mvcc_pull: None,
             enable_attach: false,
             enable_custom_types: false,
             enable_index_method: false,
@@ -292,12 +294,14 @@ impl Builder {
         self
     }
 
-    /// Use MVCC logical-log incremental pulls.
+    /// Override the sync protocol used for incremental pulls.
     ///
-    /// MVCC-mode remotes accept page-stream pulls only for bootstrap; callers
-    /// using legacy WAL/page sync should keep the default `false` value.
+    /// By default the protocol is auto-detected from the first pull-updates
+    /// response and persisted in the sync metadata, so calling this is only
+    /// needed for tests or as an escape hatch: `true` forces MVCC logical-log
+    /// pulls, `false` forces page-stream pulls.
     pub fn with_logical_mvcc_pull(mut self, enable: bool) -> Self {
-        self.logical_mvcc_pull = enable;
+        self.logical_mvcc_pull = Some(enable);
         self
     }
 
@@ -989,14 +993,21 @@ mod tests {
     }
 
     #[test]
-    fn logical_mvcc_pull_is_opt_in() {
+    fn logical_mvcc_pull_defaults_to_auto_detection() {
         use crate::sync::Builder;
 
-        assert!(!Builder::new_remote(":memory:").logical_mvcc_pull);
-        assert!(
+        assert_eq!(Builder::new_remote(":memory:").logical_mvcc_pull, None);
+        assert_eq!(
             Builder::new_remote(":memory:")
                 .with_logical_mvcc_pull(true)
-                .logical_mvcc_pull
+                .logical_mvcc_pull,
+            Some(true)
+        );
+        assert_eq!(
+            Builder::new_remote(":memory:")
+                .with_logical_mvcc_pull(false)
+                .logical_mvcc_pull,
+            Some(false)
         );
     }
 

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -17,8 +17,8 @@ use turso_sync_engine::server_proto::{
     BatchCond, BatchResult, BatchStep, BatchStreamReq, BatchStreamResp, Col, Error,
     ExecuteStreamReq, ExecuteStreamResp, MvccLogicalLogMetadataProto, MvccLogicalLogRangeProto,
     PageData, PageSetRawEncodingProto, PageUpdatesEncodingReq, PipelineReqBody, PipelineRespBody,
-    PullUpdatesApplyMode, PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, PullUpdatesStreamKind,
-    Row, StmtResult, StreamRequest, StreamResponse, StreamResult, Value,
+    PullUpdatesApplyMode, PullUpdatesProtocol, PullUpdatesReqProtoBody, PullUpdatesRespProtoBody,
+    PullUpdatesStreamKind, Row, StmtResult, StreamRequest, StreamResponse, StreamResult, Value,
 };
 
 const WAL_FRAME_HEADER_SIZE: usize = 24;
@@ -597,6 +597,15 @@ impl TursoSyncServer {
             stream_kind: PullUpdatesStreamKind::Pages as i32,
             apply_mode: apply_mode as i32,
             mvcc_log: None,
+            // The protocol hint reflects the database, not the response shape:
+            // page bootstraps of an MVCC database advertise MvccLogical so
+            // auto-detecting clients switch to logical pulls, mirroring the
+            // production server.
+            protocol: if conn.mvcc_enabled() {
+                PullUpdatesProtocol::MvccLogical as i32
+            } else {
+                PullUpdatesProtocol::Pages as i32
+            },
         };
 
         let mut response_body = Vec::new();
@@ -723,6 +732,7 @@ impl TursoSyncServer {
             stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
             apply_mode: PullUpdatesApplyMode::Incremental as i32,
             mvcc_log,
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
         };
 
         let header_bytes = header.encode_to_vec();
@@ -774,6 +784,7 @@ impl TursoSyncServer {
             stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
             apply_mode: PullUpdatesApplyMode::Incremental as i32,
             mvcc_log: None,
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
         };
 
         let mut response_body = Vec::new();
@@ -798,6 +809,8 @@ impl TursoSyncServer {
             stream_kind: PullUpdatesStreamKind::Pages as i32,
             apply_mode: PullUpdatesApplyMode::ReplaceBase as i32,
             mvcc_log: None,
+            // Replace-base is only served from the MVCC logical flow here.
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
         };
 
         let mut response_body = Vec::new();

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -101,1691 +101,6 @@ impl Default for DataStats {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        create_main_db_log_path, create_main_db_wal_path, create_meta_path,
-        create_replace_base_marker_path, create_revert_db_wal_path,
-        ensure_logical_mvcc_pull_supported, ensure_stream_kind_can_use_legacy_page_apply,
-        replace_base_backup_path, resolve_local_replay_floor_change_id,
-        resolve_remote_pull_protocol, should_replay_raw_pages_on_sql_conn,
-        should_request_logical_pull, stream_kind_applies_remote_pages,
-        stream_kind_for_pull_updates_v1_result, synced_change_id_after_remote_apply,
-        use_pushed_change_hint_for_local_replay, DatabaseSyncEngine, DatabaseSyncEngineOpts,
-        ReplaceBaseApplyGuard, REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
-    };
-    use crate::{
-        client_proto::{
-            LogicalOp, LogicalOpType, LogicalSchemaAction, LogicalSchemaKind, LogicalTxnData,
-        },
-        database_sync_engine_io::{DataCompletion, DataPollResult, SyncEngineIo},
-        database_sync_operations::{
-            count_local_changes, max_local_change_id, read_last_change_id, update_last_change_id,
-            MutexSlot, PullUpdatesV1Result, SyncEngineIoStats,
-        },
-        database_tape::{run_stmt_once, DatabaseTape, DatabaseTapeOpts},
-        errors::Error,
-        io_operations::IoOperations,
-        server_proto::{
-            PageData, PageSetRawEncodingProto, PullUpdatesApplyMode, PullUpdatesProtocol,
-            PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, PullUpdatesStreamKind,
-        },
-        types::{
-            Coro, DatabaseMetadata, DatabasePullRevision, DatabaseSavedConfiguration,
-            DatabaseSyncEngineProtocolVersion, DbChangesStatus, DbChangesStreamKind,
-            PartialSyncOpts, RemotePullProtocol, SyncEngineIoResult, DATABASE_METADATA_VERSION,
-        },
-        Result,
-    };
-    use bytes::Bytes;
-    use prost::Message;
-    use std::{
-        sync::{Arc, Mutex},
-        time::Duration,
-    };
-    use tempfile::NamedTempFile;
-    use turso_core::SqliteDialect;
-
-    #[test]
-    fn explicit_override_wins_over_persisted_protocol() {
-        for persisted in [
-            RemotePullProtocol::Unknown,
-            RemotePullProtocol::Pages,
-            RemotePullProtocol::MvccLogical,
-        ] {
-            assert_eq!(
-                resolve_remote_pull_protocol(Some(true), persisted),
-                RemotePullProtocol::MvccLogical
-            );
-            assert_eq!(
-                resolve_remote_pull_protocol(Some(false), persisted),
-                RemotePullProtocol::Pages
-            );
-            assert_eq!(resolve_remote_pull_protocol(None, persisted), persisted);
-        }
-    }
-
-    #[test]
-    fn logical_mvcc_pull_with_partial_sync_is_a_hard_error() {
-        // Silent downgrade to page pull would just defer the failure to an
-        // opaque server-side protocol error on every incremental pull.
-        assert!(ensure_logical_mvcc_pull_supported(true, None).is_err());
-    }
-
-    #[test]
-    fn logical_mvcc_pull_with_remote_encryption_is_a_hard_error() {
-        assert!(ensure_logical_mvcc_pull_supported(false, Some("key")).is_err());
-    }
-
-    #[test]
-    fn logical_mvcc_pull_remains_enabled_for_plain_full_sync() {
-        assert!(ensure_logical_mvcc_pull_supported(false, None).is_ok());
-    }
-
-    #[test]
-    fn logical_pull_is_requested_only_for_active_v1_revisions() {
-        assert!(!should_request_logical_pull(false, &None));
-        assert!(!should_request_logical_pull(true, &None));
-        assert!(!should_request_logical_pull(
-            true,
-            &Some(DatabasePullRevision::Legacy {
-                generation: 1,
-                synced_frame_no: Some(10),
-            })
-        ));
-        assert!(should_request_logical_pull(
-            true,
-            &Some(DatabasePullRevision::V1 {
-                revision: "g1:o42".to_string(),
-            })
-        ));
-    }
-
-    #[test]
-    fn legacy_page_apply_rejects_non_page_streams() {
-        assert!(
-            ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::LegacyPages).is_ok()
-        );
-        assert!(ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::Pages).is_ok());
-        let logical_err =
-            ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::Logical).unwrap_err();
-        assert!(
-            logical_err.to_string().contains("logical MVCC apply"),
-            "unexpected error: {logical_err:?}"
-        );
-        let replace_base_err =
-            ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::ReplaceBasePages)
-                .unwrap_err();
-        assert!(
-            replace_base_err
-                .to_string()
-                .contains("replace-base page apply"),
-            "unexpected error: {replace_base_err:?}"
-        );
-    }
-
-    #[test]
-    fn logical_pull_page_fallback_preserves_replace_base_kind() {
-        assert_eq!(
-            stream_kind_for_pull_updates_v1_result(&PullUpdatesV1Result::Pages {
-                replace_base: false
-            }),
-            DbChangesStreamKind::Pages
-        );
-        assert_eq!(
-            stream_kind_for_pull_updates_v1_result(&PullUpdatesV1Result::Pages {
-                replace_base: true
-            }),
-            DbChangesStreamKind::ReplaceBasePages
-        );
-        assert_eq!(
-            stream_kind_for_pull_updates_v1_result(&PullUpdatesV1Result::Logical {
-                txns: 1,
-                ops: 2
-            }),
-            DbChangesStreamKind::Logical
-        );
-    }
-
-    #[test]
-    fn replace_base_pages_use_remote_page_transport() {
-        assert!(stream_kind_applies_remote_pages(
-            DbChangesStreamKind::LegacyPages
-        ));
-        assert!(stream_kind_applies_remote_pages(DbChangesStreamKind::Pages));
-        assert!(stream_kind_applies_remote_pages(
-            DbChangesStreamKind::ReplaceBasePages
-        ));
-        assert!(!stream_kind_applies_remote_pages(
-            DbChangesStreamKind::Logical
-        ));
-    }
-
-    #[test]
-    fn sql_replay_page_routing_keeps_legacy_on_wal_session() {
-        assert!(!should_replay_raw_pages_on_sql_conn(
-            DatabaseSyncEngineProtocolVersion::Legacy,
-            true,
-            false,
-            DbChangesStreamKind::LegacyPages,
-            true,
-        ));
-        assert!(!should_replay_raw_pages_on_sql_conn(
-            DatabaseSyncEngineProtocolVersion::Legacy,
-            true,
-            false,
-            DbChangesStreamKind::ReplaceBasePages,
-            true,
-        ));
-        assert!(!should_replay_raw_pages_on_sql_conn(
-            DatabaseSyncEngineProtocolVersion::V1,
-            false,
-            false,
-            DbChangesStreamKind::Pages,
-            true,
-        ));
-        assert!(!should_replay_raw_pages_on_sql_conn(
-            DatabaseSyncEngineProtocolVersion::V1,
-            true,
-            false,
-            DbChangesStreamKind::Pages,
-            false,
-        ));
-        assert!(should_replay_raw_pages_on_sql_conn(
-            DatabaseSyncEngineProtocolVersion::V1,
-            true,
-            false,
-            DbChangesStreamKind::Pages,
-            true,
-        ));
-        assert!(should_replay_raw_pages_on_sql_conn(
-            DatabaseSyncEngineProtocolVersion::V1,
-            true,
-            false,
-            DbChangesStreamKind::ReplaceBasePages,
-            true,
-        ));
-        assert!(!should_replay_raw_pages_on_sql_conn(
-            DatabaseSyncEngineProtocolVersion::V1,
-            true,
-            true,
-            DbChangesStreamKind::ReplaceBasePages,
-            true,
-        ));
-        assert!(!should_replay_raw_pages_on_sql_conn(
-            DatabaseSyncEngineProtocolVersion::V1,
-            true,
-            false,
-            DbChangesStreamKind::Logical,
-            true,
-        ));
-    }
-
-    #[test]
-    fn v1_page_replay_uses_remote_snapshot_sync_row_not_later_push_hint() {
-        assert!(!use_pushed_change_hint_for_local_replay(
-            DbChangesStreamKind::Pages,
-            false
-        ));
-        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), 7, 34);
-        assert_eq!(floor, Some(12));
-    }
-
-    #[test]
-    fn legacy_page_replay_can_use_last_pushed_hint_when_sync_row_is_stale() {
-        assert!(use_pushed_change_hint_for_local_replay(
-            DbChangesStreamKind::LegacyPages,
-            false
-        ));
-        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), 7, 34);
-        assert_eq!(floor, Some(34));
-    }
-
-    #[test]
-    fn local_replay_ignores_last_pushed_hint_from_stale_pull_generation() {
-        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), 6, 34);
-        assert_eq!(floor, Some(12));
-    }
-
-    #[test]
-    fn raw_wal_replay_preserves_existing_floor_when_hints_are_disabled() {
-        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), 7, 34);
-        assert_eq!(floor, Some(12));
-    }
-
-    #[test]
-    fn remote_apply_acknowledges_pre_apply_cdc_when_local_changes_are_recaptured() {
-        assert_eq!(
-            synced_change_id_after_remote_apply(false, Some(12), 40),
-            40,
-            "without local replay, all CDC generated by remote apply is acknowledged"
-        );
-        assert_eq!(
-            synced_change_id_after_remote_apply(true, Some(12), 40),
-            12,
-            "with local replay, preserve the replay floor so local rows remain pushable"
-        );
-        assert_eq!(
-            synced_change_id_after_remote_apply(true, Some(11), 8),
-            8,
-            "the persisted sync floor must never advance beyond the local CDC high-water"
-        );
-        assert_eq!(
-            synced_change_id_after_remote_apply(true, None, 40),
-            0,
-            "a database with no pre-existing CDC still starts from zero"
-        );
-    }
-
-    struct EmptyPollResult<T>(Vec<T>);
-
-    impl<T: Send + Sync + 'static> DataPollResult<T> for EmptyPollResult<T> {
-        fn data(&self) -> &[T] {
-            &self.0
-        }
-    }
-
-    struct EmptyCompletion<T> {
-        data: Mutex<Option<Vec<T>>>,
-    }
-
-    impl<T> EmptyCompletion<T> {
-        fn empty() -> Self {
-            Self {
-                data: Mutex::new(Some(Vec::new())),
-            }
-        }
-
-        fn with_data(data: Vec<T>) -> Self {
-            Self {
-                data: Mutex::new(Some(data)),
-            }
-        }
-    }
-
-    impl<T: Send + Sync + 'static> DataCompletion<T> for EmptyCompletion<T> {
-        type DataPollResult = EmptyPollResult<T>;
-
-        fn status(&self) -> Result<Option<u16>> {
-            Ok(Some(200))
-        }
-
-        fn poll_data(&self) -> Result<Option<Self::DataPollResult>> {
-            let data = self.data.lock().unwrap().take().unwrap_or_default();
-            if data.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(EmptyPollResult(data)))
-            }
-        }
-
-        fn is_done(&self) -> Result<bool> {
-            Ok(self.data.lock().unwrap().as_ref().is_none_or(Vec::is_empty))
-        }
-    }
-
-    #[derive(Default)]
-    struct NoopSyncEngineIo;
-
-    impl SyncEngineIo for NoopSyncEngineIo {
-        type DataCompletionBytes = EmptyCompletion<u8>;
-        type DataCompletionTransform = EmptyCompletion<crate::types::DatabaseRowTransformResult>;
-
-        fn full_read(&self, path: &str) -> Result<Self::DataCompletionBytes> {
-            let data = match std::fs::read(path) {
-                Ok(data) => data,
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
-                Err(error) => {
-                    return Err(crate::errors::Error::DatabaseSyncEngineError(format!(
-                        "test full_read failed for {path}: {error}"
-                    )));
-                }
-            };
-            Ok(EmptyCompletion::with_data(data))
-        }
-
-        fn full_write(&self, path: &str, content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
-            std::fs::write(path, content).map_err(|error| {
-                crate::errors::Error::DatabaseSyncEngineError(format!(
-                    "test full_write failed for {path}: {error}"
-                ))
-            })?;
-            Ok(EmptyCompletion::empty())
-        }
-
-        fn transform(
-            &self,
-            _mutations: Vec<crate::types::DatabaseRowMutation>,
-        ) -> Result<Self::DataCompletionTransform> {
-            Ok(EmptyCompletion::empty())
-        }
-
-        fn http(
-            &self,
-            _url: Option<&str>,
-            _method: &str,
-            _path: &str,
-            _body: Option<Vec<u8>>,
-            _headers: &[(&str, &str)],
-        ) -> Result<Self::DataCompletionBytes> {
-            Ok(EmptyCompletion::empty())
-        }
-
-        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
-
-        fn step_io_callbacks(&self) {}
-    }
-
-    struct CapturingSyncEngineIo {
-        response: Mutex<Option<Vec<u8>>>,
-        #[allow(clippy::type_complexity)]
-        request: Mutex<Option<(String, String, Option<Vec<u8>>)>>,
-    }
-
-    impl SyncEngineIo for CapturingSyncEngineIo {
-        type DataCompletionBytes = EmptyCompletion<u8>;
-        type DataCompletionTransform = EmptyCompletion<crate::types::DatabaseRowTransformResult>;
-
-        fn full_read(&self, path: &str) -> Result<Self::DataCompletionBytes> {
-            let data = std::fs::read(path).unwrap_or_default();
-            Ok(EmptyCompletion::with_data(data))
-        }
-
-        fn full_write(&self, path: &str, content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
-            std::fs::write(path, content).map_err(|error| {
-                crate::errors::Error::DatabaseSyncEngineError(format!(
-                    "test full_write failed for {path}: {error}"
-                ))
-            })?;
-            Ok(EmptyCompletion::empty())
-        }
-
-        fn transform(
-            &self,
-            _mutations: Vec<crate::types::DatabaseRowMutation>,
-        ) -> Result<Self::DataCompletionTransform> {
-            Ok(EmptyCompletion::empty())
-        }
-
-        fn http(
-            &self,
-            _url: Option<&str>,
-            method: &str,
-            path: &str,
-            body: Option<Vec<u8>>,
-            _headers: &[(&str, &str)],
-        ) -> Result<Self::DataCompletionBytes> {
-            self.request
-                .lock()
-                .unwrap()
-                .replace((method.to_string(), path.to_string(), body));
-            let response = self.response.lock().unwrap().take().unwrap_or_default();
-            Ok(EmptyCompletion::with_data(response))
-        }
-
-        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
-
-        fn step_io_callbacks(&self) {}
-    }
-
-    /// Serves canned HTTP responses in order; panics if the engine makes more
-    /// requests than responses were queued.
-    struct QueuedSyncEngineIo {
-        responses: Mutex<std::collections::VecDeque<Vec<u8>>>,
-    }
-
-    impl SyncEngineIo for QueuedSyncEngineIo {
-        type DataCompletionBytes = EmptyCompletion<u8>;
-        type DataCompletionTransform = EmptyCompletion<crate::types::DatabaseRowTransformResult>;
-
-        fn full_read(&self, path: &str) -> Result<Self::DataCompletionBytes> {
-            let data = std::fs::read(path).unwrap_or_default();
-            Ok(EmptyCompletion::with_data(data))
-        }
-
-        fn full_write(&self, path: &str, content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
-            std::fs::write(path, content).map_err(|error| {
-                crate::errors::Error::DatabaseSyncEngineError(format!(
-                    "test full_write failed for {path}: {error}"
-                ))
-            })?;
-            Ok(EmptyCompletion::empty())
-        }
-
-        fn transform(
-            &self,
-            _mutations: Vec<crate::types::DatabaseRowMutation>,
-        ) -> Result<Self::DataCompletionTransform> {
-            Ok(EmptyCompletion::empty())
-        }
-
-        fn http(
-            &self,
-            _url: Option<&str>,
-            _method: &str,
-            _path: &str,
-            _body: Option<Vec<u8>>,
-            _headers: &[(&str, &str)],
-        ) -> Result<Self::DataCompletionBytes> {
-            let response = self
-                .responses
-                .lock()
-                .unwrap()
-                .pop_front()
-                .expect("engine made more HTTP requests than queued responses");
-            Ok(EmptyCompletion::with_data(response))
-        }
-
-        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
-
-        fn step_io_callbacks(&self) {}
-    }
-
-    fn record(values: &[turso_core::Value]) -> Bytes {
-        Bytes::from(
-            turso_core::types::ImmutableRecord::from_values(values, values.len())
-                .unwrap()
-                .into_payload(),
-        )
-    }
-
-    fn encoded_logical_txns(txns: &[LogicalTxnData]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        for txn in txns {
-            bytes.extend_from_slice(&txn.encode_length_delimited_to_vec());
-        }
-        bytes
-    }
-
-    fn default_test_opts() -> DatabaseSyncEngineOpts {
-        DatabaseSyncEngineOpts {
-            remote_url: None,
-            client_name: "test-client".to_string(),
-            tables_ignore: vec![],
-            use_transform: false,
-            wal_pull_batch_size: 0,
-            long_poll_timeout: Some(Duration::from_millis(1)),
-            protocol_version_hint: DatabaseSyncEngineProtocolVersion::V1,
-            bootstrap_if_empty: false,
-            reserved_bytes: 0,
-            db_opts: turso_core::DatabaseOpts::default(),
-            partial_sync_opts: None::<PartialSyncOpts>,
-            remote_encryption_key: None,
-            push_operations_threshold: None,
-            pull_bytes_threshold: None,
-            logical_mvcc_pull: Some(true),
-        }
-    }
-
-    fn replace_base_guard_test_paths(
-        main_path: &str,
-    ) -> Vec<(&'static str, String, Option<&'static [u8]>)> {
-        vec![
-            ("main-db", main_path.to_string(), Some(b"main-old")),
-            (
-                "main-wal",
-                create_main_db_wal_path(main_path),
-                Some(b"wal-old"),
-            ),
-            (
-                "main-log",
-                create_main_db_log_path(main_path),
-                Some(b"log-old"),
-            ),
-            ("revert-wal", create_revert_db_wal_path(main_path), None),
-            ("metadata", create_meta_path(main_path), Some(b"meta-old")),
-        ]
-    }
-
-    fn write_replace_base_guard_test_files(main_path: &str) {
-        for (_, path, content) in replace_base_guard_test_paths(main_path) {
-            if let Some(content) = content {
-                std::fs::write(path, content).unwrap();
-            }
-        }
-    }
-
-    fn assert_replace_base_backups_removed(main_path: &str) {
-        assert!(std::fs::read(create_replace_base_marker_path(main_path)).is_err());
-        for (name, _, _) in replace_base_guard_test_paths(main_path) {
-            assert!(std::fs::read(replace_base_backup_path(main_path, name)).is_err());
-        }
-    }
-
-    async fn write_replace_base_pages_file<Ctx>(
-        coro: &Coro<Ctx>,
-        io: &Arc<dyn turso_core::IO>,
-        source_db_path: &str,
-        changes_path: &str,
-    ) -> Result<Arc<dyn turso_core::File>> {
-        let pages = std::fs::read(source_db_path).unwrap();
-        assert_eq!(pages.len() % super::PAGE_SIZE, 0);
-        let db_size = (pages.len() / super::PAGE_SIZE) as u32;
-        let changes_file = io.open_file(changes_path, turso_core::OpenFlags::Create, false)?;
-
-        let truncate = changes_file.truncate(0, turso_core::Completion::new_trunc(|_| {}))?;
-        while !truncate.succeeded() {
-            coro.yield_(SyncEngineIoResult::IO).await?;
-        }
-
-        for (page_idx, page) in pages.chunks_exact(super::PAGE_SIZE).enumerate() {
-            let mut frame = vec![0; super::WAL_FRAME_SIZE];
-            frame[super::WAL_FRAME_HEADER..].copy_from_slice(page);
-            let frame_info = turso_core::types::WalFrameInfo {
-                page_no: page_idx as u32 + 1,
-                db_size: if page_idx + 1 == db_size as usize {
-                    db_size
-                } else {
-                    0
-                },
-            };
-            frame_info.put_to_frame_header(&mut frame);
-            let offset = (page_idx * super::WAL_FRAME_SIZE) as u64;
-            let len = frame.len();
-            let write = changes_file.pwrite(
-                offset,
-                Arc::new(turso_core::Buffer::new(frame)),
-                turso_core::Completion::new_write(move |result| {
-                    let Ok(size) = result else {
-                        return;
-                    };
-                    assert_eq!(size as usize, len);
-                }),
-            )?;
-            while !write.succeeded() {
-                coro.yield_(SyncEngineIoResult::IO).await?;
-            }
-        }
-
-        let sync = changes_file.sync(
-            turso_core::Completion::new_sync(|_| {}),
-            turso_core::io::FileSyncType::Fsync,
-        )?;
-        while !sync.succeeded() {
-            coro.yield_(SyncEngineIoResult::IO).await?;
-        }
-        Ok(changes_file)
-    }
-
-    #[test]
-    fn replace_base_guard_restores_original_files_and_removes_created_files() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let main_path = temp_dir
-            .path()
-            .join("guard-restore.db")
-            .to_string_lossy()
-            .to_string();
-        write_replace_base_guard_test_files(&main_path);
-
-        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let sync_io = Arc::new(CapturingSyncEngineIo {
-            response: Mutex::new(None),
-            request: Mutex::new(None),
-        });
-        let sync_stats = SyncEngineIoStats::new(sync_io);
-        let old_revision = DatabasePullRevision::V1 {
-            revision: "old-revision".to_string(),
-        };
-
-        let mut gen = genawaiter::sync::Gen::new({
-            let io = io.clone();
-            let main_path = main_path.clone();
-            move |coro| async move {
-                let coro: Coro<()> = coro.into();
-                let guard = ReplaceBaseApplyGuard::create(
-                    &coro,
-                    io.clone(),
-                    sync_stats,
-                    &main_path,
-                    Some(old_revision),
-                )
-                .await?;
-
-                std::fs::write(&main_path, b"main-new").unwrap();
-                std::fs::write(create_main_db_wal_path(&main_path), b"wal-new").unwrap();
-                std::fs::write(create_main_db_log_path(&main_path), b"log-new").unwrap();
-                std::fs::write(create_revert_db_wal_path(&main_path), b"revert-created").unwrap();
-                std::fs::write(create_meta_path(&main_path), b"meta-new").unwrap();
-
-                guard.restore(&coro).await?;
-                Result::Ok(())
-            }
-        });
-        loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
-            }
-        }
-
-        assert_eq!(std::fs::read(&main_path).unwrap(), b"main-old");
-        assert_eq!(
-            std::fs::read(create_main_db_wal_path(&main_path)).unwrap(),
-            b"wal-old"
-        );
-        assert_eq!(
-            std::fs::read(create_main_db_log_path(&main_path)).unwrap(),
-            b"log-old"
-        );
-        assert!(std::fs::read(create_revert_db_wal_path(&main_path)).is_err());
-        assert_eq!(
-            std::fs::read(create_meta_path(&main_path)).unwrap(),
-            b"meta-old"
-        );
-        assert_replace_base_backups_removed(&main_path);
-    }
-
-    #[test]
-    fn replace_base_guard_recovers_pending_marker() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let main_path = temp_dir
-            .path()
-            .join("guard-recover.db")
-            .to_string_lossy()
-            .to_string();
-        write_replace_base_guard_test_files(&main_path);
-
-        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let sync_io = Arc::new(CapturingSyncEngineIo {
-            response: Mutex::new(None),
-            request: Mutex::new(None),
-        });
-        let sync_stats = SyncEngineIoStats::new(sync_io);
-
-        let mut gen = genawaiter::sync::Gen::new({
-            let io = io.clone();
-            let main_path = main_path.clone();
-            move |coro| async move {
-                let coro: Coro<()> = coro.into();
-                let _guard = ReplaceBaseApplyGuard::create(
-                    &coro,
-                    io.clone(),
-                    sync_stats.clone(),
-                    &main_path,
-                    None,
-                )
-                .await?;
-
-                std::fs::write(&main_path, b"main-new").unwrap();
-                std::fs::write(create_meta_path(&main_path), b"meta-new").unwrap();
-
-                let recovered = ReplaceBaseApplyGuard::recover_pending(
-                    &coro,
-                    io.clone(),
-                    sync_stats,
-                    &main_path,
-                )
-                .await?;
-                assert!(recovered);
-                Result::Ok(())
-            }
-        });
-        loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
-            }
-        }
-
-        assert_eq!(std::fs::read(&main_path).unwrap(), b"main-old");
-        assert_eq!(
-            std::fs::read(create_meta_path(&main_path)).unwrap(),
-            b"meta-old"
-        );
-        assert_replace_base_backups_removed(&main_path);
-    }
-
-    #[test]
-    fn replace_base_guard_mark_complete_removes_marker_without_restoring() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let main_path = temp_dir
-            .path()
-            .join("guard-complete.db")
-            .to_string_lossy()
-            .to_string();
-        write_replace_base_guard_test_files(&main_path);
-
-        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let sync_io = Arc::new(CapturingSyncEngineIo {
-            response: Mutex::new(None),
-            request: Mutex::new(None),
-        });
-        let sync_stats = SyncEngineIoStats::new(sync_io);
-
-        let mut gen = genawaiter::sync::Gen::new({
-            let io = io.clone();
-            let main_path = main_path.clone();
-            move |coro| async move {
-                let coro: Coro<()> = coro.into();
-                let mut guard =
-                    ReplaceBaseApplyGuard::create(&coro, io.clone(), sync_stats, &main_path, None)
-                        .await?;
-                std::fs::write(&main_path, b"main-new").unwrap();
-                guard.mark_complete(&coro).await?;
-                Result::Ok(())
-            }
-        });
-        loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
-            }
-        }
-
-        assert_eq!(std::fs::read(&main_path).unwrap(), b"main-new");
-        assert_replace_base_backups_removed(&main_path);
-    }
-
-    #[test]
-    fn initial_logical_mvcc_pull_page_bootstrap_uses_replace_base_apply() {
-        let temp_file = NamedTempFile::new().unwrap();
-        let main_path = temp_file.path().to_str().unwrap().to_string();
-        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let main_db =
-            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
-                .unwrap();
-
-        let meta = DatabaseMetadata {
-            version: DATABASE_METADATA_VERSION.to_string(),
-            client_unique_id: "initial-client".to_string(),
-            synced_revision: None,
-            revert_since_wal_salt: None,
-            revert_since_wal_watermark: 0,
-            last_pull_unix_time: None,
-            last_push_unix_time: None,
-            last_pushed_pull_gen_hint: 0,
-            last_pushed_change_id_hint: 0,
-            last_pushed_replay_floor_change_id_hint: 0,
-            partial_bootstrap_server_revision: None,
-            fresh_bootstrap_pending_cdc_ack: false,
-            logical_mvcc_pull_active: true,
-            remote_pull_protocol: RemotePullProtocol::MvccLogical,
-            logical_table_names_by_stable_id: Default::default(),
-            saved_configuration: Some(DatabaseSavedConfiguration {
-                remote_url: Some("https://example.com".to_string()),
-                partial_sync_prefetch: None,
-                partial_sync_segment_size: None,
-            }),
-        };
-        std::fs::write(create_meta_path(&main_path), meta.dump().unwrap()).unwrap();
-
-        let header = PullUpdatesRespProtoBody {
-            protocol: 0,
-            server_revision: "g1:o10".to_string(),
-            db_size: 0,
-            raw_encoding: None,
-            zstd_encoding: None,
-            stream_kind: PullUpdatesStreamKind::Pages as i32,
-            apply_mode: PullUpdatesApplyMode::Incremental as i32,
-            mvcc_log: None,
-        };
-        let sync_io = Arc::new(CapturingSyncEngineIo {
-            response: Mutex::new(Some(header.encode_length_delimited_to_vec())),
-            request: Mutex::new(None),
-        });
-        let sync_stats = SyncEngineIoStats::new(sync_io.clone());
-        let mut opts = default_test_opts();
-        opts.remote_url = Some("https://example.com".to_string());
-        opts.logical_mvcc_pull = Some(true);
-
-        let mut gen = genawaiter::sync::Gen::new({
-            let io = io.clone();
-            let main_db = main_db.clone();
-            move |coro| async move {
-                let coro: Coro<()> = coro.into();
-                let engine =
-                    DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
-                let status = engine.wait_changes_from_remote(&coro).await?;
-                assert!(status.file_slot.is_none());
-                assert!(matches!(
-                    status.stream_kind,
-                    DbChangesStreamKind::ReplaceBasePages
-                ));
-                Result::Ok(())
-            }
-        });
-        loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
-            }
-        }
-
-        let (_method, path, body) = sync_io.request.lock().unwrap().clone().unwrap();
-        assert_eq!(path, "/pull-updates");
-        let request = PullUpdatesReqProtoBody::decode(body.unwrap().as_slice()).unwrap();
-        assert_eq!(request.stream_kind, PullUpdatesStreamKind::Pages as i32);
-        assert_eq!(request.client_revision, "");
-        assert_eq!(request.server_revision, "");
-    }
-
-    #[test]
-    fn apply_changes_from_remote_applies_logical_stream_without_local_replay() {
-        let db_temp = NamedTempFile::new().unwrap();
-        let meta_temp = NamedTempFile::new().unwrap();
-        let changes_temp = NamedTempFile::new().unwrap();
-        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-
-        let txns = vec![
-            LogicalTxnData {
-                end_offset: 1,
-                commit_ts: 1,
-                origin_client_id: "remote".to_string(),
-                ops: vec![LogicalOp {
-                    op_type: LogicalOpType::Schema as i32,
-                    table_name: String::new(),
-                    rowid: 0,
-                    record: Bytes::new(),
-                    sql: "CREATE TABLE items(x TEXT)".to_string(),
-                    user_version: None,
-                    application_id: None,
-                    schema_action: Some(LogicalSchemaAction::Create as i32),
-                    schema_kind: Some(LogicalSchemaKind::Table as i32),
-                    schema_name: "items".to_string(),
-                    stable_table_id: 7,
-                }],
-            },
-            LogicalTxnData {
-                end_offset: 2,
-                commit_ts: 2,
-                origin_client_id: "remote".to_string(),
-                ops: vec![LogicalOp {
-                    op_type: LogicalOpType::UpsertRow as i32,
-                    table_name: String::new(),
-                    rowid: 2,
-                    record: record(&[turso_core::Value::Text(turso_core::types::Text::new(
-                        "remote".to_string(),
-                    ))]),
-                    sql: String::new(),
-                    user_version: None,
-                    application_id: None,
-                    schema_action: None,
-                    schema_kind: None,
-                    schema_name: String::new(),
-                    stable_table_id: 7,
-                }],
-            },
-        ];
-        std::fs::write(changes_temp.path(), encoded_logical_txns(&txns)).unwrap();
-
-        let db = turso_core::Database::open_file(
-            io.clone(),
-            db_temp.path().to_str().unwrap(),
-            Arc::new(SqliteDialect),
-        )
-        .unwrap();
-        let db_file = db.db_file.clone();
-        let db_io = db.io.clone();
-        let main_tape = DatabaseTape::new_with_opts(
-            db,
-            DatabaseTapeOpts {
-                cdc_table: None,
-                cdc_mode: Some("full".to_string()),
-                disable_auto_checkpoint: true,
-            },
-        );
-        let sync_io = Arc::new(NoopSyncEngineIo);
-        let sync_engine_io = SyncEngineIoStats::new(sync_io);
-        let changes_file = io
-            .open_file(
-                changes_temp.path().to_str().unwrap(),
-                turso_core::OpenFlags::None,
-                false,
-            )
-            .unwrap();
-        let slot = Arc::new(Mutex::new(None));
-        let meta = DatabaseMetadata {
-            version: DATABASE_METADATA_VERSION.to_string(),
-            client_unique_id: "client-a".to_string(),
-            synced_revision: Some(DatabasePullRevision::V1 {
-                revision: "g1:o1".to_string(),
-            }),
-            revert_since_wal_salt: None,
-            revert_since_wal_watermark: 0,
-            last_pull_unix_time: None,
-            last_push_unix_time: None,
-            last_pushed_pull_gen_hint: 0,
-            last_pushed_change_id_hint: 0,
-            last_pushed_replay_floor_change_id_hint: 0,
-            partial_bootstrap_server_revision: None,
-            fresh_bootstrap_pending_cdc_ack: false,
-            logical_mvcc_pull_active: true,
-            remote_pull_protocol: RemotePullProtocol::MvccLogical,
-            logical_table_names_by_stable_id: Default::default(),
-            saved_configuration: Some(DatabaseSavedConfiguration {
-                remote_url: None,
-                partial_sync_prefetch: None,
-                partial_sync_segment_size: None,
-            }),
-        };
-        let engine = DatabaseSyncEngine {
-            io: db_io,
-            sync_engine_io,
-            db_file,
-            main_tape,
-            main_db_path: db_temp.path().to_str().unwrap().to_string(),
-            main_db_wal_path: super::create_main_db_wal_path(db_temp.path().to_str().unwrap()),
-            revert_db_wal_path: super::create_revert_db_wal_path(db_temp.path().to_str().unwrap()),
-            meta_path: meta_temp.path().to_str().unwrap().to_string(),
-            changes_file: Arc::new(Mutex::new(None)),
-            opts: default_test_opts(),
-            meta: Mutex::new(meta),
-            client_unique_id: "client-a".to_string(),
-        };
-        let remote_changes = DbChangesStatus {
-            time: io.current_time_wall_clock(),
-            revision: DatabasePullRevision::V1 {
-                revision: "g1:o2".to_string(),
-            },
-            file_slot: Some(crate::database_sync_operations::MutexSlot {
-                value: changes_file,
-                slot,
-            }),
-            stream_kind: DbChangesStreamKind::Logical,
-        };
-
-        let mut gen = genawaiter::sync::Gen::new({
-            let engine = engine;
-            move |coro| async move {
-                let coro: Coro<()> = coro.into();
-                engine
-                    .apply_changes_from_remote(&coro, remote_changes)
-                    .await
-                    .unwrap();
-                let conn = engine.main_tape.connect(&coro).await.unwrap();
-                let mut stmt = conn.prepare("SELECT rowid, x FROM items").unwrap();
-                let mut rows = Vec::new();
-                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
-                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
-                }
-                let (pull_gen, change_id) =
-                    read_last_change_id(&coro, &conn, &engine.client_unique_id)
-                        .await
-                        .unwrap();
-                let pending_local_changes = count_local_changes(&coro, &conn, change_id.unwrap())
-                    .await
-                    .unwrap();
-                let meta = engine.meta.lock().unwrap().clone();
-                (rows, meta, pull_gen, change_id, pending_local_changes)
-            }
-        });
-        let (rows, meta, pull_gen, change_id, pending_local_changes) = loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(result) => break result,
-            }
-        };
-
-        assert_eq!(
-            rows,
-            vec![vec![
-                turso_core::Value::from_i64(2),
-                turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
-            ]]
-        );
-        assert_eq!(
-            meta.synced_revision,
-            Some(DatabasePullRevision::V1 {
-                revision: "g1:o2".to_string(),
-            })
-        );
-        assert_eq!(
-            meta.logical_table_names_by_stable_id.get(&7).unwrap(),
-            "items"
-        );
-        assert_eq!(meta.revert_since_wal_watermark, 0);
-        assert_eq!(pull_gen, 0);
-        assert!(change_id.is_some());
-        assert_eq!(pending_local_changes, 0);
-    }
-
-    #[test]
-    fn apply_changes_from_remote_replays_pending_local_changes() {
-        let db_temp = NamedTempFile::new().unwrap();
-        let meta_temp = NamedTempFile::new().unwrap();
-        let changes_temp = NamedTempFile::new().unwrap();
-        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-
-        let txns = vec![LogicalTxnData {
-            end_offset: 1,
-            commit_ts: 1,
-            origin_client_id: "remote".to_string(),
-            ops: vec![
-                LogicalOp {
-                    op_type: LogicalOpType::Schema as i32,
-                    table_name: String::new(),
-                    rowid: 0,
-                    record: Bytes::new(),
-                    sql: "CREATE TABLE remote_items(id INTEGER PRIMARY KEY, x TEXT)".to_string(),
-                    user_version: None,
-                    application_id: None,
-                    schema_action: Some(LogicalSchemaAction::Create as i32),
-                    schema_kind: Some(LogicalSchemaKind::Table as i32),
-                    schema_name: "remote_items".to_string(),
-                    stable_table_id: 9,
-                },
-                LogicalOp {
-                    op_type: LogicalOpType::UpsertRow as i32,
-                    table_name: String::new(),
-                    rowid: 2,
-                    record: record(&[
-                        turso_core::Value::from_i64(2),
-                        turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
-                    ]),
-                    sql: String::new(),
-                    user_version: None,
-                    application_id: None,
-                    schema_action: None,
-                    schema_kind: None,
-                    schema_name: String::new(),
-                    stable_table_id: 9,
-                },
-            ],
-        }];
-        std::fs::write(changes_temp.path(), encoded_logical_txns(&txns)).unwrap();
-
-        let db = turso_core::Database::open_file(
-            io.clone(),
-            db_temp.path().to_str().unwrap(),
-            Arc::new(SqliteDialect),
-        )
-        .unwrap();
-        let db_file = db.db_file.clone();
-        let db_io = db.io.clone();
-        let main_tape = DatabaseTape::new_with_opts(
-            db,
-            DatabaseTapeOpts {
-                cdc_table: None,
-                cdc_mode: Some("full".to_string()),
-                disable_auto_checkpoint: true,
-            },
-        );
-        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
-        let changes_file = io
-            .open_file(
-                changes_temp.path().to_str().unwrap(),
-                turso_core::OpenFlags::None,
-                false,
-            )
-            .unwrap();
-        let old_revision = DatabasePullRevision::V1 {
-            revision: "g1:o1".to_string(),
-        };
-        let meta = DatabaseMetadata {
-            version: DATABASE_METADATA_VERSION.to_string(),
-            client_unique_id: "client-a".to_string(),
-            synced_revision: Some(old_revision.clone()),
-            revert_since_wal_salt: None,
-            revert_since_wal_watermark: 0,
-            last_pull_unix_time: None,
-            last_push_unix_time: None,
-            last_pushed_pull_gen_hint: 0,
-            last_pushed_change_id_hint: 0,
-            last_pushed_replay_floor_change_id_hint: 0,
-            partial_bootstrap_server_revision: None,
-            fresh_bootstrap_pending_cdc_ack: false,
-            logical_mvcc_pull_active: true,
-            remote_pull_protocol: RemotePullProtocol::MvccLogical,
-            logical_table_names_by_stable_id: Default::default(),
-            saved_configuration: Some(DatabaseSavedConfiguration {
-                remote_url: None,
-                partial_sync_prefetch: None,
-                partial_sync_segment_size: None,
-            }),
-        };
-        let engine = DatabaseSyncEngine {
-            io: db_io,
-            sync_engine_io,
-            db_file,
-            main_tape,
-            main_db_path: db_temp.path().to_str().unwrap().to_string(),
-            main_db_wal_path: super::create_main_db_wal_path(db_temp.path().to_str().unwrap()),
-            revert_db_wal_path: super::create_revert_db_wal_path(db_temp.path().to_str().unwrap()),
-            meta_path: meta_temp.path().to_str().unwrap().to_string(),
-            changes_file: Arc::new(Mutex::new(None)),
-            opts: default_test_opts(),
-            meta: Mutex::new(meta),
-            client_unique_id: "client-a".to_string(),
-        };
-        let remote_changes = DbChangesStatus {
-            time: io.current_time_wall_clock(),
-            revision: DatabasePullRevision::V1 {
-                revision: "g1:o2".to_string(),
-            },
-            file_slot: Some(crate::database_sync_operations::MutexSlot {
-                value: changes_file,
-                slot: Arc::new(Mutex::new(None)),
-            }),
-            stream_kind: DbChangesStreamKind::Logical,
-        };
-
-        let mut gen = genawaiter::sync::Gen::new({
-            let engine = engine;
-            move |coro| async move {
-                let coro: Coro<()> = coro.into();
-                let conn = engine.main_tape.connect(&coro).await.unwrap();
-                conn.execute("CREATE TABLE local_items(id INTEGER PRIMARY KEY, x TEXT)")
-                    .unwrap();
-                conn.execute("INSERT INTO local_items(id, x) VALUES (1, 'local')")
-                    .unwrap();
-
-                engine
-                    .apply_changes_from_remote(&coro, remote_changes)
-                    .await
-                    .unwrap();
-
-                let mut stmt = conn
-                    .prepare("SELECT id, x FROM remote_items ORDER BY id")
-                    .unwrap();
-                let remote_row = run_stmt_once(&coro, &mut stmt)
-                    .await
-                    .unwrap()
-                    .unwrap()
-                    .get_values()
-                    .cloned()
-                    .collect::<Vec<_>>();
-                assert!(run_stmt_once(&coro, &mut stmt).await.unwrap().is_none());
-
-                let mut stmt = conn
-                    .prepare("SELECT id, x FROM local_items ORDER BY id")
-                    .unwrap();
-                let local_row = run_stmt_once(&coro, &mut stmt)
-                    .await
-                    .unwrap()
-                    .unwrap()
-                    .get_values()
-                    .cloned()
-                    .collect::<Vec<_>>();
-                assert!(run_stmt_once(&coro, &mut stmt).await.unwrap().is_none());
-
-                let (_, synced_change_id) =
-                    read_last_change_id(&coro, &conn, &engine.client_unique_id)
-                        .await
-                        .unwrap();
-                let pending_local_changes =
-                    count_local_changes(&coro, &conn, synced_change_id.unwrap())
-                        .await
-                        .unwrap();
-                let meta = engine.meta.lock().unwrap().clone();
-                (remote_row, local_row, pending_local_changes, meta)
-            }
-        });
-        let (remote_row, local_row, pending_local_changes, meta) = loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(result) => break result,
-            }
-        };
-        assert_eq!(
-            remote_row,
-            vec![
-                turso_core::Value::from_i64(2),
-                turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
-            ]
-        );
-        assert_eq!(
-            local_row,
-            vec![
-                turso_core::Value::from_i64(1),
-                turso_core::Value::Text(turso_core::types::Text::new("local".to_string())),
-            ]
-        );
-        assert!(
-            pending_local_changes > 0,
-            "recaptured local CDC should remain pending for push"
-        );
-        assert_eq!(
-            meta.synced_revision,
-            Some(DatabasePullRevision::V1 {
-                revision: "g1:o2".to_string(),
-            })
-        );
-    }
-
-    #[test]
-    fn failed_replace_base_local_replay_does_not_advance_synced_revision() {
-        let main_file = NamedTempFile::new().unwrap();
-        let remote_file = NamedTempFile::new().unwrap();
-        let changes_file = NamedTempFile::new().unwrap();
-        let main_path = main_file.path().to_str().unwrap().to_string();
-        let remote_path = remote_file.path().to_str().unwrap().to_string();
-        let changes_path = changes_file.path().to_str().unwrap().to_string();
-
-        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let remote_db =
-            turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
-                .unwrap();
-        let remote_conn = remote_db.connect().unwrap();
-        remote_conn
-            .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")
-            .unwrap();
-        remote_conn
-            .execute("INSERT INTO items VALUES (1, 'duplicate'), (2, 'duplicate')")
-            .unwrap();
-        remote_conn
-            .checkpoint(turso_core::CheckpointMode::Truncate {
-                upper_bound_inclusive: None,
-            })
-            .unwrap();
-
-        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
-        let old_revision = DatabasePullRevision::V1 {
-            revision: "old-revision".to_string(),
-        };
-        let new_revision = DatabasePullRevision::V1 {
-            revision: "new-revision".to_string(),
-        };
-
-        let mut gen = genawaiter::sync::Gen::new({
-            let io = io.clone();
-            let sync_engine_io = sync_engine_io.clone();
-            let main_path = main_path.clone();
-            let remote_path = remote_path.clone();
-            let changes_path = changes_path.clone();
-            let old_revision = old_revision.clone();
-            let new_revision = new_revision.clone();
-            move |coro| async move {
-                let coro: Coro<()> = coro.into();
-                let engine = DatabaseSyncEngine::create_db(
-                    &coro,
-                    io.clone(),
-                    sync_engine_io.clone(),
-                    &main_path,
-                    default_test_opts(),
-                )
-                .await
-                .map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
-                })?;
-                engine
-                    .update_meta(&coro, |meta| {
-                        meta.synced_revision = Some(old_revision.clone());
-                        meta.logical_mvcc_pull_active = false;
-                    })
-                    .await
-                    .map_err(|error| {
-                        Error::DatabaseSyncEngineError(format!("test update_meta failed: {error}"))
-                    })?;
-
-                let conn = engine.connect_rw(&coro).await.map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test connect_rw failed: {error}"))
-                })?;
-                conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")?;
-                conn.execute("INSERT INTO items VALUES (1, 'local-only')")?;
-                let base_change_id = max_local_change_id(&coro, &conn).await?.unwrap_or(0);
-                update_last_change_id(&coro, &conn, &engine.client_unique_id, 1, base_change_id)
-                    .await?;
-                conn.execute("CREATE UNIQUE INDEX items_value_unique ON items(value)")?;
-
-                let changes_file =
-                    write_replace_base_pages_file(&coro, &io, &remote_path, &changes_path).await?;
-                let slot = Arc::new(Mutex::new(Some(changes_file)));
-                let file_slot = MutexSlot {
-                    value: slot.lock().unwrap().take().unwrap(),
-                    slot: slot.clone(),
-                };
-
-                REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.set(0));
-                let result = engine
-                    .apply_changes_from_remote(
-                        &coro,
-                        DbChangesStatus {
-                            time: turso_core::WallClockInstant {
-                                secs: 10,
-                                micros: 0,
-                            },
-                            revision: new_revision.clone(),
-                            file_slot: Some(file_slot),
-                            stream_kind: DbChangesStreamKind::ReplaceBasePages,
-                        },
-                    )
-                    .await;
-                REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.set(usize::MAX));
-
-                let err = result.unwrap_err();
-                assert!(
-                    format!("{err:#}").contains("injected replace-base local replay failure"),
-                    "{err:#}"
-                );
-                assert_eq!(engine.meta().synced_revision, Some(old_revision.clone()));
-
-                let on_disk_meta = DatabaseSyncEngine::<NoopSyncEngineIo>::read_db_meta(
-                    &coro,
-                    Some(io.clone()),
-                    sync_engine_io.clone(),
-                    &main_path,
-                )
-                .await
-                .map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test read_db_meta failed: {error}"))
-                })?
-                .unwrap();
-                assert_eq!(on_disk_meta.synced_revision, Some(old_revision));
-                assert!(io
-                    .try_open(&create_replace_base_marker_path(&main_path))?
-                    .is_none());
-
-                drop(conn);
-                drop(engine);
-                let verify_db = turso_core::Database::open_file(
-                    io.clone(),
-                    &main_path,
-                    Arc::new(SqliteDialect),
-                )
-                .map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test verify open failed: {error}"))
-                })?;
-                let verify_conn = verify_db.connect().map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test verify connect failed: {error}"))
-                })?;
-                let mut value_stmt = verify_conn
-                    .prepare("SELECT value FROM items WHERE id = 1")
-                    .unwrap();
-                let row = run_stmt_once(&coro, &mut value_stmt).await?.unwrap();
-                assert_eq!(
-                    row.get_values().cloned().collect::<Vec<_>>(),
-                    vec![turso_core::Value::Text(turso_core::types::Text::new(
-                        "local-only"
-                    ))]
-                );
-                assert!(run_stmt_once(&coro, &mut value_stmt).await?.is_none());
-
-                let mut index_stmt = verify_conn
-                    .prepare("SELECT sql FROM sqlite_schema WHERE name = 'items_value_unique'")
-                    .unwrap();
-                let row = run_stmt_once(&coro, &mut index_stmt).await?.unwrap();
-                assert!(row
-                    .get_value(0)
-                    .to_text()
-                    .unwrap()
-                    .contains("CREATE UNIQUE INDEX items_value_unique"));
-                assert!(run_stmt_once(&coro, &mut index_stmt).await?.is_none());
-                Result::Ok(())
-            }
-        });
-
-        loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(result) => {
-                    REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.set(usize::MAX));
-                    result.unwrap();
-                    break;
-                }
-            }
-        }
-    }
-
-    /// Full-fidelity page-stream response: header (with the given protocol
-    /// hint) followed by one PageData message per page of `db_bytes`.
-    fn encoded_page_stream_response(
-        db_bytes: &[u8],
-        server_revision: &str,
-        protocol: PullUpdatesProtocol,
-    ) -> Vec<u8> {
-        assert_eq!(db_bytes.len() % super::PAGE_SIZE, 0);
-        let header = PullUpdatesRespProtoBody {
-            server_revision: server_revision.to_string(),
-            db_size: (db_bytes.len() / super::PAGE_SIZE) as u64,
-            raw_encoding: Some(PageSetRawEncodingProto {}),
-            zstd_encoding: None,
-            stream_kind: PullUpdatesStreamKind::Pages as i32,
-            apply_mode: PullUpdatesApplyMode::Incremental as i32,
-            mvcc_log: None,
-            protocol: protocol as i32,
-        };
-        let mut bytes = header.encode_length_delimited_to_vec();
-        for (page_idx, page) in db_bytes.chunks_exact(super::PAGE_SIZE).enumerate() {
-            let page_data = PageData {
-                page_id: page_idx as u64,
-                encoded_page: Bytes::copy_from_slice(page),
-            };
-            bytes.extend_from_slice(&page_data.encode_length_delimited_to_vec());
-        }
-        bytes
-    }
-
-    /// Deferred-bootstrap replica ("converted to cloud sync later"): a local
-    /// WAL-mode database with local writes meets an MVCC-protocol remote on
-    /// first contact. The engine must detect the protocol, convert the local
-    /// database to MVCC journal mode, apply the remote base as replace-base,
-    /// replay the local changes on top, and stay MVCC across a reopen.
-    #[test]
-    fn deferred_first_contact_converts_wal_replica_to_mvcc_and_applies_base() {
-        let main_file = NamedTempFile::new().unwrap();
-        let remote_file = NamedTempFile::new().unwrap();
-        let main_path = main_file.path().to_str().unwrap().to_string();
-        let remote_path = remote_file.path().to_str().unwrap().to_string();
-
-        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let remote_db =
-            turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
-                .unwrap();
-        let remote_conn = remote_db.connect().unwrap();
-        remote_conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
-        assert!(remote_conn.mvcc_enabled());
-        remote_conn
-            .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")
-            .unwrap();
-        remote_conn
-            .execute("INSERT INTO items VALUES (1, 'remote-a'), (2, 'remote-b')")
-            .unwrap();
-        let remote_wal_state = remote_conn.wal_state().unwrap();
-        remote_conn
-            .checkpoint(turso_core::CheckpointMode::Truncate {
-                upper_bound_inclusive: Some(remote_wal_state.max_frame),
-            })
-            .unwrap();
-        drop(remote_conn);
-        drop(remote_db);
-        let remote_bytes = std::fs::read(&remote_path).unwrap();
-        assert!(!remote_bytes.is_empty());
-
-        let server_revision = "g1:o0";
-        let first_contact_response = encoded_page_stream_response(
-            &remote_bytes,
-            server_revision,
-            PullUpdatesProtocol::MvccLogical,
-        );
-        // The replace-base apply issues one follow-up logical pull from the
-        // new revision; serve it an empty logical stream.
-        let followup_logical_response = PullUpdatesRespProtoBody {
-            server_revision: server_revision.to_string(),
-            db_size: (remote_bytes.len() / super::PAGE_SIZE) as u64,
-            raw_encoding: Some(PageSetRawEncodingProto {}),
-            zstd_encoding: None,
-            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
-            apply_mode: PullUpdatesApplyMode::Incremental as i32,
-            mvcc_log: None,
-            protocol: PullUpdatesProtocol::MvccLogical as i32,
-        }
-        .encode_length_delimited_to_vec();
-        let sync_io = Arc::new(QueuedSyncEngineIo {
-            responses: Mutex::new(
-                vec![first_contact_response, followup_logical_response]
-                    .into_iter()
-                    .collect(),
-            ),
-        });
-        let sync_engine_io = SyncEngineIoStats::new(sync_io);
-
-        let mut opts = default_test_opts();
-        opts.remote_url = Some("https://example.com".to_string());
-        opts.bootstrap_if_empty = false;
-        opts.logical_mvcc_pull = None; // auto-detect
-
-        let mut gen = genawaiter::sync::Gen::new({
-            let io = io.clone();
-            let main_path = main_path.clone();
-            move |coro| async move {
-                let coro: Coro<()> = coro.into();
-                let engine = DatabaseSyncEngine::create_db(
-                    &coro,
-                    io.clone(),
-                    sync_engine_io.clone(),
-                    &main_path,
-                    opts,
-                )
-                .await
-                .map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
-                })?;
-                assert_eq!(
-                    engine.meta().remote_pull_protocol,
-                    RemotePullProtocol::Unknown
-                );
-
-                // Local writes before ever contacting the server.
-                let conn = engine.connect_rw(&coro).await.map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test connect_rw failed: {error}"))
-                })?;
-                assert!(!conn.mvcc_enabled());
-                conn.execute("CREATE TABLE local_notes(id INTEGER PRIMARY KEY, note TEXT)")?;
-                conn.execute("INSERT INTO local_notes VALUES (1, 'kept-across-conversion')")?;
-                let base_change_id = max_local_change_id(&coro, &conn).await?.unwrap_or(0);
-                update_last_change_id(&coro, &conn, &engine.client_unique_id, 1, base_change_id)
-                    .await?;
-                drop(conn);
-
-                // First contact: detection, conversion, replace-base pull.
-                let status = engine.wait_changes_from_remote(&coro).await?;
-                assert!(matches!(
-                    status.stream_kind,
-                    DbChangesStreamKind::ReplaceBasePages
-                ));
-                assert!(status.file_slot.is_some());
-                assert_eq!(
-                    engine.meta().remote_pull_protocol,
-                    RemotePullProtocol::MvccLogical
-                );
-                assert!(engine.meta().logical_mvcc_pull_active);
-
-                engine.apply_changes_from_remote(&coro, status).await?;
-                assert_eq!(
-                    engine.meta().synced_revision,
-                    Some(DatabasePullRevision::V1 {
-                        revision: server_revision.to_string(),
-                    })
-                );
-
-                // Remote base and replayed local data both present, on an
-                // MVCC-mode connection.
-                let conn = engine.connect_rw(&coro).await.map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test reconnect failed: {error}"))
-                })?;
-                assert!(conn.mvcc_enabled());
-                let mut stmt = conn.prepare("SELECT value FROM items ORDER BY id")?;
-                let mut values = Vec::new();
-                while let Some(row) = run_stmt_once(&coro, &mut stmt).await? {
-                    values.push(row.get_value(0).to_text().unwrap().to_string());
-                }
-                assert_eq!(values, vec!["remote-a".to_string(), "remote-b".to_string()]);
-                let mut stmt = conn.prepare("SELECT note FROM local_notes")?;
-                let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
-                assert_eq!(
-                    row.get_value(0).to_text().unwrap(),
-                    "kept-across-conversion"
-                );
-                assert!(run_stmt_once(&coro, &mut stmt).await?.is_none());
-                drop(stmt);
-                drop(conn);
-                drop(engine);
-
-                // The conversion must survive a reopen: header version and
-                // logical log agree, so a fresh open comes up in MVCC mode
-                // with the same data.
-                let verify_db = turso_core::Database::open_file(
-                    io.clone(),
-                    &main_path,
-                    Arc::new(SqliteDialect),
-                )
-                .map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test verify open failed: {error}"))
-                })?;
-                let verify_conn = verify_db.connect().map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test verify connect failed: {error}"))
-                })?;
-                assert!(verify_conn.mvcc_enabled());
-                let mut stmt = verify_conn.prepare("SELECT COUNT(*) FROM items")?;
-                let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
-                assert_eq!(row.get_value(0).as_int(), Some(2));
-                Result::Ok(())
-            }
-        });
-
-        loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
-            }
-        }
-    }
-
-    /// A database file that lived outside the sync engine has rows without
-    /// CDC provenance; replace-base replay would silently drop them, so the
-    /// MVCC conversion must refuse instead.
-    #[test]
-    fn first_contact_mvcc_conversion_rejects_local_data_without_cdc_history() {
-        let main_file = NamedTempFile::new().unwrap();
-        let main_path = main_file.path().to_str().unwrap().to_string();
-
-        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let foreign_db =
-            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
-                .unwrap();
-        let foreign_conn = foreign_db.connect().unwrap();
-        foreign_conn
-            .execute("CREATE TABLE orphaned(id INTEGER PRIMARY KEY)")
-            .unwrap();
-        foreign_conn
-            .execute("INSERT INTO orphaned VALUES (1)")
-            .unwrap();
-        drop(foreign_conn);
-        drop(foreign_db);
-
-        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
-        let mut opts = default_test_opts();
-        opts.remote_url = Some("https://example.com".to_string());
-        opts.bootstrap_if_empty = false;
-        opts.logical_mvcc_pull = None;
-
-        let mut gen = genawaiter::sync::Gen::new({
-            let io = io.clone();
-            let main_path = main_path.clone();
-            move |coro| async move {
-                let coro: Coro<()> = coro.into();
-                let engine = DatabaseSyncEngine::create_db(
-                    &coro,
-                    io.clone(),
-                    sync_engine_io.clone(),
-                    &main_path,
-                    opts,
-                )
-                .await
-                .map_err(|error| {
-                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
-                })?;
-                let err = engine
-                    .ensure_local_mvcc_journal_mode(&coro)
-                    .await
-                    .unwrap_err();
-                assert!(
-                    format!("{err:#}").contains("without CDC history"),
-                    "{err:#}"
-                );
-                Result::Ok(())
-            }
-        });
-
-        loop {
-            match gen.resume_with(Ok(())) {
-                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
-                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
-            }
-        }
-    }
-}
-
 impl DataStats {
     pub fn new() -> Self {
         Self {
@@ -2629,6 +944,14 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             None => None,
         };
         if forced_protocol == Some(RemotePullProtocol::MvccLogical) {
+            // The legacy wire protocol has no MVCC variant; reject the
+            // override at open time instead of failing on the first pull.
+            if opts.protocol_version_hint == DatabaseSyncEngineProtocolVersion::Legacy {
+                return Err(Error::DatabaseSyncEngineError(
+                    "the logical_mvcc_pull override is not supported with the legacy sync protocol"
+                        .to_string(),
+                ));
+            }
             ensure_logical_mvcc_pull_supported(partial, opts.remote_encryption_key.as_deref())?;
         }
 
@@ -2653,12 +976,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         partial,
                         opts.remote_encryption_key.as_deref(),
                     )?;
-                }
-                let logical_mvcc_pull_active =
-                    meta.remote_pull_protocol == RemotePullProtocol::MvccLogical;
-                if meta.logical_mvcc_pull_active != logical_mvcc_pull_active {
-                    meta.logical_mvcc_pull_active = logical_mvcc_pull_active;
-                    metadata_changed = true;
                 }
                 if metadata_changed {
                     full_write(
@@ -2713,8 +1030,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         None
                     },
                     fresh_bootstrap_pending_cdc_ack: false,
-                    logical_mvcc_pull_active: remote_pull_protocol
-                        == RemotePullProtocol::MvccLogical,
                     remote_pull_protocol,
                     logical_table_names_by_stable_id: Default::default(),
                     saved_configuration: Some(configuration),
@@ -2761,8 +1076,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: None,
                     fresh_bootstrap_pending_cdc_ack: false,
-                    logical_mvcc_pull_active: remote_pull_protocol
-                        == RemotePullProtocol::MvccLogical,
                     remote_pull_protocol,
                     logical_table_names_by_stable_id: Default::default(),
                     saved_configuration: Some(configuration),
@@ -2957,6 +1270,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         .await?;
         let meta = Self::read_db_meta(coro, Some(io.clone()), sync_engine_io.clone(), main_db_path)
             .await?;
+        let fresh_bootstrap = meta.is_none() && opts.bootstrap_if_empty;
         let meta = Self::bootstrap_db(
             coro,
             io.clone(),
@@ -2996,7 +1310,16 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             }
         };
 
-        Self::open_db(coro, io, sync_engine_io, main_db, opts).await
+        let engine = Self::open_db(coro, io, sync_engine_io, main_db, opts).await?;
+        // An MVCC bootstrap serves the last durable generation base so commits
+        // since the last natural checkpoint exist only in the retained
+        // logical log. Catch up with one incremental pull so a freshly
+        // bootstrapped database is current at connect time, matching what
+        // page-protocol bootstraps always provided.
+        if fresh_bootstrap {
+            engine.catch_up_after_fresh_bootstrap(coro).await?;
+        }
+        Ok(engine)
     }
 
     async fn open_revert_db_conn<Ctx>(
@@ -3123,7 +1446,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
     pub async fn checkpoint<Ctx>(&self, coro: &Coro<Ctx>) -> Result<()> {
         let main_conn = connect_untracked(&self.main_tape)?;
-        if self.meta().logical_mvcc_pull_active && main_conn.mvcc_enabled() {
+        if self.meta().logical_mvcc_pull_active() && main_conn.mvcc_enabled() {
             let main_wal_state = main_conn.wal_state()?;
             let result = main_conn.checkpoint(turso_core::CheckpointMode::Truncate {
                 upper_bound_inclusive: Some(main_wal_state.max_frame),
@@ -3326,7 +1649,40 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         Ok(())
     }
 
+    /// Catches a freshly bootstrapped MVCC replica up to the retained
+    /// logical log. The bootstrap page image is the last durable generation
+    /// base (the server deliberately never checkpoints for a bootstrap), so
+    /// without this pull `connect()` would hand out a database missing every
+    /// commit since the last natural checkpoint. Long-polling is disabled:
+    /// when the base is already current this must return immediately rather
+    /// than hold `connect()` open waiting for future changes.
+    ///
+    /// No-op for page-protocol replicas (their bootstrap is already
+    /// current). Every initialization path that can perform a fresh
+    /// bootstrap must call this after opening the engine — both
+    /// [`DatabaseSyncEngine::create_db`] and the sdk-kit `rsapi` create flow,
+    /// which assembles the same sequence manually.
+    pub async fn catch_up_after_fresh_bootstrap<Ctx>(&self, coro: &Coro<Ctx>) -> Result<()> {
+        if self.meta().remote_pull_protocol != RemotePullProtocol::MvccLogical {
+            return Ok(());
+        }
+        let changes = self.wait_changes_from_remote_inner(coro, None).await?;
+        if changes.file_slot.is_some() {
+            self.apply_changes_from_remote(coro, changes).await?;
+        }
+        Ok(())
+    }
+
     pub async fn wait_changes_from_remote<Ctx>(&self, coro: &Coro<Ctx>) -> Result<DbChangesStatus> {
+        self.wait_changes_from_remote_inner(coro, self.opts.long_poll_timeout)
+            .await
+    }
+
+    async fn wait_changes_from_remote_inner<Ctx>(
+        &self,
+        coro: &Coro<Ctx>,
+        long_poll_timeout: Option<std::time::Duration>,
+    ) -> Result<DbChangesStatus> {
         tracing::info!("wait_changes(path={})", self.main_db_path);
 
         let file = acquire_slot(&self.changes_file)?;
@@ -3351,15 +1707,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         );
         let next_revision = match (remote_pull_protocol, &revision) {
             (RemotePullProtocol::MvccLogical, Some(DatabasePullRevision::V1 { revision })) => {
-                match pull_updates_v1(
-                    ctx,
-                    &file.value,
-                    revision,
-                    self.opts.long_poll_timeout,
-                    true,
-                )
-                .await?
-                {
+                match pull_updates_v1(ctx, &file.value, revision, long_poll_timeout, true).await? {
                     (next_revision, result @ PullUpdatesV1Result::Logical { txns, ops }, _) => {
                         tracing::info!(
                             "wait_changes(path={}): logical pull returned {} transactions / {} ops",
@@ -3382,8 +1730,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             }
             (RemotePullProtocol::MvccLogical, None) => {
                 let (next_revision, result, _) =
-                    pull_updates_v1(ctx, &file.value, "", self.opts.long_poll_timeout, false)
-                        .await?;
+                    pull_updates_v1(ctx, &file.value, "", long_poll_timeout, false).await?;
                 tracing::info!(
                     "wait_changes(path={}): initial logical MVCC sync returned page base",
                     self.main_db_path,
@@ -3405,16 +1752,17 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 };
                 next_revision
             }
+            // A Legacy revision only exists on replicas that synced with the
+            // legacy wire protocol, which has no MVCC variant — detection
+            // never selects MvccLogical for them, so this combination can
+            // only be a caller forcing `logical_mvcc_pull: Some(true)` on a
+            // legacy replica. The server cannot resume an MVCC logical
+            // stream from a legacy revision; fail loudly rather than
+            // silently ignoring the override.
             (RemotePullProtocol::MvccLogical, Some(DatabasePullRevision::Legacy { .. })) => {
-                stream_kind = DbChangesStreamKind::LegacyPages;
-                wal_pull_to_file(
-                    ctx,
-                    &file.value,
-                    &revision,
-                    self.opts.wal_pull_batch_size,
-                    self.opts.long_poll_timeout,
-                )
-                .await?
+                return Err(Error::DatabaseSyncEngineError(
+                    "the logical_mvcc_pull override is not supported for replicas synced with the legacy protocol; remove the override to keep using legacy page sync".to_string(),
+                ));
             }
             // First server contact of an auto-mode replica whose remote
             // protocol is not yet known (deferred bootstrap). The request is
@@ -3422,8 +1770,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             // the response header tells us which protocol the remote speaks.
             (RemotePullProtocol::Unknown, None) => {
                 let (next_revision, result, detected) =
-                    pull_updates_v1(ctx, &file.value, "", self.opts.long_poll_timeout, false)
-                        .await?;
+                    pull_updates_v1(ctx, &file.value, "", long_poll_timeout, false).await?;
                 if detected == RemotePullProtocol::MvccLogical {
                     ensure_logical_mvcc_pull_supported(
                         self.opts.partial_sync_opts.is_some(),
@@ -3433,18 +1780,15 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     // MVCC page base must be applied to an MVCC-mode database.
                     self.ensure_local_mvcc_journal_mode(coro).await?;
                 }
-                if detected != RemotePullProtocol::Unknown {
-                    tracing::info!(
-                        "wait_changes(path={}): detected remote pull protocol {:?} on first contact",
-                        self.main_db_path,
-                        detected
-                    );
-                    self.update_meta(coro, |m| {
-                        m.remote_pull_protocol = detected;
-                        m.logical_mvcc_pull_active = detected == RemotePullProtocol::MvccLogical;
-                    })
-                    .await?;
-                }
+                tracing::info!(
+                    "wait_changes(path={}): detected remote pull protocol {:?} on first contact",
+                    self.main_db_path,
+                    detected
+                );
+                self.update_meta(coro, |m| {
+                    m.remote_pull_protocol = detected;
+                })
+                .await?;
                 stream_kind = match (detected, &result) {
                     // Page-protocol remote: mirror the page path exactly,
                     // including its rejection of replace-base streams.
@@ -3478,7 +1822,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     &file.value,
                     &revision,
                     self.opts.wal_pull_batch_size,
-                    self.opts.long_poll_timeout,
+                    long_poll_timeout,
                 )
                 .await?
             }
@@ -3869,7 +2213,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         // read current pull generation from local table for the given client
         let (local_pull_gen, local_last_change_id) =
             read_last_change_id(coro, &main_conn, &self.client_unique_id).await?;
-        let no_checkpoint_replace_base = replace_base_pages && self.meta().logical_mvcc_pull_active;
+        let no_checkpoint_replace_base =
+            replace_base_pages && self.meta().logical_mvcc_pull_active();
         tracing::info!(
             "apply_changes(path={}): local sync high-water before remote apply: client_id={} pull_gen={} change_id={:?} replace_base={}",
             self.main_db_path,
@@ -3894,7 +2239,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             || matches!(stream_kind, DbChangesStreamKind::Logical)
             || should_replay_raw_pages_on_sql_conn(
                 self.opts.protocol_version_hint,
-                self.meta().logical_mvcc_pull_active,
+                self.meta().logical_mvcc_pull_active(),
                 false,
                 stream_kind,
                 main_conn.mv_store().as_ref().is_some(),
@@ -4154,7 +2499,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         })?;
                         logical_replay_conn = Some(conn);
 
-                        if self.meta().logical_mvcc_pull_active {
+                        if self.meta().logical_mvcc_pull_active() {
                             let DatabasePullRevision::V1 { revision } = remote_revision else {
                                 return Err(Error::DatabaseSyncEngineError(format!(
                                     "replace-base follow-up logical pull requires a V1 revision, got {remote_revision:?}"
@@ -4233,7 +2578,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
             let raw_page_replay_on_sql_conn = should_replay_raw_pages_on_sql_conn(
                 self.opts.protocol_version_hint,
-                self.meta().logical_mvcc_pull_active,
+                self.meta().logical_mvcc_pull_active(),
                 logical_replay_conn.is_some(),
                 stream_kind,
                 main_conn.mv_store().as_ref().is_some(),
@@ -4850,5 +3195,1874 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         // todo: what happen if we will actually update the metadata on disk but fail and so in memory state will not be updated
         *self.meta.lock().unwrap() = meta;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        create_main_db_log_path, create_main_db_wal_path, create_meta_path,
+        create_replace_base_marker_path, create_revert_db_wal_path,
+        ensure_logical_mvcc_pull_supported, ensure_stream_kind_can_use_legacy_page_apply,
+        replace_base_backup_path, resolve_local_replay_floor_change_id,
+        resolve_remote_pull_protocol, should_replay_raw_pages_on_sql_conn,
+        should_request_logical_pull, stream_kind_applies_remote_pages,
+        stream_kind_for_pull_updates_v1_result, synced_change_id_after_remote_apply,
+        use_pushed_change_hint_for_local_replay, DatabaseSyncEngine, DatabaseSyncEngineOpts,
+        ReplaceBaseApplyGuard, REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
+    };
+    use crate::{
+        client_proto::{
+            LogicalOp, LogicalOpType, LogicalSchemaAction, LogicalSchemaKind, LogicalTxnData,
+        },
+        database_sync_engine_io::{DataCompletion, DataPollResult, SyncEngineIo},
+        database_sync_operations::{
+            count_local_changes, max_local_change_id, read_last_change_id, update_last_change_id,
+            MutexSlot, PullUpdatesV1Result, SyncEngineIoStats,
+        },
+        database_tape::{run_stmt_once, DatabaseTape, DatabaseTapeOpts},
+        errors::Error,
+        io_operations::IoOperations,
+        server_proto::{
+            PageData, PageSetRawEncodingProto, PullUpdatesApplyMode, PullUpdatesProtocol,
+            PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, PullUpdatesStreamKind,
+        },
+        types::{
+            Coro, DatabaseMetadata, DatabasePullRevision, DatabaseSavedConfiguration,
+            DatabaseSyncEngineProtocolVersion, DbChangesStatus, DbChangesStreamKind,
+            PartialSyncOpts, RemotePullProtocol, SyncEngineIoResult, DATABASE_METADATA_VERSION,
+        },
+        Result,
+    };
+    use bytes::Bytes;
+    use prost::Message;
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+    use tempfile::NamedTempFile;
+    use turso_core::SqliteDialect;
+
+    #[test]
+    fn explicit_override_wins_over_persisted_protocol() {
+        for persisted in [
+            RemotePullProtocol::Unknown,
+            RemotePullProtocol::Pages,
+            RemotePullProtocol::MvccLogical,
+        ] {
+            assert_eq!(
+                resolve_remote_pull_protocol(Some(true), persisted),
+                RemotePullProtocol::MvccLogical
+            );
+            assert_eq!(
+                resolve_remote_pull_protocol(Some(false), persisted),
+                RemotePullProtocol::Pages
+            );
+            assert_eq!(resolve_remote_pull_protocol(None, persisted), persisted);
+        }
+    }
+
+    #[test]
+    fn logical_mvcc_pull_with_partial_sync_is_a_hard_error() {
+        // Silent downgrade to page pull would just defer the failure to an
+        // opaque server-side protocol error on every incremental pull.
+        assert!(ensure_logical_mvcc_pull_supported(true, None).is_err());
+    }
+
+    #[test]
+    fn logical_mvcc_pull_with_remote_encryption_is_a_hard_error() {
+        assert!(ensure_logical_mvcc_pull_supported(false, Some("key")).is_err());
+    }
+
+    #[test]
+    fn logical_mvcc_pull_remains_enabled_for_plain_full_sync() {
+        assert!(ensure_logical_mvcc_pull_supported(false, None).is_ok());
+    }
+
+    #[test]
+    fn logical_pull_is_requested_only_for_active_v1_revisions() {
+        assert!(!should_request_logical_pull(false, &None));
+        assert!(!should_request_logical_pull(true, &None));
+        assert!(!should_request_logical_pull(
+            true,
+            &Some(DatabasePullRevision::Legacy {
+                generation: 1,
+                synced_frame_no: Some(10),
+            })
+        ));
+        assert!(should_request_logical_pull(
+            true,
+            &Some(DatabasePullRevision::V1 {
+                revision: "g1:o42".to_string(),
+            })
+        ));
+    }
+
+    #[test]
+    fn legacy_page_apply_rejects_non_page_streams() {
+        assert!(
+            ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::LegacyPages).is_ok()
+        );
+        assert!(ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::Pages).is_ok());
+        let logical_err =
+            ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::Logical).unwrap_err();
+        assert!(
+            logical_err.to_string().contains("logical MVCC apply"),
+            "unexpected error: {logical_err:?}"
+        );
+        let replace_base_err =
+            ensure_stream_kind_can_use_legacy_page_apply(DbChangesStreamKind::ReplaceBasePages)
+                .unwrap_err();
+        assert!(
+            replace_base_err
+                .to_string()
+                .contains("replace-base page apply"),
+            "unexpected error: {replace_base_err:?}"
+        );
+    }
+
+    #[test]
+    fn logical_pull_page_fallback_preserves_replace_base_kind() {
+        assert_eq!(
+            stream_kind_for_pull_updates_v1_result(&PullUpdatesV1Result::Pages {
+                replace_base: false
+            }),
+            DbChangesStreamKind::Pages
+        );
+        assert_eq!(
+            stream_kind_for_pull_updates_v1_result(&PullUpdatesV1Result::Pages {
+                replace_base: true
+            }),
+            DbChangesStreamKind::ReplaceBasePages
+        );
+        assert_eq!(
+            stream_kind_for_pull_updates_v1_result(&PullUpdatesV1Result::Logical {
+                txns: 1,
+                ops: 2
+            }),
+            DbChangesStreamKind::Logical
+        );
+    }
+
+    #[test]
+    fn replace_base_pages_use_remote_page_transport() {
+        assert!(stream_kind_applies_remote_pages(
+            DbChangesStreamKind::LegacyPages
+        ));
+        assert!(stream_kind_applies_remote_pages(DbChangesStreamKind::Pages));
+        assert!(stream_kind_applies_remote_pages(
+            DbChangesStreamKind::ReplaceBasePages
+        ));
+        assert!(!stream_kind_applies_remote_pages(
+            DbChangesStreamKind::Logical
+        ));
+    }
+
+    #[test]
+    fn sql_replay_page_routing_keeps_legacy_on_wal_session() {
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::Legacy,
+            true,
+            false,
+            DbChangesStreamKind::LegacyPages,
+            true,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::Legacy,
+            true,
+            false,
+            DbChangesStreamKind::ReplaceBasePages,
+            true,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            false,
+            false,
+            DbChangesStreamKind::Pages,
+            true,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            true,
+            false,
+            DbChangesStreamKind::Pages,
+            false,
+        ));
+        assert!(should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            true,
+            false,
+            DbChangesStreamKind::Pages,
+            true,
+        ));
+        assert!(should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            true,
+            false,
+            DbChangesStreamKind::ReplaceBasePages,
+            true,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            true,
+            true,
+            DbChangesStreamKind::ReplaceBasePages,
+            true,
+        ));
+        assert!(!should_replay_raw_pages_on_sql_conn(
+            DatabaseSyncEngineProtocolVersion::V1,
+            true,
+            false,
+            DbChangesStreamKind::Logical,
+            true,
+        ));
+    }
+
+    #[test]
+    fn v1_page_replay_uses_remote_snapshot_sync_row_not_later_push_hint() {
+        assert!(!use_pushed_change_hint_for_local_replay(
+            DbChangesStreamKind::Pages,
+            false
+        ));
+        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), 7, 34);
+        assert_eq!(floor, Some(12));
+    }
+
+    #[test]
+    fn legacy_page_replay_can_use_last_pushed_hint_when_sync_row_is_stale() {
+        assert!(use_pushed_change_hint_for_local_replay(
+            DbChangesStreamKind::LegacyPages,
+            false
+        ));
+        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), 7, 34);
+        assert_eq!(floor, Some(34));
+    }
+
+    #[test]
+    fn local_replay_ignores_last_pushed_hint_from_stale_pull_generation() {
+        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), 6, 34);
+        assert_eq!(floor, Some(12));
+    }
+
+    #[test]
+    fn raw_wal_replay_preserves_existing_floor_when_hints_are_disabled() {
+        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), 7, 34);
+        assert_eq!(floor, Some(12));
+    }
+
+    #[test]
+    fn remote_apply_acknowledges_pre_apply_cdc_when_local_changes_are_recaptured() {
+        assert_eq!(
+            synced_change_id_after_remote_apply(false, Some(12), 40),
+            40,
+            "without local replay, all CDC generated by remote apply is acknowledged"
+        );
+        assert_eq!(
+            synced_change_id_after_remote_apply(true, Some(12), 40),
+            12,
+            "with local replay, preserve the replay floor so local rows remain pushable"
+        );
+        assert_eq!(
+            synced_change_id_after_remote_apply(true, Some(11), 8),
+            8,
+            "the persisted sync floor must never advance beyond the local CDC high-water"
+        );
+        assert_eq!(
+            synced_change_id_after_remote_apply(true, None, 40),
+            0,
+            "a database with no pre-existing CDC still starts from zero"
+        );
+    }
+
+    struct EmptyPollResult<T>(Vec<T>);
+
+    impl<T: Send + Sync + 'static> DataPollResult<T> for EmptyPollResult<T> {
+        fn data(&self) -> &[T] {
+            &self.0
+        }
+    }
+
+    struct EmptyCompletion<T> {
+        data: Mutex<Option<Vec<T>>>,
+    }
+
+    impl<T> EmptyCompletion<T> {
+        fn empty() -> Self {
+            Self {
+                data: Mutex::new(Some(Vec::new())),
+            }
+        }
+
+        fn with_data(data: Vec<T>) -> Self {
+            Self {
+                data: Mutex::new(Some(data)),
+            }
+        }
+    }
+
+    impl<T: Send + Sync + 'static> DataCompletion<T> for EmptyCompletion<T> {
+        type DataPollResult = EmptyPollResult<T>;
+
+        fn status(&self) -> Result<Option<u16>> {
+            Ok(Some(200))
+        }
+
+        fn poll_data(&self) -> Result<Option<Self::DataPollResult>> {
+            let data = self.data.lock().unwrap().take().unwrap_or_default();
+            if data.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(EmptyPollResult(data)))
+            }
+        }
+
+        fn is_done(&self) -> Result<bool> {
+            Ok(self.data.lock().unwrap().as_ref().is_none_or(Vec::is_empty))
+        }
+    }
+
+    #[derive(Default)]
+    struct NoopSyncEngineIo;
+
+    impl SyncEngineIo for NoopSyncEngineIo {
+        type DataCompletionBytes = EmptyCompletion<u8>;
+        type DataCompletionTransform = EmptyCompletion<crate::types::DatabaseRowTransformResult>;
+
+        fn full_read(&self, path: &str) -> Result<Self::DataCompletionBytes> {
+            let data = match std::fs::read(path) {
+                Ok(data) => data,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+                Err(error) => {
+                    return Err(crate::errors::Error::DatabaseSyncEngineError(format!(
+                        "test full_read failed for {path}: {error}"
+                    )));
+                }
+            };
+            Ok(EmptyCompletion::with_data(data))
+        }
+
+        fn full_write(&self, path: &str, content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
+            std::fs::write(path, content).map_err(|error| {
+                crate::errors::Error::DatabaseSyncEngineError(format!(
+                    "test full_write failed for {path}: {error}"
+                ))
+            })?;
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn transform(
+            &self,
+            _mutations: Vec<crate::types::DatabaseRowMutation>,
+        ) -> Result<Self::DataCompletionTransform> {
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn http(
+            &self,
+            _url: Option<&str>,
+            _method: &str,
+            _path: &str,
+            _body: Option<Vec<u8>>,
+            _headers: &[(&str, &str)],
+        ) -> Result<Self::DataCompletionBytes> {
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
+
+        fn step_io_callbacks(&self) {}
+    }
+
+    struct CapturingSyncEngineIo {
+        response: Mutex<Option<Vec<u8>>>,
+        #[allow(clippy::type_complexity)]
+        request: Mutex<Option<(String, String, Option<Vec<u8>>)>>,
+    }
+
+    impl SyncEngineIo for CapturingSyncEngineIo {
+        type DataCompletionBytes = EmptyCompletion<u8>;
+        type DataCompletionTransform = EmptyCompletion<crate::types::DatabaseRowTransformResult>;
+
+        fn full_read(&self, path: &str) -> Result<Self::DataCompletionBytes> {
+            let data = std::fs::read(path).unwrap_or_default();
+            Ok(EmptyCompletion::with_data(data))
+        }
+
+        fn full_write(&self, path: &str, content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
+            std::fs::write(path, content).map_err(|error| {
+                crate::errors::Error::DatabaseSyncEngineError(format!(
+                    "test full_write failed for {path}: {error}"
+                ))
+            })?;
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn transform(
+            &self,
+            _mutations: Vec<crate::types::DatabaseRowMutation>,
+        ) -> Result<Self::DataCompletionTransform> {
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn http(
+            &self,
+            _url: Option<&str>,
+            method: &str,
+            path: &str,
+            body: Option<Vec<u8>>,
+            _headers: &[(&str, &str)],
+        ) -> Result<Self::DataCompletionBytes> {
+            self.request
+                .lock()
+                .unwrap()
+                .replace((method.to_string(), path.to_string(), body));
+            let response = self.response.lock().unwrap().take().unwrap_or_default();
+            Ok(EmptyCompletion::with_data(response))
+        }
+
+        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
+
+        fn step_io_callbacks(&self) {}
+    }
+
+    /// Serves canned HTTP responses in order; panics if the engine makes more
+    /// requests than responses were queued. Records every request for
+    /// assertions on the wire traffic.
+    struct QueuedSyncEngineIo {
+        responses: Mutex<std::collections::VecDeque<Vec<u8>>>,
+        #[allow(clippy::type_complexity)]
+        requests: Mutex<Vec<(String, String, Option<Vec<u8>>)>>,
+    }
+
+    impl SyncEngineIo for QueuedSyncEngineIo {
+        type DataCompletionBytes = EmptyCompletion<u8>;
+        type DataCompletionTransform = EmptyCompletion<crate::types::DatabaseRowTransformResult>;
+
+        fn full_read(&self, path: &str) -> Result<Self::DataCompletionBytes> {
+            let data = std::fs::read(path).unwrap_or_default();
+            Ok(EmptyCompletion::with_data(data))
+        }
+
+        fn full_write(&self, path: &str, content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
+            std::fs::write(path, content).map_err(|error| {
+                crate::errors::Error::DatabaseSyncEngineError(format!(
+                    "test full_write failed for {path}: {error}"
+                ))
+            })?;
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn transform(
+            &self,
+            _mutations: Vec<crate::types::DatabaseRowMutation>,
+        ) -> Result<Self::DataCompletionTransform> {
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn http(
+            &self,
+            _url: Option<&str>,
+            method: &str,
+            path: &str,
+            body: Option<Vec<u8>>,
+            _headers: &[(&str, &str)],
+        ) -> Result<Self::DataCompletionBytes> {
+            self.requests
+                .lock()
+                .unwrap()
+                .push((method.to_string(), path.to_string(), body));
+            let response = self
+                .responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("engine made more HTTP requests than queued responses");
+            Ok(EmptyCompletion::with_data(response))
+        }
+
+        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
+
+        fn step_io_callbacks(&self) {}
+    }
+
+    fn record(values: &[turso_core::Value]) -> Bytes {
+        Bytes::from(
+            turso_core::types::ImmutableRecord::from_values(values, values.len())
+                .unwrap()
+                .into_payload(),
+        )
+    }
+
+    fn encoded_logical_txns(txns: &[LogicalTxnData]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for txn in txns {
+            bytes.extend_from_slice(&txn.encode_length_delimited_to_vec());
+        }
+        bytes
+    }
+
+    fn default_test_opts() -> DatabaseSyncEngineOpts {
+        DatabaseSyncEngineOpts {
+            remote_url: None,
+            client_name: "test-client".to_string(),
+            tables_ignore: vec![],
+            use_transform: false,
+            wal_pull_batch_size: 0,
+            long_poll_timeout: Some(Duration::from_millis(1)),
+            protocol_version_hint: DatabaseSyncEngineProtocolVersion::V1,
+            bootstrap_if_empty: false,
+            reserved_bytes: 0,
+            db_opts: turso_core::DatabaseOpts::default(),
+            partial_sync_opts: None::<PartialSyncOpts>,
+            remote_encryption_key: None,
+            push_operations_threshold: None,
+            pull_bytes_threshold: None,
+            logical_mvcc_pull: Some(true),
+        }
+    }
+
+    fn replace_base_guard_test_paths(
+        main_path: &str,
+    ) -> Vec<(&'static str, String, Option<&'static [u8]>)> {
+        vec![
+            ("main-db", main_path.to_string(), Some(b"main-old")),
+            (
+                "main-wal",
+                create_main_db_wal_path(main_path),
+                Some(b"wal-old"),
+            ),
+            (
+                "main-log",
+                create_main_db_log_path(main_path),
+                Some(b"log-old"),
+            ),
+            ("revert-wal", create_revert_db_wal_path(main_path), None),
+            ("metadata", create_meta_path(main_path), Some(b"meta-old")),
+        ]
+    }
+
+    fn write_replace_base_guard_test_files(main_path: &str) {
+        for (_, path, content) in replace_base_guard_test_paths(main_path) {
+            if let Some(content) = content {
+                std::fs::write(path, content).unwrap();
+            }
+        }
+    }
+
+    fn assert_replace_base_backups_removed(main_path: &str) {
+        assert!(std::fs::read(create_replace_base_marker_path(main_path)).is_err());
+        for (name, _, _) in replace_base_guard_test_paths(main_path) {
+            assert!(std::fs::read(replace_base_backup_path(main_path, name)).is_err());
+        }
+    }
+
+    async fn write_replace_base_pages_file<Ctx>(
+        coro: &Coro<Ctx>,
+        io: &Arc<dyn turso_core::IO>,
+        source_db_path: &str,
+        changes_path: &str,
+    ) -> Result<Arc<dyn turso_core::File>> {
+        let pages = std::fs::read(source_db_path).unwrap();
+        assert_eq!(pages.len() % super::PAGE_SIZE, 0);
+        let db_size = (pages.len() / super::PAGE_SIZE) as u32;
+        let changes_file = io.open_file(changes_path, turso_core::OpenFlags::Create, false)?;
+
+        let truncate = changes_file.truncate(0, turso_core::Completion::new_trunc(|_| {}))?;
+        while !truncate.succeeded() {
+            coro.yield_(SyncEngineIoResult::IO).await?;
+        }
+
+        for (page_idx, page) in pages.chunks_exact(super::PAGE_SIZE).enumerate() {
+            let mut frame = vec![0; super::WAL_FRAME_SIZE];
+            frame[super::WAL_FRAME_HEADER..].copy_from_slice(page);
+            let frame_info = turso_core::types::WalFrameInfo {
+                page_no: page_idx as u32 + 1,
+                db_size: if page_idx + 1 == db_size as usize {
+                    db_size
+                } else {
+                    0
+                },
+            };
+            frame_info.put_to_frame_header(&mut frame);
+            let offset = (page_idx * super::WAL_FRAME_SIZE) as u64;
+            let len = frame.len();
+            let write = changes_file.pwrite(
+                offset,
+                Arc::new(turso_core::Buffer::new(frame)),
+                turso_core::Completion::new_write(move |result| {
+                    let Ok(size) = result else {
+                        return;
+                    };
+                    assert_eq!(size as usize, len);
+                }),
+            )?;
+            while !write.succeeded() {
+                coro.yield_(SyncEngineIoResult::IO).await?;
+            }
+        }
+
+        let sync = changes_file.sync(
+            turso_core::Completion::new_sync(|_| {}),
+            turso_core::io::FileSyncType::Fsync,
+        )?;
+        while !sync.succeeded() {
+            coro.yield_(SyncEngineIoResult::IO).await?;
+        }
+        Ok(changes_file)
+    }
+
+    #[test]
+    fn replace_base_guard_restores_original_files_and_removes_created_files() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let main_path = temp_dir
+            .path()
+            .join("guard-restore.db")
+            .to_string_lossy()
+            .to_string();
+        write_replace_base_guard_test_files(&main_path);
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(None),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io);
+        let old_revision = DatabasePullRevision::V1 {
+            revision: "old-revision".to_string(),
+        };
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let guard = ReplaceBaseApplyGuard::create(
+                    &coro,
+                    io.clone(),
+                    sync_stats,
+                    &main_path,
+                    Some(old_revision),
+                )
+                .await?;
+
+                std::fs::write(&main_path, b"main-new").unwrap();
+                std::fs::write(create_main_db_wal_path(&main_path), b"wal-new").unwrap();
+                std::fs::write(create_main_db_log_path(&main_path), b"log-new").unwrap();
+                std::fs::write(create_revert_db_wal_path(&main_path), b"revert-created").unwrap();
+                std::fs::write(create_meta_path(&main_path), b"meta-new").unwrap();
+
+                guard.restore(&coro).await?;
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        assert_eq!(std::fs::read(&main_path).unwrap(), b"main-old");
+        assert_eq!(
+            std::fs::read(create_main_db_wal_path(&main_path)).unwrap(),
+            b"wal-old"
+        );
+        assert_eq!(
+            std::fs::read(create_main_db_log_path(&main_path)).unwrap(),
+            b"log-old"
+        );
+        assert!(std::fs::read(create_revert_db_wal_path(&main_path)).is_err());
+        assert_eq!(
+            std::fs::read(create_meta_path(&main_path)).unwrap(),
+            b"meta-old"
+        );
+        assert_replace_base_backups_removed(&main_path);
+    }
+
+    #[test]
+    fn replace_base_guard_recovers_pending_marker() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let main_path = temp_dir
+            .path()
+            .join("guard-recover.db")
+            .to_string_lossy()
+            .to_string();
+        write_replace_base_guard_test_files(&main_path);
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(None),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io);
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let _guard = ReplaceBaseApplyGuard::create(
+                    &coro,
+                    io.clone(),
+                    sync_stats.clone(),
+                    &main_path,
+                    None,
+                )
+                .await?;
+
+                std::fs::write(&main_path, b"main-new").unwrap();
+                std::fs::write(create_meta_path(&main_path), b"meta-new").unwrap();
+
+                let recovered = ReplaceBaseApplyGuard::recover_pending(
+                    &coro,
+                    io.clone(),
+                    sync_stats,
+                    &main_path,
+                )
+                .await?;
+                assert!(recovered);
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        assert_eq!(std::fs::read(&main_path).unwrap(), b"main-old");
+        assert_eq!(
+            std::fs::read(create_meta_path(&main_path)).unwrap(),
+            b"meta-old"
+        );
+        assert_replace_base_backups_removed(&main_path);
+    }
+
+    #[test]
+    fn replace_base_guard_mark_complete_removes_marker_without_restoring() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let main_path = temp_dir
+            .path()
+            .join("guard-complete.db")
+            .to_string_lossy()
+            .to_string();
+        write_replace_base_guard_test_files(&main_path);
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(None),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io);
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let mut guard =
+                    ReplaceBaseApplyGuard::create(&coro, io.clone(), sync_stats, &main_path, None)
+                        .await?;
+                std::fs::write(&main_path, b"main-new").unwrap();
+                guard.mark_complete(&coro).await?;
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        assert_eq!(std::fs::read(&main_path).unwrap(), b"main-new");
+        assert_replace_base_backups_removed(&main_path);
+    }
+
+    #[test]
+    fn initial_logical_mvcc_pull_page_bootstrap_uses_replace_base_apply() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let main_path = temp_file.path().to_str().unwrap().to_string();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let main_db =
+            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
+                .unwrap();
+
+        let meta = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "initial-client".to_string(),
+            synced_revision: None,
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            remote_pull_protocol: RemotePullProtocol::MvccLogical,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: Some("https://example.com".to_string()),
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        std::fs::write(create_meta_path(&main_path), meta.dump().unwrap()).unwrap();
+
+        let header = PullUpdatesRespProtoBody {
+            protocol: 0,
+            server_revision: "g1:o10".to_string(),
+            db_size: 0,
+            raw_encoding: None,
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+        };
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(Some(header.encode_length_delimited_to_vec())),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io.clone());
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.logical_mvcc_pull = Some(true);
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_db = main_db.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine =
+                    DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
+                let status = engine.wait_changes_from_remote(&coro).await?;
+                assert!(status.file_slot.is_none());
+                assert!(matches!(
+                    status.stream_kind,
+                    DbChangesStreamKind::ReplaceBasePages
+                ));
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        let (_method, path, body) = sync_io.request.lock().unwrap().clone().unwrap();
+        assert_eq!(path, "/pull-updates");
+        let request = PullUpdatesReqProtoBody::decode(body.unwrap().as_slice()).unwrap();
+        assert_eq!(request.stream_kind, PullUpdatesStreamKind::Pages as i32);
+        assert_eq!(request.client_revision, "");
+        assert_eq!(request.server_revision, "");
+    }
+
+    #[test]
+    fn apply_changes_from_remote_applies_logical_stream_without_local_replay() {
+        let db_temp = NamedTempFile::new().unwrap();
+        let meta_temp = NamedTempFile::new().unwrap();
+        let changes_temp = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+
+        let txns = vec![
+            LogicalTxnData {
+                end_offset: 1,
+                commit_ts: 1,
+                origin_client_id: "remote".to_string(),
+                ops: vec![LogicalOp {
+                    op_type: LogicalOpType::Schema as i32,
+                    table_name: String::new(),
+                    rowid: 0,
+                    record: Bytes::new(),
+                    sql: "CREATE TABLE items(x TEXT)".to_string(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: Some(LogicalSchemaAction::Create as i32),
+                    schema_kind: Some(LogicalSchemaKind::Table as i32),
+                    schema_name: "items".to_string(),
+                    stable_table_id: 7,
+                }],
+            },
+            LogicalTxnData {
+                end_offset: 2,
+                commit_ts: 2,
+                origin_client_id: "remote".to_string(),
+                ops: vec![LogicalOp {
+                    op_type: LogicalOpType::UpsertRow as i32,
+                    table_name: String::new(),
+                    rowid: 2,
+                    record: record(&[turso_core::Value::Text(turso_core::types::Text::new(
+                        "remote".to_string(),
+                    ))]),
+                    sql: String::new(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: None,
+                    schema_kind: None,
+                    schema_name: String::new(),
+                    stable_table_id: 7,
+                }],
+            },
+        ];
+        std::fs::write(changes_temp.path(), encoded_logical_txns(&txns)).unwrap();
+
+        let db = turso_core::Database::open_file(
+            io.clone(),
+            db_temp.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let db_file = db.db_file.clone();
+        let db_io = db.io.clone();
+        let main_tape = DatabaseTape::new_with_opts(
+            db,
+            DatabaseTapeOpts {
+                cdc_table: None,
+                cdc_mode: Some("full".to_string()),
+                disable_auto_checkpoint: true,
+            },
+        );
+        let sync_io = Arc::new(NoopSyncEngineIo);
+        let sync_engine_io = SyncEngineIoStats::new(sync_io);
+        let changes_file = io
+            .open_file(
+                changes_temp.path().to_str().unwrap(),
+                turso_core::OpenFlags::None,
+                false,
+            )
+            .unwrap();
+        let slot = Arc::new(Mutex::new(None));
+        let meta = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "client-a".to_string(),
+            synced_revision: Some(DatabasePullRevision::V1 {
+                revision: "g1:o1".to_string(),
+            }),
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            remote_pull_protocol: RemotePullProtocol::MvccLogical,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: None,
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        let engine = DatabaseSyncEngine {
+            io: db_io,
+            sync_engine_io,
+            db_file,
+            main_tape,
+            main_db_path: db_temp.path().to_str().unwrap().to_string(),
+            main_db_wal_path: super::create_main_db_wal_path(db_temp.path().to_str().unwrap()),
+            revert_db_wal_path: super::create_revert_db_wal_path(db_temp.path().to_str().unwrap()),
+            meta_path: meta_temp.path().to_str().unwrap().to_string(),
+            changes_file: Arc::new(Mutex::new(None)),
+            opts: default_test_opts(),
+            meta: Mutex::new(meta),
+            client_unique_id: "client-a".to_string(),
+        };
+        let remote_changes = DbChangesStatus {
+            time: io.current_time_wall_clock(),
+            revision: DatabasePullRevision::V1 {
+                revision: "g1:o2".to_string(),
+            },
+            file_slot: Some(crate::database_sync_operations::MutexSlot {
+                value: changes_file,
+                slot,
+            }),
+            stream_kind: DbChangesStreamKind::Logical,
+        };
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let engine = engine;
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                engine
+                    .apply_changes_from_remote(&coro, remote_changes)
+                    .await
+                    .unwrap();
+                let conn = engine.main_tape.connect(&coro).await.unwrap();
+                let mut stmt = conn.prepare("SELECT rowid, x FROM items").unwrap();
+                let mut rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                let (pull_gen, change_id) =
+                    read_last_change_id(&coro, &conn, &engine.client_unique_id)
+                        .await
+                        .unwrap();
+                let pending_local_changes = count_local_changes(&coro, &conn, change_id.unwrap())
+                    .await
+                    .unwrap();
+                let meta = engine.meta.lock().unwrap().clone();
+                (rows, meta, pull_gen, change_id, pending_local_changes)
+            }
+        });
+        let (rows, meta, pull_gen, change_id, pending_local_changes) = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+
+        assert_eq!(
+            rows,
+            vec![vec![
+                turso_core::Value::from_i64(2),
+                turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
+            ]]
+        );
+        assert_eq!(
+            meta.synced_revision,
+            Some(DatabasePullRevision::V1 {
+                revision: "g1:o2".to_string(),
+            })
+        );
+        assert_eq!(
+            meta.logical_table_names_by_stable_id.get(&7).unwrap(),
+            "items"
+        );
+        assert_eq!(meta.revert_since_wal_watermark, 0);
+        assert_eq!(pull_gen, 0);
+        assert!(change_id.is_some());
+        assert_eq!(pending_local_changes, 0);
+    }
+
+    #[test]
+    fn apply_changes_from_remote_replays_pending_local_changes() {
+        let db_temp = NamedTempFile::new().unwrap();
+        let meta_temp = NamedTempFile::new().unwrap();
+        let changes_temp = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+
+        let txns = vec![LogicalTxnData {
+            end_offset: 1,
+            commit_ts: 1,
+            origin_client_id: "remote".to_string(),
+            ops: vec![
+                LogicalOp {
+                    op_type: LogicalOpType::Schema as i32,
+                    table_name: String::new(),
+                    rowid: 0,
+                    record: Bytes::new(),
+                    sql: "CREATE TABLE remote_items(id INTEGER PRIMARY KEY, x TEXT)".to_string(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: Some(LogicalSchemaAction::Create as i32),
+                    schema_kind: Some(LogicalSchemaKind::Table as i32),
+                    schema_name: "remote_items".to_string(),
+                    stable_table_id: 9,
+                },
+                LogicalOp {
+                    op_type: LogicalOpType::UpsertRow as i32,
+                    table_name: String::new(),
+                    rowid: 2,
+                    record: record(&[
+                        turso_core::Value::from_i64(2),
+                        turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
+                    ]),
+                    sql: String::new(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: None,
+                    schema_kind: None,
+                    schema_name: String::new(),
+                    stable_table_id: 9,
+                },
+            ],
+        }];
+        std::fs::write(changes_temp.path(), encoded_logical_txns(&txns)).unwrap();
+
+        let db = turso_core::Database::open_file(
+            io.clone(),
+            db_temp.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let db_file = db.db_file.clone();
+        let db_io = db.io.clone();
+        let main_tape = DatabaseTape::new_with_opts(
+            db,
+            DatabaseTapeOpts {
+                cdc_table: None,
+                cdc_mode: Some("full".to_string()),
+                disable_auto_checkpoint: true,
+            },
+        );
+        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
+        let changes_file = io
+            .open_file(
+                changes_temp.path().to_str().unwrap(),
+                turso_core::OpenFlags::None,
+                false,
+            )
+            .unwrap();
+        let old_revision = DatabasePullRevision::V1 {
+            revision: "g1:o1".to_string(),
+        };
+        let meta = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "client-a".to_string(),
+            synced_revision: Some(old_revision.clone()),
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            remote_pull_protocol: RemotePullProtocol::MvccLogical,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: None,
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        let engine = DatabaseSyncEngine {
+            io: db_io,
+            sync_engine_io,
+            db_file,
+            main_tape,
+            main_db_path: db_temp.path().to_str().unwrap().to_string(),
+            main_db_wal_path: super::create_main_db_wal_path(db_temp.path().to_str().unwrap()),
+            revert_db_wal_path: super::create_revert_db_wal_path(db_temp.path().to_str().unwrap()),
+            meta_path: meta_temp.path().to_str().unwrap().to_string(),
+            changes_file: Arc::new(Mutex::new(None)),
+            opts: default_test_opts(),
+            meta: Mutex::new(meta),
+            client_unique_id: "client-a".to_string(),
+        };
+        let remote_changes = DbChangesStatus {
+            time: io.current_time_wall_clock(),
+            revision: DatabasePullRevision::V1 {
+                revision: "g1:o2".to_string(),
+            },
+            file_slot: Some(crate::database_sync_operations::MutexSlot {
+                value: changes_file,
+                slot: Arc::new(Mutex::new(None)),
+            }),
+            stream_kind: DbChangesStreamKind::Logical,
+        };
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let engine = engine;
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = engine.main_tape.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE local_items(id INTEGER PRIMARY KEY, x TEXT)")
+                    .unwrap();
+                conn.execute("INSERT INTO local_items(id, x) VALUES (1, 'local')")
+                    .unwrap();
+
+                engine
+                    .apply_changes_from_remote(&coro, remote_changes)
+                    .await
+                    .unwrap();
+
+                let mut stmt = conn
+                    .prepare("SELECT id, x FROM remote_items ORDER BY id")
+                    .unwrap();
+                let remote_row = run_stmt_once(&coro, &mut stmt)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .get_values()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                assert!(run_stmt_once(&coro, &mut stmt).await.unwrap().is_none());
+
+                let mut stmt = conn
+                    .prepare("SELECT id, x FROM local_items ORDER BY id")
+                    .unwrap();
+                let local_row = run_stmt_once(&coro, &mut stmt)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .get_values()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                assert!(run_stmt_once(&coro, &mut stmt).await.unwrap().is_none());
+
+                let (_, synced_change_id) =
+                    read_last_change_id(&coro, &conn, &engine.client_unique_id)
+                        .await
+                        .unwrap();
+                let pending_local_changes =
+                    count_local_changes(&coro, &conn, synced_change_id.unwrap())
+                        .await
+                        .unwrap();
+                let meta = engine.meta.lock().unwrap().clone();
+                (remote_row, local_row, pending_local_changes, meta)
+            }
+        });
+        let (remote_row, local_row, pending_local_changes, meta) = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+        assert_eq!(
+            remote_row,
+            vec![
+                turso_core::Value::from_i64(2),
+                turso_core::Value::Text(turso_core::types::Text::new("remote".to_string())),
+            ]
+        );
+        assert_eq!(
+            local_row,
+            vec![
+                turso_core::Value::from_i64(1),
+                turso_core::Value::Text(turso_core::types::Text::new("local".to_string())),
+            ]
+        );
+        assert!(
+            pending_local_changes > 0,
+            "recaptured local CDC should remain pending for push"
+        );
+        assert_eq!(
+            meta.synced_revision,
+            Some(DatabasePullRevision::V1 {
+                revision: "g1:o2".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn failed_replace_base_local_replay_does_not_advance_synced_revision() {
+        let main_file = NamedTempFile::new().unwrap();
+        let remote_file = NamedTempFile::new().unwrap();
+        let changes_file = NamedTempFile::new().unwrap();
+        let main_path = main_file.path().to_str().unwrap().to_string();
+        let remote_path = remote_file.path().to_str().unwrap().to_string();
+        let changes_path = changes_file.path().to_str().unwrap().to_string();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let remote_db =
+            turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let remote_conn = remote_db.connect().unwrap();
+        remote_conn
+            .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        remote_conn
+            .execute("INSERT INTO items VALUES (1, 'duplicate'), (2, 'duplicate')")
+            .unwrap();
+        remote_conn
+            .checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            })
+            .unwrap();
+
+        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
+        let old_revision = DatabasePullRevision::V1 {
+            revision: "old-revision".to_string(),
+        };
+        let new_revision = DatabasePullRevision::V1 {
+            revision: "new-revision".to_string(),
+        };
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let sync_engine_io = sync_engine_io.clone();
+            let main_path = main_path.clone();
+            let remote_path = remote_path.clone();
+            let changes_path = changes_path.clone();
+            let old_revision = old_revision.clone();
+            let new_revision = new_revision.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine = DatabaseSyncEngine::create_db(
+                    &coro,
+                    io.clone(),
+                    sync_engine_io.clone(),
+                    &main_path,
+                    default_test_opts(),
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
+                })?;
+                engine
+                    .update_meta(&coro, |meta| {
+                        meta.synced_revision = Some(old_revision.clone());
+                        meta.remote_pull_protocol = RemotePullProtocol::Pages;
+                    })
+                    .await
+                    .map_err(|error| {
+                        Error::DatabaseSyncEngineError(format!("test update_meta failed: {error}"))
+                    })?;
+
+                let conn = engine.connect_rw(&coro).await.map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test connect_rw failed: {error}"))
+                })?;
+                conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")?;
+                conn.execute("INSERT INTO items VALUES (1, 'local-only')")?;
+                let base_change_id = max_local_change_id(&coro, &conn).await?.unwrap_or(0);
+                update_last_change_id(&coro, &conn, &engine.client_unique_id, 1, base_change_id)
+                    .await?;
+                conn.execute("CREATE UNIQUE INDEX items_value_unique ON items(value)")?;
+
+                let changes_file =
+                    write_replace_base_pages_file(&coro, &io, &remote_path, &changes_path).await?;
+                let slot = Arc::new(Mutex::new(Some(changes_file)));
+                let file_slot = MutexSlot {
+                    value: slot.lock().unwrap().take().unwrap(),
+                    slot: slot.clone(),
+                };
+
+                REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.set(0));
+                let result = engine
+                    .apply_changes_from_remote(
+                        &coro,
+                        DbChangesStatus {
+                            time: turso_core::WallClockInstant {
+                                secs: 10,
+                                micros: 0,
+                            },
+                            revision: new_revision.clone(),
+                            file_slot: Some(file_slot),
+                            stream_kind: DbChangesStreamKind::ReplaceBasePages,
+                        },
+                    )
+                    .await;
+                REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.set(usize::MAX));
+
+                let err = result.unwrap_err();
+                assert!(
+                    format!("{err:#}").contains("injected replace-base local replay failure"),
+                    "{err:#}"
+                );
+                assert_eq!(engine.meta().synced_revision, Some(old_revision.clone()));
+
+                let on_disk_meta = DatabaseSyncEngine::<NoopSyncEngineIo>::read_db_meta(
+                    &coro,
+                    Some(io.clone()),
+                    sync_engine_io.clone(),
+                    &main_path,
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test read_db_meta failed: {error}"))
+                })?
+                .unwrap();
+                assert_eq!(on_disk_meta.synced_revision, Some(old_revision));
+                assert!(io
+                    .try_open(&create_replace_base_marker_path(&main_path))?
+                    .is_none());
+
+                drop(conn);
+                drop(engine);
+                let verify_db = turso_core::Database::open_file(
+                    io.clone(),
+                    &main_path,
+                    Arc::new(SqliteDialect),
+                )
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test verify open failed: {error}"))
+                })?;
+                let verify_conn = verify_db.connect().map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test verify connect failed: {error}"))
+                })?;
+                let mut value_stmt = verify_conn
+                    .prepare("SELECT value FROM items WHERE id = 1")
+                    .unwrap();
+                let row = run_stmt_once(&coro, &mut value_stmt).await?.unwrap();
+                assert_eq!(
+                    row.get_values().cloned().collect::<Vec<_>>(),
+                    vec![turso_core::Value::Text(turso_core::types::Text::new(
+                        "local-only"
+                    ))]
+                );
+                assert!(run_stmt_once(&coro, &mut value_stmt).await?.is_none());
+
+                let mut index_stmt = verify_conn
+                    .prepare("SELECT sql FROM sqlite_schema WHERE name = 'items_value_unique'")
+                    .unwrap();
+                let row = run_stmt_once(&coro, &mut index_stmt).await?.unwrap();
+                assert!(row
+                    .get_value(0)
+                    .to_text()
+                    .unwrap()
+                    .contains("CREATE UNIQUE INDEX items_value_unique"));
+                assert!(run_stmt_once(&coro, &mut index_stmt).await?.is_none());
+                Result::Ok(())
+            }
+        });
+
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => {
+                    REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER.with(|value| value.set(usize::MAX));
+                    result.unwrap();
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Full-fidelity page-stream response: header (with the given protocol
+    /// hint) followed by one PageData message per page of `db_bytes`.
+    fn encoded_page_stream_response(
+        db_bytes: &[u8],
+        server_revision: &str,
+        protocol: PullUpdatesProtocol,
+    ) -> Vec<u8> {
+        assert_eq!(db_bytes.len() % super::PAGE_SIZE, 0);
+        let header = PullUpdatesRespProtoBody {
+            server_revision: server_revision.to_string(),
+            db_size: (db_bytes.len() / super::PAGE_SIZE) as u64,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol: protocol as i32,
+        };
+        let mut bytes = header.encode_length_delimited_to_vec();
+        for (page_idx, page) in db_bytes.chunks_exact(super::PAGE_SIZE).enumerate() {
+            let page_data = PageData {
+                page_id: page_idx as u64,
+                encoded_page: Bytes::copy_from_slice(page),
+            };
+            bytes.extend_from_slice(&page_data.encode_length_delimited_to_vec());
+        }
+        bytes
+    }
+
+    /// Deferred-bootstrap replica ("converted to cloud sync later"): a local
+    /// WAL-mode database with local writes meets an MVCC-protocol remote on
+    /// first contact. The engine must detect the protocol, convert the local
+    /// database to MVCC journal mode, apply the remote base as replace-base,
+    /// replay the local changes on top, and stay MVCC across a reopen.
+    #[test]
+    fn deferred_first_contact_converts_wal_replica_to_mvcc_and_applies_base() {
+        let main_file = NamedTempFile::new().unwrap();
+        let remote_file = NamedTempFile::new().unwrap();
+        let main_path = main_file.path().to_str().unwrap().to_string();
+        let remote_path = remote_file.path().to_str().unwrap().to_string();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let remote_db =
+            turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let remote_conn = remote_db.connect().unwrap();
+        remote_conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        assert!(remote_conn.mvcc_enabled());
+        remote_conn
+            .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        remote_conn
+            .execute("INSERT INTO items VALUES (1, 'remote-a'), (2, 'remote-b')")
+            .unwrap();
+        let remote_wal_state = remote_conn.wal_state().unwrap();
+        remote_conn
+            .checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: Some(remote_wal_state.max_frame),
+            })
+            .unwrap();
+        drop(remote_conn);
+        drop(remote_db);
+        let remote_bytes = std::fs::read(&remote_path).unwrap();
+        assert!(!remote_bytes.is_empty());
+
+        let server_revision = "g1:o0";
+        let first_contact_response = encoded_page_stream_response(
+            &remote_bytes,
+            server_revision,
+            PullUpdatesProtocol::MvccLogical,
+        );
+        // The replace-base apply issues one follow-up logical pull from the
+        // new revision; serve it an empty logical stream.
+        let followup_logical_response = PullUpdatesRespProtoBody {
+            server_revision: server_revision.to_string(),
+            db_size: (remote_bytes.len() / super::PAGE_SIZE) as u64,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
+        }
+        .encode_length_delimited_to_vec();
+        let sync_io = Arc::new(QueuedSyncEngineIo {
+            responses: Mutex::new(
+                vec![first_contact_response, followup_logical_response]
+                    .into_iter()
+                    .collect(),
+            ),
+            requests: Mutex::new(Vec::new()),
+        });
+        let sync_engine_io = SyncEngineIoStats::new(sync_io);
+
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.bootstrap_if_empty = false;
+        opts.logical_mvcc_pull = None; // auto-detect
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine = DatabaseSyncEngine::create_db(
+                    &coro,
+                    io.clone(),
+                    sync_engine_io.clone(),
+                    &main_path,
+                    opts,
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
+                })?;
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::Unknown
+                );
+
+                // Local writes before ever contacting the server.
+                let conn = engine.connect_rw(&coro).await.map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test connect_rw failed: {error}"))
+                })?;
+                assert!(!conn.mvcc_enabled());
+                conn.execute("CREATE TABLE local_notes(id INTEGER PRIMARY KEY, note TEXT)")?;
+                conn.execute("INSERT INTO local_notes VALUES (1, 'kept-across-conversion')")?;
+                let base_change_id = max_local_change_id(&coro, &conn).await?.unwrap_or(0);
+                update_last_change_id(&coro, &conn, &engine.client_unique_id, 1, base_change_id)
+                    .await?;
+                drop(conn);
+
+                // First contact: detection, conversion, replace-base pull.
+                let status = engine.wait_changes_from_remote(&coro).await?;
+                assert!(matches!(
+                    status.stream_kind,
+                    DbChangesStreamKind::ReplaceBasePages
+                ));
+                assert!(status.file_slot.is_some());
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::MvccLogical
+                );
+                assert!(engine.meta().logical_mvcc_pull_active());
+
+                engine.apply_changes_from_remote(&coro, status).await?;
+                assert_eq!(
+                    engine.meta().synced_revision,
+                    Some(DatabasePullRevision::V1 {
+                        revision: server_revision.to_string(),
+                    })
+                );
+
+                // Remote base and replayed local data both present, on an
+                // MVCC-mode connection.
+                let conn = engine.connect_rw(&coro).await.map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test reconnect failed: {error}"))
+                })?;
+                assert!(conn.mvcc_enabled());
+                let mut stmt = conn.prepare("SELECT value FROM items ORDER BY id")?;
+                let mut values = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await? {
+                    values.push(row.get_value(0).to_text().unwrap().to_string());
+                }
+                assert_eq!(values, vec!["remote-a".to_string(), "remote-b".to_string()]);
+                let mut stmt = conn.prepare("SELECT note FROM local_notes")?;
+                let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
+                assert_eq!(
+                    row.get_value(0).to_text().unwrap(),
+                    "kept-across-conversion"
+                );
+                assert!(run_stmt_once(&coro, &mut stmt).await?.is_none());
+                drop(stmt);
+                drop(conn);
+                drop(engine);
+
+                // The conversion must survive a reopen: header version and
+                // logical log agree, so a fresh open comes up in MVCC mode
+                // with the same data.
+                let verify_db = turso_core::Database::open_file(
+                    io.clone(),
+                    &main_path,
+                    Arc::new(SqliteDialect),
+                )
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test verify open failed: {error}"))
+                })?;
+                let verify_conn = verify_db.connect().map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test verify connect failed: {error}"))
+                })?;
+                assert!(verify_conn.mvcc_enabled());
+                let mut stmt = verify_conn.prepare("SELECT COUNT(*) FROM items")?;
+                let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
+                assert_eq!(row.get_value(0).as_int(), Some(2));
+                Result::Ok(())
+            }
+        });
+
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+    }
+
+    /// A fresh bootstrap of an MVCC database serves the last durable
+    /// generation base only. `create_db` must follow it with exactly one
+    /// non-long-polling incremental logical pull so `connect()` hands out a
+    /// current database instead of one missing every commit since the last
+    /// natural checkpoint.
+    #[test]
+    fn fresh_mvcc_bootstrap_catches_up_with_one_logical_pull() {
+        let main_file = NamedTempFile::new().unwrap();
+        let remote_file = NamedTempFile::new().unwrap();
+        let main_path = main_file.path().to_str().unwrap().to_string();
+        let remote_path = remote_file.path().to_str().unwrap().to_string();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let remote_db =
+            turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let remote_conn = remote_db.connect().unwrap();
+        remote_conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        remote_conn
+            .execute("CREATE TABLE items(id INTEGER PRIMARY KEY)")
+            .unwrap();
+        let remote_wal_state = remote_conn.wal_state().unwrap();
+        remote_conn
+            .checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: Some(remote_wal_state.max_frame),
+            })
+            .unwrap();
+        drop(remote_conn);
+        drop(remote_db);
+        let remote_bytes = std::fs::read(&remote_path).unwrap();
+
+        let server_revision = "g1:o64";
+        let bootstrap_response = encoded_page_stream_response(
+            &remote_bytes,
+            server_revision,
+            PullUpdatesProtocol::MvccLogical,
+        );
+        // The catch-up pull gets an empty logical stream: already current.
+        let catch_up_response = PullUpdatesRespProtoBody {
+            server_revision: server_revision.to_string(),
+            db_size: (remote_bytes.len() / super::PAGE_SIZE) as u64,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
+        }
+        .encode_length_delimited_to_vec();
+        let sync_io = Arc::new(QueuedSyncEngineIo {
+            responses: Mutex::new(
+                vec![bootstrap_response, catch_up_response]
+                    .into_iter()
+                    .collect(),
+            ),
+            requests: Mutex::new(Vec::new()),
+        });
+        let sync_engine_io = SyncEngineIoStats::new(sync_io.clone());
+
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.bootstrap_if_empty = true;
+        opts.logical_mvcc_pull = None; // auto-detect
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine = DatabaseSyncEngine::create_db(
+                    &coro,
+                    io.clone(),
+                    sync_engine_io.clone(),
+                    &main_path,
+                    opts,
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
+                })?;
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::MvccLogical
+                );
+                assert_eq!(
+                    engine.meta().synced_revision,
+                    Some(DatabasePullRevision::V1 {
+                        revision: server_revision.to_string(),
+                    })
+                );
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        // Both queued responses were consumed: the bootstrap plus exactly one
+        // catch-up pull, and the catch-up was a non-long-polling logical pull
+        // from the bootstrap revision.
+        assert!(sync_io.responses.lock().unwrap().is_empty());
+        let requests = sync_io.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        let catch_up =
+            PullUpdatesReqProtoBody::decode(requests[1].2.as_ref().unwrap().as_slice()).unwrap();
+        assert_eq!(
+            catch_up.stream_kind,
+            PullUpdatesStreamKind::MvccLogicalLog as i32
+        );
+        assert_eq!(catch_up.client_revision, server_revision);
+        assert_eq!(catch_up.long_poll_timeout_ms, 0);
+    }
+
+    /// Forcing `logical_mvcc_pull: Some(true)` on a replica whose revision
+    /// came from the legacy wire protocol is a misconfiguration: the server
+    /// cannot resume an MVCC logical stream from a legacy revision.
+    #[test]
+    fn forced_logical_pull_on_legacy_revision_replica_is_rejected() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let main_path = temp_file.path().to_str().unwrap().to_string();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let main_db =
+            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
+                .unwrap();
+
+        let meta = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "legacy-client".to_string(),
+            synced_revision: Some(DatabasePullRevision::Legacy {
+                generation: 3,
+                synced_frame_no: Some(17),
+            }),
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            remote_pull_protocol: RemotePullProtocol::Pages,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: Some("https://example.com".to_string()),
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        std::fs::write(create_meta_path(&main_path), meta.dump().unwrap()).unwrap();
+
+        let sync_stats = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.logical_mvcc_pull = Some(true);
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_db = main_db.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine =
+                    DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
+                let err = engine.wait_changes_from_remote(&coro).await.unwrap_err();
+                assert!(format!("{err:#}").contains("legacy protocol"), "{err:#}");
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+    }
+
+    /// A database file that lived outside the sync engine has rows without
+    /// CDC provenance; replace-base replay would silently drop them, so the
+    /// MVCC conversion must refuse instead.
+    #[test]
+    fn first_contact_mvcc_conversion_rejects_local_data_without_cdc_history() {
+        let main_file = NamedTempFile::new().unwrap();
+        let main_path = main_file.path().to_str().unwrap().to_string();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let foreign_db =
+            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let foreign_conn = foreign_db.connect().unwrap();
+        foreign_conn
+            .execute("CREATE TABLE orphaned(id INTEGER PRIMARY KEY)")
+            .unwrap();
+        foreign_conn
+            .execute("INSERT INTO orphaned VALUES (1)")
+            .unwrap();
+        drop(foreign_conn);
+        drop(foreign_db);
+
+        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.bootstrap_if_empty = false;
+        opts.logical_mvcc_pull = None;
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine = DatabaseSyncEngine::create_db(
+                    &coro,
+                    io.clone(),
+                    sync_engine_io.clone(),
+                    &main_path,
+                    opts,
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
+                })?;
+                let err = engine
+                    .ensure_local_mvcc_journal_mode(&coro)
+                    .await
+                    .unwrap_err();
+                assert!(
+                    format!("{err:#}").contains("without CDC history"),
+                    "{err:#}"
+                );
+                Result::Ok(())
+            }
+        });
+
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
     }
 }

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -17,16 +17,16 @@ use crate::{
         acquire_slot,
         apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats,
         apply_transformation, bootstrap_db_file, connect_untracked, count_local_changes, has_table,
-        is_logically_replayable_table, max_local_change_id, pull_updates_v1, push_logical_changes,
-        read_last_change_id, read_logical_replay_table_map, read_wal_salt, reset_wal_file,
-        should_replay_local_change, sync_file, update_last_change_id, wait_all_results,
-        wal_apply_from_file, wal_pull_to_file, PullUpdatesV1Result, SyncEngineIoStats,
-        SyncOperationCtx, PAGE_SIZE, WAL_FRAME_HEADER, WAL_FRAME_SIZE,
+        is_logically_replayable_table, list_user_tables, max_local_change_id, pull_updates_v1,
+        push_logical_changes, read_last_change_id, read_logical_replay_table_map, read_wal_salt,
+        reset_wal_file, should_replay_local_change, sync_file, update_last_change_id,
+        wait_all_results, wal_apply_from_file, wal_pull_to_file, PullUpdatesV1Result,
+        SyncEngineIoStats, SyncOperationCtx, PAGE_SIZE, WAL_FRAME_HEADER, WAL_FRAME_SIZE,
     },
     database_tape::{
-        try_wal_watermark_read_page, DatabaseChangesIteratorMode, DatabaseChangesIteratorOpts,
-        DatabaseReplaySession, DatabaseReplaySessionOpts, DatabaseTape, DatabaseTapeOpts,
-        DatabaseWalSession, CDC_PRAGMA_NAME,
+        run_stmt_ignore_rows, try_wal_watermark_read_page, DatabaseChangesIteratorMode,
+        DatabaseChangesIteratorOpts, DatabaseReplaySession, DatabaseReplaySessionOpts,
+        DatabaseTape, DatabaseTapeOpts, DatabaseWalSession, CDC_PRAGMA_NAME,
     },
     errors::Error,
     io_operations::IoOperations,
@@ -34,7 +34,8 @@ use crate::{
         Coro, DatabaseMetadata, DatabasePullRevision, DatabaseRowTransformResult,
         DatabaseSavedConfiguration, DatabaseSyncEngineProtocolVersion, DatabaseTapeOperation,
         DatabaseTapeRowChange, DatabaseTapeRowChangeType, DbChangesStatus, DbChangesStreamKind,
-        PartialSyncOpts, SyncEngineIoResult, SyncEngineStats, DATABASE_METADATA_VERSION,
+        PartialSyncOpts, RemotePullProtocol, SyncEngineIoResult, SyncEngineStats,
+        DATABASE_METADATA_VERSION,
     },
     wal_session::WalSession,
     Result,
@@ -79,10 +80,14 @@ pub struct DatabaseSyncEngineOpts {
     /// `Query` bootstrap strategy** — the server picks the page set, so the
     /// client can't chunk it locally.
     pub pull_bytes_threshold: Option<usize>,
-    /// Opt into raw MVCC logical-log pull-updates streams when the server and
-    /// local configuration can support them. Call sites should keep this
-    /// `false` until logical apply is wired end to end.
-    pub logical_mvcc_pull: bool,
+    /// Sync-protocol override for incremental pulls.
+    ///
+    /// `None` (default) auto-detects the remote protocol from the first
+    /// pull-updates response and persists it in the metadata. `Some(true)`
+    /// forces raw MVCC logical-log streams; `Some(false)` forces page streams.
+    /// Explicit values exist for tests and as an escape hatch — users should
+    /// not need to set this.
+    pub logical_mvcc_pull: Option<bool>,
 }
 
 pub struct DataStats {
@@ -101,10 +106,10 @@ mod tests {
     use super::{
         create_main_db_log_path, create_main_db_wal_path, create_meta_path,
         create_replace_base_marker_path, create_revert_db_wal_path,
-        ensure_stream_kind_can_use_legacy_page_apply, logical_mvcc_pull_disable_reason,
+        ensure_logical_mvcc_pull_supported, ensure_stream_kind_can_use_legacy_page_apply,
         replace_base_backup_path, resolve_local_replay_floor_change_id,
-        should_replay_raw_pages_on_sql_conn, should_request_logical_pull,
-        should_use_logical_mvcc_pull, stream_kind_applies_remote_pages,
+        resolve_remote_pull_protocol, should_replay_raw_pages_on_sql_conn,
+        should_request_logical_pull, stream_kind_applies_remote_pages,
         stream_kind_for_pull_updates_v1_result, synced_change_id_after_remote_apply,
         use_pushed_change_hint_for_local_replay, DatabaseSyncEngine, DatabaseSyncEngineOpts,
         ReplaceBaseApplyGuard, REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
@@ -122,13 +127,13 @@ mod tests {
         errors::Error,
         io_operations::IoOperations,
         server_proto::{
-            PullUpdatesApplyMode, PullUpdatesReqProtoBody, PullUpdatesRespProtoBody,
-            PullUpdatesStreamKind,
+            PageData, PageSetRawEncodingProto, PullUpdatesApplyMode, PullUpdatesProtocol,
+            PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, PullUpdatesStreamKind,
         },
         types::{
             Coro, DatabaseMetadata, DatabasePullRevision, DatabaseSavedConfiguration,
             DatabaseSyncEngineProtocolVersion, DbChangesStatus, DbChangesStreamKind,
-            PartialSyncOpts, SyncEngineIoResult, DATABASE_METADATA_VERSION,
+            PartialSyncOpts, RemotePullProtocol, SyncEngineIoResult, DATABASE_METADATA_VERSION,
         },
         Result,
     };
@@ -142,36 +147,39 @@ mod tests {
     use turso_core::SqliteDialect;
 
     #[test]
-    fn logical_mvcc_pull_disabled_by_config_falls_back_to_page_pull() {
-        assert_eq!(
-            logical_mvcc_pull_disable_reason(false, false, None),
-            Some("logical MVCC pull is disabled by configuration")
-        );
-        assert!(!should_use_logical_mvcc_pull(false, false, None));
+    fn explicit_override_wins_over_persisted_protocol() {
+        for persisted in [
+            RemotePullProtocol::Unknown,
+            RemotePullProtocol::Pages,
+            RemotePullProtocol::MvccLogical,
+        ] {
+            assert_eq!(
+                resolve_remote_pull_protocol(Some(true), persisted),
+                RemotePullProtocol::MvccLogical
+            );
+            assert_eq!(
+                resolve_remote_pull_protocol(Some(false), persisted),
+                RemotePullProtocol::Pages
+            );
+            assert_eq!(resolve_remote_pull_protocol(None, persisted), persisted);
+        }
     }
 
     #[test]
-    fn logical_mvcc_pull_with_partial_sync_falls_back_to_page_pull() {
-        assert_eq!(
-            logical_mvcc_pull_disable_reason(true, true, None),
-            Some("partial sync is active")
-        );
-        assert!(!should_use_logical_mvcc_pull(true, true, None));
+    fn logical_mvcc_pull_with_partial_sync_is_a_hard_error() {
+        // Silent downgrade to page pull would just defer the failure to an
+        // opaque server-side protocol error on every incremental pull.
+        assert!(ensure_logical_mvcc_pull_supported(true, None).is_err());
     }
 
     #[test]
-    fn logical_mvcc_pull_with_remote_encryption_falls_back_to_page_pull() {
-        assert_eq!(
-            logical_mvcc_pull_disable_reason(true, false, Some("key")),
-            Some("remote encryption is enabled; MVCC logical sync is unsupported for encrypted remotes")
-        );
-        assert!(!should_use_logical_mvcc_pull(true, false, Some("key")));
+    fn logical_mvcc_pull_with_remote_encryption_is_a_hard_error() {
+        assert!(ensure_logical_mvcc_pull_supported(false, Some("key")).is_err());
     }
 
     #[test]
     fn logical_mvcc_pull_remains_enabled_for_plain_full_sync() {
-        assert_eq!(logical_mvcc_pull_disable_reason(true, false, None), None);
-        assert!(should_use_logical_mvcc_pull(true, false, None));
+        assert!(ensure_logical_mvcc_pull_supported(false, None).is_ok());
     }
 
     #[test]
@@ -520,6 +528,59 @@ mod tests {
         fn step_io_callbacks(&self) {}
     }
 
+    /// Serves canned HTTP responses in order; panics if the engine makes more
+    /// requests than responses were queued.
+    struct QueuedSyncEngineIo {
+        responses: Mutex<std::collections::VecDeque<Vec<u8>>>,
+    }
+
+    impl SyncEngineIo for QueuedSyncEngineIo {
+        type DataCompletionBytes = EmptyCompletion<u8>;
+        type DataCompletionTransform = EmptyCompletion<crate::types::DatabaseRowTransformResult>;
+
+        fn full_read(&self, path: &str) -> Result<Self::DataCompletionBytes> {
+            let data = std::fs::read(path).unwrap_or_default();
+            Ok(EmptyCompletion::with_data(data))
+        }
+
+        fn full_write(&self, path: &str, content: Vec<u8>) -> Result<Self::DataCompletionBytes> {
+            std::fs::write(path, content).map_err(|error| {
+                crate::errors::Error::DatabaseSyncEngineError(format!(
+                    "test full_write failed for {path}: {error}"
+                ))
+            })?;
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn transform(
+            &self,
+            _mutations: Vec<crate::types::DatabaseRowMutation>,
+        ) -> Result<Self::DataCompletionTransform> {
+            Ok(EmptyCompletion::empty())
+        }
+
+        fn http(
+            &self,
+            _url: Option<&str>,
+            _method: &str,
+            _path: &str,
+            _body: Option<Vec<u8>>,
+            _headers: &[(&str, &str)],
+        ) -> Result<Self::DataCompletionBytes> {
+            let response = self
+                .responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("engine made more HTTP requests than queued responses");
+            Ok(EmptyCompletion::with_data(response))
+        }
+
+        fn add_io_callback(&self, _callback: Box<dyn FnMut() -> bool + Send>) {}
+
+        fn step_io_callbacks(&self) {}
+    }
+
     fn record(values: &[turso_core::Value]) -> Bytes {
         Bytes::from(
             turso_core::types::ImmutableRecord::from_values(values, values.len())
@@ -552,7 +613,7 @@ mod tests {
             remote_encryption_key: None,
             push_operations_threshold: None,
             pull_bytes_threshold: None,
-            logical_mvcc_pull: true,
+            logical_mvcc_pull: Some(true),
         }
     }
 
@@ -838,6 +899,7 @@ mod tests {
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
+            remote_pull_protocol: RemotePullProtocol::MvccLogical,
             logical_table_names_by_stable_id: Default::default(),
             saved_configuration: Some(DatabaseSavedConfiguration {
                 remote_url: Some("https://example.com".to_string()),
@@ -848,6 +910,7 @@ mod tests {
         std::fs::write(create_meta_path(&main_path), meta.dump().unwrap()).unwrap();
 
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: "g1:o10".to_string(),
             db_size: 0,
             raw_encoding: None,
@@ -863,7 +926,7 @@ mod tests {
         let sync_stats = SyncEngineIoStats::new(sync_io.clone());
         let mut opts = default_test_opts();
         opts.remote_url = Some("https://example.com".to_string());
-        opts.logical_mvcc_pull = true;
+        opts.logical_mvcc_pull = Some(true);
 
         let mut gen = genawaiter::sync::Gen::new({
             let io = io.clone();
@@ -987,6 +1050,7 @@ mod tests {
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
+            remote_pull_protocol: RemotePullProtocol::MvccLogical,
             logical_table_names_by_stable_id: Default::default(),
             saved_configuration: Some(DatabaseSavedConfiguration {
                 remote_url: None,
@@ -1161,6 +1225,7 @@ mod tests {
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
+            remote_pull_protocol: RemotePullProtocol::MvccLogical,
             logical_table_names_by_stable_id: Default::default(),
             saved_configuration: Some(DatabaseSavedConfiguration {
                 remote_url: None,
@@ -1447,6 +1512,275 @@ mod tests {
                     result.unwrap();
                     break;
                 }
+            }
+        }
+    }
+
+    /// Full-fidelity page-stream response: header (with the given protocol
+    /// hint) followed by one PageData message per page of `db_bytes`.
+    fn encoded_page_stream_response(
+        db_bytes: &[u8],
+        server_revision: &str,
+        protocol: PullUpdatesProtocol,
+    ) -> Vec<u8> {
+        assert_eq!(db_bytes.len() % super::PAGE_SIZE, 0);
+        let header = PullUpdatesRespProtoBody {
+            server_revision: server_revision.to_string(),
+            db_size: (db_bytes.len() / super::PAGE_SIZE) as u64,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol: protocol as i32,
+        };
+        let mut bytes = header.encode_length_delimited_to_vec();
+        for (page_idx, page) in db_bytes.chunks_exact(super::PAGE_SIZE).enumerate() {
+            let page_data = PageData {
+                page_id: page_idx as u64,
+                encoded_page: Bytes::copy_from_slice(page),
+            };
+            bytes.extend_from_slice(&page_data.encode_length_delimited_to_vec());
+        }
+        bytes
+    }
+
+    /// Deferred-bootstrap replica ("converted to cloud sync later"): a local
+    /// WAL-mode database with local writes meets an MVCC-protocol remote on
+    /// first contact. The engine must detect the protocol, convert the local
+    /// database to MVCC journal mode, apply the remote base as replace-base,
+    /// replay the local changes on top, and stay MVCC across a reopen.
+    #[test]
+    fn deferred_first_contact_converts_wal_replica_to_mvcc_and_applies_base() {
+        let main_file = NamedTempFile::new().unwrap();
+        let remote_file = NamedTempFile::new().unwrap();
+        let main_path = main_file.path().to_str().unwrap().to_string();
+        let remote_path = remote_file.path().to_str().unwrap().to_string();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let remote_db =
+            turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let remote_conn = remote_db.connect().unwrap();
+        remote_conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        assert!(remote_conn.mvcc_enabled());
+        remote_conn
+            .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        remote_conn
+            .execute("INSERT INTO items VALUES (1, 'remote-a'), (2, 'remote-b')")
+            .unwrap();
+        let remote_wal_state = remote_conn.wal_state().unwrap();
+        remote_conn
+            .checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: Some(remote_wal_state.max_frame),
+            })
+            .unwrap();
+        drop(remote_conn);
+        drop(remote_db);
+        let remote_bytes = std::fs::read(&remote_path).unwrap();
+        assert!(!remote_bytes.is_empty());
+
+        let server_revision = "g1:o0";
+        let first_contact_response = encoded_page_stream_response(
+            &remote_bytes,
+            server_revision,
+            PullUpdatesProtocol::MvccLogical,
+        );
+        // The replace-base apply issues one follow-up logical pull from the
+        // new revision; serve it an empty logical stream.
+        let followup_logical_response = PullUpdatesRespProtoBody {
+            server_revision: server_revision.to_string(),
+            db_size: (remote_bytes.len() / super::PAGE_SIZE) as u64,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
+        }
+        .encode_length_delimited_to_vec();
+        let sync_io = Arc::new(QueuedSyncEngineIo {
+            responses: Mutex::new(
+                vec![first_contact_response, followup_logical_response]
+                    .into_iter()
+                    .collect(),
+            ),
+        });
+        let sync_engine_io = SyncEngineIoStats::new(sync_io);
+
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.bootstrap_if_empty = false;
+        opts.logical_mvcc_pull = None; // auto-detect
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine = DatabaseSyncEngine::create_db(
+                    &coro,
+                    io.clone(),
+                    sync_engine_io.clone(),
+                    &main_path,
+                    opts,
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
+                })?;
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::Unknown
+                );
+
+                // Local writes before ever contacting the server.
+                let conn = engine.connect_rw(&coro).await.map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test connect_rw failed: {error}"))
+                })?;
+                assert!(!conn.mvcc_enabled());
+                conn.execute("CREATE TABLE local_notes(id INTEGER PRIMARY KEY, note TEXT)")?;
+                conn.execute("INSERT INTO local_notes VALUES (1, 'kept-across-conversion')")?;
+                let base_change_id = max_local_change_id(&coro, &conn).await?.unwrap_or(0);
+                update_last_change_id(&coro, &conn, &engine.client_unique_id, 1, base_change_id)
+                    .await?;
+                drop(conn);
+
+                // First contact: detection, conversion, replace-base pull.
+                let status = engine.wait_changes_from_remote(&coro).await?;
+                assert!(matches!(
+                    status.stream_kind,
+                    DbChangesStreamKind::ReplaceBasePages
+                ));
+                assert!(status.file_slot.is_some());
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::MvccLogical
+                );
+                assert!(engine.meta().logical_mvcc_pull_active);
+
+                engine.apply_changes_from_remote(&coro, status).await?;
+                assert_eq!(
+                    engine.meta().synced_revision,
+                    Some(DatabasePullRevision::V1 {
+                        revision: server_revision.to_string(),
+                    })
+                );
+
+                // Remote base and replayed local data both present, on an
+                // MVCC-mode connection.
+                let conn = engine.connect_rw(&coro).await.map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test reconnect failed: {error}"))
+                })?;
+                assert!(conn.mvcc_enabled());
+                let mut stmt = conn.prepare("SELECT value FROM items ORDER BY id")?;
+                let mut values = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await? {
+                    values.push(row.get_value(0).to_text().unwrap().to_string());
+                }
+                assert_eq!(values, vec!["remote-a".to_string(), "remote-b".to_string()]);
+                let mut stmt = conn.prepare("SELECT note FROM local_notes")?;
+                let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
+                assert_eq!(
+                    row.get_value(0).to_text().unwrap(),
+                    "kept-across-conversion"
+                );
+                assert!(run_stmt_once(&coro, &mut stmt).await?.is_none());
+                drop(stmt);
+                drop(conn);
+                drop(engine);
+
+                // The conversion must survive a reopen: header version and
+                // logical log agree, so a fresh open comes up in MVCC mode
+                // with the same data.
+                let verify_db = turso_core::Database::open_file(
+                    io.clone(),
+                    &main_path,
+                    Arc::new(SqliteDialect),
+                )
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test verify open failed: {error}"))
+                })?;
+                let verify_conn = verify_db.connect().map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test verify connect failed: {error}"))
+                })?;
+                assert!(verify_conn.mvcc_enabled());
+                let mut stmt = verify_conn.prepare("SELECT COUNT(*) FROM items")?;
+                let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
+                assert_eq!(row.get_value(0).as_int(), Some(2));
+                Result::Ok(())
+            }
+        });
+
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+    }
+
+    /// A database file that lived outside the sync engine has rows without
+    /// CDC provenance; replace-base replay would silently drop them, so the
+    /// MVCC conversion must refuse instead.
+    #[test]
+    fn first_contact_mvcc_conversion_rejects_local_data_without_cdc_history() {
+        let main_file = NamedTempFile::new().unwrap();
+        let main_path = main_file.path().to_str().unwrap().to_string();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let foreign_db =
+            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let foreign_conn = foreign_db.connect().unwrap();
+        foreign_conn
+            .execute("CREATE TABLE orphaned(id INTEGER PRIMARY KEY)")
+            .unwrap();
+        foreign_conn
+            .execute("INSERT INTO orphaned VALUES (1)")
+            .unwrap();
+        drop(foreign_conn);
+        drop(foreign_db);
+
+        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.bootstrap_if_empty = false;
+        opts.logical_mvcc_pull = None;
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine = DatabaseSyncEngine::create_db(
+                    &coro,
+                    io.clone(),
+                    sync_engine_io.clone(),
+                    &main_path,
+                    opts,
+                )
+                .await
+                .map_err(|error| {
+                    Error::DatabaseSyncEngineError(format!("test create_db failed: {error}"))
+                })?;
+                let err = engine
+                    .ensure_local_mvcc_journal_mode(&coro)
+                    .await
+                    .unwrap_err();
+                assert!(
+                    format!("{err:#}").contains("without CDC history"),
+                    "{err:#}"
+                );
+                Result::Ok(())
+            }
+        });
+
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
             }
         }
     }
@@ -1914,36 +2248,39 @@ impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
     }
 }
 
-fn should_use_logical_mvcc_pull(
-    logical_mvcc_pull_requested: bool,
-    partial_sync_active: bool,
-    remote_encryption_key: Option<&str>,
-) -> bool {
-    logical_mvcc_pull_disable_reason(
-        logical_mvcc_pull_requested,
-        partial_sync_active,
-        remote_encryption_key,
-    )
-    .is_none()
+/// Applies the explicit `logical_mvcc_pull` override on top of the persisted
+/// (detected) remote protocol. `None` (auto) defers entirely to detection.
+fn resolve_remote_pull_protocol(
+    logical_mvcc_pull_override: Option<bool>,
+    persisted: RemotePullProtocol,
+) -> RemotePullProtocol {
+    match logical_mvcc_pull_override {
+        Some(true) => RemotePullProtocol::MvccLogical,
+        Some(false) => RemotePullProtocol::Pages,
+        None => persisted,
+    }
 }
 
-fn logical_mvcc_pull_disable_reason(
-    logical_mvcc_pull_requested: bool,
+/// MVCC logical sync is incompatible with partial sync and encrypted remotes.
+/// This used to silently downgrade to page pulls, but the server rejects page
+/// incremental pulls for MVCC databases, so a silent downgrade just defers the
+/// failure to an opaque protocol error on every pull. Fail fast and loudly
+/// instead. Never called for page-mode (legacy) replicas.
+fn ensure_logical_mvcc_pull_supported(
     partial_sync_active: bool,
     remote_encryption_key: Option<&str>,
-) -> Option<&'static str> {
-    if !logical_mvcc_pull_requested {
-        return Some("logical MVCC pull is disabled by configuration");
-    }
+) -> Result<()> {
     if partial_sync_active {
-        return Some("partial sync is active");
+        return Err(Error::DatabaseSyncEngineError(
+            "MVCC logical sync does not support partial sync; disable partialSyncExperimental for this database".to_string(),
+        ));
     }
     if remote_encryption_key.is_some() {
-        return Some(
-            "remote encryption is enabled; MVCC logical sync is unsupported for encrypted remotes",
-        );
+        return Err(Error::DatabaseSyncEngineError(
+            "MVCC logical sync does not support encrypted remote databases".to_string(),
+        ));
     }
-    None
+    Ok(())
 }
 
 #[cfg(test)]
@@ -2283,17 +2620,16 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         let meta_path = create_meta_path(main_db_path);
         let partial_sync_opts = opts.partial_sync_opts.clone();
         let partial = partial_sync_opts.is_some();
-        let logical_mvcc_pull_active = should_use_logical_mvcc_pull(
-            opts.logical_mvcc_pull,
-            partial,
-            opts.remote_encryption_key.as_deref(),
-        );
-        if let Some(reason) = logical_mvcc_pull_disable_reason(
-            opts.logical_mvcc_pull,
-            partial,
-            opts.remote_encryption_key.as_deref(),
-        ) {
-            tracing::debug!("logical MVCC pull disabled: {reason}");
+        // Explicit override for tests / escape hatch. None (the default)
+        // auto-detects the remote protocol from the first pull-updates
+        // response and persists it in the metadata.
+        let forced_protocol = match opts.logical_mvcc_pull {
+            Some(true) => Some(RemotePullProtocol::MvccLogical),
+            Some(false) => Some(RemotePullProtocol::Pages),
+            None => None,
+        };
+        if forced_protocol == Some(RemotePullProtocol::MvccLogical) {
+            ensure_logical_mvcc_pull_supported(partial, opts.remote_encryption_key.as_deref())?;
         }
 
         let configuration = DatabaseSavedConfiguration {
@@ -2304,6 +2640,22 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         let meta = match meta {
             Some(mut meta) => {
                 let mut metadata_changed = meta.update_configuration(configuration);
+                if let Some(forced) = forced_protocol {
+                    if meta.remote_pull_protocol != forced {
+                        meta.remote_pull_protocol = forced;
+                        metadata_changed = true;
+                    }
+                }
+                // A replica already syncing logically must fail fast if the
+                // configuration drifted into an unsupported combination.
+                if meta.remote_pull_protocol == RemotePullProtocol::MvccLogical {
+                    ensure_logical_mvcc_pull_supported(
+                        partial,
+                        opts.remote_encryption_key.as_deref(),
+                    )?;
+                }
+                let logical_mvcc_pull_active =
+                    meta.remote_pull_protocol == RemotePullProtocol::MvccLogical;
                 if meta.logical_mvcc_pull_active != logical_mvcc_pull_active {
                     meta.logical_mvcc_pull_active = logical_mvcc_pull_active;
                     metadata_changed = true;
@@ -2323,7 +2675,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             }
             None if opts.bootstrap_if_empty => {
                 let client_unique_id = format!("{}-{}", opts.client_name, uuid::Uuid::new_v4());
-                let revision = bootstrap_db_file(
+                let (revision, detected_protocol) = bootstrap_db_file(
                     &SyncOperationCtx::new(
                         coro,
                         &sync_engine_io,
@@ -2337,6 +2689,13 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     opts.pull_bytes_threshold,
                 )
                 .await?;
+                let remote_pull_protocol = forced_protocol.unwrap_or(detected_protocol);
+                if remote_pull_protocol == RemotePullProtocol::MvccLogical {
+                    ensure_logical_mvcc_pull_supported(
+                        partial,
+                        opts.remote_encryption_key.as_deref(),
+                    )?;
+                }
                 let meta = DatabaseMetadata {
                     version: DATABASE_METADATA_VERSION.to_string(),
                     client_unique_id,
@@ -2354,7 +2713,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         None
                     },
                     fresh_bootstrap_pending_cdc_ack: false,
-                    logical_mvcc_pull_active,
+                    logical_mvcc_pull_active: remote_pull_protocol
+                        == RemotePullProtocol::MvccLogical,
+                    remote_pull_protocol,
                     logical_table_names_by_stable_id: Default::default(),
                     saved_configuration: Some(configuration),
                 };
@@ -2384,6 +2745,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     ));
                 }
                 let client_unique_id = format!("{}-{}", opts.client_name, uuid::Uuid::new_v4());
+                // Deferred bootstrap: the remote's protocol is unknowable
+                // until the first server contact; the first pull resolves it.
+                let remote_pull_protocol = forced_protocol.unwrap_or(RemotePullProtocol::Unknown);
                 let meta = DatabaseMetadata {
                     version: DATABASE_METADATA_VERSION.to_string(),
                     client_unique_id,
@@ -2397,7 +2761,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: None,
                     fresh_bootstrap_pending_cdc_ack: false,
-                    logical_mvcc_pull_active,
+                    logical_mvcc_pull_active: remote_pull_protocol
+                        == RemotePullProtocol::MvccLogical,
+                    remote_pull_protocol,
                     logical_table_names_by_stable_id: Default::default(),
                     saved_configuration: Some(configuration),
                 };
@@ -2900,6 +3266,66 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         Ok(())
     }
 
+    /// Converts the local database to MVCC journal mode when the remote
+    /// speaks the MVCC logical-log protocol but the local database is still
+    /// in WAL mode.
+    ///
+    /// This happens for deferred-bootstrap replicas ("converted to cloud
+    /// sync later"): a fresh bootstrap inherits MVCC-ness from the base
+    /// image's page-1 header, but a deferred replica opened its WAL database
+    /// before ever contacting the server. Applying an MVCC page base into a
+    /// WAL-mode process would leave the file header and the in-process
+    /// journal mode disagreeing — this process would keep WAL semantics (no
+    /// logical log, WAL checkpoint path) while the next open reads the MVCC
+    /// header and starts an empty MvStore, an uncoordinated mode flip.
+    /// Converting up front via `PRAGMA journal_mode = 'mvcc'` (WAL
+    /// checkpoint, header rewrite, MvStore bootstrap over the existing
+    /// btree) puts the replica on the same footing as a fresh MVCC bootstrap
+    /// before the replace-base apply runs.
+    async fn ensure_local_mvcc_journal_mode<Ctx>(&self, coro: &Coro<Ctx>) -> Result<()> {
+        // The pragma rejects connections with CDC capture enabled, so use an
+        // untracked connection (the tape connection has capture on).
+        let main_conn = connect_untracked(&self.main_tape)?;
+        if main_conn.mvcc_enabled() {
+            return Ok(());
+        }
+        // Replace-base preserves local data by replaying the CDC log on top
+        // of the new base. Changes without CDC provenance (a database file
+        // that lived outside the sync engine) would be silently dropped —
+        // reject loudly instead. This runs only before the first sync, when
+        // nothing has been pruned from the CDC log yet, so "user tables exist
+        // but the CDC log is empty" reliably means foreign data. (The
+        // turso_cdc table itself is created eagerly by the capture pragma,
+        // so its existence proves nothing.)
+        let cdc_high_water = max_local_change_id(coro, &main_conn).await?.unwrap_or(0);
+        if cdc_high_water == 0 {
+            let user_tables = list_user_tables(coro, &main_conn).await?;
+            if !user_tables.is_empty() {
+                return Err(Error::DatabaseSyncEngineError(format!(
+                    "local database contains tables without CDC history ({}); the sync engine cannot preserve their data across the initial sync with an MVCC-mode remote (create the local database through the sync engine, or start from an empty local file)",
+                    user_tables.join(", "),
+                )));
+            }
+        }
+        tracing::info!(
+            "ensure_local_mvcc_journal_mode(path={}): converting local database to MVCC journal mode for MVCC-protocol remote",
+            self.main_db_path
+        );
+        let mut stmt = main_conn.prepare("PRAGMA journal_mode = 'mvcc'")?;
+        run_stmt_ignore_rows(coro, &mut stmt)
+            .await
+            .map_err(|error| {
+                Error::DatabaseSyncEngineError(format!(
+                    "failed to convert local database to MVCC journal mode: {error}"
+                ))
+            })?;
+        assert!(
+            main_conn.mvcc_enabled(),
+            "journal_mode=mvcc pragma succeeded but MvStore is not open"
+        );
+        Ok(())
+    }
+
     pub async fn wait_changes_from_remote<Ctx>(&self, coro: &Coro<Ctx>) -> Result<DbChangesStatus> {
         tracing::info!("wait_changes(path={})", self.main_db_path);
 
@@ -2919,82 +3345,143 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             } else {
                 DbChangesStreamKind::Pages
             };
-        let logical_mvcc_pull_active = self.meta().logical_mvcc_pull_active;
-        let next_revision = if logical_mvcc_pull_active {
-            match &revision {
-                Some(DatabasePullRevision::V1 { revision }) => {
-                    match pull_updates_v1(
-                        ctx,
-                        &file.value,
-                        revision,
-                        self.opts.long_poll_timeout,
-                        true,
-                    )
-                    .await?
-                    {
-                        (next_revision, result @ PullUpdatesV1Result::Logical { txns, ops }) => {
-                            tracing::info!(
-                                "wait_changes(path={}): logical pull returned {} transactions / {} ops",
-                                self.main_db_path,
-                                txns,
-                                ops
-                            );
-                            stream_kind = stream_kind_for_pull_updates_v1_result(&result);
-                            next_revision
-                        }
-                        (next_revision, result @ PullUpdatesV1Result::Pages { replace_base }) => {
-                            tracing::info!(
-                                "wait_changes(path={}): logical pull returned a page stream fallback; replace_base={replace_base}",
-                                self.main_db_path,
-                            );
-                            stream_kind = stream_kind_for_pull_updates_v1_result(&result);
-                            next_revision
-                        }
+        let remote_pull_protocol = resolve_remote_pull_protocol(
+            self.opts.logical_mvcc_pull,
+            self.meta().remote_pull_protocol,
+        );
+        let next_revision = match (remote_pull_protocol, &revision) {
+            (RemotePullProtocol::MvccLogical, Some(DatabasePullRevision::V1 { revision })) => {
+                match pull_updates_v1(
+                    ctx,
+                    &file.value,
+                    revision,
+                    self.opts.long_poll_timeout,
+                    true,
+                )
+                .await?
+                {
+                    (next_revision, result @ PullUpdatesV1Result::Logical { txns, ops }, _) => {
+                        tracing::info!(
+                            "wait_changes(path={}): logical pull returned {} transactions / {} ops",
+                            self.main_db_path,
+                            txns,
+                            ops
+                        );
+                        stream_kind = stream_kind_for_pull_updates_v1_result(&result);
+                        next_revision
+                    }
+                    (next_revision, result @ PullUpdatesV1Result::Pages { replace_base }, _) => {
+                        tracing::info!(
+                            "wait_changes(path={}): logical pull returned a page stream fallback; replace_base={replace_base}",
+                            self.main_db_path,
+                        );
+                        stream_kind = stream_kind_for_pull_updates_v1_result(&result);
+                        next_revision
                     }
                 }
-                None => {
-                    let (next_revision, result) =
-                        pull_updates_v1(ctx, &file.value, "", self.opts.long_poll_timeout, false)
-                            .await?;
-                    tracing::info!(
-                        "wait_changes(path={}): initial logical MVCC sync returned page base",
-                        self.main_db_path,
-                    );
-                    stream_kind = match result {
-                        PullUpdatesV1Result::Pages { .. } => DbChangesStreamKind::ReplaceBasePages,
-                        PullUpdatesV1Result::Logical { txns, ops } => {
-                            tracing::info!(
-                                "wait_changes(path={}): initial logical MVCC sync returned logical stream with {} transactions / {} ops",
-                                self.main_db_path,
-                                txns,
-                                ops
-                            );
-                            DbChangesStreamKind::Logical
-                        }
-                    };
-                    next_revision
-                }
-                Some(DatabasePullRevision::Legacy { .. }) => {
-                    stream_kind = DbChangesStreamKind::LegacyPages;
-                    wal_pull_to_file(
-                        ctx,
-                        &file.value,
-                        &revision,
-                        self.opts.wal_pull_batch_size,
-                        self.opts.long_poll_timeout,
-                    )
-                    .await?
-                }
             }
-        } else {
-            wal_pull_to_file(
-                ctx,
-                &file.value,
-                &revision,
-                self.opts.wal_pull_batch_size,
-                self.opts.long_poll_timeout,
-            )
-            .await?
+            (RemotePullProtocol::MvccLogical, None) => {
+                let (next_revision, result, _) =
+                    pull_updates_v1(ctx, &file.value, "", self.opts.long_poll_timeout, false)
+                        .await?;
+                tracing::info!(
+                    "wait_changes(path={}): initial logical MVCC sync returned page base",
+                    self.main_db_path,
+                );
+                // Deferred replicas may still be in WAL mode locally; the
+                // MVCC page base must be applied to an MVCC-mode database.
+                self.ensure_local_mvcc_journal_mode(coro).await?;
+                stream_kind = match result {
+                    PullUpdatesV1Result::Pages { .. } => DbChangesStreamKind::ReplaceBasePages,
+                    PullUpdatesV1Result::Logical { txns, ops } => {
+                        tracing::info!(
+                            "wait_changes(path={}): initial logical MVCC sync returned logical stream with {} transactions / {} ops",
+                            self.main_db_path,
+                            txns,
+                            ops
+                        );
+                        DbChangesStreamKind::Logical
+                    }
+                };
+                next_revision
+            }
+            (RemotePullProtocol::MvccLogical, Some(DatabasePullRevision::Legacy { .. })) => {
+                stream_kind = DbChangesStreamKind::LegacyPages;
+                wal_pull_to_file(
+                    ctx,
+                    &file.value,
+                    &revision,
+                    self.opts.wal_pull_batch_size,
+                    self.opts.long_poll_timeout,
+                )
+                .await?
+            }
+            // First server contact of an auto-mode replica whose remote
+            // protocol is not yet known (deferred bootstrap). The request is
+            // identical on the wire to the page path's no-revision request;
+            // the response header tells us which protocol the remote speaks.
+            (RemotePullProtocol::Unknown, None) => {
+                let (next_revision, result, detected) =
+                    pull_updates_v1(ctx, &file.value, "", self.opts.long_poll_timeout, false)
+                        .await?;
+                if detected == RemotePullProtocol::MvccLogical {
+                    ensure_logical_mvcc_pull_supported(
+                        self.opts.partial_sync_opts.is_some(),
+                        self.opts.remote_encryption_key.as_deref(),
+                    )?;
+                    // Deferred replicas may still be in WAL mode locally; the
+                    // MVCC page base must be applied to an MVCC-mode database.
+                    self.ensure_local_mvcc_journal_mode(coro).await?;
+                }
+                if detected != RemotePullProtocol::Unknown {
+                    tracing::info!(
+                        "wait_changes(path={}): detected remote pull protocol {:?} on first contact",
+                        self.main_db_path,
+                        detected
+                    );
+                    self.update_meta(coro, |m| {
+                        m.remote_pull_protocol = detected;
+                        m.logical_mvcc_pull_active = detected == RemotePullProtocol::MvccLogical;
+                    })
+                    .await?;
+                }
+                stream_kind = match (detected, &result) {
+                    // Page-protocol remote: mirror the page path exactly,
+                    // including its rejection of replace-base streams.
+                    (
+                        RemotePullProtocol::Pages | RemotePullProtocol::Unknown,
+                        PullUpdatesV1Result::Pages { replace_base },
+                    ) => {
+                        if *replace_base {
+                            return Err(Error::DatabaseSyncEngineError(
+                                "wait_changes_from_remote does not support replace-base page streams yet".to_string(),
+                            ));
+                        }
+                        DbChangesStreamKind::Pages
+                    }
+                    // MVCC remote: the page base applies as replace-base so
+                    // local (deferred) changes are preserved and replayed.
+                    (RemotePullProtocol::MvccLogical, PullUpdatesV1Result::Pages { .. }) => {
+                        DbChangesStreamKind::ReplaceBasePages
+                    }
+                    (_, PullUpdatesV1Result::Logical { .. }) => {
+                        return Err(Error::DatabaseSyncEngineError(
+                            "server returned a logical stream for a page-stream first-contact request".to_string(),
+                        ));
+                    }
+                };
+                next_revision
+            }
+            (RemotePullProtocol::Pages | RemotePullProtocol::Unknown, _) => {
+                wal_pull_to_file(
+                    ctx,
+                    &file.value,
+                    &revision,
+                    self.opts.wal_pull_batch_size,
+                    self.opts.long_poll_timeout,
+                )
+                .await?
+            }
         };
 
         if file.value.size()? == 0 {
@@ -3685,7 +4172,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                                 self.opts.remote_encryption_key.as_deref(),
                             );
                             match pull_updates_v1(ctx, changes_file, revision, None, true).await? {
-                                (next_revision, PullUpdatesV1Result::Logical { txns, ops }) => {
+                                (next_revision, PullUpdatesV1Result::Logical { txns, ops }, _) => {
                                     tracing::info!(
                                         "apply_changes(path={}): replace-base follow-up logical pull returned {} transactions / {} ops",
                                         self.main_db_path,
@@ -3725,7 +4212,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                                         })?;
                                     }
                                 }
-                                (_, PullUpdatesV1Result::Pages { replace_base }) => {
+                                (_, PullUpdatesV1Result::Pages { replace_base }, _) => {
                                     return Err(Error::DatabaseSyncEngineError(format!(
                                         "replace-base follow-up logical pull unexpectedly returned a page stream: replace_base={replace_base}"
                                     )));

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -127,32 +127,18 @@ fn pull_updates_apply_mode(header: &PullUpdatesRespProtoBody) -> Result<PullUpda
     })
 }
 
-/// Detects the remote's sync protocol from a pull-updates response header.
+/// Detects the remote's sync protocol from the `protocol` field of a
+/// pull-updates response header.
 ///
-/// Prefers the explicit `protocol` field. For servers that predate it, falls
-/// back to the revision shape: MVCC revisions serialize as
-/// `{"generation":..,"log_offset":..}` while WAL diskless revisions use
-/// `{"generation":..,"wal_fragment_no":..}` (and legacy revisions are not
-/// JSON objects at all).
+/// Servers deploy before SDK releases, so a response without the field (or
+/// with an unknown future value) comes from a page-protocol server by
+/// definition — MVCC databases only exist behind servers that advertise it.
 pub(crate) fn detect_remote_pull_protocol(header: &PullUpdatesRespProtoBody) -> RemotePullProtocol {
     match PullUpdatesProtocol::try_from(header.protocol) {
-        Ok(PullUpdatesProtocol::Pages) => return RemotePullProtocol::Pages,
-        Ok(PullUpdatesProtocol::MvccLogical) => return RemotePullProtocol::MvccLogical,
-        Ok(PullUpdatesProtocol::Unspecified) | Err(_) => {}
-    }
-    #[derive(serde::Deserialize)]
-    struct MvccRevisionProbe {
-        #[serde(rename = "generation")]
-        _generation: u64,
-        #[serde(rename = "log_offset")]
-        _log_offset: u64,
-    }
-    if header.server_revision.is_empty() {
-        RemotePullProtocol::Unknown
-    } else if serde_json::from_str::<MvccRevisionProbe>(&header.server_revision).is_ok() {
-        RemotePullProtocol::MvccLogical
-    } else {
-        RemotePullProtocol::Pages
+        Ok(PullUpdatesProtocol::MvccLogical) => RemotePullProtocol::MvccLogical,
+        Ok(PullUpdatesProtocol::Pages | PullUpdatesProtocol::Unspecified) | Err(_) => {
+            RemotePullProtocol::Pages
+        }
     }
 }
 
@@ -5551,12 +5537,12 @@ mod tests {
     }
 
     #[test]
-    fn detect_remote_pull_protocol_prefers_explicit_field() {
+    fn detect_remote_pull_protocol_reads_the_explicit_field_only() {
         use crate::server_proto::PullUpdatesProtocol;
         use crate::types::RemotePullProtocol;
 
-        let header = |protocol: i32, revision: &str| PullUpdatesRespProtoBody {
-            server_revision: revision.to_string(),
+        let header = |protocol: i32| PullUpdatesRespProtoBody {
+            server_revision: "g1:o0".to_string(),
             db_size: 0,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
@@ -5566,68 +5552,23 @@ mod tests {
             protocol,
         };
 
-        // Explicit field wins even when the revision shape disagrees.
         assert_eq!(
-            detect_remote_pull_protocol(&header(
-                PullUpdatesProtocol::Pages as i32,
-                r#"{"generation":1,"log_offset":9}"#
-            )),
-            RemotePullProtocol::Pages
-        );
-        assert_eq!(
-            detect_remote_pull_protocol(&header(
-                PullUpdatesProtocol::MvccLogical as i32,
-                r#"{"generation":1,"wal_fragment_no":9}"#
-            )),
-            RemotePullProtocol::MvccLogical
-        );
-    }
-
-    #[test]
-    fn detect_remote_pull_protocol_falls_back_to_revision_shape_for_old_servers() {
-        use crate::server_proto::PullUpdatesProtocol;
-        use crate::types::RemotePullProtocol;
-
-        let header = |protocol: i32, revision: &str| PullUpdatesRespProtoBody {
-            server_revision: revision.to_string(),
-            db_size: 0,
-            raw_encoding: Some(PageSetRawEncodingProto {}),
-            zstd_encoding: None,
-            stream_kind: PullUpdatesStreamKind::Pages as i32,
-            apply_mode: PullUpdatesApplyMode::Incremental as i32,
-            mvcc_log: None,
-            protocol,
-        };
-        let unspecified = PullUpdatesProtocol::Unspecified as i32;
-
-        // MVCC revisions carry log_offset; WAL diskless revisions carry
-        // wal_fragment_no; legacy revisions are not JSON objects at all.
-        assert_eq!(
-            detect_remote_pull_protocol(&header(
-                unspecified,
-                r#"{"generation":4,"log_offset":128}"#
-            )),
+            detect_remote_pull_protocol(&header(PullUpdatesProtocol::MvccLogical as i32)),
             RemotePullProtocol::MvccLogical
         );
         assert_eq!(
-            detect_remote_pull_protocol(&header(
-                unspecified,
-                r#"{"generation":4,"wal_fragment_no":7}"#
-            )),
+            detect_remote_pull_protocol(&header(PullUpdatesProtocol::Pages as i32)),
+            RemotePullProtocol::Pages
+        );
+        // Servers deploy before SDK releases: a missing field (old server)
+        // or an unknown future value means a page-protocol server.
+        assert_eq!(
+            detect_remote_pull_protocol(&header(PullUpdatesProtocol::Unspecified as i32)),
             RemotePullProtocol::Pages
         );
         assert_eq!(
-            detect_remote_pull_protocol(&header(unspecified, "g142")),
+            detect_remote_pull_protocol(&header(99)),
             RemotePullProtocol::Pages
-        );
-        assert_eq!(
-            detect_remote_pull_protocol(&header(unspecified, "")),
-            RemotePullProtocol::Unknown
-        );
-        // Unknown enum values from newer servers degrade to the fallback.
-        assert_eq!(
-            detect_remote_pull_protocol(&header(99, r#"{"generation":4,"log_offset":128}"#)),
-            RemotePullProtocol::MvccLogical
         );
     }
 }

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -30,15 +30,15 @@ use crate::{
     io_operations::IoOperations,
     server_proto::{
         self, Batch, BatchCond, BatchStep, BatchStreamReq, PageData, PageUpdatesEncodingReq,
-        PullUpdatesApplyMode, PullUpdatesReqProtoBody, PullUpdatesRespProtoBody,
-        PullUpdatesStreamKind, Stmt, StmtResult, StreamRequest,
+        PullUpdatesApplyMode, PullUpdatesProtocol, PullUpdatesReqProtoBody,
+        PullUpdatesRespProtoBody, PullUpdatesStreamKind, Stmt, StmtResult, StreamRequest,
     },
     types::{
         parse_bin_record, Coro, DatabasePullRevision, DatabaseRowMutation,
         DatabaseRowTransformResult, DatabaseSchemaKind, DatabaseSchemaReplay,
         DatabaseStatementReplay, DatabaseSyncEngineProtocolVersion, DatabaseTapeOperation,
         DatabaseTapeRowChange, DatabaseTapeRowChangeType, DbSyncInfo, DbSyncStatus,
-        PartialBootstrapStrategy, PartialSyncOpts, SyncEngineIoResult,
+        PartialBootstrapStrategy, PartialSyncOpts, RemotePullProtocol, SyncEngineIoResult,
     },
     wal_session::WalSession,
     Result,
@@ -125,6 +125,35 @@ fn pull_updates_apply_mode(header: &PullUpdatesRespProtoBody) -> Result<PullUpda
             header.apply_mode
         ))
     })
+}
+
+/// Detects the remote's sync protocol from a pull-updates response header.
+///
+/// Prefers the explicit `protocol` field. For servers that predate it, falls
+/// back to the revision shape: MVCC revisions serialize as
+/// `{"generation":..,"log_offset":..}` while WAL diskless revisions use
+/// `{"generation":..,"wal_fragment_no":..}` (and legacy revisions are not
+/// JSON objects at all).
+pub(crate) fn detect_remote_pull_protocol(header: &PullUpdatesRespProtoBody) -> RemotePullProtocol {
+    match PullUpdatesProtocol::try_from(header.protocol) {
+        Ok(PullUpdatesProtocol::Pages) => return RemotePullProtocol::Pages,
+        Ok(PullUpdatesProtocol::MvccLogical) => return RemotePullProtocol::MvccLogical,
+        Ok(PullUpdatesProtocol::Unspecified) | Err(_) => {}
+    }
+    #[derive(serde::Deserialize)]
+    struct MvccRevisionProbe {
+        #[serde(rename = "generation")]
+        _generation: u64,
+        #[serde(rename = "log_offset")]
+        _log_offset: u64,
+    }
+    if header.server_revision.is_empty() {
+        RemotePullProtocol::Unknown
+    } else if serde_json::from_str::<MvccRevisionProbe>(&header.server_revision).is_ok() {
+        RemotePullProtocol::MvccLogical
+    } else {
+        RemotePullProtocol::Pages
+    }
 }
 
 fn ensure_page_stream(header: &PullUpdatesRespProtoBody, context: &str) -> Result<()> {
@@ -1817,7 +1846,11 @@ pub async fn pull_updates_v1<IO: SyncEngineIo, Ctx>(
     revision: &str,
     long_poll_timeout: Option<std::time::Duration>,
     logical_updates: bool,
-) -> Result<(DatabasePullRevision, PullUpdatesV1Result)> {
+) -> Result<(
+    DatabasePullRevision,
+    PullUpdatesV1Result,
+    RemotePullProtocol,
+)> {
     tracing::info!(
         "pull_updates_v1: remote_url={:?} revision={} logical_updates={} long_poll_timeout_ms={}",
         ctx.remote_url,
@@ -1884,6 +1917,7 @@ pub async fn pull_updates_v1<IO: SyncEngineIo, Ctx>(
     let next_revision = DatabasePullRevision::V1 {
         revision: header.server_revision.clone(),
     };
+    let remote_protocol = detect_remote_pull_protocol(&header);
     let apply_mode = pull_updates_apply_mode(&header)?;
     match pull_updates_stream_kind(&header)? {
         PullUpdatesStreamKind::Pages => {
@@ -1948,7 +1982,11 @@ pub async fn pull_updates_v1<IO: SyncEngineIo, Ctx>(
                 next_revision,
                 replace_base
             );
-            Ok((next_revision, PullUpdatesV1Result::Pages { replace_base }))
+            Ok((
+                next_revision,
+                PullUpdatesV1Result::Pages { replace_base },
+                remote_protocol,
+            ))
         }
         PullUpdatesStreamKind::MvccLogicalLog => {
             if matches!(apply_mode, PullUpdatesApplyMode::ReplaceBase) {
@@ -1976,7 +2014,11 @@ pub async fn pull_updates_v1<IO: SyncEngineIo, Ctx>(
                 txns,
                 ops
             );
-            Ok((next_revision, PullUpdatesV1Result::Logical { txns, ops }))
+            Ok((
+                next_revision,
+                PullUpdatesV1Result::Logical { txns, ops },
+                remote_protocol,
+            ))
         }
     }
 }
@@ -2382,6 +2424,28 @@ fn convert_to_args(
             },
         })
         .collect()
+}
+
+/// Lists user-created tables (i.e. anything beyond sqlite/turso internals).
+/// Used to decide whether local data exists that a replace-base apply would
+/// need to preserve.
+pub async fn list_user_tables<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'turso_%' AND name NOT LIKE '\\_\\_turso\\_%' ESCAPE '\\'",
+    )?;
+    let mut names = Vec::new();
+    while let Some(row) = run_stmt_once(coro, &mut stmt).await? {
+        let name = row
+            .get_value(0)
+            .to_text()
+            .ok_or_else(|| Error::DatabaseSyncEngineError("unexpected column type".to_string()))?
+            .to_string();
+        names.push(name);
+    }
+    Ok(names)
 }
 
 pub async fn has_table<Ctx>(
@@ -3190,7 +3254,7 @@ pub async fn bootstrap_db_file<IO: SyncEngineIo, Ctx>(
     protocol: DatabaseSyncEngineProtocolVersion,
     partial_sync: Option<PartialSyncOpts>,
     pull_bytes_threshold: Option<usize>,
-) -> Result<DatabasePullRevision> {
+) -> Result<(DatabasePullRevision, RemotePullProtocol)> {
     match protocol {
         DatabaseSyncEngineProtocolVersion::Legacy => {
             if partial_sync.is_some() {
@@ -3198,7 +3262,9 @@ pub async fn bootstrap_db_file<IO: SyncEngineIo, Ctx>(
                     "can't bootstrap prefix of database with legacy protocol".to_string(),
                 ));
             }
-            bootstrap_db_file_legacy(ctx, io, main_db_path).await
+            // The legacy wire protocol has no MVCC variant; it is pages by definition.
+            let revision = bootstrap_db_file_legacy(ctx, io, main_db_path).await?;
+            Ok((revision, RemotePullProtocol::Pages))
         }
         DatabaseSyncEngineProtocolVersion::V1 => {
             bootstrap_db_file_v1(ctx, io, main_db_path, partial_sync, pull_bytes_threshold).await
@@ -3327,7 +3393,7 @@ pub async fn bootstrap_db_file_v1<IO: SyncEngineIo, Ctx>(
     main_db_path: &str,
     partial_sync: Option<PartialSyncOpts>,
     pull_bytes_threshold: Option<usize>,
-) -> Result<DatabasePullRevision> {
+) -> Result<(DatabasePullRevision, RemotePullProtocol)> {
     if let Some(PartialSyncOpts {
         bootstrap_strategy: None,
         ..
@@ -3416,9 +3482,13 @@ pub async fn bootstrap_db_file_v1<IO: SyncEngineIo, Ctx>(
     // with unflushed pages while the metadata claims a completed bootstrap.
     sync_file(ctx.coro, &file).await?;
 
-    Ok(DatabasePullRevision::V1 {
-        revision: header.server_revision,
-    })
+    let remote_protocol = detect_remote_pull_protocol(&header);
+    Ok((
+        DatabasePullRevision::V1 {
+            revision: header.server_revision,
+        },
+        remote_protocol,
+    ))
 }
 
 fn decode_page(header: &PullUpdatesRespProtoBody, page_data: PageData) -> Result<Vec<u8>> {
@@ -3837,10 +3907,10 @@ mod tests {
         database_sync_engine_io::{DataCompletion, DataPollResult, SyncEngineIo},
         database_sync_operations::{
             apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats,
-            ensure_incremental_page_stream, ensure_page_stream, is_logically_replayable_table,
-            logical_txn_to_tape_operations, pull_pages_v1, pull_updates_v1, should_push_change,
-            should_replay_local_change, wait_proto_message, wal_pull_to_file_v1,
-            PullUpdatesV1Result, SyncEngineIoStats, SyncOperationCtx,
+            detect_remote_pull_protocol, ensure_incremental_page_stream, ensure_page_stream,
+            is_logically_replayable_table, logical_txn_to_tape_operations, pull_pages_v1,
+            pull_updates_v1, should_push_change, should_replay_local_change, wait_proto_message,
+            wal_pull_to_file_v1, PullUpdatesV1Result, SyncEngineIoStats, SyncOperationCtx,
         },
         database_tape::{run_stmt_once, DatabaseReplaySessionOpts, DatabaseTape},
         server_proto,
@@ -4419,6 +4489,7 @@ mod tests {
             raw_mvcc_log_frame_with_crc(77, &portable_payload, &recovery_payload, 2, initial_crc);
         let end_offset = (log_header.len() + frame.len()) as u64;
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: format!("g1:o{end_offset}"),
             db_size: 0,
             raw_encoding: None,
@@ -4496,6 +4567,7 @@ mod tests {
         let range_start = super::MVCC_LOG_HEADER_SIZE as u64;
         let range_end = range_start + raw_frame.len() as u64;
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: format!("g1:o{range_end}"),
             db_size: 0,
             raw_encoding: None,
@@ -4543,7 +4615,8 @@ mod tests {
                     Some("https://example.com".to_string()),
                     None,
                 );
-                let (revision, result) = pull_updates_v1(&ctx, &file, "g1:o56", None, true).await?;
+                let (revision, result, _) =
+                    pull_updates_v1(&ctx, &file, "g1:o56", None, true).await?;
                 let DatabasePullRevision::V1 { revision } = revision else {
                     panic!("expected V1 revision");
                 };
@@ -4578,6 +4651,7 @@ mod tests {
     fn pull_updates_v1_accepts_page_stream_when_logical_pull_is_requested() {
         let page = vec![7u8; super::PAGE_SIZE];
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: "g1:o45".to_string(),
             db_size: 1,
             raw_encoding: Some(PageSetRawEncodingProto {}),
@@ -4619,7 +4693,8 @@ mod tests {
                     Some("https://example.com".to_string()),
                     None,
                 );
-                let (revision, result) = pull_updates_v1(&ctx, &file, "g1:o40", None, true).await?;
+                let (revision, result, _) =
+                    pull_updates_v1(&ctx, &file, "g1:o40", None, true).await?;
                 let DatabasePullRevision::V1 { revision } = revision else {
                     panic!("expected V1 revision");
                 };
@@ -4662,6 +4737,7 @@ mod tests {
     fn pull_updates_v1_preserves_replace_base_page_fallback() {
         let page = vec![9u8; super::PAGE_SIZE];
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: "g1:o80".to_string(),
             db_size: 1,
             raw_encoding: Some(PageSetRawEncodingProto {}),
@@ -4703,7 +4779,8 @@ mod tests {
                     Some("https://example.com".to_string()),
                     None,
                 );
-                let (revision, result) = pull_updates_v1(&ctx, &file, "g1:o40", None, true).await?;
+                let (revision, result, _) =
+                    pull_updates_v1(&ctx, &file, "g1:o40", None, true).await?;
                 let DatabasePullRevision::V1 { revision } = revision else {
                     panic!("expected V1 revision");
                 };
@@ -4734,6 +4811,7 @@ mod tests {
     #[test]
     fn wal_pull_to_file_v1_rejects_replace_base_page_stream() {
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: "g1:o80".to_string(),
             db_size: 1,
             raw_encoding: Some(PageSetRawEncodingProto {}),
@@ -4799,6 +4877,7 @@ mod tests {
     fn pull_pages_v1_accepts_replace_base_page_stream_for_revision_pinned_reads() {
         let page = vec![11u8; super::PAGE_SIZE];
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: "g1:o80".to_string(),
             db_size: 3,
             raw_encoding: Some(PageSetRawEncodingProto {}),
@@ -4927,6 +5006,7 @@ mod tests {
         let range_start = super::MVCC_LOG_HEADER_SIZE as u64;
         let range_end = range_start + frame.len() as u64;
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: format!("g1:o{range_end}"),
             db_size: 0,
             raw_encoding: None,
@@ -4970,6 +5050,7 @@ mod tests {
         log_header[super::MVCC_LOG_HEADER_CRC_START] ^= 0x01;
         let end_offset = (log_header.len() + frame.len()) as u64;
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: format!("g1:o{end_offset}"),
             db_size: 0,
             raw_encoding: None,
@@ -5004,6 +5085,7 @@ mod tests {
         frame[super::MVCC_TX_EXT_HEADER_SIZE + super::MVCC_EXTENSION_RECORD_HEADER_SIZE] ^= 0x01;
         let end_offset = (log_header.len() + frame.len()) as u64;
         let header = PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: format!("g1:o{end_offset}"),
             db_size: 0,
             raw_encoding: None,
@@ -5284,7 +5366,7 @@ mod tests {
             remote_encryption_key: None,
             push_operations_threshold: None,
             pull_bytes_threshold: None,
-            logical_mvcc_pull: true,
+            logical_mvcc_pull: Some(true),
         };
         let internal_schema_change = DatabaseTapeRowChange {
             change_id: 1,
@@ -5365,6 +5447,7 @@ mod tests {
 
     fn page_header(stream_kind: i32, apply_mode: i32) -> PullUpdatesRespProtoBody {
         PullUpdatesRespProtoBody {
+            protocol: 0,
             server_revision: "rev".to_string(),
             db_size: 1,
             raw_encoding: Some(PageSetRawEncodingProto {}),
@@ -5465,5 +5548,86 @@ mod tests {
         assert!(super::rewrite_create_ddl_as_if_not_exists("ALTER TABLE q ADD COLUMN w").is_none());
         assert!(super::rewrite_create_ddl_as_if_not_exists("DROP TABLE q").is_none());
         assert!(super::rewrite_create_ddl_as_if_not_exists("not valid sql").is_none());
+    }
+
+    #[test]
+    fn detect_remote_pull_protocol_prefers_explicit_field() {
+        use crate::server_proto::PullUpdatesProtocol;
+        use crate::types::RemotePullProtocol;
+
+        let header = |protocol: i32, revision: &str| PullUpdatesRespProtoBody {
+            server_revision: revision.to_string(),
+            db_size: 0,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol,
+        };
+
+        // Explicit field wins even when the revision shape disagrees.
+        assert_eq!(
+            detect_remote_pull_protocol(&header(
+                PullUpdatesProtocol::Pages as i32,
+                r#"{"generation":1,"log_offset":9}"#
+            )),
+            RemotePullProtocol::Pages
+        );
+        assert_eq!(
+            detect_remote_pull_protocol(&header(
+                PullUpdatesProtocol::MvccLogical as i32,
+                r#"{"generation":1,"wal_fragment_no":9}"#
+            )),
+            RemotePullProtocol::MvccLogical
+        );
+    }
+
+    #[test]
+    fn detect_remote_pull_protocol_falls_back_to_revision_shape_for_old_servers() {
+        use crate::server_proto::PullUpdatesProtocol;
+        use crate::types::RemotePullProtocol;
+
+        let header = |protocol: i32, revision: &str| PullUpdatesRespProtoBody {
+            server_revision: revision.to_string(),
+            db_size: 0,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol,
+        };
+        let unspecified = PullUpdatesProtocol::Unspecified as i32;
+
+        // MVCC revisions carry log_offset; WAL diskless revisions carry
+        // wal_fragment_no; legacy revisions are not JSON objects at all.
+        assert_eq!(
+            detect_remote_pull_protocol(&header(
+                unspecified,
+                r#"{"generation":4,"log_offset":128}"#
+            )),
+            RemotePullProtocol::MvccLogical
+        );
+        assert_eq!(
+            detect_remote_pull_protocol(&header(
+                unspecified,
+                r#"{"generation":4,"wal_fragment_no":7}"#
+            )),
+            RemotePullProtocol::Pages
+        );
+        assert_eq!(
+            detect_remote_pull_protocol(&header(unspecified, "g142")),
+            RemotePullProtocol::Pages
+        );
+        assert_eq!(
+            detect_remote_pull_protocol(&header(unspecified, "")),
+            RemotePullProtocol::Unknown
+        );
+        // Unknown enum values from newer servers degrade to the fallback.
+        assert_eq!(
+            detect_remote_pull_protocol(&header(99, r#"{"generation":4,"log_offset":128}"#)),
+            RemotePullProtocol::MvccLogical
+        );
     }
 }

--- a/sync/engine/src/server_proto.rs
+++ b/sync/engine/src/server_proto.rs
@@ -72,6 +72,20 @@ pub enum PullUpdatesApplyMode {
     ReplaceBase = 1,
 }
 
+/// Sync protocol the remote database speaks for incremental pulls, advertised
+/// by the server in every pull-updates response (including page bootstraps).
+/// `Unspecified` means the server predates the field; callers fall back to
+/// sniffing the revision shape.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+#[derive(prost::Enumeration)]
+#[repr(i32)]
+pub enum PullUpdatesProtocol {
+    Unspecified = 0,
+    Pages = 1,
+    MvccLogical = 2,
+}
+
 #[derive(prost::Message)]
 pub struct PageSetRawEncodingProto {}
 
@@ -124,6 +138,8 @@ pub struct PullUpdatesRespProtoBody {
     pub apply_mode: i32,
     #[prost(optional, message, tag = "7")]
     pub mvcc_log: Option<MvccLogicalLogMetadataProto>,
+    #[prost(enumeration = "PullUpdatesProtocol", tag = "8")]
+    pub protocol: i32,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -532,7 +548,7 @@ pub(crate) mod bytes_as_base64_pad {
 mod pull_updates_tests {
     use super::{
         MvccLogicalLogMetadataProto, MvccLogicalLogRangeProto, PageSetRawEncodingProto,
-        PageUpdatesEncodingReq, PullUpdatesApplyMode, PullUpdatesReqProtoBody,
+        PageUpdatesEncodingReq, PullUpdatesApplyMode, PullUpdatesProtocol, PullUpdatesReqProtoBody,
         PullUpdatesRespProtoBody, PullUpdatesStreamKind,
     };
     use prost::Message;
@@ -561,6 +577,7 @@ mod pull_updates_tests {
     fn pull_updates_mvcc_log_header_round_trips_metadata() {
         let header = PullUpdatesRespProtoBody {
             server_revision: "rev-42".to_string(),
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
             db_size: 3,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -163,14 +163,10 @@ pub struct DatabaseMetadata {
     pub partial_bootstrap_server_revision: Option<DatabasePullRevision>,
     #[serde(default)]
     pub fresh_bootstrap_pending_cdc_ack: bool,
-    /// Operative switch for MVCC logical pulls; kept as a bool (mirroring
-    /// `remote_pull_protocol == MvccLogical`) so metadata files stay readable
-    /// by older engine versions.
-    #[serde(default)]
-    pub logical_mvcc_pull_active: bool,
     /// Detected remote sync protocol; source of truth for pull dispatch.
-    /// Older metadata files deserialize to `Unknown` and are migrated in
-    /// [`DatabaseMetadata::load`] from `logical_mvcc_pull_active`.
+    /// Metadata files written before this field existed deserialize to
+    /// `Unknown` and are pinned to `Pages` in [`DatabaseMetadata::load`]
+    /// (MVCC logical sync never shipped without this field).
     #[serde(default)]
     pub remote_pull_protocol: RemotePullProtocol,
     #[serde(default)]
@@ -271,17 +267,15 @@ impl DatabaseMetadata {
                 let mut meta: DatabaseMetadata = serde_json::from_value(value).map_err(|err|
                     Error::JsonDecode(format!("unable to parse metadata file with version {version}: {err}"))
                 )?;
-                // Migrate metadata written before remote_pull_protocol existed:
-                // a replica that already holds a revision has talked to the
-                // server, so the legacy bool is authoritative for its protocol.
+                // Metadata written before remote_pull_protocol existed belongs
+                // to a page-protocol replica (MVCC logical sync never shipped
+                // without this field). A replica that already holds a revision
+                // has talked to the server, so pin it to Pages; deferred
+                // replicas stay Unknown and detect on first contact.
                 if meta.remote_pull_protocol == RemotePullProtocol::Unknown
                     && meta.synced_revision.is_some()
                 {
-                    meta.remote_pull_protocol = if meta.logical_mvcc_pull_active {
-                        RemotePullProtocol::MvccLogical
-                    } else {
-                        RemotePullProtocol::Pages
-                    };
+                    meta.remote_pull_protocol = RemotePullProtocol::Pages;
                 }
                 Ok(meta)
             }
@@ -293,6 +287,10 @@ impl DatabaseMetadata {
     pub fn dump(&self) -> Result<Vec<u8>> {
         let data = serde_json::to_string(self)?;
         Ok(data.into_bytes())
+    }
+    /// True when this replica syncs via MVCC logical-log pulls.
+    pub fn logical_mvcc_pull_active(&self) -> bool {
+        self.remote_pull_protocol == RemotePullProtocol::MvccLogical
     }
 }
 
@@ -769,16 +767,16 @@ mod tests {
 
         assert_eq!(meta.last_pushed_replay_floor_change_id_hint, 0);
         assert!(!meta.fresh_bootstrap_pending_cdc_ack);
-        assert!(!meta.logical_mvcc_pull_active);
+        assert!(!meta.logical_mvcc_pull_active());
         assert!(meta.logical_table_names_by_stable_id.is_empty());
     }
 
     #[test]
-    fn metadata_load_migrates_pre_protocol_files_from_legacy_bool() {
-        // A pre-remote_pull_protocol replica that already holds a revision has
-        // talked to the server, so the legacy bool is authoritative. This is
-        // what keeps existing page-protocol (WAL) replicas on the exact same
-        // code path after upgrading the engine.
+    fn metadata_load_pins_pre_protocol_replicas_with_revisions_to_pages() {
+        // A replica whose metadata predates remote_pull_protocol is a
+        // page-protocol replica by definition (MVCC logical sync never
+        // shipped without the field). Pinning it to Pages keeps existing
+        // WAL replicas on the exact same code path after upgrading.
         let pages_meta = DatabaseMetadata::load(
             br#"{
                 "version": "v1",
@@ -796,30 +794,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(pages_meta.remote_pull_protocol, RemotePullProtocol::Pages);
-        assert!(!pages_meta.logical_mvcc_pull_active);
-
-        let logical_meta = DatabaseMetadata::load(
-            br#"{
-                "version": "v1",
-                "client_unique_id": "client-a",
-                "synced_revision": {"type": "v1", "revision": "{\"generation\":3,\"log_offset\":128}"},
-                "revert_since_wal_salt": null,
-                "revert_since_wal_watermark": 0,
-                "last_pull_unix_time": null,
-                "last_push_unix_time": null,
-                "last_pushed_pull_gen_hint": 0,
-                "last_pushed_change_id_hint": 0,
-                "partial_bootstrap_server_revision": null,
-                "logical_mvcc_pull_active": true,
-                "saved_configuration": null
-            }"#,
-        )
-        .unwrap();
-        assert_eq!(
-            logical_meta.remote_pull_protocol,
-            RemotePullProtocol::MvccLogical
-        );
-        assert!(logical_meta.logical_mvcc_pull_active);
+        assert!(!pages_meta.logical_mvcc_pull_active());
     }
 
     #[test]
@@ -864,12 +839,11 @@ mod tests {
         )
         .unwrap();
         meta.remote_pull_protocol = RemotePullProtocol::MvccLogical;
-        meta.logical_mvcc_pull_active = true;
         let reloaded = DatabaseMetadata::load(&meta.dump().unwrap()).unwrap();
         assert_eq!(
             reloaded.remote_pull_protocol,
             RemotePullProtocol::MvccLogical
         );
-        assert!(reloaded.logical_mvcc_pull_active);
+        assert!(reloaded.logical_mvcc_pull_active());
     }
 }

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -126,6 +126,22 @@ pub enum DatabaseChangeType {
 
 pub const DATABASE_METADATA_VERSION: &str = "v1";
 
+/// Sync protocol the remote database speaks for incremental pulls.
+///
+/// `Unknown` means the client has not yet learned the remote's protocol —
+/// either the replica predates auto-detection or it was created with deferred
+/// bootstrap and has not contacted the server yet. The first pull-updates
+/// response resolves it (explicit `protocol` header field, revision shape as
+/// fallback for older servers) and the result is persisted in the metadata.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RemotePullProtocol {
+    #[default]
+    Unknown,
+    Pages,
+    MvccLogical,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct DatabaseMetadata {
     pub version: String,
@@ -147,8 +163,16 @@ pub struct DatabaseMetadata {
     pub partial_bootstrap_server_revision: Option<DatabasePullRevision>,
     #[serde(default)]
     pub fresh_bootstrap_pending_cdc_ack: bool,
+    /// Operative switch for MVCC logical pulls; kept as a bool (mirroring
+    /// `remote_pull_protocol == MvccLogical`) so metadata files stay readable
+    /// by older engine versions.
     #[serde(default)]
     pub logical_mvcc_pull_active: bool,
+    /// Detected remote sync protocol; source of truth for pull dispatch.
+    /// Older metadata files deserialize to `Unknown` and are migrated in
+    /// [`DatabaseMetadata::load`] from `logical_mvcc_pull_active`.
+    #[serde(default)]
+    pub remote_pull_protocol: RemotePullProtocol,
     #[serde(default)]
     pub logical_table_names_by_stable_id: BTreeMap<u64, String>,
     /// optional saved configuration
@@ -244,9 +268,21 @@ impl DatabaseMetadata {
         match value.get("version").and_then(serde_json::Value::as_str) {
             Some(version) => {
                 let version = version.to_string();
-                let meta: DatabaseMetadata = serde_json::from_value(value).map_err(|err|
+                let mut meta: DatabaseMetadata = serde_json::from_value(value).map_err(|err|
                     Error::JsonDecode(format!("unable to parse metadata file with version {version}: {err}"))
                 )?;
+                // Migrate metadata written before remote_pull_protocol existed:
+                // a replica that already holds a revision has talked to the
+                // server, so the legacy bool is authoritative for its protocol.
+                if meta.remote_pull_protocol == RemotePullProtocol::Unknown
+                    && meta.synced_revision.is_some()
+                {
+                    meta.remote_pull_protocol = if meta.logical_mvcc_pull_active {
+                        RemotePullProtocol::MvccLogical
+                    } else {
+                        RemotePullProtocol::Pages
+                    };
+                }
                 Ok(meta)
             }
             None => Err(Error::JsonDecode(
@@ -670,7 +706,7 @@ pub fn parse_bin_record(
 
 #[cfg(test)]
 mod tests {
-    use super::{DatabaseMetadata, DatabaseSavedConfiguration};
+    use super::{DatabaseMetadata, DatabaseSavedConfiguration, RemotePullProtocol};
 
     #[test]
     fn update_configuration_reports_change_only_when_values_differ() {
@@ -735,5 +771,105 @@ mod tests {
         assert!(!meta.fresh_bootstrap_pending_cdc_ack);
         assert!(!meta.logical_mvcc_pull_active);
         assert!(meta.logical_table_names_by_stable_id.is_empty());
+    }
+
+    #[test]
+    fn metadata_load_migrates_pre_protocol_files_from_legacy_bool() {
+        // A pre-remote_pull_protocol replica that already holds a revision has
+        // talked to the server, so the legacy bool is authoritative. This is
+        // what keeps existing page-protocol (WAL) replicas on the exact same
+        // code path after upgrading the engine.
+        let pages_meta = DatabaseMetadata::load(
+            br#"{
+                "version": "v1",
+                "client_unique_id": "client-a",
+                "synced_revision": {"type": "v1", "revision": "{\"generation\":3,\"wal_fragment_no\":7}"},
+                "revert_since_wal_salt": null,
+                "revert_since_wal_watermark": 0,
+                "last_pull_unix_time": null,
+                "last_push_unix_time": null,
+                "last_pushed_pull_gen_hint": 0,
+                "last_pushed_change_id_hint": 0,
+                "partial_bootstrap_server_revision": null,
+                "saved_configuration": null
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(pages_meta.remote_pull_protocol, RemotePullProtocol::Pages);
+        assert!(!pages_meta.logical_mvcc_pull_active);
+
+        let logical_meta = DatabaseMetadata::load(
+            br#"{
+                "version": "v1",
+                "client_unique_id": "client-a",
+                "synced_revision": {"type": "v1", "revision": "{\"generation\":3,\"log_offset\":128}"},
+                "revert_since_wal_salt": null,
+                "revert_since_wal_watermark": 0,
+                "last_pull_unix_time": null,
+                "last_push_unix_time": null,
+                "last_pushed_pull_gen_hint": 0,
+                "last_pushed_change_id_hint": 0,
+                "partial_bootstrap_server_revision": null,
+                "logical_mvcc_pull_active": true,
+                "saved_configuration": null
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            logical_meta.remote_pull_protocol,
+            RemotePullProtocol::MvccLogical
+        );
+        assert!(logical_meta.logical_mvcc_pull_active);
+    }
+
+    #[test]
+    fn metadata_load_keeps_unknown_protocol_for_replicas_without_revision() {
+        // Deferred-bootstrap replicas have never contacted the server; the
+        // first pull must detect the protocol instead of assuming one.
+        let meta = DatabaseMetadata::load(
+            br#"{
+                "version": "v1",
+                "client_unique_id": "client-a",
+                "synced_revision": null,
+                "revert_since_wal_salt": null,
+                "revert_since_wal_watermark": 0,
+                "last_pull_unix_time": null,
+                "last_push_unix_time": null,
+                "last_pushed_pull_gen_hint": 0,
+                "last_pushed_change_id_hint": 0,
+                "partial_bootstrap_server_revision": null,
+                "saved_configuration": null
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(meta.remote_pull_protocol, RemotePullProtocol::Unknown);
+    }
+
+    #[test]
+    fn metadata_round_trips_remote_pull_protocol() {
+        let mut meta = DatabaseMetadata::load(
+            br#"{
+                "version": "v1",
+                "client_unique_id": "client-a",
+                "synced_revision": null,
+                "revert_since_wal_salt": null,
+                "revert_since_wal_watermark": 0,
+                "last_pull_unix_time": null,
+                "last_push_unix_time": null,
+                "last_pushed_pull_gen_hint": 0,
+                "last_pushed_change_id_hint": 0,
+                "partial_bootstrap_server_revision": null,
+                "saved_configuration": null
+            }"#,
+        )
+        .unwrap();
+        meta.remote_pull_protocol = RemotePullProtocol::MvccLogical;
+        meta.logical_mvcc_pull_active = true;
+        let reloaded = DatabaseMetadata::load(&meta.dump().unwrap()).unwrap();
+        assert_eq!(
+            reloaded.remote_pull_protocol,
+            RemotePullProtocol::MvccLogical
+        );
+        assert!(reloaded.logical_mvcc_pull_active);
     }
 }

--- a/sync/sdk-kit/src/rsapi.rs
+++ b/sync/sdk-kit/src/rsapi.rs
@@ -365,6 +365,7 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
                         sync_engine_opts.partial_sync_opts.is_some()
                     })?,
                 };
+                let fresh_bootstrap = metadata.is_none() && sync_engine_opts.bootstrap_if_empty;
                 let metadata = database_sync_engine::DatabaseSyncEngine::bootstrap_db(
                     &coro,
                     io.clone(),
@@ -398,6 +399,15 @@ impl<TBytes: AsRef<[u8]> + Send + Sync + 'static> TursoDatabaseSync<TBytes> {
                     sync_engine_opts,
                 )
                 .await?;
+                // A fresh MVCC bootstrap only carries the last durable
+                // generation base; catch up to the retained logical log so
+                // the database is current at connect time (no-op for
+                // page-protocol replicas).
+                if fresh_bootstrap {
+                    sync_engine_opened
+                        .catch_up_after_fresh_bootstrap(&coro)
+                        .await?;
+                }
                 *sync_engine.lock() = Some(sync_engine_opened);
                 Ok(None)
             })

--- a/sync/sdk-kit/src/rsapi.rs
+++ b/sync/sdk-kit/src/rsapi.rs
@@ -37,10 +37,11 @@ pub struct TursoDatabaseSyncConfig {
     /// `None` => single-request bootstrap. No-op when partial-sync uses the
     /// query bootstrap strategy.
     pub pull_bytes_threshold: Option<usize>,
-    /// Use the MVCC logical-log stream for incremental V1 pulls. This is
-    /// required when syncing against an MVCC-mode remote; legacy page/WAL sync
-    /// keeps the default `false` value.
-    pub logical_mvcc_pull: bool,
+    /// Sync-protocol override for incremental V1 pulls. `None` (default)
+    /// auto-detects the remote protocol from the first pull-updates response
+    /// and persists it in the sync metadata; `Some(true)` forces MVCC
+    /// logical-log streams; `Some(false)` forces page streams.
+    pub logical_mvcc_pull: Option<bool>,
 }
 
 pub type PartialSyncOpts = turso_sync_engine::types::PartialSyncOpts;
@@ -122,7 +123,14 @@ impl TursoDatabaseSyncConfig {
             } else {
                 Some(config.pull_bytes_threshold)
             },
-            logical_mvcc_pull: config.logical_mvcc_pull,
+            // The C ABI has no tri-state: `true` forces MVCC logical pulls,
+            // `false` means auto-detect (which behaves identically to page
+            // pulls against page-protocol remotes).
+            logical_mvcc_pull: if config.logical_mvcc_pull {
+                Some(true)
+            } else {
+                None
+            },
         })
     }
 }

--- a/sync/sdk-kit/turso_sync.h
+++ b/sync/sdk-kit/turso_sync.h
@@ -138,8 +138,10 @@ typedef struct
     // is fetched in chunks via the server_pages_selector bitmap. 0 (default) bootstraps
     // in a single round-trip. no-op when partial-sync uses the query bootstrap strategy.
     size_t pull_bytes_threshold;
-    // when true, V1 incremental pulls use the MVCC logical-log stream instead of
-    // the page stream. required for MVCC-mode remotes; leave false for legacy sync.
+    // when true, forces V1 incremental pulls to use the MVCC logical-log stream.
+    // false (default) auto-detects the remote's protocol from the first
+    // pull-updates response and persists it in the sync metadata, so this only
+    // needs to be set as an escape hatch.
     bool logical_mvcc_pull;
 } turso_sync_database_config_t;
 


### PR DESCRIPTION
Syncing against an MVCC-mode database requires the sync engine to use logical-log
pulls, but this was gated behind an opt-in flag (`logical_mvcc_pull`) that the JS,
Python, Go, and react-native SDKs never exposed. Every SDK client pulling from an
MVCC database bootstrapped a stale base and then failed with:

```
status=400 "MVCC incremental pull-updates requires stream_kind=mvcc_logical_log"
```

Even after plumbing the flag through, users would have to know their database's
journal mode and configure the client accordingly/we don't want to force a client to configure this flag. 
The protocol is a property of the server, so the client should learn it there.

## Solution

The server now advertises its pull protocol in every pull-updates response. 
The engine reads it on first contact and persists it in the sync metadata:

- New `remote_pull_protocol` field in `DatabaseMetadata`: `unknown`, `pages`,
  or `mvcc_logical`. Old metadata files deserialize to `unknown` and are
  migrated on load from the existing `logical_mvcc_pull_active` bool whenever
  the replica already holds a revision.
- `DatabaseSyncEngineOpts.logical_mvcc_pull` is now `Option<bool>`. `None`
  (the new default) auto-detects; `Some(true/false)` forces a protocol and
  remains available in every SDK as an escape hatch. `Builder::with_logical_mvcc_pull`
  keeps its signature.
- For servers that predate the header field, detection falls back to the shape
  of the advertised revision: MVCC revisions contain `log_offset`, WAL diskless
  revisions only `generation`/`wal_fragment_no`.
- A replica created with deferred bootstrap stays `unknown` until its first
  pull; that request is wire-identical to the existing no-revision page request,
  so the response tells us the protocol before any mode-specific behavior kicks in.
- Partial sync or remote encryption combined with an MVCC remote is now a hard
  error at configuration/detection time.

### Deferred bootstrap ("converted to cloud sync later")

A replica created with deferred bootstrap has already committed to a local
journal mode before the remote's protocol is knowable. When first contact
detects an MVCC remote and the local database is still in WAL mode, the
engine now converts it in place with `PRAGMA journal_mode = 'mvcc'` (core
already implements the full transition for populated databases: WAL
checkpoint, header rewrite, MvStore bootstrap over the existing btree)
before applying the remote base as replace-base. Local changes survive via
the existing CDC replay, and the conversion is durable across reopens.

Without this, applying an MVCC-headered base into a WAL-mode process would
leave the file header and the running journal mode disagreeing: the process
keeps WAL semantics while the next open reads the MVCC header and starts an
empty MvStore: essentially an uncoordinated journal mode flip across restarts.


### CDC Guard

also added here: since `replace-base` preserves local data by replaying the CDC log, so a database file that lived outside
the sync engine (user tables present but an empty CDC log before the first sync) is rejected with a
descriptive error instead of silently dropping its rows.