### PR TITLE
build: fix uv project reference in Makefile test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,11 @@ test-sqltest-pg:
 .PHONY: test-sqltest-pg
 
 test-extensions: build uv-sync-test
-	RUST_LOG=$(RUST_LOG) uv run --project limbo_test test-extensions
+	RUST_LOG=$(RUST_LOG) uv run --package turso_test test-extensions
 .PHONY: test-extensions
 
 test-shell: build uv-sync-test
-	RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-shell
+	RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --package turso_test test-shell
 .PHONY: test-shell
 
 test-compat: check-tcl-version
@@ -114,12 +114,12 @@ test-sqlite3: reset-db
 .PHONY: test-sqlite3
 
 test-memory: build uv-sync-test
-	RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-memory
+	RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --package turso_test test-memory
 .PHONY: test-memory
 
 test-write: build uv-sync-test
 	@if [ "$(SQLITE_EXEC)" != "scripts/limbo-sqlite3" ]; then \
-		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-write; \
+		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --package turso_test test-write; \
 	else \
 		echo "Skipping test-write: SQLITE_EXEC does not have indexes scripts/limbo-sqlite3"; \
 	fi
@@ -127,7 +127,7 @@ test-write: build uv-sync-test
 
 test-update: build uv-sync-test
 	@if [ "$(SQLITE_EXEC)" != "scripts/limbo-sqlite3" ]; then \
-		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-update; \
+		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --package turso_test test-update; \
 	else \
 		echo "Skipping test-update: SQLITE_EXEC does not have indexes scripts/limbo-sqlite3"; \
 	fi
@@ -135,7 +135,7 @@ test-update: build uv-sync-test
 
 test-collate: build uv-sync-test
 	@if [ "$(SQLITE_EXEC)" != "scripts/limbo-sqlite3" ]; then \
-		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-collate; \
+		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --package turso_test test-collate; \
 	else \
 		echo "Skipping test-collate: SQLITE_EXEC does not have indexes scripts/limbo-sqlite3"; \
 	fi
@@ -143,7 +143,7 @@ test-collate: build uv-sync-test
 
 test-constraint: build uv-sync-test
 	@if [ "$(SQLITE_EXEC)" != "scripts/limbo-sqlite3" ]; then \
-		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-constraint; \
+		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --package turso_test test-constraint; \
 	else \
 		echo "Skipping test-constraint: SQLITE_EXEC does not have indexes scripts/limbo-sqlite3"; \
 	fi
@@ -161,10 +161,10 @@ whopper-coverage:
 .PHONY: whopper-coverage
 
 bench-vfs: uv-sync-test build-release
-	RUST_LOG=$(RUST_LOG) uv run --project limbo_test bench-vfs "$(SQL)" "$(N)"
+	RUST_LOG=$(RUST_LOG) uv run --package turso_test bench-vfs "$(SQL)" "$(N)"
 
 bench-sqlite: uv-sync-test build-release
-	RUST_LOG=$(RUST_LOG) uv run --project limbo_test bench-sqlite "$(VFS)" "$(SQL)" "$(N)"
+	RUST_LOG=$(RUST_LOG) uv run --package turso_test bench-sqlite "$(VFS)" "$(SQL)" "$(N)"
 
 clickbench:
 	./perf/clickbench/benchmark.sh

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 dependencies = [
     "faker>=37.1.0",
  "pydantic>=2.11.1",
+ "rich>=15.0.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -509,12 +509,14 @@ source = { editable = "testing" }
 dependencies = [
     { name = "faker" },
     { name = "pydantic" },
+    { name = "rich" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "faker", specifier = ">=37.1.0" },
     { name = "pydantic", specifier = ">=2.11.1" },
+    { name = "rich", specifier = ">=15.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Addresses "Rust / test-limbo (push)" currently red on [main](https://github.com/tursodatabase/turso/actions/runs/30391190068/job/90382896317) from a error on `test-shell`.

The test targets invoke `uv run --project limbo_test`, but that directory does not exist: the python test package is `turso_test` in testing/. uv resolved it anyway by falling back to the workspace root with a deprecation warning, so the reference worked until uv [0.12.0](https://github.com/astral-sh/uv/releases/tag/0.12.0) (released today) turned the warning into a hard error, breaking the test-limbo CI job (reproducible on main). 

Fix: select the package by name, matching the existing `uv sync --package turso_test` in uv-sync-test.

Also, declare `rich` as a turso_test dependency. cli_tests imports rich but testing/pyproject.toml did not declare it and previously this fell back to the root pyproject.toml