### PR TITLE
postgres/cli: auto-attach persisted schemas on startup

### DIFF
--- a/postgres/cli/main.rs
+++ b/postgres/cli/main.rs
@@ -1006,9 +1006,9 @@ fn main() -> anyhow::Result<()> {
         .expect("Error setting Ctrl-C handler");
     }
 
+    auto_attach_pg_schemas(&conn, &db_file);
     // Server mode: start PG wire protocol server and exit
     if let Some(ref address) = opts.server {
-        auto_attach_pg_schemas(&conn, &db_file);
         let server = TursoPgServer::new(address.clone(), db_file, conn, interrupt_count);
         return server.run();
     }

--- a/postgres/cli/tests/tursopg.rs
+++ b/postgres/cli/tests/tursopg.rs
@@ -3,8 +3,12 @@ use std::net::{TcpListener, TcpStream};
 use std::process::{Child, Command, Output, Stdio};
 
 fn run_tursopg(input: &[u8]) -> Output {
+    run_tursopg_with_db(":memory:", input)
+}
+
+fn run_tursopg_with_db(db_path: impl AsRef<std::ffi::OsStr>, input: &[u8]) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_tursopg"))
-        .arg(":memory:")
+        .arg(db_path)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1372,4 +1376,48 @@ fn wire_multi_column_select_classifies_each() {
             vec![OID_INT4, OID_TEXT, OID_FLOAT8, OID_INT4, OID_TEXT]
         );
     });
+}
+
+/// Verify that a schema created in one tursopg session is accessible in a
+/// subsequent session opened against the same file.
+#[test]
+fn schema_sidecar_reattaches_on_reopen() {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let test_dir = std::env::temp_dir().join(format!("tursopg_schema_persist_{timestamp}"));
+    std::fs::create_dir(&test_dir).expect("failed to create temp test directory");
+
+    let db_path = test_dir.join("main.db");
+    let schema_name = "persist_sidecar";
+
+    let first_sql = format!(
+        "CREATE SCHEMA {schema_name};\n\
+         CREATE TABLE {schema_name}.demo(id INT, label TEXT);\n\
+         INSERT INTO {schema_name}.demo VALUES (1, 'persisted');\n"
+    );
+    let out1 = run_tursopg_with_db(&db_path, first_sql.as_bytes());
+    assert_eq!(
+        out1.status.code(),
+        Some(0),
+        "first run failed: {}",
+        stdout(&out1)
+    );
+
+    let second_sql = format!("SELECT id, label FROM {schema_name}.demo;\n");
+    let out2 = run_tursopg_with_db(&db_path, second_sql.as_bytes());
+
+    std::fs::remove_dir_all(&test_dir).ok();
+
+    let out = stdout(&out2);
+    assert_eq!(
+        out2.status.code(),
+        Some(0),
+        "second run failed, schema sidecar not reattached on reopen: {out}"
+    );
+    assert!(
+        out.contains("persisted"),
+        "expected 'persisted' in output, got: {out}"
+    );
 }


### PR DESCRIPTION
## Description

Auto-attaches persisted PostgreSQL schema sidecar databases during tursopg startup.

`CREATE SCHEMA` stores non-public schemas as sidecar database files. This change runs the existing schema auto-attach step before dispatching to server, one-shot SQL, stdin, or interactive CLI modes, so schema-qualified queries continue to work after reopening the main database.

Adds a CLI regression test that creates a schema/table in one tursopg process and reads it back from a second process using the same file-backed database.

## Motivation and context

Before this change, sidecar schema files persisted on disk, but the regular CLI startup path did not reattach them. Reopening the main database and querying `schema.table` failed with `no such database` until `CREATE SCHEMA` was run again.

This makes persisted schema behavior consistent across tursopg startup modes.

## Description of AI Usage

I used AI for codebase navigation, debugging guidance, and review of the implementation approach and tests. The implementation itself was written and reviewed by me