### PR TITLE
cli: switch syntect back to crates.io release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,27 +540,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -2191,12 +2176,13 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.11.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
- "bit-set 0.5.3",
- "regex",
+ "bit-set",
+ "regex-automata 0.4.13",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4794,8 +4780,8 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.9.4",
  "num-traits",
  "rand 0.9.4",
@@ -6472,11 +6458,11 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "5.2.0"
-source = "git+https://github.com/trishume/syntect.git?rev=64644ffe064457265cbcee12a0c1baf9485ba6ee#64644ffe064457265cbcee12a0c1baf9485ba6ee"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
- "bitflags 1.3.2",
  "fancy-regex",
  "flate2",
  "fnv",
@@ -6486,7 +6472,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "walkdir",
  "yaml-rust",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -46,7 +46,7 @@ rustyline = { version = "15.0.0", default-features = true, features = [
     "derive",
 ] }
 shlex = "1.3.0"
-syntect = { git = "https://github.com/trishume/syntect.git", rev = "64644ffe064457265cbcee12a0c1baf9485ba6ee", default-features = false, features = ["default-fancy"] }
+syntect = { version = "5.3.0", default-features = false, features = ["default-fancy"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
@@ -77,5 +77,5 @@ stacker = ["turso_core/stacker"]
 test_helper = ["turso_core/test_helper"]
 
 [build-dependencies]
-syntect = { git = "https://github.com/trishume/syntect.git", rev = "64644ffe064457265cbcee12a0c1baf9485ba6ee", default-features = false, features = ["default-fancy"] }
+syntect = { version = "5.3.0", default-features = false, features = ["default-fancy"] }
 include_dir = "0.7"

--- a/postgres/cli/Cargo.toml
+++ b/postgres/cli/Cargo.toml
@@ -25,7 +25,7 @@ clap = { workspace = true, features = ["derive"] }
 comfy-table = "7.1.4"
 dirs = "5.0.1"
 rustyline = { version = "15.0.0", default-features = true, features = ["derive"] }
-syntect = { git = "https://github.com/trishume/syntect.git", rev = "64644ffe064457265cbcee12a0c1baf9485ba6ee", default-features = false, features = ["default-fancy"] }
+syntect = { version = "5.3.0", default-features = false, features = ["default-fancy"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
@@ -51,7 +51,7 @@ io_uring = ["turso_core/io_uring"]
 mimalloc = ["dep:mimalloc"]
 
 [build-dependencies]
-syntect = { git = "https://github.com/trishume/syntect.git", rev = "64644ffe064457265cbcee12a0c1baf9485ba6ee", default-features = false, features = ["default-fancy"] }
+syntect = { version = "5.3.0", default-features = false, features = ["default-fancy"] }
 include_dir = "0.7"
 
 [lints]


### PR DESCRIPTION
The git pin (rev 64644ffe, added in June 2025 for the onig/GCC 15 build fix) forces cargo to clone syntect with its testdata/Packages submodule, so CI randomly fails whenever fetching sublimehq/Packages flakes.

syntect 5.3.0 on crates.io contains the pinned rev (v5.3.0 is 36 commits ahead of it, 0 behind) and ships as a self-contained tarball, so the git clone and submodule fetch disappear entirely. Applies to both tursodb and tursopg, dependencies and build-dependencies alike.

Tests: cargo build -p turso_cli -p tursopg; tursodb answers queries.