### PR TITLE
sync/engine: push-boundary log for exact rebase and push floors

### DIFF
--- a/.claude/skills/cdc/SKILL.md
+++ b/.claude/skills/cdc/SKILL.md
@@ -421,12 +421,20 @@ contract; the client-side pull/push race is what makes cuts predate pushes.
   batch's floor (conditional row UPDATE, abort txn on zero affected rows).
   The row-boundary contract also assumes at most one in-flight push per
   client id — overlapping pushes could commit out of order and regress it.
-- IMPLEMENTED DESIGN (branch sync-confirmed-watermark / PR #8069):
-  `DatabaseMetadata::push_boundaries` — an ordered log of batch-boundary
-  records (sent_gen, sent_last, cur, confirmed), one per pushed batch,
-  persisted BEFORE each send, confirmed on response, translated at each
-  rebase, pruned once an applied cut's boundary reaches it (applied cuts are
-  monotone since pulls are incremental from the client revision). Any
+- IMPLEMENTED DESIGN (branch sync-confirmed-watermark / PR #8069): the
+  local-only internal table `turso_sync_push_boundaries` (next to
+  `turso_sync_last_change_id`) — an ordered log of batch-boundary records
+  (sent_gen, sent_last, cur_pull_gen, cur, confirmed), one per pushed batch,
+  persisted in a small txn BEFORE each send, confirmed on response,
+  translated + rewritten by each rebase next to the final sync-row update,
+  pruned once an applied cut's boundary reaches it (applied cuts are
+  monotone since pulls are incremental from the client revision). WAL-mode
+  flow only (logical MVCC never renumbers). NEVER touch this table
+  mid-apply: creating it there publishes a schema that briefly lacks
+  turso_cdc and breaks concurrent CDC-enabled prepares (this exact failure
+  was caught by the concurrent-actions-consistency JS test). Rows carry
+  cur_pull_gen; stale-numbering rows (crash between rebase commit and the
+  post-rebase rewrite) are dropped on read. Any
   consistent cut names some batch end of ours in its sync row, so the rebase
   replay floor is the exact translation of what the cut provably contains —
   under ANY pull lag; no freshness contract exists (an earlier two-scalar

--- a/.claude/skills/cdc/SKILL.md
+++ b/.claude/skills/cdc/SKILL.md
@@ -421,3 +421,14 @@ contract; the client-side pull/push race is what makes cuts predate pushes.
   batch's floor (conditional row UPDATE, abort txn on zero affected rows).
   The row-boundary contract also assumes at most one in-flight push per
   client id — overlapping pushes could commit out of order and regress it.
+- REPLICA CAVEAT: the pull-freshness contract (pull at time t contains every
+  push confirmed before t) holds trivially single-primary but breaks with
+  lagging read replicas — which silently breaks the gen-mismatch replay floor
+  (local loss of own confirmed writes) AND pending-push resolution in push()
+  ("provably didn't land" needs boundary reads reflecting all own commits).
+  Enforcement path: session token — client pins the commit position
+  (replication_index) of its last confirmed push; replicas serve pulls and
+  boundary reads only at-or-after it. Fallback: trim nothing on gen mismatch
+  (correct, but re-opens O(n²) CDC/WAL growth). Push floor, translation and
+  no-duplicate properties do NOT depend on freshness — only on boundary
+  atomicity and confirmed⇒durable.

--- a/.claude/skills/cdc/SKILL.md
+++ b/.claude/skills/cdc/SKILL.md
@@ -423,12 +423,18 @@ contract; the client-side pull/push race is what makes cuts predate pushes.
   client id — overlapping pushes could commit out of order and regress it.
 - REPLICA CAVEAT: the pull-freshness contract (pull at time t contains every
   push confirmed before t) holds trivially single-primary but breaks with
-  lagging read replicas — which silently breaks the gen-mismatch replay floor
-  (local loss of own confirmed writes) AND pending-push resolution in push()
-  ("provably didn't land" needs boundary reads reflecting all own commits).
-  Enforcement path: session token — client pins the commit position
-  (replication_index) of its last confirmed push; replicas serve pulls and
-  boundary reads only at-or-after it. Fallback: trim nothing on gen mismatch
-  (correct, but re-opens O(n²) CDC/WAL growth). Push floor, translation and
-  no-duplicate properties do NOT depend on freshness — only on boundary
+  lagging read replicas — silently breaking the gen-mismatch replay floor
+  (local loss of own confirmed writes). Pending-push resolution in push()
+  also needs boundary reads reflecting all own commits (read the primary —
+  it's the write path anyway). The contract is NOT fundamental: it is what
+  lets two scalars (confirmed + pending) suffice. Lag-proof generalization:
+  keep an ordered log of batch-boundary records (sent_gen, sent_last, cur) —
+  the shape of pending_push — one per pushed batch, translated at each
+  rebase, pruned once an applied cut's boundary reaches it (applied cuts are
+  monotone since pulls are incremental from the client revision). Any
+  consistent cut names some batch end of ours, so the replay floor becomes
+  the exact translation of what the cut provably contains, under any lag;
+  the issue-time snapshot and the freshness assert then disappear. Log size
+  is bounded by the replication-lag window. Push floor, translation and
+  no-duplicate properties never depended on freshness — only on boundary
   atomicity and confirmed⇒durable.

--- a/.claude/skills/cdc/SKILL.md
+++ b/.claude/skills/cdc/SKILL.md
@@ -412,3 +412,12 @@ contract; the client-side pull/push race is what makes cuts predate pushes.
   against the dev server; the pathology needs concurrent `pull()`/`push()`
   loops (see `concurrent-updates` test in
   `bindings/javascript/sync/packages/*/promise.test.ts`).
+- KNOWN PROTOCOL GAP (as of July 2026): an HTTP-layer retry (`retryFetch`)
+  that re-delivers a push batch whose response was lost re-APPLIES the data
+  later in the server order — the sync row stays correct (same value
+  rewritten) but the duplicate apply can clobber other clients' interleaved
+  writes, one level below what `pending_push` can see. Fix requires a
+  server-side guard: apply a batch only when the sync row still equals the
+  batch's floor (conditional row UPDATE, abort txn on zero affected rows).
+  The row-boundary contract also assumes at most one in-flight push per
+  client id — overlapping pushes could commit out of order and regress it.

--- a/.claude/skills/cdc/SKILL.md
+++ b/.claude/skills/cdc/SKILL.md
@@ -421,20 +421,20 @@ contract; the client-side pull/push race is what makes cuts predate pushes.
   batch's floor (conditional row UPDATE, abort txn on zero affected rows).
   The row-boundary contract also assumes at most one in-flight push per
   client id — overlapping pushes could commit out of order and regress it.
-- REPLICA CAVEAT: the pull-freshness contract (pull at time t contains every
-  push confirmed before t) holds trivially single-primary but breaks with
-  lagging read replicas — silently breaking the gen-mismatch replay floor
-  (local loss of own confirmed writes). Pending-push resolution in push()
-  also needs boundary reads reflecting all own commits (read the primary —
-  it's the write path anyway). The contract is NOT fundamental: it is what
-  lets two scalars (confirmed + pending) suffice. Lag-proof generalization:
-  keep an ordered log of batch-boundary records (sent_gen, sent_last, cur) —
-  the shape of pending_push — one per pushed batch, translated at each
+- IMPLEMENTED DESIGN (branch sync-confirmed-watermark / PR #8069):
+  `DatabaseMetadata::push_boundaries` — an ordered log of batch-boundary
+  records (sent_gen, sent_last, cur, confirmed), one per pushed batch,
+  persisted BEFORE each send, confirmed on response, translated at each
   rebase, pruned once an applied cut's boundary reaches it (applied cuts are
   monotone since pulls are incremental from the client revision). Any
-  consistent cut names some batch end of ours, so the replay floor becomes
-  the exact translation of what the cut provably contains, under any lag;
-  the issue-time snapshot and the freshness assert then disappear. Log size
-  is bounded by the replication-lag window. Push floor, translation and
-  no-duplicate properties never depended on freshness — only on boundary
-  atomicity and confirmed⇒durable.
+  consistent cut names some batch end of ours in its sync row, so the rebase
+  replay floor is the exact translation of what the cut provably contains —
+  under ANY pull lag; no freshness contract exists (an earlier two-scalar
+  revision needed one; it was unverifiable on gen mismatch and replica-
+  hostile). Unconfirmed records (response lost) are resolved against the
+  live boundary read at the next push, or by a cut naming them. Pending-
+  resolution boundary reads must reflect all own commits (read the primary —
+  it's the write path anyway). Log capped (PUSH_BOUNDARIES_LIMIT); dropping
+  old confirmed records only costs extra replay for pulls staler than the
+  whole log. Raw page-replay paths can't translate per change: log collapses
+  to the newest confirmed record with the acknowledge-all watermark.

--- a/.claude/skills/cdc/SKILL.md
+++ b/.claude/skills/cdc/SKILL.md
@@ -339,3 +339,76 @@ Run: `cargo test -- test_cdc` (integration) or `cargo test -p turso_sync_engine 
 10. **Backward-compatible version detection.** Pre-existing v1 CDC tables (without `turso_cdc_version`) are detected by checking table existence before creation. Existing tables get `CdcVersion::V1` inserted into the version table.
 11. **Typed version enum.** `CdcVersion` enum with `#[repr(u8)]` and `Ord`/`PartialOrd` enables feature gating via integer comparison (`has_commit_record()` = `self >= V2`). `Display`/`FromStr` handles database round-trip.
 12. **CDC and MVCC mutual exclusion.** Enabling CDC when MVCC is active (or vice versa) returns an error. Checked at PRAGMA set time and journal mode switch time.
+
+## Sync Engine Watermark Bookkeeping (pull generations, floors, rebase)
+
+Learned from analyzing PR #8065 (quadratic pull/push under continuous bidirectional
+sync) and implementing the confirmed-watermark/pending-push fix. Key facts:
+
+### Coordinate system
+- CDC `change_id`s are **epoch-local**: every pull rebase drops `turso_cdc`
+  (the remote apply replaces the DB content) and rebuilds it by re-capturing
+  replayed local changes, which **renumbers** all ids. The *pull generation*
+  (`pull_gen`) is the epoch counter; ids from different generations are not
+  comparable. Renumbering is unavoidable in general: logical remote apply can
+  emit its own CDC rows below the re-captured ones, and `use_transform` can
+  map one old change to 0..k new rows (`Skip`/`Rewrite`).
+- The **sync row** (`turso_sync_last_change_id`, per client) exists locally
+  and remotely. The remote row is written **atomically with each push batch**
+  (`send_push_batch` bundles data + `TURSO_SYNC_UPSERT_LAST_CHANGE_ID` +
+  COMMIT into one hrana batch) — it is the authoritative record of what the
+  server applied. The local row is written by the rebase (`gen+1`, translated
+  acknowledged boundary).
+
+### Two floors with different meanings — never conflate them
+- **Push floor** = "what the server has". Sources: live remote row read
+  (`fetch_last_change_id`, same-gen only), persisted confirmed watermark,
+  resolved pending push.
+- **Replay floor** (rebase) = "what the *pulled state being applied* contains".
+  A push confirmed **after the pull request was issued** may be absent from the
+  pulled state: its changes must be REPLAYED (not skipped), yet must NOT be
+  re-pushed. Hence: replay floor uses the **issue-time** confirmed snapshot
+  (`DbChangesStatus::confirmed_at_issue`), while translation of the
+  not-to-be-re-pushed boundary uses the **apply-time** confirmed value.
+- Boundary translation across a renumbering is only possible **during the
+  rebase replay loop**, where old ids and freshly captured new ids coexist:
+  track `max_local_change_id()` after replaying each change whose old id is at
+  or below the boundary.
+
+### Failure modes this bookkeeping prevents
+- **O(n²) sync**: on any gen mismatch both floors used to collapse to 0 →
+  every push re-sent the whole CDC history and every rebase re-captured it
+  (WAL grows without bound). Gen mismatch is the *steady state* when pull and
+  push run as independent loops (JS bindings do exactly that; the pull's cut
+  races the in-flight push).
+- **Duplicate apply**: re-pushing an already-applied batch re-applies stale row
+  images *later in the server order* and can clobber other clients' newer
+  writes. Duplicate replay is NOT idempotent under concurrency — never assume
+  it is safe.
+- **Failed-but-applied push**: response lost but server applied the batch. Must
+  be recorded (`DatabaseMetadata::pending_push`) BEFORE the request leaves,
+  with frozen send-time `(pull_gen, last_change_id)`; resolved later by
+  comparing the server row against the frozen coordinates (valid across any
+  number of rebases). Batches are atomic server-side, so `row >= sent_last`
+  ⟺ landed.
+
+### Server contract (load-bearing, assert it)
+A pull issued at time t must return state containing every push this client
+confirmed before t. Checkable only when the pulled row is same-gen
+(`pulled row >= confirmed_at_issue`, else protocol error); the gen-mismatch
+branch trusts it blindly. The dev sync server (`cli/sync_server.rs`) serves
+cuts pinned at request-arrival `wal_state().max_frame`, so it satisfies the
+contract; the client-side pull/push race is what makes cuts predate pushes.
+
+### Misc sharp edges
+- A replayed DELETE over a row absent from the pulled state captures NOTHING —
+  old→new id mapping has holes; boundary tracking must simply not advance
+  (this is also why `preserve_local_replay_floor` clamps the local row for
+  deletes).
+- Transform `Skip` entries never reach the server but are real local changes:
+  the remote row only advances past non-skipped ids; do not confirm past a
+  skipped entry's id ahead of its surrounding pushes.
+- `sync()` = push-then-pull sequentially and cannot produce gen mismatch
+  against the dev server; the pathology needs concurrent `pull()`/`push()`
+  loops (see `concurrent-updates` test in
+  `bindings/javascript/sync/packages/*/promise.test.ts`).

--- a/bindings/javascript/sync/packages/native/promise.test.ts
+++ b/bindings/javascript/sync/packages/native/promise.test.ts
@@ -1259,3 +1259,131 @@ test('push failure leaves server state on transaction boundary', async ({ server
     const rows = await (await db2.prepare('SELECT x FROM q ORDER BY x')).all();
     expect(rows).toEqual([{ x: 0 }, { x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }]);
 })
+
+// Rebase racing an in-flight push: the pull below is issued (and its state is
+// cut on the server) BEFORE the racing push lands, but applied after the push
+// confirmed. The rebase must still replay the racing change locally (the
+// pulled state lacks it), and the next push must NOT re-send it — a re-sent
+// row image is applied later in the server order and clobbers other clients'
+// newer writes.
+test('pull racing a push must not re-push confirmed changes', { timeout: 30000 }, async ({ server }) => {
+    let releaseHeldPull = () => { };
+    let heldPull: Promise<void> | null = null;
+    const racingFetch: typeof fetch = async (input, init) => {
+        if (heldPull !== null && input.toString().includes('/pull-updates')) {
+            const gate = heldPull;
+            heldPull = null;
+            const response = fetch(input, init); // the request reaches the server NOW
+            await gate;                          // the response is parked until released
+            return response;
+        }
+        return fetch(input, init);
+    };
+
+    const a = await connect({ path: ':memory:', url: server.dbUrl(), fetch: racingFetch });
+    await a.exec("CREATE TABLE IF NOT EXISTS race(k TEXT PRIMARY KEY, v)");
+    await a.exec("DELETE FROM race");
+    await a.exec("INSERT INTO race VALUES ('k', 'a1')");
+    await a.push();
+    await a.pull();
+
+    // another client pushes anything: its sync-row update rewrites the shared
+    // sync bookkeeping page server-side, so A's parked pull below ships that
+    // page and re-materializes A's row in its pre-rebase generation
+    const b = await connect({ path: ':memory:', url: server.dbUrl() });
+    await b.exec("INSERT INTO race VALUES ('seed', 's')");
+    await b.push();
+
+    await a.exec("UPDATE race SET v = 'a2' WHERE k = 'k'");
+
+    heldPull = new Promise<void>(resolve => { releaseHeldPull = resolve; });
+    const parkedPull = a.pull();
+    await new Promise(resolve => setTimeout(resolve, 200)); // let the pull request reach the server first
+    await a.push();                                         // confirmed AFTER the pull was issued
+    releaseHeldPull();
+    await parkedPull;                                       // rebase onto the pre-push state
+
+    // the rebase must keep A's own committed write visible locally
+    expect(await (await a.prepare("SELECT v FROM race WHERE k = 'k'")).all()).toEqual([{ v: 'a2' }]);
+
+    // another client overwrites the row...
+    await b.pull();
+    await b.exec("UPDATE race SET v = 'b3' WHERE k = 'k'");
+    await b.push();
+
+    // ...and A's next push must not clobber it with the stale 'a2' image
+    await a.push();
+    await b.pull();
+    expect(await (await b.prepare("SELECT v FROM race WHERE k = 'k'")).all()).toEqual([{ v: 'b3' }]);
+    await a.close();
+    await b.close();
+})
+
+// A push whose response is lost after the server applied it ("failed-but-
+// applied") must not be re-sent once a rebase renumbers the CDC: the server
+// already applied the batch, and a duplicate would land later in the server
+// order, resurrecting stale values over other clients' newer writes.
+test('lost push response must not re-apply the batch after a rebase', { timeout: 30000 }, async ({ server }) => {
+    let releaseHeldPull = () => { };
+    let heldPull: Promise<void> | null = null;
+    let losePushResponse = false;
+    const faultyFetch: typeof fetch = async (input, init) => {
+        if (heldPull !== null && input.toString().includes('/pull-updates')) {
+            const gate = heldPull;
+            heldPull = null;
+            const response = fetch(input, init);
+            await gate;
+            return response;
+        }
+        if (losePushResponse && init?.method === 'POST' && input.toString().endsWith('/v2/pipeline')) {
+            const body = init.body ? new TextDecoder().decode(init.body as Uint8Array) : '';
+            if (body.includes('BEGIN IMMEDIATE')) {
+                losePushResponse = false;
+                await fetch(input, init); // the server applies the batch...
+                // ...but the client never learns about it
+                return new Response('injected: push response lost', { status: 500 });
+            }
+        }
+        return fetch(input, init);
+    };
+
+    const a = await connect({ path: ':memory:', url: server.dbUrl(), fetch: faultyFetch });
+    await a.exec("CREATE TABLE IF NOT EXISTS lost(k TEXT PRIMARY KEY, v)");
+    await a.exec("DELETE FROM lost");
+    await a.exec("INSERT INTO lost VALUES ('k', 'a1')");
+    await a.push();
+    await a.pull();
+
+    const b = await connect({ path: ':memory:', url: server.dbUrl() });
+    await b.exec("INSERT INTO lost VALUES ('seed', 's')");
+    await b.push();
+
+    // the lost batch carries an update and a delete: the delete exercises
+    // re-capture holes during the rebase replay (a replayed delete over an
+    // absent row captures nothing)
+    await a.exec("UPDATE lost SET v = 'a2' WHERE k = 'k'");
+    await a.exec("INSERT INTO lost VALUES ('tmp', 'x')");
+    await a.exec("DELETE FROM lost WHERE k = 'tmp'");
+
+    heldPull = new Promise<void>(resolve => { releaseHeldPull = resolve; });
+    const parkedPull = a.pull();
+    await new Promise(resolve => setTimeout(resolve, 200));
+    losePushResponse = true;
+    await expect(a.push()).rejects.toThrow(); // applied server-side, response lost
+    releaseHeldPull();
+    await parkedPull;                         // rebase onto the pre-push state
+
+    expect(await (await a.prepare("SELECT v FROM lost WHERE k = 'k'")).all()).toEqual([{ v: 'a2' }]);
+
+    await b.pull();
+    await b.exec("UPDATE lost SET v = 'b3' WHERE k = 'k'");
+    await b.push();
+
+    // A's next push must discover that the lost batch landed and send nothing
+    await a.push();
+    await b.pull();
+    expect(await (await b.prepare("SELECT v FROM lost WHERE k = 'k'")).all()).toEqual([{ v: 'b3' }]);
+    expect(await (await b.prepare("SELECT count(*) AS cnt FROM lost WHERE k = 'tmp'")).all()).toEqual([{ cnt: 0 }]);
+    await a.close();
+    await b.close();
+})

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -103,11 +103,12 @@ mod tests {
         create_replace_base_marker_path, create_revert_db_wal_path,
         ensure_stream_kind_can_use_legacy_page_apply, logical_mvcc_pull_disable_reason,
         replace_base_backup_path, resolve_local_replay_floor_change_id,
-        should_replay_raw_pages_on_sql_conn, should_request_logical_pull,
-        should_use_logical_mvcc_pull, stream_kind_applies_remote_pages,
-        stream_kind_for_pull_updates_v1_result, synced_change_id_after_remote_apply,
-        use_pushed_change_hint_for_local_replay, DatabaseSyncEngine, DatabaseSyncEngineOpts,
-        ReplaceBaseApplyGuard, REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
+        resolve_pending_push_update, should_replay_raw_pages_on_sql_conn,
+        should_request_logical_pull, should_use_logical_mvcc_pull,
+        stream_kind_applies_remote_pages, stream_kind_for_pull_updates_v1_result,
+        synced_change_id_after_remote_apply, use_pushed_change_hint_for_local_replay,
+        DatabaseSyncEngine, DatabaseSyncEngineOpts, PendingPushUpdate, ReplaceBaseApplyGuard,
+        REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
     };
     use crate::{
         client_proto::{
@@ -319,7 +320,7 @@ mod tests {
             DbChangesStreamKind::Pages,
             false
         ));
-        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), 7, 34);
+        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), None, 7, 34);
         assert_eq!(floor, Some(12));
     }
 
@@ -329,20 +330,84 @@ mod tests {
             DbChangesStreamKind::LegacyPages,
             false
         ));
-        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), 7, 34);
+        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), None, 7, 34);
         assert_eq!(floor, Some(34));
     }
 
     #[test]
     fn local_replay_ignores_last_pushed_hint_from_stale_pull_generation() {
-        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), 6, 34);
+        let floor = resolve_local_replay_floor_change_id(true, 7, 7, Some(12), None, 6, 34);
         assert_eq!(floor, Some(12));
     }
 
     #[test]
     fn raw_wal_replay_preserves_existing_floor_when_hints_are_disabled() {
-        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), 7, 34);
+        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), None, 7, 34);
         assert_eq!(floor, Some(12));
+    }
+
+    #[test]
+    fn local_replay_floor_falls_back_to_confirmed_watermark_on_pull_gen_mismatch() {
+        // without the watermark a stale sync row collapses the floor to
+        // nothing and the whole CDC history is re-captured on every rebase
+        let floor = resolve_local_replay_floor_change_id(false, 7, 6, Some(12), None, 0, 0);
+        assert_eq!(floor, None);
+        // the issue-time confirmed watermark carries the floor across the
+        // generation mismatch: everything it covers was confirmed before the
+        // pull was issued, so the pulled state contains it
+        let floor = resolve_local_replay_floor_change_id(false, 7, 6, Some(12), Some(20), 0, 0);
+        assert_eq!(floor, Some(20));
+    }
+
+    #[test]
+    fn local_replay_floor_uses_max_of_sync_row_and_confirmed_watermark() {
+        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), Some(20), 0, 0);
+        assert_eq!(floor, Some(20));
+        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(25), Some(20), 0, 0);
+        assert_eq!(floor, Some(25));
+    }
+
+    #[test]
+    fn pending_push_kept_when_apply_does_not_renumber_cdc() {
+        assert!(matches!(
+            resolve_pending_push_update(true, false, true, 7, 5, false),
+            PendingPushUpdate::Keep
+        ));
+        assert!(matches!(
+            resolve_pending_push_update(false, false, false, 7, 0, true),
+            PendingPushUpdate::Keep
+        ));
+    }
+
+    #[test]
+    fn pending_push_cleared_when_landed_or_untranslatable() {
+        // proven landed by the pulled state: folded into the confirmed
+        // watermark, the record itself is finished
+        assert!(matches!(
+            resolve_pending_push_update(true, true, true, 7, 5, true),
+            PendingPushUpdate::Clear
+        ));
+        // renumbered without per-change translation (raw page replay): the
+        // boundary cannot be carried over
+        assert!(matches!(
+            resolve_pending_push_update(true, false, false, 7, 0, true),
+            PendingPushUpdate::Clear
+        ));
+    }
+
+    #[test]
+    fn pending_push_translated_into_post_rebase_numbering() {
+        assert!(matches!(
+            resolve_pending_push_update(true, false, true, 7, 5, true),
+            PendingPushUpdate::Translate((8, 5))
+        ));
+        // a pending batch whose changes re-captured nothing (e.g. deletes
+        // replayed over rows absent from the pulled state) translates to a
+        // zero boundary: nothing re-pushable came out of it
+        assert!(matches!(
+            resolve_pending_push_update(true, false, true, 7, 0, true),
+            PendingPushUpdate::Translate((8, 0))
+        ));
     }
 
     #[test]
@@ -835,6 +900,9 @@ mod tests {
             last_pushed_pull_gen_hint: 0,
             last_pushed_change_id_hint: 0,
             last_pushed_replay_floor_change_id_hint: 0,
+            confirmed_pull_gen: 0,
+            confirmed_change_id: 0,
+            pending_push: None,
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
@@ -984,6 +1052,9 @@ mod tests {
             last_pushed_pull_gen_hint: 0,
             last_pushed_change_id_hint: 0,
             last_pushed_replay_floor_change_id_hint: 0,
+            confirmed_pull_gen: 0,
+            confirmed_change_id: 0,
+            pending_push: None,
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
@@ -1013,6 +1084,7 @@ mod tests {
             revision: DatabasePullRevision::V1 {
                 revision: "g1:o2".to_string(),
             },
+            confirmed_at_issue: (0, 0),
             file_slot: Some(crate::database_sync_operations::MutexSlot {
                 value: changes_file,
                 slot,
@@ -1158,6 +1230,9 @@ mod tests {
             last_pushed_pull_gen_hint: 0,
             last_pushed_change_id_hint: 0,
             last_pushed_replay_floor_change_id_hint: 0,
+            confirmed_pull_gen: 0,
+            confirmed_change_id: 0,
+            pending_push: None,
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
@@ -1187,6 +1262,7 @@ mod tests {
             revision: DatabasePullRevision::V1 {
                 revision: "g1:o2".to_string(),
             },
+            confirmed_at_issue: (0, 0),
             file_slot: Some(crate::database_sync_operations::MutexSlot {
                 value: changes_file,
                 slot: Arc::new(Mutex::new(None)),
@@ -1369,6 +1445,7 @@ mod tests {
                                 secs: 10,
                                 micros: 0,
                             },
+                            confirmed_at_issue: (0, 0),
                             revision: new_revision.clone(),
                             file_slot: Some(file_slot),
                             stream_kind: DbChangesStreamKind::ReplaceBasePages,
@@ -2210,18 +2287,78 @@ fn should_replay_raw_pages_on_sql_conn(
         )
 }
 
+/// Outcome of applying one batch of remote changes to the local database.
+struct AppliedRemoteChanges {
+    revert_since_wal_watermark: u64,
+    logical_table_names_by_stable_id: BTreeMap<u64, String>,
+    followup_revision: Option<DatabasePullRevision>,
+    /// Confirmed watermark `(pull_gen, change_id)` translated into the
+    /// post-rebase numbering; mirrored into the metadata by the caller.
+    /// `None` when the apply did not renumber the CDC.
+    confirmed_watermark: Option<(i64, i64)>,
+    /// What the caller must do with `DatabaseMetadata::pending_push`.
+    pending_push_update: PendingPushUpdate,
+}
+
+enum PendingPushUpdate {
+    /// the apply did not renumber the CDC - the record stays valid as is
+    Keep,
+    /// the record was folded into the confirmed watermark (the pulled state
+    /// proved the batch landed) or cannot be translated - forget it
+    Clear,
+    /// the apply renumbered the CDC - `cur` becomes this `(pull_gen,
+    /// change_id)` boundary
+    Translate((i64, i64)),
+}
+
+/// Decide what happens to `DatabaseMetadata::pending_push` after an apply.
+/// `renumbered` says whether this apply re-numbered the CDC (bumped the local
+/// pull generation) - if it did not, the record stays valid as is.
+fn resolve_pending_push_update(
+    pending_push_exists: bool,
+    pending_push_proven_landed: bool,
+    pending_translated: bool,
+    local_pull_gen: i64,
+    translated_pending_cur: i64,
+    renumbered: bool,
+) -> PendingPushUpdate {
+    if !pending_push_exists || !renumbered {
+        PendingPushUpdate::Keep
+    } else if pending_push_proven_landed || !pending_translated {
+        // proven landed: already folded into the confirmed watermark;
+        // otherwise the boundary cannot be carried across the renumbering
+        // and forgetting it only means a conservative re-push resolution
+        PendingPushUpdate::Clear
+    } else {
+        PendingPushUpdate::Translate((local_pull_gen + 1, translated_pending_cur))
+    }
+}
+
 fn resolve_local_replay_floor_change_id(
     use_pushed_change_hint: bool,
     local_pull_gen: i64,
     remote_pull_gen: i64,
     remote_last_change_id: Option<i64>,
+    confirmed_at_issue_change_id: Option<i64>,
     last_pushed_pull_gen_hint: i64,
     last_pushed_change_id_hint: i64,
 ) -> Option<i64> {
+    // `confirmed_at_issue_change_id` is the confirmed watermark snapshotted
+    // when the pull request was issued (already validated by the caller to be
+    // in the local numbering). Every push it covers was confirmed before the
+    // pull left, so the pulled state contains those changes and they must not
+    // be replayed. When the remote sync row belongs to an older generation its
+    // ids are not comparable and the watermark is the only usable floor -
+    // without it the floor collapses to zero and the entire CDC history is
+    // re-captured (and later re-pushed) on every pull whose state predates
+    // this client's latest push.
     let mut last_change_id = if remote_pull_gen == local_pull_gen {
-        remote_last_change_id
+        match (remote_last_change_id, confirmed_at_issue_change_id) {
+            (Some(remote), Some(confirmed)) => Some(remote.max(confirmed)),
+            (remote, confirmed) => remote.or(confirmed),
+        }
     } else {
-        Some(0)
+        confirmed_at_issue_change_id
     };
 
     if use_pushed_change_hint
@@ -2346,6 +2483,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     last_pushed_change_id_hint: 0,
                     last_pushed_pull_gen_hint: 0,
                     last_pushed_replay_floor_change_id_hint: 0,
+                    confirmed_pull_gen: 0,
+                    confirmed_change_id: 0,
+                    pending_push: None,
                     last_pull_unix_time: Some(io.current_time_wall_clock().secs),
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: if partial {
@@ -2393,6 +2533,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     last_pushed_change_id_hint: 0,
                     last_pushed_pull_gen_hint: 0,
                     last_pushed_replay_floor_change_id_hint: 0,
+                    confirmed_pull_gen: 0,
+                    confirmed_change_id: 0,
+                    pending_push: None,
                     last_pull_unix_time: None,
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: None,
@@ -2907,6 +3050,15 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
         let now = self.io.current_time_wall_clock();
         let revision = self.meta().synced_revision.clone();
+        // Snapshot the confirmed watermark BEFORE the pull request leaves: the
+        // pulled state is guaranteed to contain only pushes confirmed before
+        // the request was issued. A push confirmed while the pull is in flight
+        // may be absent from the response, and the rebase must replay its
+        // changes rather than skip them.
+        let confirmed_at_issue = {
+            let meta = self.meta();
+            (meta.confirmed_pull_gen, meta.confirmed_change_id)
+        };
         let ctx = &SyncOperationCtx::new(
             coro,
             &self.sync_engine_io,
@@ -3012,6 +3164,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 revision: next_revision,
                 file_slot: None,
                 stream_kind,
+                confirmed_at_issue,
             });
         }
 
@@ -3027,6 +3180,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             revision: next_revision,
             file_slot: Some(file),
             stream_kind,
+            confirmed_at_issue,
         })
     }
 
@@ -3076,10 +3230,16 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 &changes_file,
                 remote_changes.stream_kind,
                 &remote_changes.revision,
+                remote_changes.confirmed_at_issue,
             )
             .await;
-        let Ok((revert_since_wal_watermark, logical_table_names_by_stable_id, followup_revision)) =
-            pull_result
+        let Ok(AppliedRemoteChanges {
+            revert_since_wal_watermark,
+            logical_table_names_by_stable_id,
+            followup_revision,
+            confirmed_watermark,
+            pending_push_update,
+        }) = pull_result
         else {
             return Err(pull_result.err().unwrap());
         };
@@ -3102,6 +3262,20 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             m.last_pushed_replay_floor_change_id_hint = 0;
             m.last_pull_unix_time = Some(remote_changes.time.secs);
             m.logical_table_names_by_stable_id = logical_table_names_by_stable_id;
+            if let Some((pull_gen, change_id)) = confirmed_watermark {
+                m.confirmed_pull_gen = pull_gen;
+                m.confirmed_change_id = change_id;
+            }
+            match pending_push_update {
+                PendingPushUpdate::Keep => {}
+                PendingPushUpdate::Clear => m.pending_push = None,
+                PendingPushUpdate::Translate((pull_gen, change_id)) => {
+                    if let Some(pending) = &mut m.pending_push {
+                        pending.cur_pull_gen = pull_gen;
+                        pending.cur_change_id = change_id;
+                    }
+                }
+            }
         })
         .await?;
         Ok(())
@@ -3190,6 +3364,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 local_pull_gen,
                 local_pull_gen,
                 local_last_change_id,
+                None,
                 last_pushed_pull_gen_hint,
                 last_pushed_change_id_hint,
             );
@@ -3340,7 +3515,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         changes_file: &Arc<dyn turso_core::File>,
         stream_kind: DbChangesStreamKind,
         remote_revision: &DatabasePullRevision,
-    ) -> Result<(u64, BTreeMap<u64, String>, Option<DatabasePullRevision>)> {
+        confirmed_at_issue: (i64, i64),
+    ) -> Result<AppliedRemoteChanges> {
         tracing::info!("apply_changes(path={})", self.main_db_path);
 
         let (_, watermark) = self.checkpoint_passive(coro).await?;
@@ -3398,6 +3574,29 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 meta.last_pushed_change_id_hint,
             )
         };
+        // The issue-time snapshot bounds the replay floor (a push confirmed
+        // while the pull was in flight may be absent from the pulled state);
+        // the live values bound what must not be re-pushed and are translated
+        // into the new numbering during the local replay below. Both are only
+        // meaningful while still expressed in the current local numbering.
+        let confirmed_at_issue_change_id = (confirmed_at_issue.0 == local_pull_gen
+            && confirmed_at_issue.1 > 0)
+            .then_some(confirmed_at_issue.1);
+        let (confirmed_at_apply_change_id, pending_push, pending_push_exists) = {
+            let meta = self.meta();
+            let confirmed = (meta.confirmed_pull_gen == local_pull_gen
+                && meta.confirmed_change_id > 0)
+                .then_some(meta.confirmed_change_id);
+            let exists = meta.pending_push.is_some();
+            // a record whose translated boundary is no longer in the current
+            // numbering cannot be carried across this rebase - it will be
+            // cleared below
+            let pending = meta
+                .pending_push
+                .clone()
+                .filter(|p| p.cur_pull_gen == local_pull_gen);
+            (confirmed, pending, exists)
+        };
 
         // read schema version after initiating WAL session (in order to read it with consistent max_frame_no)
         // note, that as we initiated WAL session earlier - no changes can be made in between and we will have consistent race-free view of schema version
@@ -3421,6 +3620,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     local_pull_gen,
                     local_pull_gen,
                     local_last_change_id,
+                    None,
                     last_pushed_pull_gen_hint,
                     last_pushed_change_id_hint,
                 )
@@ -3482,11 +3682,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             None
         };
 
-        let apply_result: Result<(
-            u64,
-            BTreeMap<u64, String>,
-            Option<DatabasePullRevision>,
-        )> = async {
+        let apply_result: Result<AppliedRemoteChanges> = async {
             let mut main_session = Some(DatabaseWalSession::new(coro, main_session).await?);
 
             // Phase 1 (start): rollback local changes from the WAL
@@ -3829,11 +4025,29 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     "protocol error: remote_pull_gen > local_pull_gen: {remote_pull_gen} > {local_pull_gen}"
                 )));
             }
+            // CONTRACT: a pull issued at time t returns state containing every
+            // push this client confirmed before t. Only this client's pushes
+            // write its sync row, so when the pulled row is in the current
+            // generation it must be at or above the issue-time confirmed
+            // watermark; a lower value means the server served state that lost
+            // acknowledged pushes, and skipping/replaying based on it would
+            // silently lose or duplicate data.
+            if remote_pull_gen == local_pull_gen {
+                if let Some(confirmed) = confirmed_at_issue_change_id {
+                    let remote_id = remote_last_change_id.unwrap_or(0);
+                    if remote_id < confirmed {
+                        return Err(Error::DatabaseSyncEngineError(format!(
+                            "protocol error: pulled state sync row ({remote_pull_gen}, {remote_id}) is behind the confirmed watermark ({local_pull_gen}, {confirmed})"
+                        )));
+                    }
+                }
+            }
             let last_change_id = resolve_local_replay_floor_change_id(
                 use_pushed_change_hint,
                 local_pull_gen,
                 remote_pull_gen,
                 remote_last_change_id,
+                confirmed_at_issue_change_id,
                 last_pushed_pull_gen_hint,
                 last_pushed_change_id_hint,
             );
@@ -3892,6 +4106,35 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             let replayed_local_changes = !local_changes.is_empty();
             let recaptured_local_changes = replayed_local_changes;
             let mut preserve_local_replay_floor = None;
+            // Pre-rebase-numbering watermark of replayed changes whose effect
+            // is known to be applied on the remote: everything the live
+            // confirmed watermark covers, plus a pending push that the pulled
+            // state itself proves landed (its frozen send-time coordinates are
+            // comparable against the pulled sync row regardless of the local
+            // generation). Re-captured changes at or below this watermark get
+            // new CDC ids that must not be pushed again, so the highest new id
+            // they produce is tracked below as the translated watermark.
+            let mut pending_push_proven_landed = false;
+            let confirmed_watermark_old = {
+                let mut watermark = replay_floor.max(confirmed_at_apply_change_id.unwrap_or(0));
+                if let Some(pending) = &pending_push {
+                    if remote_pull_gen == pending.sent_pull_gen
+                        && remote_last_change_id.unwrap_or(0) >= pending.sent_last_change_id
+                    {
+                        watermark = watermark.max(pending.cur_change_id);
+                        pending_push_proven_landed = true;
+                    }
+                }
+                watermark
+            };
+            let mut translated_confirmed: i64 = 0;
+            let mut translated_pending_cur: i64 = 0;
+            // set when the local replay re-captured changes with per-change
+            // boundary tracking, i.e. the translated_* values above are exact
+            let mut local_replay_translation_ran = false;
+            // (pull_gen, change_id) confirmed watermark as persisted into the
+            // local sync row by this apply, in the post-rebase numbering
+            let mut confirmed_watermark: Option<(i64, i64)> = None;
             tracing::info!(
                 "apply_changes(path={}): collected {} changes, skipped_internal_local_changes={}",
                 self.main_db_path,
@@ -3933,6 +4176,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         ))
                     })
                     .inspect_err(|e| tracing::error!("update_last_change_id failed: {e}"))?;
+                    confirmed_watermark = Some((local_pull_gen + 1, 0));
                 }
 
                 let mut cdc_enabled_for_local_replay = false;
@@ -3999,6 +4243,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 for (i, change) in local_changes.into_iter().enumerate() {
                     let preserve_original_change_floor =
                         matches!(&change.change, DatabaseTapeRowChangeType::Delete { .. });
+                    let original_change_id = change.change_id;
                     let original_change_floor = change.change_id.saturating_sub(1);
                     let operation = if should_transform_local_change(&change) {
                         if let Some(transformed) = &mut transformed {
@@ -4050,7 +4295,38 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                             "failed to replay local change after remote apply: {error}",
                         ))
                     })?;
+                    // Translate watermark boundaries into the new numbering
+                    // while both numberings still exist: the highest re-captured
+                    // CDC id produced by a change at or below an old-numbering
+                    // boundary is that boundary in the new numbering. A change
+                    // that captured nothing (e.g. a delete replayed over a row
+                    // absent from the pulled state) leaves the boundary as is -
+                    // it produced no re-pushable entry.
+                    if cdc_enabled_for_local_replay
+                        && !replace_base_pages
+                        && !raw_page_replay_on_sql_conn
+                    {
+                        let track_confirmed = original_change_id <= confirmed_watermark_old;
+                        let track_pending = !pending_push_proven_landed
+                            && pending_push
+                                .as_ref()
+                                .is_some_and(|p| original_change_id <= p.cur_change_id);
+                        if track_confirmed || track_pending {
+                            let recaptured_id = max_local_change_id(coro, phase_conn).await?;
+                            if let Some(recaptured_id) = recaptured_id {
+                                if track_confirmed {
+                                    translated_confirmed = recaptured_id;
+                                }
+                                if track_pending {
+                                    translated_pending_cur = recaptured_id;
+                                }
+                            }
+                        }
+                    }
                 }
+                local_replay_translation_ran = cdc_enabled_for_local_replay
+                    && !replace_base_pages
+                    && !raw_page_replay_on_sql_conn;
                 assert!(!replay.conn().get_auto_commit());
             }
 
@@ -4078,17 +4354,33 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         self.main_db_path,
                         change_id
                     );
-                    let synced_change_id = synced_change_id_after_remote_apply(
-                        recaptured_local_changes,
-                        pre_apply_local_change_id,
-                        change_id,
-                    );
                     let synced_change_id = if recaptured_local_changes && raw_page_replay_on_sql_conn
                     {
                         post_remote_apply_change_id
+                    } else if local_replay_translation_ran {
+                        // exact translation of the confirmed watermark into the
+                        // post-rebase numbering, tracked during the replay above
+                        translated_confirmed
                     } else {
-                        synced_change_id
+                        synced_change_id_after_remote_apply(
+                            recaptured_local_changes,
+                            pre_apply_local_change_id,
+                            change_id,
+                        )
                     };
+                    // the local sync row keeps the historical delete clamp
+                    // (`preserve_local_replay_floor`), but the metadata
+                    // confirmed watermark stays exact: the translation already
+                    // handles deletes that re-captured nothing, and lowering it
+                    // would re-push entries the server already applied
+                    confirmed_watermark = Some((
+                        local_pull_gen + 1,
+                        if local_replay_translation_ran {
+                            translated_confirmed.min(change_id)
+                        } else {
+                            synced_change_id.min(change_id)
+                        },
+                    ));
                     let synced_change_id = preserve_local_replay_floor
                         .map_or(synced_change_id, |floor| synced_change_id.min(floor));
                     let synced_change_id = synced_change_id.min(change_id);
@@ -4119,11 +4411,21 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 logical_conn.publish_schema_if_newer();
                 let logical_table_names_by_stable_id =
                     read_logical_replay_table_map(coro, &logical_conn).await?;
-                return Ok((
-                    logical_conn.wal_state()?.max_frame,
+                let pending_push_update = resolve_pending_push_update(
+                    pending_push_exists,
+                    pending_push_proven_landed,
+                    local_replay_translation_ran && pending_push.is_some(),
+                    local_pull_gen,
+                    translated_pending_cur,
+                    confirmed_watermark.is_some(),
+                );
+                return Ok(AppliedRemoteChanges {
+                    revert_since_wal_watermark: logical_conn.wal_state()?.max_frame,
                     logical_table_names_by_stable_id,
                     followup_revision,
-                ));
+                    confirmed_watermark,
+                    pending_push_update,
+                });
             }
             let raw_replay_refresh = replace_base_pages || raw_page_replay_on_sql_conn;
             let recreate_cdc =
@@ -4218,18 +4520,27 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     self.main_db_path,
                     change_id
                 );
-                let synced_change_id = synced_change_id_after_remote_apply(
-                    recaptured_local_changes,
-                    pre_apply_local_change_id,
-                    change_id,
-                );
                 let synced_change_id =
                     if recaptured_local_changes && (replace_base_pages || raw_page_replay_on_sql_conn)
                     {
                         post_remote_apply_change_id
+                    } else if local_replay_translation_ran {
+                        // exact translation of the confirmed watermark into the
+                        // post-rebase numbering, tracked during the replay above
+                        translated_confirmed
                     } else {
-                        synced_change_id
+                        synced_change_id_after_remote_apply(
+                            recaptured_local_changes,
+                            pre_apply_local_change_id,
+                            change_id,
+                        )
                 };
+                // the local sync row keeps the historical delete clamp
+                // (`preserve_local_replay_floor`), but the metadata confirmed
+                // watermark stays exact: the translation already handles
+                // deletes that re-captured nothing, and lowering it would
+                // re-push entries the server already applied
+                confirmed_watermark = Some((local_pull_gen + 1, synced_change_id.min(change_id)));
                 let synced_change_id = preserve_local_replay_floor
                     .map_or(synced_change_id, |floor| synced_change_id.min(floor));
                 let synced_change_id = synced_change_id.min(change_id);
@@ -4252,11 +4563,21 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 read_logical_replay_table_map(coro, &main_conn).await?;
             let revert_since_wal_watermark =
                 revert_since_wal_watermark.unwrap_or(main_conn.wal_state()?.max_frame);
-            Ok((
+            let pending_push_update = resolve_pending_push_update(
+                pending_push_exists,
+                pending_push_proven_landed,
+                local_replay_translation_ran && pending_push.is_some(),
+                local_pull_gen,
+                translated_pending_cur,
+                confirmed_watermark.is_some(),
+            );
+            Ok(AppliedRemoteChanges {
                 revert_since_wal_watermark,
                 logical_table_names_by_stable_id,
                 followup_revision,
-            ))
+                confirmed_watermark,
+                pending_push_update,
+            })
         }
         .await;
 
@@ -4298,8 +4619,14 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             self.meta().remote_url(),
             self.opts.remote_encryption_key.as_deref(),
         );
-        let (pull_gen, replay_floor_change_id, change_id) =
-            push_logical_changes(ctx, &self.main_tape, &self.client_unique_id, &self.opts).await?;
+        let (pull_gen, replay_floor_change_id, change_id) = push_logical_changes(
+            ctx,
+            self,
+            &self.main_tape,
+            &self.client_unique_id,
+            &self.opts,
+        )
+        .await?;
 
         self.update_meta(coro, |m| {
             m.last_pushed_pull_gen_hint = pull_gen;
@@ -4339,11 +4666,11 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         Ok(())
     }
 
-    fn meta(&self) -> std::sync::MutexGuard<'_, DatabaseMetadata> {
+    pub(crate) fn meta(&self) -> std::sync::MutexGuard<'_, DatabaseMetadata> {
         self.meta.lock().unwrap()
     }
 
-    async fn update_meta<Ctx>(
+    pub(crate) async fn update_meta<Ctx>(
         &self,
         coro: &Coro<Ctx>,
         update: impl FnOnce(&mut DatabaseMetadata),

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -34,7 +34,8 @@ use crate::{
         Coro, DatabaseMetadata, DatabasePullRevision, DatabaseRowTransformResult,
         DatabaseSavedConfiguration, DatabaseSyncEngineProtocolVersion, DatabaseTapeOperation,
         DatabaseTapeRowChange, DatabaseTapeRowChangeType, DbChangesStatus, DbChangesStreamKind,
-        PartialSyncOpts, SyncEngineIoResult, SyncEngineStats, DATABASE_METADATA_VERSION,
+        PartialSyncOpts, PushBoundary, SyncEngineIoResult, SyncEngineStats,
+        DATABASE_METADATA_VERSION,
     },
     wal_session::WalSession,
     Result,
@@ -102,12 +103,12 @@ mod tests {
         create_main_db_log_path, create_main_db_wal_path, create_meta_path,
         create_replace_base_marker_path, create_revert_db_wal_path,
         ensure_stream_kind_can_use_legacy_page_apply, logical_mvcc_pull_disable_reason,
-        replace_base_backup_path, resolve_local_replay_floor_change_id,
-        resolve_pending_push_update, should_replay_raw_pages_on_sql_conn,
+        lookup_pulled_boundary, rebased_push_boundaries, replace_base_backup_path,
+        resolve_local_replay_floor_change_id, should_replay_raw_pages_on_sql_conn,
         should_request_logical_pull, should_use_logical_mvcc_pull,
         stream_kind_applies_remote_pages, stream_kind_for_pull_updates_v1_result,
         synced_change_id_after_remote_apply, use_pushed_change_hint_for_local_replay,
-        DatabaseSyncEngine, DatabaseSyncEngineOpts, PendingPushUpdate, ReplaceBaseApplyGuard,
+        DatabaseSyncEngine, DatabaseSyncEngineOpts, ReplaceBaseApplyGuard,
         REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
     };
     use crate::{
@@ -129,7 +130,7 @@ mod tests {
         types::{
             Coro, DatabaseMetadata, DatabasePullRevision, DatabaseSavedConfiguration,
             DatabaseSyncEngineProtocolVersion, DbChangesStatus, DbChangesStreamKind,
-            PartialSyncOpts, SyncEngineIoResult, DATABASE_METADATA_VERSION,
+            PartialSyncOpts, PushBoundary, SyncEngineIoResult, DATABASE_METADATA_VERSION,
         },
         Result,
     };
@@ -346,68 +347,70 @@ mod tests {
         assert_eq!(floor, Some(12));
     }
 
+    fn boundary(
+        sent_pull_gen: i64,
+        sent_last_change_id: i64,
+        cur: i64,
+        confirmed: bool,
+    ) -> PushBoundary {
+        PushBoundary {
+            sent_pull_gen,
+            sent_last_change_id,
+            cur_change_id: cur,
+            confirmed,
+        }
+    }
+
     #[test]
-    fn local_replay_floor_falls_back_to_confirmed_watermark_on_pull_gen_mismatch() {
-        // without the watermark a stale sync row collapses the floor to
+    fn local_replay_floor_uses_pulled_boundary_translation_on_pull_gen_mismatch() {
+        // without a matched boundary a stale sync row collapses the floor to
         // nothing and the whole CDC history is re-captured on every rebase
         let floor = resolve_local_replay_floor_change_id(false, 7, 6, Some(12), None, 0, 0);
         assert_eq!(floor, None);
-        // the issue-time confirmed watermark carries the floor across the
-        // generation mismatch: everything it covers was confirmed before the
-        // pull was issued, so the pulled state contains it
+        // the boundary-log translation carries the floor across the
+        // generation mismatch: the pulled state provably contains everything
+        // at or before the boundary it names
         let floor = resolve_local_replay_floor_change_id(false, 7, 6, Some(12), Some(20), 0, 0);
         assert_eq!(floor, Some(20));
     }
 
     #[test]
-    fn local_replay_floor_uses_max_of_sync_row_and_confirmed_watermark() {
-        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(12), Some(20), 0, 0);
-        assert_eq!(floor, Some(20));
-        let floor = resolve_local_replay_floor_change_id(false, 7, 7, Some(25), Some(20), 0, 0);
-        assert_eq!(floor, Some(25));
+    fn pulled_boundary_lookup_matches_frozen_send_coordinates() {
+        let log = vec![
+            boundary(5, 10, 3, true),
+            boundary(6, 4, 7, true),
+            boundary(6, 9, 12, false),
+        ];
+        // exact match, regardless of confirmation state
+        assert_eq!(lookup_pulled_boundary(&log, 6, Some(4)), Some(1));
+        assert_eq!(lookup_pulled_boundary(&log, 6, Some(9)), Some(2));
+        // a row that names no retained boundary predates the whole log
+        assert_eq!(lookup_pulled_boundary(&log, 5, Some(2)), None);
+        assert_eq!(lookup_pulled_boundary(&log, 6, None), None);
     }
 
     #[test]
-    fn pending_push_kept_when_apply_does_not_renumber_cdc() {
-        assert!(matches!(
-            resolve_pending_push_update(true, false, true, 7, 5, false),
-            PendingPushUpdate::Keep
-        ));
-        assert!(matches!(
-            resolve_pending_push_update(false, false, false, 7, 0, true),
-            PendingPushUpdate::Keep
-        ));
+    fn rebased_boundaries_carry_exact_translations() {
+        let retained = vec![boundary(6, 9, 12, true), boundary(6, 15, 18, false)];
+        let rebased = rebased_push_boundaries(&retained, &[2, 5], true, 99);
+        assert_eq!(
+            rebased,
+            vec![boundary(6, 9, 2, true), boundary(6, 15, 5, false)]
+        );
+        // frozen send-time coordinates never change - only the translation does
+        assert_eq!(rebased[1].sent_pull_gen, 6);
+        assert_eq!(rebased[1].sent_last_change_id, 15);
     }
 
     #[test]
-    fn pending_push_cleared_when_landed_or_untranslatable() {
-        // proven landed by the pulled state: folded into the confirmed
-        // watermark, the record itself is finished
-        assert!(matches!(
-            resolve_pending_push_update(true, true, true, 7, 5, true),
-            PendingPushUpdate::Clear
-        ));
-        // renumbered without per-change translation (raw page replay): the
-        // boundary cannot be carried over
-        assert!(matches!(
-            resolve_pending_push_update(true, false, false, 7, 0, true),
-            PendingPushUpdate::Clear
-        ));
-    }
-
-    #[test]
-    fn pending_push_translated_into_post_rebase_numbering() {
-        assert!(matches!(
-            resolve_pending_push_update(true, false, true, 7, 5, true),
-            PendingPushUpdate::Translate((8, 5))
-        ));
-        // a pending batch whose changes re-captured nothing (e.g. deletes
-        // replayed over rows absent from the pulled state) translates to a
-        // zero boundary: nothing re-pushable came out of it
-        assert!(matches!(
-            resolve_pending_push_update(true, false, true, 7, 0, true),
-            PendingPushUpdate::Translate((8, 0))
-        ));
+    fn rebased_boundaries_collapse_to_ack_all_without_translation() {
+        // bulk page replay cannot translate per change: keep only the newest
+        // confirmed record with the acknowledge-all watermark, drop the
+        // unconfirmed one (resolved conservatively by the next push)
+        let retained = vec![boundary(6, 9, 12, true), boundary(6, 15, 18, false)];
+        let rebased = rebased_push_boundaries(&retained, &[0, 0], false, 42);
+        assert_eq!(rebased, vec![boundary(6, 9, 42, true)]);
+        assert_eq!(rebased_push_boundaries(&[], &[], false, 42), vec![]);
     }
 
     #[test]
@@ -900,9 +903,8 @@ mod tests {
             last_pushed_pull_gen_hint: 0,
             last_pushed_change_id_hint: 0,
             last_pushed_replay_floor_change_id_hint: 0,
-            confirmed_pull_gen: 0,
-            confirmed_change_id: 0,
-            pending_push: None,
+            push_boundaries_pull_gen: 0,
+            push_boundaries: Vec::new(),
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
@@ -1052,9 +1054,8 @@ mod tests {
             last_pushed_pull_gen_hint: 0,
             last_pushed_change_id_hint: 0,
             last_pushed_replay_floor_change_id_hint: 0,
-            confirmed_pull_gen: 0,
-            confirmed_change_id: 0,
-            pending_push: None,
+            push_boundaries_pull_gen: 0,
+            push_boundaries: Vec::new(),
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
@@ -1084,7 +1085,6 @@ mod tests {
             revision: DatabasePullRevision::V1 {
                 revision: "g1:o2".to_string(),
             },
-            confirmed_at_issue: (0, 0),
             file_slot: Some(crate::database_sync_operations::MutexSlot {
                 value: changes_file,
                 slot,
@@ -1230,9 +1230,8 @@ mod tests {
             last_pushed_pull_gen_hint: 0,
             last_pushed_change_id_hint: 0,
             last_pushed_replay_floor_change_id_hint: 0,
-            confirmed_pull_gen: 0,
-            confirmed_change_id: 0,
-            pending_push: None,
+            push_boundaries_pull_gen: 0,
+            push_boundaries: Vec::new(),
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
@@ -1262,7 +1261,6 @@ mod tests {
             revision: DatabasePullRevision::V1 {
                 revision: "g1:o2".to_string(),
             },
-            confirmed_at_issue: (0, 0),
             file_slot: Some(crate::database_sync_operations::MutexSlot {
                 value: changes_file,
                 slot: Arc::new(Mutex::new(None)),
@@ -1445,7 +1443,6 @@ mod tests {
                                 secs: 10,
                                 micros: 0,
                             },
-                            confirmed_at_issue: (0, 0),
                             revision: new_revision.clone(),
                             file_slot: Some(file_slot),
                             stream_kind: DbChangesStreamKind::ReplaceBasePages,
@@ -2292,45 +2289,68 @@ struct AppliedRemoteChanges {
     revert_since_wal_watermark: u64,
     logical_table_names_by_stable_id: BTreeMap<u64, String>,
     followup_revision: Option<DatabasePullRevision>,
-    /// Confirmed watermark `(pull_gen, change_id)` translated into the
-    /// post-rebase numbering; mirrored into the metadata by the caller.
-    /// `None` when the apply did not renumber the CDC.
-    confirmed_watermark: Option<(i64, i64)>,
-    /// What the caller must do with `DatabaseMetadata::pending_push`.
-    pending_push_update: PendingPushUpdate,
+    /// `(pull_gen, records)` replacement for the push-boundary log, with the
+    /// `cur_change_id` values translated into the post-rebase numbering;
+    /// mirrored into the metadata by the caller. `None` when the apply did
+    /// not renumber the CDC (the stored log stays valid as is).
+    push_boundaries_update: Option<(i64, Vec<PushBoundary>)>,
 }
 
-enum PendingPushUpdate {
-    /// the apply did not renumber the CDC - the record stays valid as is
-    Keep,
-    /// the record was folded into the confirmed watermark (the pulled state
-    /// proved the batch landed) or cannot be translated - forget it
-    Clear,
-    /// the apply renumbered the CDC - `cur` becomes this `(pull_gen,
-    /// change_id)` boundary
-    Translate((i64, i64)),
+/// The pulled state names one of this client's push-batch boundaries in its
+/// sync row (the row is written atomically with every batch). Find it in the
+/// boundary log: its translated `cur_change_id` is the exact replay floor
+/// for this pull - every retained batch at or before it is contained in the
+/// pulled state, everything after is not - no matter how stale the pulled
+/// state is. `None` when the row predates the whole log (then nothing
+/// retained is contained) or names no known boundary.
+fn lookup_pulled_boundary(
+    push_boundaries: &[PushBoundary],
+    remote_pull_gen: i64,
+    remote_last_change_id: Option<i64>,
+) -> Option<usize> {
+    let remote_last_change_id = remote_last_change_id?;
+    push_boundaries.iter().position(|b| {
+        b.sent_pull_gen == remote_pull_gen && b.sent_last_change_id == remote_last_change_id
+    })
 }
 
-/// Decide what happens to `DatabaseMetadata::pending_push` after an apply.
-/// `renumbered` says whether this apply re-numbered the CDC (bumped the local
-/// pull generation) - if it did not, the record stays valid as is.
-fn resolve_pending_push_update(
-    pending_push_exists: bool,
-    pending_push_proven_landed: bool,
-    pending_translated: bool,
-    local_pull_gen: i64,
-    translated_pending_cur: i64,
-    renumbered: bool,
-) -> PendingPushUpdate {
-    if !pending_push_exists || !renumbered {
-        PendingPushUpdate::Keep
-    } else if pending_push_proven_landed || !pending_translated {
-        // proven landed: already folded into the confirmed watermark;
-        // otherwise the boundary cannot be carried across the renumbering
-        // and forgetting it only means a conservative re-push resolution
-        PendingPushUpdate::Clear
+/// Build the post-rebase boundary log. With per-change translation the
+/// retained records carry their exact translated values. Without it (bulk
+/// page replay) per-record translation is impossible: keep only the newest
+/// confirmed record with the acknowledge-all watermark as its value, and
+/// drop an unconfirmed record - same conservative resolution as before,
+/// a lost-response batch may be re-sent after a raw rebase.
+fn rebased_push_boundaries(
+    retained_boundaries: &[PushBoundary],
+    translated_curs: &[i64],
+    translation_ran: bool,
+    ack_all_watermark: i64,
+) -> Vec<PushBoundary> {
+    if translation_ran {
+        retained_boundaries
+            .iter()
+            .zip(translated_curs.iter())
+            .map(|(boundary, cur)| PushBoundary {
+                sent_pull_gen: boundary.sent_pull_gen,
+                sent_last_change_id: boundary.sent_last_change_id,
+                cur_change_id: *cur,
+                confirmed: boundary.confirmed,
+            })
+            .collect()
     } else {
-        PendingPushUpdate::Translate((local_pull_gen + 1, translated_pending_cur))
+        retained_boundaries
+            .iter()
+            .rev()
+            .find(|boundary| boundary.confirmed)
+            .map(|boundary| {
+                vec![PushBoundary {
+                    sent_pull_gen: boundary.sent_pull_gen,
+                    sent_last_change_id: boundary.sent_last_change_id,
+                    cur_change_id: ack_all_watermark,
+                    confirmed: true,
+                }]
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -2339,26 +2359,24 @@ fn resolve_local_replay_floor_change_id(
     local_pull_gen: i64,
     remote_pull_gen: i64,
     remote_last_change_id: Option<i64>,
-    confirmed_at_issue_change_id: Option<i64>,
+    pulled_boundary_change_id: Option<i64>,
     last_pushed_pull_gen_hint: i64,
     last_pushed_change_id_hint: i64,
 ) -> Option<i64> {
-    // `confirmed_at_issue_change_id` is the confirmed watermark snapshotted
-    // when the pull request was issued (already validated by the caller to be
-    // in the local numbering). Every push it covers was confirmed before the
-    // pull left, so the pulled state contains those changes and they must not
-    // be replayed. When the remote sync row belongs to an older generation its
-    // ids are not comparable and the watermark is the only usable floor -
-    // without it the floor collapses to zero and the entire CDC history is
-    // re-captured (and later re-pushed) on every pull whose state predates
-    // this client's latest push.
+    // `pulled_boundary_change_id` is the boundary-log translation of the
+    // pulled sync row into the current local numbering (see
+    // [`lookup_pulled_boundary`]). When the row belongs to an older
+    // generation its ids are not comparable and the translation is the only
+    // usable floor - without it the floor collapses to zero and the entire
+    // CDC history is re-captured (and later re-pushed) on every pull whose
+    // state predates this client's latest push.
     let mut last_change_id = if remote_pull_gen == local_pull_gen {
-        match (remote_last_change_id, confirmed_at_issue_change_id) {
-            (Some(remote), Some(confirmed)) => Some(remote.max(confirmed)),
-            (remote, confirmed) => remote.or(confirmed),
+        match (remote_last_change_id, pulled_boundary_change_id) {
+            (Some(remote), Some(translated)) => Some(remote.max(translated)),
+            (remote, translated) => remote.or(translated),
         }
     } else {
-        confirmed_at_issue_change_id
+        pulled_boundary_change_id
     };
 
     if use_pushed_change_hint
@@ -2483,9 +2501,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     last_pushed_change_id_hint: 0,
                     last_pushed_pull_gen_hint: 0,
                     last_pushed_replay_floor_change_id_hint: 0,
-                    confirmed_pull_gen: 0,
-                    confirmed_change_id: 0,
-                    pending_push: None,
+                    push_boundaries_pull_gen: 0,
+                    push_boundaries: Vec::new(),
                     last_pull_unix_time: Some(io.current_time_wall_clock().secs),
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: if partial {
@@ -2533,9 +2550,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     last_pushed_change_id_hint: 0,
                     last_pushed_pull_gen_hint: 0,
                     last_pushed_replay_floor_change_id_hint: 0,
-                    confirmed_pull_gen: 0,
-                    confirmed_change_id: 0,
-                    pending_push: None,
+                    push_boundaries_pull_gen: 0,
+                    push_boundaries: Vec::new(),
                     last_pull_unix_time: None,
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: None,
@@ -3050,15 +3066,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
         let now = self.io.current_time_wall_clock();
         let revision = self.meta().synced_revision.clone();
-        // Snapshot the confirmed watermark BEFORE the pull request leaves: the
-        // pulled state is guaranteed to contain only pushes confirmed before
-        // the request was issued. A push confirmed while the pull is in flight
-        // may be absent from the response, and the rebase must replay its
-        // changes rather than skip them.
-        let confirmed_at_issue = {
-            let meta = self.meta();
-            (meta.confirmed_pull_gen, meta.confirmed_change_id)
-        };
         let ctx = &SyncOperationCtx::new(
             coro,
             &self.sync_engine_io,
@@ -3164,7 +3171,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 revision: next_revision,
                 file_slot: None,
                 stream_kind,
-                confirmed_at_issue,
             });
         }
 
@@ -3180,7 +3186,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             revision: next_revision,
             file_slot: Some(file),
             stream_kind,
-            confirmed_at_issue,
         })
     }
 
@@ -3230,15 +3235,13 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 &changes_file,
                 remote_changes.stream_kind,
                 &remote_changes.revision,
-                remote_changes.confirmed_at_issue,
             )
             .await;
         let Ok(AppliedRemoteChanges {
             revert_since_wal_watermark,
             logical_table_names_by_stable_id,
             followup_revision,
-            confirmed_watermark,
-            pending_push_update,
+            push_boundaries_update,
         }) = pull_result
         else {
             return Err(pull_result.err().unwrap());
@@ -3262,19 +3265,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             m.last_pushed_replay_floor_change_id_hint = 0;
             m.last_pull_unix_time = Some(remote_changes.time.secs);
             m.logical_table_names_by_stable_id = logical_table_names_by_stable_id;
-            if let Some((pull_gen, change_id)) = confirmed_watermark {
-                m.confirmed_pull_gen = pull_gen;
-                m.confirmed_change_id = change_id;
-            }
-            match pending_push_update {
-                PendingPushUpdate::Keep => {}
-                PendingPushUpdate::Clear => m.pending_push = None,
-                PendingPushUpdate::Translate((pull_gen, change_id)) => {
-                    if let Some(pending) = &mut m.pending_push {
-                        pending.cur_pull_gen = pull_gen;
-                        pending.cur_change_id = change_id;
-                    }
-                }
+            if let Some((pull_gen, push_boundaries)) = push_boundaries_update {
+                m.push_boundaries_pull_gen = pull_gen;
+                m.push_boundaries = push_boundaries;
             }
         })
         .await?;
@@ -3515,7 +3508,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         changes_file: &Arc<dyn turso_core::File>,
         stream_kind: DbChangesStreamKind,
         remote_revision: &DatabasePullRevision,
-        confirmed_at_issue: (i64, i64),
     ) -> Result<AppliedRemoteChanges> {
         tracing::info!("apply_changes(path={})", self.main_db_path);
 
@@ -3574,28 +3566,18 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 meta.last_pushed_change_id_hint,
             )
         };
-        // The issue-time snapshot bounds the replay floor (a push confirmed
-        // while the pull was in flight may be absent from the pulled state);
-        // the live values bound what must not be re-pushed and are translated
-        // into the new numbering during the local replay below. Both are only
-        // meaningful while still expressed in the current local numbering.
-        let confirmed_at_issue_change_id = (confirmed_at_issue.0 == local_pull_gen
-            && confirmed_at_issue.1 > 0)
-            .then_some(confirmed_at_issue.1);
-        let (confirmed_at_apply_change_id, pending_push, pending_push_exists) = {
+        // The boundary log translates the pulled sync row into the current
+        // numbering (exact replay floor) and names what must never be
+        // re-pushed. Its translated values are only meaningful while still
+        // expressed in the current numbering; a stale log (crash between a
+        // rebase commit and the metadata write) is unusable and dropped.
+        let push_boundaries = {
             let meta = self.meta();
-            let confirmed = (meta.confirmed_pull_gen == local_pull_gen
-                && meta.confirmed_change_id > 0)
-                .then_some(meta.confirmed_change_id);
-            let exists = meta.pending_push.is_some();
-            // a record whose translated boundary is no longer in the current
-            // numbering cannot be carried across this rebase - it will be
-            // cleared below
-            let pending = meta
-                .pending_push
-                .clone()
-                .filter(|p| p.cur_pull_gen == local_pull_gen);
-            (confirmed, pending, exists)
+            if meta.push_boundaries_pull_gen == local_pull_gen {
+                meta.push_boundaries.clone()
+            } else {
+                Vec::new()
+            }
         };
 
         // read schema version after initiating WAL session (in order to read it with consistent max_frame_no)
@@ -4025,29 +4007,29 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     "protocol error: remote_pull_gen > local_pull_gen: {remote_pull_gen} > {local_pull_gen}"
                 )));
             }
-            // CONTRACT: a pull issued at time t returns state containing every
-            // push this client confirmed before t. Only this client's pushes
-            // write its sync row, so when the pulled row is in the current
-            // generation it must be at or above the issue-time confirmed
-            // watermark; a lower value means the server served state that lost
-            // acknowledged pushes, and skipping/replaying based on it would
-            // silently lose or duplicate data.
-            if remote_pull_gen == local_pull_gen {
-                if let Some(confirmed) = confirmed_at_issue_change_id {
-                    let remote_id = remote_last_change_id.unwrap_or(0);
-                    if remote_id < confirmed {
-                        return Err(Error::DatabaseSyncEngineError(format!(
-                            "protocol error: pulled state sync row ({remote_pull_gen}, {remote_id}) is behind the confirmed watermark ({local_pull_gen}, {confirmed})"
-                        )));
-                    }
-                }
-            }
+            // The pulled sync row names one of this client's batch boundaries
+            // (it is written atomically with every batch). On a generation
+            // mismatch its ids are not comparable, but the boundary log holds
+            // the translation: everything at or before the matched boundary is
+            // contained in the pulled state - exactly the replay floor - no
+            // matter how stale the pulled state is. An unmatched row predates
+            // the whole log, so nothing retained is contained and the floor is
+            // empty. A match also proves an unconfirmed batch (response lost)
+            // landed.
+            let pulled_boundary = lookup_pulled_boundary(
+                &push_boundaries,
+                remote_pull_gen,
+                remote_last_change_id,
+            );
+            let pulled_boundary_change_id = (remote_pull_gen != local_pull_gen)
+                .then(|| pulled_boundary.map(|i| push_boundaries[i].cur_change_id))
+                .flatten();
             let last_change_id = resolve_local_replay_floor_change_id(
                 use_pushed_change_hint,
                 local_pull_gen,
                 remote_pull_gen,
                 remote_last_change_id,
-                confirmed_at_issue_change_id,
+                pulled_boundary_change_id,
                 last_pushed_pull_gen_hint,
                 last_pushed_change_id_hint,
             );
@@ -4106,35 +4088,34 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             let replayed_local_changes = !local_changes.is_empty();
             let recaptured_local_changes = replayed_local_changes;
             let mut preserve_local_replay_floor = None;
-            // Pre-rebase-numbering watermark of replayed changes whose effect
-            // is known to be applied on the remote: everything the live
-            // confirmed watermark covers, plus a pending push that the pulled
-            // state itself proves landed (its frozen send-time coordinates are
-            // comparable against the pulled sync row regardless of the local
-            // generation). Re-captured changes at or below this watermark get
-            // new CDC ids that must not be pushed again, so the highest new id
-            // they produce is tracked below as the translated watermark.
-            let mut pending_push_proven_landed = false;
-            let confirmed_watermark_old = {
-                let mut watermark = replay_floor.max(confirmed_at_apply_change_id.unwrap_or(0));
-                if let Some(pending) = &pending_push {
-                    if remote_pull_gen == pending.sent_pull_gen
-                        && remote_last_change_id.unwrap_or(0) >= pending.sent_last_change_id
-                    {
-                        watermark = watermark.max(pending.cur_change_id);
-                        pending_push_proven_landed = true;
-                    }
-                }
-                watermark
+            // Prune boundaries contained in the pulled state: on a
+            // generation match everything in an older generation (pushed
+            // before the current generation existed) plus same-generation
+            // batches at or below the pulled row; on a mismatch everything at
+            // or before the matched boundary. Retained boundaries get their
+            // `cur_change_id` translated into the new numbering below: the
+            // highest re-captured CDC id produced by changes at or below the
+            // old value IS the boundary in the new numbering. Values start at
+            // 0 - a boundary is only what the re-capture proves.
+            let retained_boundaries: Vec<PushBoundary> = if remote_pull_gen == local_pull_gen {
+                let remote_id = remote_last_change_id.unwrap_or(0);
+                push_boundaries
+                    .iter()
+                    .filter(|b| b.sent_pull_gen == local_pull_gen && b.sent_last_change_id > remote_id)
+                    .cloned()
+                    .collect()
+            } else if let Some(matched) = pulled_boundary {
+                push_boundaries[matched + 1..].to_vec()
+            } else {
+                push_boundaries.clone()
             };
-            let mut translated_confirmed: i64 = 0;
-            let mut translated_pending_cur: i64 = 0;
+            let mut translated_boundary_curs: Vec<i64> = vec![0; retained_boundaries.len()];
             // set when the local replay re-captured changes with per-change
-            // boundary tracking, i.e. the translated_* values above are exact
+            // boundary tracking, i.e. the translated values above are exact
             let mut local_replay_translation_ran = false;
-            // (pull_gen, change_id) confirmed watermark as persisted into the
-            // local sync row by this apply, in the post-rebase numbering
-            let mut confirmed_watermark: Option<(i64, i64)> = None;
+            // replacement boundary log as persisted by the caller, in the
+            // post-rebase numbering; None while no renumbering happened
+            let mut push_boundaries_update: Option<(i64, Vec<PushBoundary>)> = None;
             tracing::info!(
                 "apply_changes(path={}): collected {} changes, skipped_internal_local_changes={}",
                 self.main_db_path,
@@ -4176,7 +4157,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         ))
                     })
                     .inspect_err(|e| tracing::error!("update_last_change_id failed: {e}"))?;
-                    confirmed_watermark = Some((local_pull_gen + 1, 0));
+                    push_boundaries_update = Some((local_pull_gen + 1, Vec::new()));
                 }
 
                 let mut cdc_enabled_for_local_replay = false;
@@ -4305,20 +4286,18 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     if cdc_enabled_for_local_replay
                         && !replace_base_pages
                         && !raw_page_replay_on_sql_conn
+                        && retained_boundaries
+                            .iter()
+                            .any(|b| original_change_id <= b.cur_change_id)
                     {
-                        let track_confirmed = original_change_id <= confirmed_watermark_old;
-                        let track_pending = !pending_push_proven_landed
-                            && pending_push
-                                .as_ref()
-                                .is_some_and(|p| original_change_id <= p.cur_change_id);
-                        if track_confirmed || track_pending {
-                            let recaptured_id = max_local_change_id(coro, phase_conn).await?;
-                            if let Some(recaptured_id) = recaptured_id {
-                                if track_confirmed {
-                                    translated_confirmed = recaptured_id;
-                                }
-                                if track_pending {
-                                    translated_pending_cur = recaptured_id;
+                        let recaptured_id = max_local_change_id(coro, phase_conn).await?;
+                        if let Some(recaptured_id) = recaptured_id {
+                            for (boundary, translated) in retained_boundaries
+                                .iter()
+                                .zip(translated_boundary_curs.iter_mut())
+                            {
+                                if original_change_id <= boundary.cur_change_id {
+                                    *translated = recaptured_id;
                                 }
                             }
                         }
@@ -4354,12 +4333,19 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         self.main_db_path,
                         change_id
                     );
+                    let translated_confirmed = retained_boundaries
+                        .iter()
+                        .zip(translated_boundary_curs.iter())
+                        .rev()
+                        .find(|(b, _)| b.confirmed)
+                        .map(|(_, cur)| *cur)
+                        .unwrap_or(0);
                     let synced_change_id = if recaptured_local_changes && raw_page_replay_on_sql_conn
                     {
                         post_remote_apply_change_id
                     } else if local_replay_translation_ran {
-                        // exact translation of the confirmed watermark into the
-                        // post-rebase numbering, tracked during the replay above
+                        // exact translation of the newest confirmed boundary
+                        // into the post-rebase numbering
                         translated_confirmed
                     } else {
                         synced_change_id_after_remote_apply(
@@ -4368,18 +4354,14 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                             change_id,
                         )
                     };
-                    // the local sync row keeps the historical delete clamp
-                    // (`preserve_local_replay_floor`), but the metadata
-                    // confirmed watermark stays exact: the translation already
-                    // handles deletes that re-captured nothing, and lowering it
-                    // would re-push entries the server already applied
-                    confirmed_watermark = Some((
+                    push_boundaries_update = Some((
                         local_pull_gen + 1,
-                        if local_replay_translation_ran {
-                            translated_confirmed.min(change_id)
-                        } else {
-                            synced_change_id.min(change_id)
-                        },
+                        rebased_push_boundaries(
+                            &retained_boundaries,
+                            &translated_boundary_curs,
+                            local_replay_translation_ran,
+                            synced_change_id.min(change_id),
+                        ),
                     ));
                     let synced_change_id = preserve_local_replay_floor
                         .map_or(synced_change_id, |floor| synced_change_id.min(floor));
@@ -4411,20 +4393,11 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 logical_conn.publish_schema_if_newer();
                 let logical_table_names_by_stable_id =
                     read_logical_replay_table_map(coro, &logical_conn).await?;
-                let pending_push_update = resolve_pending_push_update(
-                    pending_push_exists,
-                    pending_push_proven_landed,
-                    local_replay_translation_ran && pending_push.is_some(),
-                    local_pull_gen,
-                    translated_pending_cur,
-                    confirmed_watermark.is_some(),
-                );
                 return Ok(AppliedRemoteChanges {
                     revert_since_wal_watermark: logical_conn.wal_state()?.max_frame,
                     logical_table_names_by_stable_id,
                     followup_revision,
-                    confirmed_watermark,
-                    pending_push_update,
+                    push_boundaries_update,
                 });
             }
             let raw_replay_refresh = replace_base_pages || raw_page_replay_on_sql_conn;
@@ -4520,13 +4493,20 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     self.main_db_path,
                     change_id
                 );
+                let translated_confirmed = retained_boundaries
+                    .iter()
+                    .zip(translated_boundary_curs.iter())
+                    .rev()
+                    .find(|(boundary, _)| boundary.confirmed)
+                    .map(|(_, cur)| *cur)
+                    .unwrap_or(0);
                 let synced_change_id =
                     if recaptured_local_changes && (replace_base_pages || raw_page_replay_on_sql_conn)
                     {
                         post_remote_apply_change_id
                     } else if local_replay_translation_ran {
-                        // exact translation of the confirmed watermark into the
-                        // post-rebase numbering, tracked during the replay above
+                        // exact translation of the newest confirmed boundary
+                        // into the post-rebase numbering
                         translated_confirmed
                     } else {
                         synced_change_id_after_remote_apply(
@@ -4535,12 +4515,15 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                             change_id,
                         )
                 };
-                // the local sync row keeps the historical delete clamp
-                // (`preserve_local_replay_floor`), but the metadata confirmed
-                // watermark stays exact: the translation already handles
-                // deletes that re-captured nothing, and lowering it would
-                // re-push entries the server already applied
-                confirmed_watermark = Some((local_pull_gen + 1, synced_change_id.min(change_id)));
+                push_boundaries_update = Some((
+                    local_pull_gen + 1,
+                    rebased_push_boundaries(
+                        &retained_boundaries,
+                        &translated_boundary_curs,
+                        local_replay_translation_ran,
+                        synced_change_id.min(change_id),
+                    ),
+                ));
                 let synced_change_id = preserve_local_replay_floor
                     .map_or(synced_change_id, |floor| synced_change_id.min(floor));
                 let synced_change_id = synced_change_id.min(change_id);
@@ -4563,20 +4546,11 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 read_logical_replay_table_map(coro, &main_conn).await?;
             let revert_since_wal_watermark =
                 revert_since_wal_watermark.unwrap_or(main_conn.wal_state()?.max_frame);
-            let pending_push_update = resolve_pending_push_update(
-                pending_push_exists,
-                pending_push_proven_landed,
-                local_replay_translation_ran && pending_push.is_some(),
-                local_pull_gen,
-                translated_pending_cur,
-                confirmed_watermark.is_some(),
-            );
             Ok(AppliedRemoteChanges {
                 revert_since_wal_watermark,
                 logical_table_names_by_stable_id,
                 followup_revision,
-                confirmed_watermark,
-                pending_push_update,
+                push_boundaries_update,
             })
         }
         .await;

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -18,10 +18,11 @@ use crate::{
         apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats,
         apply_transformation, bootstrap_db_file, connect_untracked, count_local_changes, has_table,
         is_logically_replayable_table, max_local_change_id, pull_updates_v1, push_logical_changes,
-        read_last_change_id, read_logical_replay_table_map, read_wal_salt, reset_wal_file,
-        should_replay_local_change, sync_file, update_last_change_id, wait_all_results,
-        wal_apply_from_file, wal_pull_to_file, PullUpdatesV1Result, SyncEngineIoStats,
-        SyncOperationCtx, PAGE_SIZE, WAL_FRAME_HEADER, WAL_FRAME_SIZE,
+        read_last_change_id, read_logical_replay_table_map, read_push_boundaries, read_wal_salt,
+        reset_wal_file, should_replay_local_change, sync_file, update_last_change_id,
+        wait_all_results, wal_apply_from_file, wal_pull_to_file, write_push_boundaries,
+        PullUpdatesV1Result, SyncEngineIoStats, SyncOperationCtx, PAGE_SIZE, WAL_FRAME_HEADER,
+        WAL_FRAME_SIZE,
     },
     database_tape::{
         try_wal_watermark_read_page, DatabaseChangesIteratorMode, DatabaseChangesIteratorOpts,
@@ -903,8 +904,6 @@ mod tests {
             last_pushed_pull_gen_hint: 0,
             last_pushed_change_id_hint: 0,
             last_pushed_replay_floor_change_id_hint: 0,
-            push_boundaries_pull_gen: 0,
-            push_boundaries: Vec::new(),
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
@@ -1054,8 +1053,6 @@ mod tests {
             last_pushed_pull_gen_hint: 0,
             last_pushed_change_id_hint: 0,
             last_pushed_replay_floor_change_id_hint: 0,
-            push_boundaries_pull_gen: 0,
-            push_boundaries: Vec::new(),
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
@@ -1230,8 +1227,6 @@ mod tests {
             last_pushed_pull_gen_hint: 0,
             last_pushed_change_id_hint: 0,
             last_pushed_replay_floor_change_id_hint: 0,
-            push_boundaries_pull_gen: 0,
-            push_boundaries: Vec::new(),
             partial_bootstrap_server_revision: None,
             fresh_bootstrap_pending_cdc_ack: false,
             logical_mvcc_pull_active: true,
@@ -2289,11 +2284,6 @@ struct AppliedRemoteChanges {
     revert_since_wal_watermark: u64,
     logical_table_names_by_stable_id: BTreeMap<u64, String>,
     followup_revision: Option<DatabasePullRevision>,
-    /// `(pull_gen, records)` replacement for the push-boundary log, with the
-    /// `cur_change_id` values translated into the post-rebase numbering;
-    /// mirrored into the metadata by the caller. `None` when the apply did
-    /// not renumber the CDC (the stored log stays valid as is).
-    push_boundaries_update: Option<(i64, Vec<PushBoundary>)>,
 }
 
 /// The pulled state names one of this client's push-batch boundaries in its
@@ -2501,8 +2491,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     last_pushed_change_id_hint: 0,
                     last_pushed_pull_gen_hint: 0,
                     last_pushed_replay_floor_change_id_hint: 0,
-                    push_boundaries_pull_gen: 0,
-                    push_boundaries: Vec::new(),
                     last_pull_unix_time: Some(io.current_time_wall_clock().secs),
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: if partial {
@@ -2550,8 +2538,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     last_pushed_change_id_hint: 0,
                     last_pushed_pull_gen_hint: 0,
                     last_pushed_replay_floor_change_id_hint: 0,
-                    push_boundaries_pull_gen: 0,
-                    push_boundaries: Vec::new(),
                     last_pull_unix_time: None,
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: None,
@@ -3241,7 +3227,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             revert_since_wal_watermark,
             logical_table_names_by_stable_id,
             followup_revision,
-            push_boundaries_update,
         }) = pull_result
         else {
             return Err(pull_result.err().unwrap());
@@ -3265,10 +3250,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             m.last_pushed_replay_floor_change_id_hint = 0;
             m.last_pull_unix_time = Some(remote_changes.time.secs);
             m.logical_table_names_by_stable_id = logical_table_names_by_stable_id;
-            if let Some((pull_gen, push_boundaries)) = push_boundaries_update {
-                m.push_boundaries_pull_gen = pull_gen;
-                m.push_boundaries = push_boundaries;
-            }
         })
         .await?;
         Ok(())
@@ -3568,16 +3549,15 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         };
         // The boundary log translates the pulled sync row into the current
         // numbering (exact replay floor) and names what must never be
-        // re-pushed. Its translated values are only meaningful while still
-        // expressed in the current numbering; a stale log (crash between a
-        // rebase commit and the metadata write) is unusable and dropped.
-        let push_boundaries = {
-            let meta = self.meta();
-            if meta.push_boundaries_pull_gen == local_pull_gen {
-                meta.push_boundaries.clone()
-            } else {
-                Vec::new()
-            }
+        // re-pushed. Read it BEFORE the local WAL revert below: boundary rows
+        // written by pushes since the last rebase are rolled back with
+        // everything else and are rewritten - translated - next to the sync
+        // row at the end of the apply. WAL-mode flow only: the logical MVCC
+        // flow never renumbers, so its sync-row values need no translation.
+        let push_boundaries = if main_conn.mvcc_enabled() {
+            Vec::new()
+        } else {
+            read_push_boundaries(coro, &main_conn, &self.client_unique_id, local_pull_gen).await?
         };
 
         // read schema version after initiating WAL session (in order to read it with consistent max_frame_no)
@@ -4113,9 +4093,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             // set when the local replay re-captured changes with per-change
             // boundary tracking, i.e. the translated values above are exact
             let mut local_replay_translation_ran = false;
-            // replacement boundary log as persisted by the caller, in the
-            // post-rebase numbering; None while no renumbering happened
-            let mut push_boundaries_update: Option<(i64, Vec<PushBoundary>)> = None;
             tracing::info!(
                 "apply_changes(path={}): collected {} changes, skipped_internal_local_changes={}",
                 self.main_db_path,
@@ -4157,7 +4134,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         ))
                     })
                     .inspect_err(|e| tracing::error!("update_last_change_id failed: {e}"))?;
-                    push_boundaries_update = Some((local_pull_gen + 1, Vec::new()));
                 }
 
                 let mut cdc_enabled_for_local_replay = false;
@@ -4354,18 +4330,25 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                             change_id,
                         )
                     };
-                    push_boundaries_update = Some((
-                        local_pull_gen + 1,
-                        rebased_push_boundaries(
-                            &retained_boundaries,
-                            &translated_boundary_curs,
-                            local_replay_translation_ran,
-                            synced_change_id.min(change_id),
-                        ),
-                    ));
+                    let rebased_boundaries = rebased_push_boundaries(
+                        &retained_boundaries,
+                        &translated_boundary_curs,
+                        local_replay_translation_ran,
+                        synced_change_id.min(change_id),
+                    );
                     let synced_change_id = preserve_local_replay_floor
                         .map_or(synced_change_id, |floor| synced_change_id.min(floor));
                     let synced_change_id = synced_change_id.min(change_id);
+                    if !logical_conn.mvcc_enabled() {
+                        write_push_boundaries(
+                            coro,
+                            &logical_conn,
+                            &self.client_unique_id,
+                            local_pull_gen + 1,
+                            &rebased_boundaries,
+                        )
+                        .await?;
+                    }
                     if raw_page_replay_on_sql_conn {
                         rebuild_local_sync_metadata_table(
                             coro,
@@ -4397,7 +4380,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     revert_since_wal_watermark: logical_conn.wal_state()?.max_frame,
                     logical_table_names_by_stable_id,
                     followup_revision,
-                    push_boundaries_update,
                 });
             }
             let raw_replay_refresh = replace_base_pages || raw_page_replay_on_sql_conn;
@@ -4515,15 +4497,22 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                             change_id,
                         )
                 };
-                push_boundaries_update = Some((
-                    local_pull_gen + 1,
-                    rebased_push_boundaries(
-                        &retained_boundaries,
-                        &translated_boundary_curs,
-                        local_replay_translation_ran,
-                        synced_change_id.min(change_id),
-                    ),
-                ));
+                let rebased_boundaries = rebased_push_boundaries(
+                    &retained_boundaries,
+                    &translated_boundary_curs,
+                    local_replay_translation_ran,
+                    synced_change_id.min(change_id),
+                );
+                if !main_conn.mvcc_enabled() {
+                    write_push_boundaries(
+                        coro,
+                        &main_conn,
+                        &self.client_unique_id,
+                        local_pull_gen + 1,
+                        &rebased_boundaries,
+                    )
+                    .await?;
+                }
                 let synced_change_id = preserve_local_replay_floor
                     .map_or(synced_change_id, |floor| synced_change_id.min(floor));
                 let synced_change_id = synced_change_id.min(change_id);
@@ -4550,7 +4539,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 revert_since_wal_watermark,
                 logical_table_names_by_stable_id,
                 followup_revision,
-                push_boundaries_update,
             })
         }
         .await;
@@ -4593,14 +4581,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             self.meta().remote_url(),
             self.opts.remote_encryption_key.as_deref(),
         );
-        let (pull_gen, replay_floor_change_id, change_id) = push_logical_changes(
-            ctx,
-            self,
-            &self.main_tape,
-            &self.client_unique_id,
-            &self.opts,
-        )
-        .await?;
+        let (pull_gen, replay_floor_change_id, change_id) =
+            push_logical_changes(ctx, &self.main_tape, &self.client_unique_id, &self.opts).await?;
 
         self.update_meta(coro, |m| {
             m.last_pushed_pull_gen_hint = pull_gen;
@@ -4640,11 +4622,11 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         Ok(())
     }
 
-    pub(crate) fn meta(&self) -> std::sync::MutexGuard<'_, DatabaseMetadata> {
+    fn meta(&self) -> std::sync::MutexGuard<'_, DatabaseMetadata> {
         self.meta.lock().unwrap()
     }
 
-    pub(crate) async fn update_meta<Ctx>(
+    async fn update_meta<Ctx>(
         &self,
         coro: &Coro<Ctx>,
         update: impl FnOnce(&mut DatabaseMetadata),

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -38,7 +38,8 @@ use crate::{
         DatabaseRowTransformResult, DatabaseSchemaKind, DatabaseSchemaReplay,
         DatabaseStatementReplay, DatabaseSyncEngineProtocolVersion, DatabaseTapeOperation,
         DatabaseTapeRowChange, DatabaseTapeRowChangeType, DbSyncInfo, DbSyncStatus,
-        PartialBootstrapStrategy, PartialSyncOpts, PendingPush, SyncEngineIoResult,
+        PartialBootstrapStrategy, PartialSyncOpts, PushBoundary, SyncEngineIoResult,
+        PUSH_BOUNDARIES_LIMIT,
     },
     wal_session::WalSession,
     Result,
@@ -2766,43 +2767,53 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
 
     let (source_pull_gen, remote_row) = fetch_last_change_id(ctx, &source_conn, client_id).await?;
 
-    // Resolve the confirmed watermark and any pending push with an unknown
-    // outcome. The server sync row is written atomically with each push
-    // batch, so a pending batch landed iff the row reached its frozen
-    // send-time coordinates - a check that stays valid across rebases because
-    // the send-time coordinates are never renumbered.
-    let (mut confirmed, pending) = {
-        let meta = engine.meta();
-        let confirmed = if meta.confirmed_pull_gen == source_pull_gen {
-            meta.confirmed_change_id
-        } else {
-            0
-        };
-        (confirmed, meta.pending_push.clone())
-    };
-    if let Some(pending) = pending {
+    // Resolve an unconfirmed boundary (batch sent, response lost) against the
+    // live remote row: the row is written atomically with each batch, so the
+    // batch landed iff the row is at or past its frozen send-time
+    // coordinates - a check that stays valid across rebases because the
+    // send-time coordinates are never renumbered.
+    let unconfirmed = engine
+        .meta()
+        .push_boundaries
+        .iter()
+        .find(|b| !b.confirmed)
+        .cloned();
+    if let Some(unconfirmed) = unconfirmed {
         let landed = remote_row.is_some_and(|(row_gen, row_id)| {
-            row_gen == pending.sent_pull_gen && row_id >= pending.sent_last_change_id
+            row_gen == unconfirmed.sent_pull_gen && row_id >= unconfirmed.sent_last_change_id
         });
-        // a landed batch can be folded into the confirmed watermark only when
-        // its translated boundary is still in the current numbering
-        if landed && pending.cur_pull_gen == source_pull_gen {
-            confirmed = confirmed.max(pending.cur_change_id);
-        }
         tracing::info!(
-            "push_logical_changes: client_id={client_id}, pending push resolved: landed={landed}, pending={pending:?}"
+            "push_logical_changes: client_id={client_id}, unconfirmed boundary resolved: landed={landed}, boundary={unconfirmed:?}"
         );
-        let folded = confirmed;
         engine
             .update_meta(ctx.coro, |m| {
-                m.pending_push = None;
                 if landed {
-                    m.confirmed_pull_gen = source_pull_gen;
-                    m.confirmed_change_id = folded;
+                    for boundary in m.push_boundaries.iter_mut() {
+                        boundary.confirmed = true;
+                    }
+                } else {
+                    // the batch provably never landed - it is not a boundary
+                    // on the remote and its changes are still unconfirmed
+                    m.push_boundaries.retain(|b| b.confirmed);
                 }
             })
             .await?;
     }
+    // push floor: the newest confirmed boundary, usable only while its
+    // translated value is still in the current numbering
+    let confirmed = {
+        let meta = engine.meta();
+        if meta.push_boundaries_pull_gen == source_pull_gen {
+            meta.push_boundaries
+                .iter()
+                .rev()
+                .find(|b| b.confirmed)
+                .map(|b| b.cur_change_id)
+                .unwrap_or(0)
+        } else {
+            0
+        }
+    };
     if let Some((row_gen, row_id)) = remote_row {
         // Only this client's pushes write its sync row, and every push starts
         // at or above the confirmed watermark - so a same-generation row below
@@ -2910,18 +2921,34 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                     batch.clear();
                     continue;
                 };
-                // persist the pending-push record BEFORE the request leaves
-                // the process: if the response is lost, this is the only
-                // record that the batch may have been applied - without it the
-                // batch would be pushed (and applied) twice after a rebase
+                // persist the boundary record BEFORE the request leaves the
+                // process: if the response is lost, this is the only record
+                // that the batch may have been applied - without it the batch
+                // would be pushed (and applied) twice after a rebase
                 engine
                     .update_meta(ctx.coro, |m| {
-                        m.pending_push = Some(PendingPush {
+                        debug_assert!(
+                            m.push_boundaries.iter().all(|b| b.confirmed),
+                            "an unconfirmed boundary must be resolved before sending more"
+                        );
+                        if m.push_boundaries_pull_gen != source_pull_gen {
+                            // translated values in an old numbering are
+                            // unusable - matching them against future pulls
+                            // would produce wrong floors, so start over
+                            m.push_boundaries.clear();
+                            m.push_boundaries_pull_gen = source_pull_gen;
+                        }
+                        m.push_boundaries.push(PushBoundary {
                             sent_pull_gen: source_pull_gen,
                             sent_last_change_id,
-                            cur_pull_gen: source_pull_gen,
                             cur_change_id: sent_last_change_id,
+                            confirmed: false,
                         });
+                        // dropping the oldest confirmed record only costs
+                        // extra replay for pulls staler than the whole log
+                        while m.push_boundaries.len() > PUSH_BOUNDARIES_LIMIT {
+                            m.push_boundaries.remove(0);
+                        }
                     })
                     .await?;
                 let (rows_changed, next_change_id) = send_push_batch(
@@ -2942,12 +2969,8 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                 last_change_id = Some(next_change_id);
                 engine
                     .update_meta(ctx.coro, |m| {
-                        m.pending_push = None;
-                        if m.confirmed_pull_gen == source_pull_gen {
-                            m.confirmed_change_id = m.confirmed_change_id.max(next_change_id);
-                        } else {
-                            m.confirmed_pull_gen = source_pull_gen;
-                            m.confirmed_change_id = next_change_id;
+                        for boundary in m.push_boundaries.iter_mut() {
+                            boundary.confirmed = true;
                         }
                     })
                     .await?;

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -305,6 +305,7 @@ pub(crate) fn is_logically_replayable_table(name: &str) -> bool {
     !name.starts_with(SQLITE_INTERNAL_PREFIX)
         && !name.starts_with(TURSO_INTERNAL_PREFIX)
         && name != TURSO_SYNC_TABLE_NAME
+        && name != TURSO_SYNC_PUSH_BOUNDARIES_TABLE_NAME
         && name != TURSO_CDC_TABLE_NAME
         && name != TURSO_CDC_VERSION_TABLE_NAME
 }
@@ -2351,6 +2352,21 @@ pub async fn wal_push<IO: SyncEngineIo, Ctx>(
 }
 
 pub const TURSO_SYNC_TABLE_NAME: &str = "turso_sync_last_change_id";
+/// Local-only internal table holding the push-boundary log (see
+/// [`crate::types::PushBoundary`]). Lives in the database itself - next to
+/// `turso_sync_last_change_id` - so that boundary rows always stay mutually
+/// consistent with the sync row they are interpreted against, and so that the
+/// rebase can persist translated values adjacent to the renumbering that
+/// produced them. Never pushed to the remote.
+pub const TURSO_SYNC_PUSH_BOUNDARIES_TABLE_NAME: &str = "turso_sync_push_boundaries";
+const TURSO_SYNC_CREATE_PUSH_BOUNDARIES_TABLE: &str =
+    "CREATE TABLE IF NOT EXISTS turso_sync_push_boundaries (client_id TEXT, sent_pull_gen INTEGER, sent_last_change_id INTEGER, cur_pull_gen INTEGER, cur_change_id INTEGER, confirmed INTEGER, PRIMARY KEY (client_id, sent_pull_gen, sent_last_change_id))";
+const TURSO_SYNC_SELECT_PUSH_BOUNDARIES: &str =
+    "SELECT sent_pull_gen, sent_last_change_id, cur_pull_gen, cur_change_id, confirmed FROM turso_sync_push_boundaries WHERE client_id = ? ORDER BY sent_pull_gen, sent_last_change_id";
+const TURSO_SYNC_DELETE_PUSH_BOUNDARIES: &str =
+    "DELETE FROM turso_sync_push_boundaries WHERE client_id = ?";
+const TURSO_SYNC_INSERT_PUSH_BOUNDARY: &str =
+    "INSERT INTO turso_sync_push_boundaries (client_id, sent_pull_gen, sent_last_change_id, cur_pull_gen, cur_change_id, confirmed) VALUES (?, ?, ?, ?, ?, ?)";
 pub const TURSO_SYNC_CREATE_TABLE: &str =
     "CREATE TABLE IF NOT EXISTS turso_sync_last_change_id (client_id TEXT PRIMARY KEY, pull_gen INTEGER, change_id INTEGER)";
 pub const TURSO_SYNC_INSERT_LAST_CHANGE_ID: &str =
@@ -2568,32 +2584,44 @@ pub async fn ensure_sync_last_change_id_table<Ctx>(
     conn: &Arc<turso_core::Connection>,
     client_id: &str,
 ) -> Result<()> {
+    ensure_internal_table(
+        coro,
+        conn,
+        TURSO_SYNC_TABLE_NAME,
+        TURSO_SYNC_CREATE_TABLE,
+        &format!("sync high-water mark table initialization: client_id={client_id}"),
+    )
+    .await
+}
+
+async fn ensure_internal_table<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+    table_name: &str,
+    create_sql: &str,
+    context: &str,
+) -> Result<()> {
     for attempt in 0..=2 {
-        match conn.execute(TURSO_SYNC_CREATE_TABLE) {
+        match conn.execute(create_sql) {
             Ok(()) => {
                 conn.publish_schema_if_newer();
                 return Ok(());
             }
             Err(LimboError::ParseError(err)) if err.contains("already exists") => {
                 tracing::debug!(
-                    "update_last_change_id(client_id={client_id}): sync table already exists while initializing; refreshing schema"
+                    "{context}: table already exists while initializing; refreshing schema"
                 );
                 conn.publish_schema_if_newer();
                 return Ok(());
             }
             Err(LimboError::SchemaUpdated) => {
-                tracing::debug!(
-                    "update_last_change_id(client_id={client_id}): schema updated while initializing sync table; refreshing schema"
-                );
+                tracing::debug!("{context}: schema updated while initializing; refreshing schema");
                 force_reparse_schema_with_retry(conn)?;
-                publish_schema_after_external_restore(
-                    conn,
-                    "sync high-water mark table initialization",
-                )?;
+                publish_schema_after_external_restore(conn, context)?;
                 if attempt == 2 {
                     return Ok(());
                 }
-                match has_table(coro, conn, TURSO_SYNC_TABLE_NAME).await {
+                match has_table(coro, conn, table_name).await {
                     Ok(true) => return Ok(()),
                     Ok(false) => continue,
                     Err(Error::TursoError(LimboError::SchemaUpdated)) => continue,
@@ -2604,7 +2632,7 @@ pub async fn ensure_sync_last_change_id_table<Ctx>(
         }
     }
     Err(Error::DatabaseSyncEngineError(format!(
-        "failed to initialize sync high-water mark table after schema refresh: client_id={client_id}"
+        "failed to initialize internal table after schema refresh: {context}"
     )))
 }
 
@@ -2663,6 +2691,137 @@ pub async fn read_last_change_id<Ctx>(
         None => {
             tracing::info!("read_last_change_id: client_id={client_id}, turso_sync_last_change_id client id is not found");
             Ok((0, None))
+        }
+    }
+}
+
+/// Read this client's push-boundary log in log order. Returns an empty log
+/// when the table does not exist yet (the client never pushed) or when the
+/// stored rows are expressed in a numbering other than `cur_pull_gen` - a
+/// crash between a rebase commit and the post-rebase log rewrite leaves
+/// stale-numbering rows behind, and using their translated values would
+/// produce wrong floors; dropping them degrades to the conservative row-only
+/// behavior instead.
+pub async fn read_push_boundaries<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+    client_id: &str,
+    cur_pull_gen: i64,
+) -> Result<Vec<PushBoundary>> {
+    let mut select_stmt = match conn.prepare(TURSO_SYNC_SELECT_PUSH_BOUNDARIES) {
+        Ok(stmt) => stmt,
+        Err(LimboError::ParseError(..)) => return Ok(Vec::new()),
+        Err(err) => return Err(err.into()),
+    };
+    select_stmt.bind_at(
+        1.try_into().unwrap(),
+        Value::Text(Text::new(client_id.to_string())),
+    )?;
+    let mut boundaries = Vec::new();
+    while let Some(row) = run_stmt_once(coro, &mut select_stmt).await? {
+        let values: Vec<turso_core::Value> = row.get_values().cloned().collect();
+        let int = |i: usize, what: &str| {
+            values[i].as_int().ok_or_else(|| {
+                Error::DatabaseSyncEngineError(format!("unexpected push boundary {what} type"))
+            })
+        };
+        if int(2, "cur_pull_gen")? != cur_pull_gen {
+            tracing::warn!(
+                "read_push_boundaries(client_id={client_id}): dropping stale-numbering boundary log"
+            );
+            return Ok(Vec::new());
+        }
+        boundaries.push(PushBoundary {
+            sent_pull_gen: int(0, "sent_pull_gen")?,
+            sent_last_change_id: int(1, "sent_last_change_id")?,
+            cur_change_id: int(3, "cur_change_id")?,
+            confirmed: int(4, "confirmed")? != 0,
+        });
+    }
+    Ok(boundaries)
+}
+
+/// Replace this client's push-boundary log. Must be called adjacent to the
+/// sync row write it is interpreted against (same transaction when the
+/// caller holds one) so the two stay mutually consistent.
+pub async fn write_push_boundaries<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+    client_id: &str,
+    cur_pull_gen: i64,
+    boundaries: &[PushBoundary],
+) -> Result<()> {
+    tracing::info!(
+        "write_push_boundaries(client_id={client_id}): {} records, cur_pull_gen={cur_pull_gen}",
+        boundaries.len()
+    );
+    if !has_table(coro, conn, TURSO_SYNC_PUSH_BOUNDARIES_TABLE_NAME).await? {
+        ensure_internal_table(
+            coro,
+            conn,
+            TURSO_SYNC_PUSH_BOUNDARIES_TABLE_NAME,
+            TURSO_SYNC_CREATE_PUSH_BOUNDARIES_TABLE,
+            "push boundaries table initialization",
+        )
+        .await?;
+    }
+    let mut delete_stmt = conn.prepare(TURSO_SYNC_DELETE_PUSH_BOUNDARIES)?;
+    delete_stmt.bind_at(
+        1.try_into().unwrap(),
+        Value::Text(Text::new(client_id.to_string())),
+    )?;
+    run_stmt_ignore_rows(coro, &mut delete_stmt).await?;
+    for boundary in boundaries {
+        let mut insert_stmt = conn.prepare(TURSO_SYNC_INSERT_PUSH_BOUNDARY)?;
+        insert_stmt.bind_at(
+            1.try_into().unwrap(),
+            Value::Text(Text::new(client_id.to_string())),
+        )?;
+        insert_stmt.bind_at(
+            2.try_into().unwrap(),
+            Value::from_i64(boundary.sent_pull_gen),
+        )?;
+        insert_stmt.bind_at(
+            3.try_into().unwrap(),
+            Value::from_i64(boundary.sent_last_change_id),
+        )?;
+        insert_stmt.bind_at(4.try_into().unwrap(), Value::from_i64(cur_pull_gen))?;
+        insert_stmt.bind_at(
+            5.try_into().unwrap(),
+            Value::from_i64(boundary.cur_change_id),
+        )?;
+        insert_stmt.bind_at(
+            6.try_into().unwrap(),
+            Value::from_i64(boundary.confirmed as i64),
+        )?;
+        run_stmt_ignore_rows(coro, &mut insert_stmt).await?;
+    }
+    Ok(())
+}
+
+/// Persist the push-boundary log in one transaction: the DELETE + INSERT
+/// rewrite must never be observable half-done, or a crash could lose the only
+/// record of an in-flight batch.
+async fn persist_push_boundaries<Ctx>(
+    coro: &Coro<Ctx>,
+    conn: &Arc<turso_core::Connection>,
+    client_id: &str,
+    cur_pull_gen: i64,
+    boundaries: &[PushBoundary],
+) -> Result<()> {
+    let mut begin_stmt = conn.prepare("BEGIN IMMEDIATE")?;
+    run_stmt_ignore_rows(coro, &mut begin_stmt).await?;
+    match write_push_boundaries(coro, conn, client_id, cur_pull_gen, boundaries).await {
+        Ok(()) => {
+            let mut commit_stmt = conn.prepare("COMMIT")?;
+            run_stmt_ignore_rows(coro, &mut commit_stmt).await?;
+            Ok(())
+        }
+        Err(err) => {
+            if let Err(rollback_err) = conn.execute("ROLLBACK") {
+                tracing::error!("failed to rollback push boundaries rewrite: {rollback_err}");
+            }
+            Err(err)
         }
     }
 }
@@ -2757,7 +2916,6 @@ pub async fn fetch_last_change_id<IO: SyncEngineIo, Ctx>(
 
 pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
     ctx: &SyncOperationCtx<'_, IO, Ctx>,
-    engine: &crate::database_sync_engine::DatabaseSyncEngine<IO>,
     source: &DatabaseTape,
     client_id: &str,
     opts: &DatabaseSyncEngineOpts,
@@ -2767,53 +2925,55 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
 
     let (source_pull_gen, remote_row) = fetch_last_change_id(ctx, &source_conn, client_id).await?;
 
+    // The boundary log is maintained for the WAL-mode flow only: the logical
+    // MVCC flow never bumps the pull generation, so its sync-row values stay
+    // directly comparable and need no translation.
+    let boundaries_enabled = !source_conn.mvcc_enabled();
+    let mut boundaries = if boundaries_enabled {
+        read_push_boundaries(ctx.coro, &source_conn, client_id, source_pull_gen).await?
+    } else {
+        Vec::new()
+    };
+
     // Resolve an unconfirmed boundary (batch sent, response lost) against the
     // live remote row: the row is written atomically with each batch, so the
     // batch landed iff the row is at or past its frozen send-time
     // coordinates - a check that stays valid across rebases because the
     // send-time coordinates are never renumbered.
-    let unconfirmed = engine
-        .meta()
-        .push_boundaries
-        .iter()
-        .find(|b| !b.confirmed)
-        .cloned();
-    if let Some(unconfirmed) = unconfirmed {
+    if let Some(unconfirmed) = boundaries.iter().find(|b| !b.confirmed).cloned() {
         let landed = remote_row.is_some_and(|(row_gen, row_id)| {
             row_gen == unconfirmed.sent_pull_gen && row_id >= unconfirmed.sent_last_change_id
         });
         tracing::info!(
             "push_logical_changes: client_id={client_id}, unconfirmed boundary resolved: landed={landed}, boundary={unconfirmed:?}"
         );
-        engine
-            .update_meta(ctx.coro, |m| {
-                if landed {
-                    for boundary in m.push_boundaries.iter_mut() {
-                        boundary.confirmed = true;
-                    }
-                } else {
-                    // the batch provably never landed - it is not a boundary
-                    // on the remote and its changes are still unconfirmed
-                    m.push_boundaries.retain(|b| b.confirmed);
-                }
-            })
-            .await?;
-    }
-    // push floor: the newest confirmed boundary, usable only while its
-    // translated value is still in the current numbering
-    let confirmed = {
-        let meta = engine.meta();
-        if meta.push_boundaries_pull_gen == source_pull_gen {
-            meta.push_boundaries
-                .iter()
-                .rev()
-                .find(|b| b.confirmed)
-                .map(|b| b.cur_change_id)
-                .unwrap_or(0)
+        if landed {
+            for boundary in boundaries.iter_mut() {
+                boundary.confirmed = true;
+            }
         } else {
-            0
+            // the batch provably never landed - it is not a boundary on the
+            // remote and its changes are still unconfirmed
+            boundaries.retain(|b| b.confirmed);
         }
-    };
+        persist_push_boundaries(
+            ctx.coro,
+            &source_conn,
+            client_id,
+            source_pull_gen,
+            &boundaries,
+        )
+        .await?;
+    }
+    // push floor: the newest confirmed boundary. The table is rewritten
+    // adjacent to every sync-row renumbering, so its translated values are
+    // always in the current numbering.
+    let confirmed = boundaries
+        .iter()
+        .rev()
+        .find(|b| b.confirmed)
+        .map(|b| b.cur_change_id)
+        .unwrap_or(0);
     if let Some((row_gen, row_id)) = remote_row {
         // Only this client's pushes write its sync row, and every push starts
         // at or above the confirmed watermark - so a same-generation row below
@@ -2855,7 +3015,7 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
         use_implicit_rowid: false,
     };
 
-    let generator = DatabaseReplayGenerator::new(source_conn, replay_opts);
+    let generator = DatabaseReplayGenerator::new(source_conn.clone(), replay_opts);
 
     let iterate_opts = DatabaseChangesIteratorOpts {
         first_change_id: last_change_id.map(|x| x + 1),
@@ -2925,32 +3085,31 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                 // process: if the response is lost, this is the only record
                 // that the batch may have been applied - without it the batch
                 // would be pushed (and applied) twice after a rebase
-                engine
-                    .update_meta(ctx.coro, |m| {
-                        debug_assert!(
-                            m.push_boundaries.iter().all(|b| b.confirmed),
-                            "an unconfirmed boundary must be resolved before sending more"
-                        );
-                        if m.push_boundaries_pull_gen != source_pull_gen {
-                            // translated values in an old numbering are
-                            // unusable - matching them against future pulls
-                            // would produce wrong floors, so start over
-                            m.push_boundaries.clear();
-                            m.push_boundaries_pull_gen = source_pull_gen;
-                        }
-                        m.push_boundaries.push(PushBoundary {
-                            sent_pull_gen: source_pull_gen,
-                            sent_last_change_id,
-                            cur_change_id: sent_last_change_id,
-                            confirmed: false,
-                        });
-                        // dropping the oldest confirmed record only costs
-                        // extra replay for pulls staler than the whole log
-                        while m.push_boundaries.len() > PUSH_BOUNDARIES_LIMIT {
-                            m.push_boundaries.remove(0);
-                        }
-                    })
+                if boundaries_enabled {
+                    debug_assert!(
+                        boundaries.iter().all(|b| b.confirmed),
+                        "an unconfirmed boundary must be resolved before sending more"
+                    );
+                    boundaries.push(PushBoundary {
+                        sent_pull_gen: source_pull_gen,
+                        sent_last_change_id,
+                        cur_change_id: sent_last_change_id,
+                        confirmed: false,
+                    });
+                    // dropping the oldest confirmed record only costs extra
+                    // replay for pulls staler than the whole log
+                    while boundaries.len() > PUSH_BOUNDARIES_LIMIT {
+                        boundaries.remove(0);
+                    }
+                    persist_push_boundaries(
+                        ctx.coro,
+                        &source_conn,
+                        client_id,
+                        source_pull_gen,
+                        &boundaries,
+                    )
                     .await?;
+                }
                 let (rows_changed, next_change_id) = send_push_batch(
                     ctx,
                     &generator,
@@ -2967,13 +3126,19 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                 );
                 total_rows_changed += rows_changed;
                 last_change_id = Some(next_change_id);
-                engine
-                    .update_meta(ctx.coro, |m| {
-                        for boundary in m.push_boundaries.iter_mut() {
-                            boundary.confirmed = true;
-                        }
-                    })
+                if boundaries_enabled {
+                    for boundary in boundaries.iter_mut() {
+                        boundary.confirmed = true;
+                    }
+                    persist_push_boundaries(
+                        ctx.coro,
+                        &source_conn,
+                        client_id,
+                        source_pull_gen,
+                        &boundaries,
+                    )
                     .await?;
+                }
                 batch.clear();
             }
         }

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -38,7 +38,7 @@ use crate::{
         DatabaseRowTransformResult, DatabaseSchemaKind, DatabaseSchemaReplay,
         DatabaseStatementReplay, DatabaseSyncEngineProtocolVersion, DatabaseTapeOperation,
         DatabaseTapeRowChange, DatabaseTapeRowChangeType, DbSyncInfo, DbSyncStatus,
-        PartialBootstrapStrategy, PartialSyncOpts, SyncEngineIoResult,
+        PartialBootstrapStrategy, PartialSyncOpts, PendingPush, SyncEngineIoResult,
     },
     wal_session::WalSession,
     Result,
@@ -2666,11 +2666,17 @@ pub async fn read_last_change_id<Ctx>(
     }
 }
 
+/// Read the local pull generation and the live remote sync row for
+/// `client_id`. Returns `(source_pull_gen, Some((target_pull_gen,
+/// target_change_id)))`, or `None` when the remote has no row yet. The row is
+/// the authoritative record of what the remote applied — it is written
+/// atomically with every push batch — so the caller resolves push floors and
+/// pending-push outcomes against it.
 pub async fn fetch_last_change_id<IO: SyncEngineIo, Ctx>(
     ctx: &SyncOperationCtx<'_, IO, Ctx>,
     source_conn: &Arc<turso_core::Connection>,
     client_id: &str,
-) -> Result<(i64, Option<i64>)> {
+) -> Result<(i64, Option<(i64, i64)>)> {
     tracing::info!("fetch_last_change_id: client_id={client_id}");
 
     // fetch last_change_id from the target DB in order to guarantee atomic replay of changes and avoid conflicts in case of failure
@@ -2745,16 +2751,12 @@ pub async fn fetch_last_change_id<IO: SyncEngineIo, Ctx>(
     if target_pull_gen > source_pull_gen {
         return Err(Error::DatabaseSyncEngineError(format!("protocol error: target_pull_gen > source_pull_gen: {target_pull_gen} > {source_pull_gen}")));
     }
-    let last_change_id = if target_pull_gen == source_pull_gen {
-        Some(target_change_id)
-    } else {
-        Some(0)
-    };
-    Ok((source_pull_gen, last_change_id))
+    Ok((source_pull_gen, Some((target_pull_gen, target_change_id))))
 }
 
 pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
     ctx: &SyncOperationCtx<'_, IO, Ctx>,
+    engine: &crate::database_sync_engine::DatabaseSyncEngine<IO>,
     source: &DatabaseTape,
     client_id: &str,
     opts: &DatabaseSyncEngineOpts,
@@ -2762,9 +2764,65 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
     tracing::info!("push_logical_changes: client_id={client_id}");
     let source_conn = connect_untracked(source)?;
 
-    let (source_pull_gen, mut last_change_id) =
-        fetch_last_change_id(ctx, &source_conn, client_id).await?;
-    let replay_floor_change_id = last_change_id.unwrap_or(0);
+    let (source_pull_gen, remote_row) = fetch_last_change_id(ctx, &source_conn, client_id).await?;
+
+    // Resolve the confirmed watermark and any pending push with an unknown
+    // outcome. The server sync row is written atomically with each push
+    // batch, so a pending batch landed iff the row reached its frozen
+    // send-time coordinates - a check that stays valid across rebases because
+    // the send-time coordinates are never renumbered.
+    let (mut confirmed, pending) = {
+        let meta = engine.meta();
+        let confirmed = if meta.confirmed_pull_gen == source_pull_gen {
+            meta.confirmed_change_id
+        } else {
+            0
+        };
+        (confirmed, meta.pending_push.clone())
+    };
+    if let Some(pending) = pending {
+        let landed = remote_row.is_some_and(|(row_gen, row_id)| {
+            row_gen == pending.sent_pull_gen && row_id >= pending.sent_last_change_id
+        });
+        // a landed batch can be folded into the confirmed watermark only when
+        // its translated boundary is still in the current numbering
+        if landed && pending.cur_pull_gen == source_pull_gen {
+            confirmed = confirmed.max(pending.cur_change_id);
+        }
+        tracing::info!(
+            "push_logical_changes: client_id={client_id}, pending push resolved: landed={landed}, pending={pending:?}"
+        );
+        let folded = confirmed;
+        engine
+            .update_meta(ctx.coro, |m| {
+                m.pending_push = None;
+                if landed {
+                    m.confirmed_pull_gen = source_pull_gen;
+                    m.confirmed_change_id = folded;
+                }
+            })
+            .await?;
+    }
+    if let Some((row_gen, row_id)) = remote_row {
+        // Only this client's pushes write its sync row, and every push starts
+        // at or above the confirmed watermark - so a same-generation row below
+        // it means the remote lost acknowledged state (e.g. was restored from
+        // an older backup). Re-pushing silently could apply stale row images
+        // over other clients' newer writes, so fail loudly instead.
+        if row_gen == source_pull_gen && row_id < confirmed {
+            return Err(Error::DatabaseSyncEngineError(format!(
+                "protocol error: remote sync row ({row_gen}, {row_id}) is behind the locally confirmed watermark ({source_pull_gen}, {confirmed})"
+            )));
+        }
+    }
+    let mut floor = confirmed;
+    if let Some((row_gen, row_id)) = remote_row {
+        if row_gen == source_pull_gen {
+            floor = floor.max(row_id);
+        }
+    }
+    let replay_floor_change_id = floor;
+    let mut last_change_id = if floor > 0 { Some(floor) } else { None };
 
     tracing::debug!("push_logical_changes: last_change_id={:?}", last_change_id);
 
@@ -2829,18 +2887,70 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                 if !must_push {
                     continue;
                 }
+                let transformed = if opts.use_transform {
+                    Some(apply_transformation(ctx, &batch, &generator).await?)
+                } else {
+                    None
+                };
+                // last change id that will actually reach the remote: the
+                // remote sync row advances only past non-skipped changes
+                let sent_last_change_id = batch
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .find(|(i, _)| {
+                        transformed
+                            .as_ref()
+                            .is_none_or(|t| !matches!(t[*i], DatabaseRowTransformResult::Skip))
+                    })
+                    .map(|(_, change)| change.change_id);
+                let Some(sent_last_change_id) = sent_last_change_id else {
+                    // the transform skipped the whole batch - nothing will
+                    // reach the remote, so there is nothing to send or record
+                    batch.clear();
+                    continue;
+                };
+                // persist the pending-push record BEFORE the request leaves
+                // the process: if the response is lost, this is the only
+                // record that the batch may have been applied - without it the
+                // batch would be pushed (and applied) twice after a rebase
+                engine
+                    .update_meta(ctx.coro, |m| {
+                        m.pending_push = Some(PendingPush {
+                            sent_pull_gen: source_pull_gen,
+                            sent_last_change_id,
+                            cur_pull_gen: source_pull_gen,
+                            cur_change_id: sent_last_change_id,
+                        });
+                    })
+                    .await?;
                 let (rows_changed, next_change_id) = send_push_batch(
                     ctx,
                     &generator,
-                    opts,
+                    transformed,
                     &batch,
                     client_id,
                     source_pull_gen,
                     last_change_id,
                 )
                 .await?;
+                assert!(
+                    next_change_id == sent_last_change_id,
+                    "sent batch boundary must match the pending record: {next_change_id} != {sent_last_change_id}"
+                );
                 total_rows_changed += rows_changed;
                 last_change_id = Some(next_change_id);
+                engine
+                    .update_meta(ctx.coro, |m| {
+                        m.pending_push = None;
+                        if m.confirmed_pull_gen == source_pull_gen {
+                            m.confirmed_change_id = m.confirmed_change_id.max(next_change_id);
+                        } else {
+                            m.confirmed_pull_gen = source_pull_gen;
+                            m.confirmed_change_id = next_change_id;
+                        }
+                    })
+                    .await?;
                 batch.clear();
             }
         }
@@ -2862,27 +2972,29 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
     ))
 }
 
-/// Build and send a single push batch over HTTP. The caller owns the
-/// per-batch slice of changes; transformations (if enabled) run lazily here so
-/// the user-defined transform sees one batch's worth of rows at a time —
-/// matching the streaming semantics of the outer loop.
+/// Build and send a single push batch over HTTP. The caller pre-computes the
+/// transformation results (if enabled) for exactly this batch — they are taken
+/// as a parameter so the caller can persist the pending-push watermark (the
+/// last post-transform change id that will reach the remote) BEFORE the
+/// request leaves the process.
 ///
 /// Returns the count of rows that actually produced SQL steps
 /// (post-transformation, excluding `Skip`).
-async fn send_push_batch<IO: SyncEngineIo, Ctx>(
+pub async fn send_push_batch<IO: SyncEngineIo, Ctx>(
     ctx: &SyncOperationCtx<'_, IO, Ctx>,
     generator: &DatabaseReplayGenerator,
-    opts: &DatabaseSyncEngineOpts,
+    mut transformed: Option<Vec<DatabaseRowTransformResult>>,
     batch_changes: &[DatabaseTapeRowChange],
     client_id: &str,
     source_pull_gen: i64,
     mut last_change_id: Option<i64>,
 ) -> Result<(i64, i64)> {
-    let mut transformed = if opts.use_transform {
-        Some(apply_transformation(ctx, batch_changes, generator).await?)
-    } else {
-        None
-    };
+    assert!(
+        transformed
+            .as_ref()
+            .is_none_or(|t| t.len() == batch_changes.len()),
+        "transformation results must match the batch"
+    );
 
     let step = |query, args| BatchStep {
         stmt: Stmt {

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -144,25 +144,6 @@ pub struct DatabaseMetadata {
     pub last_pushed_change_id_hint: i64,
     #[serde(default)]
     pub last_pushed_replay_floor_change_id_hint: i64,
-    /// Pull generation in which the `cur_change_id` values of
-    /// `push_boundaries` are expressed. A rebase re-numbers CDC change ids;
-    /// every rebase translates the values into the new numbering, so
-    /// consumers must ignore them when this tag does not match the local
-    /// pull generation (e.g. after a crash between the rebase commit and the
-    /// metadata write). The frozen `sent_*` coordinates stay valid always.
-    #[serde(default)]
-    pub push_boundaries_pull_gen: i64,
-    /// Ordered log of push-batch boundaries: one record per batch sent to
-    /// the remote, retained until an applied pull proves the batch is
-    /// contained in the pulled state (or proves a lost batch never landed).
-    /// The remote sync row is written atomically with each batch, so any
-    /// consistent pulled state names one of these boundaries - looking it up
-    /// gives the exact replay floor for that pull, no matter how stale the
-    /// pulled state is. The newest confirmed record is the push floor.
-    /// Capped at [`PUSH_BOUNDARIES_LIMIT`]; dropping old confirmed records
-    /// only costs extra replay for extremely stale pulls, never correctness.
-    #[serde(default)]
-    pub push_boundaries: Vec<PushBoundary>,
     pub partial_bootstrap_server_revision: Option<DatabasePullRevision>,
     #[serde(default)]
     pub fresh_bootstrap_pending_cdc_ack: bool,
@@ -179,17 +160,25 @@ pub struct DatabaseMetadata {
 /// record is never dropped; old confirmed records are.
 pub const PUSH_BOUNDARIES_LIMIT: usize = 32;
 
-/// One push batch boundary.
+/// One push batch boundary — a row of the local-only internal
+/// `turso_sync_push_boundaries` table. One record per batch sent to the
+/// remote, persisted BEFORE the batch leaves, retained until an applied pull
+/// proves the batch contained in the pulled state (or proves a lost batch
+/// never landed). The remote sync row is written atomically with each batch,
+/// so any consistent pulled state names one of these boundaries — looking it
+/// up gives the exact replay floor for that pull, no matter how stale the
+/// pulled state is. The newest confirmed record is the push floor.
 ///
 /// `sent_*` are frozen in the numbering that was current when the batch was
-/// sent: the server sync row is written atomically with the batch, so a
-/// consistent server-side state contains the batch iff its row is at or past
+/// sent: the batch landed iff an observed sync row is at or past
 /// `(sent_pull_gen, sent_last_change_id)` in batch order — a comparison that
 /// stays valid after any number of local rebases. `cur_change_id` is the
-/// same boundary translated into the current local numbering by each rebase
-/// (numbering tagged by `DatabaseMetadata::push_boundaries_pull_gen`).
+/// same boundary translated into the current local numbering by each rebase,
+/// rewritten next to the sync row so the two stay mutually consistent.
 /// `confirmed` is false while the batch response is lost and the outcome is
-/// unknown; at most the newest record can be unconfirmed.
+/// unknown; at most the newest record can be unconfirmed. The log is capped
+/// at [`PUSH_BOUNDARIES_LIMIT`]; dropping old confirmed records only costs
+/// extra replay for pulls staler than the whole log, never correctness.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct PushBoundary {
     pub sent_pull_gen: i64,

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -85,12 +85,6 @@ pub struct DbChangesStatus {
     pub revision: DatabasePullRevision,
     pub file_slot: Option<MutexSlot<Arc<dyn turso_core::File>>>,
     pub stream_kind: DbChangesStreamKind,
-    /// `(confirmed_pull_gen, confirmed_change_id)` snapshotted BEFORE the pull
-    /// request was sent. The replay floor of the rebase that applies these
-    /// changes must use this snapshot, not the live metadata: a push confirmed
-    /// after the pull was issued may be absent from the pulled state, and its
-    /// changes must be replayed, not skipped.
-    pub confirmed_at_issue: (i64, i64),
 }
 
 impl DbChangesStatus {
@@ -150,29 +144,25 @@ pub struct DatabaseMetadata {
     pub last_pushed_change_id_hint: i64,
     #[serde(default)]
     pub last_pushed_replay_floor_change_id_hint: i64,
-    /// Pull generation in which `confirmed_change_id` is expressed. A rebase
-    /// re-numbers CDC change ids; every rebase either translates the value
-    /// into the new numbering or resets it, so consumers must ignore the
-    /// value when this tag does not match the local pull generation.
+    /// Pull generation in which the `cur_change_id` values of
+    /// `push_boundaries` are expressed. A rebase re-numbers CDC change ids;
+    /// every rebase translates the values into the new numbering, so
+    /// consumers must ignore them when this tag does not match the local
+    /// pull generation (e.g. after a crash between the rebase commit and the
+    /// metadata write). The frozen `sent_*` coordinates stay valid always.
     #[serde(default)]
-    pub confirmed_pull_gen: i64,
-    /// Highest local CDC change id (in the numbering of `confirmed_pull_gen`)
-    /// whose effect is confirmed to be applied on the remote: either a push
-    /// response acknowledged it, or a pulled state contained it. Push uses it
-    /// as a send floor and the rebase uses it as a replay floor when the
-    /// remote sync row belongs to an older generation and its ids are not
-    /// comparable. Relies on the server contract that a pull issued at time t
-    /// returns state containing every push confirmed before t.
+    pub push_boundaries_pull_gen: i64,
+    /// Ordered log of push-batch boundaries: one record per batch sent to
+    /// the remote, retained until an applied pull proves the batch is
+    /// contained in the pulled state (or proves a lost batch never landed).
+    /// The remote sync row is written atomically with each batch, so any
+    /// consistent pulled state names one of these boundaries - looking it up
+    /// gives the exact replay floor for that pull, no matter how stale the
+    /// pulled state is. The newest confirmed record is the push floor.
+    /// Capped at [`PUSH_BOUNDARIES_LIMIT`]; dropping old confirmed records
+    /// only costs extra replay for extremely stale pulls, never correctness.
     #[serde(default)]
-    pub confirmed_change_id: i64,
-    /// Push batch that was sent to the remote but whose response was lost, so
-    /// it is unknown whether the server applied it. Persisted before every
-    /// batch send and cleared on response; resolved on the next push (or
-    /// rebase) by comparing the server sync row against the frozen send-time
-    /// coordinates. Without it, a failed-but-applied batch would be re-pushed
-    /// after a rebase and applied twice, later in the server order.
-    #[serde(default)]
-    pub pending_push: Option<PendingPush>,
+    pub push_boundaries: Vec<PushBoundary>,
     pub partial_bootstrap_server_revision: Option<DatabasePullRevision>,
     #[serde(default)]
     pub fresh_bootstrap_pending_cdc_ack: bool,
@@ -185,21 +175,27 @@ pub struct DatabaseMetadata {
     pub saved_configuration: Option<DatabaseSavedConfiguration>,
 }
 
-/// A push batch with an unknown outcome (sent, response lost).
+/// Maximum number of retained [`PushBoundary`] records. The unconfirmed tail
+/// record is never dropped; old confirmed records are.
+pub const PUSH_BOUNDARIES_LIMIT: usize = 32;
+
+/// One push batch boundary.
 ///
 /// `sent_*` are frozen in the numbering that was current when the batch was
-/// sent: the server sync row is written atomically with the batch, so the
-/// batch landed iff the row reaches `(sent_pull_gen, >= sent_last_change_id)`
-/// — a comparison that stays valid after any number of local rebases.
-/// `cur_*` is the same boundary translated into the current local numbering
-/// by each rebase, so a landed batch can be folded into
-/// `confirmed_change_id`.
+/// sent: the server sync row is written atomically with the batch, so a
+/// consistent server-side state contains the batch iff its row is at or past
+/// `(sent_pull_gen, sent_last_change_id)` in batch order — a comparison that
+/// stays valid after any number of local rebases. `cur_change_id` is the
+/// same boundary translated into the current local numbering by each rebase
+/// (numbering tagged by `DatabaseMetadata::push_boundaries_pull_gen`).
+/// `confirmed` is false while the batch response is lost and the outcome is
+/// unknown; at most the newest record can be unconfirmed.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct PendingPush {
+pub struct PushBoundary {
     pub sent_pull_gen: i64,
     pub sent_last_change_id: i64,
-    pub cur_pull_gen: i64,
     pub cur_change_id: i64,
+    pub confirmed: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -85,6 +85,12 @@ pub struct DbChangesStatus {
     pub revision: DatabasePullRevision,
     pub file_slot: Option<MutexSlot<Arc<dyn turso_core::File>>>,
     pub stream_kind: DbChangesStreamKind,
+    /// `(confirmed_pull_gen, confirmed_change_id)` snapshotted BEFORE the pull
+    /// request was sent. The replay floor of the rebase that applies these
+    /// changes must use this snapshot, not the live metadata: a push confirmed
+    /// after the pull was issued may be absent from the pulled state, and its
+    /// changes must be replayed, not skipped.
+    pub confirmed_at_issue: (i64, i64),
 }
 
 impl DbChangesStatus {
@@ -144,6 +150,29 @@ pub struct DatabaseMetadata {
     pub last_pushed_change_id_hint: i64,
     #[serde(default)]
     pub last_pushed_replay_floor_change_id_hint: i64,
+    /// Pull generation in which `confirmed_change_id` is expressed. A rebase
+    /// re-numbers CDC change ids; every rebase either translates the value
+    /// into the new numbering or resets it, so consumers must ignore the
+    /// value when this tag does not match the local pull generation.
+    #[serde(default)]
+    pub confirmed_pull_gen: i64,
+    /// Highest local CDC change id (in the numbering of `confirmed_pull_gen`)
+    /// whose effect is confirmed to be applied on the remote: either a push
+    /// response acknowledged it, or a pulled state contained it. Push uses it
+    /// as a send floor and the rebase uses it as a replay floor when the
+    /// remote sync row belongs to an older generation and its ids are not
+    /// comparable. Relies on the server contract that a pull issued at time t
+    /// returns state containing every push confirmed before t.
+    #[serde(default)]
+    pub confirmed_change_id: i64,
+    /// Push batch that was sent to the remote but whose response was lost, so
+    /// it is unknown whether the server applied it. Persisted before every
+    /// batch send and cleared on response; resolved on the next push (or
+    /// rebase) by comparing the server sync row against the frozen send-time
+    /// coordinates. Without it, a failed-but-applied batch would be re-pushed
+    /// after a rebase and applied twice, later in the server order.
+    #[serde(default)]
+    pub pending_push: Option<PendingPush>,
     pub partial_bootstrap_server_revision: Option<DatabasePullRevision>,
     #[serde(default)]
     pub fresh_bootstrap_pending_cdc_ack: bool,
@@ -154,6 +183,23 @@ pub struct DatabaseMetadata {
     /// optional saved configuration
     /// this will be used by sync engine if some parameters were omitted
     pub saved_configuration: Option<DatabaseSavedConfiguration>,
+}
+
+/// A push batch with an unknown outcome (sent, response lost).
+///
+/// `sent_*` are frozen in the numbering that was current when the batch was
+/// sent: the server sync row is written atomically with the batch, so the
+/// batch landed iff the row reaches `(sent_pull_gen, >= sent_last_change_id)`
+/// — a comparison that stays valid after any number of local rebases.
+/// `cur_*` is the same boundary translated into the current local numbering
+/// by each rebase, so a landed batch can be folded into
+/// `confirmed_change_id`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PendingPush {
+    pub sent_pull_gen: i64,
+    pub sent_last_change_id: i64,
+    pub cur_pull_gen: i64,
+    pub cur_change_id: i64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
## Description

Persist an ordered **log of push-batch boundaries** in an internal table of the local database and use it to resolve the push floor and the rebase replay floor, which previously collapsed to change id `0` on every pull-generation mismatch.

One record per batch sent to the remote: `(sent_gen, sent_last, cur, confirmed)`, stored in a local-only internal table `turso_sync_push_boundaries` — next to `turso_sync_last_change_id`, and for the same reason: the log is interpreted against the sync row and the CDC numbering, so it lives in the database whose transactions define them. The remote sync row is written atomically with each batch, so **any consistent pulled state names one of these boundaries in its sync row** — looking that boundary up in the log yields the exact replay floor for that pull, *no matter how stale the pulled state is*. The frozen `sent_*` coordinates never get renumbered, so the lookup (and the landed-or-lost resolution of a batch whose response was lost) stays valid across any number of rebases; `cur` is the same boundary kept translated into the current CDC numbering by every rebase. Records are pruned once an applied pull proves the batch contained, so the log length is bounded by the pull lag (plus a hard cap — dropping old confirmed records only costs extra replay for pulls staler than the whole log, never correctness).

The whole protocol, as Python pseudocode:

```python
# STATE (persisted client metadata)
client_id = uuid()  # generated at bootstrap; owns the server-side boundary row
revision = None     # server revision of the last applied cut; pulls are
                    # incremental from here => applied cuts are monotone
gen = 1             # CDC numbering epoch; += 1 on every rebase; the server
                    # learns it only from the next push
boundaries = []     # internal turso_sync_push_boundaries table, one record per
                    # pushed batch: (sent_gen, sent_last, cur, confirmed).
                    # sent_* frozen in send-time numbering; cur is the same
                    # boundary kept translated into the CURRENT numbering;
                    # confirmed=False while the batch response is lost (at most
                    # the newest record, by RULE). pruned once an applied cut
                    # proves the batch contained; capped in the implementation.

# RULE: at most one in-flight push per client id. Only our pushes write our
# boundary => the value read in push() is stable.

# SERVER CONTRACTS
# C1  the client boundary - a per-client (gen, last_id) row in the synced
#     DB - is written in the same txn as its batch and only by this client:
#     it always equals the boundary of the last applied batch. no network
#     failure shrinks it; a smaller value = server lost committed state
#     => ProtocolError.
#     known gap (pre-existing): an HTTP-layer retry of an already-applied
#     batch re-applies its data; needs a server-side conditional-floor guard.
# C2  applied pulls are monotone: each applies a superset of the previous one
#     (enforced by pulling incrementally from `revision`).
# (there is deliberately no freshness contract: the replay floor is derived
#  from the pulled state's own boundary row, so an arbitrarily lagging pull -
#  e.g. served by a stale read replica - skips exactly what it contains)

# CLIENT INVARIANTS
# I1  change ids are epoch-local: boundaries cross a rebase only via
#     translation in the replay loop, never by reusing raw ids
# I2  a record is confirmed only by a push response or by a pulled state
#     naming it - never guessed; an unconfirmed record is resolved against
#     the live boundary before anything else is sent
# I3  the replay floor is the ONLY place the CDC shrinks, and only for
#     entries proven contained in the pulled state

def push(self):
    srv_gen, srv_id = server.read_client_boundary(self.client_id)  # stable (RULE)

    if srv_gen > self.gen:                       # boundary gens come from our landed
        raise ProtocolError("local state regressed")  # pushes => always <= self.gen

    if unresolved := [b for b in self.boundaries if not b.confirmed]:
        [b] = unresolved                         # at most one (RULE)
        if srv_gen == b.sent_gen and srv_id >= b.sent_last:
            b.confirmed = True                   # it landed
        else:
            self.boundaries.remove(b)            # provably didn't

    confirmed = max((b.cur for b in self.boundaries if b.confirmed), default=0)
    if srv_gen == self.gen and srv_id < confirmed:
        raise ProtocolError("server lost acknowledged state")   # C1

    floor = confirmed
    if srv_gen == self.gen:
        floor = max(floor, srv_id)

    for batch in cdc_entries(id > floor):
        self.boundaries.append(                              # persist BEFORE send
            Boundary(self.gen, batch.last_id, cur=batch.last_id, confirmed=False))
        server.push(batch, boundary=(self.gen, batch.last_id))  # one txn: apply
        self.boundaries[-1].confirmed = True                    # batch + boundary

def pull(self):
    cut = server.pull(since=self.revision)
    if not cut.empty:
        self.rebase(cut)

def rebase(self, cut):
    cut_gen, cut_id = cut.client_boundary(self.client_id)
    if cut_gen > self.gen:
        raise ProtocolError("local state regressed")

    # the cut names one of our batch boundaries (C1): everything at or before
    # it is contained in the cut, everything after is not - no matter how
    # stale the cut is. gen match: ids directly comparable. mismatch: the log
    # record holds the translation; no matching record => the cut predates
    # the whole log, so nothing retained is contained.
    if cut_gen == self.gen:
        floor = cut_id
        self.boundaries = [b for b in self.boundaries
                           if b.sent_gen == self.gen and b.sent_last > cut_id]
    elif i := index_of(self.boundaries, sent=(cut_gen, cut_id)):
        floor = self.boundaries[i].cur           # exact, even if the batch's
        self.boundaries = self.boundaries[i+1:]  # response was lost: the cut
                                                 # proves it landed
    else:
        floor = 0

    keep = [c for c in self.cdc if c.id > floor]  # rest: contained in cut (I3)
    apply_cut_and_revert_wal(cut)
    self.gen += 1

    # translate retained records while old and new numberings coexist (I1);
    # values start at 0 - a boundary is only what the re-capture proves
    translated = [0] * len(self.boundaries)
    self.cdc = []
    for change in keep:
        # executes the change with CDC capture on; the captured entry's id IS
        # the change's new id. a replay that affects 0 rows (delete of a row
        # the rebased state no longer has) captures nothing => the change has
        # no id in the new numbering and can never be re-pushed
        new_id = replay_with_capture(change)
        if new_id is None:
            continue
        for i, b in enumerate(self.boundaries):
            if change.id <= b.cur:
                translated[i] = new_id
    for b, cur in zip(self.boundaries, translated):
        b.cur = cur
    self.revision = cut.revision
```

Implementation notes:

- The log is maintained for the WAL-mode flow only: the logical MVCC flow never bumps the pull generation, so its sync-row values stay directly comparable and need no translation.
- `push_logical_changes` persists the boundary record in a small transaction before every batch send and confirms it on response, which also makes multi-batch pushes resume exactly after a mid-push failure. The transformation step was hoisted out of `send_push_batch` so the record can name the last change id that actually reaches the remote (transform `Skip`s excluded).
- The rebase reads the log before the local WAL revert (boundary rows written by pushes since the last rebase are rolled back with everything else) and rewrites the translated log next to the final sync-row update. The table is deliberately never touched mid-apply: creating it there would publish a schema that briefly lacks `turso_cdc` and break concurrent CDC-enabled statements.
- Rows are stamped with the pull generation their translated values are expressed in; a crash between the rebase commit and the post-rebase rewrite leaves stale-numbering rows, detected and dropped on read — degrading to a conservative re-send for one cycle, never to a wrong floor.
- Raw page-replay / replace-base paths cannot translate per change; there the log collapses to the newest confirmed record carrying the acknowledge-all watermark, and an unconfirmed record is dropped (conservatively resolved by the next push).
- A same-generation server row *behind* the newest confirmed boundary is a protocol error instead of a silent re-send: only this client writes its row and every push starts at or above the confirmed value, so a lower value means the server lost acknowledged state.

## Motivation and context

Same pathology as #8065, plus one more hole. Every pull rebase drops and re-captures `turso_cdc`, renumbering change ids and bumping the local pull generation, while the remote sync row only advances when a push lands. Under bidirectional sync the pulled state regularly re-materializes the sync row in an older generation (any client's push rewrites the shared sync bookkeeping page, which then ships in a pull and overwrites the locally-bumped row), and both floors collapsed to `0` on the mismatch:

- **every push re-sent the entire CDC history** and **every rebase re-captured all of it** — per-cycle work linear in total history, O(n²) across cycles, unbounded client WAL growth;
- worse than a perf bug: a re-sent batch is applied **later in the server order**, so stale row images **clobber other clients' newer writes**. Duplicate replay is not idempotent under concurrency.

Concretely:

```text
O(n^2) (both floors collapse every cycle):
  cycle k: CDC holds N changes (gen g); server boundary is (g-1, _)
    1. push:   srv_gen g-1 != g      -> floor 0 -> re-send ALL N changes
    2. pull:   cut was taken before step 1 landed -> its boundary is still (g-1, _)
    3. rebase: cut_gen g-1 != g      -> replay floor 0 -> re-capture ALL N
               into the fresh CDC (N new WAL frames); gen := g+1
  nothing is ever trimmed, N grows by the new writes each cycle
  => per-cycle work ~ k, total ~ k^2 (the concurrent-updates wasm test: 49MB
     WAL, timeout at ~620/1000 iterations)

stale replay clobber (the correctness half; both new JS tests):
  1. A: UPDATE k='a2'; push lands, but A's pull was already in flight
  2. A: rebase onto the pre-push cut: gen mismatch -> replay floor 0 ->
        'a2' re-captured into the new CDC as if it was never pushed
  3. B: UPDATE k='b3'; push lands
  4. A: push: boundary gen stale -> floor 0 -> re-sends 'a2', applied
        AFTER b3 -> B's write silently lost
```

Differences from #8065's approach:

1. **No freshness assumption.** #8065's ack (like an earlier revision of this PR) relies on "a pull issued at time t contains every push confirmed before t" — unverifiable exactly where it matters (generation mismatch) and broken by lagging read replicas, where it silently turns into local loss of the client's own confirmed writes. The boundary log derives the floor from the pulled state's *own* sync row instead: an arbitrarily stale pull skips exactly what it contains.
2. **Failed-but-applied pushes are handled.** A push whose response is lost but which the server applied is re-sent by #8065 after a rebase. Here the unconfirmed boundary record resolves it exactly: the next push (or a pull that names the boundary) proves it landed and never re-sends it. The second JS test fails without this even with an ack-style fix.
3. One uniform mechanism (the log) instead of an ack/hint pair with per-consumer generation-tag checks.

## Testing

- `cargo test -p turso_sync_engine` — 81/81, including unit tests for the boundary lookup, floor resolution and post-rebase log construction.
- Full native JS suite green, including `concurrent-actions-consistency` (concurrent user writes + pull/push loops against the boundary-table writes). Two deterministic JS tests (`bindings/javascript/sync/packages/native/promise.test.ts`) drive the exact failure modes with client-side `fetch`-override fault injection — a parked pull response racing a push, and a lost push response after server-side apply (the lost batch contains a delete to exercise re-capture holes). **Both fail against main's engine** with the predicted corruption (`expected [{v: 'a2'}] to deeply equal [{v: 'b3'}]` — the stale image clobbering another client's newer write) and pass with this change. Full native JS suite green.

## Description of AI Usage

This PR was implemented by Claude Code (Claude Fable 5) working under close direction: the session started as an adversarial review of #8065, derived this design through pseudocode iterations reviewed by the committer (including replacing an earlier freshness-contract design with the boundary log after the committer challenged the contract), then implemented it, wrote the tests, and verified them red against main's engine binary and green with the fix. All output was reviewed by the committer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
