### PR TITLE
github: Cache Rust toolchain for Codspeed jobs

### DIFF
--- a/.github/actions/setup-rust-toolchain/action.yml
+++ b/.github/actions/setup-rust-toolchain/action.yml
@@ -1,0 +1,39 @@
+name: Setup Rust toolchain (cached)
+description: >
+  Install a pinned Rust toolchain, restoring the rustup installation from the
+  Actions cache when possible. The Blacksmith runner images ship without
+  rustup, so without this cache every job downloads rustup from sh.rustup.rs
+  and the toolchain from static.rust-lang.org, and transient network failures
+  fail the job. With the cache, those hosts are only contacted when the pinned
+  toolchain version changes.
+inputs:
+  toolchain:
+    description: Toolchain version to install (e.g. "1.88.0" or "nightly-2025-12-17")
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Cache rustup toolchain
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/rustup
+          ~/.cargo/bin/cargo
+          ~/.cargo/bin/rustc
+          ~/.rustup/toolchains
+          ~/.rustup/settings.toml
+        key: rustup-${{ runner.os }}-${{ runner.arch }}-${{ inputs.toolchain }}
+
+    - name: Install Rust toolchain
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ inputs.toolchain }}
+
+    - name: Activate cached Rust toolchain
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        "$HOME/.cargo/bin/rustup" default ${{ inputs.toolchain }}

--- a/.github/actions/setup-rust-toolchain/action.yml
+++ b/.github/actions/setup-rust-toolchain/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Install Rust toolchain
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
       with:
         toolchain: ${{ inputs.toolchain }}
 

--- a/.github/workflows/codspeed-memory.yml
+++ b/.github/workflows/codspeed-memory.yml
@@ -22,7 +22,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: ./.github/actions/setup-rust-toolchain
+        with:
+          toolchain: "1.88.0"
 
       - name: Setup mold linker
         uses: rui314/setup-mold@v1
@@ -71,7 +73,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: ./.github/actions/setup-rust-toolchain
+        with:
+          toolchain: "1.88.0"
 
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -38,7 +38,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: ./.github/actions/setup-rust-toolchain
+        with:
+          toolchain: "1.88.0"
 
       - name: Resolve benchmark shards
         id: benchmarks
@@ -75,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: ./.github/actions/setup-rust-toolchain
         with:
           toolchain: ${{ env.TOOLCHAIN_VERSION }}
 
@@ -143,7 +145,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: ./.github/actions/setup-rust-toolchain
         with:
           toolchain: ${{ env.TOOLCHAIN_VERSION }}
 
@@ -216,7 +218,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: ./.github/actions/setup-rust-toolchain
         with:
           toolchain: ${{ env.TOOLCHAIN_VERSION }}
 
@@ -271,7 +273,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: ./.github/actions/setup-rust-toolchain
         with:
           toolchain: ${{ env.TOOLCHAIN_VERSION }}
 


### PR DESCRIPTION
The Blacksmith runner images do not ship rustup, so every CodSpeed job (discover, both builds, and each matrix run job) downloaded rustup from sh.rustup.rs and the toolchain from static.rust-lang.org. Any transient network failure, such as the DNS resolution error that killed a recent run, failed the job.

Add a composite action that restores the rustup installation from the Actions cache keyed by toolchain version and only falls back to dtolnay/rust-toolchain on a cache miss. On a hit, setup is purely local: put ~/.cargo/bin on PATH and select the toolchain with rustup default. The cached rustup shim keeps existing "cargo +<version>" invocations working. rust-lang.org is now only contacted when the pinned toolchain version changes.