### PR TITLE
core/mvcc: reclaim Passive checkpoint versions and empty SkipMap slots

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1320,12 +1320,21 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                     // Just need to pick the smaller one
                     (false, false)
                 }
-                CursorPosition::Loaded { in_btree, .. } => {
-                    // Advance whichever cursor we just consumed
-                    if *in_btree {
-                        (false, true) // Last row was from btree, advance btree
+                CursorPosition::Loaded {
+                    row_id, in_btree, ..
+                } => {
+                    // Sorted-merge: if the other peek still holds the same key
+                    // (GC made fallthrough valid under a live MVCC peek), advance
+                    // both so we do not emit K twice.
+                    let other_same_key = if *in_btree {
+                        self.dual_peek.mvcc_peek.get_row_key() == Some(&row_id.row_id)
                     } else {
-                        (true, false) // Last row was from MVCC, advance MVCC
+                        self.dual_peek.btree_peek.get_row_key() == Some(&row_id.row_id)
+                    };
+                    if *in_btree {
+                        (other_same_key, true)
+                    } else {
+                        (true, other_same_key)
                     }
                 }
                 CursorPosition::End => {
@@ -1402,12 +1411,21 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                     // First call after last() - peek values should already be populated
                     (false, false)
                 }
-                CursorPosition::Loaded { in_btree, .. } => {
-                    // Advance whichever cursor we just consumed
-                    if *in_btree {
-                        (false, true) // Last row was from btree, advance btree
+                CursorPosition::Loaded {
+                    row_id, in_btree, ..
+                } => {
+                    // Sorted-merge: if the other peek still holds the same key
+                    // (GC made fallthrough valid under a live MVCC peek), advance
+                    // both so we do not emit K twice.
+                    let other_same_key = if *in_btree {
+                        self.dual_peek.mvcc_peek.get_row_key() == Some(&row_id.row_id)
                     } else {
-                        (true, false) // Last row was from MVCC, advance MVCC
+                        self.dual_peek.btree_peek.get_row_key() == Some(&row_id.row_id)
+                    };
+                    if *in_btree {
+                        (other_same_key, true)
+                    } else {
+                        (true, other_same_key)
                     }
                 }
                 CursorPosition::BeforeFirst => {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2982,12 +2982,32 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             CheckpointState::Finalize => {
                 if self.lock_states.blocking_checkpoint_lock_held {
                     // Truncate: B-trees stable under the lock — drop currents + unlink slots.
+                    // Safe because acquiring `blocking_checkpoint_lock` for write (`AcquireLock`)
+                    // drains every already-open MVCC transaction first (`begin_tx` holds it for
+                    // read for its whole lifetime), so no reader that might still need a
+                    // dropped current's B-tree-equivalent value can observe a *later* physical
+                    // overwrite of that row — there is no later writer until this lock releases.
                     self.mvstore.drop_unused_row_versions_and_slots();
                 } else {
-                    // Passive: reclaim history + unlink empty slots. Keep last currents —
-                    // dropping them makes dual-cursor fall through to B-trees that can
-                    // disagree with still-present index/table SkipMap state under concurrency.
-                    self.mvstore.drop_unused_row_versions_unlink_empty();
+                    // Passive: reclaim history and unlink empty slots, but keep last currents
+                    // (Rule 3 stays off — see `gc_version_chain` doc comment). Passive writers
+                    // are never excluded by a lock the way Truncate's are, so a row whose sole
+                    // current was dropped could be overwritten again by a *later*, unrelated
+                    // commit + auto-checkpoint while an old reader (whose `read_mark` predates
+                    // that commit) is still open; the dual cursor's "no SkipMap entry" fallback
+                    // has no per-reader isolation of its own (`read_mark` is a logical
+                    // bookkeeping value, not an actual WAL pin on the physical page read), so
+                    // such a reader would observe the newer, not-yet-visible value. Keeping the
+                    // current version anchors the chain so `is_btree_invalidating_version` can
+                    // still hide that later B-tree state from the old reader.
+                    //
+                    // We still close the "begin-tx publish window" gap for Rule 2 here: a reader
+                    // that pinned a WAL frame via `Pager::begin_read_tx` before publishing its
+                    // MVCC transaction into `txs` is invisible to `MvStore::compute_min_reader_mark`
+                    // alone, so a superseded version it still needs could otherwise be reclaimed.
+                    // Rule 3 ON for Passive Finalize (write-matrix / short-profile recovery path).
+                    self.mvstore
+                        .drop_unused_row_versions_and_slots_passive(self.gc_floor_reader_mark());
                 }
                 // Locks stay held until `step()` runs `on_checkpoint_end`, then
                 // `release_checkpoint_locks_if_needed`.

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1476,6 +1476,44 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         }
     }
 
+    /// Advance shared `nbackfills` after MVCC's WAL backfill (+ DB sync when enabled).
+    ///
+    /// The pager checkpoint path publishes this in `CheckpointPhase::PublishBackfill`.
+    /// MVCC drives `wal.checkpoint` directly and previously synced the DB without publishing,
+    /// so Passive left `nbackfills` at 0 forever — `backfill_floor` never advanced and Passive
+    /// GC Rules 2/3 could not reclaim stamped versions (SkipMap grew without bound).
+    ///
+    /// Truncate/Restart must not publish here: `wal.checkpoint` already restarted the log
+    /// (max_frame/nbackfills reset to 0) before SyncDbFile runs, and the pager Truncate path
+    /// similarly skips PublishBackfill in favor of WAL truncate.
+    fn publish_wal_backfill_if_needed(&mut self) {
+        if self.mode.should_restart_log() {
+            if let Some(result) = self.checkpoint_result.as_mut() {
+                result.release_guard();
+            }
+            return;
+        }
+        let Some(result) = self.checkpoint_result.as_mut() else {
+            return;
+        };
+        if result.wal_checkpoint_backfilled == 0 {
+            // No frames copied: drop the checkpoint guard if WAL held it for a no-op Passive.
+            result.release_guard();
+            return;
+        }
+        let max_frame = result.wal_total_backfilled;
+        let Some(wal) = self.pager.wal.as_ref() else {
+            panic!("No WAL to publish backfill");
+        };
+        tracing::debug!(
+            max_frame,
+            backfilled = result.wal_checkpoint_backfilled,
+            "publishing WAL backfill after MVCC checkpoint"
+        );
+        wal.publish_backfill(max_frame);
+        result.release_guard();
+    }
+
     fn has_unpublished_schema_changes(&self) -> bool {
         let schema = self.connection.db.schema.lock();
         if !schema.dropped_root_pages.is_empty() {
@@ -1771,13 +1809,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         materialized_frame,
                         snapshot_ts,
                     );
-                    MvStore::<Clock, A>::gc_version_chain(
+                    let dropped = MvStore::<Clock, A>::gc_version_chain(
                         &mut versions,
                         lwm,
                         ckpt_max,
                         self.mvstore.experimental_mvcc_passive_checkpoint,
                         min_reader_mark,
                     );
+                    self.mvstore.dec_live_version_count_approx(dropped);
                     versions.is_empty()
                 };
                 if is_now_empty && remove_empty_slots {
@@ -1848,13 +1887,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         materialized_frame,
                         snapshot_ts,
                     );
-                    MvStore::<Clock, A>::gc_version_chain(
+                    let dropped = MvStore::<Clock, A>::gc_version_chain(
                         &mut versions,
                         lwm,
                         ckpt_max,
                         self.mvstore.experimental_mvcc_passive_checkpoint,
                         min_reader_mark,
                     );
+                    self.mvstore.dec_live_version_count_approx(dropped);
                     versions.is_empty()
                 };
                 if is_now_empty && remove_empty_slots {
@@ -2831,23 +2871,50 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             }
 
             CheckpointState::CheckpointWal => {
-                tracing::debug!("Performing TRUNCATE checkpoint on WAL");
-                match self.checkpoint_wal()? {
-                    IOResult::Done(result) => {
+                tracing::debug!("Performing checkpoint on WAL");
+                match self.checkpoint_wal() {
+                    Ok(IOResult::Done(result)) => {
                         self.checkpoint_result = Some(result);
                         self.state = CheckpointState::SyncDbFile;
                         Ok(TransitionResult::Continue)
                     }
-                    IOResult::IO(io) => Ok(TransitionResult::Io(io)),
+                    Ok(IOResult::IO(io)) => Ok(TransitionResult::Io(io)),
+                    // Passive WAL backfill needs exclusive read-mark 0. A reader that began when
+                    // max_frame == nbackfills holds that slot as DbFile and correctly Busy-blocks
+                    // backfill. MVCC publish + logical-log truncate can still complete; frames
+                    // remain in the WAL until a later Passive pass. Skipping publish_backfill keeps
+                    // backfill_floor honest so Passive GC will not reclaim un-backfilled versions.
+                    Err(crate::LimboError::Busy)
+                        if matches!(self.mode, CheckpointMode::Passive { .. }) =>
+                    {
+                        tracing::debug!(
+                            "Passive WAL checkpoint Busy under pinned DbFile reader; continuing without backfill"
+                        );
+                        let (max_frame, nbackfills) = self
+                            .pager
+                            .wal
+                            .as_ref()
+                            .map(|wal| (wal.get_max_frame_in_wal(), wal.backfill_frame()))
+                            .unwrap_or((0, 0));
+                        self.checkpoint_result =
+                            Some(CheckpointResult::new(max_frame, nbackfills, 0));
+                        self.state = CheckpointState::TruncateLogicalLog;
+                        Ok(TransitionResult::Continue)
+                    }
+                    Err(e) => Err(e),
                 }
             }
 
             CheckpointState::SyncDbFile => {
-                // Fsync database file before truncating WAL.
+                // Fsync database file before truncating WAL / publishing nbackfills.
                 // This ensures durability: if we crash after WAL truncation but before DB fsync,
-                // the checkpointed data would be lost.
+                // the checkpointed data would be lost. Publishing nbackfills (below) must not
+                // race ahead of that durable DB content — same ordering as pager PublishBackfill.
                 if self.sync_mode == SyncMode::Off {
                     tracing::debug!("Skipping fsync of database file (synchronous=off)");
+                    // sync=off already accepts durability risk; still publish so Passive GC's
+                    // backfill_floor can advance with the frames already copied to the DB file.
+                    self.publish_wal_backfill_if_needed();
                     self.state = CheckpointState::TruncateLogicalLog;
                     return Ok(TransitionResult::Continue);
                 }
@@ -2859,12 +2926,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
                 // Only sync if we actually backfilled any frames
                 if checkpoint_result.wal_checkpoint_backfilled == 0 {
+                    checkpoint_result.release_guard();
                     self.state = CheckpointState::TruncateLogicalLog;
                     return Ok(TransitionResult::Continue);
                 }
 
                 // Check if we already sent the sync
                 if checkpoint_result.db_sync_sent {
+                    self.publish_wal_backfill_if_needed();
                     self.state = CheckpointState::TruncateLogicalLog;
                     return Ok(TransitionResult::Continue);
                 }

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1489,9 +1489,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             return;
         }
         let max_frame = result.wal_total_backfilled;
-        let Some(wal) = self.pager.wal.as_ref() else {
-            panic!("No WAL to publish backfill");
-        };
+        turso_assert!(self.pager.wal.is_some(), "No WAL to publish backfill");
+        let wal = self.pager.wal.as_ref().unwrap();
         tracing::debug!(
             max_frame,
             backfilled = result.wal_checkpoint_backfilled,

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1476,29 +1476,16 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         }
     }
 
-    /// Advance shared `nbackfills` after MVCC's WAL backfill (+ DB sync when enabled).
-    ///
-    /// The pager checkpoint path publishes this in `CheckpointPhase::PublishBackfill`.
-    /// MVCC drives `wal.checkpoint` directly and previously synced the DB without publishing,
-    /// so Passive left `nbackfills` at 0 forever — `backfill_floor` never advanced and Passive
-    /// GC Rules 2/3 could not reclaim stamped versions (SkipMap grew without bound).
-    ///
-    /// Truncate/Restart must not publish here: `wal.checkpoint` already restarted the log
-    /// (max_frame/nbackfills reset to 0) before SyncDbFile runs, and the pager Truncate path
-    /// similarly skips PublishBackfill in favor of WAL truncate.
+    /// Publish `nbackfills` after Passive backfill + DB sync. Skip Truncate/Restart.
+    /// Leaves the checkpoint guard held until Finalize (same as the pager).
     fn publish_wal_backfill_if_needed(&mut self) {
         if self.mode.should_restart_log() {
-            if let Some(result) = self.checkpoint_result.as_mut() {
-                result.release_guard();
-            }
             return;
         }
-        let Some(result) = self.checkpoint_result.as_mut() else {
+        let Some(result) = self.checkpoint_result.as_ref() else {
             return;
         };
         if result.wal_checkpoint_backfilled == 0 {
-            // No frames copied: drop the checkpoint guard if WAL held it for a no-op Passive.
-            result.release_guard();
             return;
         }
         let max_frame = result.wal_total_backfilled;
@@ -1511,7 +1498,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             "publishing WAL backfill after MVCC checkpoint"
         );
         wal.publish_backfill(max_frame);
-        result.release_guard();
     }
 
     fn has_unpublished_schema_changes(&self) -> bool {
@@ -1772,19 +1758,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     fn gc_checkpointed_table_versions(&mut self) -> Option<IOCompletions> {
-        // Empty-slot removal after dropping the version-chain write lock has a TOCTOU
-        // gap — a concurrent writer could `get_or_insert_with` between the emptiness
-        // check and `remove()`. It is only safe under the stop-the-world blocking lock,
-        // which the Truncate/Restart path holds. The passive path runs lazily
-        // (slots are reclaimed by a later insert or a future blocking checkpoint), exactly
-        // like the inline commit-path GC (`gc_incremental`).
-        let remove_empty_slots = self.lock_states.blocking_checkpoint_lock_held;
+        // Keep empty SkipMap slots; Truncate Finalize `_and_slots` unlinks them later.
         let ckpt_max = self.durable_txid_max_new;
-        // Reader floor for the per-version GC, including readers pinned at the pager/WAL level
-        // that have not yet published an MVCC transaction (the begin-tx publish window).
+        // Includes pager/WAL-pinned readers not yet in `txs` (begin-tx publish window).
         let min_reader_mark = self.gc_floor_reader_mark();
-        // The WAL position this checkpoint's pages reached durability at; what we stamp the
-        // just-materialized versions with. (Unchanged since CommitPagerTxn — single orchestrator.)
         let materialized_frame = WalPos::from_pair(self.pager.wal_pos());
         let snapshot_ts = self.snapshot_ts;
         let CheckpointState::GcTableRows { next_index, lwm } = self.state else {
@@ -1792,6 +1769,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         };
         let mut index = next_index;
         let mut processed = 0;
+        // Drop current SkipMap versions only when B-trees are stable (blocking Truncate).
+        let drop_current_if_in_btree = self.lock_states.blocking_checkpoint_lock_held
+            || !self.mvstore.experimental_mvcc_passive_checkpoint;
         while index < self.write_set.len() {
             let current = index;
             index += 1;
@@ -1802,26 +1782,21 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             }
             let row_id = &self.write_set[current].0.row.id;
             if let Some(entry) = self.mvstore.rows.get(row_id) {
-                let is_now_empty = {
-                    let mut versions = entry.value().write();
-                    self.mvstore.stamp_chain_materialized(
-                        &mut versions,
-                        materialized_frame,
-                        snapshot_ts,
-                    );
-                    let dropped = MvStore::<Clock, A>::gc_version_chain(
-                        &mut versions,
-                        lwm,
-                        ckpt_max,
-                        self.mvstore.experimental_mvcc_passive_checkpoint,
-                        min_reader_mark,
-                    );
-                    self.mvstore.dec_live_version_count_approx(dropped);
-                    versions.is_empty()
-                };
-                if is_now_empty && remove_empty_slots {
-                    self.mvstore.rows.remove(row_id);
-                }
+                let mut versions = entry.value().write();
+                self.mvstore.stamp_chain_materialized(
+                    &mut versions,
+                    materialized_frame,
+                    snapshot_ts,
+                );
+                let dropped = MvStore::<Clock, A>::gc_version_chain(
+                    &mut versions,
+                    lwm,
+                    ckpt_max,
+                    self.mvstore.experimental_mvcc_passive_checkpoint,
+                    min_reader_mark,
+                    drop_current_if_in_btree,
+                );
+                self.mvstore.dec_live_version_count_approx(dropped);
             } else {
                 // The MVCC metadata table row (persistent_tx_ts_max) is staged
                 // directly into the write set by maybe_stage_mvcc_metadata_write() and do not
@@ -1850,9 +1825,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     fn gc_checkpointed_index_versions(&mut self) -> Option<IOCompletions> {
-        // See gc_checkpointed_table_versions: slot removal only under the blocking lock
-        // (Truncate/Restart); the passive path is lazy.
-        let remove_empty_slots = self.lock_states.blocking_checkpoint_lock_held;
         let ckpt_max = self.durable_txid_max_new;
         let min_reader_mark = self.gc_floor_reader_mark();
         let materialized_frame = WalPos::from_pair(self.pager.wal_pos());
@@ -1862,6 +1834,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         };
         let mut index = next_index;
         let mut processed = 0;
+        let drop_current_if_in_btree = self.lock_states.blocking_checkpoint_lock_held
+            || !self.mvstore.experimental_mvcc_passive_checkpoint;
         while index < self.index_write_set.len() {
             let current = index;
             index += 1;
@@ -1877,29 +1851,24 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     .get(&index_id)
                     .expect("index_id from write set must exist in index_rows");
                 let inner_map = outer_entry.value();
-                let is_now_empty = {
-                    let inner_entry = inner_map
-                        .get(sortable_key)
-                        .expect("index row from write set must exist in inner map");
-                    let mut versions = inner_entry.value().write();
-                    self.mvstore.stamp_chain_materialized(
-                        &mut versions,
-                        materialized_frame,
-                        snapshot_ts,
-                    );
-                    let dropped = MvStore::<Clock, A>::gc_version_chain(
-                        &mut versions,
-                        lwm,
-                        ckpt_max,
-                        self.mvstore.experimental_mvcc_passive_checkpoint,
-                        min_reader_mark,
-                    );
-                    self.mvstore.dec_live_version_count_approx(dropped);
-                    versions.is_empty()
-                };
-                if is_now_empty && remove_empty_slots {
-                    inner_map.remove(sortable_key);
-                }
+                let inner_entry = inner_map
+                    .get(sortable_key)
+                    .expect("index row from write set must exist in inner map");
+                let mut versions = inner_entry.value().write();
+                self.mvstore.stamp_chain_materialized(
+                    &mut versions,
+                    materialized_frame,
+                    snapshot_ts,
+                );
+                let dropped = MvStore::<Clock, A>::gc_version_chain(
+                    &mut versions,
+                    lwm,
+                    ckpt_max,
+                    self.mvstore.experimental_mvcc_passive_checkpoint,
+                    min_reader_mark,
+                    drop_current_if_in_btree,
+                );
+                self.mvstore.dec_live_version_count_approx(dropped);
             }
             processed += 1;
             if processed >= COLLECT_PREEMPTION_THRESHOLD {
@@ -2879,11 +2848,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         Ok(TransitionResult::Continue)
                     }
                     Ok(IOResult::IO(io)) => Ok(TransitionResult::Io(io)),
-                    // Passive WAL backfill needs exclusive read-mark 0. A reader that began when
-                    // max_frame == nbackfills holds that slot as DbFile and correctly Busy-blocks
-                    // backfill. MVCC publish + logical-log truncate can still complete; frames
-                    // remain in the WAL until a later Passive pass. Skipping publish_backfill keeps
-                    // backfill_floor honest so Passive GC will not reclaim un-backfilled versions.
+                    // Busy under a DbFile reader: finish without publishing nbackfills.
                     Err(crate::LimboError::Busy)
                         if matches!(self.mode, CheckpointMode::Passive { .. }) =>
                     {
@@ -2906,14 +2871,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             }
 
             CheckpointState::SyncDbFile => {
-                // Fsync database file before truncating WAL / publishing nbackfills.
-                // This ensures durability: if we crash after WAL truncation but before DB fsync,
-                // the checkpointed data would be lost. Publishing nbackfills (below) must not
-                // race ahead of that durable DB content — same ordering as pager PublishBackfill.
+                // Sync before publish_backfill (pager PublishBackfill order).
                 if self.sync_mode == SyncMode::Off {
                     tracing::debug!("Skipping fsync of database file (synchronous=off)");
-                    // sync=off already accepts durability risk; still publish so Passive GC's
-                    // backfill_floor can advance with the frames already copied to the DB file.
                     self.publish_wal_backfill_if_needed();
                     self.state = CheckpointState::TruncateLogicalLog;
                     return Ok(TransitionResult::Continue);
@@ -2926,7 +2886,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
                 // Only sync if we actually backfilled any frames
                 if checkpoint_result.wal_checkpoint_backfilled == 0 {
-                    checkpoint_result.release_guard();
                     self.state = CheckpointState::TruncateLogicalLog;
                     return Ok(TransitionResult::Continue);
                 }
@@ -3022,11 +2981,16 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
             CheckpointState::Finalize => {
                 if self.lock_states.blocking_checkpoint_lock_held {
-                    // Slot-removing GC is safe while the blocking lock is held.
+                    tracing::debug!("Releasing blocking checkpoint lock");
+                    // Truncate: B-trees stable under the lock — drop currents + unlink slots.
                     self.mvstore.drop_unused_row_versions_and_slots();
+                    self.checkpoint_lock.unlock();
+                    self.lock_states.blocking_checkpoint_lock_held = false;
                 } else {
-                    // Passive: GC chains in place; empty slots reclaimed on next insert.
-                    self.mvstore.drop_unused_row_versions();
+                    // Passive: reclaim history + unlink empty slots. Keep last currents —
+                    // dropping them makes dual-cursor fall through to B-trees that can
+                    // disagree with still-present index/table SkipMap state under concurrency.
+                    self.mvstore.drop_unused_row_versions_unlink_empty();
                 }
                 // Locks stay held until `step()` runs `on_checkpoint_end`.
                 self.finalize(&())?;
@@ -3714,6 +3678,25 @@ mod tests {
         );
 
         while checkpoint.gc_checkpointed_table_versions().is_some() {}
+        // Write-set GC clears version chains but leaves empty SkipMap slots;
+        // Truncate Finalize `_and_slots` unlinks them.
+        let slots = mvstore
+            .rows
+            .iter()
+            .filter(|entry| entry.key().table_id == table_id)
+            .count();
+        let versions: usize = mvstore
+            .rows
+            .iter()
+            .filter(|entry| entry.key().table_id == table_id)
+            .map(|entry| entry.value().read().len())
+            .sum();
+        assert_eq!(versions, 0, "write-set GC must reclaim version chains");
+        assert_eq!(
+            slots, row_count,
+            "empty slots remain until Finalize `_and_slots`"
+        );
+        mvstore.drop_unused_row_versions_and_slots();
         let remaining = mvstore
             .rows
             .iter()
@@ -3763,6 +3746,27 @@ mod tests {
         );
 
         while checkpoint.gc_checkpointed_index_versions().is_some() {}
+        // Write-set GC clears version chains but leaves empty SkipMap slots;
+        // Truncate Finalize `_and_slots` unlinks them.
+        let inner = mvstore
+            .index_rows
+            .get(&index_id)
+            .expect("index map must exist");
+        let slots = inner.value().len();
+        let versions: usize = inner
+            .value()
+            .iter()
+            .map(|entry| entry.value().read().len())
+            .sum();
+        assert_eq!(
+            versions, 0,
+            "write-set GC must reclaim index version chains"
+        );
+        assert_eq!(
+            slots, row_count,
+            "empty index slots remain until Finalize `_and_slots`"
+        );
+        mvstore.drop_unused_row_versions_and_slots();
         let remaining = mvstore
             .index_rows
             .get(&index_id)

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2981,33 +2981,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
             CheckpointState::Finalize => {
                 if self.lock_states.blocking_checkpoint_lock_held {
-                    // Truncate: B-trees stable under the lock — drop currents + unlink slots.
-                    // Safe because acquiring `blocking_checkpoint_lock` for write (`AcquireLock`)
-                    // drains every already-open MVCC transaction first (`begin_tx` holds it for
-                    // read for its whole lifetime), so no reader that might still need a
-                    // dropped current's B-tree-equivalent value can observe a *later* physical
-                    // overwrite of that row — there is no later writer until this lock releases.
+                    // Truncate: under the blocking lock, drop last SkipMap copies and empty slots.
+                    // That lock waits out open MVCC txs, so no old reader can see a later rewrite.
                     self.mvstore.drop_unused_row_versions_and_slots();
                 } else {
-                    // Passive: reclaim history and unlink empty slots, but keep last currents
-                    // (Rule 3 stays off — see `gc_version_chain` doc comment). Passive writers
-                    // are never excluded by a lock the way Truncate's are, so a row whose sole
-                    // current was dropped could be overwritten again by a *later*, unrelated
-                    // commit + auto-checkpoint while an old reader (whose `read_mark` predates
-                    // that commit) is still open; the dual cursor's "no SkipMap entry" fallback
-                    // has no per-reader isolation of its own (`read_mark` is a logical
-                    // bookkeeping value, not an actual WAL pin on the physical page read), so
-                    // such a reader would observe the newer, not-yet-visible value. Keeping the
-                    // current version anchors the chain so `is_btree_invalidating_version` can
-                    // still hide that later B-tree state from the old reader.
-                    //
-                    // We still close the "begin-tx publish window" gap for Rule 2 here: a reader
-                    // that pinned a WAL frame via `Pager::begin_read_tx` before publishing its
-                    // MVCC transaction into `txs` is invisible to `MvStore::compute_min_reader_mark`
-                    // alone, so a superseded version it still needs could otherwise be reclaimed.
-                    // Rule 3 ON for Passive Finalize (write-matrix / short-profile recovery path).
+                    // Passive: drop old versions and empty slots, but keep the latest SkipMap
+                    // copy of each row. Without it, an older reader can fall through to a
+                    // B-tree page that a later checkpoint already rewrote.
+                    // Also use the pager reader mark so we don't GC versions a brand-new
+                    // reader still needs before its MVCC tx is registered.
                     self.mvstore
-                        .drop_unused_row_versions_and_slots_passive(self.gc_floor_reader_mark());
+                        .drop_unused_row_versions_unlink_empty_at(self.gc_floor_reader_mark());
                 }
                 // Locks stay held until `step()` runs `on_checkpoint_end`, then
                 // `release_checkpoint_locks_if_needed`.

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2981,18 +2981,16 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
             CheckpointState::Finalize => {
                 if self.lock_states.blocking_checkpoint_lock_held {
-                    tracing::debug!("Releasing blocking checkpoint lock");
                     // Truncate: B-trees stable under the lock — drop currents + unlink slots.
                     self.mvstore.drop_unused_row_versions_and_slots();
-                    self.checkpoint_lock.unlock();
-                    self.lock_states.blocking_checkpoint_lock_held = false;
                 } else {
                     // Passive: reclaim history + unlink empty slots. Keep last currents —
                     // dropping them makes dual-cursor fall through to B-trees that can
                     // disagree with still-present index/table SkipMap state under concurrency.
                     self.mvstore.drop_unused_row_versions_unlink_empty();
                 }
-                // Locks stay held until `step()` runs `on_checkpoint_end`.
+                // Locks stay held until `step()` runs `on_checkpoint_end`, then
+                // `release_checkpoint_locks_if_needed`.
                 self.finalize(&())?;
                 Ok(TransitionResult::Done(
                     self.checkpoint_result.take().ok_or_else(|| {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1762,6 +1762,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         let ckpt_max = self.durable_txid_max_new;
         // Includes pager/WAL-pinned readers not yet in `txs` (begin-tx publish window).
         let min_reader_mark = self.gc_floor_reader_mark();
+        // WAL pos this checkpoint made durable; stamp just-materialized versions with it
+        // (unchanged since CommitPagerTxn — single orchestrator).
         let materialized_frame = WalPos::from_pair(self.pager.wal_pos());
         let snapshot_ts = self.snapshot_ts;
         let CheckpointState::GcTableRows { next_index, lwm } = self.state else {
@@ -1825,8 +1827,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     fn gc_checkpointed_index_versions(&mut self) -> Option<IOCompletions> {
+        // Same as table GC: keep empty SkipMap slots; Truncate Finalize unlinks later.
         let ckpt_max = self.durable_txid_max_new;
         let min_reader_mark = self.gc_floor_reader_mark();
+        // Same stamp as table GC (unchanged since CommitPagerTxn).
         let materialized_frame = WalPos::from_pair(self.pager.wal_pos());
         let snapshot_ts = self.snapshot_ts;
         let CheckpointState::GcIndexRows { next_index, lwm } = self.state else {
@@ -2871,7 +2875,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             }
 
             CheckpointState::SyncDbFile => {
-                // Sync before publish_backfill (pager PublishBackfill order).
+                // Fsync DB before WAL truncate / publish_backfill (pager PublishBackfill order).
+                // Crash after truncate but before fsync would lose checkpointed data.
                 if self.sync_mode == SyncMode::Off {
                     tracing::debug!("Skipping fsync of database file (synchronous=off)");
                     self.publish_wal_backfill_if_needed();

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -7209,26 +7209,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         self.drop_unused_row_versions_inner(true, true, WalPos::STAGED)
     }
 
-    /// Passive Finalize: reclaim history and unlink empty SkipMap slots, but keep
-    /// last currents (Rule 3 stays off — see the module doc comment on why Passive
-    /// cannot safely drop a chain's only remaining version).
-    ///
-    /// `reader_mark_floor` must be the *pager-level* reader floor
-    /// ([`crate::mvcc::database::checkpoint_state_machine::CheckpointStateMachine::gc_floor_reader_mark`]),
-    /// not just [`Self::compute_min_reader_mark`]. A reader that has pinned a WAL
-    /// read frame via `Pager::begin_read_tx` but has not yet published its MVCC
-    /// transaction into `self.txs` (the begin-tx publish window) is invisible to
-    /// `compute_min_reader_mark` alone; without the pager floor Rule 2 could reclaim
-    /// a superseded version this reader still needs.
+    /// Drop old versions and empty SkipMap slots, but keep the latest copy of each
+    /// row (Rule 3 off). Passive Finalize uses this. `reader_mark_floor` should
+    /// include pager-held readers, not only `txs`.
     pub fn drop_unused_row_versions_unlink_empty_at(&self, reader_mark_floor: WalPos) -> usize {
         self.drop_unused_row_versions_inner(true, false, reader_mark_floor)
-    }
-
-    /// Passive Finalize: reclaim history, unlink empty SkipMap slots, **and** drop last
-    /// currents already in the B-tree (Rule 3 ON). Uses pager `reader_mark_floor` so
-    /// Rule 2 respects begin-tx publish-window readers.
-    pub fn drop_unused_row_versions_and_slots_passive(&self, reader_mark_floor: WalPos) -> usize {
-        self.drop_unused_row_versions_inner(true, true, reader_mark_floor)
     }
 
     /// Incremental GC on the commit path: reclaim up to `max_chains` table chains
@@ -7640,44 +7625,19 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     ///
     /// Rule 1: aborted garbage (begin=None, end=None) — always remove.
     /// Rule 2: superseded (end=Timestamp(e)) — remove once no reader can see it,
-    ///         unless it's a tombstone (no committed current version) whose
-    ///         deletion hasn't been checkpointed, or a B-tree-resident version
-    ///         (flagged, or with a checkpointed insert: begin <= ckpt_max)
-    ///         whose physical delete/overwrite hasn't been checkpointed.
-    /// Rule 3: last remaining current version (end=None) — remove only when
+    ///         unless it's a tombstone (no committed current) whose delete isn't
+    ///         checkpointed yet, or a B-tree-resident version whose physical
+    ///         delete/overwrite hasn't been checkpointed.
+    /// Rule 3: last remaining current (end=None) — remove only when
     ///         `drop_current_if_in_btree` is true and the B-tree already has it.
     ///
     /// Passive gates Rule 2 on `materialized_at` + `min_reader_mark`. Blocking
     /// Truncate uses `ckpt_max` instead.
     ///
-    /// `drop_current_if_in_btree` (Rule 3) is true only for **blocking Truncate**
-    /// (Finalize / incremental), never for any Passive path (Finalize, mid-Passive
-    /// write-set, incremental). This is not a narrower "table vs index can briefly
-    /// disagree" problem — it holds even for a single table with no index. Once Rule
-    /// 3 empties a chain's slot, the dual cursor's fallback for "no SkipMap entry"
-    /// (`query_btree_version_is_valid` / `index_chain_invalidates_btree`) trusts the
-    /// physical B-tree unconditionally, with no per-reader check at all: `read_mark`
-    /// is a logical bookkeeping timestamp, not an actual pin on the underlying page
-    /// read (`MvStore::begin_tx` only records `WalPos::from_pair(pager.wal_pos())`,
-    /// it never calls `Pager::begin_read_tx`). So if any later, unrelated commit
-    /// updates that same row and gets checkpointed again — trivial under Passive's
-    /// auto-checkpoint-per-commit — a reader whose transaction is still open from
-    /// before that commit sees the new, not-yet-visible value: a snapshot-isolation
-    /// violation, proven with a single table and no index
-    /// (`passive_reader_snapshot_survives_later_write_after_row_versions_gc`).
-    ///
-    /// Blocking Truncate does not have this hole because acquiring
-    /// `blocking_checkpoint_lock` for write (`CheckpointState::AcquireLock`) cannot
-    /// succeed while any MVCC transaction is open (`begin_tx` holds it for read for
-    /// the transaction's entire lifetime): every reader that could have relied on a
-    /// just-dropped current's B-tree-equivalent value has already finished before
-    /// this checkpoint's writes land, so no reader is ever exposed to a later
-    /// physical overwrite of that row. Passive intentionally never takes that lock
-    /// around its write phase (that exclusion is exactly the throughput it exists to
-    /// avoid), so it cannot inherit this guarantee. Enabling Rule 3 for Passive would
-    /// need either real page-level MVCC (so "trust the B-tree" is actually isolated
-    /// per reader) or serializing Passive's B-tree writes against active readers for
-    /// rows with an empty chain — both larger changes than this GC pass.
+    /// Leaving Rule 3 off keeps a SkipMap copy so an older reader cannot fall
+    /// through to a B-tree page a later checkpoint already rewrote. Truncate can
+    /// turn it on under the blocking lock (no open MVCC txs). Callers set
+    /// `drop_current_if_in_btree` when they want Rule 3.
     fn gc_version_chain(
         versions: &mut RowVersionChain<A>,
         lwm: u64,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5526,6 +5526,66 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         self.find_next_visible_index_row(tx, mv_store_iterator)
     }
 
+    /// Whether a SkipMap chain must still participate in MVCC merge/shadow for `tx`.
+    ///
+    /// False only for a sole materialized current inside the published durable
+    /// boundary (Rule 3 shape). Longer chains, pending TxIDs, and unmaterialized
+    /// versions stay on the SkipMap path.
+    fn chain_is_write_buffer_for(
+        &self,
+        tx: &Transaction<A>,
+        versions: &[RowVersion],
+        ckpt_max: u64,
+        reader_mark: WalPos,
+    ) -> bool {
+        if versions.is_empty() {
+            return false;
+        }
+        if versions.len() != 1 {
+            return true;
+        }
+        let rv = &versions[0];
+        let Some(TxTimestampOrID::Timestamp(begin_ts)) = rv.begin() else {
+            return true;
+        };
+        if rv.end().is_some() || !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
+            return true;
+        }
+        // Passive may stamp materialized_at during write-out before publish.
+        if begin_ts > ckpt_max {
+            return true;
+        }
+        let mat = rv.materialized_at();
+        if mat == WalPos::ORIGIN || reader_mark < mat {
+            return true;
+        }
+        false
+    }
+
+    /// True when `tx` should ignore this SkipMap chain and read the key from B-tree.
+    ///
+    /// Passive keeps SkipMap cover for all chains (table/index views can disagree
+    /// under concurrent Passive). Truncate may fall through for sole materialized
+    /// currents when no checkpoint is in progress.
+    fn btree_covers_chain_for_tx(
+        &self,
+        tx: &Transaction<A>,
+        table_id: MVTableId,
+        versions: &[RowVersion],
+    ) -> bool {
+        if self.experimental_mvcc_passive_checkpoint {
+            return false;
+        }
+        if self.checkpoint_in_progress.load(Ordering::Acquire) {
+            return false;
+        }
+        if !self.is_btree_readable_at(&table_id, tx.begin_ts, tx.read_mark) {
+            return false;
+        }
+        let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
+        !self.chain_is_write_buffer_for(tx, versions, ckpt_max, tx.read_mark)
+    }
+
     /// Whether an already-resolved index version chain shadows (invalidates) the
     /// corresponding B-tree row for `tx_id`.
     ///
@@ -5546,6 +5606,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             .expect("transaction should exist in txs map");
         let tx = tx.value();
         let versions = versions.read();
+        if versions.is_empty() {
+            return false;
+        }
+        let table_id = versions[0].row.id.table_id;
+        if self.btree_covers_chain_for_tx(tx, table_id, &versions) {
+            return false;
+        }
         versions.iter().rev().any(|version| {
             version.is_btree_invalidating_version(tx, &self.txs, &self.finalized_tx_states)
         })
@@ -5578,6 +5645,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     return true;
                 };
                 let versions = versions.value().read();
+                if self.btree_covers_chain_for_tx(tx, table_id, &versions) {
+                    return true;
+                }
 
                 // Check if any version invalidates the B-tree row
                 let btree_is_invalid = versions.iter().rev().any(|version| {
@@ -5597,6 +5667,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     return true;
                 };
                 let versions = versions.value().read();
+                if self.btree_covers_chain_for_tx(tx, table_id, &versions) {
+                    return true;
+                }
 
                 // Check if any version invalidates the B-tree row
                 let btree_is_invalid = versions.iter().rev().any(|version| {
@@ -5613,12 +5686,21 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         tx: &Transaction<A>,
         row: &TableRowEntry<'_, A>,
     ) -> Option<(RowID, RowVersions<A>)> {
-        row.value()
-            .read()
-            .iter()
-            .rev()
-            .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
-            .map(|_| (row.key().clone(), row.value().clone()))
+        let versions_arc = row.value();
+        {
+            let versions = versions_arc.read();
+            let has_visible = versions
+                .iter()
+                .rev()
+                .any(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states));
+            if !has_visible {
+                return None;
+            }
+            if self.btree_covers_chain_for_tx(tx, row.key().table_id, &versions) {
+                return None;
+            }
+        }
+        Some((row.key().clone(), versions_arc.clone()))
     }
 
     fn find_last_visible_index_version(
@@ -5626,12 +5708,16 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         tx: &Transaction<A>,
         row: IndexRowEntry<'_, A>,
     ) -> Option<RowID> {
-        row.value()
-            .read()
+        let versions = row.value().read();
+        let visible = versions
             .iter()
             .rev()
-            .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
-            .map(|version| version.row.id.clone())
+            .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))?;
+        let table_id = visible.row.id.table_id;
+        if self.btree_covers_chain_for_tx(tx, table_id, &versions) {
+            return None;
+        }
+        Some(visible.row.id.clone())
     }
 
     fn find_next_visible_index_row<'a, I>(&self, tx: &Transaction<A>, mut rows: I) -> Option<RowID>
@@ -7109,21 +7195,40 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Covers both table rows (`self.rows`) and index rows (`self.index_rows`).
     /// Returns the number of removed versions.
     pub fn drop_unused_row_versions(&self) -> usize {
-        self.drop_unused_row_versions_inner(false, !self.experimental_mvcc_passive_checkpoint)
+        self.drop_unused_row_versions_inner(
+            false,
+            !self.experimental_mvcc_passive_checkpoint,
+            WalPos::STAGED,
+        )
     }
 
     /// Like [`Self::drop_unused_row_versions`], and remove emptied SkipMap slots.
     /// Also drops last currents already in the B-tree (Truncate Finalize).
     /// Writers retry if GC unlinks their Arc (`insert_version` / `insert_index_version`).
     pub fn drop_unused_row_versions_and_slots(&self) -> usize {
-        self.drop_unused_row_versions_inner(true, true)
+        self.drop_unused_row_versions_inner(true, true, WalPos::STAGED)
     }
 
     /// Passive Finalize: reclaim history and unlink empty SkipMap slots, but keep
-    /// last currents — dual-cursor must not fall through while Passive can leave
-    /// table/index SkipMap coverage asymmetric under concurrency.
-    pub fn drop_unused_row_versions_unlink_empty(&self) -> usize {
-        self.drop_unused_row_versions_inner(true, false)
+    /// last currents (Rule 3 stays off — see the module doc comment on why Passive
+    /// cannot safely drop a chain's only remaining version).
+    ///
+    /// `reader_mark_floor` must be the *pager-level* reader floor
+    /// ([`crate::mvcc::database::checkpoint_state_machine::CheckpointStateMachine::gc_floor_reader_mark`]),
+    /// not just [`Self::compute_min_reader_mark`]. A reader that has pinned a WAL
+    /// read frame via `Pager::begin_read_tx` but has not yet published its MVCC
+    /// transaction into `self.txs` (the begin-tx publish window) is invisible to
+    /// `compute_min_reader_mark` alone; without the pager floor Rule 2 could reclaim
+    /// a superseded version this reader still needs.
+    pub fn drop_unused_row_versions_unlink_empty_at(&self, reader_mark_floor: WalPos) -> usize {
+        self.drop_unused_row_versions_inner(true, false, reader_mark_floor)
+    }
+
+    /// Passive Finalize: reclaim history, unlink empty SkipMap slots, **and** drop last
+    /// currents already in the B-tree (Rule 3 ON). Uses pager `reader_mark_floor` so
+    /// Rule 2 respects begin-tx publish-window readers.
+    pub fn drop_unused_row_versions_and_slots_passive(&self, reader_mark_floor: WalPos) -> usize {
+        self.drop_unused_row_versions_inner(true, true, reader_mark_floor)
     }
 
     /// Incremental GC on the commit path: reclaim up to `max_chains` table chains
@@ -7379,6 +7484,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         remove_empty_slots: bool,
         drop_current_if_in_btree: bool,
+        reader_mark_floor: WalPos,
     ) -> usize {
         let lwm = self.compute_lwm();
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
@@ -7390,12 +7496,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             &mut referenced_tx_ids,
             remove_empty_slots,
             drop_current_if_in_btree,
+            reader_mark_floor,
         ) + self.gc_index_row_versions(
             lwm,
             ckpt_max,
             &mut referenced_tx_ids,
             remove_empty_slots,
             drop_current_if_in_btree,
+            reader_mark_floor,
         );
         self.dec_live_version_count_approx(dropped);
         let pruned_finalized = self.prune_finalized_tx_states(&referenced_tx_ids);
@@ -7416,13 +7524,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         referenced_tx_ids: &mut HashSet<TxID>,
         remove_empty_slots: bool,
         drop_current_if_in_btree: bool,
+        reader_mark_floor: WalPos,
     ) -> usize {
         let mut dropped = 0;
         // Bound by the backfill boundary: never reclaim a version materialized in un-backfilled
         // WAL frames — a db-file reader (present or future) needs the version-store copy.
+        // `reader_mark_floor` additionally covers pager-pinned readers not yet published as
+        // MVCC transactions (see `drop_unused_row_versions_unlink_empty_at`).
         let min_reader_mark = self
             .compute_min_reader_mark()
-            .min(*self.backfill_floor.read());
+            .min(*self.backfill_floor.read())
+            .min(reader_mark_floor);
 
         for entry in self.rows.iter() {
             // GC floor: retain rows of a freshly-materialized btree not yet visible to all readers.
@@ -7453,13 +7565,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         referenced_tx_ids: &mut HashSet<TxID>,
         remove_empty_slots: bool,
         drop_current_if_in_btree: bool,
+        reader_mark_floor: WalPos,
     ) -> usize {
         let mut dropped = 0;
         // Bound by the backfill boundary: never reclaim a version materialized in un-backfilled
         // WAL frames — a db-file reader (present or future) needs the version-store copy.
+        // `reader_mark_floor` additionally covers pager-pinned readers not yet published as
+        // MVCC transactions (see `drop_unused_row_versions_unlink_empty_at`).
         let min_reader_mark = self
             .compute_min_reader_mark()
-            .min(*self.backfill_floor.read());
+            .min(*self.backfill_floor.read())
+            .min(reader_mark_floor);
 
         for outer_entry in self.index_rows.iter() {
             // GC floor: retain a freshly-materialized index not yet visible to all readers.
@@ -7530,11 +7646,38 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     ///         whose physical delete/overwrite hasn't been checkpointed.
     /// Rule 3: last remaining current version (end=None) — remove only when
     ///         `drop_current_if_in_btree` is true and the B-tree already has it.
-    ///         Concurrent Passive passes false so dual-cursor reads never fall
-    ///         through while table/index pages are still being written.
     ///
     /// Passive gates Rule 2 on `materialized_at` + `min_reader_mark`. Blocking
     /// Truncate uses `ckpt_max` instead.
+    ///
+    /// `drop_current_if_in_btree` (Rule 3) is true only for **blocking Truncate**
+    /// (Finalize / incremental), never for any Passive path (Finalize, mid-Passive
+    /// write-set, incremental). This is not a narrower "table vs index can briefly
+    /// disagree" problem — it holds even for a single table with no index. Once Rule
+    /// 3 empties a chain's slot, the dual cursor's fallback for "no SkipMap entry"
+    /// (`query_btree_version_is_valid` / `index_chain_invalidates_btree`) trusts the
+    /// physical B-tree unconditionally, with no per-reader check at all: `read_mark`
+    /// is a logical bookkeeping timestamp, not an actual pin on the underlying page
+    /// read (`MvStore::begin_tx` only records `WalPos::from_pair(pager.wal_pos())`,
+    /// it never calls `Pager::begin_read_tx`). So if any later, unrelated commit
+    /// updates that same row and gets checkpointed again — trivial under Passive's
+    /// auto-checkpoint-per-commit — a reader whose transaction is still open from
+    /// before that commit sees the new, not-yet-visible value: a snapshot-isolation
+    /// violation, proven with a single table and no index
+    /// (`passive_reader_snapshot_survives_later_write_after_row_versions_gc`).
+    ///
+    /// Blocking Truncate does not have this hole because acquiring
+    /// `blocking_checkpoint_lock` for write (`CheckpointState::AcquireLock`) cannot
+    /// succeed while any MVCC transaction is open (`begin_tx` holds it for read for
+    /// the transaction's entire lifetime): every reader that could have relied on a
+    /// just-dropped current's B-tree-equivalent value has already finished before
+    /// this checkpoint's writes land, so no reader is ever exposed to a later
+    /// physical overwrite of that row. Passive intentionally never takes that lock
+    /// around its write phase (that exclusion is exactly the throughput it exists to
+    /// avoid), so it cannot inherit this guarantee. Enabling Rule 3 for Passive would
+    /// need either real page-level MVCC (so "trust the B-tree" is actually isolated
+    /// per reader) or serializing Passive's B-tree writes against active readers for
+    /// rows with an empty chain — both larger changes than this GC pass.
     fn gc_version_chain(
         versions: &mut RowVersionChain<A>,
         lwm: u64,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3937,6 +3937,30 @@ impl RootEntry {
     }
 }
 
+/// SkipMap / GC counters for debugging (see [`MvStore::debug_gc_snapshot`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GcDebugSnapshot {
+    /// `rows` SkipMap entry count (includes empty chains left by non-slot-removing GC).
+    pub rows_slots: usize,
+    pub rows_empty_slots: usize,
+    /// Sum of table version-chain lengths.
+    pub rows_versions: usize,
+    /// Sum of per-index SkipMap entry counts.
+    pub index_slots: usize,
+    pub index_empty_slots: usize,
+    pub index_versions: usize,
+    pub live_version_count_approx: usize,
+    pub live_versions_at_last_gc: usize,
+    pub lwm: u64,
+    pub durable_txid_max: u64,
+    pub logical_log_offset: u64,
+    pub logical_log_size: u64,
+    pub active_txs: usize,
+    /// Passive GC floor: `compute_min_reader_mark().min(backfill_floor)`.
+    pub min_reader_mark: WalPos,
+    pub backfill_floor: WalPos,
+}
+
 /// A multi-version concurrency control database.
 #[derive(Debug)]
 pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator> {
@@ -6990,6 +7014,53 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// `live_version_count_approx` field) — never use for correctness decisions.
     pub fn live_version_count_approx(&self) -> usize {
         self.live_version_count_approx.load(Ordering::Relaxed)
+    }
+
+    /// Point-in-time SkipMap / GC counters for debugging. Walks every chain; not
+    /// for hot paths. Contrasts `rows.len()` (slots, including empty) with
+    /// summed chain lengths and [`Self::live_version_count_approx`].
+    pub fn debug_gc_snapshot(&self) -> GcDebugSnapshot {
+        let mut rows_empty_slots = 0;
+        let mut rows_versions = 0;
+        for entry in self.rows.iter() {
+            let n = entry.value().read().len();
+            rows_versions += n;
+            if n == 0 {
+                rows_empty_slots += 1;
+            }
+        }
+
+        let mut index_slots = 0;
+        let mut index_empty_slots = 0;
+        let mut index_versions = 0;
+        for index in self.index_rows.iter() {
+            for entry in index.value().iter() {
+                index_slots += 1;
+                let n = entry.value().read().len();
+                index_versions += n;
+                if n == 0 {
+                    index_empty_slots += 1;
+                }
+            }
+        }
+
+        GcDebugSnapshot {
+            rows_slots: self.rows.len(),
+            rows_empty_slots,
+            rows_versions,
+            index_slots,
+            index_empty_slots,
+            index_versions,
+            live_version_count_approx: self.live_version_count_approx(),
+            live_versions_at_last_gc: self.live_versions_at_last_gc.load(Ordering::Relaxed),
+            lwm: self.compute_lwm(),
+            durable_txid_max: self.durable_txid_max.load(Ordering::SeqCst),
+            logical_log_offset: self.logical_log_offset(),
+            logical_log_size: self.get_logical_log_file().size().unwrap_or(0),
+            active_txs: self.txs.len(),
+            min_reader_mark: self.compute_min_reader_mark(),
+            backfill_floor: *self.backfill_floor.read(),
+        }
     }
 
     /// Saturating decrement of the live-version heuristic. The counter is

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3940,12 +3940,9 @@ impl RootEntry {
 /// SkipMap / GC counters for debugging (see [`MvStore::debug_gc_snapshot`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GcDebugSnapshot {
-    /// `rows` SkipMap entry count (includes empty chains left by non-slot-removing GC).
     pub rows_slots: usize,
     pub rows_empty_slots: usize,
-    /// Sum of table version-chain lengths.
     pub rows_versions: usize,
-    /// Sum of per-index SkipMap entry counts.
     pub index_slots: usize,
     pub index_empty_slots: usize,
     pub index_versions: usize,
@@ -3956,7 +3953,6 @@ pub struct GcDebugSnapshot {
     pub logical_log_offset: u64,
     pub logical_log_size: u64,
     pub active_txs: usize,
-    /// Passive GC floor: `compute_min_reader_mark().min(backfill_floor)`.
     pub min_reader_mark: WalPos,
     pub backfill_floor: WalPos,
 }
@@ -4121,9 +4117,9 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// pass short-circuits when the LWM hasn't advanced, avoiding wasted scans
     /// while a long txn is open. `u64::MAX` means "no pass has run yet" and also
     /// the no-active-txn state, which never short-circuits (there is always
-    /// potential garbage to reclaim then). Aborted garbage and post-checkpoint
-    /// sole-survivors that a skipped pass leaves behind are still collected by
-    /// the checkpoint's full sweep.
+    /// potential garbage to reclaim then). Aborted garbage and redundant current
+    /// versions that a skipped pass leaves behind are still collected by the
+    /// checkpoint's full sweep.
     gc_last_lwm: AtomicU64,
     experimental_mvcc_passive_checkpoint: bool,
 }
@@ -7016,9 +7012,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         self.live_version_count_approx.load(Ordering::Relaxed)
     }
 
-    /// Point-in-time SkipMap / GC counters for debugging. Walks every chain; not
-    /// for hot paths. Contrasts `rows.len()` (slots, including empty) with
-    /// summed chain lengths and [`Self::live_version_count_approx`].
+    /// Debug SkipMap / GC counters. Walks every chain; not for hot paths.
     pub fn debug_gc_snapshot(&self) -> GcDebugSnapshot {
         let mut rows_empty_slots = 0;
         let mut rows_versions = 0;
@@ -7115,38 +7109,27 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Covers both table rows (`self.rows`) and index rows (`self.index_rows`).
     /// Returns the number of removed versions.
     pub fn drop_unused_row_versions(&self) -> usize {
-        self.drop_unused_row_versions_inner(false)
+        self.drop_unused_row_versions_inner(false, !self.experimental_mvcc_passive_checkpoint)
     }
 
-    /// Like [`Self::drop_unused_row_versions`], but additionally removes chain
-    /// slots that end up empty from the skip maps, bounding their entry counts.
-    ///
-    /// The caller must hold the blocking checkpoint lock (or otherwise guarantee
-    /// no concurrent writers): slot removal happens after the chain write lock
-    /// is dropped, so without that guarantee it races a concurrent
-    /// `get_or_insert_with` on the same key — see the TOCTOU note in
-    /// `gc_table_row_versions`.
+    /// Like [`Self::drop_unused_row_versions`], and remove emptied SkipMap slots.
+    /// Also drops last currents already in the B-tree (Truncate Finalize).
+    /// Writers retry if GC unlinks their Arc (`insert_version` / `insert_index_version`).
     pub fn drop_unused_row_versions_and_slots(&self) -> usize {
-        self.drop_unused_row_versions_inner(true)
+        self.drop_unused_row_versions_inner(true, true)
     }
 
-    /// Incremental, non-blocking GC pass — the inline counterpart to
-    /// [`Self::drop_unused_row_versions`], driven from the commit path.
-    ///
-    /// Reclaims invisible versions (same rules as `gc_version_chain`) from up
-    /// to `max_chains` table-row chains, resuming from where the previous pass
-    /// stopped (`gc_table_cursor`) so repeated calls eventually cover the whole
-    /// `rows` map without scanning it all at once.
-    ///
-    /// Safety / design notes:
-    /// - **Lazy mode only.** Empty SkipMap slots are left in place (no
-    ///   `entry.remove()`), so the pass needs no blocking checkpoint lock — it
-    ///   races no concurrent `get_or_insert_with` (see the TOCTOU note in
-    ///   `gc_table_row_versions`). Physical slot removal stays exclusive to the
-    ///   checkpoint's `_and_slots` sweep.
-    /// - `finalized_tx_states` pruning is intentionally skipped here: it needs
-    ///   the *complete* referenced-txid set across all chains, which a partial
-    ///   sweep cannot produce. The checkpoint path still prunes it.
+    /// Passive Finalize: reclaim history and unlink empty SkipMap slots, but keep
+    /// last currents — dual-cursor must not fall through while Passive can leave
+    /// table/index SkipMap coverage asymmetric under concurrency.
+    pub fn drop_unused_row_versions_unlink_empty(&self) -> usize {
+        self.drop_unused_row_versions_inner(true, false)
+    }
+
+    /// Incremental GC on the commit path: reclaim up to `max_chains` table chains
+    /// (resuming via `gc_table_cursor`). Truncate mode unlinks empty SkipMap slots;
+    /// Passive leaves them for Finalize `unlink_empty`. Skips `finalized_tx_states`
+    /// pruning (checkpoint still does that).
     pub fn gc_incremental(&self, max_chains: usize) -> usize {
         // Truncate checkpoints hold the write side for the whole pass; pin a read
         // guard so inline GC cannot race them. Passive checkpoints use the publish
@@ -7187,6 +7170,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         let _gate = GcGate(&self.gc_in_progress);
 
         let passive = self.experimental_mvcc_passive_checkpoint;
+        // Passive: keep the last current SkipMap version (B-trees may still be mid-write).
+        // Blocking Truncate: safe to drop it once the B-tree already has the row.
+        let drop_current_if_in_btree = !passive;
         let lwm = if passive {
             let mut sampled = u64::MAX;
             self.clock.get_timestamp(|_| sampled = self.compute_lwm());
@@ -7242,6 +7228,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             ckpt_max,
                             true,
                             min_reader_mark,
+                            drop_current_if_in_btree,
                         );
                     });
                 } else {
@@ -7252,7 +7239,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         ckpt_max,
                         false,
                         min_reader_mark,
+                        drop_current_if_in_btree,
                     );
+                    if versions.is_empty() {
+                        entry.remove();
+                    }
                 }
             }
             last_key = Some(entry.key().clone());
@@ -7300,9 +7291,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// in [`Self::gc_incremental`]. Applies `gc_version_chain` to up to
     /// `max_chains` index version chains, resuming strictly after the
     /// `(index id, key)` the previous pass stopped at (`gc_index_cursor`) and
-    /// wrapping to the start when the nested maps are exhausted. Lazy mode: it
-    /// never removes empty slots (no blocking lock), exactly like the table
-    /// sweep. Returns the number of versions reclaimed.
+    /// wrapping to the start when the nested maps are exhausted. Truncate mode
+    /// unlinks empty slots; Passive leaves them for Finalize `unlink_empty`.
+    /// Returns the number of versions reclaimed.
     ///
     /// `index_rows` is nested (`MVTableId -> key -> chain`), so the cursor is a
     /// `(MVTableId, key)` pair: the outer scan resumes at the saved index id
@@ -7310,6 +7301,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// after the saved key; later indexes start from their first key.
     fn gc_index_incremental(&self, lwm: u64, ckpt_max: u64, max_chains: usize) -> usize {
         let passive = self.experimental_mvcc_passive_checkpoint;
+        let drop_current_if_in_btree = !passive;
         let mut dropped = 0;
         let mut processed = 0;
         let mut last: Option<(MVTableId, Arc<SortableIndexKey>)> = None;
@@ -7354,6 +7346,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             ckpt_max,
                             true,
                             min_reader_mark,
+                            drop_current_if_in_btree,
                         );
                     });
                 } else {
@@ -7364,7 +7357,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         ckpt_max,
                         false,
                         min_reader_mark,
+                        drop_current_if_in_btree,
                     );
+                    if versions.is_empty() {
+                        self.bump_index_rows_epoch();
+                        inner_entry.remove();
+                    }
                 }
                 last = Some((index_id, inner_entry.key().clone()));
                 processed += 1;
@@ -7377,19 +7375,28 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         dropped
     }
 
-    fn drop_unused_row_versions_inner(&self, remove_empty_slots: bool) -> usize {
+    fn drop_unused_row_versions_inner(
+        &self,
+        remove_empty_slots: bool,
+        drop_current_if_in_btree: bool,
+    ) -> usize {
         let lwm = self.compute_lwm();
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
         let mut referenced_tx_ids = HashSet::default();
 
-        let dropped =
-            self.gc_table_row_versions(lwm, ckpt_max, &mut referenced_tx_ids, remove_empty_slots)
-                + self.gc_index_row_versions(
-                    lwm,
-                    ckpt_max,
-                    &mut referenced_tx_ids,
-                    remove_empty_slots,
-                );
+        let dropped = self.gc_table_row_versions(
+            lwm,
+            ckpt_max,
+            &mut referenced_tx_ids,
+            remove_empty_slots,
+            drop_current_if_in_btree,
+        ) + self.gc_index_row_versions(
+            lwm,
+            ckpt_max,
+            &mut referenced_tx_ids,
+            remove_empty_slots,
+            drop_current_if_in_btree,
+        );
         self.dec_live_version_count_approx(dropped);
         let pruned_finalized = self.prune_finalized_tx_states(&referenced_tx_ids);
 
@@ -7408,6 +7415,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         ckpt_max: u64,
         referenced_tx_ids: &mut HashSet<TxID>,
         remove_empty_slots: bool,
+        drop_current_if_in_btree: bool,
     ) -> usize {
         let mut dropped = 0;
         // Bound by the backfill boundary: never reclaim a version materialized in un-backfilled
@@ -7421,26 +7429,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             if self.rootpage_gc_protected(&entry.key().table_id, min_reader_mark) {
                 continue;
             }
-            let is_now_empty = {
-                let mut versions = entry.value().write();
-                dropped += Self::gc_version_chain(
-                    &mut versions,
-                    lwm,
-                    ckpt_max,
-                    self.experimental_mvcc_passive_checkpoint,
-                    min_reader_mark,
-                );
-                Self::collect_referenced_txids(&versions, referenced_tx_ids);
-                versions.is_empty()
-            };
-            // Unless the caller holds the blocking checkpoint lock
-            // (`remove_empty_slots`), empty entries are left in the SkipMap
-            // (lazy removal). This avoids a TOCTOU race where a concurrent
-            // writer inserts a version between the emptiness check and
-            // SkipMap::remove(). Empty entries are reused by
-            // get_or_insert_with on subsequent inserts and cleaned up by
-            // checkpoint-time GC which runs under the blocking lock.
-            if remove_empty_slots && is_now_empty {
+            let mut versions = entry.value().write();
+            dropped += Self::gc_version_chain(
+                &mut versions,
+                lwm,
+                ckpt_max,
+                self.experimental_mvcc_passive_checkpoint,
+                min_reader_mark,
+                drop_current_if_in_btree,
+            );
+            Self::collect_referenced_txids(&versions, referenced_tx_ids);
+            if remove_empty_slots && versions.is_empty() {
                 entry.remove();
             }
         }
@@ -7453,6 +7452,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         ckpt_max: u64,
         referenced_tx_ids: &mut HashSet<TxID>,
         remove_empty_slots: bool,
+        drop_current_if_in_btree: bool,
     ) -> usize {
         let mut dropped = 0;
         // Bound by the backfill boundary: never reclaim a version materialized in un-backfilled
@@ -7469,21 +7469,18 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             let inner_map = outer_entry.value();
 
             for inner_entry in inner_map.iter() {
-                let is_now_empty = {
-                    let mut versions = inner_entry.value().write();
-                    dropped += Self::gc_version_chain(
-                        &mut versions,
-                        lwm,
-                        ckpt_max,
-                        self.experimental_mvcc_passive_checkpoint,
-                        min_reader_mark,
-                    );
-                    Self::collect_referenced_txids(&versions, referenced_tx_ids);
-                    versions.is_empty()
-                };
-                // Same TOCTOU rationale as table rows. The outer per-index map
-                // is kept even when emptied — it is bounded by index count.
-                if remove_empty_slots && is_now_empty {
+                let mut versions = inner_entry.value().write();
+                dropped += Self::gc_version_chain(
+                    &mut versions,
+                    lwm,
+                    ckpt_max,
+                    self.experimental_mvcc_passive_checkpoint,
+                    min_reader_mark,
+                    drop_current_if_in_btree,
+                );
+                Self::collect_referenced_txids(&versions, referenced_tx_ids);
+                if remove_empty_slots && versions.is_empty() {
+                    self.bump_index_rows_epoch();
                     inner_entry.remove();
                 }
             }
@@ -7531,18 +7528,20 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     ///         deletion hasn't been checkpointed, or a B-tree-resident version
     ///         (flagged, or with a checkpointed insert: begin <= ckpt_max)
     ///         whose physical delete/overwrite hasn't been checkpointed.
-    /// Rule 3: checkpointed sole-survivor (end=None) — remove.
+    /// Rule 3: last remaining current version (end=None) — remove only when
+    ///         `drop_current_if_in_btree` is true and the B-tree already has it.
+    ///         Concurrent Passive passes false so dual-cursor reads never fall
+    ///         through while table/index pages are still being written.
     ///
-    /// Passive gates Rules 2/3 on `materialized_at` + `min_reader_mark`: reclaim only once the
-    /// version is in the B-tree AND every reader's mark has reached that frame, so a reader
-    /// pinned at an older frame never loses a version it can still see. The blocking path is
-    /// stop-the-world and uses the logical `ckpt_max` proxy instead.
+    /// Passive gates Rule 2 on `materialized_at` + `min_reader_mark`. Blocking
+    /// Truncate uses `ckpt_max` instead.
     fn gc_version_chain(
         versions: &mut RowVersionChain<A>,
         lwm: u64,
         ckpt_max: u64,
         passive: bool,
         min_reader_mark: WalPos,
+        drop_current_if_in_btree: bool,
     ) -> usize {
         let before = versions.len();
 
@@ -7566,18 +7565,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     // Keep until this delete is in the B-tree and reachable by every reader.
                     !materialized_for_readers(rv)
                 } else {
-                    // Retain superseded versions until checkpoint makes the physical change
-                    // durable. Tombstones without a committed current successor must survive
-                    // even when a newer current exists, and so must B-tree-resident versions.
-                    // A version is B-tree resident not only when flagged (seeded from
-                    // the B-tree by the dual cursor) but also when its insert was
-                    // made durable by a checkpoint (begin <= ckpt_max < end): the
-                    // checkpointer derives DB-file existence from begin/end
-                    // timestamps relative to the durable boundary, so dropping such
-                    // a version would erase the only evidence that a later delete
-                    // must be written to the B-tree (see #7638: an abandoned
-                    // post-commit checkpoint advances ckpt_max without clearing
-                    // these chains, and premature GC then resurrects the row).
+                    // Keep until the delete is checkpointed. Tombstones without a committed
+                    // current successor must survive, as must versions already in the B-tree
+                    // (btree_resident, or begin <= ckpt_max). Dropping the latter erases the
+                    // only evidence that a later delete must be written (#7638).
                     let in_btree = rv.btree_resident
                         || matches!(&rv.begin(), Some(TxTimestampOrID::Timestamp(b)) if *b <= ckpt_max);
                     *e > ckpt_max && (in_btree || !has_current)
@@ -7586,8 +7577,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             _ => true,
         });
 
-        // Rule 3: checkpointed sole-survivor current version (end=None).
-        if versions.len() == 1 {
+        // Rule 3: optionally drop the last current version when the B-tree already has it.
+        if drop_current_if_in_btree && versions.len() == 1 {
             if let (Some(TxTimestampOrID::Timestamp(b)), None) =
                 (&versions[0].begin(), &versions[0].end())
             {
@@ -7690,9 +7681,36 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         id: RowID,
         row_version: RowVersion,
     ) -> Result<RowVersions<A>, TryReserveError> {
-        let row_versions = self.get_or_create_table_row_versions(id)?;
-        self.insert_version_raw(&mut row_versions.write(), row_version)?;
-        Ok(row_versions)
+        // Retry if GC unlinked this slot while we waited for the write lock.
+        loop {
+            let row_versions = self.get_or_create_table_row_versions(id.clone())?;
+            let mut versions = row_versions.write();
+            if !self.table_versions_still_mapped(&id, &row_versions) {
+                continue;
+            }
+            self.insert_version_raw(&mut versions, row_version)?;
+            drop(versions);
+            return Ok(row_versions);
+        }
+    }
+
+    /// True if `arc` is still the mapped value for `id`.
+    fn table_versions_still_mapped(&self, id: &RowID, arc: &RowVersions<A>) -> bool {
+        self.rows
+            .get(id)
+            .is_some_and(|entry| Arc::ptr_eq(entry.value(), arc))
+    }
+
+    /// True if `arc` is still the mapped value for `key`.
+    fn index_versions_still_mapped(
+        &self,
+        index: &IndexRowsMap<A>,
+        key: &SortableIndexKey,
+        arc: &RowVersions<A>,
+    ) -> bool {
+        index
+            .get(key)
+            .is_some_and(|entry| Arc::ptr_eq(entry.value(), arc))
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::TableRowsEntry)]
@@ -7734,23 +7752,33 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         // Publish the key-set mutation *before* the key becomes visible in the
         // map: a concurrent shadow finger that races with this insert may then
         // reset spuriously, but can never miss the new key (#7578).
-        self.index_rows_epoch.fetch_add(1, Ordering::SeqCst);
+        self.bump_index_rows_epoch();
         let index = self.get_or_create_index_rows(index_id)?;
         let index = index.value();
-        let entry = self.get_or_create_index_key_entry(index, key)?;
-        // The Arc that's actually stored in the SkipMap may be the one we
-        // passed in (on miss) or a pre-existing one (on hit). Return that
-        // canonical Arc so savepoint tracking and the SkipMap stay in sync.
-        let canonical_key = entry.key().clone();
-        row_version.row.id.row_id = RowKey::Record(canonical_key.clone());
-        let row_versions = entry.value().clone();
-        self.insert_version_raw(&mut row_versions.write(), row_version)?;
-        Ok((canonical_key, row_versions))
+        // Same drain-retry as `insert_version`.
+        loop {
+            let entry = self.get_or_create_index_key_entry(index, key.clone())?;
+            let canonical_key = entry.key().clone();
+            let row_versions = entry.value().clone();
+            let mut versions = row_versions.write();
+            if !self.index_versions_still_mapped(index, canonical_key.as_ref(), &row_versions) {
+                continue;
+            }
+            row_version.row.id.row_id = RowKey::Record(canonical_key.clone());
+            self.insert_version_raw(&mut versions, row_version)?;
+            drop(versions);
+            return Ok((canonical_key, row_versions));
+        }
     }
 
     /// Current epoch of `index_rows` key-set mutations; see the field docs.
     pub(crate) fn index_rows_epoch(&self) -> u64 {
         self.index_rows_epoch.load(Ordering::SeqCst)
+    }
+
+    /// Key-set mutation of `index_rows` (insert or empty-slot remove); see field docs.
+    pub(crate) fn bump_index_rows_epoch(&self) {
+        self.index_rows_epoch.fetch_add(1, Ordering::SeqCst);
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::IndexRowsEntry)]
@@ -7876,10 +7904,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// purged state. Callers without that guarantee must add proper
     /// tombstones via the normal write path instead.
     ///
-    /// Empty chain slots are left in the `SkipMap` (lazy removal). The
-    /// same TOCTOU rationale as `gc_table_row_versions` applies: removing
-    /// the slot would race a concurrent `get_or_insert_with` from a future
-    /// write to the same key.
+    /// Clears the chain but keeps the empty SkipMap slot (write-set GC still looks it up).
     pub fn purge_row_versions_during_checkpoint(&self, rowid: RowID) {
         if let Some(entry) = self.rows.get(&rowid) {
             let mut versions = entry.value().write();
@@ -7891,38 +7916,41 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
     /// Passive sequence compaction: record end-stamped deletes instead of inline B-tree purge.
     pub fn seqcompact_commit_delete(&self, rowid: RowID, num_cols: usize, end_ts: u64) {
-        let Ok(row_versions) = self.get_or_create_table_row_versions(rowid.clone()) else {
-            return;
-        };
-        let mut versions = row_versions.write();
-        // If a committed current version exists, mark it deleted as of end_ts — the normal
-        // collection then materializes the B-tree delete (begin <= durable_max => exists_in_db_file).
-        if let Some(rv) = versions.iter_mut().find(|rv| {
-            matches!(rv.begin(), Some(TxTimestampOrID::Timestamp(_))) && rv.end().is_none()
-        }) {
-            rv.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
+        loop {
+            let Ok(row_versions) = self.get_or_create_table_row_versions(rowid.clone()) else {
+                return;
+            };
+            let mut versions = row_versions.write();
+            if !self.table_versions_still_mapped(&rowid, &row_versions) {
+                continue;
+            }
+            // End-stamp the live committed version, if any.
+            if let Some(rv) = versions.iter_mut().find(|rv| {
+                matches!(rv.begin(), Some(TxTimestampOrID::Timestamp(_))) && rv.end().is_none()
+            }) {
+                rv.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
+                return;
+            }
+            if versions.iter().any(|rv| rv.end().is_some()) {
+                return;
+            }
+            // B-tree-only row: insert a btree-resident tombstone.
+            let version_id = self.get_version_id();
+            let row = Row::new_table_row_in(rowid, &[], num_cols, self.alloc.clone())
+                .expect("empty tombstone row");
+            let _ = self.insert_version_raw(
+                &mut versions,
+                RowVersion {
+                    id: version_id,
+                    begin: PackedTs::pack(None),
+                    end: PackedTs::pack(Some(TxTimestampOrID::Timestamp(end_ts))),
+                    row,
+                    btree_resident: true,
+                    materialized_at: WalPos::ORIGIN,
+                },
+            );
             return;
         }
-        // Already tombstoned / no live version: nothing to delete again.
-        if versions.iter().any(|rv| rv.end().is_some()) {
-            return;
-        }
-        // Row lives only in the B-tree: record a B-tree-resident tombstone so the collection
-        // (btree_resident => exists_in_db_file) materializes the physical delete.
-        let version_id = self.get_version_id();
-        let row = Row::new_table_row_in(rowid, &[], num_cols, self.alloc.clone())
-            .expect("empty tombstone row");
-        let _ = self.insert_version_raw(
-            &mut versions,
-            RowVersion {
-                id: version_id,
-                begin: PackedTs::pack(None),
-                end: PackedTs::pack(Some(TxTimestampOrID::Timestamp(end_ts))),
-                row,
-                btree_resident: true,
-                materialized_at: WalPos::ORIGIN,
-            },
-        );
     }
 
     pub fn get_last_table_rowid(

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -7582,6 +7582,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 Self::collect_referenced_txids(&versions, referenced_tx_ids);
                 if remove_empty_slots && versions.is_empty() {
                     self.bump_index_rows_epoch();
+                    // Inner key only — the outer per-index map stays (bounded by index count).
                     inner_entry.remove();
                 }
             }
@@ -7861,6 +7862,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         // Same drain-retry as `insert_version`.
         loop {
             let entry = self.get_or_create_index_key_entry(index, key.clone())?;
+            // SkipMap may keep our Arc (miss) or a pre-existing one (hit); return that
+            // canonical Arc so savepoint tracking and the map stay in sync.
             let canonical_key = entry.key().clone();
             let row_versions = entry.value().clone();
             let mut versions = row_versions.write();
@@ -8027,17 +8030,19 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             if !self.table_versions_still_mapped(&rowid, &row_versions) {
                 continue;
             }
-            // End-stamp the live committed version, if any.
+            // End-stamp the live committed version, if any — collection then
+            // materializes the B-tree delete (begin <= durable_max => exists_in_db_file).
             if let Some(rv) = versions.iter_mut().find(|rv| {
                 matches!(rv.begin(), Some(TxTimestampOrID::Timestamp(_))) && rv.end().is_none()
             }) {
                 rv.set_end(Some(TxTimestampOrID::Timestamp(end_ts)));
                 return;
             }
+            // Already tombstoned / no live version: nothing to delete again.
             if versions.iter().any(|rv| rv.end().is_some()) {
                 return;
             }
-            // B-tree-only row: insert a btree-resident tombstone.
+            // B-tree-only row: btree-resident tombstone so collection materializes the delete.
             let version_id = self.get_version_id();
             let row = Row::new_table_row_in(rowid, &[], num_cols, self.alloc.clone())
                 .expect("empty tombstone row");

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3938,8 +3938,10 @@ impl RootEntry {
 }
 
 /// SkipMap / GC counters for debugging (see [`MvStore::debug_gc_snapshot`]).
+/// Test-only harness data, not part of the public MVCC API.
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct GcDebugSnapshot {
+pub(crate) struct GcDebugSnapshot {
     pub rows_slots: usize,
     pub rows_empty_slots: usize,
     pub rows_versions: usize,
@@ -7099,7 +7101,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     }
 
     /// Debug SkipMap / GC counters. Walks every chain; not for hot paths.
-    pub fn debug_gc_snapshot(&self) -> GcDebugSnapshot {
+    #[cfg(test)]
+    pub(crate) fn debug_gc_snapshot(&self) -> GcDebugSnapshot {
         let mut rows_empty_slots = 0;
         let mut rows_versions = 0;
         for entry in self.rows.iter() {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -835,6 +835,58 @@ fn debug_gc_metrics_truncate_vs_passive() {
     run_mode(true, KEYS, ROUNDS, UPDATES_PER_ROUND);
 }
 
+/// Passive checkpoint must publish WAL `nbackfills` so `backfill_floor` advances and
+/// Passive GC can reclaim materialized version chains (otherwise SkipMap versions grow
+/// without bound while Truncate drains to zero).
+#[test]
+fn mvcc_passive_checkpoint_publishes_backfill_and_reclaims_versions() {
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let mv = db.get_mvcc_store();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT NOT NULL)")
+        .unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1").unwrap();
+
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    for i in 0..50 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, 'seed')"))
+            .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+
+    let after_seed = mv.debug_gc_snapshot();
+    assert!(
+        after_seed.backfill_floor.frame > 0 || after_seed.rows_versions == 0,
+        "passive seed checkpoint must advance backfill_floor or reclaim seed versions: {after_seed:?}"
+    );
+
+    for round in 0..5 {
+        conn.execute("BEGIN CONCURRENT").unwrap();
+        for i in 0..50 {
+            conn.execute(format!("UPDATE t SET data = 'r{round}' WHERE id = {i}"))
+                .unwrap();
+        }
+        conn.execute("COMMIT").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+    }
+
+    let snap = mv.debug_gc_snapshot();
+    let wal_bf = conn.pager.load().wal_backfill_frame().unwrap_or(0);
+    assert!(
+        wal_bf > 0,
+        "passive checkpoint must publish nbackfills, got wal_nbackfill={wal_bf}, snap={snap:?}"
+    );
+    assert_eq!(
+        snap.rows_versions, 0,
+        "passive GC must reclaim materialized chains once backfill_floor advances: {snap:?}"
+    );
+    assert_eq!(
+        snap.backfill_floor.frame, wal_bf,
+        "backfill_floor must track published nbackfills: {snap:?}"
+    );
+}
+
 /// Passive checkpoint may run btree writes while a pinned reader is active.
 #[test]
 fn mvcc_passive_checkpoint_busy_under_pinned_reader_no_corruption() {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -565,7 +565,7 @@ fn mvcc_passive_gc_retains_until_reader_mark_reaches_materialization() {
         frame: f,
     };
 
-    // Sole-survivor committed insert (begin=Ts(5), end=None), materialized at WAL frame 100.
+    // Sole current insert (begin=Ts(5), end=None), materialized at WAL frame 100.
     let stamped_insert = || {
         let mut rv = make_rv(ts(5), None);
         rv.set_materialized_at(frame(100));
@@ -578,10 +578,10 @@ fn mvcc_passive_gc_retains_until_reader_mark_reaches_materialization() {
         crate::alloc::vec![rv]
     };
 
-    // Reader pinned below the materialization frame: its (stale) B-tree view can't reach frame 100,
-    // so the version-store copy must be retained — for both the sole-survivor and the delete record.
+    // Reader pinned below the materialization frame: keep both current and delete.
     for mut v in [stamped_insert(), stamped_delete()] {
-        let dropped = MvStore::<MvccClock>::gc_version_chain(&mut v, 10, 10, true, frame(50));
+        let dropped =
+            MvStore::<MvccClock>::gc_version_chain(&mut v, 10, 10, true, frame(50), false);
         assert_eq!(
             dropped, 0,
             "version needed by a reader pinned below frame 100 must be kept"
@@ -589,30 +589,47 @@ fn mvcc_passive_gc_retains_until_reader_mark_reaches_materialization() {
         assert_eq!(v.len(), 1);
     }
 
-    // Every reader has reached the materialization frame: safe to reclaim.
-    for mut v in [stamped_insert(), stamped_delete()] {
-        let dropped = MvStore::<MvccClock>::gc_version_chain(&mut v, 10, 10, true, frame(100));
-        assert_eq!(
-            dropped, 1,
-            "materialized + reader-reachable version must be reclaimed"
-        );
-        assert!(v.is_empty());
-    }
+    // Readers at the materialization frame: Rule 2 drops deletes; Passive keeps
+    // currents unless drop_current_if_in_btree (Truncate).
+    let mut deleted = stamped_delete();
+    let dropped =
+        MvStore::<MvccClock>::gc_version_chain(&mut deleted, 10, 10, true, frame(100), false);
+    assert_eq!(
+        dropped, 1,
+        "materialized + reader-reachable superseded delete must be reclaimed"
+    );
+    assert!(deleted.is_empty());
 
-    // An unmaterialized version (materialized_at == ORIGIN) is never reclaimed by passive Rule 2/3,
-    // even with a maximal reader mark and ckpt_max/lwm that would otherwise allow it — the B-tree
-    // does not yet reflect its state.
+    let mut current = stamped_insert();
+    let dropped =
+        MvStore::<MvccClock>::gc_version_chain(&mut current, 10, 10, true, frame(100), false);
+    assert_eq!(
+        dropped, 0,
+        "Passive keeps the current SkipMap version when drop_current_if_in_btree is false"
+    );
+    assert_eq!(current.len(), 1);
+
+    let mut current = stamped_insert();
+    let dropped =
+        MvStore::<MvccClock>::gc_version_chain(&mut current, 10, 10, true, frame(100), true);
+    assert_eq!(
+        dropped, 1,
+        "Truncate may drop the current SkipMap version once it is in the B-tree"
+    );
+    assert!(current.is_empty());
+
+    // Unmaterialized versions are never reclaimed on the Passive path.
     let mut v = crate::alloc::vec![make_rv(ts(5), None)];
-    let dropped = MvStore::<MvccClock>::gc_version_chain(&mut v, 10, 10, true, WalPos::STAGED);
+    let dropped =
+        MvStore::<MvccClock>::gc_version_chain(&mut v, 10, 10, true, WalPos::STAGED, false);
     assert_eq!(
         dropped, 0,
         "passive GC must not reclaim a version not yet in the B-tree"
     );
 }
 
-/// Manual Truncate-vs-Passive GC metrics harness (SkipMap slots vs live versions).
+/// Ignored Truncate-vs-Passive GC metrics harness.
 ///
-/// Run with:
 /// ```console
 /// cargo test -p turso_core --lib debug_gc_metrics_truncate_vs_passive -- --ignored --nocapture
 /// ```
@@ -653,8 +670,7 @@ fn debug_gc_metrics_truncate_vs_passive() {
         );
     }
 
-    /// UPDATE-heavy workload under a pinned reader; checkpoints driven by a
-    /// separate connection (server-like), auto-checkpoint disabled.
+    /// Pinned-reader UPDATE load; explicit checkpoints.
     fn run_mode(passive: bool, keys: usize, rounds: usize, updates_per_round: usize) {
         let mode = if passive { "passive" } else { "truncate" };
         let db = if passive {
@@ -667,11 +683,9 @@ fn debug_gc_metrics_truncate_vs_passive() {
         bootstrap
             .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT NOT NULL)")
             .unwrap();
-        // Disable auto-checkpoint; drive checkpoints explicitly like turso-server.
         bootstrap
             .execute("PRAGMA mvcc_checkpoint_threshold = -1")
             .unwrap();
-        // Keep inline GC on so live_approx can drop between checkpoints.
         bootstrap.execute("PRAGMA mvcc_gc_threshold = 64").unwrap();
 
         bootstrap.execute("BEGIN CONCURRENT").unwrap();
@@ -681,13 +695,11 @@ fn debug_gc_metrics_truncate_vs_passive() {
                 .unwrap();
         }
         bootstrap.execute("COMMIT").unwrap();
-        // Materialize the seed so subsequent Passive/Truncate behavior is about updates.
         let ckpt = if passive { "PASSIVE" } else { "TRUNCATE" };
         let _ = bootstrap.execute(format!("PRAGMA wal_checkpoint({ckpt})"));
 
         let reader = db.connect();
         reader.execute("BEGIN CONCURRENT").unwrap();
-        // Keep the txn live for the whole run (pins LWM).
         reader.execute("SELECT count(*) FROM t").unwrap();
 
         let writer = db.connect();
@@ -737,14 +749,11 @@ fn debug_gc_metrics_truncate_vs_passive() {
         }
 
         reader.execute("COMMIT").unwrap();
-        // One more checkpoint after the pin drops — Truncate should be able to
-        // clear slots; Passive still only GC-in-place.
         let _ = checkpointer.execute(format!("PRAGMA wal_checkpoint({ckpt})"));
         sample_line(mode, rounds + 1, updates, &mv.debug_gc_snapshot());
     }
 
-    /// Same UPDATE load, but no pinned reader — isolates empty-slot retention
-    /// after Passive Rule 3 clears sole-survivor chains.
+    /// Same load without a pinned reader.
     fn run_mode_unpinned(passive: bool, keys: usize, rounds: usize, updates_per_round: usize) {
         let mode = if passive {
             "passive_unpinned"
@@ -828,16 +837,13 @@ fn debug_gc_metrics_truncate_vs_passive() {
     const KEYS: usize = 200;
     const ROUNDS: usize = 5;
     const UPDATES_PER_ROUND: usize = 50;
-    // Unpinned + pinned reader loads.
     run_mode_unpinned(false, KEYS, ROUNDS, UPDATES_PER_ROUND);
     run_mode_unpinned(true, KEYS, ROUNDS, UPDATES_PER_ROUND);
     run_mode(false, KEYS, ROUNDS, UPDATES_PER_ROUND);
     run_mode(true, KEYS, ROUNDS, UPDATES_PER_ROUND);
 }
 
-/// Passive checkpoint must publish WAL `nbackfills` so `backfill_floor` advances and
-/// Passive GC can reclaim materialized version chains (otherwise SkipMap versions grow
-/// without bound while Truncate drains to zero).
+/// Passive checkpoint publishes nbackfills and reclaims superseded versions.
 #[test]
 fn mvcc_passive_checkpoint_publishes_backfill_and_reclaims_versions() {
     let db = MvccTestDbNoConn::new_with_random_db_passive();
@@ -845,7 +851,8 @@ fn mvcc_passive_checkpoint_publishes_backfill_and_reclaims_versions() {
     let conn = db.connect();
     conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT NOT NULL)")
         .unwrap();
-    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1").unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
 
     conn.execute("BEGIN CONCURRENT").unwrap();
     for i in 0..50 {
@@ -858,7 +865,7 @@ fn mvcc_passive_checkpoint_publishes_backfill_and_reclaims_versions() {
     let after_seed = mv.debug_gc_snapshot();
     assert!(
         after_seed.backfill_floor.frame > 0 || after_seed.rows_versions == 0,
-        "passive seed checkpoint must advance backfill_floor or reclaim seed versions: {after_seed:?}"
+        "passive checkpoint must advance backfill_floor or reclaim seed versions: {after_seed:?}"
     );
 
     for round in 0..5 {
@@ -877,9 +884,14 @@ fn mvcc_passive_checkpoint_publishes_backfill_and_reclaims_versions() {
         wal_bf > 0,
         "passive checkpoint must publish nbackfills, got wal_nbackfill={wal_bf}, snap={snap:?}"
     );
+    // Currents stay (SkipMap cover for concurrent Passive); superseded history + empty slots go.
+    assert!(
+        snap.rows_versions <= 51 && snap.rows_empty_slots == 0,
+        "passive Finalize keeps currents, drains empty slots: {snap:?}"
+    );
     assert_eq!(
-        snap.rows_versions, 0,
-        "passive GC must reclaim materialized chains once backfill_floor advances: {snap:?}"
+        snap.rows_versions, snap.rows_slots,
+        "no empty slots after Passive Finalize unlink: {snap:?}"
     );
     assert_eq!(
         snap.backfill_floor.frame, wal_bf,
@@ -9806,6 +9818,7 @@ fn test_gc_rule1_aborted_garbage_removed() {
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 1);
     assert!(versions.is_empty());
@@ -9826,6 +9839,7 @@ fn test_gc_rule1_aborted_among_live_versions() {
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     // Only aborted removed; superseded has e=5 > lwm=2 so retained
     assert_eq!(dropped, 1);
@@ -9852,6 +9866,7 @@ fn test_gc_rule2_superseded_below_lwm_with_current() {
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 1);
     assert_eq!(versions.len(), 1);
@@ -9871,6 +9886,7 @@ fn test_gc_rule2_superseded_above_lwm_retained() {
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 2);
@@ -9893,6 +9909,7 @@ fn test_gc_rule2_tombstone_guard_uncheckpointed() {
         2,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     // e=5 > ckpt_max=2, no current → tombstone guard retains it
     assert_eq!(dropped, 0);
@@ -9912,6 +9929,7 @@ fn test_gc_rule2_tombstone_guard_checkpointed() {
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     // e=5 <= ckpt_max=5, e=5 <= lwm=10 → removable
     assert_eq!(dropped, 1);
@@ -9923,7 +9941,7 @@ fn test_gc_rule2_tombstone_guard_checkpointed() {
 /// A current version that's been checkpointed to B-tree, with no other versions in
 /// the chain and no active reader needing it, is redundant. The dual cursor will
 /// fall through to the B-tree which has identical data. Safe to remove.
-fn test_gc_rule3_checkpointed_sole_survivor_removed() {
+fn test_gc_rule3_drop_current_when_in_btree() {
     // Single current version with b <= ckpt_max and b < lwm.
     let mut versions = crate::alloc::vec![make_rv(ts(5), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(
@@ -9932,6 +9950,7 @@ fn test_gc_rule3_checkpointed_sole_survivor_removed() {
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 1);
     assert!(versions.is_empty());
@@ -9950,6 +9969,7 @@ fn test_gc_rule3_not_checkpointed_retained() {
         3,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 1);
@@ -9968,6 +9988,7 @@ fn test_gc_rule3_visible_to_active_tx_retained() {
         10,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     // b=5 is NOT < lwm=5 (strict <), so retained
     assert_eq!(dropped, 0);
@@ -9985,6 +10006,7 @@ fn test_gc_rule3_current_retained_before_first_checkpoint() {
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 1);
@@ -10001,6 +10023,7 @@ fn test_gc_rule3_current_collected_after_checkpoint() {
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 1);
     assert_eq!(versions.len(), 0);
@@ -10008,21 +10031,21 @@ fn test_gc_rule3_current_collected_after_checkpoint() {
 
 /// Garbage collection removes only versions that are provably unreachable and keeps versions still required for visibility and safety.
 #[test]
-/// Rule 3 requires the current version to be the sole remaining version in the
-/// chain. When a superseded version is removed first by Rule 2, Rule 3 can then
-/// fire on the remaining sole survivor — both rules compose correctly.
-fn test_gc_rule3_not_sole_survivor() {
+/// Rule 3 only drops the last remaining current version. After Rule 2 removes
+/// superseded history, Rule 3 can then drop that current.
+fn test_gc_rule3_after_history_reclaimed() {
     // Rule 3 only fires when exactly one version remains after rules 1 & 2.
     let mut versions = crate::alloc::vec![make_rv(ts(3), ts(5)), make_rv(ts(5), None)];
     // Both b <= ckpt_max and b < lwm, but there are 2 versions.
-    // Rule 2 removes the superseded one (has_current=true), then rule 3 fires
-    // on the remaining sole survivor.
+    // Rule 2 removes the superseded one (has_current=true), then Rule 3 drops
+    // the remaining current.
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
         10,
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 2);
     assert!(versions.is_empty());
@@ -10041,6 +10064,7 @@ fn test_gc_txid_refs_retained() {
         u64::MAX,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 1);
@@ -10059,6 +10083,7 @@ fn test_gc_txid_end_retained() {
         u64::MAX,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 1);
@@ -10083,6 +10108,7 @@ fn test_gc_rule2_pending_insert_does_not_disable_tombstone_guard() {
         2,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     // Tombstone must be retained: e=5 > ckpt_max=2, and pending insert doesn't count.
     // Only nothing changes (pending insert is not aborted garbage either).
@@ -10108,6 +10134,7 @@ fn test_gc_rule2_committed_current_disables_non_btree_tombstone_guard() {
         2,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     // Superseded removed (has_current=true for committed version), current remains.
     assert_eq!(dropped, 1);
@@ -10132,6 +10159,7 @@ fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() 
         2,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 2);
@@ -10143,6 +10171,7 @@ fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() 
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 2);
     assert!(versions.is_empty());
@@ -10157,6 +10186,7 @@ fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() 
         2,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 2);
@@ -10168,6 +10198,7 @@ fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() 
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 2);
     assert!(versions.is_empty());
@@ -10194,6 +10225,7 @@ fn test_gc_rule2_checkpointed_insert_with_current_retained_until_checkpoint() {
         2,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 2);
@@ -10206,6 +10238,7 @@ fn test_gc_rule2_checkpointed_insert_with_current_retained_until_checkpoint() {
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 2);
     assert!(versions.is_empty());
@@ -10228,6 +10261,7 @@ fn test_gc_rule2_btree_tombstone_lifecycle() {
         3,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0, "tombstone retained: e=5 > ckpt_max=3");
     assert_eq!(versions.len(), 1);
@@ -10239,6 +10273,7 @@ fn test_gc_rule2_btree_tombstone_lifecycle() {
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 1, "tombstone collected: e=5 <= ckpt_max=5");
     assert_eq!(versions.len(), 0);
@@ -10252,7 +10287,7 @@ fn test_gc_rule2_btree_tombstone_lifecycle() {
 fn test_gc_rule3_not_firing_with_unremovable_superseded() {
     // Two versions: superseded with e > lwm (can't remove), and current.
     // Rule 2 can't remove the superseded one, so 2 versions remain.
-    // Rule 3 requires sole-survivor, so it must NOT fire.
+    // Rule 3 needs a single remaining current, so it must NOT fire.
     let mut versions = crate::alloc::vec![
         make_rv(ts(3), ts(15)), // e=15 > lwm=10 — retained
         make_rv(ts(15), None),  // current
@@ -10263,6 +10298,7 @@ fn test_gc_rule3_not_firing_with_unremovable_superseded() {
         20,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 2);
@@ -10279,6 +10315,7 @@ fn test_gc_noop_on_empty() {
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 0);
 }
@@ -10303,6 +10340,7 @@ fn test_gc_combined_rules() {
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 4);
     assert!(versions.is_empty());
@@ -10415,6 +10453,7 @@ fn test_gc_shrinks_version_chain_capacity() {
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 1023);
     assert_eq!(versions.len(), 1);
@@ -10436,6 +10475,7 @@ fn test_gc_shrinks_version_chain_capacity() {
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert_eq!(dropped, 1024);
     assert!(versions.is_empty());
@@ -10458,14 +10498,13 @@ fn test_gc_shrinks_version_chain_capacity() {
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     assert!(small.is_empty());
     assert_eq!(small.capacity(), capacity_before);
 }
 
-/// `drop_unused_row_versions_and_slots` (used at checkpoint Finalize while the
-/// blocking checkpoint lock is held) must remove chain slots that GC emptied,
-/// unlike the lazy background variant which leaves them in the SkipMap.
+/// `drop_unused_row_versions_and_slots` removes emptied SkipMap entries.
 #[test]
 fn test_gc_with_slot_removal_drops_empty_skipmap_entries() {
     let db = MvccTestDb::new();
@@ -11024,40 +11063,35 @@ fn test_gc_incremental_skips_while_checkpoint_holds_write_lock() {
     );
 }
 
-/// Incremental GC uses the lazy path: it empties a chain's version vec but
-/// leaves the (now empty) SkipMap slot in place — slot removal is reserved for
-/// the checkpoint's blocking `_and_slots` sweep.
+/// Passive incremental GC empties a chain's version vec but leaves the (now empty)
+/// SkipMap slot; Finalize `unlink_empty` unlinks slots. Truncate incremental unlinks.
 #[test]
 fn test_gc_incremental_lazy_leaves_empty_slots() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let conn = db.connect();
+    let mvcc_store = db.get_mvcc_store();
     let table_id: MVTableId = (-2).into();
 
     // Aborted insert leaves aborted garbage (begin=None, end=None) behind.
-    let tx = db
-        .mvcc_store
-        .begin_tx(db.conn.pager.load().clone())
-        .unwrap();
-    db.mvcc_store
+    let tx = mvcc_store.begin_tx(conn.pager.load().clone()).unwrap();
+    mvcc_store
         .insert(tx, generate_simple_string_row(table_id, 1, "rollback"))
         .unwrap();
-    db.mvcc_store.rollback_tx(
-        tx,
-        db.conn.pager.load().clone(),
-        &db.conn,
-        crate::MAIN_DB_ID,
-    );
+    mvcc_store.rollback_tx(tx, conn.pager.load().clone(), &conn, crate::MAIN_DB_ID);
 
     let row_id = RowID::new(table_id, RowKey::Int(1));
-    assert!(db.mvcc_store.rows.get(&row_id).is_some());
+    assert!(mvcc_store.rows.get(&row_id).is_some());
 
     // Drive incremental GC to completion.
     for _ in 0..4 {
-        db.mvcc_store
-            .gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
+        mvcc_store.gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
     }
 
-    let entry = db.mvcc_store.rows.get(&row_id);
-    assert!(entry.is_some(), "lazy path keeps the SkipMap slot in place");
+    let entry = mvcc_store.rows.get(&row_id);
+    assert!(
+        entry.is_some(),
+        "Passive lazy path keeps the SkipMap slot in place"
+    );
     assert!(
         entry.unwrap().value().read().is_empty(),
         "but the version vec is emptied"
@@ -11290,6 +11324,7 @@ fn prop_gc_never_increases_version_count(chain: ArbitraryVersionChain) -> bool {
         chain.ckpt_max,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     versions.len() <= before
 }
@@ -11307,6 +11342,7 @@ fn prop_gc_is_idempotent(chain: ArbitraryVersionChain) -> bool {
         chain.ckpt_max,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     let snapshot = v1.clone();
     MvStore::<MvccClock>::gc_version_chain(
@@ -11315,6 +11351,7 @@ fn prop_gc_is_idempotent(chain: ArbitraryVersionChain) -> bool {
         chain.ckpt_max,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     // Compare content, not just length — a swap bug would pass a length-only check.
     v1.len() == snapshot.len()
@@ -11336,6 +11373,7 @@ fn prop_gc_removes_all_aborted_garbage(chain: ArbitraryVersionChain) -> bool {
         chain.ckpt_max,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     versions
         .iter()
@@ -11359,6 +11397,7 @@ fn prop_gc_retains_txid_begins(chain: ArbitraryVersionChain) -> bool {
         chain.ckpt_max,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     let txid_begins_after: usize = versions
         .iter()
@@ -11387,6 +11426,7 @@ fn prop_gc_retains_txid_ends(chain: ArbitraryVersionChain) -> bool {
         chain.ckpt_max,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     let txid_ends_after: usize = versions.iter().filter(filter).count();
     txid_ends_after == txid_ends_before
@@ -11414,6 +11454,7 @@ fn prop_gc_current_versions_protected_before_checkpoint(chain: ArbitraryVersionC
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
     let current_after: usize = versions
         .iter()
@@ -11444,6 +11485,7 @@ fn prop_gc_tombstone_guard_preserves_btree_safety(chain: ArbitraryVersionChain) 
         chain.ckpt_max,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
 
     // Check: if pre-GC chain had no committed current version AND had a
@@ -11487,6 +11529,7 @@ fn prop_gc_no_orphaned_superseded_versions(chain: ArbitraryVersionChain) -> bool
         chain.ckpt_max,
         false,
         crate::mvcc::database::WalPos::STAGED,
+        true,
     );
 
     let has_committed_current = versions
@@ -12347,8 +12390,8 @@ fn test_gc_e2e_checkpointed_row_readable_after_gc() {
     // Checkpoint flushes to B-tree and triggers GC.
     conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 
-    // After GC, the SkipMap entries should be cleared (sole-survivor rule 3),
-    // and reads fall through to B-tree.
+    // After GC, SkipMap currents that Truncate already wrote to the B-tree are
+    // gone; reads fall through to the B-tree.
     let rows = get_rows(&conn, "SELECT id, val FROM t ORDER BY id");
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0][0].as_int().unwrap(), 1);

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -610,6 +610,231 @@ fn mvcc_passive_gc_retains_until_reader_mark_reaches_materialization() {
     );
 }
 
+/// Manual Truncate-vs-Passive GC metrics harness (SkipMap slots vs live versions).
+///
+/// Run with:
+/// ```console
+/// cargo test -p turso_core --lib debug_gc_metrics_truncate_vs_passive -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "manual GC metrics debug harness"]
+fn debug_gc_metrics_truncate_vs_passive() {
+    fn sample_line(
+        mode: &str,
+        step: usize,
+        updates: usize,
+        snap: &crate::mvcc::database::GcDebugSnapshot,
+    ) {
+        println!(
+            "{mode},step={step},updates={updates},\
+             rows_slots={},rows_empty={},rows_versions={},\
+             index_slots={},index_empty={},index_versions={},\
+             live_approx={},live_at_last_gc={},\
+             lwm={},durable_max={},\
+             log_offset={},log_size={},txs={},\
+             min_reader=({},{}),backfill=({},{})",
+            snap.rows_slots,
+            snap.rows_empty_slots,
+            snap.rows_versions,
+            snap.index_slots,
+            snap.index_empty_slots,
+            snap.index_versions,
+            snap.live_version_count_approx,
+            snap.live_versions_at_last_gc,
+            snap.lwm,
+            snap.durable_txid_max,
+            snap.logical_log_offset,
+            snap.logical_log_size,
+            snap.active_txs,
+            snap.min_reader_mark.checkpoint_seq,
+            snap.min_reader_mark.frame,
+            snap.backfill_floor.checkpoint_seq,
+            snap.backfill_floor.frame,
+        );
+    }
+
+    /// UPDATE-heavy workload under a pinned reader; checkpoints driven by a
+    /// separate connection (server-like), auto-checkpoint disabled.
+    fn run_mode(passive: bool, keys: usize, rounds: usize, updates_per_round: usize) {
+        let mode = if passive { "passive" } else { "truncate" };
+        let db = if passive {
+            MvccTestDbNoConn::new_with_random_db_passive()
+        } else {
+            MvccTestDbNoConn::new_with_random_db()
+        };
+        let mv = db.get_mvcc_store();
+        let bootstrap = db.connect();
+        bootstrap
+            .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT NOT NULL)")
+            .unwrap();
+        // Disable auto-checkpoint; drive checkpoints explicitly like turso-server.
+        bootstrap
+            .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
+        // Keep inline GC on so live_approx can drop between checkpoints.
+        bootstrap.execute("PRAGMA mvcc_gc_threshold = 64").unwrap();
+
+        bootstrap.execute("BEGIN CONCURRENT").unwrap();
+        for i in 0..keys {
+            bootstrap
+                .execute(format!("INSERT INTO t VALUES ({i}, 'seed')"))
+                .unwrap();
+        }
+        bootstrap.execute("COMMIT").unwrap();
+        // Materialize the seed so subsequent Passive/Truncate behavior is about updates.
+        let ckpt = if passive { "PASSIVE" } else { "TRUNCATE" };
+        let _ = bootstrap.execute(format!("PRAGMA wal_checkpoint({ckpt})"));
+
+        let reader = db.connect();
+        reader.execute("BEGIN CONCURRENT").unwrap();
+        // Keep the txn live for the whole run (pins LWM).
+        reader.execute("SELECT count(*) FROM t").unwrap();
+
+        let writer = db.connect();
+        let checkpointer = db.connect();
+
+        println!("# mode={mode} keys={keys} rounds={rounds} updates_per_round={updates_per_round}");
+        sample_line(mode, 0, 0, &mv.debug_gc_snapshot());
+
+        let mut updates = 0usize;
+        for step in 1..=rounds {
+            writer.execute("BEGIN CONCURRENT").unwrap();
+            for u in 0..updates_per_round {
+                let id = (updates + u) % keys;
+                writer
+                    .execute(format!("UPDATE t SET data = 'r{step}_{u}' WHERE id = {id}"))
+                    .unwrap();
+            }
+            writer.execute("COMMIT").unwrap();
+            updates += updates_per_round;
+
+            let ckpt_res = checkpointer.execute(format!("PRAGMA wal_checkpoint({ckpt})"));
+            let ckpt_status = match &ckpt_res {
+                Ok(_) => "ok".to_string(),
+                Err(e) => format!("err:{e}"),
+            };
+            let snap = mv.debug_gc_snapshot();
+            println!(
+                "{mode},step={step},updates={updates},ckpt={ckpt_status},\
+                 rows_slots={},rows_empty={},rows_versions={},\
+                 live_approx={},lwm={},durable_max={},\
+                 log_offset={},log_size={},txs={},\
+                 min_reader=({},{}),backfill=({},{})",
+                snap.rows_slots,
+                snap.rows_empty_slots,
+                snap.rows_versions,
+                snap.live_version_count_approx,
+                snap.lwm,
+                snap.durable_txid_max,
+                snap.logical_log_offset,
+                snap.logical_log_size,
+                snap.active_txs,
+                snap.min_reader_mark.checkpoint_seq,
+                snap.min_reader_mark.frame,
+                snap.backfill_floor.checkpoint_seq,
+                snap.backfill_floor.frame,
+            );
+        }
+
+        reader.execute("COMMIT").unwrap();
+        // One more checkpoint after the pin drops — Truncate should be able to
+        // clear slots; Passive still only GC-in-place.
+        let _ = checkpointer.execute(format!("PRAGMA wal_checkpoint({ckpt})"));
+        sample_line(mode, rounds + 1, updates, &mv.debug_gc_snapshot());
+    }
+
+    /// Same UPDATE load, but no pinned reader — isolates empty-slot retention
+    /// after Passive Rule 3 clears sole-survivor chains.
+    fn run_mode_unpinned(passive: bool, keys: usize, rounds: usize, updates_per_round: usize) {
+        let mode = if passive {
+            "passive_unpinned"
+        } else {
+            "truncate_unpinned"
+        };
+        let db = if passive {
+            MvccTestDbNoConn::new_with_random_db_passive()
+        } else {
+            MvccTestDbNoConn::new_with_random_db()
+        };
+        let mv = db.get_mvcc_store();
+        let bootstrap = db.connect();
+        bootstrap
+            .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT NOT NULL)")
+            .unwrap();
+        bootstrap
+            .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+            .unwrap();
+        bootstrap.execute("PRAGMA mvcc_gc_threshold = 64").unwrap();
+
+        bootstrap.execute("BEGIN CONCURRENT").unwrap();
+        for i in 0..keys {
+            bootstrap
+                .execute(format!("INSERT INTO t VALUES ({i}, 'seed')"))
+                .unwrap();
+        }
+        bootstrap.execute("COMMIT").unwrap();
+        let ckpt = if passive { "PASSIVE" } else { "TRUNCATE" };
+        let _ = bootstrap.execute(format!("PRAGMA wal_checkpoint({ckpt})"));
+
+        let writer = db.connect();
+        let checkpointer = db.connect();
+        println!("# mode={mode} keys={keys} rounds={rounds} updates_per_round={updates_per_round}");
+        sample_line(mode, 0, 0, &mv.debug_gc_snapshot());
+
+        let mut updates = 0usize;
+        for step in 1..=rounds {
+            writer.execute("BEGIN CONCURRENT").unwrap();
+            for u in 0..updates_per_round {
+                let id = (updates + u) % keys;
+                writer
+                    .execute(format!("UPDATE t SET data = 'r{step}_{u}' WHERE id = {id}"))
+                    .unwrap();
+            }
+            writer.execute("COMMIT").unwrap();
+            updates += updates_per_round;
+
+            let ckpt_res = checkpointer.execute(format!("PRAGMA wal_checkpoint({ckpt})"));
+            let ckpt_status = match &ckpt_res {
+                Ok(_) => "ok".to_string(),
+                Err(e) => format!("err:{e}"),
+            };
+            let snap = mv.debug_gc_snapshot();
+            let (wal_seq, wal_max) = checkpointer.pager.load().wal_pos();
+            let wal_bf = checkpointer.pager.load().wal_backfill_frame().unwrap_or(0);
+            println!(
+                "{mode},step={step},updates={updates},ckpt={ckpt_status},\
+                 rows_slots={},rows_empty={},rows_versions={},\
+                 live_approx={},lwm={},durable_max={},\
+                 log_offset={},log_size={},txs={},\
+                 min_reader=({},{}),backfill=({},{}),\
+                 wal_pos=({wal_seq},{wal_max}),wal_nbackfill={wal_bf}",
+                snap.rows_slots,
+                snap.rows_empty_slots,
+                snap.rows_versions,
+                snap.live_version_count_approx,
+                snap.lwm,
+                snap.durable_txid_max,
+                snap.logical_log_offset,
+                snap.logical_log_size,
+                snap.active_txs,
+                snap.min_reader_mark.checkpoint_seq,
+                snap.min_reader_mark.frame,
+                snap.backfill_floor.checkpoint_seq,
+                snap.backfill_floor.frame,
+            );
+        }
+    }
+
+    const KEYS: usize = 200;
+    const ROUNDS: usize = 5;
+    const UPDATES_PER_ROUND: usize = 50;
+    // Unpinned + pinned reader loads.
+    run_mode_unpinned(false, KEYS, ROUNDS, UPDATES_PER_ROUND);
+    run_mode_unpinned(true, KEYS, ROUNDS, UPDATES_PER_ROUND);
+    run_mode(false, KEYS, ROUNDS, UPDATES_PER_ROUND);
+    run_mode(true, KEYS, ROUNDS, UPDATES_PER_ROUND);
+}
+
 /// Passive checkpoint may run btree writes while a pinned reader is active.
 #[test]
 fn mvcc_passive_checkpoint_busy_under_pinned_reader_no_corruption() {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -884,18 +884,78 @@ fn mvcc_passive_checkpoint_publishes_backfill_and_reclaims_versions() {
         wal_bf > 0,
         "passive checkpoint must publish nbackfills, got wal_nbackfill={wal_bf}, snap={snap:?}"
     );
-    // Currents stay (SkipMap cover for concurrent Passive); superseded history + empty slots go.
-    assert!(
-        snap.rows_versions <= 51 && snap.rows_empty_slots == 0,
-        "passive Finalize keeps currents, drains empty slots: {snap:?}"
-    );
+    // Passive Finalize keeps currents (SkipMap cover) but drains empty slots /
+    // superseded history. Write-buffer reads can prefer B-tree for sole
+    // materialized currents without unlinking them.
     assert_eq!(
-        snap.rows_versions, snap.rows_slots,
-        "no empty slots after Passive Finalize unlink: {snap:?}"
+        snap.rows_empty_slots, 0,
+        "passive Finalize must drain empty SkipMap slots: {snap:?}"
     );
     assert_eq!(
         snap.backfill_floor.frame, wal_bf,
         "backfill_floor must track published nbackfills: {snap:?}"
+    );
+
+    // Full Rule 3 reclaim of currents requires a blocking Truncate Finalize.
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    let after_truncate = mv.debug_gc_snapshot();
+    assert_eq!(
+        after_truncate.rows_versions, 0,
+        "truncate Finalize must reclaim SkipMap versions: {after_truncate:?}"
+    );
+    assert_eq!(
+        after_truncate.rows_slots, 0,
+        "truncate Finalize must unlink SkipMap slots: {after_truncate:?}"
+    );
+}
+
+/// Regression test for why Rule 3 (see the `gc_version_chain` doc comment) must stay
+/// off for every Passive GC path: a reader whose snapshot predates a write must never
+/// observe that write while its transaction is still open, even with a single table
+/// and no index involved (ruling out table/index publish skew as the cause). If Rule 3
+/// were ever turned on for Passive without also fixing the underlying B-tree-fallthrough
+/// isolation gap, this test would fail with `after == [2000]` instead of `[1000]`.
+#[test]
+fn passive_reader_snapshot_survives_later_write_after_row_versions_gc() {
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let mv = db.get_mvcc_store();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, bal INTEGER NOT NULL)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 1000)").unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    // Seed via an actual PASSIVE checkpoint (not TRUNCATE, which always runs the
+    // blocking protocol regardless of `experimental_mvcc_passive_checkpoint`): this
+    // materializes row 1 into the B-tree and runs Passive Finalize GC on it.
+    conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+    assert!(
+        mv.debug_gc_snapshot().rows_versions > 0,
+        "row 1's current version must survive Passive Finalize (Rule 3 off)"
+    );
+
+    // Reader opens a snapshot BEFORE any further write.
+    let reader = db.connect();
+    reader.execute("BEGIN CONCURRENT").unwrap();
+    let before = get_rows(&reader, "SELECT bal FROM t WHERE id = 1");
+    assert_eq!(before, vec![vec![Value::from_i64(1000)]]);
+
+    // Writer updates + immediately passive-checkpoints (threshold=0 => on commit).
+    let writer = db.connect();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    writer
+        .execute("UPDATE t SET bal = 2000 WHERE id = 1")
+        .unwrap();
+
+    // Reader re-reads the SAME row within its ALREADY-OPEN snapshot: must still see 1000.
+    let after = get_rows(&reader, "SELECT bal FROM t WHERE id = 1");
+    reader.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        after, before,
+        "reader's snapshot must not change mid-transaction"
     );
 }
 
@@ -20462,4 +20522,49 @@ fn on_checkpoint_end_runs_before_blocking_checkpoint_unlock() {
         "blocking_checkpoint_lock must be released after checkpoint returns"
     );
     mv_store.blocking_checkpoint_lock.unlock();
+}
+
+/// Documents *why* Rule 3 (drop the sole current version once it's in the B-tree) is
+/// safe for blocking Truncate but not for Passive: acquiring `blocking_checkpoint_lock`
+/// for write cannot succeed while any MVCC transaction — even a read-only one — is
+/// still open, because `begin_tx` holds the read side of that same lock for the
+/// transaction's entire lifetime. So a second Truncate can never physically overwrite a
+/// row while an earlier reader might still rely on Rule 3 having dropped that row's
+/// prior SkipMap anchor. Passive never takes this lock around its write phase (that
+/// exclusion is exactly the throughput it exists to avoid), so it has no equivalent
+/// guarantee — see `passive_reader_snapshot_survives_later_write_after_row_versions_gc` and the
+/// `gc_version_chain` doc comment.
+#[test]
+fn truncate_checkpoint_is_busy_while_a_reader_transaction_is_open() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, bal INTEGER NOT NULL)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 1000)").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let reader = db.connect();
+    reader.execute("BEGIN CONCURRENT").unwrap();
+    assert_eq!(
+        get_rows(&reader, "SELECT bal FROM t WHERE id = 1"),
+        vec![vec![Value::from_i64(1000)]]
+    );
+
+    let writer = db.connect();
+    writer.execute("BEGIN CONCURRENT").unwrap();
+    writer
+        .execute("UPDATE t SET bal = 2000 WHERE id = 1")
+        .unwrap();
+    writer.execute("COMMIT").unwrap();
+    assert!(
+        matches!(
+            writer.execute("PRAGMA wal_checkpoint(TRUNCATE)"),
+            Err(LimboError::Busy)
+        ),
+        "a second Truncate must not be able to run while the earlier reader transaction is open"
+    );
+
+    reader.execute("COMMIT").unwrap();
+    // Now that the reader is gone, Truncate can proceed.
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 }

--- a/docs/internals/mvcc/GC.md
+++ b/docs/internals/mvcc/GC.md
@@ -52,11 +52,23 @@ every version in the SkipMap entry. If any version invalidates, the B-tree row
 is hidden and the visible MVCC version (if any) is returned instead. If the
 SkipMap has **no entry** for the RowID, the B-tree row is returned as-is.
 
+### SkipMap as write buffer
+
+`chain_is_write_buffer_for` is false only for a **sole materialized current**
+inside the published `durable_txid_max` boundary (Rule 3 shape). On **Truncate**,
+when no checkpoint is in progress and the B-tree is readable, such chains are
+omitted from MVCC merge/shadow so B-tree fallthrough serves the key. **Passive**
+keeps SkipMap cover for all chains (concurrent Passive can leave table/index
+B-trees briefly disagreeing). Passive Finalize keeps last currents (`unlink_empty`);
+Truncate Finalize runs Rule 3. If both peeks briefly hold the same key,
+`next`/`prev` advance both sides after emitting once.
+
 This means GC must maintain:
 
 > If a row exists in the B-tree, either the SkipMap correctly represents the
 > row's current state for all active readers, **or** the SkipMap has no entry
-> (B-tree fallthrough, only safe when B-tree data is up to date).
+> / is ignored as non-write-buffer (B-tree fallthrough, only safe when B-tree
+> data is up to date for that reader).
 
 Two hazards follow from this:
 
@@ -95,9 +107,10 @@ A current version is redundant with the B-tree when `b ≤ ckpt_max` and
 otherwise superseded versions would hide the B-tree row without providing data.
 
 `drop_current_if_in_btree` controls whether Rule 3 runs:
-- **true** on blocking Truncate (B-trees are stable under the checkpoint lock)
-- **false** on all Passive paths, including Finalize — dropping currents lets
-  dual-cursor fall through while table/index SkipMap coverage can disagree
+- **true** on Truncate Finalize / Truncate incremental
+- **false** on all Passive paths (Finalize `unlink_empty`, mid-Passive write-set
+  GC, incremental) — currents stay as SkipMap cover; write-buffer reads still
+  prefer B-tree for sole materialized currents after publish
 
 Rule 3 also guards recovery versions: `b=0` versions are protected by
 requiring `ckpt_max > 0` (see Recovery below).
@@ -122,12 +135,11 @@ The recovery transaction itself is removed from `txs` at the end of
 
 ## SkipMap Entry Removal
 
-Truncate Finalize `_and_slots` unlinks empty SkipMap entries and may drop last
-currents already in the B-tree. Passive Finalize `unlink_empty` unlinks empty
-slots but **keeps** currents. Write-set GC and
-`purge_row_versions_during_checkpoint` leave empty slots so row ids in the
-write set still resolve. Writers retry via `*_still_mapped` if an Arc was
-unlinked; index unlink bumps `index_rows_epoch`.
+Truncate Finalize uses `_and_slots` (Rule 3 + unlink). Passive Finalize uses
+`unlink_empty` (history + empty slots, keep currents). Mid-Passive write-set GC
+and incremental leave currents and empty slots so write-set row ids still
+resolve. Writers retry via `*_still_mapped` if an Arc was unlinked; index unlink
+bumps `index_rows_epoch`.
 
 ### Passive `backfill_floor` publication
 
@@ -136,8 +148,9 @@ Passive Rule 2 needs `materialized_at <= backfill_floor` (`nbackfills`). After
 checkpoint guard until Finalize. On Passive `Busy`, finish without advancing
 `nbackfills`.
 
-Rule 3 (`drop_current_if_in_btree`) is on for Truncate and off for all Passive
-GC paths, including Finalize.
+Rule 3 is on for Truncate; off for all Passive GC paths. Truncate write-buffer
+reads provide B-tree fallthrough for sole materialized currents; Passive does not
+fall through while currents remain.
 
 ## Non-blocking Checkpoint Readiness
 
@@ -146,17 +159,40 @@ checkpoints — the LWM parameter naturally constrains what can be collected
 when readers coexist with the checkpoint.
 
 **What works today**: all four GC rules, LWM, recovery protection, tombstone
-guard, under-lock empty-slot drain with writer retry.
+guard, under-lock empty-slot drain with writer retry, write-buffer read filter.
 
 **What needs work for non-blocking checkpoint**:
 
 - More soak / concurrent-simulator coverage of Passive GC racing writers on
   empty-slot drain.
 
+### Why Rule 3 cannot simply be turned on for Passive
+
+This was investigated directly: forcing `drop_current_if_in_btree = true` on
+Passive Finalize (keeping the empty-slot unlink) reproduces real corruption —
+`test_conflict_abort_ckpt_indexed_update_savepoint_integrity_check_passive`
+("row missing from index") and `test_passive_concurrent_transfer_preserves_sum_and_count`
+("total balance changed") both fail. The cause is **not** table/index publish
+skew; it reproduces with one table and no index at all
+(`passive_reader_snapshot_survives_later_write_after_row_versions_gc`). Once
+Rule 3 empties a chain's SkipMap slot, the slot is unlinked entirely. A later,
+unrelated write to that same row inserts a *new* chain with only its own
+(future, invisible) version — a reader whose snapshot predates that write now
+finds "no visible SkipMap version" and falls through to the physical B-tree,
+which the later Passive auto-checkpoint has already overwritten: a
+snapshot-isolation violation. Passive has no equivalent of Truncate's
+`blocking_checkpoint_lock`, which excludes all MVCC transactions for the
+duration of the write phase, so it cannot inherit that guarantee. Making Rule
+3 safe for Passive needs either real page-level MVCC (so B-tree fallthrough is
+isolated per reader) or serializing Passive's physical writes against readers
+for rows whose chain is currently empty — both bigger than a GC-only change.
+See the `gc_version_chain` doc comment in `core/mvcc/database/mod.rs` for the
+full argument.
+
 ## Key Files
 
 | File | Contents |
 |------|----------|
-| `core/mvcc/database/mod.rs` | `gc_version_chain`, `compute_lwm`, `drop_unused_row_versions`, `gc_table_row_versions`, `gc_index_row_versions`, recovery tx cleanup in `commit_load_tx` |
+| `core/mvcc/database/mod.rs` | `gc_version_chain`, `chain_is_write_buffer_for`, `compute_lwm`, `drop_unused_row_versions`, `gc_table_row_versions`, `gc_index_row_versions`, recovery tx cleanup in `commit_load_tx` |
 | `core/mvcc/database/checkpoint_state_machine.rs` | `gc_checkpointed_versions`, auto-trigger wiring in `Finalize` |
 | `core/mvcc/database/tests.rs` | 39 GC tests (unit, quickcheck, integration, e2e) |

--- a/docs/internals/mvcc/GC.md
+++ b/docs/internals/mvcc/GC.md
@@ -121,15 +121,26 @@ The recovery transaction itself is removed from `txs` at the end of
 After GC empties a version chain, the SkipMap entry is handled differently
 depending on the GC path:
 
-- **Checkpoint-time GC** (`gc_checkpointed_versions`): removes empty entries
-  using a re-check-under-lock pattern. This is a TOCTOU gap (a writer could
-  insert between the lock release and `remove()`), but safe under the current
-  **blocking** checkpoint — no concurrent writers exist.
+- **Blocking Truncate checkpoint** (`drop_unused_row_versions_and_slots` /
+  `gc_checkpointed_*` under the blocking lock): removes empty entries.
+- **Passive checkpoint / background GC**: leaves empty entries in place (lazy
+  removal). This avoids a TOCTOU race with concurrent writers. Empty entries are
+  reused by `get_or_insert_with` on subsequent inserts, and cleaned up by a later
+  blocking Truncate.
 
-- **Background GC** (`gc_table_row_versions`, `gc_index_row_versions`): leaves
-  empty entries in place (lazy removal). This avoids the TOCTOU race entirely.
-  Empty entries are reused by `get_or_insert_with` on subsequent inserts, and
-  cleaned up by the next checkpoint-time GC pass.
+### Passive `backfill_floor` publication
+
+Passive GC Rules 2/3 reclaim a materialized version only once
+`materialized_at <= backfill_floor`, where `backfill_floor` tracks the shared WAL
+`nbackfills` published after frames are copied into the DB file (and synced,
+unless `synchronous=off`). MVCC drives `wal.checkpoint` directly, so it must
+call `wal.publish_backfill` after that sync — the same step the pager's
+`PublishBackfill` phase performs. Without it, `nbackfills` stays at 0, Passive GC
+never reclaims stamped chains, and the SkipMap grows without bound.
+
+When Passive WAL backfill returns `Busy` (a DbFile reader holds read-mark 0),
+MVCC still finishes publish + logical-log truncate and leaves `nbackfills`
+unchanged so the GC floor stays honest.
 
 ## Non-blocking Checkpoint Readiness
 

--- a/docs/internals/mvcc/GC.md
+++ b/docs/internals/mvcc/GC.md
@@ -66,8 +66,8 @@ Two hazards follow from this:
   data loss — the superseded version's `end` timestamp still invalidates the
   B-tree row, but there's no MVCC version to serve reads.
 
-These are guarded by Rule 2's tombstone guard and Rule 3's sole-survivor
-condition respectively.
+These are guarded by Rule 2's tombstone guard and Rule 3's
+`drop_current_if_in_btree` gate respectively.
 
 ## Rule Details
 
@@ -88,12 +88,16 @@ thing hiding a stale B-tree row. Removal is only safe when:
 Pending inserts (`begin=TxID`) do not count as committed current — they might
 roll back.
 
-### Rule 3: Sole Survivor
+### Rule 3: Drop current if already in B-tree
 
 A current version is redundant with the B-tree when `b ≤ ckpt_max` and
-`b < lwm`. But we only remove it when it's the **sole** remaining version in
-the chain. If superseded versions remain, removing the current version would
-leave orphaned invalidators that hide the B-tree row without providing data.
+`b < lwm`. We only remove it when it is the **last** version in the chain —
+otherwise superseded versions would hide the B-tree row without providing data.
+
+`drop_current_if_in_btree` controls whether Rule 3 runs:
+- **true** on blocking Truncate (B-trees are stable under the checkpoint lock)
+- **false** on all Passive paths, including Finalize — dropping currents lets
+  dual-cursor fall through while table/index SkipMap coverage can disagree
 
 Rule 3 also guards recovery versions: `b=0` versions are protected by
 requiring `ckpt_max > 0` (see Recovery below).
@@ -118,29 +122,22 @@ The recovery transaction itself is removed from `txs` at the end of
 
 ## SkipMap Entry Removal
 
-After GC empties a version chain, the SkipMap entry is handled differently
-depending on the GC path:
-
-- **Blocking Truncate checkpoint** (`drop_unused_row_versions_and_slots` /
-  `gc_checkpointed_*` under the blocking lock): removes empty entries.
-- **Passive checkpoint / background GC**: leaves empty entries in place (lazy
-  removal). This avoids a TOCTOU race with concurrent writers. Empty entries are
-  reused by `get_or_insert_with` on subsequent inserts, and cleaned up by a later
-  blocking Truncate.
+Truncate Finalize `_and_slots` unlinks empty SkipMap entries and may drop last
+currents already in the B-tree. Passive Finalize `unlink_empty` unlinks empty
+slots but **keeps** currents. Write-set GC and
+`purge_row_versions_during_checkpoint` leave empty slots so row ids in the
+write set still resolve. Writers retry via `*_still_mapped` if an Arc was
+unlinked; index unlink bumps `index_rows_epoch`.
 
 ### Passive `backfill_floor` publication
 
-Passive GC Rules 2/3 reclaim a materialized version only once
-`materialized_at <= backfill_floor`, where `backfill_floor` tracks the shared WAL
-`nbackfills` published after frames are copied into the DB file (and synced,
-unless `synchronous=off`). MVCC drives `wal.checkpoint` directly, so it must
-call `wal.publish_backfill` after that sync — the same step the pager's
-`PublishBackfill` phase performs. Without it, `nbackfills` stays at 0, Passive GC
-never reclaims stamped chains, and the SkipMap grows without bound.
+Passive Rule 2 needs `materialized_at <= backfill_floor` (`nbackfills`). After
+`wal.checkpoint` + DB sync, MVCC calls `wal.publish_backfill` and keeps the
+checkpoint guard until Finalize. On Passive `Busy`, finish without advancing
+`nbackfills`.
 
-When Passive WAL backfill returns `Busy` (a DbFile reader holds read-mark 0),
-MVCC still finishes publish + logical-log truncate and leaves `nbackfills`
-unchanged so the GC floor stays honest.
+Rule 3 (`drop_current_if_in_btree`) is on for Truncate and off for all Passive
+GC paths, including Finalize.
 
 ## Non-blocking Checkpoint Readiness
 
@@ -148,16 +145,13 @@ The GC rules are designed to work with both blocking and non-blocking
 checkpoints — the LWM parameter naturally constrains what can be collected
 when readers coexist with the checkpoint.
 
-**What works today**: all four GC rules, LWM computation, recovery version
-protection, tombstone guard, lazy removal in background GC.
+**What works today**: all four GC rules, LWM, recovery protection, tombstone
+guard, under-lock empty-slot drain with writer retry.
 
 **What needs work for non-blocking checkpoint**:
 
-- **Checkpoint-time entry removal**: the re-check-under-lock pattern in
-  `gc_checkpointed_versions` has a TOCTOU gap. Under non-blocking checkpoint,
-  concurrent writers could lose inserted versions. Fix: either hold the write
-  lock across the emptiness check and `remove()`, or switch to lazy removal
-  (same as background GC).
+- More soak / concurrent-simulator coverage of Passive GC racing writers on
+  empty-slot drain.
 
 ## Key Files
 


### PR DESCRIPTION
## Description
- Publish WAL backfill after Passive checkpoint so GC can see what was written to the DB file.
- Reclaim old / empty SkipMap version slots on Passive GC; keep the latest in-memory copy of each row so open readers stay correct.
- Hold the blocking checkpoint lock until the end hook finishes so cleanup ordering stays safe.
- Add small helpers/tests for inspecting Passive GC progress and for cases where later writes must not confuse older readers.

