### PR TITLE
postgres: evaluate = ANY(array) and <> ALL(array) instead of stubbing to false

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -40,7 +40,7 @@ Basics not enumerated by the official feature matrix.
 | SELECT (projections, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT/OFFSET) | ✅ Supported | |
 | JOINs (INNER, LEFT, RIGHT, FULL, CROSS, NATURAL, USING) | ✅ Supported | |
 | UNION / UNION ALL / INTERSECT / EXCEPT | ✅ Supported | Including ORDER BY/LIMIT on compounds |
-| Subqueries (FROM, IN, EXISTS, scalar) | ✅ Supported | `= ANY(array)` is stubbed to false (pg_catalog hack); `ALL`/row comparison subqueries error |
+| Subqueries (FROM, IN, EXISTS, scalar) | ✅ Supported | `= ANY(array)` and `<> ALL(array)` work, including bound text-array parameters; other ANY/ALL array operators are rejected; `ALL`/row comparison subqueries error |
 | INSERT (column lists, multi-row VALUES, DEFAULT, INSERT ... SELECT) | ✅ Supported | |
 | UPDATE (incl. FROM clause) | ✅ Supported | Multi-column `SET (a,b) = (...)` not supported |
 | DELETE | 🟡 Partial | `USING` clause silently dropped |

--- a/postgres/conformance/pg-sqltests/select.sqltest
+++ b/postgres/conformance/pg-sqltests/select.sqltest
@@ -87,3 +87,55 @@ test select-abs {
 expect {
     7
 }
+
+# = ANY / != ALL over arrays. Comparisons stay in WHERE position: turso
+# renders a bare boolean expression as 0/1 where PostgreSQL renders t/f.
+
+setup any_ids {
+    CREATE TABLE t (id int);
+    INSERT INTO t VALUES (1), (2), (5);
+}
+
+@setup any_ids
+test any-array-literal {
+    SELECT id FROM t WHERE id = ANY(ARRAY[1, 2, 7]) ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+# The PG lexer rewrites != to <>; both spellings must behave identically.
+
+@setup any_ids
+test all-array-literal-not-equal {
+    SELECT id FROM t WHERE id <> ALL(ARRAY[1, 2]);
+}
+expect {
+    5
+}
+
+@setup any_ids
+test all-array-literal-not-equal-bang-spelling {
+    SELECT id FROM t WHERE id != ALL(ARRAY[1, 2]);
+}
+expect {
+    5
+}
+
+@setup any_ids
+test any-array-null-element-filters {
+    SELECT id FROM t WHERE id = ANY(ARRAY[1, NULL]);
+}
+expect {
+    1
+}
+
+@setup any_ids
+test any-subquery {
+    SELECT id FROM t WHERE id = ANY(SELECT 1 UNION SELECT 5) ORDER BY id;
+}
+expect {
+    1
+    5
+}

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -2422,12 +2422,8 @@ impl PostgreSQLTranslator {
                 // ILIKE/NOT ILIKE → LOWER(lhs) LIKE LOWER(rhs)
                 self.translate_ilike_expr(a_expr)
             }
-            AExprKind::AexprOpAny => {
-                // expr = ANY(array) → stub as 0 (false).
-                // Our pg_catalog tables that use arrays are empty stubs,
-                // so this never actually evaluates.
-                Ok(ast::Expr::Literal(ast::Literal::Numeric("0".to_string())))
-            }
+            AExprKind::AexprOpAny => self.translate_any_all_expr(a_expr, false),
+            AExprKind::AexprOpAll => self.translate_any_all_expr(a_expr, true),
             AExprKind::AexprBetween | AExprKind::AexprBetweenSym => {
                 self.translate_between_expr(a_expr, false)
             }
@@ -2740,6 +2736,80 @@ impl PostgreSQLTranslator {
             .unwrap_or(false);
 
         Ok(ast::Expr::InList { lhs, not, rhs })
+    }
+
+    /// Translate `<lhs> <op> ANY(<array>)` / `<lhs> <op> ALL(<array>)`.
+    /// Only the membership forms are supported: `= ANY` (IN) and `<> ALL`
+    /// (NOT IN); other operators error as not supported. A literal ARRAY[...]
+    /// operand lowers to IN/NOT IN. Any other operand (bound parameter, column,
+    /// expression) lowers to array_contains(array, elem). `= ANY(<subquery>)`
+    /// parses as a SubLink and lowers to InSelect, so it never reaches here.
+    fn translate_any_all_expr(
+        &self,
+        a_expr: &pg_query::protobuf::AExpr,
+        is_all: bool,
+    ) -> Result<ast::Expr, ParseError> {
+        let kw = if is_all { "ALL" } else { "ANY" };
+        let op_name = a_expr
+            .name
+            .first()
+            .and_then(|n| match &n.node {
+                Some(pg_query::protobuf::node::Node::String(s)) => Some(s.sval.as_str()),
+                _ => None,
+            })
+            .ok_or_else(|| ParseError::ParseError(format!("{kw}: missing operator name")))?;
+
+        // The PG lexer rewrites != to <>.
+        let not = match (op_name, is_all) {
+            ("=", false) => false,
+            ("<>", true) => true,
+            _ => {
+                return Err(ParseError::ParseError(format!(
+                    "{op_name} {kw} (array) is not supported"
+                )));
+            }
+        };
+
+        let lhs_node = a_expr
+            .lexpr
+            .as_ref()
+            .ok_or_else(|| ParseError::ParseError(format!("{kw}: missing lhs")))?;
+        let rhs_node = a_expr
+            .rexpr
+            .as_ref()
+            .ok_or_else(|| ParseError::ParseError(format!("{kw}: missing rhs")))?;
+        let lhs = self.translate_expr(lhs_node)?;
+
+        if let Some(pg_query::protobuf::node::Node::AArrayExpr(arr)) = &rhs_node.node {
+            let rhs = arr
+                .elements
+                .iter()
+                .map(|e| Ok(Box::new(self.translate_expr(e)?)))
+                .collect::<Result<Vec<_>, ParseError>>()?;
+            return Ok(ast::Expr::InList {
+                lhs: Box::new(lhs),
+                not,
+                rhs,
+            });
+        }
+
+        let array = self.translate_expr(rhs_node)?;
+        let call = ast::Expr::FunctionCall {
+            name: ast::Name::from_string("array_contains"),
+            distinctness: None,
+            args: vec![Box::new(array), Box::new(lhs)],
+            order_by: vec![],
+            within_group: vec![],
+            filter_over: ast::FunctionTail {
+                filter_clause: None,
+                over_clause: None,
+            },
+        };
+        Ok(if not {
+            ast::Expr::Unary(ast::UnaryOperator::Not, Box::new(call))
+        } else {
+            call
+        })
     }
 
     fn translate_like_expr(
@@ -6447,6 +6517,87 @@ mod tests {
             }
         } else {
             panic!("Expected Select statement");
+        }
+    }
+
+    /// Extract the WHERE clause of a translated single SELECT.
+    fn where_clause_of(sql: &str) -> ast::Expr {
+        let translator = PostgreSQLTranslator::new();
+        let parsed = crate::parse(sql).unwrap();
+        let translated = translator.translate(&parsed).unwrap();
+        let ast::Stmt::Select(select) = translated else {
+            panic!("Expected Select statement");
+        };
+        let ast::OneSelect::Select { where_clause, .. } = &select.body.select else {
+            panic!("Expected Select variant");
+        };
+        *where_clause
+            .as_ref()
+            .expect("Expected WHERE clause")
+            .clone()
+    }
+
+    #[test]
+    fn test_eq_any_array_literal_becomes_in_list() {
+        let wc = where_clause_of("SELECT id FROM t WHERE id = ANY(ARRAY[1, 2, 3])");
+        let ast::Expr::InList { not, rhs, .. } = wc else {
+            panic!("Expected InList for = ANY(array literal), got: {wc:?}");
+        };
+        assert!(!not);
+        assert_eq!(rhs.len(), 3);
+    }
+
+    #[test]
+    fn test_eq_any_param_becomes_array_contains() {
+        let wc = where_clause_of("SELECT id FROM t WHERE id = ANY($1)");
+        let ast::Expr::FunctionCall { name, args, .. } = wc else {
+            panic!("Expected FunctionCall for = ANY(param), got: {wc:?}");
+        };
+        assert_eq!(name.as_str(), "array_contains");
+        assert_eq!(args.len(), 2);
+        assert!(
+            matches!(&*args[0], ast::Expr::Variable(_)),
+            "array argument must come first, got: {:?}",
+            args[0]
+        );
+    }
+
+    #[test]
+    fn test_ne_all_array_literal_becomes_not_in_list() {
+        let wc = where_clause_of("SELECT id FROM t WHERE id <> ALL(ARRAY[1, 2])");
+        let ast::Expr::InList { not, rhs, .. } = wc else {
+            panic!("Expected InList for != ALL(array literal), got: {wc:?}");
+        };
+        assert!(not);
+        assert_eq!(rhs.len(), 2);
+    }
+
+    #[test]
+    fn test_ne_all_param_becomes_not_array_contains() {
+        let wc = where_clause_of("SELECT id FROM t WHERE id != ALL($1)");
+        let ast::Expr::Unary(ast::UnaryOperator::Not, inner) = wc else {
+            panic!("Expected NOT(...) for != ALL(param), got: {wc:?}");
+        };
+        let ast::Expr::FunctionCall { name, .. } = &*inner else {
+            panic!("Expected FunctionCall under NOT, got: {inner:?}");
+        };
+        assert_eq!(name.as_str(), "array_contains");
+    }
+
+    #[test]
+    fn test_unsupported_any_all_operators_error() {
+        let translator = PostgreSQLTranslator::new();
+        for sql in [
+            "SELECT 1 WHERE 2 > ANY(ARRAY[1, 5])",
+            "SELECT 1 WHERE 2 <> ANY(ARRAY[1, 5])",
+            "SELECT 1 WHERE 2 = ALL(ARRAY[2, 2])",
+        ] {
+            let parsed = crate::parse(sql).unwrap();
+            let err = translator.translate(&parsed).unwrap_err();
+            assert!(
+                err.to_string().contains("not supported"),
+                "expected loud error for {sql}, got: {err}"
+            );
         }
     }
 

--- a/postgres/tests/integration/postgres/dialect.rs
+++ b/postgres/tests/integration/postgres/dialect.rs
@@ -3434,3 +3434,85 @@ fn test_postgres_statement_reprepare_uses_pg_dialect(db: TempDatabase) {
         1
     );
 }
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_eq_any_bound_array_param(db: TempDatabase) {
+    let conn = db.connect_postgres();
+    conn.execute("CREATE TABLE t (id int)").unwrap();
+    conn.execute("INSERT INTO t VALUES (1), (2), (5)").unwrap();
+
+    // Drivers like psycopg bind list parameters as PG text arrays.
+    let mut stmt = conn
+        .prepare("SELECT id FROM t WHERE id = ANY($1) ORDER BY id")
+        .unwrap();
+    stmt.bind_at(
+        std::num::NonZero::new(1).unwrap(),
+        Value::from_text("{1,2}".to_owned()),
+    )
+    .unwrap();
+    let rows = stmt.run_collect_rows().unwrap();
+    assert_eq!(
+        rows,
+        vec![vec![Value::from_i64(1)], vec![Value::from_i64(2)]]
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_eq_any_empty_bound_array(db: TempDatabase) {
+    let conn = db.connect_postgres();
+    conn.execute("CREATE TABLE t (id int)").unwrap();
+    conn.execute("INSERT INTO t VALUES (1)").unwrap();
+
+    let mut stmt = conn.prepare("SELECT id FROM t WHERE id = ANY($1)").unwrap();
+    stmt.bind_at(
+        std::num::NonZero::new(1).unwrap(),
+        Value::from_text("{}".to_owned()),
+    )
+    .unwrap();
+    let rows = stmt.run_collect_rows().unwrap();
+    assert_eq!(rows, Vec::<Vec<Value>>::new());
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_ne_all_bound_array_param(db: TempDatabase) {
+    let conn = db.connect_postgres();
+    conn.execute("CREATE TABLE t (id int)").unwrap();
+    conn.execute("INSERT INTO t VALUES (1), (2), (5)").unwrap();
+
+    let mut stmt = conn
+        .prepare("SELECT id FROM t WHERE id != ALL($1)")
+        .unwrap();
+    stmt.bind_at(
+        std::num::NonZero::new(1).unwrap(),
+        Value::from_text("{1,2}".to_owned()),
+    )
+    .unwrap();
+    let rows = stmt.run_collect_rows().unwrap();
+    assert_eq!(rows, vec![vec![Value::from_i64(5)]]);
+}
+
+#[turso_macros::test(mvcc)]
+fn test_postgres_catalog_conkey_any_matches_no_rows(db: TempDatabase) {
+    let conn = db.connect_postgres();
+    conn.execute("CREATE TABLE pkt (a int, b int, PRIMARY KEY (a, b))")
+        .unwrap();
+
+    let mut stmt = conn.prepare("SELECT count(*) FROM pg_constraint").unwrap();
+    let rows = stmt.run_collect_rows().unwrap();
+    assert_eq!(
+        rows,
+        vec![vec![Value::from_i64(1)]],
+        "pkey constraint row must be present"
+    );
+
+    // conkey is space-separated TEXT, not a PG array; array_contains
+    // yields NULL over it, so attnum = ANY(conkey) matches no rows.
+    let mut stmt = conn
+        .prepare(
+            "SELECT count(*) FROM pg_attribute a, pg_constraint c \
+             WHERE a.attnum = ANY(c.conkey)",
+        )
+        .unwrap();
+    let rows = stmt.run_collect_rows().unwrap();
+    assert_eq!(rows, vec![vec![Value::from_i64(0)]]);
+}


### PR DESCRIPTION
  ## Description

  The translator's `AexprOpAny` arm replaced the whole `<lhs> <op> ANY(<array>)`
  expression with literal `0`, and `AexprOpAll` errored. This made various standard
  dynamic IN-list idioms return zero rows with no error, such as:

  - psycopg3's documented list binding: `WHERE id = ANY(%s)`
  - asyncpg's canonical form: `WHERE id = ANY($1::int[])`

  Now: literal `ARRAY[...]` operands lower to IN/NOT IN (exact PG NULL
  semantics); other operands (bound parameters, columns) lower to
  `array_contains(array, elem)`, whose NULL result is equivalent to false in
  WHERE position. `<> ALL` lowers to the NOT variants. Other ANY/ALL operators
  error loudly instead of misevaluating (noted in COMPAT.md). The stub existed
  so pg_catalog introspection queries (`attnum = ANY(conkey)`, where conkey
  is space-separated TEXT) would not error; those evaluate to NULL and still
  match no rows, with a regression test.

  Test placement: pg-sqltests covers the literal, NULL-element, and subquery
  forms (each validated against PostgreSQL 16); bound-parameter coverage
  lives in Rust integration tests.

  Verified end to end against PostgreSQL 16 with real drivers: psycopg2 and
  psycopg3 idioms return identical rows on both servers after this change
  (before it, both silently returned `[]` against tursopg).

  ## Motivation and context

  Silent wrong results on common ways (Python) drivers express "WHERE column 
  IN <dynamic list>". COMPAT.md previously documented the stub.

  ## Description of AI Usage
  
  Developed with Claude Code under my direction. I reviewed and take responsibility for the
  final diff.