### PR TITLE
bindings: accept turso:// scheme in sync remote URLs

### DIFF
--- a/bindings/go/bindings_sync.go
+++ b/bindings/go/bindings_sync.go
@@ -45,7 +45,7 @@ const (
 type TursoSyncDatabaseConfig struct {
 	// Path to the main database file (auxiliary files will derive names from this path)
 	Path string
-	// optional remote url (libsql://..., https://... or http://...)
+	// optional remote url (libsql://..., turso://..., https://... or http://...)
 	// this URL will be saved in the database metadata file in order to be able to reuse it if later client will be constructed without explicit remote url
 	RemoteUrl string
 	// Namespace for remote host

--- a/bindings/go/driver_sync.go
+++ b/bindings/go/driver_sync.go
@@ -614,6 +614,9 @@ func normalizeUrl(base string) string {
 	if cut, ok := strings.CutPrefix(base, "libsql://"); ok {
 		return "https://" + cut
 	}
+	if cut, ok := strings.CutPrefix(base, "turso://"); ok {
+		return "https://" + cut
+	}
 	return base
 }
 

--- a/bindings/go/driver_sync_test.go
+++ b/bindings/go/driver_sync_test.go
@@ -81,6 +81,13 @@ func TestSyncDSNParsing(t *testing.T) {
 	}
 }
 
+func TestSyncNormalizeUrl(t *testing.T) {
+	require.Equal(t, "https://db.turso.io", normalizeUrl("libsql://db.turso.io"))
+	require.Equal(t, "https://db.turso.io", normalizeUrl("turso://db.turso.io"))
+	require.Equal(t, "https://db.turso.io", normalizeUrl("https://db.turso.io"))
+	require.Equal(t, "http://localhost:8080", normalizeUrl("http://localhost:8080"))
+}
+
 func TestSyncBusyTimeoutConfigPrecedence(t *testing.T) {
 	// Test that explicit BusyTimeout in config takes precedence over DSN
 	t.Run("config overrides DSN", func(t *testing.T) {

--- a/bindings/javascript/sync/packages/common/run.ts
+++ b/bindings/javascript/sync/packages/common/run.ts
@@ -19,7 +19,7 @@ function timeoutMs(ms: number): Promise<void> {
 }
 
 function normalizeUrl(url: string): string {
-    return url.replace(/^libsql:\/\//, 'https://');
+    return url.replace(/^(libsql|turso):\/\//, 'https://');
 }
 
 async function process(opts: RunOpts, io: ProtocolIo, request: any) {

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -88,7 +88,7 @@ impl PyRemoteEncryptionCipher {
 pub struct PyTursoSyncDatabaseConfig {
     // path to the main database file (auxilary files like metadata, WAL, revert, changes will derive names from this path)
     pub path: String,
-    // optional remote url (libsql://..., https://... or http://...)
+    // optional remote url (libsql://..., turso://..., https://... or http://...)
     // this URL will be saved in the database metadata file in order to be able to reuse it if later client will be constructed without explicit remote url
     pub remote_url: Option<String>,
     // arbitrary client name which will be used as a prefix for unique client id

--- a/bindings/python/turso/lib_sync.py
+++ b/bindings/python/turso/lib_sync.py
@@ -456,8 +456,11 @@ def connect_sync(
     """
     # Resolve client name
     cname = client_name or "turso-sync-py"
-    if remote_url and isinstance(remote_url, str) and remote_url.startswith("libsql://"):
-        remote_url = remote_url.replace("libsql://", "https://", 1)
+    if remote_url and isinstance(remote_url, str):
+        if remote_url.startswith("libsql://"):
+            remote_url = "https://" + remote_url[len("libsql://"):]
+        elif remote_url.startswith("turso://"):
+            remote_url = "https://" + remote_url[len("turso://"):]
     http_ctx = _HttpContext(remote_url=remote_url, auth_token=auth_token, client_name=cname)
 
     # Database config: async_io must be True to let Python drive IO

--- a/bindings/react-native/src/internal/ioProcessor.ts
+++ b/bindings/react-native/src/internal/ioProcessor.ts
@@ -110,13 +110,10 @@ export async function processIoItem(item: NativeSyncIoItem, context: IoContext):
 }
 
 /**
- * Normalize URL from libsql:// to https://
+ * Normalize URL from libsql:// or turso:// to https://
  */
 function normalizeUrl(url: string): string {
-  if (url.startsWith('libsql://')) {
-    return url.replace('libsql://', 'https://');
-  }
-  return url;
+  return url.replace(/^(libsql|turso):\/\//, 'https://');
 }
 
 /**

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -91,7 +91,8 @@ impl std::str::FromStr for RemoteEncryptionCipher {
 pub struct Builder {
     // Absolute or relative path to local database file (":memory:" is supported).
     path: String,
-    // Remote URL base. Supports https://, http:// and libsql:// (translated to https://).
+    // Remote URL base. Supports https://, http://, libsql:// and turso:// (the latter two are
+    // translated to https://).
     remote_url: Option<String>,
     // Optional authorization token provider (static string or async callback).
     auth_token: Option<AuthTokenFn>,
@@ -592,10 +593,14 @@ impl Future for AsyncOpFuture {
     }
 }
 
-// Normalize remote base URL, mapping libsql:// to https:// and validating allowed schemes.
+// Normalize remote base URL, mapping libsql:// and turso:// to https:// and validating allowed
+// schemes.
 fn normalize_base_url(input: &str) -> std::result::Result<String, String> {
     let s = input.trim();
-    let s = if let Some(rest) = s.strip_prefix("libsql://") {
+    let s = if let Some(rest) = s
+        .strip_prefix("libsql://")
+        .or_else(|| s.strip_prefix("turso://"))
+    {
         format!("https://{rest}")
     } else {
         s.to_string()
@@ -949,6 +954,29 @@ mod tests {
             .take(8)
             .map(char::from)
             .collect()
+    }
+
+    #[test]
+    fn normalize_base_url_schemes() {
+        use crate::sync::normalize_base_url;
+
+        assert_eq!(
+            normalize_base_url("libsql://db.turso.io").unwrap(),
+            "https://db.turso.io"
+        );
+        assert_eq!(
+            normalize_base_url("turso://db.turso.io").unwrap(),
+            "https://db.turso.io"
+        );
+        assert_eq!(
+            normalize_base_url("https://db.turso.io/").unwrap(),
+            "https://db.turso.io"
+        );
+        assert_eq!(
+            normalize_base_url("http://localhost:8080").unwrap(),
+            "http://localhost:8080"
+        );
+        assert!(normalize_base_url("ftp://db.turso.io").is_err());
     }
 
     #[test]


### PR DESCRIPTION
The sync packages (Rust, Python, JavaScript, React Native, Go) only rewrote libsql:// remote URLs to https://, so turso:// URLs were either rejected or passed through unmodified and failed at request time. The serverless packages already accept both schemes; normalize turso:// the same way in every sync binding so the two URL forms are interchangeable.

Tests: normalize_base_url_schemes in bindings/rust, TestSyncNormalizeUrl in bindings/go