### PR TITLE
github: Reclaim Windows runner disk space before cross-platform simulator tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -475,8 +475,20 @@ jobs:
           cache-on-failure: true
       - name: Run Windows concurrent simulator multiprocess regressions
         run: cargo test -q -p turso_whopper --test regression_tests
+      - name: Reclaim Windows runner disk space
+        shell: pwsh
+        run: |
+          Get-PSDrive -PSProvider FileSystem
+          if (Get-Command docker -ErrorAction SilentlyContinue) {
+            docker system prune --all --force
+          }
+          Get-ChildItem -LiteralPath ([System.IO.Path]::GetTempPath()) -Force -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+          Get-PSDrive -PSProvider FileSystem
       - name: Run Windows concurrent simulator cross-platform regression
-        run: cargo test -q -p turso_whopper --test regression_tests_cross_platform
+        # Each test preallocates 8 GiB backing files. Run serially to stay below
+        # the Windows runner's per-job allocation limit.
+        run: cargo test -q -p turso_whopper --test regression_tests_cross_platform -- --test-threads=1
       - name: Run Windows CLI multiprocess VFS regression
         run: cargo test -q -p turso_cli input::tests::experimental_win_iocp_backend_is_available_for_path_databases -- --exact
       - name: Run Windows core multiprocess regressions


### PR DESCRIPTION
The Windows concurrent simulator cross-platform regression tests preallocate 8 GiB backing files each, which can exhaust the Windows runner's disk and per-job allocation limits. Prune docker images and clear the runner temp directory before running them, and run the tests serially so only one backing file is allocated at a time.