### PR TITLE
cli/sync_server: fix quadratic header scan and Content-Length overflow

### DIFF
--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -37,6 +37,7 @@ const MVCC_TX_HEADER_SIZE: usize = 24;
 const MVCC_TX_EXT_HEADER_SIZE: usize = 40;
 const MVCC_TX_TRAILER_SIZE: usize = 8;
 const MVCC_TX_FRAME_FLAG_HAS_EXTENSION_BLOCK: u32 = 1 << 0;
+const MAX_HEADER_BYTES: usize = 32 * 1024;
 
 pub struct TursoSyncServer {
     address: String,
@@ -126,21 +127,27 @@ impl TursoSyncServer {
             let unscanned = request_data.len().saturating_sub(3);
             request_data.extend_from_slice(&buffer[..n]);
 
-            if let Some(header_end) = find_header_end(&request_data, unscanned) {
-                let headers = String::from_utf8_lossy(&request_data[..header_end]);
-                if let Some(content_length) = parse_content_length(&headers) {
-                    let body_start = header_end + 4;
-                    let total_expected = body_start + content_length;
-                    while request_data.len() < total_expected {
-                        let n = stream.read(&mut buffer)?;
-                        if n == 0 {
-                            break;
-                        }
-                        request_data.extend_from_slice(&buffer[..n]);
-                    }
+            let Some(header_end) = find_header_end(&request_data, unscanned) else {
+                if request_data.len() > MAX_HEADER_BYTES {
+                    return Err(anyhow!(
+                        "HTTP request headers exceed {MAX_HEADER_BYTES} bytes"
+                    ));
                 }
-                break;
+                continue;
+            };
+            let headers = String::from_utf8_lossy(&request_data[..header_end]);
+            if let Some(content_length) = parse_content_length(&headers) {
+                let body_start = header_end + 4;
+                let total_expected = body_start + content_length;
+                while request_data.len() < total_expected {
+                    let n = stream.read(&mut buffer)?;
+                    if n == 0 {
+                        break;
+                    }
+                    request_data.extend_from_slice(&buffer[..n]);
+                }
             }
+            break;
         }
 
         let (method, path, body) = parse_http_request(&request_data)?;

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -137,8 +137,7 @@ impl TursoSyncServer {
             };
             let headers = String::from_utf8_lossy(&request_data[..header_end]);
             if let Some(content_length) = parse_content_length(&headers) {
-                let body_start = header_end + 4;
-                let total_expected = body_start + content_length;
+                let total_expected = request_end(header_end, content_length)?;
                 while request_data.len() < total_expected {
                     let n = stream.read(&mut buffer)?;
                     if n == 0 {
@@ -1130,6 +1129,14 @@ fn db_size_from_page(page: &[u8]) -> u32 {
     u32::from_be_bytes(page[28..32].try_into().unwrap())
 }
 
+/// A client controls Content-Length, so the end of the body has to be
+/// computed without trusting it to fit.
+fn request_end(header_end: usize, content_length: usize) -> Result<usize> {
+    (header_end + 4)
+        .checked_add(content_length)
+        .ok_or_else(|| anyhow!("HTTP request length overflows: {content_length}"))
+}
+
 fn find_header_end(data: &[u8], start: usize) -> Option<usize> {
     (start..data.len().saturating_sub(3)).find(|&i| &data[i..i + 4] == b"\r\n\r\n")
 }
@@ -1259,5 +1266,11 @@ mod tests {
             }
             assert_eq!(found, Some(expected), "missed terminator at chunk {chunk}");
         }
+    }
+
+    #[test]
+    fn rejects_content_length_that_overflows() {
+        assert!(request_end(0, usize::MAX).is_err());
+        assert_eq!(request_end(10, 5).unwrap(), 19);
     }
 }

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -121,9 +121,12 @@ impl TursoSyncServer {
             if n == 0 {
                 break;
             }
+            // Bytes before this offset hold no terminator, and one can still
+            // straddle the last three of them.
+            let unscanned = request_data.len().saturating_sub(3);
             request_data.extend_from_slice(&buffer[..n]);
 
-            if let Some(header_end) = find_header_end(&request_data) {
+            if let Some(header_end) = find_header_end(&request_data, unscanned) {
                 let headers = String::from_utf8_lossy(&request_data[..header_end]);
                 if let Some(content_length) = parse_content_length(&headers) {
                     let body_start = header_end + 4;
@@ -1120,8 +1123,8 @@ fn db_size_from_page(page: &[u8]) -> u32 {
     u32::from_be_bytes(page[28..32].try_into().unwrap())
 }
 
-fn find_header_end(data: &[u8]) -> Option<usize> {
-    (0..data.len().saturating_sub(3)).find(|&i| &data[i..i + 4] == b"\r\n\r\n")
+fn find_header_end(data: &[u8], start: usize) -> Option<usize> {
+    (start..data.len().saturating_sub(3)).find(|&i| &data[i..i + 4] == b"\r\n\r\n")
 }
 
 fn parse_content_length(headers: &str) -> Option<usize> {
@@ -1136,7 +1139,7 @@ fn parse_content_length(headers: &str) -> Option<usize> {
 }
 
 fn parse_http_request(data: &[u8]) -> Result<(String, String, Vec<u8>)> {
-    let header_end = find_header_end(data).ok_or_else(|| anyhow!("Invalid HTTP request"))?;
+    let header_end = find_header_end(data, 0).ok_or_else(|| anyhow!("Invalid HTTP request"))?;
     let headers = String::from_utf8_lossy(&data[..header_end]);
 
     let first_line = headers
@@ -1222,5 +1225,32 @@ fn convert_core_to_value(value: CoreValue) -> Value {
         CoreValue::Blob(b) => Value::Blob {
             value: Bytes::from(b),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirrors the read loop: the terminator must be found whatever the chunk
+    /// boundaries, including when it straddles two reads.
+    #[test]
+    fn finds_header_end_across_read_boundaries() {
+        let request = b"POST / HTTP/1.1\r\nHost: x\r\n\r\nbody".to_vec();
+        let expected = find_header_end(&request, 0).expect("terminator is present");
+
+        for chunk in 1..=request.len() {
+            let mut data = Vec::new();
+            let mut found = None;
+            for piece in request.chunks(chunk) {
+                let unscanned = data.len().saturating_sub(3);
+                data.extend_from_slice(piece);
+                if let Some(end) = find_header_end(&data, unscanned) {
+                    found = Some(end);
+                    break;
+                }
+            }
+            assert_eq!(found, Some(expected), "missed terminator at chunk {chunk}");
+        }
     }
 }


### PR DESCRIPTION
## Description

Three small fixes to the sync server's HTTP request reader. All three affect the
existing single-database server; none of them depend on any new feature.

- **Scan HTTP headers once per byte.** `find_header_end()` restarted at offset
  zero after every 8 KiB read, so a request whose headers never terminate cost
  O(n²). The accept loop handles connections inline, so that CPU blocks every
  other request: 8 MiB of padding with no `CRLFCRLF` burned ~56 seconds of CPU.
  The scan now resumes from the previous length less three bytes, the earliest
  position a terminator straddling the read boundary can start.

- **Bound header accumulation.** A connection that never sends the terminator
  was read into an ever-growing buffer with no limit. Give up past 32 KiB.

- **Reject a `Content-Length` that overflows.** The body end was computed as
  `header_end + 4 + content_length` from a client-supplied value, so
  `Content-Length: 18446744073709551615` wrapped the addition — a debug build
  panics and takes the process down, a release build wraps and misreads the
  request. Now computed with `checked_add`.

No ceiling is imposed on body size: the read loop grows its buffer from bytes
actually received rather than reserving `Content-Length` up front, and pipeline
bodies carry blobs up to `MAX_BLOB_LENGTH`, which base64 expands beyond any
limit that would be safe to hard-code.

Measured on a build from this branch, before → after:

| | before | after |
|---|---|---|
| 8 MiB of unterminated headers | 55.74s CPU | 0.04s CPU |
| `Content-Length: u64::MAX` | process dies (debug) | request rejected, server alive |
| normal request | 200 | 200 |

## Motivation and context

Found while reviewing a separate change to the same file. Both issues are
reachable by any client that can open a socket to the sync server, and the
single-threaded accept loop means one connection's cost is every connection's
cost. Sending them separately from the feature work that surfaced them, since
they stand on their own and apply to the server as it ships today.

## Description of AI Usage

This PR was AI-assisted throughout, and the disclosure is worth reading because
the AI's role differed by phase.

The bugs were found by Claude Fable 5 running an adversarial review of a
separate feature branch touching `cli/sync_server.rs`, prompted to attack the
code rather than summarize it. It reproduced both issues against a running
server — measuring the 55.74 seconds of CPU, and crashing a debug build with a
`u64::MAX` Content-Length — before either was accepted as real.

The fixes and their tests were written by Claude Fable 5, then verified by
re-running the same reproductions against the patched build. The header-scan
test was checked by deliberately reverting the resume offset to confirm it fails
("missed terminator at chunk 1") without the fix.

`cargo fmt`, `cargo clippy --workspace --all-features --all-targets --
--deny=warnings`, and the CLI test suite all pass on the pinned 1.88 toolchain.
`make test` was run with `test-extensions` excluded, because macOS ships sqlite3
compiled with `OMIT_LOAD_EXTENSION`; `test-write`, `test-update`,
`test-constraint`, and `test-collate` skipped themselves for an unrelated
missing-indexes precondition.

I reviewed the result and am responsible for it.