### PR TITLE
Pg search path resolution

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -167,17 +167,9 @@ impl Drop for SchemaReparseGuard {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PrepareOptions {
     pub unqualified_database_search_path: Option<Vec<String>>,
-}
-
-impl Default for PrepareOptions {
-    fn default() -> Self {
-        Self {
-            unqualified_database_search_path: None,
-        }
-    }
 }
 
 /// Re-entrant state for [`Connection::reparse_schema_nonblock`] and the

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -167,6 +167,19 @@ impl Drop for SchemaReparseGuard {
     }
 }
 
+#[derive(Debug)]
+pub struct PrepareOptions {
+    pub unqualified_database_search_path: Option<Vec<String>>,
+}
+
+impl Default for PrepareOptions {
+    fn default() -> Self {
+        Self {
+            unqualified_database_search_path: None,
+        }
+    }
+}
+
 /// Re-entrant state for [`Connection::reparse_schema_nonblock`] and the
 /// VACUUM-only [`Connection::reparse_schema_with_cookie_keeping_sequences`].
 /// `Start` is the fresh state (cookie not yet read / schema build not yet
@@ -895,6 +908,7 @@ impl Connection {
         cmd: Cmd,
         input: &str,
         origin: StatementOrigin,
+        prepare_options: &PrepareOptions,
     ) -> Result<(Program, Arc<Pager>, QueryMode)> {
         self.maybe_update_schema();
 
@@ -912,6 +926,7 @@ impl Connection {
             mode,
             input,
             origin,
+            prepare_options,
         ) {
             Ok(program) => Ok((program, pager, mode)),
             Err(err) if self.should_retry_cross_process_schema_lookup(&err)? => {
@@ -942,6 +957,7 @@ impl Connection {
                     mode,
                     input,
                     origin,
+                    prepare_options,
                 )
                 .map(|program| (program, pager, mode))
             }
@@ -1005,7 +1021,8 @@ impl Connection {
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(cmd, input, origin)?;
+            let prepare_options = PrepareOptions::default();
+            let (program, pager, mode) = self.compile_cmd(cmd, input, origin, &prepare_options)?;
 
             Ok(Statement::new_with_origin(
                 program,
@@ -1034,7 +1051,21 @@ impl Connection {
         stmt: ast::Stmt,
         input: &str,
     ) -> Result<Statement> {
-        self.prepare_stmt_with_input_and_origin(stmt, input, StatementOrigin::Root)
+        self.prepare_stmt_with_input_and_origin(
+            stmt,
+            input,
+            StatementOrigin::Root,
+            &PrepareOptions::default(),
+        )
+    }
+
+    pub fn prepare_translated_stmt_with_options(
+        self: &Arc<Connection>,
+        stmt: ast::Stmt,
+        input: &str,
+        prepare_options: &PrepareOptions,
+    ) -> Result<Statement> {
+        self.prepare_stmt_with_input_and_origin(stmt, input, StatementOrigin::Root, prepare_options)
     }
 
     #[turso_macros::trace_stack]
@@ -1043,6 +1074,7 @@ impl Connection {
         stmt: ast::Stmt,
         input: &str,
         origin: StatementOrigin,
+        prepare_options: &PrepareOptions,
     ) -> Result<Statement> {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
@@ -1052,7 +1084,8 @@ impl Connection {
             self.start_nested();
         }
         let result = (|| {
-            let (program, pager, mode) = self.compile_cmd(Cmd::Stmt(stmt), input, origin)?;
+            let (program, pager, mode) =
+                self.compile_cmd(Cmd::Stmt(stmt), input, origin, prepare_options)?;
             Ok(Statement::new_with_origin(
                 program,
                 pager,
@@ -1640,11 +1673,13 @@ impl Connection {
         tracing::trace!("Preparing and executing batch: {}", sql);
 
         let mut remaining = sql;
+        let prepare_options = PrepareOptions::default();
         while let (Some(cmd), byte_offset_end) = self.parse_sql(remaining)? {
             let input = str::from_utf8(&remaining.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(cmd, input, StatementOrigin::Root)?;
+            let (program, pager, mode) =
+                self.compile_cmd(cmd, input, StatementOrigin::Root, &prepare_options)?;
             Statement::new(program, pager, mode, 0).run_ignore_rows()?;
             remaining = &remaining[byte_offset_end..];
         }
@@ -1678,7 +1713,9 @@ impl Connection {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
-        let (program, pager, mode) = self.compile_cmd(cmd, input, StatementOrigin::Root)?;
+        let prepare_options = PrepareOptions::default();
+        let (program, pager, mode) =
+            self.compile_cmd(cmd, input, StatementOrigin::Root, &prepare_options)?;
         let stmt = Statement::new(program, pager, mode, 0);
         Ok(Some(stmt))
     }
@@ -1697,11 +1734,13 @@ impl Connection {
         }
         let sql = sql.as_ref();
         let mut remaining = sql;
+        let prepare_options = PrepareOptions::default();
         while let (Some(cmd), byte_offset_end) = self.parse_sql(remaining)? {
             let input = str::from_utf8(&remaining.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(cmd, input, StatementOrigin::Root)?;
+            let (program, pager, mode) =
+                self.compile_cmd(cmd, input, StatementOrigin::Root, &prepare_options)?;
             {
                 crate::stack::trace_stack!("run");
                 Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
@@ -1723,7 +1762,9 @@ impl Connection {
         let input = str::from_utf8(&sql.as_ref().as_bytes()[..byte_offset_end])
             .unwrap()
             .trim();
-        let (program, pager, mode) = self.compile_cmd(cmd, input, StatementOrigin::Root)?;
+        let prepare_options = PrepareOptions::default();
+        let (program, pager, mode) =
+            self.compile_cmd(cmd, input, StatementOrigin::Root, &prepare_options)?;
         let stmt = Statement::new(program, pager, mode, 0);
         Ok(Some((stmt, byte_offset_end)))
     }

--- a/core/incremental/expr_compiler.rs
+++ b/core/incremental/expr_compiler.rs
@@ -333,6 +333,7 @@ impl CompiledExpression {
             true,
             DoubleQuotedDml::Enabled,
             std::sync::Arc::new(crate::dialect::SqliteDialect),
+            &None,
         );
 
         // Translate the transformed expression to bytecode

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -136,7 +136,7 @@ use tracing::{instrument, Level};
 use turso_macros::AtomicEnum;
 use turso_parser::{ast, ast::Cmd};
 
-pub use connection::{resolve_ext_path, Connection, Row, StepResult, SymbolTable};
+pub use connection::{resolve_ext_path, Connection, PrepareOptions, Row, StepResult, SymbolTable};
 pub(crate) use connection::{AtomicTransactionState, TransactionState};
 pub use dialect::{Dialect, SqliteDialect};
 pub use error::{io_error, CompletionError, LimboError};

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -10,7 +10,7 @@ use std::{
 use tracing::{instrument, Level};
 use turso_parser::ast::{fmt::ToTokens, Cmd};
 
-use crate::alloc::TursoIteratorExt;
+use crate::{alloc::TursoIteratorExt, connection::PrepareOptions};
 use crate::{
     busy::BusyHandlerState,
     parameters,
@@ -878,6 +878,7 @@ impl Statement {
             crate::turso_assert_eq!(QueryMode::new(&cmd), mode);
             let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
             let schema = conn.schema.read().clone();
+            let prepare_options = PrepareOptions::default();
             translate::translate(
                 &schema,
                 stmt,
@@ -887,6 +888,7 @@ impl Statement {
                 mode,
                 &self.program.sql,
                 self.origin,
+                &prepare_options,
             )?
         };
 

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -195,6 +195,7 @@ pub struct Resolver<'a> {
     /// shared state, a self-referential `ON DELETE CASCADE` could fail to see
     /// that its own action program is already being built.
     pub(super) fk_action_compile_stack: FkActionCompileStack,
+    unqualified_database_search_path: Option<Vec<String>>,
 }
 
 #[derive(Clone)]
@@ -285,6 +286,7 @@ impl<'a> Resolver<'a> {
         enable_custom_types: bool,
         dqs_dml: DoubleQuotedDml,
         dialect: Arc<dyn crate::dialect::Dialect>,
+        unqualified_database_search_path: &Option<Vec<String>>,
     ) -> Self {
         let has_temp_schema = temp_database.read().is_some();
         Self {
@@ -306,6 +308,7 @@ impl<'a> Resolver<'a> {
             trigger_context: None,
             has_temp_schema,
             fk_action_compile_stack: FkActionCompileStack::default(),
+            unqualified_database_search_path: unqualified_database_search_path.clone(),
         }
     }
 
@@ -337,6 +340,7 @@ impl<'a> Resolver<'a> {
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,
             fk_action_compile_stack: self.fk_action_compile_stack.clone(),
+            unqualified_database_search_path: self.unqualified_database_search_path.clone(),
         }
     }
 
@@ -360,6 +364,7 @@ impl<'a> Resolver<'a> {
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,
             fk_action_compile_stack: self.fk_action_compile_stack.clone(),
+            unqualified_database_search_path: self.unqualified_database_search_path.clone(),
         }
     }
 
@@ -592,6 +597,22 @@ impl<'a> Resolver<'a> {
             return Ok(crate::TEMP_DB_ID);
         }
 
+        if let Some(search_path) = &self.unqualified_database_search_path {
+            for schema_name in search_path {
+                let Some(database_id) = self.resolve_search_path_database_id(schema_name) else {
+                    continue;
+                };
+                if self.with_schema(database_id, |schema| {
+                    schema_contains_object(schema, object_name)
+                }) {
+                    return Ok(database_id);
+                }
+            }
+            return Err(LimboError::ParseError(format!(
+                "no such object: {object_name}"
+            )));
+        }
+
         if self.with_schema(crate::MAIN_DB_ID, |schema| {
             schema_contains_object(schema, object_name)
         }) {
@@ -607,6 +628,13 @@ impl<'a> Resolver<'a> {
         }
 
         Ok(crate::MAIN_DB_ID)
+    }
+
+    fn resolve_search_path_database_id(&self, schema_name: &str) -> Option<usize> {
+        if schema_name.eq_ignore_ascii_case("public") {
+            return Some(crate::MAIN_DB_ID);
+        }
+        self.get_attached_database(schema_name).map(|x| x.0)
     }
 
     fn schema_has_table_like_object(schema: &Schema, table_name: &str) -> bool {

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -48,6 +48,7 @@ mod values;
 pub(crate) mod view;
 mod window;
 
+use crate::connection::PrepareOptions;
 use crate::schema::Schema;
 use crate::storage::pager::Pager;
 use crate::sync::Arc;
@@ -81,6 +82,7 @@ pub fn translate(
     query_mode: QueryMode,
     input: &str,
     origin: crate::statement::StatementOrigin,
+    prepare_options: &PrepareOptions,
 ) -> Result<Program> {
     tracing::trace!("querying {}", input);
     let change_cnt_on = matches!(
@@ -122,6 +124,7 @@ pub fn translate(
         } else {
             connection.dialect()
         },
+        &prepare_options.unqualified_database_search_path,
     );
 
     match stmt {
@@ -553,6 +556,7 @@ mod tests {
             QueryMode::Normal,
             "",
             crate::statement::StatementOrigin::Root,
+            &crate::connection::PrepareOptions::default(),
         );
         let err = result.unwrap_err().to_string();
         assert!(
@@ -636,6 +640,7 @@ mod tests {
             QueryMode::Normal,
             "",
             crate::statement::StatementOrigin::Root,
+            &crate::connection::PrepareOptions::default(),
         )
         .expect_err("translation should fail with malformed sqlite_sequence");
         match err {
@@ -679,6 +684,7 @@ mod tests {
             QueryMode::Normal,
             "",
             crate::statement::StatementOrigin::Root,
+            &crate::connection::PrepareOptions::default(),
         )
         .expect_err("translation should fail with missing sqlite_sequence");
         match err {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3783,6 +3783,7 @@ mod tests {
             true,
             DoubleQuotedDml::Enabled,
             crate::sync::Arc::new(crate::dialect::SqliteDialect),
+            &None,
         )
     }
 

--- a/postgres/cli/TODO.md
+++ b/postgres/cli/TODO.md
@@ -8,11 +8,11 @@ Sorted by implementation difficulty.
 2. **PREPARE / EXECUTE / DEALLOCATE** — wire protocol already handles this; just need the SQL syntax to not error
 3. **GRANT/REVOKE** — parse + ignore (single-user system, just don't error)
 4. **More PG system functions** — still missing: `current_setting`, `current_schemas(bool)`, a real `pg_get_expr` (currently a NULL stub), and the regexp functions (`extensions/regexp` is not linked into tursopg); session information functions and the `string_agg` family already resolve
-5. **SET search_path** — intercept in try_prepare_pg, store on connection, use in table resolution
-
+5. ~~**SET search_path**~~ — intercept in try_prepare_pg, store on connection, use in table resolution
+∑
 ## Easy (a day or two)
 
-6. ~~**CREATE TABLE AS / SELECT INTO**~~ — DONE (translates to `CREATE TABLE ... AS SELECT`; WITH NO DATA supported, explicit column list rejected)
+6. **CREATE TABLE AS / SELECT INTO** — translate to `CREATE TABLE ... AS SELECT` which Turso already supports
 7. **ALTER COLUMN SET/DROP DEFAULT, SET/DROP NOT NULL** — Turso's ALTER TABLE is limited but these map to SQLite operations
 8. **CONCURRENTLY on CREATE INDEX** — just ignore the keyword (SQLite doesn't do concurrent DDL anyway)
 9. **COPY ... FROM/TO with simple CSV** — implement as INSERT loop or SELECT output (not the wire protocol COPY)

--- a/postgres/conformance/pg-sqltests/search_path.sqltest
+++ b/postgres/conformance/pg-sqltests/search_path.sqltest
@@ -1,0 +1,59 @@
+# Runtime coverage for SET search_path in the PostgreSQL frontend.
+# Schema databases are file-backed, so schema tables are dropped before each
+# create to keep repeated test runs independent of old sidecar files.
+
+@database :memory:
+
+test search-path-first-schema-wins {
+    DROP TABLE IF EXISTS demo;
+    CREATE TABLE demo (id int, label text);
+    INSERT INTO demo VALUES (0, 'from public');
+    CREATE SCHEMA IF NOT EXISTS sp_fw_a;
+    DROP TABLE IF EXISTS sp_fw_a.demo;
+    CREATE TABLE sp_fw_a.demo (id int, label text);
+    INSERT INTO sp_fw_a.demo VALUES (1, 'from a');
+    CREATE SCHEMA IF NOT EXISTS sp_fw_b;
+    DROP TABLE IF EXISTS sp_fw_b.demo;
+    CREATE TABLE sp_fw_b.demo (id int, label text);
+    INSERT INTO sp_fw_b.demo VALUES (2, 'from b');
+    SET search_path TO sp_fw_b, sp_fw_a;
+    SELECT id, label FROM demo;
+}
+expect {
+    2|from b
+}
+
+test search-path-single-schema {
+    DROP TABLE IF EXISTS demo;
+    CREATE TABLE demo (id int, label text);
+    INSERT INTO demo VALUES (0, 'from public');
+    CREATE SCHEMA IF NOT EXISTS sp_ss_a;
+    DROP TABLE IF EXISTS sp_ss_a.demo;
+    CREATE TABLE sp_ss_a.demo (id int, label text);
+    INSERT INTO sp_ss_a.demo VALUES (1, 'from a');
+    SET search_path TO sp_ss_a;
+    SELECT id, label FROM demo;
+}
+expect {
+    1|from a
+}
+
+test search-path-missing-schema-errors {
+    DROP TABLE IF EXISTS demo;
+    CREATE TABLE demo (id int, label text);
+    INSERT INTO demo VALUES (0, 'from public');
+    SET search_path TO missing_schema_ms;
+    SELECT id, label FROM demo;
+}
+expect error {}
+
+test search-path-public-resolves-to-main {
+    DROP TABLE IF EXISTS demo;
+    CREATE TABLE demo (id int, label text);
+    INSERT INTO demo VALUES (0, 'from public');
+    SET search_path TO public;
+    SELECT id, label FROM demo;
+}
+expect {
+    0|from public
+}

--- a/postgres/frontend/session.rs
+++ b/postgres/frontend/session.rs
@@ -1,22 +1,39 @@
 use std::num::NonZero;
 use std::str;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::aliases;
 use crate::catalog::{self, PostgresDialect};
-use turso_core::{Connection, LimboError, Result, Statement, Value};
-use turso_parser::ast;
+use turso_core::{Connection, LimboError, PrepareOptions, Result, Statement, Value};
+use turso_parser::ast::{self};
 use turso_pg_parser::translator::{
     is_comment_on, is_refresh_matview, try_extract_copy_from, try_extract_create_schema,
     try_extract_drop_schema, try_extract_set, try_extract_show, PgCopyFromStmt, PgCreateSchemaStmt,
-    PgDropSchemaStmt, PostgreSQLTranslator,
+    PgDropSchemaStmt, PgSetStmt, PostgreSQLTranslator,
 };
 
 use crate::copy::parse_copy_text_format;
 
 #[derive(Clone)]
 pub struct PgConnection {
+    inner: Arc<PgConnectionInner>,
+}
+
+struct PgConnectionInner {
     conn: Arc<Connection>,
+    session_state: Mutex<SessionState>,
+}
+
+impl PgConnectionInner {
+    fn set_search_path(&self, path: Vec<String>) {
+        let mut state = self.session_state.lock().unwrap();
+        state.search_path = path;
+    }
+}
+
+#[derive(Default)]
+struct SessionState {
+    search_path: Vec<String>,
 }
 
 /// Open a database with the PostgreSQL schema dialect, resolving the IO
@@ -58,15 +75,20 @@ pub fn open_database_with_io(
 impl PgConnection {
     pub fn new(conn: Arc<Connection>) -> Self {
         aliases::install(&conn);
-        Self { conn }
+        Self {
+            inner: Arc::new(PgConnectionInner {
+                conn,
+                session_state: Mutex::new(SessionState::default()),
+            }),
+        }
     }
 
     pub fn inner(&self) -> &Arc<Connection> {
-        &self.conn
+        &self.inner.conn
     }
 
     pub fn prepare(&self, sql: impl AsRef<str>) -> Result<Statement> {
-        prepare_statement(&self.conn, sql.as_ref())
+        prepare_statement(&self.inner, sql.as_ref())
     }
 
     pub fn query(&self, sql: impl AsRef<str>) -> Result<Option<Statement>> {
@@ -87,28 +109,28 @@ impl PgConnection {
     }
 
     pub fn close(&self) -> Result<()> {
-        self.conn.close()
+        self.inner.conn.close()
     }
 
     pub fn pragma_update(&self, name: &str, value: impl std::fmt::Display) -> Result<()> {
         let sql = format!("PRAGMA {name} = {value}");
-        let mut stmt = self.conn.prepare_internal(sql)?;
+        let mut stmt = self.inner.conn.prepare_internal(sql)?;
         stmt.run_ignore_rows()
     }
 
     pub fn query_runner<'a>(&'a self, sql: &'a [u8]) -> PgQueryRunner<'a> {
-        PgQueryRunner::new(&self.conn, sql)
+        PgQueryRunner::new(&self.inner, sql)
     }
 }
 
 pub struct PgQueryRunner<'a> {
-    conn: &'a Arc<Connection>,
+    conn: &'a Arc<PgConnectionInner>,
     stmts: Vec<String>,
     index: usize,
 }
 
 impl<'a> PgQueryRunner<'a> {
-    fn new(conn: &'a Arc<Connection>, sql: &'a [u8]) -> Self {
+    fn new(conn: &'a Arc<PgConnectionInner>, sql: &'a [u8]) -> Self {
         let sql = str::from_utf8(sql).unwrap_or("");
         Self {
             conn,
@@ -144,7 +166,7 @@ pub fn split_statements(sql: &str) -> Result<Vec<String>> {
     }
 }
 
-fn prepare_statement(conn: &Arc<Connection>, sql: &str) -> Result<Statement> {
+fn prepare_statement(pg_conn: &Arc<PgConnectionInner>, sql: &str) -> Result<Statement> {
     let sql = sql.trim();
     if sql.is_empty() {
         return Err(LimboError::InvalidArgument(
@@ -154,7 +176,7 @@ fn prepare_statement(conn: &Arc<Connection>, sql: &str) -> Result<Statement> {
 
     reject_sqlite_catalog_access(sql)?;
 
-    if let Some(stmt) = try_prepare_special(conn, sql)? {
+    if let Some(stmt) = try_prepare_special(pg_conn, sql)? {
         return Ok(stmt);
     }
 
@@ -166,13 +188,24 @@ fn prepare_statement(conn: &Arc<Connection>, sql: &str) -> Result<Statement> {
         .map_err(|e| LimboError::ParseError(e.to_string()))?;
     reject_catalog_dml(&translated.stmt)?;
 
+    let options = {
+        let state = pg_conn.session_state.lock().unwrap();
+        let path = state.search_path.clone();
+        PrepareOptions {
+            unqualified_database_search_path: if path.is_empty() { None } else { Some(path) },
+        }
+    };
     for prereq in translated.prereqs {
         let input = prereq.to_string();
-        let mut stmt = conn.prepare_translated_stmt(prereq, &input)?;
+        let mut stmt = pg_conn
+            .conn
+            .prepare_translated_stmt_with_options(prereq, &input, &options)?;
         stmt.run_ignore_rows()?;
     }
 
-    conn.prepare_translated_stmt(translated.stmt, sql)
+    pg_conn
+        .conn
+        .prepare_translated_stmt_with_options(translated.stmt, sql, &options)
 }
 
 fn reject_catalog_dml(stmt: &ast::Stmt) -> Result<()> {
@@ -214,43 +247,43 @@ fn reject_sqlite_catalog_access(sql: &str) -> Result<()> {
     Ok(())
 }
 
-fn try_prepare_special(conn: &Arc<Connection>, sql: &str) -> Result<Option<Statement>> {
+fn try_prepare_special(pg_conn: &Arc<PgConnectionInner>, sql: &str) -> Result<Option<Statement>> {
     let parse_result = match turso_pg_parser::parse(sql) {
         Ok(result) => result,
         Err(_) => return Ok(None),
     };
 
     if let Some(set_stmt) = try_extract_set(&parse_result) {
-        let pragma_sql = format!("PRAGMA {} = {}", set_stmt.name, set_stmt.value);
-        return Ok(Some(conn.prepare(&pragma_sql)?));
+        let stmt = handle_pg_set(pg_conn, &set_stmt)?;
+        return Ok(Some(stmt));
     }
 
     if let Some(show_stmt) = try_extract_show(&parse_result) {
         let pragma_sql = format!("PRAGMA {}", show_stmt.name);
-        return Ok(Some(conn.prepare(&pragma_sql)?));
+        return Ok(Some(pg_conn.conn.prepare(&pragma_sql)?));
     }
 
     if let Some(stmt) = try_extract_create_schema(&parse_result) {
-        handle_pg_create_schema(conn, &stmt)?;
-        return Ok(Some(noop_statement(conn)?));
+        handle_pg_create_schema(&pg_conn.conn, &stmt)?;
+        return Ok(Some(noop_statement(&pg_conn.conn)?));
     }
 
     if let Some(stmt) = try_extract_drop_schema(&parse_result) {
-        handle_pg_drop_schema(conn, &stmt)?;
-        return Ok(Some(noop_statement(conn)?));
+        handle_pg_drop_schema(&pg_conn.conn, &stmt)?;
+        return Ok(Some(noop_statement(&pg_conn.conn)?));
     }
 
     if is_refresh_matview(&parse_result) {
-        return Ok(Some(noop_statement(conn)?));
+        return Ok(Some(noop_statement(&pg_conn.conn)?));
     }
 
     if is_comment_on(&parse_result) {
-        return Ok(Some(noop_statement(conn)?));
+        return Ok(Some(noop_statement(&pg_conn.conn)?));
     }
 
     if let Some(stmt) = try_extract_copy_from(&parse_result) {
-        let rows_inserted = handle_pg_copy_from(conn, &stmt)?;
-        let stmt = noop_statement(conn)?;
+        let rows_inserted = handle_pg_copy_from(&pg_conn.conn, &stmt)?;
+        let stmt = noop_statement(&pg_conn.conn)?;
         stmt.set_n_change(rows_inserted as i64);
         return Ok(Some(stmt));
     }
@@ -265,6 +298,24 @@ fn noop_statement(conn: &Arc<Connection>) -> Result<Statement> {
 fn execute_sqlite_internal(conn: &Arc<Connection>, sql: impl AsRef<str>) -> Result<()> {
     let mut stmt = conn.prepare_internal(sql)?;
     stmt.run_ignore_rows()
+}
+
+fn handle_pg_set(pg_conn: &Arc<PgConnectionInner>, set_stmt: &PgSetStmt) -> Result<Statement> {
+    if set_stmt.name == "search_path" {
+        let path = set_stmt
+            .values
+            .iter()
+            .map(|value| value.as_search_path_name().map(str::to_owned))
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| LimboError::ParseError("incorrect format".to_string()))?;
+        pg_conn.set_search_path(path);
+        return noop_statement(&pg_conn.conn);
+    }
+    let value = set_stmt.values.first().ok_or_else(|| {
+        LimboError::ParseError(format!("SET {}: no value provided", set_stmt.name))
+    })?;
+    let pragma_sql = format!("PRAGMA {} = {}", set_stmt.name, value.to_sql_string());
+    pg_conn.conn.prepare(&pragma_sql)
 }
 
 fn handle_pg_create_schema(conn: &Arc<Connection>, stmt: &PgCreateSchemaStmt) -> Result<()> {
@@ -340,7 +391,7 @@ fn handle_pg_drop_schema_public(conn: &Arc<Connection>, cascade: bool) -> Result
     }
 
     for table_name in table_names {
-        let mut stmt = prepare_statement(conn, &format!("DROP TABLE \"{table_name}\""))?;
+        let mut stmt = conn.prepare(&format!("DROP TABLE \"{table_name}\""))?;
         stmt.run_ignore_rows()?;
     }
     Ok(())
@@ -348,10 +399,7 @@ fn handle_pg_drop_schema_public(conn: &Arc<Connection>, cascade: bool) -> Result
 
 fn drop_all_tables_in_schema(conn: &Arc<Connection>, schema_name: &str) -> Result<()> {
     for table_name in list_user_tables(conn, Some(schema_name))? {
-        let mut stmt = prepare_statement(
-            conn,
-            &format!("DROP TABLE \"{schema_name}\".\"{table_name}\""),
-        )?;
+        let mut stmt = conn.prepare(&format!("DROP TABLE \"{schema_name}\".\"{table_name}\"",))?;
         stmt.run_ignore_rows()?;
     }
     Ok(())

--- a/postgres/frontend/session.rs
+++ b/postgres/frontend/session.rs
@@ -391,7 +391,7 @@ fn handle_pg_drop_schema_public(conn: &Arc<Connection>, cascade: bool) -> Result
     }
 
     for table_name in table_names {
-        let mut stmt = conn.prepare(&format!("DROP TABLE \"{table_name}\""))?;
+        let mut stmt = conn.prepare(format!("DROP TABLE \"{table_name}\""))?;
         stmt.run_ignore_rows()?;
     }
     Ok(())
@@ -399,7 +399,7 @@ fn handle_pg_drop_schema_public(conn: &Arc<Connection>, cascade: bool) -> Result
 
 fn drop_all_tables_in_schema(conn: &Arc<Connection>, schema_name: &str) -> Result<()> {
     for table_name in list_user_tables(conn, Some(schema_name))? {
-        let mut stmt = conn.prepare(&format!("DROP TABLE \"{schema_name}\".\"{table_name}\"",))?;
+        let mut stmt = conn.prepare(format!("DROP TABLE \"{schema_name}\".\"{table_name}\"",))?;
         stmt.run_ignore_rows()?;
     }
     Ok(())

--- a/postgres/parser/tests/parse_valid.rs
+++ b/postgres/parser/tests/parse_valid.rs
@@ -511,6 +511,40 @@ fn test_analyze_statements() {
 }
 
 #[test]
+fn test_set_search_path_extractor_multi_value() {
+    use turso_pg_parser::translator::try_extract_set;
+    let result = parse("SET search_path TO sp_a_test, sp_b_test").unwrap();
+    let set_stmt = try_extract_set(&result).expect("should extract SET stmt");
+    assert_eq!(set_stmt.name, "search_path");
+    assert_eq!(set_stmt.values.len(), 2, "expected two path entries");
+    assert_eq!(
+        set_stmt.values[0].as_search_path_name(),
+        Some("sp_a_test"),
+        "first entry"
+    );
+    assert_eq!(
+        set_stmt.values[1].as_search_path_name(),
+        Some("sp_b_test"),
+        "second entry"
+    );
+}
+
+#[test]
+fn test_set_search_path_extractor_quoted_literal() {
+    use turso_pg_parser::translator::try_extract_set;
+    // Quoted form: SET search_path TO 'schema_name' is valid PostgreSQL.
+    // as_search_path_name() must return the bare name without SQL quotes.
+    let result = parse("SET search_path TO 'sp_literal_test'").unwrap();
+    let set_stmt = try_extract_set(&result).expect("should extract SET stmt");
+    assert_eq!(set_stmt.values.len(), 1);
+    assert_eq!(
+        set_stmt.values[0].as_search_path_name(),
+        Some("sp_literal_test"),
+        "quoted literal should be returned without quotes"
+    );
+}
+
+#[test]
 fn test_set_statements() {
     let queries = vec![
         "SET search_path TO public, other_schema",

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -4448,12 +4448,71 @@ fn pg_fk_action_to_string(action: &str) -> Option<String> {
     }
 }
 
-/// Deparse a simple default expression from PG protobuf into a SQL string.
-/// Only handles simple literals for now.
-/// Extracted SET statement: `SET name = value`
+/// Represents a parsed SET statement from the PostgreSQL protocol.
 pub struct PgSetStmt {
     pub name: String,
-    pub value: String,
+    pub values: Vec<PgSetValue>,
+}
+
+#[derive(Clone)]
+pub enum PgSetValue {
+    Identifier(String),
+    StringLiteral(String),
+    Number(String),
+    Bool(bool),
+    RawSql(String),
+    Null,
+}
+
+impl PgSetValue {
+    fn from_node(node: &pg_query::protobuf::Node) -> Option<Self> {
+        use pg_query::protobuf::{a_const::Val, node::Node};
+
+        match &node.node {
+            Some(Node::Integer(i)) => Some(Self::Number(i.ival.to_string())),
+            Some(Node::Float(f)) => Some(Self::Number(f.fval.clone())),
+            Some(Node::String(s)) => Some(Self::Identifier(s.sval.clone())),
+            Some(Node::AConst(a_const)) => {
+                if a_const.isnull {
+                    return Some(Self::Null);
+                }
+
+                match a_const.val.as_ref()? {
+                    Val::Ival(i) => Some(Self::Number(i.ival.to_string())),
+                    Val::Fval(f) => Some(Self::Number(f.fval.clone())),
+                    Val::Sval(s) => Some(Self::StringLiteral(s.sval.clone())),
+                    Val::Boolval(b) => Some(Self::Bool(b.boolval)),
+                    Val::Bsval(_) => deparse_default_expr(node).map(Self::RawSql),
+                }
+            }
+            _ => deparse_default_expr(node).map(Self::RawSql),
+        }
+    }
+
+    pub fn to_sql_string(&self) -> String {
+        match self {
+            PgSetValue::Identifier(value) => value.clone(),
+            PgSetValue::StringLiteral(value) => format!("'{}'", value.replace('\'', "''")),
+            PgSetValue::Number(value) => value.clone(),
+            PgSetValue::Bool(value) => {
+                if *value {
+                    "1".to_string()
+                } else {
+                    "0".to_string()
+                }
+            }
+            PgSetValue::Null => "NULL".to_string(),
+            PgSetValue::RawSql(value) => value.clone(),
+        }
+    }
+
+    pub fn as_search_path_name(&self) -> Option<&str> {
+        match self {
+            PgSetValue::Identifier(value) => Some(value),
+            PgSetValue::StringLiteral(value) => Some(value),
+            _ => None,
+        }
+    }
 }
 
 /// Extracted SHOW statement: `SHOW name`
@@ -4482,11 +4541,15 @@ pub fn try_extract_set(parse_result: &ParseResult) -> Option<PgSetStmt> {
     }
 
     // Extract the value from args
-    let value = set_stmt.args.first().and_then(deparse_default_expr)?;
+    let values = set_stmt
+        .args
+        .iter()
+        .map(PgSetValue::from_node)
+        .collect::<Option<Vec<_>>>()?;
 
     Some(PgSetStmt {
         name: set_stmt.name.clone(),
-        value,
+        values,
     })
 }
 


### PR DESCRIPTION
## Description

Adds PostgreSQL frontend support for `SET search_path` when resolving unqualified table names.

The change stores `search_path` as PostgreSQL session state, passes it into statement preparation, and makes table resolution honor the configured schema order. Explicitly qualified names keep their existing
behavior. The resolver also preserves temp-schema priority and maps `public` to the main database.

This also updates the PostgreSQL SET parser helper to support multi-value `search_path` assignments and adds regression coverage for the new behavior.

## Motivation and context

`SET search_path` was already accepted by the PostgreSQL parser, but it did not affect name resolution. As a result, queries like `SELECT * FROM demo` could resolve to whichever attached schema happened to be
found first instead of following PostgreSQL search path semantics.

This makes the PostgreSQL frontend behave closer to Postgres for schema-qualified and unqualified table lookup, especially when multiple schemas contain tables with the same name.

Related to the PostgreSQL frontend TODO for `SET search_path`.

## Description of AI Usage

I used AI for codebase navigation, debugging guidance, and review of the implementation approach and tests. The implementation itself was written and reviewed by me