### PR TITLE
core/storage: add page codec interface

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -622,7 +622,7 @@ impl Connection {
                 None,
                 self.db.dialect(),
             )?;
-            let pager = Arc::new(db._init(None)?);
+            let pager = Arc::new(db._init(None, None)?);
             pager.set_initial_page_size(page_size)?;
             return Ok(TempDatabase {
                 db,
@@ -653,7 +653,7 @@ impl Connection {
                 None,
                 self.db.dialect(),
             )?;
-            let pager = Arc::new(db._init(None)?);
+            let pager = Arc::new(db._init(None, None)?);
             pager.set_initial_page_size(page_size)?;
             Ok(TempDatabase {
                 db,
@@ -673,7 +673,7 @@ impl Connection {
                 None,
                 self.db.dialect(),
             )?;
-            let pager = Arc::new(db._init(None)?);
+            let pager = Arc::new(db._init(None, None)?);
             pager.set_initial_page_size(page_size)?;
             Ok(TempDatabase { db, pager })
         }
@@ -690,7 +690,7 @@ impl Connection {
             None,
             self.db.dialect(),
         )?;
-        let pager = Arc::new(db._init(None)?);
+        let pager = Arc::new(db._init(None, None)?);
         pager.set_initial_page_size(self.get_page_size())?;
         Ok(TempDatabase {
             db,
@@ -3358,6 +3358,12 @@ impl Connection {
                             "reserved name {alias} is already in use"
                         )));
                     }
+                    if self.pager.load().has_page_codec() {
+                        return Err(LimboError::InvalidArgument(
+                            "ATTACH is unsupported for connections using an external page codec"
+                                .to_string(),
+                        ));
+                    }
 
                     let db_opts = DatabaseOpts::new()
                         .with_views(self.db.experimental_views_enabled())
@@ -3408,9 +3414,11 @@ impl Connection {
                     }));
                 }
                 AttachDatabaseState::Init(init) => {
-                    let mut pager = Arc::new(crate::return_if_io!(init
-                        .db
-                        ._init_nonblock(&mut init.init_st, init.encryption_key.as_ref(),)));
+                    let mut pager = Arc::new(crate::return_if_io!(init.db._init_nonblock(
+                        &mut init.init_st,
+                        init.encryption_key.as_ref(),
+                        None,
+                    )));
 
                     if !init.attached_is_fresh {
                         self.reject_initialized_attach_mismatches(&init.alias, &init.db, &pager)?;
@@ -4493,6 +4501,20 @@ impl Connection {
 
     pub fn set_reserved_bytes(&self, reserved_bytes: u8) -> Result<()> {
         let pager = self.pager.load();
+        if let Some(required_reserved_bytes) = pager.encryption_reserved_space() {
+            if reserved_bytes != required_reserved_bytes {
+                return Err(LimboError::InvalidArgument(format!(
+                    "built-in encryption requires exactly {required_reserved_bytes} reserved bytes"
+                )));
+            }
+        } else if let Some(codec) = pager.page_codec() {
+            let required_reserved_bytes = codec.required_reserved_bytes();
+            if reserved_bytes != required_reserved_bytes {
+                return Err(LimboError::InvalidArgument(format!(
+                    "page codec requires exactly {required_reserved_bytes} reserved bytes"
+                )));
+            }
+        }
         pager.set_reserved_space_bytes(reserved_bytes);
         Ok(())
     }
@@ -4513,9 +4535,16 @@ impl Connection {
 
     fn ensure_can_change_encryption_settings(&self) -> Result<()> {
         let pager = self.pager.load();
-        if pager.is_encryption_ctx_set() {
+        if pager.has_encryption() {
             return Err(LimboError::InvalidArgument(
-                "cannot reset encryption attributes if already set in the session".to_string(),
+                "cannot change encryption settings after built-in encryption is configured"
+                    .to_string(),
+            ));
+        }
+        if pager.has_page_codec() {
+            return Err(LimboError::InvalidArgument(
+                "cannot configure built-in encryption while an external page codec is installed"
+                    .to_string(),
             ));
         }
         if self.db.get_mv_store().is_some() {

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2645,8 +2645,8 @@ impl Connection {
             return Ok(());
         };
 
-        self.page_size.store(size.get_raw(), Ordering::SeqCst);
         self.pager.load().set_initial_page_size(size)?;
+        self.page_size.store(size.get_raw(), Ordering::SeqCst);
         // MvStore caches a copy of the database header in `global_header`, captured from the
         // pager during bootstrap (before any PRAGMA page_size can run). Propagate the new
         // page size so subsequent transactions and any header lookups see the same value the

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3358,7 +3358,7 @@ impl Connection {
                             "reserved name {alias} is already in use"
                         )));
                     }
-                    if self.pager.load().has_page_codec() {
+                    if self.pager.load().has_external_page_codec() {
                         return Err(LimboError::InvalidArgument(
                             "ATTACH is unsupported for connections using an external page codec"
                                 .to_string(),
@@ -4501,13 +4501,7 @@ impl Connection {
 
     pub fn set_reserved_bytes(&self, reserved_bytes: u8) -> Result<()> {
         let pager = self.pager.load();
-        if let Some(required_reserved_bytes) = pager.encryption_reserved_space() {
-            if reserved_bytes != required_reserved_bytes {
-                return Err(LimboError::InvalidArgument(format!(
-                    "built-in encryption requires exactly {required_reserved_bytes} reserved bytes"
-                )));
-            }
-        } else if let Some(codec) = pager.page_codec() {
+        if let Some(codec) = pager.page_codec_external() {
             let required_reserved_bytes = codec.required_reserved_bytes();
             if reserved_bytes != required_reserved_bytes {
                 return Err(LimboError::InvalidArgument(format!(
@@ -4535,13 +4529,12 @@ impl Connection {
 
     fn ensure_can_change_encryption_settings(&self) -> Result<()> {
         let pager = self.pager.load();
-        if pager.has_encryption() {
+        if pager.is_encryption_ctx_set() {
             return Err(LimboError::InvalidArgument(
-                "cannot change encryption settings after built-in encryption is configured"
-                    .to_string(),
+                "cannot reset encryption attributes if already set in the session".to_string(),
             ));
         }
-        if pager.has_page_codec() {
+        if pager.has_external_page_codec() {
             return Err(LimboError::InvalidArgument(
                 "cannot configure built-in encryption while an external page codec is installed"
                     .to_string(),

--- a/core/error.rs
+++ b/core/error.rs
@@ -185,6 +185,8 @@ pub enum CompletionError {
     Aborted,
     #[error("Decryption failed for page={page_idx}")]
     DecryptionError { page_idx: usize },
+    #[error("Page codec failed for page={page_idx}")]
+    PageCodecError { page_idx: usize },
     #[error("I/O error: partial write")]
     ShortWrite,
     #[error("I/O error: short read on page {page_idx}: expected {expected} bytes, got {actual}")]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -162,12 +162,12 @@ pub use io::{
 };
 pub use numeric::{nonnan::NonNan, Numeric};
 pub use statement::{ColumnTypeInfo, ColumnTypeKind, Statement, StatementStatusCounter};
+use storage::page_transform::PageTransform;
 pub use storage::{
     buffer_pool::BufferPool,
-    database::{
-        DatabaseStorage, IOContext, PageCodec, PageCodecHeaderInfo, PageCodecId, PageCodecLocation,
-    },
+    database::{DatabaseStorage, IOContext},
     encryption::{CipherMode, EncryptionContext, EncryptionKey},
+    page_transform::{PageCodec, PageCodecContext, PageCodecHeaderInfo, PageCodecId, PageLocation},
     pager::{Page, PageRef, Pager},
     wal::{CheckpointMode, CheckpointResult, Wal, WalAutoActions, WalFile, WalFileShared},
 };
@@ -736,7 +736,6 @@ pub struct Database<A: alloc::ConcurrentAllocator = alloc::DynAllocator> {
 
     // Encryption
     encryption_cipher_mode: AtomicCipherMode,
-    requires_page_codec: bool,
     page_codec_id: Option<PageCodecId>,
 }
 
@@ -797,42 +796,27 @@ impl fmt::Debug for Database {
     }
 }
 
-struct DatabaseNewArgs<'a> {
-    opts: DatabaseOpts,
-    flags: OpenFlags,
-    path: &'a str,
-    wal_path: &'a str,
-    io: &'a Arc<dyn IO>,
-    db_file: Arc<dyn DatabaseStorage>,
-    encryption_opts: Option<EncryptionOpts>,
-    mv_store_allocator: alloc::DynAllocator,
-    requires_page_codec: bool,
-    page_codec_id: Option<PageCodecId>,
-    dialect: Arc<dyn Dialect>,
-}
-
 impl Database {
     /// Returns true if this database is backed by MemoryIO.
     pub fn is_in_memory_db(&self) -> bool {
         is_memory_like(&self.path)
     }
 
-    fn new(args: DatabaseNewArgs<'_>) -> Result<Self> {
-        let DatabaseNewArgs {
-            opts,
-            flags,
-            path,
-            wal_path,
-            io,
-            db_file,
-            encryption_opts,
-            mv_store_allocator,
-            requires_page_codec,
-            page_codec_id,
-            dialect,
-        } = args;
-        let path = path.to_string();
-        let wal_path = wal_path.to_string();
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        opts: DatabaseOpts,
+        flags: OpenFlags,
+        path: impl Into<String>,
+        wal_path: impl Into<String>,
+        io: &Arc<dyn IO>,
+        db_file: Arc<dyn DatabaseStorage>,
+        encryption_opts: Option<EncryptionOpts>,
+        mv_store_allocator: alloc::DynAllocator,
+        page_codec_id: Option<PageCodecId>,
+        dialect: Arc<dyn Dialect>,
+    ) -> Result<Self> {
+        let path = path.into();
+        let wal_path = wal_path.into();
         let shared_wal = WalFileShared::new_noop();
         let mv_store = ArcSwapOption::empty();
 
@@ -891,7 +875,6 @@ impl Database {
             encryption_cipher_mode: AtomicCipherMode::new(
                 encryption_cipher_mode.unwrap_or(CipherMode::None),
             ),
-            requires_page_codec,
             page_codec_id,
 
             durable_storage: None,
@@ -1199,31 +1182,6 @@ impl Database {
                 .flags(flags)
                 .db_opts(opts)
                 .encryption(encryption_opts),
-        )
-    }
-
-    /// Open a file-backed database with an external page codec.
-    #[cfg(feature = "fs")]
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_file_with_flags_and_page_codec(
-        io: Arc<dyn IO>,
-        path: &str,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        page_codec: Arc<dyn PageCodec>,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<Arc<Database>> {
-        Self::open(
-            io,
-            path,
-            OpenOptions::new(dialect)
-                .flags(flags)
-                .db_opts(opts)
-                .encryption(encryption_opts)
-                .durable_storage(durable_storage)
-                .page_codec(page_codec),
         )
     }
 
@@ -1574,38 +1532,6 @@ impl Database {
         result
     }
 
-    /// Async version of database opening with an external page codec.
-    /// Caller must drive the IO loop and pass state between calls.
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_with_flags_bypass_registry_and_page_codec_async(
-        state: &mut OpenDbAsyncState,
-        io: Arc<dyn IO>,
-        path: &str,
-        wal_path: Option<&str>,
-        db_file: Arc<dyn DatabaseStorage>,
-        flags: OpenFlags,
-        opts: DatabaseOpts,
-        encryption_opts: Option<EncryptionOpts>,
-        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
-        page_codec: Arc<dyn PageCodec>,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<IOResult<Arc<Database>>> {
-        Self::do_open_async_guarded(
-            state,
-            io,
-            path,
-            wal_path,
-            db_file,
-            flags,
-            opts,
-            encryption_opts,
-            durable_storage,
-            Some(page_codec),
-            alloc::DynAllocator::default(),
-            dialect,
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
     fn do_open_async_internal(
         state: &mut OpenDbAsyncState,
@@ -1637,19 +1563,18 @@ impl Database {
                     } else {
                         &format!("{path}-wal")
                     };
-                    let mut db = Self::new(DatabaseNewArgs {
+                    let mut db = Self::new(
                         opts,
                         flags,
                         path,
                         wal_path,
-                        io: &io,
-                        db_file: db_file.clone(),
-                        encryption_opts: encryption_opts.clone(),
-                        mv_store_allocator: allocator.clone(),
-                        requires_page_codec: page_codec.is_some(),
-                        page_codec_id: page_codec.as_deref().map(PageCodec::codec_id),
-                        dialect: dialect.clone(),
-                    })?;
+                        &io,
+                        db_file.clone(),
+                        encryption_opts.clone(),
+                        allocator.clone(),
+                        page_codec.as_deref().map(PageCodec::codec_id),
+                        dialect.clone(),
+                    )?;
                     db.durable_storage.clone_from(&durable_storage);
 
                     // Header validation + WAL recovery runs as a sub state
@@ -1950,6 +1875,48 @@ impl Database {
                     let mode = match HeaderRef::from_pager(pager) {
                         Ok(IOResult::Done(header_ref)) => {
                             let header = header_ref.borrow();
+                            let validate_codec_header = || -> Result<()> {
+                                if self.initialized() {
+                                    let page_transform =
+                                        pager.io_ctx.read().page_transform().clone();
+                                    if let PageTransform::Codec(codec) = page_transform {
+                                        let bootstrap_page_size =
+                                            pager.get_page_size_unchecked().get() as usize;
+                                        let bootstrap_reserved_space =
+                                            pager.get_reserved_space().ok_or_else(|| {
+                                                LimboError::InternalError(
+                                                    "page codec reserved space was not initialized"
+                                                        .to_string(),
+                                                )
+                                            })?;
+                                        let decoded_page_size = header.page_size.get() as usize;
+                                        if decoded_page_size != bootstrap_page_size {
+                                            return Err(LimboError::InvalidArgument(format!(
+                                            "page codec bootstrap page size {bootstrap_page_size} does not match decoded page-1 size {decoded_page_size}"
+                                        )));
+                                        }
+                                        if header.reserved_space != bootstrap_reserved_space {
+                                            return Err(LimboError::InvalidArgument(format!(
+                                            "page codec bootstrap reserved space {bootstrap_reserved_space} does not match decoded page-1 reserved space {}",
+                                            header.reserved_space
+                                        )));
+                                        }
+                                        let required_reserved_space =
+                                            codec.required_reserved_bytes();
+                                        if header.reserved_space != required_reserved_space {
+                                            return Err(LimboError::InvalidArgument(format!(
+                                            "page codec requires exactly {required_reserved_space} reserved bytes, but decoded page 1 provides {}",
+                                            header.reserved_space
+                                        )));
+                                        }
+                                    }
+                                }
+                                Ok(())
+                            };
+                            if let Err(err) = validate_codec_header() {
+                                pager.end_read_tx();
+                                return Err(err);
+                            }
                             if header.vacuum_mode_largest_root_page.get() > 0 {
                                 if header.incremental_vacuum_enabled.get() > 0 {
                                     AutoVacuumMode::Incremental
@@ -2238,7 +2205,7 @@ impl Database {
                 HeaderValidationState::OpenWal {
                     open_mv_store,
                     driver,
-                    pager,
+                    ..
                 } => {
                     // Always open shared WAL and set it in the Database and Pager.
                     // MVCC currently requires a WAL open to function.
@@ -2264,14 +2231,12 @@ impl Database {
                             let shared_authority = self.open_shared_wal_coordination_for_open()?;
                             if let Some(authority) = shared_authority.as_ref() {
                                 if !authority.frame_index_overflowed() {
-                                    let io_ctx = pager.io_ctx.read();
                                     WalFileShared::open_shared_from_authority_if_exists(
                                         &self.io,
                                         &self.wal_path,
                                         flags,
                                         authority,
                                         &self.db_file,
-                                        Some(&io_ctx),
                                     )?
                                 } else {
                                     WalFileShared::open_shared_if_exists(
@@ -2347,7 +2312,7 @@ impl Database {
     /// Rebuild the process-local shared WAL view after a caller restores the
     /// database and WAL files outside the pager.
     pub fn reload_wal_after_external_restore(self: &Arc<Self>) -> Result<()> {
-        if self.requires_page_codec {
+        if self.page_codec_id.is_some() {
             return Err(LimboError::InvalidArgument(
                 "reloading a WAL after external restore is not supported with an external page codec"
                     .to_string(),
@@ -2370,7 +2335,6 @@ impl Database {
                             flags,
                             authority,
                             &self.db_file,
-                            None,
                         )?
                     } else {
                         WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
@@ -2454,12 +2418,12 @@ impl Database {
         encryption_key: Option<EncryptionKey>,
         page_codec: Option<Arc<dyn PageCodec>>,
     ) -> Result<Arc<Connection>> {
-        if self.requires_page_codec && page_codec.is_none() {
+        if self.page_codec_id.is_some() && page_codec.is_none() {
             return Err(LimboError::InvalidArgument(
                 "database requires an external page codec".to_string(),
             ));
         }
-        if !self.requires_page_codec && page_codec.is_some() {
+        if self.page_codec_id.is_none() && page_codec.is_some() {
             return Err(LimboError::InvalidArgument(
                 "database was opened without an external page codec".to_string(),
             ));
@@ -3062,33 +3026,27 @@ impl Database {
         let (header_reserved_bytes, header_page_size) = if self.initialized() {
             let buf = return_if_io!(self.read_db_header_buf(hdr_st));
             if let Some(codec) = page_codec {
-                if let Some(header_info) = codec.probe_header(buf.as_slice())? {
-                    let page_size_u32 = u32::try_from(header_info.page_size).map_err(|_| {
-                        LimboError::InvalidArgument(format!(
-                            "page codec reported invalid page size {}",
-                            header_info.page_size
-                        ))
-                    })?;
-                    let Some(page_size) = PageSize::new(page_size_u32) else {
-                        return Err(LimboError::InvalidArgument(format!(
-                            "page codec reported invalid page size {}",
-                            header_info.page_size
-                        )));
-                    };
-                    if !page_size.has_valid_reserved_space(header_info.reserved_space) {
-                        return Err(LimboError::InvalidArgument(format!(
-                            "page codec reported invalid reserved space {} for page size {}",
-                            header_info.reserved_space,
-                            page_size.get()
-                        )));
-                    }
-                    (Some(header_info.reserved_space), Some(page_size))
-                } else {
-                    return Err(LimboError::InvalidArgument(
-                        "page codec must implement probe_header to reopen an initialized database"
-                            .to_string(),
-                    ));
+                let header_info = codec.bootstrap_page_info(buf.as_slice())?;
+                let page_size_u32 = u32::try_from(header_info.page_size).map_err(|_| {
+                    LimboError::InvalidArgument(format!(
+                        "page codec reported invalid page size {}",
+                        header_info.page_size
+                    ))
+                })?;
+                let Some(page_size) = PageSize::new(page_size_u32) else {
+                    return Err(LimboError::InvalidArgument(format!(
+                        "page codec reported invalid page size {}",
+                        header_info.page_size
+                    )));
+                };
+                if !page_size.has_valid_reserved_space(header_info.reserved_space) {
+                    return Err(LimboError::InvalidArgument(format!(
+                        "page codec reported invalid reserved space {} for page size {}",
+                        header_info.reserved_space,
+                        page_size.get()
+                    )));
                 }
+                (Some(header_info.reserved_space), Some(page_size))
             } else {
                 let reserved = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
                 let ps_raw = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -3618,7 +3618,7 @@ impl Iterator for QueryRunner<'_> {
 #[cfg(test)]
 mod database_tests {
     use std::sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     };
 
@@ -3629,9 +3629,9 @@ mod database_tests {
     };
     use crate::storage::sqlite3_ondisk::DatabaseHeader;
     use crate::{
-        storage::database::DatabaseFile, Connection, DatabaseOpts, DatabaseStorage, EncryptionOpts,
-        IOResult, LimboError, OpenDbAsyncState, OpenFlags, OpenOptions, PlatformIO, SqliteDialect,
-        IO,
+        storage::database::DatabaseFile, CompletionError, Connection, DatabaseOpts,
+        DatabaseStorage, EncryptionOpts, IOResult, LimboError, OpenDbAsyncState, OpenFlags,
+        OpenOptions, PlatformIO, SqliteDialect, IO,
     };
 
     #[test]
@@ -3850,6 +3850,57 @@ mod database_tests {
                 && context.location == PageLocation::Database
             {
                 self.database_page1_decodes.fetch_add(1, Ordering::Relaxed);
+            }
+            self.inner.decode_page(context, input, output)
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailOncePageCodec {
+        inner: XorPageCodec,
+        fail_database_page1_decode: Arc<AtomicBool>,
+    }
+
+    impl PageCodec for FailOncePageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            self.inner.codec_id()
+        }
+
+        fn bootstrap_page_info(
+            &self,
+            raw_page1_prefix: &[u8],
+        ) -> crate::Result<PageCodecHeaderInfo> {
+            self.inner.bootstrap_page_info(raw_page1_prefix)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            self.inner.required_reserved_bytes()
+        }
+
+        fn encode_page(
+            &self,
+            context: PageCodecContext,
+            input: &[u8],
+            output: &mut [u8],
+        ) -> crate::Result<()> {
+            self.inner.encode_page(context, input, output)
+        }
+
+        fn decode_page(
+            &self,
+            context: PageCodecContext,
+            input: &[u8],
+            output: &mut [u8],
+        ) -> crate::Result<()> {
+            if context.page_no == DatabaseHeader::PAGE_ID as u32
+                && context.location == PageLocation::Database
+                && self
+                    .fail_database_page1_decode
+                    .swap(false, Ordering::Relaxed)
+            {
+                return Err(LimboError::InternalError(
+                    "injected database page-1 decode failure".into(),
+                ));
             }
             self.inner.decode_page(context, input, output)
         }
@@ -4286,6 +4337,51 @@ mod database_tests {
             1,
             "checkpoint identity must decode database page 1 exactly once"
         );
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_checkpoint_recovers_after_page1_decode_failure() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-checkpoint-retry.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let fail_database_page1_decode = Arc::new(AtomicBool::new(false));
+        let codec: Arc<dyn PageCodec> = Arc::new(FailOncePageCodec {
+            inner: XorPageCodec {
+                mask: 0x5a,
+                reserved_bytes: 1,
+            },
+            fail_database_page1_decode: fail_database_page1_decode.clone(),
+        });
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+        conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+        conn.execute(
+            "create table test(id integer primary key, value text);
+             insert into test(value) values ('alpha');",
+        )
+        .unwrap();
+        conn.set_sync_mode(crate::SyncMode::Full);
+
+        fail_database_page1_decode.store(true, Ordering::Relaxed);
+        let err = conn
+            .checkpoint(crate::storage::wal::CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            })
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            LimboError::CompletionError(CompletionError::PageCodecError { page_idx: 1 })
+        ));
+
+        let checkpoint = conn
+            .checkpoint(crate::storage::wal::CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            })
+            .unwrap();
+        assert!(checkpoint.wal_checkpoint_backfilled > 0);
+        assert_eq!(count_test_rows(&conn), 1);
     }
 
     #[cfg(feature = "fs")]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -3858,7 +3858,8 @@ mod database_tests {
     #[derive(Debug)]
     struct FailOncePageCodec {
         inner: XorPageCodec,
-        fail_database_page1_decode: Arc<AtomicBool>,
+        fail_decode: Arc<AtomicBool>,
+        fail_context: PageCodecContext,
     }
 
     impl PageCodec for FailOncePageCodec {
@@ -3892,14 +3893,9 @@ mod database_tests {
             input: &[u8],
             output: &mut [u8],
         ) -> crate::Result<()> {
-            if context.page_no == DatabaseHeader::PAGE_ID as u32
-                && context.location == PageLocation::Database
-                && self
-                    .fail_database_page1_decode
-                    .swap(false, Ordering::Relaxed)
-            {
+            if context == self.fail_context && self.fail_decode.swap(false, Ordering::Relaxed) {
                 return Err(LimboError::InternalError(
-                    "injected database page-1 decode failure".into(),
+                    "injected page decode failure".into(),
                 ));
             }
             self.inner.decode_page(context, input, output)
@@ -4132,6 +4128,19 @@ mod database_tests {
     }
 
     #[cfg(feature = "fs")]
+    fn passive_checkpoint_busy(conn: &Arc<Connection>) -> crate::Result<i64> {
+        let mut stmt = conn.prepare("PRAGMA wal_checkpoint(PASSIVE)")?;
+        let mut busy = None;
+        stmt.run_with_row_callback(|row| {
+            busy = Some(row.get(0)?);
+            Ok(())
+        })?;
+        busy.ok_or_else(|| {
+            LimboError::InternalError("wal_checkpoint did not return a result row".to_owned())
+        })
+    }
+
+    #[cfg(feature = "fs")]
     #[test]
     fn registry_reuses_cached_database_without_retaining_page_codec() {
         let temp_dir = tempfile::TempDir::new().unwrap();
@@ -4352,7 +4361,11 @@ mod database_tests {
                 mask: 0x5a,
                 reserved_bytes: 1,
             },
-            fail_database_page1_decode: fail_database_page1_decode.clone(),
+            fail_decode: fail_database_page1_decode.clone(),
+            fail_context: PageCodecContext::new(
+                DatabaseHeader::PAGE_ID as u32,
+                PageLocation::Database,
+            ),
         });
         let db = open_with_page_codec(io, path, codec.clone());
         let conn = db.connect_with_page_codec(codec).unwrap();
@@ -4382,6 +4395,66 @@ mod database_tests {
             .unwrap();
         assert!(checkpoint.wal_checkpoint_backfilled > 0);
         assert_eq!(count_test_rows(&conn), 1);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn pragma_checkpoint_codec_error_releases_checkpoint_lock() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-pragma-checkpoint-retry.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let fail_wal_page2_decode = Arc::new(AtomicBool::new(false));
+        let codec: Arc<dyn PageCodec> = Arc::new(FailOncePageCodec {
+            inner: XorPageCodec {
+                mask: 0x5a,
+                reserved_bytes: 1,
+            },
+            fail_decode: fail_wal_page2_decode.clone(),
+            fail_context: PageCodecContext::new(2, PageLocation::Wal),
+        });
+        let db = open_with_page_codec(io, path, codec.clone());
+        let writer = db.connect_with_page_codec(codec.clone()).unwrap();
+        writer.wal_auto_actions_disable();
+        writer.execute("PRAGMA journal_mode = 'wal'").unwrap();
+        writer
+            .execute(
+                "create table test(id integer primary key, value text);
+                 insert into test(value) values ('alpha');",
+            )
+            .unwrap();
+
+        let pager = writer.get_pager();
+        assert!(
+            pager.wal_pos().1 > 0,
+            "test setup must leave committed WAL frames"
+        );
+        assert_eq!(
+            pager.wal_backfill_frame(),
+            Some(0),
+            "test setup must not checkpoint the WAL before injecting the codec error"
+        );
+        assert!(
+            pager.wal_changed_pages_after(0).unwrap().contains(&2),
+            "test setup must leave page 2 in the WAL"
+        );
+
+        let first = db.connect_with_page_codec(codec.clone()).unwrap();
+        assert!(first.get_pager().has_wal());
+        fail_wal_page2_decode.store(true, Ordering::Relaxed);
+        let first_error = passive_checkpoint_busy(&first).unwrap_err();
+        assert!(matches!(first_error, LimboError::CheckpointFailed(_)));
+        assert!(!fail_wal_page2_decode.load(Ordering::Relaxed));
+
+        let second = db.connect_with_page_codec(codec).unwrap();
+        assert!(second.get_pager().has_wal());
+        let other_connection_retry = passive_checkpoint_busy(&second);
+        let same_connection_retry = passive_checkpoint_busy(&first);
+        assert!(
+            matches!(same_connection_retry, Ok(0)) && matches!(other_connection_retry, Ok(0)),
+            "checkpoint failure must not leave stale state or retain its guard: same connection \
+             returned {same_connection_retry:?}, other connection returned {other_connection_retry:?}"
+        );
     }
 
     #[cfg(feature = "fs")]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -3659,7 +3659,18 @@ impl Iterator for QueryRunner<'_> {
 
 #[cfg(test)]
 mod database_tests {
-    use super::{is_memory_like, Database};
+    use std::sync::Arc;
+
+    use super::{is_memory_like, Database, InitState};
+    use crate::storage::encryption::{CipherMode, EncryptionKey};
+    use crate::storage::sqlite3_ondisk::DatabaseHeader;
+    use crate::{
+        storage::database::{
+            DatabaseFile, PageCodec, PageCodecHeaderInfo, PageCodecId, PageCodecLocation,
+        },
+        Connection, DatabaseOpts, DatabaseStorage, EncryptionOpts, IOResult, LimboError,
+        OpenDbAsyncState, OpenFlags, OpenOptions, PlatformIO, SqliteDialect, IO,
+    };
 
     #[test]
     fn memory_path_classifies_named_memory_databases() {
@@ -3681,5 +3692,1105 @@ mod database_tests {
 
         assert!(io.file_id(&path).is_ok());
         assert!(std::fs::metadata(&path).is_err());
+    }
+
+    #[derive(Debug)]
+    struct IdentityPageCodec;
+
+    impl PageCodec for IdentityPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            PageCodecId::new(*b"identity-codec--")
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            output.copy_from_slice(page);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            output.copy_from_slice(page);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct InvalidHeaderPageCodec {
+        page_size: usize,
+        reserved_space: u8,
+    }
+
+    impl PageCodec for InvalidHeaderPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            PageCodecId::new(*b"invalid-header-c")
+        }
+
+        fn probe_header(
+            &self,
+            _raw_page1_prefix: &[u8],
+        ) -> crate::Result<Option<PageCodecHeaderInfo>> {
+            Ok(Some(PageCodecHeaderInfo {
+                page_size: self.page_size,
+                reserved_space: self.reserved_space,
+            }))
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            output.copy_from_slice(page);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            output.copy_from_slice(page);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct XorPageCodec {
+        mask: u8,
+        reserved_bytes: u8,
+    }
+
+    impl XorPageCodec {
+        fn transform(&self, page: &[u8], output: &mut [u8]) {
+            for (input, output) in page.iter().zip(output) {
+                *output = input ^ self.mask;
+            }
+        }
+    }
+
+    impl PageCodec for XorPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"xor-page-codec--";
+            id[15] = self.mask;
+            id[14] = self.reserved_bytes;
+            PageCodecId::new(id)
+        }
+
+        fn probe_header(
+            &self,
+            raw_page1_prefix: &[u8],
+        ) -> crate::Result<Option<PageCodecHeaderInfo>> {
+            if raw_page1_prefix.len() < 21 {
+                return Ok(None);
+            }
+
+            let decoded_magic = raw_page1_prefix[..16]
+                .iter()
+                .map(|byte| byte ^ self.mask)
+                .collect::<Vec<_>>();
+            if decoded_magic.as_slice() != b"SQLite format 3\0" {
+                return Ok(None);
+            }
+
+            let ps_raw = u16::from_be_bytes([
+                raw_page1_prefix[16] ^ self.mask,
+                raw_page1_prefix[17] ^ self.mask,
+            ]);
+            let page_size = if ps_raw == 1 { 65536 } else { ps_raw as usize };
+            Ok(Some(PageCodecHeaderInfo {
+                page_size,
+                reserved_space: raw_page1_prefix[20] ^ self.mask,
+            }))
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            self.reserved_bytes
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct LocationPageCodec;
+
+    impl LocationPageCodec {
+        const MASK: u8 = 0x6d;
+
+        fn byte_key(page_idx: usize, location: PageCodecLocation, offset: usize) -> u8 {
+            // Persisted transforms must not depend on the host pointer width.
+            let page_id_byte = (page_idx as u64).to_le_bytes()[offset % std::mem::size_of::<u64>()];
+            let page_id_rotation =
+                ((offset / std::mem::size_of::<u64>()) % (u8::BITS as usize)) as u32;
+            Self::MASK
+                ^ page_id_byte.rotate_left(page_id_rotation)
+                ^ match location {
+                    PageCodecLocation::Database => 0,
+                    PageCodecLocation::Wal => 0xa5,
+                }
+        }
+
+        fn transform(page: &[u8], output: &mut [u8], page_idx: usize, location: PageCodecLocation) {
+            for (offset, (input, output)) in page.iter().zip(output).enumerate() {
+                *output = input ^ Self::byte_key(page_idx, location, offset);
+            }
+        }
+    }
+
+    impl PageCodec for LocationPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            PageCodecId::new(*b"location-page-co")
+        }
+
+        fn probe_header(
+            &self,
+            raw_page1_prefix: &[u8],
+        ) -> crate::Result<Option<PageCodecHeaderInfo>> {
+            if raw_page1_prefix.len() < 21 {
+                return Ok(None);
+            }
+            if !raw_page1_prefix[..16]
+                .iter()
+                .enumerate()
+                .zip(b"SQLite format 3\0")
+                .all(|((offset, encoded), expected)| {
+                    *encoded
+                        ^ Self::byte_key(
+                            DatabaseHeader::PAGE_ID,
+                            PageCodecLocation::Database,
+                            offset,
+                        )
+                        == *expected
+                })
+            {
+                return Ok(None);
+            }
+
+            let page_size = u16::from_be_bytes([
+                raw_page1_prefix[16]
+                    ^ Self::byte_key(DatabaseHeader::PAGE_ID, PageCodecLocation::Database, 16),
+                raw_page1_prefix[17]
+                    ^ Self::byte_key(DatabaseHeader::PAGE_ID, PageCodecLocation::Database, 17),
+            ]);
+            Ok(Some(PageCodecHeaderInfo {
+                page_size: if page_size == 1 {
+                    65_536
+                } else {
+                    page_size as usize
+                },
+                reserved_space: raw_page1_prefix[20]
+                    ^ Self::byte_key(DatabaseHeader::PAGE_ID, PageCodecLocation::Database, 20),
+            }))
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            1
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            page_idx: usize,
+            location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            Self::transform(page, output, page_idx, location);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            page_idx: usize,
+            location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            Self::transform(page, output, page_idx, location);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn location_page_codec_uses_full_page_id() {
+        let input = vec![0; 512];
+        let mut page_one = vec![0; input.len()];
+        let mut page_two_fifty_seven = vec![0; input.len()];
+        LocationPageCodec::transform(&input, &mut page_one, 1, PageCodecLocation::Database);
+        LocationPageCodec::transform(
+            &input,
+            &mut page_two_fifty_seven,
+            257,
+            PageCodecLocation::Database,
+        );
+
+        assert_ne!(page_one, page_two_fifty_seven);
+
+        let mut decoded = vec![0; input.len()];
+        LocationPageCodec::transform(
+            &page_two_fifty_seven,
+            &mut decoded,
+            257,
+            PageCodecLocation::Database,
+        );
+        assert_eq!(decoded, input);
+    }
+
+    #[derive(Debug)]
+    struct XorNoProbePageCodec {
+        mask: u8,
+        reserved_bytes: u8,
+    }
+
+    impl XorNoProbePageCodec {
+        fn transform(&self, page: &[u8], output: &mut [u8]) {
+            for (input, output) in page.iter().zip(output) {
+                *output = input ^ self.mask;
+            }
+        }
+    }
+
+    impl PageCodec for XorNoProbePageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"xor-no-probe----";
+            id[15] = self.mask;
+            id[14] = self.reserved_bytes;
+            PageCodecId::new(id)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            self.reserved_bytes
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> crate::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+    }
+
+    #[cfg(feature = "fs")]
+    fn open_with_page_codec_result(
+        io: Arc<dyn IO>,
+        path: &str,
+        codec: Arc<dyn PageCodec>,
+    ) -> crate::Result<Arc<Database>> {
+        open_with_page_codec_with_opts_result(io, path, codec, DatabaseOpts::new())
+    }
+
+    #[cfg(feature = "fs")]
+    fn open_with_page_codec_with_opts_result(
+        io: Arc<dyn IO>,
+        path: &str,
+        codec: Arc<dyn PageCodec>,
+        opts: DatabaseOpts,
+    ) -> crate::Result<Arc<Database>> {
+        let file = io.open_file(path, OpenFlags::Create, true).unwrap();
+        let db_file: Arc<dyn DatabaseStorage> = Arc::new(DatabaseFile::new(file));
+        let mut state = OpenDbAsyncState::new();
+        let options = OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file)
+            .flags(OpenFlags::Create)
+            .db_opts(opts)
+            .page_codec(codec);
+
+        loop {
+            match Database::open_async(&mut state, io.clone(), path, &options)? {
+                IOResult::Done(db) => return Ok(db),
+                IOResult::IO(completion) => completion.wait(&*io).unwrap(),
+            }
+        }
+    }
+
+    #[cfg(feature = "fs")]
+    fn open_with_page_codec(
+        io: Arc<dyn IO>,
+        path: &str,
+        codec: Arc<dyn PageCodec>,
+    ) -> Arc<Database> {
+        open_with_page_codec_result(io, path, codec).unwrap()
+    }
+
+    #[cfg(feature = "fs")]
+    fn count_test_rows(conn: &Arc<Connection>) -> i64 {
+        let mut stmt = conn.prepare("select count(*) from test").unwrap();
+        let mut count = 0;
+        stmt.run_with_row_callback(|row| {
+            count = row.get(0).unwrap();
+            Ok(())
+        })
+        .unwrap();
+        count
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn registry_reuses_cached_database_without_retaining_page_codec() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-registry.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let first_codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let first_codec_weak = Arc::downgrade(&first_codec);
+        let second_codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+
+        let first = open_with_page_codec(io.clone(), path, first_codec);
+        assert!(
+            first_codec_weak.upgrade().is_none(),
+            "cached Database must not retain the page codec"
+        );
+        let second = open_with_page_codec(io, path, second_codec);
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_identity_must_match_cached_database() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-identity.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let first_codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 1,
+        });
+        let different_codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 1,
+        });
+
+        let db = open_with_page_codec(io.clone(), path, first_codec);
+
+        let err = match db.connect_with_page_codec(different_codec.clone()) {
+            Ok(_) => panic!("a cached codec-backed database must reject a different codec"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("page codec identity does not match the existing database"));
+
+        let err = open_with_page_codec_result(io, path, different_codec).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("page codec identity does not match the existing database"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cached_database_rejects_encryption_and_page_codec() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-encryption-cached.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let _db = open_with_page_codec(io.clone(), path, codec.clone());
+
+        let err = Database::open_file_with_flags_and_page_codec(
+            io,
+            path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            Some(EncryptionOpts {
+                cipher: "aes256gcm".to_string(),
+                hexkey: "00".repeat(32),
+            }),
+            None,
+            codec,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("built-in encryption cannot be combined with an external page codec"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn external_page_codec_rejects_multiprocess_wal_before_opening_file() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-multiprocess-wal.db");
+        let path_str = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let err = Database::open_file_with_flags_and_page_codec(
+            io,
+            path_str,
+            OpenFlags::Create,
+            DatabaseOpts::new().with_multiprocess_wal(true),
+            None,
+            None,
+            Arc::new(IdentityPageCodec),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            LimboError::InvalidArgument(ref message)
+                if message
+                    == "external page codecs are not supported with experimental multiprocess WAL"
+        ));
+        assert!(!path.exists());
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn bypass_registry_page_codec_open_rejects_multiprocess_wal() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-bypass-multiprocess-wal.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let file = io.open_file(path, OpenFlags::Create, true).unwrap();
+        let db_file: Arc<dyn DatabaseStorage> = Arc::new(DatabaseFile::new(file));
+        let mut state = OpenDbAsyncState::new();
+
+        let err = match Database::open_with_flags_bypass_registry_and_page_codec_async(
+            &mut state,
+            io,
+            path,
+            None,
+            db_file,
+            OpenFlags::Create,
+            DatabaseOpts::new().with_multiprocess_wal(true),
+            None,
+            None,
+            Arc::new(IdentityPageCodec),
+            Arc::new(SqliteDialect),
+        ) {
+            Err(err) => err,
+            Ok(_) => panic!("multiprocess WAL must reject an external page codec"),
+        };
+
+        assert!(matches!(
+            err,
+            LimboError::InvalidArgument(ref message)
+                if message
+                    == "external page codecs are not supported with experimental multiprocess WAL"
+        ));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cached_page_codec_database_requires_codec_at_connection_time() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-registry-no-codec.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 1,
+        });
+        let _db = open_with_page_codec(io.clone(), path, codec.clone());
+        let db = open_with_page_codec(io.clone(), path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+        conn.execute("create table test(id integer primary key)")
+            .unwrap();
+        drop(conn);
+
+        assert!(
+            Database::open_file_with_flags(
+                io,
+                path,
+                OpenFlags::Create,
+                DatabaseOpts::new(),
+                None,
+                Arc::new(SqliteDialect),
+            )
+            .is_err(),
+            "opening without the codec must not reuse a codec-required database"
+        );
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_round_trips_wal_and_checkpointed_database_with_probe_header() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-roundtrip.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 1,
+        });
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+            conn.execute(
+                "create table test(id integer primary key, value text);
+                 insert into test(value) values ('alpha'), ('bravo');",
+            )
+            .unwrap();
+            assert_eq!(count_test_rows(&conn), 2);
+            conn.set_sync_mode(crate::SyncMode::Full);
+            let passive = conn
+                .checkpoint(crate::storage::wal::CheckpointMode::Passive {
+                    upper_bound_inclusive: None,
+                })
+                .unwrap();
+            assert!(
+                passive.wal_checkpoint_backfilled > 0,
+                "PASSIVE checkpoint must backfill codec-transformed pages"
+            );
+            conn.execute("insert into test(value) values ('charlie')")
+                .unwrap();
+            let full = conn
+                .checkpoint(crate::storage::wal::CheckpointMode::Full)
+                .unwrap();
+            assert!(
+                full.wal_checkpoint_backfilled > 0,
+                "FULL checkpoint must backfill codec-transformed pages"
+            );
+            assert_eq!(count_test_rows(&conn), 3);
+        }
+
+        let raw_database = std::fs::read(path).unwrap();
+        assert_ne!(&raw_database[..16], b"SQLite format 3\0");
+
+        let reopened = open_with_page_codec(io, path, codec.clone());
+        let conn = reopened.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&conn), 3);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopens_live_wal_then_checkpointed_database() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-live-wal-recovery.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(LocationPageCodec);
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+            conn.execute(
+                "create table test(id integer primary key, value text);
+                 insert into test(value) values ('alpha'), ('bravo'), ('charlie');",
+            )
+            .unwrap();
+            assert_eq!(count_test_rows(&conn), 3);
+        }
+        let wal_path = format!("{path}-wal");
+        assert!(
+            std::fs::metadata(&wal_path).unwrap().len() > 0,
+            "the first reopen must recover committed codec-transformed WAL frames"
+        );
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            assert_eq!(count_test_rows(&conn), 3);
+            let checkpoint = conn
+                .checkpoint(crate::storage::wal::CheckpointMode::Full)
+                .unwrap();
+            assert!(
+                checkpoint.wal_checkpoint_backfilled > 0,
+                "the recovery checkpoint must backfill codec-transformed WAL frames"
+            );
+        }
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&conn), 3);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopen_requires_header_probe() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-no-probe-roundtrip.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorNoProbePageCodec {
+            mask: 0x3c,
+            reserved_bytes: 1,
+        });
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            conn.execute(
+                "create table test(id integer primary key, value text);
+                 insert into test(value) values ('alpha'), ('bravo');",
+            )
+            .unwrap();
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        }
+
+        let err = open_with_page_codec_result(io, path, codec).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("page codec must implement probe_header"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_rejects_mvcc_mode() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-mvcc.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+
+        let err = conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("external page codecs are not supported with MVCC"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn plaintext_database_rejects_page_codec_connection() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("plaintext-codec-connection.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io,
+            path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+
+        let err = match db.connect_with_page_codec(Arc::new(IdentityPageCodec)) {
+            Ok(_) => panic!("plaintext databases must reject external page codecs"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("database was opened without an external page codec"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_database_rejects_codecless_connection() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-requires-connection-codec.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db = open_with_page_codec(io, path, Arc::new(IdentityPageCodec));
+
+        let err = match db.connect() {
+            Ok(_) => panic!("codec-backed databases must reject codec-less connections"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("database requires an external page codec"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopen_rejects_mismatched_reserved_space() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-reserved-space.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let initial_codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 1,
+        });
+
+        {
+            let db = open_with_page_codec(io.clone(), path, initial_codec.clone());
+            let conn = db.connect_with_page_codec(initial_codec).unwrap();
+            conn.execute("create table test(id integer primary key)")
+                .unwrap();
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        }
+
+        for required_reserved_bytes in [0, 2] {
+            let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+                mask: 0x5a,
+                reserved_bytes: required_reserved_bytes,
+            });
+            let err = open_with_page_codec_result(io.clone(), path, codec).unwrap_err();
+            assert!(err.to_string().contains(&format!(
+                "page codec requires exactly {required_reserved_bytes} reserved bytes, but database provides 1"
+            )));
+        }
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopen_rejects_invalid_header_layout() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-invalid-header-layout.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        {
+            let db = open_with_page_codec(io.clone(), path, Arc::new(IdentityPageCodec));
+            let conn = db
+                .connect_with_page_codec(Arc::new(IdentityPageCodec))
+                .unwrap();
+            conn.execute("create table test(id integer primary key)")
+                .unwrap();
+        }
+
+        for (codec, expected_error) in [
+            (
+                InvalidHeaderPageCodec {
+                    page_size: 513,
+                    reserved_space: 0,
+                },
+                "page codec reported invalid page size 513",
+            ),
+            (
+                InvalidHeaderPageCodec {
+                    page_size: 512,
+                    reserved_space: 33,
+                },
+                "page codec reported invalid reserved space 33 for page size 512",
+            ),
+        ] {
+            let err = open_with_page_codec_result(io.clone(), path, Arc::new(codec)).unwrap_err();
+            assert!(err.to_string().contains(expected_error));
+        }
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_reopen_reports_short_header_read() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-short-header.db");
+        std::fs::write(&path, [0u8]).unwrap();
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let err = open_with_page_codec_result(io, path, Arc::new(IdentityPageCodec)).unwrap_err();
+        assert!(err.to_string().contains("short read on page 1"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_and_encryption_cannot_share_pager() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-encryption-conflict.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let db = open_with_page_codec(io, path, codec.clone());
+        let encryption_key = EncryptionKey::from_hex_string(&"00".repeat(32)).unwrap();
+        let mut state = InitState::default();
+
+        let err = match db._init_nonblock(&mut state, Some(&encryption_key), Some(&codec)) {
+            Ok(_) => panic!("encryption and an external page codec must not share a pager"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("built-in encryption cannot be combined with an external page codec"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_connection_rejects_builtin_encryption_settings() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-encryption-settings.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+
+        let err = conn
+            .set_encryption_key(EncryptionKey::from_hex_string(&"00".repeat(32)).unwrap())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            LimboError::InvalidArgument(message)
+                if message
+                    == "cannot configure built-in encryption while an external page codec is installed"
+        ));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_vacuum_preserves_encoded_database() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-vacuum.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x4d,
+            reserved_bytes: 1,
+        });
+        let db = open_with_page_codec_with_opts_result(
+            io.clone(),
+            path,
+            codec.clone(),
+            DatabaseOpts::new().with_vacuum(true),
+        )
+        .unwrap();
+        let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+        conn.execute(
+            "create table test(id integer primary key, value text);
+             insert into test(value) values ('alpha'), ('bravo');",
+        )
+        .unwrap();
+        conn.execute("VACUUM").unwrap();
+        assert_eq!(count_test_rows(&conn), 2);
+        drop(conn);
+        drop(db);
+
+        assert_ne!(&std::fs::read(path).unwrap()[..16], b"SQLite format 3\0");
+        let reopened = open_with_page_codec(io, path, codec.clone());
+        let conn = reopened.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&conn), 2);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_vacuum_into_preserves_encoded_database() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-vacuum-into.db");
+        let output_path = temp_dir.path().join("codec-vacuum-into-copy.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x4d,
+            reserved_bytes: 1,
+        });
+        let db = open_with_page_codec_with_opts_result(
+            io.clone(),
+            path,
+            codec.clone(),
+            DatabaseOpts::new().with_vacuum(true),
+        )
+        .unwrap();
+        let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+        conn.execute(
+            "create table test(id integer primary key, value text);
+             insert into test(value) values ('secret-value');",
+        )
+        .unwrap();
+        conn.execute(format!("VACUUM INTO '{}'", output_path.display()))
+            .unwrap();
+
+        let raw_output = std::fs::read(&output_path).unwrap();
+        assert_ne!(&raw_output[..16], b"SQLite format 3\0");
+        let output = open_with_page_codec(io, output_path.to_str().unwrap(), codec.clone());
+        let output_conn = output.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&output_conn), 1);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn location_page_codec_round_trips_wal_checkpoint_and_overflow_pages() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("location-codec.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(LocationPageCodec);
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            conn.execute(
+                "create table test(id integer primary key, value blob);
+                 insert into test(value) values (zeroblob(12000));
+                 delete from test where id = 1;
+                 insert into test(value)
+                 values (cast(replace(printf('%0*d', 16000, 0), '0', 'x') as blob));",
+            )
+            .unwrap();
+            let checkpoint = conn
+                .checkpoint(crate::storage::wal::CheckpointMode::Full)
+                .unwrap();
+            assert!(checkpoint.wal_checkpoint_backfilled > 0);
+        }
+
+        let raw_database = std::fs::read(path).unwrap();
+        assert_ne!(&raw_database[..16], b"SQLite format 3\0");
+        let reopened = open_with_page_codec(io, path, codec.clone());
+        let conn = reopened.connect_with_page_codec(codec).unwrap();
+        let mut values: Vec<(i64, String)> = Vec::new();
+        conn.prepare("select length(value), hex(substr(value, 1, 8)) from test order by id")
+            .unwrap()
+            .run_with_row_callback(|row| {
+                values.push((row.get(0).unwrap(), row.get(1).unwrap()));
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(values, vec![(16_000, "7878787878787878".to_string())]);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_attach_is_rejected() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let main_path = temp_dir.path().join("codec-main.db");
+        let aux_path = temp_dir.path().join("codec-aux.db");
+        let main_path = main_path.to_str().unwrap();
+        let aux_path = aux_path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x91,
+            reserved_bytes: 1,
+        });
+        let db = open_with_page_codec_with_opts_result(
+            io.clone(),
+            main_path,
+            codec.clone(),
+            DatabaseOpts::new().with_attach(true),
+        )
+        .unwrap();
+        let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+        let err = conn
+            .execute(format!("ATTACH '{aux_path}' AS aux"))
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("ATTACH is unsupported for connections using an external page codec"));
+        assert!(!std::path::Path::new(aux_path).exists());
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_rejects_reserved_space_mutation() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-reserved-space.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x91,
+            reserved_bytes: 1,
+        });
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+
+        let err = conn.set_reserved_bytes(0).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("page codec requires exactly 1 reserved bytes"));
+        assert_eq!(conn.get_reserved_bytes(), Some(1));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn encryption_rejects_reserved_space_mutation() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("encrypted-reserved-space.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io,
+            path,
+            OpenFlags::Create,
+            DatabaseOpts::new().with_encryption(true),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.set_encryption_cipher(CipherMode::Aes256Gcm).unwrap();
+        conn.set_encryption_key(EncryptionKey::from_hex_string(&"00".repeat(32)).unwrap())
+            .unwrap();
+        let reserved_before = conn.get_reserved_bytes();
+
+        let err = conn.set_reserved_bytes(0).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("built-in encryption requires exactly 28 reserved bytes"));
+        assert_eq!(conn.get_reserved_bytes(), reserved_before);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_rejects_page_size_incompatible_with_reserved_space() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-page-size.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 33,
+        });
+
+        {
+            let db = open_with_page_codec(io.clone(), path, codec.clone());
+            let conn = db.connect_with_page_codec(codec.clone()).unwrap();
+            // 512 - 33 = 479 usable bytes < 480: must be rejected up front,
+            // otherwise the engine creates a database it refuses to reopen.
+            let err = conn.execute("PRAGMA page_size = 512").unwrap_err();
+            assert!(err.to_string().contains("usable bytes"));
+            // The database must remain usable at a compatible page size.
+            conn.execute("create table test(id integer primary key, value text)")
+                .unwrap();
+            conn.execute("insert into test(value) values ('alpha')")
+                .unwrap();
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        }
+
+        let reopened = open_with_page_codec(io, path, codec.clone());
+        let conn = reopened.connect_with_page_codec(codec).unwrap();
+        assert_eq!(count_test_rows(&conn), 1);
     }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -3617,7 +3617,10 @@ impl Iterator for QueryRunner<'_> {
 
 #[cfg(test)]
 mod database_tests {
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     use super::{is_memory_like, Database, InitState};
     use crate::storage::encryption::EncryptionKey;
@@ -3803,6 +3806,52 @@ mod database_tests {
         ) -> crate::Result<()> {
             self.transform(input, output);
             Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingPageCodec {
+        inner: XorPageCodec,
+        database_page1_decodes: Arc<AtomicUsize>,
+    }
+
+    impl PageCodec for CountingPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            self.inner.codec_id()
+        }
+
+        fn bootstrap_page_info(
+            &self,
+            raw_page1_prefix: &[u8],
+        ) -> crate::Result<PageCodecHeaderInfo> {
+            self.inner.bootstrap_page_info(raw_page1_prefix)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            self.inner.required_reserved_bytes()
+        }
+
+        fn encode_page(
+            &self,
+            context: PageCodecContext,
+            input: &[u8],
+            output: &mut [u8],
+        ) -> crate::Result<()> {
+            self.inner.encode_page(context, input, output)
+        }
+
+        fn decode_page(
+            &self,
+            context: PageCodecContext,
+            input: &[u8],
+            output: &mut [u8],
+        ) -> crate::Result<()> {
+            if context.page_no == DatabaseHeader::PAGE_ID as u32
+                && context.location == PageLocation::Database
+            {
+                self.database_page1_decodes.fetch_add(1, Ordering::Relaxed);
+            }
+            self.inner.decode_page(context, input, output)
         }
     }
 
@@ -4196,6 +4245,46 @@ mod database_tests {
             )
             .is_err(),
             "opening without the codec must not reuse a codec-required database"
+        );
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn page_codec_checkpoint_decodes_database_page1_for_identity() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("codec-checkpoint-identity.db");
+        let path = path.to_str().unwrap();
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let database_page1_decodes = Arc::new(AtomicUsize::new(0));
+        let codec: Arc<dyn PageCodec> = Arc::new(CountingPageCodec {
+            inner: XorPageCodec {
+                mask: 0x5a,
+                reserved_bytes: 1,
+            },
+            database_page1_decodes: database_page1_decodes.clone(),
+        });
+        let db = open_with_page_codec(io, path, codec.clone());
+        let conn = db.connect_with_page_codec(codec).unwrap();
+        conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+        conn.execute(
+            "create table test(id integer primary key, value text);
+             insert into test(value) values ('alpha');",
+        )
+        .unwrap();
+        conn.set_sync_mode(crate::SyncMode::Full);
+
+        database_page1_decodes.store(0, Ordering::Relaxed);
+        let checkpoint = conn
+            .checkpoint(crate::storage::wal::CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            })
+            .unwrap();
+
+        assert!(checkpoint.wal_checkpoint_backfilled > 0);
+        assert_eq!(
+            database_page1_decodes.load(Ordering::Relaxed),
+            1,
+            "checkpoint identity must decode database page 1 exactly once"
         );
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -4788,6 +4788,7 @@ mod database_tests {
             // otherwise the engine creates a database it refuses to reopen.
             let err = conn.execute("PRAGMA page_size = 512").unwrap_err();
             assert!(err.to_string().contains("usable bytes"));
+            assert_eq!(conn.get_page_size().get(), 4096);
             // The database must remain usable at a compatible page size.
             conn.execute("create table test(id integer primary key, value text)")
                 .unwrap();

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -164,7 +164,9 @@ pub use numeric::{nonnan::NonNan, Numeric};
 pub use statement::{ColumnTypeInfo, ColumnTypeKind, Statement, StatementStatusCounter};
 pub use storage::{
     buffer_pool::BufferPool,
-    database::{DatabaseStorage, IOContext},
+    database::{
+        DatabaseStorage, IOContext, PageCodec, PageCodecHeaderInfo, PageCodecId, PageCodecLocation,
+    },
     encryption::{CipherMode, EncryptionContext, EncryptionKey},
     pager::{Page, PageRef, Pager},
     wal::{CheckpointMode, CheckpointResult, Wal, WalAutoActions, WalFile, WalFileShared},
@@ -372,6 +374,7 @@ pub struct OpenOptions {
     flags: OpenFlags,
     db_opts: DatabaseOpts,
     encryption: Option<EncryptionOpts>,
+    page_codec: Option<Arc<dyn PageCodec>>,
     durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
     allocator: alloc::DynAllocator,
     /// SQL dialect the database is opened with. The dialect is fixed at open
@@ -390,6 +393,7 @@ impl OpenOptions {
             flags: OpenFlags::default(),
             db_opts: DatabaseOpts::default(),
             encryption: None,
+            page_codec: None,
             durable_storage: None,
             allocator: alloc::DynAllocator::default(),
             dialect,
@@ -421,6 +425,11 @@ impl OpenOptions {
 
     pub fn encryption(mut self, encryption: impl Into<Option<EncryptionOpts>>) -> Self {
         self.encryption = encryption.into();
+        self
+    }
+
+    pub fn page_codec(mut self, page_codec: impl Into<Option<Arc<dyn PageCodec>>>) -> Self {
+        self.page_codec = page_codec.into();
         self
     }
 
@@ -727,6 +736,8 @@ pub struct Database<A: alloc::ConcurrentAllocator = alloc::DynAllocator> {
 
     // Encryption
     encryption_cipher_mode: AtomicCipherMode,
+    requires_page_codec: bool,
+    page_codec_id: Option<PageCodecId>,
 }
 
 // SAFETY: This needs to be audited for thread safety.
@@ -786,26 +797,42 @@ impl fmt::Debug for Database {
     }
 }
 
+struct DatabaseNewArgs<'a> {
+    opts: DatabaseOpts,
+    flags: OpenFlags,
+    path: &'a str,
+    wal_path: &'a str,
+    io: &'a Arc<dyn IO>,
+    db_file: Arc<dyn DatabaseStorage>,
+    encryption_opts: Option<EncryptionOpts>,
+    mv_store_allocator: alloc::DynAllocator,
+    requires_page_codec: bool,
+    page_codec_id: Option<PageCodecId>,
+    dialect: Arc<dyn Dialect>,
+}
+
 impl Database {
     /// Returns true if this database is backed by MemoryIO.
     pub fn is_in_memory_db(&self) -> bool {
         is_memory_like(&self.path)
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        opts: DatabaseOpts,
-        flags: OpenFlags,
-        path: impl Into<String>,
-        wal_path: impl Into<String>,
-        io: &Arc<dyn IO>,
-        db_file: Arc<dyn DatabaseStorage>,
-        encryption_opts: Option<EncryptionOpts>,
-        mv_store_allocator: alloc::DynAllocator,
-        dialect: Arc<dyn Dialect>,
-    ) -> Result<Self> {
-        let path = path.into();
-        let wal_path = wal_path.into();
+    fn new(args: DatabaseNewArgs<'_>) -> Result<Self> {
+        let DatabaseNewArgs {
+            opts,
+            flags,
+            path,
+            wal_path,
+            io,
+            db_file,
+            encryption_opts,
+            mv_store_allocator,
+            requires_page_codec,
+            page_codec_id,
+            dialect,
+        } = args;
+        let path = path.to_string();
+        let wal_path = wal_path.to_string();
         let shared_wal = WalFileShared::new_noop();
         let mv_store = ArcSwapOption::empty();
 
@@ -864,6 +891,8 @@ impl Database {
             encryption_cipher_mode: AtomicCipherMode::new(
                 encryption_cipher_mode.unwrap_or(CipherMode::None),
             ),
+            requires_page_codec,
+            page_codec_id,
 
             durable_storage: None,
         };
@@ -964,6 +993,29 @@ impl Database {
         // cross-platform helpers/tests can request multiprocess WAL without
         // breaking legacy single-process behavior.
         Ok(flags)
+    }
+
+    fn validate_external_page_codec_options(
+        opts: DatabaseOpts,
+        has_external_page_codec: bool,
+    ) -> Result<()> {
+        if has_external_page_codec && opts.enable_multiprocess_wal {
+            return Err(LimboError::InvalidArgument(
+                "external page codecs are not supported with experimental multiprocess WAL"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_open_options(options: &OpenOptions) -> Result<()> {
+        Self::validate_external_page_codec_options(options.db_opts, options.page_codec.is_some())?;
+        if options.encryption.is_some() && options.page_codec.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
+        Ok(())
     }
 
     #[cfg(feature = "fs")]
@@ -1075,6 +1127,7 @@ impl Database {
         path: &str,
         encryption_opts: &Option<EncryptionOpts>,
         dialect: &dyn Dialect,
+        page_codec: Option<&dyn PageCodec>,
     ) -> Result<Option<Arc<Database>>> {
         if is_memory_like(path) {
             return Ok(None);
@@ -1101,10 +1154,29 @@ impl Database {
                 "Database is encrypted but no encryption options provided".to_string(),
             ));
         }
+        db.validate_page_codec(page_codec)?;
 
         Self::check_registry_dialect(&db, dialect)?;
 
         Ok(Some(db))
+    }
+
+    fn validate_page_codec(&self, page_codec: Option<&dyn PageCodec>) -> Result<()> {
+        match (self.page_codec_id, page_codec) {
+            (Some(_), None) => Err(LimboError::InvalidArgument(
+                "Database was opened with an external page codec; reopen with a page codec"
+                    .to_string(),
+            )),
+            (None, Some(_)) => Err(LimboError::InvalidArgument(
+                "Database is already open without an external page codec".to_string(),
+            )),
+            (Some(expected), Some(codec)) if expected != codec.codec_id() => {
+                Err(LimboError::InvalidArgument(
+                    "page codec identity does not match the existing database".to_string(),
+                ))
+            }
+            _ => Ok(()),
+        }
     }
 
     /// Deprecated convenience shim: prefer [`Database::open`] with
@@ -1130,6 +1202,31 @@ impl Database {
         )
     }
 
+    /// Open a file-backed database with an external page codec.
+    #[cfg(feature = "fs")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_file_with_flags_and_page_codec(
+        io: Arc<dyn IO>,
+        path: &str,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Arc<dyn PageCodec>,
+        dialect: Arc<dyn Dialect>,
+    ) -> Result<Arc<Database>> {
+        Self::open(
+            io,
+            path,
+            OpenOptions::new(dialect)
+                .flags(flags)
+                .db_opts(opts)
+                .encryption(encryption_opts)
+                .durable_storage(durable_storage)
+                .page_codec(page_codec),
+        )
+    }
+
     /// Resolve `OpenOptions::storage` for a file-backed open when the caller
     /// did not supply pre-opened storage: optionally consult the registry, run
     /// the legacy/multiprocess WAL probes, open the file, and fill in
@@ -1146,9 +1243,12 @@ impl Database {
         // Check the registry before opening the file to avoid acquiring a file
         // lock that would conflict with an already-open Database in this process.
         if use_registry {
-            if let Some(db) =
-                Self::lookup_in_registry(path, &options.encryption, options.dialect.as_ref())?
-            {
+            if let Some(db) = Self::lookup_in_registry(
+                path,
+                &options.encryption,
+                options.dialect.as_ref(),
+                options.page_codec.as_deref(),
+            )? {
                 if options.durable_storage.is_some() && db.durable_storage.is_none() {
                     return Err(LimboError::InvalidArgument(
                         "database already open without custom durable storage; \
@@ -1233,6 +1333,7 @@ impl Database {
         // otherwise return the cached default-WAL instance and silently ignore
         // the custom wal_path before open_async runs its own check.
         Self::reject_wal_path_for_registry_open(&options)?;
+        Self::validate_open_options(&options)?;
         if options.storage.is_none() {
             if let Some(db) = Self::resolve_default_storage(&io, path, &mut options, true)? {
                 return Ok(db);
@@ -1271,6 +1372,7 @@ impl Database {
         options: &OpenOptions,
     ) -> Result<IOResult<Arc<Database>>> {
         Self::reject_wal_path_for_registry_open(options)?;
+        Self::validate_open_options(options)?;
         let Some(storage) = options.storage.clone() else {
             return Err(LimboError::InvalidArgument(
                 "OpenOptions::storage is required for Database::open_async".to_string(),
@@ -1310,6 +1412,7 @@ impl Database {
                                         .to_string(),
                                 ));
                             }
+                            db.validate_page_codec(options.page_codec.as_deref())?;
                             Self::check_registry_dialect(&db, options.dialect.as_ref())?;
                             return Ok(IOResult::Done(db));
                         }
@@ -1345,6 +1448,7 @@ impl Database {
             options.db_opts,
             options.encryption.clone(),
             options.durable_storage.clone(),
+            options.page_codec.clone(),
             options.allocator.clone(),
             options.dialect.clone(),
         );
@@ -1376,6 +1480,7 @@ impl Database {
     /// production code uses the registry-aware [`Database::open`].
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
     pub fn do_open(io: Arc<dyn IO>, path: &str, mut options: OpenOptions) -> Result<Arc<Database>> {
+        Self::validate_open_options(&options)?;
         if options.storage.is_none() {
             // `use_registry = false`: the raw path never consults the registry,
             // so this only opens the file and never returns a cached Database.
@@ -1403,6 +1508,7 @@ impl Database {
         path: &str,
         options: &OpenOptions,
     ) -> Result<IOResult<Arc<Database>>> {
+        Self::validate_open_options(options)?;
         let Some(storage) = options.storage.clone() else {
             return Err(LimboError::InvalidArgument(
                 "OpenOptions::storage is required for Database::do_open_async".to_string(),
@@ -1418,6 +1524,7 @@ impl Database {
             options.db_opts,
             options.encryption.clone(),
             options.durable_storage.clone(),
+            options.page_codec.clone(),
             options.allocator.clone(),
             options.dialect.clone(),
         )
@@ -1437,9 +1544,16 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Option<Arc<dyn PageCodec>>,
         allocator: alloc::DynAllocator,
         dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
+        Self::validate_external_page_codec_options(opts, page_codec.is_some())?;
+        if encryption_opts.is_some() && page_codec.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
         let result = Self::do_open_async_internal(
             state,
             io,
@@ -1450,6 +1564,7 @@ impl Database {
             opts,
             encryption_opts,
             durable_storage,
+            page_codec,
             allocator,
             dialect,
         );
@@ -1457,6 +1572,38 @@ impl Database {
             let _ = state.schema_guard.take();
         }
         result
+    }
+
+    /// Async version of database opening with an external page codec.
+    /// Caller must drive the IO loop and pass state between calls.
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_with_flags_bypass_registry_and_page_codec_async(
+        state: &mut OpenDbAsyncState,
+        io: Arc<dyn IO>,
+        path: &str,
+        wal_path: Option<&str>,
+        db_file: Arc<dyn DatabaseStorage>,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+        encryption_opts: Option<EncryptionOpts>,
+        durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Arc<dyn PageCodec>,
+        dialect: Arc<dyn Dialect>,
+    ) -> Result<IOResult<Arc<Database>>> {
+        Self::do_open_async_guarded(
+            state,
+            io,
+            path,
+            wal_path,
+            db_file,
+            flags,
+            opts,
+            encryption_opts,
+            durable_storage,
+            Some(page_codec),
+            alloc::DynAllocator::default(),
+            dialect,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1470,6 +1617,7 @@ impl Database {
         opts: DatabaseOpts,
         encryption_opts: Option<EncryptionOpts>,
         durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
+        page_codec: Option<Arc<dyn PageCodec>>,
         allocator: alloc::DynAllocator,
         dialect: Arc<dyn Dialect>,
     ) -> Result<IOResult<Arc<Database>>> {
@@ -1489,17 +1637,19 @@ impl Database {
                     } else {
                         &format!("{path}-wal")
                     };
-                    let mut db = Self::new(
+                    let mut db = Self::new(DatabaseNewArgs {
                         opts,
                         flags,
                         path,
                         wal_path,
-                        &io,
-                        db_file.clone(),
-                        encryption_opts.clone(),
-                        allocator.clone(),
-                        dialect.clone(),
-                    )?;
+                        io: &io,
+                        db_file: db_file.clone(),
+                        encryption_opts: encryption_opts.clone(),
+                        mv_store_allocator: allocator.clone(),
+                        requires_page_codec: page_codec.is_some(),
+                        page_codec_id: page_codec.as_deref().map(PageCodec::codec_id),
+                        dialect: dialect.clone(),
+                    })?;
                     db.durable_storage.clone_from(&durable_storage);
 
                     // Header validation + WAL recovery runs as a sub state
@@ -1518,7 +1668,11 @@ impl Database {
                         .as_mut()
                         .expect("building_db must be set in Init phase");
                     let mut hv_state = std::mem::take(&mut state.header_validation_state);
-                    let result = db.header_validation(&mut hv_state, state.encryption_key.as_ref());
+                    let result = db.header_validation(
+                        &mut hv_state,
+                        state.encryption_key.as_ref(),
+                        page_codec.as_ref(),
+                    );
                     state.header_validation_state = hv_state;
                     let pager = return_if_io!(result);
 
@@ -1543,8 +1697,12 @@ impl Database {
                     let db = Arc::new(db);
 
                     // Check: https://github.com/tursodatabase/turso/pull/1761#discussion_r2154013123
-                    let conn =
-                        db._connect(false, Some(pager.clone()), state.encryption_key.clone())?;
+                    let conn = db._connect(
+                        false,
+                        Some(pager.clone()),
+                        state.encryption_key.clone(),
+                        page_codec.clone(),
+                    )?;
 
                     // Acquire schema lock and hold it through ReadingHeader and LoadingSchema phases
                     // to ensure schema_version and make_from_btree are atomic
@@ -1681,6 +1839,7 @@ impl Database {
                                 true,
                                 Some(pager.clone()),
                                 state.encryption_key.clone(),
+                                page_codec.clone(),
                             )?);
                         }
                         let conn = state.mvcc_bootstrap_conn.as_ref().expect("created above");
@@ -1712,10 +1871,14 @@ impl Database {
     /// Blocking shim over [`Database::_init_nonblock`], retained for the
     /// synchronous callers (connection setup paths). The open state machine
     /// uses `_init_nonblock` directly so a fresh open never blocks here.
-    pub(crate) fn _init(&self, encryption_key: Option<&EncryptionKey>) -> Result<Pager> {
+    pub(crate) fn _init(
+        &self,
+        encryption_key: Option<&EncryptionKey>,
+        page_codec: Option<Arc<dyn PageCodec>>,
+    ) -> Result<Pager> {
         let mut st = InitState::default();
         self.io
-            .block(|| self._init_nonblock(&mut st, encryption_key))
+            .block(|| self._init_nonblock(&mut st, encryption_key, page_codec.as_ref()))
     }
 
     /// Necessary Pager initialization, so that we are prepared to read from
@@ -1726,14 +1889,20 @@ impl Database {
         &self,
         st: &mut InitState,
         encryption_key: Option<&EncryptionKey>,
+        page_codec: Option<&Arc<dyn PageCodec>>,
     ) -> Result<IOResult<Pager>> {
+        if encryption_key.is_some() && page_codec.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
         loop {
             match st {
                 InitState::Start => {
                     *st = InitState::InitPager(DbHeaderReadState::default());
                 }
                 InitState::InitPager(hdr_st) => {
-                    let pager = return_if_io!(self.init_pager(None, hdr_st));
+                    let pager = return_if_io!(self.init_pager(None, hdr_st, page_codec));
                     pager.enable_encryption(self.opts.enable_encryption);
 
                     // Set up encryption context BEFORE reading the header page.
@@ -1745,6 +1914,8 @@ impl Database {
                     if let Some(key) = encryption_key {
                         let cipher_mode = self.encryption_cipher_mode.get();
                         pager.set_encryption_context(cipher_mode, key)?;
+                    } else if let Some(codec) = page_codec {
+                        pager.set_page_codec(codec.clone())?;
                     }
 
                     // Start a read transaction before reading page 1 to prevent a concurrent
@@ -1821,6 +1992,7 @@ impl Database {
         &mut self,
         st: &mut HeaderValidationState,
         encryption_key: Option<&EncryptionKey>,
+        page_codec: Option<&Arc<dyn PageCodec>>,
     ) -> Result<IOResult<Arc<Pager>>> {
         loop {
             match st {
@@ -1828,7 +2000,8 @@ impl Database {
                     // `_init` does not modify `open_flags` (the autovacuum
                     // override happens later in `Validate`), so capturing
                     // `is_readonly` across the `_init` yields is stable.
-                    let pager = return_if_io!(self._init_nonblock(init, encryption_key));
+                    let pager =
+                        return_if_io!(self._init_nonblock(init, encryption_key, page_codec));
                     let log_exists =
                         journal_mode::logical_log_exists(std::path::Path::new(&self.path));
                     let is_readonly = self.open_flags.contains(OpenFlags::ReadOnly);
@@ -1960,6 +2133,12 @@ impl Database {
                     // Determine if we should open in MVCC mode based on the database header version
                     // MVCC is controlled only by the database header (set via PRAGMA journal_mode)
                     let open_mv_store = matches!(read_version, Version::Mvcc);
+                    if open_mv_store && page_codec.is_some() {
+                        return Err(LimboError::InvalidArgument(
+                            "external page codecs are not supported with MVCC databases"
+                                .to_string(),
+                        ));
+                    }
 
                     // MVCC has no cross-process coordination: commit
                     // serialization, the logical-log append offset, and
@@ -2059,7 +2238,7 @@ impl Database {
                 HeaderValidationState::OpenWal {
                     open_mv_store,
                     driver,
-                    ..
+                    pager,
                 } => {
                     // Always open shared WAL and set it in the Database and Pager.
                     // MVCC currently requires a WAL open to function.
@@ -2085,12 +2264,14 @@ impl Database {
                             let shared_authority = self.open_shared_wal_coordination_for_open()?;
                             if let Some(authority) = shared_authority.as_ref() {
                                 if !authority.frame_index_overflowed() {
+                                    let io_ctx = pager.io_ctx.read();
                                     WalFileShared::open_shared_from_authority_if_exists(
                                         &self.io,
                                         &self.wal_path,
                                         flags,
                                         authority,
                                         &self.db_file,
+                                        Some(&io_ctx),
                                     )?
                                 } else {
                                     WalFileShared::open_shared_if_exists(
@@ -2166,6 +2347,12 @@ impl Database {
     /// Rebuild the process-local shared WAL view after a caller restores the
     /// database and WAL files outside the pager.
     pub fn reload_wal_after_external_restore(self: &Arc<Self>) -> Result<()> {
+        if self.requires_page_codec {
+            return Err(LimboError::InvalidArgument(
+                "reloading a WAL after external restore is not supported with an external page codec"
+                    .to_string(),
+            ));
+        }
         let flags = self.open_flags;
         #[cfg(host_shared_wal)]
         let shared_authority = self.open_shared_wal_coordination_for_open()?;
@@ -2183,6 +2370,7 @@ impl Database {
                             flags,
                             authority,
                             &self.db_file,
+                            None,
                         )?
                     } else {
                         WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
@@ -2216,7 +2404,7 @@ impl Database {
                 self.experimental_mvcc_passive_checkpoint_enabled(),
             )?;
             self.mv_store.store(Some(mv_store.clone()));
-            let mvcc_bootstrap_conn = self._connect(true, None, None)?;
+            let mvcc_bootstrap_conn = self._connect(true, None, None, None)?;
             match mv_store.bootstrap(mvcc_bootstrap_conn.clone()) {
                 Ok(()) => {}
                 Err(LimboError::SchemaUpdated) => {
@@ -2233,7 +2421,7 @@ impl Database {
 
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn connect(self: &Arc<Database>) -> Result<Arc<Connection>> {
-        self._connect(false, None, None)
+        self._connect(false, None, None, None)
     }
 
     /// Connect with an encryption key.
@@ -2243,7 +2431,19 @@ impl Database {
         self: &Arc<Database>,
         encryption_key: Option<EncryptionKey>,
     ) -> Result<Arc<Connection>> {
-        self._connect(false, None, encryption_key)
+        self._connect(false, None, encryption_key, None)
+    }
+
+    /// Connect with an external page codec.
+    ///
+    /// The codec may contain sensitive key material, so it is installed only on
+    /// the pager for this connection and is not cached on the shared `Database`.
+    #[instrument(skip_all, level = Level::DEBUG)]
+    pub fn connect_with_page_codec(
+        self: &Arc<Database>,
+        page_codec: Arc<dyn PageCodec>,
+    ) -> Result<Arc<Connection>> {
+        self._connect(false, None, None, Some(page_codec))
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
@@ -2252,13 +2452,27 @@ impl Database {
         is_mvcc_bootstrap_connection: bool,
         pager: Option<Arc<Pager>>,
         encryption_key: Option<EncryptionKey>,
+        page_codec: Option<Arc<dyn PageCodec>>,
     ) -> Result<Arc<Connection>> {
+        if self.requires_page_codec && page_codec.is_none() {
+            return Err(LimboError::InvalidArgument(
+                "database requires an external page codec".to_string(),
+            ));
+        }
+        if !self.requires_page_codec && page_codec.is_some() {
+            return Err(LimboError::InvalidArgument(
+                "database was opened without an external page codec".to_string(),
+            ));
+        }
+        if let Some(page_codec) = page_codec.as_deref() {
+            self.validate_page_codec(Some(page_codec))?;
+        }
         let pager = if let Some(pager) = pager {
             pager
         } else {
             // Pass encryption key to _init so it can set up encryption context
             // before reading page 1. This is required for reopening encrypted databases.
-            Arc::new(self._init(encryption_key.as_ref())?)
+            Arc::new(self._init(encryption_key.as_ref(), page_codec.clone())?)
         };
         let default_cache_size = pager
             .io
@@ -2382,6 +2596,10 @@ impl Database {
                     *st = DbHeaderReadState::Reading { buf, completion: c };
                 }
                 DbHeaderReadState::Reading { buf, completion } => {
+                    if let Some(err) = completion.get_error() {
+                        *st = DbHeaderReadState::Start;
+                        return Err(err.into());
+                    }
                     if !completion.succeeded() {
                         let c = completion.clone();
                         io_yield_one!(c);
@@ -2834,6 +3052,7 @@ impl Database {
         &self,
         requested_page_size: Option<usize>,
         hdr_st: &mut DbHeaderReadState,
+        page_codec: Option<&Arc<dyn PageCodec>>,
     ) -> Result<IOResult<Pager>> {
         let cipher = self.encryption_cipher_mode.get();
 
@@ -2842,13 +3061,51 @@ impl Database {
         // on-disk page size from it.
         let (header_reserved_bytes, header_page_size) = if self.initialized() {
             let buf = return_if_io!(self.read_db_header_buf(hdr_st));
-            let reserved = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
-            let ps_raw = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
-            let page_size = PageSize::new_from_header_u16(ps_raw)?;
-            (Some(reserved), Some(page_size))
+            if let Some(codec) = page_codec {
+                if let Some(header_info) = codec.probe_header(buf.as_slice())? {
+                    let page_size_u32 = u32::try_from(header_info.page_size).map_err(|_| {
+                        LimboError::InvalidArgument(format!(
+                            "page codec reported invalid page size {}",
+                            header_info.page_size
+                        ))
+                    })?;
+                    let Some(page_size) = PageSize::new(page_size_u32) else {
+                        return Err(LimboError::InvalidArgument(format!(
+                            "page codec reported invalid page size {}",
+                            header_info.page_size
+                        )));
+                    };
+                    if !page_size.has_valid_reserved_space(header_info.reserved_space) {
+                        return Err(LimboError::InvalidArgument(format!(
+                            "page codec reported invalid reserved space {} for page size {}",
+                            header_info.reserved_space,
+                            page_size.get()
+                        )));
+                    }
+                    (Some(header_info.reserved_space), Some(page_size))
+                } else {
+                    return Err(LimboError::InvalidArgument(
+                        "page codec must implement probe_header to reopen an initialized database"
+                            .to_string(),
+                    ));
+                }
+            } else {
+                let reserved = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
+                let ps_raw = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
+                let page_size = PageSize::new_from_header_u16(ps_raw)?;
+                (Some(reserved), Some(page_size))
+            }
         } else {
             (None, None)
         };
+        if let (Some(codec), Some(reserved_bytes)) = (page_codec, header_reserved_bytes) {
+            let required_reserved_bytes = codec.required_reserved_bytes();
+            if reserved_bytes != required_reserved_bytes {
+                return Err(LimboError::InvalidArgument(format!(
+                    "page codec requires exactly {required_reserved_bytes} reserved bytes, but database provides {reserved_bytes}"
+                )));
+            }
+        }
 
         let reserved_bytes = header_reserved_bytes.or_else(|| {
             if !matches!(cipher, CipherMode::None) {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -3620,14 +3620,15 @@ mod database_tests {
     use std::sync::Arc;
 
     use super::{is_memory_like, Database, InitState};
-    use crate::storage::encryption::{CipherMode, EncryptionKey};
+    use crate::storage::encryption::EncryptionKey;
+    use crate::storage::page_transform::{
+        PageCodec, PageCodecContext, PageCodecHeaderInfo, PageCodecId, PageLocation,
+    };
     use crate::storage::sqlite3_ondisk::DatabaseHeader;
     use crate::{
-        storage::database::{
-            DatabaseFile, PageCodec, PageCodecHeaderInfo, PageCodecId, PageCodecLocation,
-        },
-        Connection, DatabaseOpts, DatabaseStorage, EncryptionOpts, IOResult, LimboError,
-        OpenDbAsyncState, OpenFlags, OpenOptions, PlatformIO, SqliteDialect, IO,
+        storage::database::DatabaseFile, Connection, DatabaseOpts, DatabaseStorage, EncryptionOpts,
+        IOResult, LimboError, OpenDbAsyncState, OpenFlags, OpenOptions, PlatformIO, SqliteDialect,
+        IO,
     };
 
     #[test]
@@ -3666,23 +3667,21 @@ mod database_tests {
 
         fn encode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> crate::Result<()> {
-            output.copy_from_slice(page);
+            output.copy_from_slice(input);
             Ok(())
         }
 
         fn decode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> crate::Result<()> {
-            output.copy_from_slice(page);
+            output.copy_from_slice(input);
             Ok(())
         }
     }
@@ -3698,14 +3697,14 @@ mod database_tests {
             PageCodecId::new(*b"invalid-header-c")
         }
 
-        fn probe_header(
+        fn bootstrap_page_info(
             &self,
             _raw_page1_prefix: &[u8],
-        ) -> crate::Result<Option<PageCodecHeaderInfo>> {
-            Ok(Some(PageCodecHeaderInfo {
+        ) -> crate::Result<PageCodecHeaderInfo> {
+            Ok(PageCodecHeaderInfo {
                 page_size: self.page_size,
                 reserved_space: self.reserved_space,
-            }))
+            })
         }
 
         fn required_reserved_bytes(&self) -> u8 {
@@ -3714,23 +3713,21 @@ mod database_tests {
 
         fn encode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> crate::Result<()> {
-            output.copy_from_slice(page);
+            output.copy_from_slice(input);
             Ok(())
         }
 
         fn decode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> crate::Result<()> {
-            output.copy_from_slice(page);
+            output.copy_from_slice(input);
             Ok(())
         }
     }
@@ -3757,12 +3754,12 @@ mod database_tests {
             PageCodecId::new(id)
         }
 
-        fn probe_header(
+        fn bootstrap_page_info(
             &self,
             raw_page1_prefix: &[u8],
-        ) -> crate::Result<Option<PageCodecHeaderInfo>> {
+        ) -> crate::Result<PageCodecHeaderInfo> {
             if raw_page1_prefix.len() < 21 {
-                return Ok(None);
+                return Err(LimboError::NotADB);
             }
 
             let decoded_magic = raw_page1_prefix[..16]
@@ -3770,7 +3767,7 @@ mod database_tests {
                 .map(|byte| byte ^ self.mask)
                 .collect::<Vec<_>>();
             if decoded_magic.as_slice() != b"SQLite format 3\0" {
-                return Ok(None);
+                return Err(LimboError::NotADB);
             }
 
             let ps_raw = u16::from_be_bytes([
@@ -3778,10 +3775,10 @@ mod database_tests {
                 raw_page1_prefix[17] ^ self.mask,
             ]);
             let page_size = if ps_raw == 1 { 65536 } else { ps_raw as usize };
-            Ok(Some(PageCodecHeaderInfo {
+            Ok(PageCodecHeaderInfo {
                 page_size,
                 reserved_space: raw_page1_prefix[20] ^ self.mask,
-            }))
+            })
         }
 
         fn required_reserved_bytes(&self) -> u8 {
@@ -3790,23 +3787,21 @@ mod database_tests {
 
         fn encode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> crate::Result<()> {
-            self.transform(page, output);
+            self.transform(input, output);
             Ok(())
         }
 
         fn decode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> crate::Result<()> {
-            self.transform(page, output);
+            self.transform(input, output);
             Ok(())
         }
     }
@@ -3817,22 +3812,22 @@ mod database_tests {
     impl LocationPageCodec {
         const MASK: u8 = 0x6d;
 
-        fn byte_key(page_idx: usize, location: PageCodecLocation, offset: usize) -> u8 {
+        fn byte_key(page_no: u32, location: PageLocation, offset: usize) -> u8 {
             // Persisted transforms must not depend on the host pointer width.
-            let page_id_byte = (page_idx as u64).to_le_bytes()[offset % std::mem::size_of::<u64>()];
+            let page_id_byte = (page_no as u64).to_le_bytes()[offset % std::mem::size_of::<u64>()];
             let page_id_rotation =
                 ((offset / std::mem::size_of::<u64>()) % (u8::BITS as usize)) as u32;
             Self::MASK
                 ^ page_id_byte.rotate_left(page_id_rotation)
                 ^ match location {
-                    PageCodecLocation::Database => 0,
-                    PageCodecLocation::Wal => 0xa5,
+                    PageLocation::Database => 0,
+                    PageLocation::Wal => 0xa5,
                 }
         }
 
-        fn transform(page: &[u8], output: &mut [u8], page_idx: usize, location: PageCodecLocation) {
-            for (offset, (input, output)) in page.iter().zip(output).enumerate() {
-                *output = input ^ Self::byte_key(page_idx, location, offset);
+        fn transform(input: &[u8], output: &mut [u8], context: PageCodecContext) {
+            for (offset, (input, output)) in input.iter().zip(output).enumerate() {
+                *output = input ^ Self::byte_key(context.page_no, context.location, offset);
             }
         }
     }
@@ -3842,12 +3837,12 @@ mod database_tests {
             PageCodecId::new(*b"location-page-co")
         }
 
-        fn probe_header(
+        fn bootstrap_page_info(
             &self,
             raw_page1_prefix: &[u8],
-        ) -> crate::Result<Option<PageCodecHeaderInfo>> {
+        ) -> crate::Result<PageCodecHeaderInfo> {
             if raw_page1_prefix.len() < 21 {
-                return Ok(None);
+                return Err(LimboError::NotADB);
             }
             if !raw_page1_prefix[..16]
                 .iter()
@@ -3856,31 +3851,31 @@ mod database_tests {
                 .all(|((offset, encoded), expected)| {
                     *encoded
                         ^ Self::byte_key(
-                            DatabaseHeader::PAGE_ID,
-                            PageCodecLocation::Database,
+                            DatabaseHeader::PAGE_ID as u32,
+                            PageLocation::Database,
                             offset,
                         )
                         == *expected
                 })
             {
-                return Ok(None);
+                return Err(LimboError::NotADB);
             }
 
             let page_size = u16::from_be_bytes([
                 raw_page1_prefix[16]
-                    ^ Self::byte_key(DatabaseHeader::PAGE_ID, PageCodecLocation::Database, 16),
+                    ^ Self::byte_key(DatabaseHeader::PAGE_ID as u32, PageLocation::Database, 16),
                 raw_page1_prefix[17]
-                    ^ Self::byte_key(DatabaseHeader::PAGE_ID, PageCodecLocation::Database, 17),
+                    ^ Self::byte_key(DatabaseHeader::PAGE_ID as u32, PageLocation::Database, 17),
             ]);
-            Ok(Some(PageCodecHeaderInfo {
+            Ok(PageCodecHeaderInfo {
                 page_size: if page_size == 1 {
                     65_536
                 } else {
                     page_size as usize
                 },
                 reserved_space: raw_page1_prefix[20]
-                    ^ Self::byte_key(DatabaseHeader::PAGE_ID, PageCodecLocation::Database, 20),
-            }))
+                    ^ Self::byte_key(DatabaseHeader::PAGE_ID as u32, PageLocation::Database, 20),
+            })
         }
 
         fn required_reserved_bytes(&self) -> u8 {
@@ -3889,23 +3884,21 @@ mod database_tests {
 
         fn encode_page(
             &self,
-            page: &[u8],
+            context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            page_idx: usize,
-            location: PageCodecLocation,
         ) -> crate::Result<()> {
-            Self::transform(page, output, page_idx, location);
+            Self::transform(input, output, context);
             Ok(())
         }
 
         fn decode_page(
             &self,
-            page: &[u8],
+            context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            page_idx: usize,
-            location: PageCodecLocation,
         ) -> crate::Result<()> {
-            Self::transform(page, output, page_idx, location);
+            Self::transform(input, output, context);
             Ok(())
         }
     }
@@ -3915,12 +3908,15 @@ mod database_tests {
         let input = vec![0; 512];
         let mut page_one = vec![0; input.len()];
         let mut page_two_fifty_seven = vec![0; input.len()];
-        LocationPageCodec::transform(&input, &mut page_one, 1, PageCodecLocation::Database);
+        LocationPageCodec::transform(
+            &input,
+            &mut page_one,
+            PageCodecContext::new(1, PageLocation::Database),
+        );
         LocationPageCodec::transform(
             &input,
             &mut page_two_fifty_seven,
-            257,
-            PageCodecLocation::Database,
+            PageCodecContext::new(257, PageLocation::Database),
         );
 
         assert_ne!(page_one, page_two_fifty_seven);
@@ -3929,19 +3925,18 @@ mod database_tests {
         LocationPageCodec::transform(
             &page_two_fifty_seven,
             &mut decoded,
-            257,
-            PageCodecLocation::Database,
+            PageCodecContext::new(257, PageLocation::Database),
         );
         assert_eq!(decoded, input);
     }
 
     #[derive(Debug)]
-    struct XorNoProbePageCodec {
+    struct XorDefaultBootstrapPageCodec {
         mask: u8,
         reserved_bytes: u8,
     }
 
-    impl XorNoProbePageCodec {
+    impl XorDefaultBootstrapPageCodec {
         fn transform(&self, page: &[u8], output: &mut [u8]) {
             for (input, output) in page.iter().zip(output) {
                 *output = input ^ self.mask;
@@ -3949,7 +3944,7 @@ mod database_tests {
         }
     }
 
-    impl PageCodec for XorNoProbePageCodec {
+    impl PageCodec for XorDefaultBootstrapPageCodec {
         fn codec_id(&self) -> PageCodecId {
             let mut id = *b"xor-no-probe----";
             id[15] = self.mask;
@@ -3963,23 +3958,21 @@ mod database_tests {
 
         fn encode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> crate::Result<()> {
-            self.transform(page, output);
+            self.transform(input, output);
             Ok(())
         }
 
         fn decode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> crate::Result<()> {
-            self.transform(page, output);
+            self.transform(input, output);
             Ok(())
         }
     }
@@ -4012,7 +4005,7 @@ mod database_tests {
         loop {
             match Database::open_async(&mut state, io.clone(), path, &options)? {
                 IOResult::Done(db) => return Ok(db),
-                IOResult::IO(completion) => completion.wait(&*io).unwrap(),
+                IOResult::IO(completion) => completion.wait(&*io)?,
             }
         }
     }
@@ -4101,18 +4094,16 @@ mod database_tests {
         let codec: Arc<dyn PageCodec> = Arc::new(IdentityPageCodec);
         let _db = open_with_page_codec(io.clone(), path, codec.clone());
 
-        let err = Database::open_file_with_flags_and_page_codec(
+        let err = Database::open(
             io,
             path,
-            OpenFlags::Create,
-            DatabaseOpts::new(),
-            Some(EncryptionOpts {
-                cipher: "aes256gcm".to_string(),
-                hexkey: "00".repeat(32),
-            }),
-            None,
-            codec,
-            Arc::new(SqliteDialect),
+            OpenOptions::new(Arc::new(SqliteDialect))
+                .flags(OpenFlags::Create)
+                .encryption(EncryptionOpts {
+                    cipher: "aes256gcm".to_string(),
+                    hexkey: "00".repeat(32),
+                })
+                .page_codec(codec),
         )
         .unwrap_err();
         assert!(err
@@ -4128,15 +4119,13 @@ mod database_tests {
         let path_str = path.to_str().unwrap();
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-        let err = Database::open_file_with_flags_and_page_codec(
+        let err = Database::open(
             io,
             path_str,
-            OpenFlags::Create,
-            DatabaseOpts::new().with_multiprocess_wal(true),
-            None,
-            None,
-            Arc::new(IdentityPageCodec),
-            Arc::new(SqliteDialect),
+            OpenOptions::new(Arc::new(SqliteDialect))
+                .flags(OpenFlags::Create)
+                .db_opts(DatabaseOpts::new().with_multiprocess_wal(true))
+                .page_codec(Arc::new(IdentityPageCodec) as Arc<dyn PageCodec>),
         )
         .unwrap_err();
 
@@ -4160,19 +4149,12 @@ mod database_tests {
         let db_file: Arc<dyn DatabaseStorage> = Arc::new(DatabaseFile::new(file));
         let mut state = OpenDbAsyncState::new();
 
-        let err = match Database::open_with_flags_bypass_registry_and_page_codec_async(
-            &mut state,
-            io,
-            path,
-            None,
-            db_file,
-            OpenFlags::Create,
-            DatabaseOpts::new().with_multiprocess_wal(true),
-            None,
-            None,
-            Arc::new(IdentityPageCodec),
-            Arc::new(SqliteDialect),
-        ) {
+        let options = OpenOptions::new(Arc::new(SqliteDialect))
+            .storage(db_file)
+            .flags(OpenFlags::Create)
+            .db_opts(DatabaseOpts::new().with_multiprocess_wal(true))
+            .page_codec(Arc::new(IdentityPageCodec) as Arc<dyn PageCodec>);
+        let err = match Database::do_open_async(&mut state, io, path, &options) {
             Err(err) => err,
             Ok(_) => panic!("multiprocess WAL must reject an external page codec"),
         };
@@ -4219,7 +4201,7 @@ mod database_tests {
 
     #[cfg(feature = "fs")]
     #[test]
-    fn page_codec_round_trips_wal_and_checkpointed_database_with_probe_header() {
+    fn page_codec_round_trips_wal_and_checkpointed_database_with_bootstrap_header() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let path = temp_dir.path().join("codec-roundtrip.db");
         let path = path.to_str().unwrap();
@@ -4314,12 +4296,12 @@ mod database_tests {
 
     #[cfg(feature = "fs")]
     #[test]
-    fn page_codec_reopen_requires_header_probe() {
+    fn page_codec_reopen_requires_recoverable_bootstrap_header() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let path = temp_dir.path().join("codec-no-probe-roundtrip.db");
         let path = path.to_str().unwrap();
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let codec: Arc<dyn PageCodec> = Arc::new(XorNoProbePageCodec {
+        let codec: Arc<dyn PageCodec> = Arc::new(XorDefaultBootstrapPageCodec {
             mask: 0x3c,
             reserved_bytes: 1,
         });
@@ -4338,7 +4320,7 @@ mod database_tests {
         let err = open_with_page_codec_result(io, path, codec).unwrap_err();
         assert!(err
             .to_string()
-            .contains("page codec must implement probe_header"));
+            .contains("page codec reported invalid page size"));
     }
 
     #[cfg(feature = "fs")]
@@ -4449,6 +4431,7 @@ mod database_tests {
                 .unwrap();
             conn.execute("create table test(id integer primary key)")
                 .unwrap();
+            conn.execute("pragma wal_checkpoint(truncate)").unwrap();
         }
 
         for (codec, expected_error) in [
@@ -4465,6 +4448,13 @@ mod database_tests {
                     reserved_space: 33,
                 },
                 "page codec reported invalid reserved space 33 for page size 512",
+            ),
+            (
+                InvalidHeaderPageCodec {
+                    page_size: 8192,
+                    reserved_space: 0,
+                },
+                "page codec bootstrap page size 8192 does not match decoded page-1 size 4096",
             ),
         ] {
             let err = open_with_page_codec_result(io.clone(), path, Arc::new(codec)).unwrap_err();
@@ -4688,36 +4678,6 @@ mod database_tests {
             .to_string()
             .contains("page codec requires exactly 1 reserved bytes"));
         assert_eq!(conn.get_reserved_bytes(), Some(1));
-    }
-
-    #[cfg(feature = "fs")]
-    #[test]
-    fn encryption_rejects_reserved_space_mutation() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let path = temp_dir.path().join("encrypted-reserved-space.db");
-        let path = path.to_str().unwrap();
-        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file_with_flags(
-            io,
-            path,
-            OpenFlags::Create,
-            DatabaseOpts::new().with_encryption(true),
-            None,
-            Arc::new(SqliteDialect),
-        )
-        .unwrap();
-        let conn = db.connect().unwrap();
-        conn.set_encryption_cipher(CipherMode::Aes256Gcm).unwrap();
-        conn.set_encryption_key(EncryptionKey::from_hex_string(&"00".repeat(32)).unwrap())
-            .unwrap();
-        let reserved_before = conn.get_reserved_bytes();
-
-        let err = conn.set_reserved_bytes(0).unwrap_err();
-
-        assert!(err
-            .to_string()
-            .contains("built-in encryption requires exactly 28 reserved bytes"));
-        assert_eq!(conn.get_reserved_bytes(), reserved_before);
     }
 
     #[cfg(feature = "fs")]

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -1,11 +1,11 @@
 use crate::io::FileSyncType;
 use crate::storage::checksum::ChecksumContext;
 use crate::storage::encryption::EncryptionContext;
-use crate::storage::sqlite3_ondisk::PageSize;
 use crate::storage::page_transform::{
     page_codec_completion_error, page_codec_encryption_context, page_codec_from_encryption,
     PageCodec, PageCodecContext, PageLocation, PageTransform,
 };
+use crate::storage::sqlite3_ondisk::PageSize;
 use crate::sync::Arc;
 use crate::{io::Completion, Buffer, CompletionError, LimboError, Result};
 use crate::{

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -74,8 +74,11 @@ impl IOContext {
         &self.page_transform
     }
 
-    pub fn has_transform(&self) -> bool {
-        !matches!(self.page_transform, PageTransform::None)
+    /// Returns whether page I/O uses a codec transform.
+    ///
+    /// Checksums are maintained separately and do not count as codecs. So encryption
+    pub fn has_codec_transform(&self) -> bool {
+        matches!(self.page_transform, PageTransform::Codec(_))
     }
 
     pub fn reset_checksum(&mut self) {

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -177,11 +177,7 @@ impl DatabaseStorage for DatabaseFile {
                             }
                         };
                         if bytes_read == 0 {
-                            original_c.error(CompletionError::ShortRead {
-                                page_idx,
-                                expected: buf.len(),
-                                actual: 0,
-                            });
+                            original_c.complete(bytes_read);
                             return original_c.get_error();
                         }
                         turso_assert_greater_than!(
@@ -190,8 +186,13 @@ impl DatabaseStorage for DatabaseFile {
                             "database: expected positive bytes for page codec page",
                             { "page_idx": page_idx }
                         );
-                        if bytes_read as usize != buf.len() {
-                            original_c.complete(bytes_read);
+                        let expected = original_c.as_read().buf().len();
+                        if bytes_read as usize != expected {
+                            original_c.error(CompletionError::ShortRead {
+                                page_idx,
+                                expected,
+                                actual: bytes_read as usize,
+                            });
                             return original_c.get_error();
                         }
                         let original_buf = original_c.as_read().buf();
@@ -550,7 +551,7 @@ mod page_codec_tests {
     }
 
     #[test]
-    fn page_codec_zero_byte_read_reports_short_read() {
+    fn page_codec_zero_byte_read_reaches_original_completion() {
         let db_file = DatabaseFile {
             file: Arc::new(MockFile {
                 read_result: Ok(0),
@@ -560,28 +561,61 @@ mod page_codec_tests {
         let mut io_ctx = IOContext::default();
         io_ctx.set_page_codec(Arc::new(XorPageCodec(0xa5)));
         let page_idx = 9usize;
-        let original = Completion::new_read(Arc::new(Buffer::new_temporary(4096)), |_| None);
+        let bytes_seen = Arc::new(AtomicUsize::new(usize::MAX));
+        let bytes_seen_callback = bytes_seen.clone();
+        let original = Completion::new_read(Arc::new(Buffer::new_temporary(4096)), move |result| {
+            let (_, bytes_read) = result.expect("zero-byte read should reach the callback");
+            bytes_seen_callback.store(bytes_read as usize, Ordering::Relaxed);
+            None
+        });
 
         let wrapped = db_file
             .read_page(page_idx, &io_ctx, original.clone())
             .unwrap();
-        let err = MemoryIO::new()
-            .wait_for_completion(wrapped)
-            .expect_err("a zero-byte transformed page read must fail");
+        MemoryIO::new().wait_for_completion(wrapped).unwrap();
+
+        assert!(original.succeeded());
+        assert_eq!(bytes_seen.load(Ordering::Relaxed), 0);
+        assert!(
+            original
+                .as_read()
+                .buf()
+                .as_slice()
+                .iter()
+                .all(|byte| *byte == 0),
+            "an absent page must not be decoded"
+        );
+    }
+
+    #[test]
+    fn page_codec_partial_database_read_fails_before_decode() {
+        let db_file = DatabaseFile {
+            file: Arc::new(MockFile {
+                read_result: Ok(128),
+                writes_submitted: Arc::new(AtomicUsize::new(0)),
+            }),
+        };
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(Arc::new(XorPageCodec(0xa5)));
+        let original = Completion::new_read(Arc::new(Buffer::new_temporary(512)), |_| None);
+
+        let wrapped = db_file.read_page(1, &io_ctx, original.clone()).unwrap();
+        let err = MemoryIO::new().wait_for_completion(wrapped).unwrap_err();
+
         assert!(matches!(
             err,
             LimboError::CompletionError(CompletionError::ShortRead {
-                page_idx: 9,
-                expected: 4096,
-                actual: 0,
+                page_idx: 1,
+                expected: 512,
+                actual: 128,
             })
         ));
         assert!(matches!(
             original.get_error(),
             Some(CompletionError::ShortRead {
-                page_idx: 9,
-                expected: 4096,
-                actual: 0,
+                page_idx: 1,
+                expected: 512,
+                actual: 128,
             })
         ));
     }

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -10,62 +10,176 @@ use crate::{
 };
 use tracing::{instrument, Level};
 
-#[derive(Debug, Clone)]
-pub enum EncryptionOrChecksum {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageCodecHeaderInfo {
+    pub page_size: usize,
+    pub reserved_space: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageCodecLocation {
+    Database,
+    Wal,
+}
+
+/// A stable, non-secret identifier for a page codec configuration.
+///
+/// This identifies the transform configuration rather than the codec
+/// implementation. Callers must return the same value when reopening or
+/// sharing a database with an equivalent codec, and a different value for any
+/// codec that could transform pages differently. Do not include key material.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PageCodecId([u8; 16]);
+
+impl PageCodecId {
+    pub const fn new(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Converts complete SQLite page images between their on-disk and in-memory
+/// representations.
+///
+/// The engine supplies an output buffer exactly as large as the input page,
+/// enforcing SQLite's fixed page-size invariant without codec allocations.
+/// Codecs needing per-page metadata must store it in reserved bytes.
+///
+/// Codecs that support reopening initialized databases must implement
+/// [`Self::probe_header`]. The engine cannot safely decode an arbitrary
+/// full-page transform before it knows the physical page size.
+pub trait PageCodec: Send + Sync {
+    /// Returns a stable, non-secret identifier for this codec configuration.
+    ///
+    /// The identifier is retained by the shared [`crate::Database`] so every
+    /// connection and cached open for the same file uses an equivalent codec.
+    /// It must change whenever the codec could produce different on-disk bytes.
+    fn codec_id(&self) -> PageCodecId;
+
+    /// Reports page layout metadata from the raw prefix of page 1.
+    ///
+    /// Return `None` only when the codec cannot reopen initialized databases.
+    fn probe_header(&self, _raw_page1_prefix: &[u8]) -> Result<Option<PageCodecHeaderInfo>> {
+        Ok(None)
+    }
+
+    /// Returns the exact number of reserved bytes required in every page.
+    fn required_reserved_bytes(&self) -> u8;
+    fn encode_page(
+        &self,
+        page: &[u8],
+        output: &mut [u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> Result<()>;
+    fn decode_page(
+        &self,
+        page: &[u8],
+        output: &mut [u8],
+        page_idx: usize,
+        location: PageCodecLocation,
+    ) -> Result<()>;
+}
+
+#[derive(Clone)]
+/// Storage-layer operations applied to complete SQLite page images.
+///
+/// `Checksum` is separate because it only maintains and verifies bytes in the
+/// reserved page tail; it does not transform logical SQLite content.
+pub enum PageTransform {
     Encryption(EncryptionContext),
+    PageCodec(Arc<dyn PageCodec>),
     Checksum(ChecksumContext),
     None,
 }
 
+#[deprecated(note = "renamed to PageTransform")]
+pub type EncryptionOrChecksum = PageTransform;
+
+impl std::fmt::Debug for PageTransform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Encryption(_) => "Encryption",
+            Self::PageCodec(_) => "PageCodec",
+            Self::Checksum(_) => "Checksum",
+            Self::None => "None",
+        };
+        f.write_str(name)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct IOContext {
-    encryption_or_checksum: EncryptionOrChecksum,
+    page_transform: PageTransform,
 }
 
 impl IOContext {
     pub fn encryption_context(&self) -> Option<&EncryptionContext> {
-        match &self.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => Some(ctx),
+        match &self.page_transform {
+            PageTransform::Encryption(ctx) => Some(ctx),
             _ => None,
         }
     }
 
     pub fn get_reserved_space_bytes(&self) -> u8 {
-        match &self.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => ctx.required_reserved_bytes(),
-            EncryptionOrChecksum::Checksum(ctx) => ctx.required_reserved_bytes(),
-            EncryptionOrChecksum::None => Default::default(),
+        match &self.page_transform {
+            PageTransform::Encryption(ctx) => ctx.required_reserved_bytes(),
+            PageTransform::PageCodec(ctx) => ctx.required_reserved_bytes(),
+            PageTransform::Checksum(ctx) => ctx.required_reserved_bytes(),
+            PageTransform::None => Default::default(),
         }
     }
 
     pub fn set_encryption(&mut self, encryption_ctx: EncryptionContext) {
-        self.encryption_or_checksum = EncryptionOrChecksum::Encryption(encryption_ctx);
+        self.page_transform = PageTransform::Encryption(encryption_ctx);
     }
 
     pub(crate) fn reset_page_size_in_encryption_ctx(&mut self, page_size: PageSize) {
-        if let EncryptionOrChecksum::Encryption(ctx) = &mut self.encryption_or_checksum {
+        if let PageTransform::Encryption(ctx) = &mut self.page_transform {
             ctx.set_page_size(page_size);
         }
     }
 
+    pub fn set_page_codec(&mut self, codec: Arc<dyn PageCodec>) {
+        self.page_transform = PageTransform::PageCodec(codec);
+    }
+
+    pub fn has_encryption(&self) -> bool {
+        matches!(self.page_transform, PageTransform::Encryption(_))
+    }
+
+    pub fn has_page_codec(&self) -> bool {
+        matches!(self.page_transform, PageTransform::PageCodec(_))
+    }
+
+    pub fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
+        match &self.page_transform {
+            PageTransform::PageCodec(codec) => Some(codec.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn page_transform(&self) -> &PageTransform {
+        &self.page_transform
+    }
+
+    #[deprecated(note = "renamed to page_transform")]
+    #[allow(deprecated)]
     pub fn encryption_or_checksum(&self) -> &EncryptionOrChecksum {
-        &self.encryption_or_checksum
+        self.page_transform()
     }
 
     pub fn reset_checksum(&mut self) {
-        self.encryption_or_checksum = EncryptionOrChecksum::None;
+        self.page_transform = PageTransform::None;
     }
 }
 
 impl Default for IOContext {
     fn default() -> Self {
         #[cfg(feature = "checksum")]
-        let encryption_or_checksum = EncryptionOrChecksum::Checksum(ChecksumContext::default());
+        let page_transform = PageTransform::Checksum(ChecksumContext::default());
         #[cfg(not(feature = "checksum"))]
-        let encryption_or_checksum = EncryptionOrChecksum::None;
-        Self {
-            encryption_or_checksum,
-        }
+        let page_transform = PageTransform::None;
+        Self { page_transform }
     }
 }
 
@@ -124,8 +238,8 @@ impl DatabaseStorage for DatabaseFile {
             return Err(LimboError::IntegerOverflow);
         };
 
-        match &io_ctx.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => {
+        match &io_ctx.page_transform {
+            PageTransform::Encryption(ctx) => {
                 let encryption_ctx = ctx.clone();
                 let read_buffer = r.buf_arc();
                 let original_c = c.clone();
@@ -139,15 +253,28 @@ impl DatabaseStorage for DatabaseFile {
                                 return original_c.get_error();
                             }
                         };
+                        if bytes_read == 0 {
+                            original_c.error(CompletionError::ShortRead {
+                                page_idx,
+                                expected: buf.len(),
+                                actual: 0,
+                            });
+                            return original_c.get_error();
+                        }
                         turso_assert_greater_than!(
-                            bytes_read, 0,
-                            "database: expected to read data on success for encrypted page",
+                            bytes_read,
+                            0,
+                            "database: expected positive bytes for encrypted page",
                             { "page_idx": page_idx }
                         );
+                        if bytes_read as usize != buf.len() {
+                            original_c.complete(bytes_read);
+                            return original_c.get_error();
+                        }
+                        let original_buf = original_c.as_read().buf();
                         match encryption_ctx.decrypt_page(buf.as_slice(), page_idx) {
-                            Ok(decrypted_data) => {
-                                let original_buf = original_c.as_read().buf();
-                                original_buf.as_mut_slice().copy_from_slice(&decrypted_data);
+                            Ok(decrypted) => {
+                                original_buf.as_mut_slice().copy_from_slice(&decrypted);
                                 original_c.complete(bytes_read);
                                 original_c.get_error()
                             }
@@ -167,7 +294,66 @@ impl DatabaseStorage for DatabaseFile {
                 let wrapped_completion = Completion::new_read(read_buffer, decrypt_complete);
                 self.file.pread(pos, wrapped_completion)
             }
-            EncryptionOrChecksum::Checksum(ctx) => {
+            PageTransform::PageCodec(ctx) => {
+                let page_codec = ctx.clone();
+                let read_buffer = Arc::new(Buffer::new_temporary(r.buf_arc().len()));
+                let original_c = c;
+                let decode_complete =
+                    Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                        let (buf, bytes_read) = match res {
+                            Ok((buf, bytes_read)) => (buf, bytes_read),
+                            Err(err) => {
+                                tracing::error!(err = ?err);
+                                original_c.error(err);
+                                return original_c.get_error();
+                            }
+                        };
+                        if bytes_read == 0 {
+                            original_c.error(CompletionError::ShortRead {
+                                page_idx,
+                                expected: buf.len(),
+                                actual: 0,
+                            });
+                            return original_c.get_error();
+                        }
+                        turso_assert_greater_than!(
+                            bytes_read,
+                            0,
+                            "database: expected positive bytes for page codec page",
+                            { "page_idx": page_idx }
+                        );
+                        if bytes_read as usize != buf.len() {
+                            original_c.complete(bytes_read);
+                            return original_c.get_error();
+                        }
+                        let original_buf = original_c.as_read().buf();
+                        match page_codec.decode_page(
+                            buf.as_slice(),
+                            original_buf.as_mut_slice(),
+                            page_idx,
+                            PageCodecLocation::Database,
+                        ) {
+                            Ok(()) => {
+                                original_c.complete(bytes_read);
+                                original_c.get_error()
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to decode page data for page_id={page_idx}: {e}"
+                                );
+                                turso_assert!(
+                                    !original_c.failed(),
+                                    "Original completion already has an error"
+                                );
+                                original_c.error(CompletionError::PageCodecError { page_idx });
+                                original_c.get_error()
+                            }
+                        }
+                    });
+                let wrapped_completion = Completion::new_read(read_buffer, decode_complete);
+                self.file.pread(pos, wrapped_completion)
+            }
+            PageTransform::Checksum(ctx) => {
                 let checksum_ctx = ctx.clone();
                 let read_buffer = r.buf_arc();
                 let original_c = c.clone();
@@ -208,7 +394,7 @@ impl DatabaseStorage for DatabaseFile {
                 let wrapped_completion = Completion::new_read(read_buffer, verify_complete);
                 self.file.pread(pos, wrapped_completion)
             }
-            EncryptionOrChecksum::None => self.file.pread(pos, c),
+            PageTransform::None => self.file.pread(pos, c),
         }
     }
 
@@ -228,10 +414,13 @@ impl DatabaseStorage for DatabaseFile {
         let Some(pos) = (page_idx as u64 - 1).checked_mul(buffer_size as u64) else {
             return Err(LimboError::IntegerOverflow);
         };
-        let buffer = match &io_ctx.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => encrypt_buffer(page_idx, buffer, ctx),
-            EncryptionOrChecksum::Checksum(ctx) => checksum_buffer(page_idx, buffer, ctx),
-            EncryptionOrChecksum::None => buffer,
+        let buffer = match &io_ctx.page_transform {
+            PageTransform::Encryption(ctx) => encrypt_buffer(page_idx, buffer, ctx)?,
+            PageTransform::PageCodec(ctx) => {
+                encode_buffer(page_idx, buffer, ctx.as_ref(), PageCodecLocation::Database)?
+            }
+            PageTransform::Checksum(ctx) => checksum_buffer(page_idx, buffer, ctx),
+            PageTransform::None => buffer,
         };
         self.file.pwrite(pos, buffer, c)
     }
@@ -252,18 +441,30 @@ impl DatabaseStorage for DatabaseFile {
         let Some(pos) = (first_page_idx as u64 - 1).checked_mul(page_size as u64) else {
             return Err(LimboError::IntegerOverflow);
         };
-        let buffers = match &io_ctx.encryption_or_checksum() {
-            EncryptionOrChecksum::Encryption(ctx) => buffers
+        let buffers = match &io_ctx.page_transform() {
+            PageTransform::Encryption(ctx) => buffers
                 .into_iter()
                 .enumerate()
                 .map(|(i, buffer)| encrypt_buffer(first_page_idx + i, buffer, ctx))
-                .collect::<Vec<_>>(),
-            EncryptionOrChecksum::Checksum(ctx) => buffers
+                .collect::<Result<Vec<_>>>()?,
+            PageTransform::PageCodec(ctx) => buffers
+                .into_iter()
+                .enumerate()
+                .map(|(i, buffer)| {
+                    encode_buffer(
+                        first_page_idx + i,
+                        buffer,
+                        ctx.as_ref(),
+                        PageCodecLocation::Database,
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?,
+            PageTransform::Checksum(ctx) => buffers
                 .into_iter()
                 .enumerate()
                 .map(|(i, buffer)| checksum_buffer(first_page_idx + i, buffer, ctx))
                 .collect::<Vec<_>>(),
-            EncryptionOrChecksum::None => buffers,
+            PageTransform::None => buffers,
         };
         let c = self.file.pwritev(pos, buffers, c)?;
         Ok(c)
@@ -293,15 +494,303 @@ impl DatabaseFile {
     }
 }
 
-fn encrypt_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &EncryptionContext) -> Arc<Buffer> {
-    let encrypted_data = ctx.encrypt_page(buffer.as_slice(), page_idx).unwrap();
-    Arc::new(Buffer::new(encrypted_data.to_vec()))
+fn encode_buffer(
+    page_idx: usize,
+    buffer: Arc<Buffer>,
+    ctx: &dyn PageCodec,
+    location: PageCodecLocation,
+) -> Result<Arc<Buffer>> {
+    let encoded = Arc::new(Buffer::new_temporary(buffer.len()));
+    ctx.encode_page(
+        buffer.as_slice(),
+        encoded.as_mut_slice(),
+        page_idx,
+        location,
+    )?;
+    Ok(encoded)
+}
+
+fn encrypt_buffer(
+    page_idx: usize,
+    buffer: Arc<Buffer>,
+    ctx: &EncryptionContext,
+) -> Result<Arc<Buffer>> {
+    Ok(Arc::new(Buffer::new(
+        ctx.encrypt_page(buffer.as_slice(), page_idx)?,
+    )))
 }
 
 fn checksum_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &ChecksumContext) -> Arc<Buffer> {
     ctx.add_checksum_to_page(buffer.as_mut_slice(), page_idx)
         .unwrap();
     buffer
+}
+
+#[cfg(test)]
+mod page_codec_tests {
+    use super::*;
+    use crate::File;
+    use crate::{io::IO, MemoryIO};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug)]
+    struct XorPageCodec(u8);
+
+    impl PageCodec for XorPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"xor-page-codec--";
+            id[15] = self.0;
+            PageCodecId::new(id)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            for (input, output) in page.iter().zip(output) {
+                *output = input ^ self.0;
+            }
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            self.encode_page(page, output, _page_idx, _location)
+        }
+    }
+
+    #[derive(Debug)]
+    enum FailingPageCodec {
+        Encode,
+        Decode,
+    }
+
+    impl PageCodec for FailingPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"failing-page-cod";
+            id[15] = match self {
+                Self::Encode => 1,
+                Self::Decode => 2,
+            };
+            PageCodecId::new(id)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            match self {
+                Self::Encode => Err(LimboError::InternalError("codec encode failed".into())),
+                Self::Decode => {
+                    output.copy_from_slice(page);
+                    Ok(())
+                }
+            }
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            match self {
+                Self::Encode => {
+                    output.copy_from_slice(page);
+                    Ok(())
+                }
+                Self::Decode => Err(LimboError::InternalError("codec decode failed".into())),
+            }
+        }
+    }
+
+    struct MockFile {
+        read_result: std::result::Result<i32, CompletionError>,
+        writes_submitted: Arc<AtomicUsize>,
+    }
+
+    impl File for MockFile {
+        fn lock_file(&self, _exclusive: bool) -> Result<()> {
+            Ok(())
+        }
+
+        fn unlock_file(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn pread(&self, _pos: u64, c: Completion) -> Result<Completion> {
+            match self.read_result {
+                Ok(bytes_read) => c.complete(bytes_read),
+                Err(err) => c.error(err),
+            }
+            Ok(c)
+        }
+
+        fn pwrite(&self, _pos: u64, _buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
+            self.writes_submitted.fetch_add(1, Ordering::Relaxed);
+            c.complete(0);
+            Ok(c)
+        }
+
+        fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
+            c.complete(0);
+            Ok(c)
+        }
+
+        fn size(&self) -> Result<u64> {
+            Ok(0)
+        }
+
+        fn truncate(&self, _len: u64, c: Completion) -> Result<Completion> {
+            c.complete(0);
+            Ok(c)
+        }
+    }
+
+    #[test]
+    fn page_codec_encodes_into_fixed_size_database_buffer() {
+        let buffer = Arc::new(Buffer::new(vec![1, 2, 3, 4]));
+        let encoded =
+            encode_buffer(7, buffer, &XorPageCodec(0xa5), PageCodecLocation::Database).unwrap();
+        assert_eq!(encoded.as_slice(), &[0xa4, 0xa7, 0xa6, 0xa1]);
+    }
+
+    #[test]
+    fn page_codec_read_decodes_into_original_database_buffer() {
+        let db_file = DatabaseFile {
+            file: Arc::new(MockFile {
+                read_result: Ok(4096),
+                writes_submitted: Arc::new(AtomicUsize::new(0)),
+            }),
+        };
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(Arc::new(XorPageCodec(0xa5)));
+        let page_idx = 9usize;
+        let original = Completion::new_read(Arc::new(Buffer::new_temporary(4096)), |_res| None);
+
+        let wrapped = db_file
+            .read_page(page_idx, &io_ctx, original.clone())
+            .unwrap();
+        MemoryIO::new().wait_for_completion(wrapped).unwrap();
+        assert!(original.succeeded());
+        assert!(original
+            .as_read()
+            .buf()
+            .as_slice()
+            .iter()
+            .all(|byte| *byte == 0xa5));
+    }
+
+    #[test]
+    fn page_codec_zero_byte_read_reports_short_read() {
+        let db_file = DatabaseFile {
+            file: Arc::new(MockFile {
+                read_result: Ok(0),
+                writes_submitted: Arc::new(AtomicUsize::new(0)),
+            }),
+        };
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(Arc::new(XorPageCodec(0xa5)));
+        let page_idx = 9usize;
+        let original = Completion::new_read(Arc::new(Buffer::new_temporary(4096)), |_| None);
+
+        let wrapped = db_file
+            .read_page(page_idx, &io_ctx, original.clone())
+            .unwrap();
+        let err = MemoryIO::new()
+            .wait_for_completion(wrapped)
+            .expect_err("a zero-byte transformed page read must fail");
+        assert!(matches!(
+            err,
+            LimboError::CompletionError(CompletionError::ShortRead {
+                page_idx: 9,
+                expected: 4096,
+                actual: 0,
+            })
+        ));
+        assert!(matches!(
+            original.get_error(),
+            Some(CompletionError::ShortRead {
+                page_idx: 9,
+                expected: 4096,
+                actual: 0,
+            })
+        ));
+    }
+
+    #[test]
+    fn page_codec_database_write_error_does_not_submit_io() {
+        let writes_submitted = Arc::new(AtomicUsize::new(0));
+        let db_file = DatabaseFile {
+            file: Arc::new(MockFile {
+                read_result: Ok(0),
+                writes_submitted: writes_submitted.clone(),
+            }),
+        };
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(Arc::new(FailingPageCodec::Encode));
+
+        let err = db_file
+            .write_page(
+                1,
+                Arc::new(Buffer::new_temporary(512)),
+                &io_ctx,
+                Completion::new_write(|_| {}),
+            )
+            .unwrap_err();
+
+        assert!(err.to_string().contains("codec encode failed"));
+        assert_eq!(
+            writes_submitted.load(Ordering::Relaxed),
+            0,
+            "a codec error must prevent the database write from being submitted"
+        );
+    }
+
+    #[test]
+    fn page_codec_database_read_reports_decode_error() {
+        let db_file = DatabaseFile {
+            file: Arc::new(MockFile {
+                read_result: Ok(512),
+                writes_submitted: Arc::new(AtomicUsize::new(0)),
+            }),
+        };
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(Arc::new(FailingPageCodec::Decode));
+        let original = Completion::new_read(Arc::new(Buffer::new_temporary(512)), |_| None);
+
+        let wrapped = db_file.read_page(1, &io_ctx, original.clone()).unwrap();
+        let err = MemoryIO::new().wait_for_completion(wrapped).unwrap_err();
+
+        assert!(matches!(
+            err,
+            LimboError::CompletionError(CompletionError::PageCodecError { page_idx: 1 })
+        ));
+        assert!(matches!(
+            original.get_error(),
+            Some(CompletionError::PageCodecError { page_idx: 1 })
+        ));
+    }
 }
 
 #[cfg(all(test, feature = "checksum"))]

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -59,11 +59,11 @@ impl IOContext {
         self.encryption_context().is_some()
     }
 
-    pub(crate) fn has_page_codec(&self) -> bool {
+    pub(crate) fn has_external_page_codec(&self) -> bool {
         matches!(self.page_transform, PageTransform::Codec(_)) && !self.has_encryption()
     }
 
-    pub(crate) fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
+    pub(crate) fn page_codec_external(&self) -> Option<Arc<dyn PageCodec>> {
         match &self.page_transform {
             PageTransform::Codec(codec) if !self.has_encryption() => Some(codec.clone()),
             _ => None,

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -2,6 +2,10 @@ use crate::io::FileSyncType;
 use crate::storage::checksum::ChecksumContext;
 use crate::storage::encryption::EncryptionContext;
 use crate::storage::sqlite3_ondisk::PageSize;
+use crate::storage::page_transform::{
+    page_codec_completion_error, page_codec_encryption_context, page_codec_from_encryption,
+    PageCodec, PageCodecContext, PageLocation, PageTransform,
+};
 use crate::sync::Arc;
 use crate::{io::Completion, Buffer, CompletionError, LimboError, Result};
 use crate::{
@@ -9,103 +13,6 @@ use crate::{
     turso_assert_less_than_or_equal,
 };
 use tracing::{instrument, Level};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PageCodecHeaderInfo {
-    pub page_size: usize,
-    pub reserved_space: u8,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PageCodecLocation {
-    Database,
-    Wal,
-}
-
-/// A stable, non-secret identifier for a page codec configuration.
-///
-/// This identifies the transform configuration rather than the codec
-/// implementation. Callers must return the same value when reopening or
-/// sharing a database with an equivalent codec, and a different value for any
-/// codec that could transform pages differently. Do not include key material.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct PageCodecId([u8; 16]);
-
-impl PageCodecId {
-    pub const fn new(bytes: [u8; 16]) -> Self {
-        Self(bytes)
-    }
-}
-
-/// Converts complete SQLite page images between their on-disk and in-memory
-/// representations.
-///
-/// The engine supplies an output buffer exactly as large as the input page,
-/// enforcing SQLite's fixed page-size invariant without codec allocations.
-/// Codecs needing per-page metadata must store it in reserved bytes.
-///
-/// Codecs that support reopening initialized databases must implement
-/// [`Self::probe_header`]. The engine cannot safely decode an arbitrary
-/// full-page transform before it knows the physical page size.
-pub trait PageCodec: Send + Sync {
-    /// Returns a stable, non-secret identifier for this codec configuration.
-    ///
-    /// The identifier is retained by the shared [`crate::Database`] so every
-    /// connection and cached open for the same file uses an equivalent codec.
-    /// It must change whenever the codec could produce different on-disk bytes.
-    fn codec_id(&self) -> PageCodecId;
-
-    /// Reports page layout metadata from the raw prefix of page 1.
-    ///
-    /// Return `None` only when the codec cannot reopen initialized databases.
-    fn probe_header(&self, _raw_page1_prefix: &[u8]) -> Result<Option<PageCodecHeaderInfo>> {
-        Ok(None)
-    }
-
-    /// Returns the exact number of reserved bytes required in every page.
-    fn required_reserved_bytes(&self) -> u8;
-    fn encode_page(
-        &self,
-        page: &[u8],
-        output: &mut [u8],
-        page_idx: usize,
-        location: PageCodecLocation,
-    ) -> Result<()>;
-    fn decode_page(
-        &self,
-        page: &[u8],
-        output: &mut [u8],
-        page_idx: usize,
-        location: PageCodecLocation,
-    ) -> Result<()>;
-}
-
-#[derive(Clone)]
-/// Storage-layer operations applied to complete SQLite page images.
-///
-/// `Checksum` is separate because it only maintains and verifies bytes in the
-/// reserved page tail; it does not transform logical SQLite content.
-pub enum PageTransform {
-    Encryption(EncryptionContext),
-    PageCodec(Arc<dyn PageCodec>),
-    Checksum(ChecksumContext),
-    None,
-}
-
-#[deprecated(note = "renamed to PageTransform")]
-pub type EncryptionOrChecksum = PageTransform;
-
-impl std::fmt::Debug for PageTransform {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = match self {
-            Self::Encryption(_) => "Encryption",
-            Self::PageCodec(_) => "PageCodec",
-            Self::Checksum(_) => "Checksum",
-            Self::None => "None",
-        };
-        f.write_str(name)
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct IOContext {
@@ -115,61 +22,66 @@ pub struct IOContext {
 impl IOContext {
     pub fn encryption_context(&self) -> Option<&EncryptionContext> {
         match &self.page_transform {
-            PageTransform::Encryption(ctx) => Some(ctx),
+            PageTransform::Codec(codec) => page_codec_encryption_context(codec.as_ref()),
             _ => None,
         }
     }
 
     pub fn get_reserved_space_bytes(&self) -> u8 {
         match &self.page_transform {
-            PageTransform::Encryption(ctx) => ctx.required_reserved_bytes(),
-            PageTransform::PageCodec(ctx) => ctx.required_reserved_bytes(),
             PageTransform::Checksum(ctx) => ctx.required_reserved_bytes(),
+            PageTransform::Codec(ctx) => ctx.required_reserved_bytes(),
             PageTransform::None => Default::default(),
         }
     }
 
     pub fn set_encryption(&mut self, encryption_ctx: EncryptionContext) {
-        self.page_transform = PageTransform::Encryption(encryption_ctx);
+        self.page_transform = PageTransform::Codec(page_codec_from_encryption(encryption_ctx));
     }
 
     pub(crate) fn reset_page_size_in_encryption_ctx(&mut self, page_size: PageSize) {
-        if let PageTransform::Encryption(ctx) = &mut self.page_transform {
-            ctx.set_page_size(page_size);
-        }
+        let PageTransform::Codec(codec) = &mut self.page_transform else {
+            return;
+        };
+        let Some(encryption_ctx) = page_codec_encryption_context(codec.as_ref()) else {
+            return;
+        };
+        let mut encryption_ctx = encryption_ctx.clone();
+        encryption_ctx.set_page_size(page_size);
+        *codec = page_codec_from_encryption(encryption_ctx);
     }
 
-    pub fn set_page_codec(&mut self, codec: Arc<dyn PageCodec>) {
-        self.page_transform = PageTransform::PageCodec(codec);
+    pub(crate) fn set_page_codec(&mut self, codec: Arc<dyn PageCodec>) {
+        self.page_transform = PageTransform::Codec(codec);
     }
 
-    pub fn has_encryption(&self) -> bool {
-        matches!(self.page_transform, PageTransform::Encryption(_))
+    pub(crate) fn has_encryption(&self) -> bool {
+        self.encryption_context().is_some()
     }
 
-    pub fn has_page_codec(&self) -> bool {
-        matches!(self.page_transform, PageTransform::PageCodec(_))
+    pub(crate) fn has_page_codec(&self) -> bool {
+        matches!(self.page_transform, PageTransform::Codec(_)) && !self.has_encryption()
     }
 
-    pub fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
+    pub(crate) fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
         match &self.page_transform {
-            PageTransform::PageCodec(codec) => Some(codec.clone()),
+            PageTransform::Codec(codec) if !self.has_encryption() => Some(codec.clone()),
             _ => None,
         }
     }
 
-    pub fn page_transform(&self) -> &PageTransform {
+    pub(crate) fn page_transform(&self) -> &PageTransform {
         &self.page_transform
     }
 
-    #[deprecated(note = "renamed to page_transform")]
-    #[allow(deprecated)]
-    pub fn encryption_or_checksum(&self) -> &EncryptionOrChecksum {
-        self.page_transform()
+    pub fn has_transform(&self) -> bool {
+        !matches!(self.page_transform, PageTransform::None)
     }
 
     pub fn reset_checksum(&mut self) {
-        self.page_transform = PageTransform::None;
+        if matches!(self.page_transform, PageTransform::Checksum(_)) {
+            self.page_transform = PageTransform::None;
+        }
     }
 }
 
@@ -189,6 +101,11 @@ impl Default for IOContext {
 /// the storage medium. A database can either be a file on disk, like in SQLite,
 /// or something like a remote page server service.
 pub trait DatabaseStorage: Send + Sync {
+    /// Reads the encoded prefix of page 1 without applying a page transform.
+    ///
+    /// This is only for bootstrapping the page layout before a complete page
+    /// can be read and decoded. Callers that need logical page-1 contents must
+    /// use [`DatabaseStorage::read_page`].
     fn read_header(&self, c: Completion) -> Result<Completion>;
 
     fn read_page(&self, page_idx: usize, io_ctx: &IOContext, c: Completion) -> Result<Completion>;
@@ -238,66 +155,14 @@ impl DatabaseStorage for DatabaseFile {
             return Err(LimboError::IntegerOverflow);
         };
 
-        match &io_ctx.page_transform {
-            PageTransform::Encryption(ctx) => {
-                let encryption_ctx = ctx.clone();
-                let read_buffer = r.buf_arc();
-                let original_c = c.clone();
-                let decrypt_complete =
-                    Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
-                        let (buf, bytes_read) = match res {
-                            Ok((buf, bytes_read)) => (buf, bytes_read),
-                            Err(err) => {
-                                tracing::error!(err = ?err);
-                                original_c.error(err);
-                                return original_c.get_error();
-                            }
-                        };
-                        if bytes_read == 0 {
-                            original_c.error(CompletionError::ShortRead {
-                                page_idx,
-                                expected: buf.len(),
-                                actual: 0,
-                            });
-                            return original_c.get_error();
-                        }
-                        turso_assert_greater_than!(
-                            bytes_read,
-                            0,
-                            "database: expected positive bytes for encrypted page",
-                            { "page_idx": page_idx }
-                        );
-                        if bytes_read as usize != buf.len() {
-                            original_c.complete(bytes_read);
-                            return original_c.get_error();
-                        }
-                        let original_buf = original_c.as_read().buf();
-                        match encryption_ctx.decrypt_page(buf.as_slice(), page_idx) {
-                            Ok(decrypted) => {
-                                original_buf.as_mut_slice().copy_from_slice(&decrypted);
-                                original_c.complete(bytes_read);
-                                original_c.get_error()
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to decrypt page data for page_id={page_idx}: {e}"
-                                );
-                                turso_assert!(
-                                    !original_c.failed(),
-                                    "Original completion already has an error"
-                                );
-                                original_c.error(CompletionError::DecryptionError { page_idx });
-                                original_c.get_error()
-                            }
-                        }
-                    });
-                let wrapped_completion = Completion::new_read(read_buffer, decrypt_complete);
-                self.file.pread(pos, wrapped_completion)
-            }
-            PageTransform::PageCodec(ctx) => {
+        match io_ctx.page_transform() {
+            PageTransform::Codec(ctx) => {
                 let page_codec = ctx.clone();
+                // TODO(v): support in-place codec decoding to avoid this extra page buffer.
                 let read_buffer = Arc::new(Buffer::new_temporary(r.buf_arc().len()));
                 let original_c = c;
+                let codec_context =
+                    PageCodecContext::from_page_idx(page_idx, PageLocation::Database)?;
                 let decode_complete =
                     Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
                         let (buf, bytes_read) = match res {
@@ -328,10 +193,9 @@ impl DatabaseStorage for DatabaseFile {
                         }
                         let original_buf = original_c.as_read().buf();
                         match page_codec.decode_page(
+                            codec_context,
                             buf.as_slice(),
                             original_buf.as_mut_slice(),
-                            page_idx,
-                            PageCodecLocation::Database,
                         ) {
                             Ok(()) => {
                                 original_c.complete(bytes_read);
@@ -345,7 +209,10 @@ impl DatabaseStorage for DatabaseFile {
                                     !original_c.failed(),
                                     "Original completion already has an error"
                                 );
-                                original_c.error(CompletionError::PageCodecError { page_idx });
+                                original_c.error(page_codec_completion_error(
+                                    page_codec.as_ref(),
+                                    page_idx,
+                                ));
                                 original_c.get_error()
                             }
                         }
@@ -414,10 +281,9 @@ impl DatabaseStorage for DatabaseFile {
         let Some(pos) = (page_idx as u64 - 1).checked_mul(buffer_size as u64) else {
             return Err(LimboError::IntegerOverflow);
         };
-        let buffer = match &io_ctx.page_transform {
-            PageTransform::Encryption(ctx) => encrypt_buffer(page_idx, buffer, ctx)?,
-            PageTransform::PageCodec(ctx) => {
-                encode_buffer(page_idx, buffer, ctx.as_ref(), PageCodecLocation::Database)?
+        let buffer = match io_ctx.page_transform() {
+            PageTransform::Codec(ctx) => {
+                encode_buffer(page_idx, buffer, ctx.as_ref(), PageLocation::Database)?
             }
             PageTransform::Checksum(ctx) => checksum_buffer(page_idx, buffer, ctx),
             PageTransform::None => buffer,
@@ -441,13 +307,8 @@ impl DatabaseStorage for DatabaseFile {
         let Some(pos) = (first_page_idx as u64 - 1).checked_mul(page_size as u64) else {
             return Err(LimboError::IntegerOverflow);
         };
-        let buffers = match &io_ctx.page_transform() {
-            PageTransform::Encryption(ctx) => buffers
-                .into_iter()
-                .enumerate()
-                .map(|(i, buffer)| encrypt_buffer(first_page_idx + i, buffer, ctx))
-                .collect::<Result<Vec<_>>>()?,
-            PageTransform::PageCodec(ctx) => buffers
+        let buffers = match io_ctx.page_transform() {
+            PageTransform::Codec(ctx) => buffers
                 .into_iter()
                 .enumerate()
                 .map(|(i, buffer)| {
@@ -455,7 +316,7 @@ impl DatabaseStorage for DatabaseFile {
                         first_page_idx + i,
                         buffer,
                         ctx.as_ref(),
-                        PageCodecLocation::Database,
+                        PageLocation::Database,
                     )
                 })
                 .collect::<Result<Vec<_>>>()?,
@@ -498,26 +359,12 @@ fn encode_buffer(
     page_idx: usize,
     buffer: Arc<Buffer>,
     ctx: &dyn PageCodec,
-    location: PageCodecLocation,
+    location: PageLocation,
 ) -> Result<Arc<Buffer>> {
     let encoded = Arc::new(Buffer::new_temporary(buffer.len()));
-    ctx.encode_page(
-        buffer.as_slice(),
-        encoded.as_mut_slice(),
-        page_idx,
-        location,
-    )?;
+    let context = PageCodecContext::from_page_idx(page_idx, location)?;
+    ctx.encode_page(context, buffer.as_slice(), encoded.as_mut_slice())?;
     Ok(encoded)
-}
-
-fn encrypt_buffer(
-    page_idx: usize,
-    buffer: Arc<Buffer>,
-    ctx: &EncryptionContext,
-) -> Result<Arc<Buffer>> {
-    Ok(Arc::new(Buffer::new(
-        ctx.encrypt_page(buffer.as_slice(), page_idx)?,
-    )))
 }
 
 fn checksum_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &ChecksumContext) -> Arc<Buffer> {
@@ -529,6 +376,7 @@ fn checksum_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &ChecksumContext) 
 #[cfg(test)]
 mod page_codec_tests {
     use super::*;
+    use crate::storage::page_transform::PageCodecId;
     use crate::File;
     use crate::{io::IO, MemoryIO};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -549,12 +397,12 @@ mod page_codec_tests {
 
         fn encode_page(
             &self,
-            page: &[u8],
+            context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> Result<()> {
-            for (input, output) in page.iter().zip(output) {
+            let _ = context;
+            for (input, output) in input.iter().zip(output) {
                 *output = input ^ self.0;
             }
             Ok(())
@@ -562,12 +410,11 @@ mod page_codec_tests {
 
         fn decode_page(
             &self,
-            page: &[u8],
+            context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> Result<()> {
-            self.encode_page(page, output, _page_idx, _location)
+            self.encode_page(context, input, output)
         }
     }
 
@@ -593,15 +440,14 @@ mod page_codec_tests {
 
         fn encode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> Result<()> {
             match self {
                 Self::Encode => Err(LimboError::InternalError("codec encode failed".into())),
                 Self::Decode => {
-                    output.copy_from_slice(page);
+                    output.copy_from_slice(input);
                     Ok(())
                 }
             }
@@ -609,14 +455,13 @@ mod page_codec_tests {
 
         fn decode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> Result<()> {
             match self {
                 Self::Encode => {
-                    output.copy_from_slice(page);
+                    output.copy_from_slice(input);
                     Ok(())
                 }
                 Self::Decode => Err(LimboError::InternalError("codec decode failed".into())),
@@ -671,7 +516,7 @@ mod page_codec_tests {
     fn page_codec_encodes_into_fixed_size_database_buffer() {
         let buffer = Arc::new(Buffer::new(vec![1, 2, 3, 4]));
         let encoded =
-            encode_buffer(7, buffer, &XorPageCodec(0xa5), PageCodecLocation::Database).unwrap();
+            encode_buffer(7, buffer, &XorPageCodec(0xa5), PageLocation::Database).unwrap();
         assert_eq!(encoded.as_slice(), &[0xa4, 0xa7, 0xa6, 0xa1]);
     }
 

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -17,6 +17,7 @@ pub mod database;
 pub(crate) mod encryption;
 pub(crate) mod journal_mode;
 pub(crate) mod page_cache;
+pub(crate) mod page_transform;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;
 #[cfg(host_shared_wal)]

--- a/core/storage/page_transform.rs
+++ b/core/storage/page_transform.rs
@@ -1,0 +1,217 @@
+use std::any::Any;
+
+use crate::storage::checksum::ChecksumContext;
+use crate::storage::encryption::EncryptionContext;
+use crate::sync::Arc;
+use crate::{CompletionError, LimboError, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageCodecHeaderInfo {
+    pub page_size: usize,
+    pub reserved_space: u8,
+}
+
+impl PageCodecHeaderInfo {
+    const SQLITE_BOOTSTRAP_HEADER_LEN: usize = 21;
+
+    /// Reads the SQLite page-layout fields that must remain visible before page
+    /// 1 can be decoded. Codecs that transform these bytes must override
+    /// [`PageCodec::bootstrap_page_info`].
+    pub fn from_visible_sqlite_header(raw_page1_prefix: &[u8]) -> Result<Self> {
+        if raw_page1_prefix.len() < Self::SQLITE_BOOTSTRAP_HEADER_LEN {
+            return Err(LimboError::InvalidArgument(format!(
+                "page codec bootstrap requires at least {} bytes, got {}",
+                Self::SQLITE_BOOTSTRAP_HEADER_LEN,
+                raw_page1_prefix.len()
+            )));
+        }
+        // SQLite stores the two-byte page size at offsets 16..18 and the
+        // per-page reserved-space byte at offset 20.
+        let raw_page_size =
+            u16::from_be_bytes(raw_page1_prefix[16..18].try_into().expect("two bytes"));
+        let page_size = if raw_page_size == 1 {
+            65_536
+        } else {
+            usize::from(raw_page_size)
+        };
+        Ok(Self {
+            page_size,
+            reserved_space: raw_page1_prefix[20],
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageLocation {
+    Database,
+    Wal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageCodecContext {
+    /// One-based SQLite page number.
+    pub page_no: u32,
+    pub location: PageLocation,
+}
+
+impl PageCodecContext {
+    pub const fn new(page_no: u32, location: PageLocation) -> Self {
+        Self { page_no, location }
+    }
+
+    pub(crate) fn from_page_idx(page_idx: usize, location: PageLocation) -> Result<Self> {
+        let page_no = u32::try_from(page_idx).map_err(|_| LimboError::IntegerOverflow)?;
+        Ok(Self::new(page_no, location))
+    }
+}
+
+/// A stable, non-secret identifier for a page codec configuration.
+///
+/// This identifies the transform configuration rather than the codec
+/// implementation. Callers must return the same value when reopening or
+/// sharing a database with an equivalent codec, and a different value for any
+/// codec that could transform pages differently. Do not include any secrets or confidential
+/// info in the PageCodecId.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PageCodecId([u8; 16]);
+
+impl PageCodecId {
+    pub const fn new(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Converts complete SQLite page images between their on-disk and in-memory
+/// representations.
+///
+/// The engine supplies an output buffer exactly as large as the input page,
+/// enforcing SQLite's fixed page-size invariant without codec allocations.
+/// Codecs needing per-page metadata must store it in reserved bytes.
+///
+/// Before decoding page 1, the engine uses [`Self::bootstrap_page_info`] to
+/// discover the physical page size and reserved space.
+pub trait PageCodec: Any + Send + Sync {
+    /// Returns a stable, non-secret identifier for this codec configuration.
+    ///
+    /// The identifier is retained by the shared [`crate::Database`] so every
+    /// connection and cached open for the same file uses an equivalent codec.
+    /// It must change whenever the codec could produce different on-disk bytes.
+    fn codec_id(&self) -> PageCodecId;
+
+    /// Reports page layout metadata from the encoded prefix of page 1.
+    ///
+    /// The default requires the SQLite page-size and reserved-space fields at
+    /// bytes 16..18 and 20 to remain visible. Codecs such as SQLCipher that
+    /// transform those fields must recover the values themselves.
+    fn bootstrap_page_info(&self, raw_page1_prefix: &[u8]) -> Result<PageCodecHeaderInfo> {
+        PageCodecHeaderInfo::from_visible_sqlite_header(raw_page1_prefix)
+    }
+
+    /// Returns the exact number of reserved bytes required in every page.
+    fn required_reserved_bytes(&self) -> u8;
+    fn encode_page(&self, context: PageCodecContext, input: &[u8], output: &mut [u8])
+        -> Result<()>;
+    fn decode_page(&self, context: PageCodecContext, input: &[u8], output: &mut [u8])
+        -> Result<()>;
+}
+
+impl dyn PageCodec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    pub(crate) fn is_builtin_encryption(&self) -> bool {
+        self.as_any().is::<EncryptionPageCodec>()
+    }
+}
+
+pub(crate) fn page_codec_from_encryption(context: EncryptionContext) -> Arc<dyn PageCodec> {
+    Arc::new(EncryptionPageCodec::new(context))
+}
+
+pub(crate) fn page_codec_encryption_context(codec: &dyn PageCodec) -> Option<&EncryptionContext> {
+    codec
+        .as_any()
+        .downcast_ref::<EncryptionPageCodec>()
+        .map(|codec| &codec.context)
+}
+
+pub(crate) fn page_codec_completion_error(
+    codec: &dyn PageCodec,
+    page_idx: usize,
+) -> CompletionError {
+    if codec.is_builtin_encryption() {
+        CompletionError::DecryptionError { page_idx }
+    } else {
+        CompletionError::PageCodecError { page_idx }
+    }
+}
+
+struct EncryptionPageCodec {
+    context: EncryptionContext,
+}
+
+impl EncryptionPageCodec {
+    fn new(context: EncryptionContext) -> Self {
+        Self { context }
+    }
+}
+
+impl PageCodec for EncryptionPageCodec {
+    fn codec_id(&self) -> PageCodecId {
+        let mut id = *b"turso-encrypt-v0";
+        id[15] = self.context.cipher_mode().cipher_id();
+        PageCodecId::new(id)
+    }
+
+    fn required_reserved_bytes(&self) -> u8 {
+        self.context.required_reserved_bytes()
+    }
+
+    fn encode_page(
+        &self,
+        context: PageCodecContext,
+        input: &[u8],
+        output: &mut [u8],
+    ) -> Result<()> {
+        // todo(v): once we have in place encryption, we can avoid allocations here
+        let encrypted = self.context.encrypt_page(input, context.page_no as usize)?;
+        output.copy_from_slice(&encrypted);
+        Ok(())
+    }
+
+    fn decode_page(
+        &self,
+        context: PageCodecContext,
+        input: &[u8],
+        output: &mut [u8],
+    ) -> Result<()> {
+        // todo(v): once we have in place encryption, we can avoid allocations here
+        let decrypted = self.context.decrypt_page(input, context.page_no as usize)?;
+        output.copy_from_slice(&decrypted);
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+/// Storage-layer operations applied to complete SQLite page images.
+///
+/// `Checksum` is separate because it only maintains and verifies bytes in the
+/// reserved page tail; it does not transform logical SQLite content.
+pub(crate) enum PageTransform {
+    #[cfg_attr(not(feature = "checksum"), allow(dead_code))]
+    Checksum(ChecksumContext),
+    Codec(Arc<dyn PageCodec>),
+    None,
+}
+
+impl std::fmt::Debug for PageTransform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Checksum(_) => "Checksum",
+            Self::Codec(_) => "Codec",
+            Self::None => "None",
+        };
+        f.write_str(name)
+    }
+}

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2778,16 +2778,16 @@ impl Pager {
     /// Set the initial page size for the database. Should only be called before the database is initialized
     pub fn set_initial_page_size(&self, size: PageSize) -> Result<()> {
         turso_assert!(!self.db_initialized());
-        let reserved_space = self
-            .get_reserved_space()
-            .unwrap_or_else(|| self.io_ctx.read().get_reserved_space_bytes());
-        if !size.has_valid_reserved_space(reserved_space) {
-            return Err(LimboError::InvalidArgument(format!(
-                "page size {} with reserved space {} leaves less than {} usable bytes",
-                size.get(),
-                reserved_space,
-                PageSize::MIN_USABLE_SPACE
-            )));
+        if let Some(codec) = self.page_codec() {
+            let reserved_space = codec.required_reserved_bytes();
+            if !size.has_valid_reserved_space(reserved_space) {
+                return Err(LimboError::InvalidArgument(format!(
+                    "page size {} with reserved space {} leaves less than {} usable bytes",
+                    size.get(),
+                    reserved_space,
+                    PageSize::MIN_USABLE_SPACE
+                )));
+            }
         }
         let IOResult::Done(mut header) = self.with_header(|header| *header)? else {
             panic!("DB should not be initialized and should not do any IO");
@@ -2884,7 +2884,7 @@ impl Pager {
     }
 
     /// Set the page size. Used internally when page size is determined.
-    pub(crate) fn set_page_size(&self, size: PageSize) {
+    pub fn set_page_size(&self, size: PageSize) {
         self.page_size.store(size.get(), Ordering::SeqCst);
     }
 
@@ -2899,7 +2899,7 @@ impl Pager {
     }
 
     /// Set the reserved space. Must fit in u8.
-    fn set_reserved_space(&self, space: u8) {
+    pub fn set_reserved_space(&self, space: u8) {
         self.reserved_space.store(space as u16, Ordering::SeqCst);
     }
 
@@ -4576,13 +4576,19 @@ impl Pager {
                 CheckpointMode::Restart | CheckpointMode::Truncate { .. }
             )
         {
+            if self.has_page_codec() {
+                // External codecs are restricted to in-process WAL, whose
+                // backfill publication does not install a durable proof.
+                return CheckpointPhase::PublishBackfill {
+                    clear_page_cache,
+                    max_frame: result.wal_total_backfilled,
+                };
+            }
             return CheckpointPhase::ReadDbIdentity {
                 clear_page_cache,
                 read: PendingCheckpointDbIdentityRead {
                     max_frame: result.wal_total_backfilled,
-                    header_buf: Arc::new(Buffer::new_temporary(
-                        self.get_page_size_unchecked().get() as usize,
-                    )),
+                    header_buf: Arc::new(Buffer::new_temporary(PageSize::MIN as usize)),
                     bytes_read: Arc::new(AtomicUsize::new(usize::MAX)),
                     read_sent: false,
                 },
@@ -4813,19 +4819,14 @@ impl Pager {
                     if !read.read_sent {
                         let header_buf = read.header_buf.clone();
                         let bytes_read = read.bytes_read.clone();
-                        let io_ctx = self.io_ctx.read();
-                        let c = self.db_file.read_page(
-                            1,
-                            &io_ctx,
-                            Completion::new_read(header_buf, {
-                                Box::new(move |res| {
-                                    if let Ok((_buf, count)) = res {
-                                        bytes_read.store(count as usize, Ordering::Release);
-                                    }
-                                    None
-                                })
-                            }),
-                        )?;
+                        let c = self.db_file.read_header(Completion::new_read(header_buf, {
+                            Box::new(move |res| {
+                                if let Ok((_buf, count)) = res {
+                                    bytes_read.store(count as usize, Ordering::Release);
+                                }
+                                None
+                            })
+                        }))?;
                         read.read_sent = true;
                         self.checkpoint_state.write().phase = CheckpointPhase::ReadDbIdentity {
                             clear_page_cache,
@@ -5693,22 +5694,15 @@ impl Pager {
         Ok(IOResult::Done(result))
     }
 
-    pub fn has_encryption(&self) -> bool {
-        self.io_ctx.read().has_encryption()
+    pub fn is_encryption_ctx_set(&self) -> bool {
+        self.io_ctx.read().encryption_context().is_some()
     }
 
-    pub fn encryption_reserved_space(&self) -> Option<u8> {
-        self.io_ctx
-            .read()
-            .encryption_context()
-            .map(EncryptionContext::required_reserved_bytes)
-    }
-
-    pub fn has_page_codec(&self) -> bool {
+    pub(crate) fn has_page_codec(&self) -> bool {
         self.io_ctx.read().has_page_codec()
     }
 
-    pub fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
+    pub(crate) fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
         self.io_ctx.read().page_codec()
     }
 
@@ -5756,7 +5750,7 @@ impl Pager {
     }
 
     pub(crate) fn set_page_codec(&self, codec: Arc<dyn PageCodec>) -> Result<()> {
-        if self.has_encryption() {
+        if self.is_encryption_ctx_set() {
             return Err(LimboError::InvalidArgument(
                 "cannot install an external page codec while built-in encryption is configured"
                     .into(),
@@ -5804,7 +5798,7 @@ impl Pager {
         wal.set_io_context(self.io_ctx.read().clone())
     }
 
-    pub(crate) fn set_reserved_space_bytes(&self, value: u8) {
+    pub fn set_reserved_space_bytes(&self, value: u8) {
         self.set_reserved_space(value);
     }
 
@@ -6644,9 +6638,7 @@ mod ptrmap_tests {
 #[cfg(all(test, feature = "fs", host_shared_wal))]
 mod checkpoint_phase_tests {
     use super::*;
-    #[cfg(not(all(target_os = "windows", feature = "experimental_win_iocp")))]
-    use crate::io::PlatformIO;
-    use crate::io::IO;
+    use crate::io::{PlatformIO, IO};
     use crate::storage::sqlite3_ondisk::DatabaseHeader;
     use crate::storage::wal::CheckpointMode;
     use crate::sync::atomic::Ordering;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -27,7 +27,7 @@ use crate::{
     io::CompletionGroup, return_if_io, types::WalFrameInfo, Completion, Connection, IOResult,
     LimboError, Result, TransactionState,
 };
-use crate::{io_yield_one, Buffer, CompletionError, IOContext, OpenFlags, SyncMode, IO};
+use crate::{io_yield_one, Buffer, CompletionError, IOContext, OpenFlags, PageCodec, SyncMode, IO};
 #[allow(unused_imports)]
 use crate::{
     turso_assert, turso_assert_eq, turso_assert_greater_than, turso_assert_greater_than_or_equal,
@@ -2778,6 +2778,17 @@ impl Pager {
     /// Set the initial page size for the database. Should only be called before the database is initialized
     pub fn set_initial_page_size(&self, size: PageSize) -> Result<()> {
         turso_assert!(!self.db_initialized());
+        let reserved_space = self
+            .get_reserved_space()
+            .unwrap_or_else(|| self.io_ctx.read().get_reserved_space_bytes());
+        if !size.has_valid_reserved_space(reserved_space) {
+            return Err(LimboError::InvalidArgument(format!(
+                "page size {} with reserved space {} leaves less than {} usable bytes",
+                size.get(),
+                reserved_space,
+                PageSize::MIN_USABLE_SPACE
+            )));
+        }
         let IOResult::Done(mut header) = self.with_header(|header| *header)? else {
             panic!("DB should not be initialized and should not do any IO");
         };
@@ -2873,7 +2884,7 @@ impl Pager {
     }
 
     /// Set the page size. Used internally when page size is determined.
-    pub fn set_page_size(&self, size: PageSize) {
+    pub(crate) fn set_page_size(&self, size: PageSize) {
         self.page_size.store(size.get(), Ordering::SeqCst);
     }
 
@@ -2888,7 +2899,7 @@ impl Pager {
     }
 
     /// Set the reserved space. Must fit in u8.
-    pub fn set_reserved_space(&self, space: u8) {
+    fn set_reserved_space(&self, space: u8) {
         self.reserved_space.store(space as u16, Ordering::SeqCst);
     }
 
@@ -3710,6 +3721,12 @@ impl Pager {
         completion: Completion,
     ) -> Result<CacheFlushStep> {
         if !completion.succeeded() {
+            if completion.finished() {
+                let err = completion
+                    .get_error()
+                    .expect("finished unsuccessful cacheflush read must have an error");
+                return Err(err.into());
+            }
             return Ok(CacheFlushStep::Yield(
                 CacheFlushState::WaitingForRead {
                     state,
@@ -4563,7 +4580,9 @@ impl Pager {
                 clear_page_cache,
                 read: PendingCheckpointDbIdentityRead {
                     max_frame: result.wal_total_backfilled,
-                    header_buf: Arc::new(Buffer::new_temporary(PageSize::MIN as usize)),
+                    header_buf: Arc::new(Buffer::new_temporary(
+                        self.get_page_size_unchecked().get() as usize,
+                    )),
                     bytes_read: Arc::new(AtomicUsize::new(usize::MAX)),
                     read_sent: false,
                 },
@@ -4794,14 +4813,19 @@ impl Pager {
                     if !read.read_sent {
                         let header_buf = read.header_buf.clone();
                         let bytes_read = read.bytes_read.clone();
-                        let c = self.db_file.read_header(Completion::new_read(header_buf, {
-                            Box::new(move |res| {
-                                if let Ok((_buf, count)) = res {
-                                    bytes_read.store(count as usize, Ordering::Release);
-                                }
-                                None
-                            })
-                        }))?;
+                        let io_ctx = self.io_ctx.read();
+                        let c = self.db_file.read_page(
+                            1,
+                            &io_ctx,
+                            Completion::new_read(header_buf, {
+                                Box::new(move |res| {
+                                    if let Ok((_buf, count)) = res {
+                                        bytes_read.store(count as usize, Ordering::Release);
+                                    }
+                                    None
+                                })
+                            }),
+                        )?;
                         read.read_sent = true;
                         self.checkpoint_state.write().phase = CheckpointPhase::ReadDbIdentity {
                             clear_page_cache,
@@ -5669,8 +5693,23 @@ impl Pager {
         Ok(IOResult::Done(result))
     }
 
-    pub fn is_encryption_ctx_set(&self) -> bool {
-        self.io_ctx.read().encryption_context().is_some()
+    pub fn has_encryption(&self) -> bool {
+        self.io_ctx.read().has_encryption()
+    }
+
+    pub fn encryption_reserved_space(&self) -> Option<u8> {
+        self.io_ctx
+            .read()
+            .encryption_context()
+            .map(EncryptionContext::required_reserved_bytes)
+    }
+
+    pub fn has_page_codec(&self) -> bool {
+        self.io_ctx.read().has_page_codec()
+    }
+
+    pub fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
+        self.io_ctx.read().page_codec()
     }
 
     pub fn is_encryption_enabled(&self) -> bool {
@@ -5686,6 +5725,12 @@ impl Pager {
         if !self.enable_encryption.load(Ordering::SeqCst) {
             return Err(LimboError::InvalidArgument(
                 "encryption is an opt in feature. enable it via passing `--experimental-encryption`"
+                    .into(),
+            ));
+        }
+        if self.has_page_codec() {
+            return Err(LimboError::InvalidArgument(
+                "cannot configure built-in encryption while an external page codec is installed"
                     .into(),
             ));
         }
@@ -5710,6 +5755,46 @@ impl Pager {
         Ok(())
     }
 
+    pub(crate) fn set_page_codec(&self, codec: Arc<dyn PageCodec>) -> Result<()> {
+        if self.has_encryption() {
+            return Err(LimboError::InvalidArgument(
+                "cannot install an external page codec while built-in encryption is configured"
+                    .into(),
+            ));
+        }
+        let required_reserved_space = codec.required_reserved_bytes();
+        if let Some(reserved_space) = self.get_reserved_space() {
+            if reserved_space != required_reserved_space {
+                return Err(LimboError::InvalidArgument(format!(
+                    "page codec requires exactly {required_reserved_space} reserved bytes, but database provides {reserved_space}"
+                )));
+            }
+        } else {
+            if let Some(page_size) = self.get_page_size() {
+                if !page_size.has_valid_reserved_space(required_reserved_space) {
+                    return Err(LimboError::InvalidArgument(format!(
+                        "page codec requires {} reserved bytes, which leaves less than {} usable bytes for page size {}",
+                        required_reserved_space,
+                        PageSize::MIN_USABLE_SPACE,
+                        page_size.get()
+                    )));
+                }
+            }
+            self.set_reserved_space(required_reserved_space);
+        }
+        {
+            let mut io_ctx = self.io_ctx.write();
+            io_ctx.set_page_codec(codec);
+        }
+        if let Some(wal) = self.wal.as_ref() {
+            let io_ctx = self.io_ctx.read().clone();
+            wal.set_io_context(io_ctx);
+        }
+        self.clear_page_cache(false);
+        self.set_schema_cookie(None);
+        Ok(())
+    }
+
     pub fn reset_checksum_context(&self) {
         {
             let mut io_ctx = self.io_ctx.write();
@@ -5719,7 +5804,7 @@ impl Pager {
         wal.set_io_context(self.io_ctx.read().clone())
     }
 
-    pub fn set_reserved_space_bytes(&self, value: u8) {
+    pub(crate) fn set_reserved_space_bytes(&self, value: u8) {
         self.set_reserved_space(value);
     }
 
@@ -5993,7 +6078,8 @@ mod tests {
     use crate::util::IOExt;
     use arc_swap::ArcSwapOption;
 
-    use super::{default_page1, Page, PageRef, Pager};
+    use super::{default_page1, CacheFlushState, CollectingState, Page, PageRef, Pager};
+    use crate::{Buffer, Completion, CompletionError, LimboError};
 
     fn pager_with_cache_capacity(cache_capacity: usize, database_pages: u32) -> Arc<Pager> {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
@@ -6102,6 +6188,32 @@ mod tests {
             pager.page_cache.read().len() > CAP,
             "page must have been admitted over capacity"
         );
+    }
+
+    #[test]
+    fn cacheflush_propagates_failed_page_codec_reread() {
+        let pager = pager_with_cache_capacity(5, 2);
+        let page = Arc::new(Page::new(2));
+        page.set_loaded();
+        let completion =
+            Completion::new_read(Arc::new(Buffer::new_temporary(4096)), Box::new(|_| None));
+        completion.error(CompletionError::PageCodecError { page_idx: 2 });
+        *pager.cacheflush_state.write() = CacheFlushState::WaitingForRead {
+            state: CollectingState::default(),
+            page_id: 2,
+            page,
+            completion,
+        };
+
+        let err = pager.cacheflush().unwrap_err();
+        assert!(matches!(
+            err,
+            LimboError::CompletionError(CompletionError::PageCodecError { page_idx: 2 })
+        ));
+        assert!(matches!(
+            *pager.cacheflush_state.read(),
+            CacheFlushState::Init
+        ));
     }
 
     #[test]
@@ -6532,7 +6644,9 @@ mod ptrmap_tests {
 #[cfg(all(test, feature = "fs", host_shared_wal))]
 mod checkpoint_phase_tests {
     use super::*;
-    use crate::io::{PlatformIO, IO};
+    #[cfg(not(all(target_os = "windows", feature = "experimental_win_iocp")))]
+    use crate::io::PlatformIO;
+    use crate::io::IO;
     use crate::storage::sqlite3_ondisk::DatabaseHeader;
     use crate::storage::wal::CheckpointMode;
     use crate::sync::atomic::Ordering;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1044,7 +1044,8 @@ struct PendingCheckpointDbIdentityRead {
     max_frame: u64,
     header_buf: Arc<Buffer>,
     bytes_read: Arc<AtomicUsize>,
-    read_sent: bool,
+    read_page: bool,
+    completion: Option<Completion>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -4576,21 +4577,22 @@ impl Pager {
                 CheckpointMode::Restart | CheckpointMode::Truncate { .. }
             )
         {
-            if self.has_page_codec() {
-                // External codecs are restricted to in-process WAL, whose
-                // backfill publication does not install a durable proof.
-                return CheckpointPhase::PublishBackfill {
-                    clear_page_cache,
-                    max_frame: result.wal_total_backfilled,
-                };
-            }
+            // if we are using a custom codec, then we might have to read the whole page 1 so that
+            // it can be decoded. Otherwise reading the header is enough.
+            let read_page = self.io_ctx.read().has_codec_transform();
+            let read_size = if read_page {
+                self.get_page_size_unchecked().get() as usize
+            } else {
+                PageSize::MIN as usize
+            };
             return CheckpointPhase::ReadDbIdentity {
                 clear_page_cache,
                 read: PendingCheckpointDbIdentityRead {
                     max_frame: result.wal_total_backfilled,
-                    header_buf: Arc::new(Buffer::new_temporary(PageSize::MIN as usize)),
+                    header_buf: Arc::new(Buffer::new_temporary(read_size)),
                     bytes_read: Arc::new(AtomicUsize::new(usize::MAX)),
-                    read_sent: false,
+                    read_page,
+                    completion: None,
                 },
             };
         }
@@ -4816,18 +4818,27 @@ impl Pager {
                     clear_page_cache,
                     mut read,
                 } => {
-                    if !read.read_sent {
+                    if read.completion.is_none() {
                         let header_buf = read.header_buf.clone();
                         let bytes_read = read.bytes_read.clone();
-                        let c = self.db_file.read_header(Completion::new_read(header_buf, {
+                        let completion = Completion::new_read(header_buf, {
                             Box::new(move |res| {
                                 if let Ok((_buf, count)) = res {
                                     bytes_read.store(count as usize, Ordering::Release);
                                 }
                                 None
                             })
-                        }))?;
-                        read.read_sent = true;
+                        });
+                        let c = if read.read_page {
+                            self.db_file.read_page(
+                                DatabaseHeader::PAGE_ID,
+                                &self.io_ctx.read(),
+                                completion,
+                            )?
+                        } else {
+                            self.db_file.read_header(completion)?
+                        };
+                        read.completion = Some(c.clone());
                         self.checkpoint_state.write().phase = CheckpointPhase::ReadDbIdentity {
                             clear_page_cache,
                             read,
@@ -4835,7 +4846,32 @@ impl Pager {
                         io_yield_one!(c);
                     }
 
+                    let completion = read
+                        .completion
+                        .as_ref()
+                        .expect("database identity read completion should be set");
+                    if !completion.finished() {
+                        io_yield_one!(completion.clone());
+                    }
+                    if !completion.succeeded() {
+                        return Err(completion
+                            .get_error()
+                            .expect("finished database identity read should have an error")
+                            .into());
+                    }
                     let bytes_read = read.bytes_read.load(Ordering::Acquire);
+                    turso_assert!(
+                        bytes_read != usize::MAX,
+                        "successful database identity read must record the byte count"
+                    );
+                    if read.read_page && bytes_read != read.header_buf.len() {
+                        return Err(CompletionError::ShortRead {
+                            page_idx: DatabaseHeader::PAGE_ID,
+                            expected: read.header_buf.len(),
+                            actual: bytes_read,
+                        }
+                        .into());
+                    }
                     if bytes_read < DatabaseHeader::SIZE {
                         return Err(LimboError::Corrupt(
                             "database header unreadable after checkpoint sync".into(),

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -5126,7 +5126,11 @@ impl Pager {
         mode: CheckpointMode,
         sync_mode: crate::SyncMode,
     ) -> Result<CheckpointResult> {
-        self.io.block(|| self.checkpoint(mode, sync_mode, true))
+        let result = self.io.block(|| self.checkpoint(mode, sync_mode, true));
+        if result.is_err() {
+            self.cleanup_after_checkpoint_failure();
+        }
+        result
     }
 
     pub fn freepage_list(&self) -> u32 {
@@ -6220,6 +6224,8 @@ mod tests {
         );
     }
 
+    /// Verifies that cacheflush returns a codec error when rereading an evicted page fails,
+    /// and resets its state so a later flush can retry.
     #[test]
     fn cacheflush_propagates_failed_page_codec_reread() {
         let pager = pager_with_cache_capacity(5, 2);

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2778,7 +2778,7 @@ impl Pager {
     /// Set the initial page size for the database. Should only be called before the database is initialized
     pub fn set_initial_page_size(&self, size: PageSize) -> Result<()> {
         turso_assert!(!self.db_initialized());
-        if let Some(codec) = self.page_codec() {
+        if let Some(codec) = self.page_codec_external() {
             let reserved_space = codec.required_reserved_bytes();
             if !size.has_valid_reserved_space(reserved_space) {
                 return Err(LimboError::InvalidArgument(format!(
@@ -5698,12 +5698,12 @@ impl Pager {
         self.io_ctx.read().encryption_context().is_some()
     }
 
-    pub(crate) fn has_page_codec(&self) -> bool {
-        self.io_ctx.read().has_page_codec()
+    pub(crate) fn has_external_page_codec(&self) -> bool {
+        self.io_ctx.read().has_external_page_codec()
     }
 
-    pub(crate) fn page_codec(&self) -> Option<Arc<dyn PageCodec>> {
-        self.io_ctx.read().page_codec()
+    pub(crate) fn page_codec_external(&self) -> Option<Arc<dyn PageCodec>> {
+        self.io_ctx.read().page_codec_external()
     }
 
     pub fn is_encryption_enabled(&self) -> bool {
@@ -5722,7 +5722,7 @@ impl Pager {
                     .into(),
             ));
         }
-        if self.has_page_codec() {
+        if self.has_external_page_codec() {
             return Err(LimboError::InvalidArgument(
                 "cannot configure built-in encryption while an external page codec is installed"
                     .into(),

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1981,6 +1981,7 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
         PageTransform::Codec(ctx) => {
             let page_codec = ctx.clone();
             let original_complete = complete;
+            // TODO(v): support in-place codec decoding to avoid this extra page buffer.
             let decoded_buf = Arc::new(buffer_pool.get_page());
             let codec_context = PageCodecContext::from_page_idx(page_idx, PageLocation::Wal)?;
 
@@ -1989,6 +1990,9 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
                     let Ok((encoded_buf, bytes_read)) = res else {
                         return original_complete(res);
                     };
+                    if bytes_read == 0 {
+                        return original_complete(Ok((encoded_buf, bytes_read)));
+                    }
                     turso_assert_greater_than!(
                         bytes_read,
                         0,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -62,7 +62,10 @@ use crate::io::{Buffer, Completion, FileSyncType, ReadComplete};
 use crate::numeric::Numeric;
 use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_threshold_min};
 use crate::storage::buffer_pool::BufferPool;
-use crate::storage::database::{DatabaseStorage, PageCodecLocation, PageTransform};
+use crate::storage::database::DatabaseStorage;
+use crate::storage::page_transform::{
+    page_codec_completion_error, PageCodecContext, PageLocation, PageTransform,
+};
 use crate::storage::pager::Pager;
 use crate::storage::wal::READMARK_NOT_USED;
 use crate::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
@@ -101,7 +104,7 @@ impl PageSize {
     pub const MIN: u32 = 512;
     pub const MAX: u32 = 65536;
     pub const DEFAULT: u16 = 4096;
-    pub const MIN_USABLE_SPACE: u32 = 480;
+    pub(crate) const MIN_USABLE_SPACE: u32 = 480;
 
     /// Interpret a user-provided u32 as either a valid page size or None.
     pub const fn new(size: u32) -> Option<Self> {
@@ -144,7 +147,7 @@ impl PageSize {
         }
     }
 
-    pub const fn has_valid_reserved_space(self, reserved_space: u8) -> bool {
+    pub(crate) const fn has_valid_reserved_space(self, reserved_space: u8) -> bool {
         self.get().saturating_sub(reserved_space as u32) >= Self::MIN_USABLE_SPACE
     }
 
@@ -1975,49 +1978,11 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
     let buf = Arc::new(buf);
 
     match io_ctx.page_transform() {
-        PageTransform::Encryption(ctx) => {
-            let encryption_ctx = ctx.clone();
-            let original_complete = complete;
-
-            let decrypt_complete =
-                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
-                    let Ok((encrypted_buf, bytes_read)) = res else {
-                        return original_complete(res);
-                    };
-                    turso_assert_greater_than!(
-                        bytes_read,
-                        0,
-                        "expected to read data for encrypted page",
-                        { "page_idx": page_idx }
-                    );
-                    if bytes_read as usize != encrypted_buf.len() {
-                        return original_complete(Ok((encrypted_buf, bytes_read)));
-                    }
-                    match encryption_ctx.decrypt_page(encrypted_buf.as_slice(), page_idx) {
-                        Ok(decrypted_data) => {
-                            encrypted_buf
-                                .as_mut_slice()
-                                .copy_from_slice(&decrypted_data);
-                            original_complete(Ok((encrypted_buf, bytes_read)))
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to decrypt WAL frame data for page_idx={page_idx}: {e}"
-                            );
-                            let err = CompletionError::DecryptionError { page_idx };
-                            original_complete(Err(err));
-                            Some(err)
-                        }
-                    }
-                });
-
-            let new_completion = Completion::new_read(buf, decrypt_complete);
-            io.pread(offset, new_completion)
-        }
-        PageTransform::PageCodec(ctx) => {
+        PageTransform::Codec(ctx) => {
             let page_codec = ctx.clone();
             let original_complete = complete;
             let decoded_buf = Arc::new(buffer_pool.get_page());
+            let codec_context = PageCodecContext::from_page_idx(page_idx, PageLocation::Wal)?;
 
             let decode_complete =
                 Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
@@ -2034,17 +1999,16 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
                         return original_complete(Ok((encoded_buf, bytes_read)));
                     }
                     match page_codec.decode_page(
+                        codec_context,
                         encoded_buf.as_slice(),
                         decoded_buf.as_mut_slice(),
-                        page_idx,
-                        PageCodecLocation::Wal,
                     ) {
                         Ok(()) => original_complete(Ok((decoded_buf.clone(), bytes_read))),
                         Err(e) => {
                             tracing::error!(
                                 "Failed to decode WAL frame data for page_idx={page_idx}: {e}"
                             );
-                            let err = CompletionError::PageCodecError { page_idx };
+                            let err = page_codec_completion_error(page_codec.as_ref(), page_idx);
                             original_complete(Err(err));
                             Some(err)
                         }
@@ -2132,7 +2096,7 @@ pub fn prepare_wal_frame(
 ///
 /// The caller must write every byte after [`WAL_FRAME_HEADER_SIZE`] before computing
 /// the frame checksum or submitting the frame to storage.
-pub fn prepare_wal_frame_header(
+pub(crate) fn prepare_wal_frame_header(
     buffer_pool: &Arc<BufferPool>,
     wal_header: &WalHeader,
     page_number: u32,
@@ -2148,7 +2112,7 @@ pub fn prepare_wal_frame_header(
 }
 
 /// Recompute a frame checksum after transforming its page body in place.
-pub fn recompute_wal_frame_checksum(
+pub(crate) fn recompute_wal_frame_checksum(
     frame: &mut [u8],
     wal_header: &WalHeader,
     prev_checksums: (u32, u32),

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -62,7 +62,7 @@ use crate::io::{Buffer, Completion, FileSyncType, ReadComplete};
 use crate::numeric::Numeric;
 use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_threshold_min};
 use crate::storage::buffer_pool::BufferPool;
-use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum};
+use crate::storage::database::{DatabaseStorage, PageCodecLocation, PageTransform};
 use crate::storage::pager::Pager;
 use crate::storage::wal::READMARK_NOT_USED;
 use crate::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
@@ -101,6 +101,7 @@ impl PageSize {
     pub const MIN: u32 = 512;
     pub const MAX: u32 = 65536;
     pub const DEFAULT: u16 = 4096;
+    pub const MIN_USABLE_SPACE: u32 = 480;
 
     /// Interpret a user-provided u32 as either a valid page size or None.
     pub const fn new(size: u32) -> Option<Self> {
@@ -141,6 +142,10 @@ impl PageSize {
             1 => Self::MAX,
             v => v as u32,
         }
+    }
+
+    pub const fn has_valid_reserved_space(self, reserved_space: u8) -> bool {
+        self.get().saturating_sub(reserved_space as u32) >= Self::MIN_USABLE_SPACE
     }
 
     /// Get the raw u16 value stored internally
@@ -1969,8 +1974,8 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
     let buf = buffer_pool.get_page();
     let buf = Arc::new(buf);
 
-    match io_ctx.encryption_or_checksum() {
-        EncryptionOrChecksum::Encryption(ctx) => {
+    match io_ctx.page_transform() {
+        PageTransform::Encryption(ctx) => {
             let encryption_ctx = ctx.clone();
             let original_complete = complete;
 
@@ -1980,10 +1985,14 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
                         return original_complete(res);
                     };
                     turso_assert_greater_than!(
-                        bytes_read, 0,
+                        bytes_read,
+                        0,
                         "expected to read data for encrypted page",
                         { "page_idx": page_idx }
                     );
+                    if bytes_read as usize != encrypted_buf.len() {
+                        return original_complete(Ok((encrypted_buf, bytes_read)));
+                    }
                     match encryption_ctx.decrypt_page(encrypted_buf.as_slice(), page_idx) {
                         Ok(decrypted_data) => {
                             encrypted_buf
@@ -2005,7 +2014,47 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
             let new_completion = Completion::new_read(buf, decrypt_complete);
             io.pread(offset, new_completion)
         }
-        EncryptionOrChecksum::Checksum(ctx) => {
+        PageTransform::PageCodec(ctx) => {
+            let page_codec = ctx.clone();
+            let original_complete = complete;
+            let decoded_buf = Arc::new(buffer_pool.get_page());
+
+            let decode_complete =
+                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                    let Ok((encoded_buf, bytes_read)) = res else {
+                        return original_complete(res);
+                    };
+                    turso_assert_greater_than!(
+                        bytes_read,
+                        0,
+                        "expected to read data for page codec page",
+                        { "page_idx": page_idx }
+                    );
+                    if bytes_read as usize != encoded_buf.len() {
+                        return original_complete(Ok((encoded_buf, bytes_read)));
+                    }
+                    match page_codec.decode_page(
+                        encoded_buf.as_slice(),
+                        decoded_buf.as_mut_slice(),
+                        page_idx,
+                        PageCodecLocation::Wal,
+                    ) {
+                        Ok(()) => original_complete(Ok((decoded_buf.clone(), bytes_read))),
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to decode WAL frame data for page_idx={page_idx}: {e}"
+                            );
+                            let err = CompletionError::PageCodecError { page_idx };
+                            original_complete(Err(err));
+                            Some(err)
+                        }
+                    }
+                });
+
+            let new_completion = Completion::new_read(buf, decode_complete);
+            io.pread(offset, new_completion)
+        }
+        PageTransform::Checksum(ctx) => {
             let checksum_ctx = ctx.clone();
             let original_c = complete;
             let verify_complete =
@@ -2033,7 +2082,7 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
             let c = Completion::new_read(buf, verify_complete);
             io.pread(offset, c)
         }
-        EncryptionOrChecksum::None => {
+        PageTransform::None => {
             let c = Completion::new_read(buf, complete);
             io.pread(offset, c)
         }
@@ -2063,37 +2112,60 @@ pub fn prepare_wal_frame(
     buffer_pool: &Arc<BufferPool>,
     wal_header: &WalHeader,
     prev_checksums: (u32, u32),
-    page_size: u32,
+    _page_size: u32,
     page_number: u32,
     db_size: u32,
     page: &[u8],
 ) -> ((u32, u32), Arc<Buffer>) {
     tracing::trace!(page_number);
 
-    let buffer = buffer_pool.get_wal_frame();
+    let buffer = prepare_wal_frame_header(buffer_pool, wal_header, page_number, db_size);
     let frame = buffer.as_mut_slice();
     frame[WAL_FRAME_HEADER_SIZE..].copy_from_slice(page);
 
+    let final_checksum = recompute_wal_frame_checksum(frame, wal_header, prev_checksums);
+
+    (final_checksum, buffer)
+}
+
+/// Prepares a WAL frame header while leaving the page body for a transform to fill.
+///
+/// The caller must write every byte after [`WAL_FRAME_HEADER_SIZE`] before computing
+/// the frame checksum or submitting the frame to storage.
+pub fn prepare_wal_frame_header(
+    buffer_pool: &Arc<BufferPool>,
+    wal_header: &WalHeader,
+    page_number: u32,
+    db_size: u32,
+) -> Arc<Buffer> {
+    let buffer = Arc::new(buffer_pool.get_wal_frame());
+    let frame = buffer.as_mut_slice();
     frame[0..4].copy_from_slice(&page_number.to_be_bytes());
     frame[4..8].copy_from_slice(&db_size.to_be_bytes());
     frame[8..12].copy_from_slice(&wal_header.salt_1.to_be_bytes());
     frame[12..16].copy_from_slice(&wal_header.salt_2.to_be_bytes());
+    buffer
+}
 
+/// Recompute a frame checksum after transforming its page body in place.
+pub fn recompute_wal_frame_checksum(
+    frame: &mut [u8],
+    wal_header: &WalHeader,
+    prev_checksums: (u32, u32),
+) -> (u32, u32) {
     let expects_be = wal_header.magic & 1;
     let use_native_endian = cfg!(target_endian = "big") as u32 == expects_be;
     let header_checksum = checksum_wal(&frame[0..8], wal_header, prev_checksums, use_native_endian);
     let final_checksum = checksum_wal(
-        &frame[WAL_FRAME_HEADER_SIZE..WAL_FRAME_HEADER_SIZE + page_size as usize],
+        &frame[WAL_FRAME_HEADER_SIZE..],
         wal_header,
         header_checksum,
         use_native_endian,
     );
     frame[16..20].copy_from_slice(&final_checksum.0.to_be_bytes());
     frame[20..24].copy_from_slice(&final_checksum.1.to_be_bytes());
-
-    (final_checksum, Arc::new(buffer))
+    final_checksum
 }
-
 pub fn begin_write_wal_header<F: File + ?Sized>(io: &F, header: &WalHeader) -> Result<Completion> {
     tracing::trace!("begin_write_wal_header");
     let buffer = {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -27,7 +27,10 @@ use crate::fast_lock::SpinLock;
 use crate::io::clock::MonotonicInstant;
 use crate::io::CompletionGroup;
 use crate::io::{File, IO};
-use crate::storage::database::{DatabaseStorage, PageCodecLocation, PageTransform};
+use crate::storage::database::DatabaseStorage;
+use crate::storage::page_transform::{
+    page_codec_completion_error, PageCodecContext, PageLocation, PageTransform,
+};
 #[cfg(host_shared_wal)]
 use crate::storage::shared_wal_coordination::SharedWalCoordinationOpenMode;
 #[cfg(host_shared_wal)]
@@ -35,9 +38,9 @@ use crate::storage::shared_wal_coordination::{
     MappedSharedWalCoordination, SharedOwnerRecord, SharedReaderSlot, SharedWalCoordinationHeader,
 };
 use crate::storage::sqlite3_ondisk::{
-    begin_read_wal_frame, begin_read_wal_frame_raw, finish_read_page, prepare_wal_frame,
-    prepare_wal_frame_header, recompute_wal_frame_checksum, write_pages_vectored, PageSize,
-    WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
+    begin_read_wal_frame, begin_read_wal_frame_raw, finish_read_page, prepare_wal_frame_header,
+    recompute_wal_frame_checksum, write_pages_vectored, PageSize, WAL_FRAME_HEADER_SIZE,
+    WAL_HEADER_SIZE,
 };
 use crate::types::{IOCompletions, IOResult};
 use crate::util::IOExt as _;
@@ -3068,6 +3071,66 @@ enum TryBeginReadResult {
 }
 
 impl WalFile {
+    fn prepare_transformed_frame(
+        buffer_pool: &Arc<BufferPool>,
+        wal_header: &WalHeader,
+        previous_checksums: (u32, u32),
+        page_number: u32,
+        db_size: u32,
+        page: &[u8],
+        page_transform: &PageTransform,
+    ) -> Result<((u32, u32), Arc<Buffer>)> {
+        turso_assert!(
+            page_number > 0,
+            "WAL page number must be one-based",
+            { "page_number": page_number }
+        );
+        let page_size = wal_header.page_size as usize;
+        turso_assert!(
+            PageSize::new(wal_header.page_size).is_some(),
+            "WAL header must contain a valid page size",
+            { "page_size": wal_header.page_size }
+        );
+        turso_assert!(
+            page.len() == page_size,
+            "WAL input page size must match the WAL header",
+            { "input_len": page.len(), "page_size": page_size }
+        );
+
+        let frame = prepare_wal_frame_header(buffer_pool, wal_header, page_number, db_size);
+        turso_assert!(
+            frame.len() == WAL_FRAME_HEADER_SIZE + page_size,
+            "WAL frame buffer size must match its header and page body",
+            {
+                "frame_len": frame.len(),
+                "expected_len": WAL_FRAME_HEADER_SIZE + page_size
+            }
+        );
+        let frame_body = &mut frame.as_mut_slice()[WAL_FRAME_HEADER_SIZE..];
+        turso_assert!(
+            frame_body.len() == page.len(),
+            "WAL frame body size must match the input page",
+            { "frame_body_len": frame_body.len(), "input_len": page.len() }
+        );
+
+        match page_transform {
+            PageTransform::Codec(codec) => codec.encode_page(
+                PageCodecContext::new(page_number, PageLocation::Wal),
+                page,
+                frame_body,
+            )?,
+            PageTransform::Checksum(checksum) => {
+                frame_body.copy_from_slice(page);
+                checksum.add_checksum_to_page(frame_body, page_number as usize)?;
+            }
+            PageTransform::None => frame_body.copy_from_slice(page),
+        }
+
+        let checksum =
+            recompute_wal_frame_checksum(frame.as_mut_slice(), wal_header, previous_checksums);
+        Ok((checksum, frame))
+    }
+
     /// Load the authoritative WAL snapshot through the coordination backend.
     fn load_coordination_snapshot(&self) -> WalSnapshot {
         self.coordination.load_snapshot()
@@ -3533,14 +3596,13 @@ impl Wal for WalFile {
         // important not to hold shared state locks beyond this point to avoid deadlock with
         // completions that re-enter WAL state while a writer is waiting.
         let file = self.coordination.wal_file()?;
-        let io_ctx = self.io_ctx.read();
         begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
             buffer_pool,
             complete,
             page_idx,
-            &io_ctx,
+            &self.io_ctx.read(),
         )
     }
 
@@ -3651,29 +3713,11 @@ impl Wal for WalFile {
                     { "buffer_len": body_slice.len(), "page_size": page_size }
                 );
                 match &page_transform {
-                    PageTransform::Encryption(ctx) => {
-                        body_slice.copy_from_slice(page_body);
-                        match ctx.decrypt_page(body_slice, expected_page_id) {
-                            Ok(decrypted) => body_slice.copy_from_slice(&decrypted),
-                            Err(e) => {
-                                mark_unlikely();
-                                tracing::error!(
-                                    "Failed to decrypt WAL batch frame for page_idx={expected_page_id}: {e}"
-                                );
-                                clear_slots_on_err(&slots);
-                                return Some(CompletionError::DecryptionError {
-                                    page_idx: expected_page_id,
-                                });
-                            }
-                        }
-                    }
-                    PageTransform::PageCodec(ctx) => {
-                        match ctx.decode_page(
-                            page_body,
-                            body_slice,
-                            expected_page_id,
-                            PageCodecLocation::Wal,
-                        ) {
+                    PageTransform::Codec(ctx) => {
+                        let codec_context =
+                            PageCodecContext::from_page_idx(expected_page_id, PageLocation::Wal)
+                                .expect("WAL page numbers fit in u32");
+                        match ctx.decode_page(codec_context, page_body, body_slice) {
                             Ok(()) => {}
                             Err(e) => {
                                 mark_unlikely();
@@ -3681,9 +3725,10 @@ impl Wal for WalFile {
                                     "Failed to decode WAL batch frame for page_idx={expected_page_id}: {e}"
                                 );
                                 clear_slots_on_err(&slots);
-                                return Some(CompletionError::PageCodecError {
-                                    page_idx: expected_page_id,
-                                });
+                                return Some(page_codec_completion_error(
+                                    ctx.as_ref(),
+                                    expected_page_id,
+                                ));
                             }
                         }
                     }
@@ -3721,22 +3766,19 @@ impl Wal for WalFile {
     fn read_frame_raw(&self, frame_id: u64, frame: &mut [u8]) -> Result<Completion> {
         tracing::debug!("read_frame_raw({})", frame_id);
         let offset = self.frame_offset(frame_id);
+        let expected_frame_len = WAL_FRAME_HEADER_SIZE + self.page_size() as usize;
+        if frame.len() != expected_frame_len {
+            return Err(LimboError::InvalidArgument(format!(
+                "unexpected WAL frame buffer size: got={}, expected={expected_frame_len}",
+                frame.len()
+            )));
+        }
 
         // HACK: *mut u8 can't be Sent between threads safely, cast it to usize then
         // for the time of writing this comment - this is *safe* as all callers immediately call synchronous method wait_for_completion and hold necessary references
         let (frame_ptr, frame_len) = (frame.as_mut_ptr() as usize, frame.len());
 
-        let encryption_ctx = {
-            let io_ctx = self.io_ctx.read();
-            io_ctx.encryption_context().cloned()
-        };
-        let page_codec = {
-            let io_ctx = self.io_ctx.read();
-            match io_ctx.page_transform() {
-                PageTransform::PageCodec(ctx) => Some(ctx.clone()),
-                _ => None,
-            }
-        };
+        let page_transform = self.io_ctx.read().page_transform().clone();
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 return None; // IO error already captured in completion
@@ -3760,40 +3802,32 @@ impl Wal for WalFile {
                 .copy_from_slice(&buf.as_slice()[..WAL_FRAME_HEADER_SIZE]);
             let (header, raw_page) = sqlite3_ondisk::parse_wal_frame_header(buf.as_slice());
 
-            if let Some(ctx) = encryption_ctx.as_ref() {
-                match ctx.decrypt_page(raw_page, header.page_number as usize) {
-                    Ok(decrypted_data) => {
-                        turso_assert!(
-                            (frame_len - WAL_FRAME_HEADER_SIZE) == decrypted_data.len(),
-                            "frame_len minus header_size does not equal expected decrypted data length",
-                            { "frame_len_minus_header": frame_len - WAL_FRAME_HEADER_SIZE, "decrypted_data_len": decrypted_data.len() }
-                        );
-                        frame_ref[WAL_FRAME_HEADER_SIZE..].copy_from_slice(&decrypted_data);
-                    }
-                    Err(_) => {
-                        tracing::debug!("Failed to decrypt page data for frame_id={frame_id}");
-                        return Some(CompletionError::DecryptionError {
-                            page_idx: header.page_number as usize,
-                        });
-                    }
-                }
-            } else if let Some(ctx) = page_codec.as_ref() {
-                match ctx.decode_page(
-                    raw_page,
-                    &mut frame_ref[WAL_FRAME_HEADER_SIZE..],
-                    header.page_number as usize,
-                    PageCodecLocation::Wal,
-                ) {
-                    Ok(()) => {}
-                    Err(e) => {
-                        tracing::debug!("Failed to decode page data for frame_id={frame_id}: {e}");
-                        return Some(CompletionError::PageCodecError {
-                            page_idx: header.page_number as usize,
-                        });
+            match &page_transform {
+                PageTransform::Codec(ctx) => {
+                    let codec_context =
+                        PageCodecContext::new(header.page_number, PageLocation::Wal);
+                    let output = &mut frame_ref[WAL_FRAME_HEADER_SIZE..];
+                    turso_assert!(
+                        output.len() == raw_page.len(),
+                        "decoded WAL page buffer size must match encoded page size",
+                        { "output_len": output.len(), "input_len": raw_page.len() }
+                    );
+                    match ctx.decode_page(codec_context, raw_page, output) {
+                        Ok(()) => {}
+                        Err(e) => {
+                            tracing::debug!(
+                                "Failed to decode page data for frame_id={frame_id}: {e}"
+                            );
+                            return Some(page_codec_completion_error(
+                                ctx.as_ref(),
+                                header.page_number as usize,
+                            ));
+                        }
                     }
                 }
-            } else {
-                frame_ref[WAL_FRAME_HEADER_SIZE..].copy_from_slice(raw_page);
+                PageTransform::Checksum(_) | PageTransform::None => {
+                    frame_ref[WAL_FRAME_HEADER_SIZE..].copy_from_slice(raw_page);
+                }
             }
             None
         });
@@ -3869,14 +3903,13 @@ impl Wal for WalFile {
                 }
             });
             let file = self.coordination.wal_file()?;
-            let io_ctx = self.io_ctx.read();
             let c = begin_read_wal_frame(
                 file.as_ref(),
                 offset + WAL_FRAME_HEADER_SIZE as u64,
                 buffer_pool,
                 complete,
                 page_id as usize,
-                &io_ctx,
+                &self.io_ctx.read(),
             )?;
             self.io.wait_for_completion(c)?;
             return if *conflict.lock() {
@@ -3893,54 +3926,18 @@ impl Wal for WalFile {
         let header = self.coordination.wal_header();
         let file = self.coordination.wal_file()?;
         let previous_checksums = *self.last_checksum.read();
-        let (checksums, frame_bytes) = match self.io_ctx.read().page_transform() {
-            PageTransform::Encryption(ctx) => {
-                let encrypted_page = ctx.encrypt_page(page, page_id as usize)?;
-                let frame_bytes = prepare_wal_frame_header(
-                    &self.buffer_pool,
-                    &header,
-                    page_id as u32,
-                    db_size as u32,
-                );
-                frame_bytes.as_mut_slice()[WAL_FRAME_HEADER_SIZE..]
-                    .copy_from_slice(&encrypted_page);
-                let checksums = recompute_wal_frame_checksum(
-                    frame_bytes.as_mut_slice(),
-                    &header,
-                    previous_checksums,
-                );
-                (checksums, frame_bytes)
-            }
-            PageTransform::PageCodec(ctx) => {
-                let frame_bytes = prepare_wal_frame_header(
-                    &self.buffer_pool,
-                    &header,
-                    page_id as u32,
-                    db_size as u32,
-                );
-                ctx.encode_page(
-                    page,
-                    &mut frame_bytes.as_mut_slice()[WAL_FRAME_HEADER_SIZE..],
-                    page_id as usize,
-                    PageCodecLocation::Wal,
-                )?;
-                let checksums = recompute_wal_frame_checksum(
-                    frame_bytes.as_mut_slice(),
-                    &header,
-                    previous_checksums,
-                );
-                (checksums, frame_bytes)
-            }
-            PageTransform::Checksum(_) | PageTransform::None => prepare_wal_frame(
-                &self.buffer_pool,
-                &header,
-                previous_checksums,
-                header.page_size,
-                page_id as u32,
-                db_size as u32,
-                page,
-            ),
-        };
+        let page_number = u32::try_from(page_id).map_err(|_| LimboError::IntegerOverflow)?;
+        let db_size = u32::try_from(db_size).map_err(|_| LimboError::IntegerOverflow)?;
+        let page_transform = self.io_ctx.read().page_transform().clone();
+        let (checksums, frame_bytes) = Self::prepare_transformed_frame(
+            &buffer_pool,
+            &header,
+            previous_checksums,
+            page_number,
+            db_size,
+            page,
+            &page_transform,
+        )?;
         let c = Completion::new_write(|_| {});
         let c = file.pwrite(offset, frame_bytes, c)?;
         self.io.wait_for_completion(c)?;
@@ -4439,61 +4436,16 @@ impl Wal for WalFile {
             } else {
                 0
             };
-            let (checksum, frame_buf) = match &page_transform {
-                PageTransform::PageCodec(ctx) => {
-                    let frame_buf = prepare_wal_frame_header(
-                        &self.buffer_pool,
-                        &header,
-                        page_id as u32,
-                        frame_db_size,
-                    );
-                    ctx.encode_page(
-                        plain,
-                        &mut frame_buf.as_mut_slice()[WAL_FRAME_HEADER_SIZE..],
-                        page_id,
-                        PageCodecLocation::Wal,
-                    )?;
-                    let checksum = recompute_wal_frame_checksum(
-                        frame_buf.as_mut_slice(),
-                        &header,
-                        rolling_checksum,
-                    );
-                    (checksum, frame_buf)
-                }
-                PageTransform::Encryption(ctx) => {
-                    let data = ctx.encrypt_page(plain, page_id)?;
-                    prepare_wal_frame(
-                        &self.buffer_pool,
-                        &header,
-                        rolling_checksum,
-                        header.page_size,
-                        page_id as u32,
-                        frame_db_size,
-                        &data,
-                    )
-                }
-                PageTransform::Checksum(ctx) => {
-                    ctx.add_checksum_to_page(plain, page_id)?;
-                    prepare_wal_frame(
-                        &self.buffer_pool,
-                        &header,
-                        rolling_checksum,
-                        header.page_size,
-                        page_id as u32,
-                        frame_db_size,
-                        plain,
-                    )
-                }
-                PageTransform::None => prepare_wal_frame(
-                    &self.buffer_pool,
-                    &header,
-                    rolling_checksum,
-                    header.page_size,
-                    page_id as u32,
-                    frame_db_size,
-                    plain,
-                ),
-            };
+            let page_number = u32::try_from(page_id).map_err(|_| LimboError::IntegerOverflow)?;
+            let (checksum, frame_buf) = Self::prepare_transformed_frame(
+                &self.buffer_pool,
+                &header,
+                rolling_checksum,
+                page_number,
+                frame_db_size,
+                plain,
+                &page_transform,
+            )?;
             bufs.push(frame_buf);
             metadata.push((page.clone(), next_frame_id, checksum));
             rolling_checksum = checksum;
@@ -4583,61 +4535,16 @@ impl Wal for WalFile {
             let plain = page.get_contents().as_ptr();
 
             let frame_db_size = 0; // this method is not used for the commit path
-            let (new_checksum, frame_bytes) = match &page_transform {
-                PageTransform::PageCodec(ctx) => {
-                    let frame_bytes = prepare_wal_frame_header(
-                        &self.buffer_pool,
-                        &header,
-                        page_id as u32,
-                        frame_db_size,
-                    );
-                    ctx.encode_page(
-                        plain,
-                        &mut frame_bytes.as_mut_slice()[WAL_FRAME_HEADER_SIZE..],
-                        page_id,
-                        PageCodecLocation::Wal,
-                    )?;
-                    let checksum = recompute_wal_frame_checksum(
-                        frame_bytes.as_mut_slice(),
-                        &header,
-                        rolling_checksum,
-                    );
-                    (checksum, frame_bytes)
-                }
-                PageTransform::Encryption(ctx) => {
-                    let data = ctx.encrypt_page(plain, page_id)?;
-                    prepare_wal_frame(
-                        &self.buffer_pool,
-                        &header,
-                        rolling_checksum,
-                        shared_page_size,
-                        page_id as u32,
-                        frame_db_size,
-                        &data,
-                    )
-                }
-                PageTransform::Checksum(ctx) => {
-                    ctx.add_checksum_to_page(plain, page_id)?;
-                    prepare_wal_frame(
-                        &self.buffer_pool,
-                        &header,
-                        rolling_checksum,
-                        shared_page_size,
-                        page_id as u32,
-                        frame_db_size,
-                        plain,
-                    )
-                }
-                PageTransform::None => prepare_wal_frame(
-                    &self.buffer_pool,
-                    &header,
-                    rolling_checksum,
-                    shared_page_size,
-                    page_id as u32,
-                    frame_db_size,
-                    plain,
-                ),
-            };
+            let page_number = u32::try_from(page_id).map_err(|_| LimboError::IntegerOverflow)?;
+            let (new_checksum, frame_bytes) = Self::prepare_transformed_frame(
+                &self.buffer_pool,
+                &header,
+                rolling_checksum,
+                page_number,
+                frame_db_size,
+                plain,
+                &page_transform,
+            )?;
             iovecs.push(frame_bytes);
 
             // (page, assigned_frame_id, cumulative_checksum_at_this_frame)
@@ -5405,14 +5312,13 @@ impl WalFile {
         };
         // schedule read of the page payload
         let file = self.coordination.wal_file()?;
-        let io_ctx = self.io_ctx.read();
         let c = begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
             self.buffer_pool.clone(),
             complete,
             page_id,
-            &io_ctx,
+            &self.io_ctx.read(),
         )?;
 
         Ok(InflightRead {
@@ -5535,14 +5441,10 @@ pub(crate) fn database_identity_from_header_bytes(header_bytes: &[u8]) -> Result
 fn read_database_identity_from_storage(
     io: &Arc<dyn IO>,
     db_file: &Arc<dyn DatabaseStorage>,
-    io_ctx: Option<&IOContext>,
-    page_size: usize,
 ) -> Result<Option<(u32, u32)>> {
-    let read_buf = Arc::new(Buffer::new_temporary(
-        io_ctx.map_or(PageSize::MIN as usize, |_| page_size),
-    ));
+    let read_buf = Arc::new(Buffer::new_temporary(PageSize::MIN as usize));
     let bytes_read = Arc::new(AtomicUsize::new(usize::MAX));
-    let completion = Completion::new_read(read_buf.clone(), {
+    let c = db_file.read_header(Completion::new_read(read_buf.clone(), {
         let bytes_read = bytes_read.clone();
         Box::new(move |res| {
             if let Ok((_buf, count)) = res {
@@ -5550,11 +5452,7 @@ fn read_database_identity_from_storage(
             }
             None
         })
-    });
-    let c = match io_ctx {
-        Some(io_ctx) => db_file.read_page(1, io_ctx, completion)?,
-        None => db_file.read_header(completion)?,
-    };
+    }))?;
     io.wait_for_completion(c)?;
     if bytes_read.load(Ordering::Acquire) < DatabaseHeader::SIZE {
         return Ok(None);
@@ -5708,7 +5606,6 @@ impl WalFileShared {
         flags: crate::OpenFlags,
         authority: &Arc<MappedSharedWalCoordination>,
         db_file: &Arc<dyn DatabaseStorage>,
-        io_ctx: Option<&IOContext>,
     ) -> Result<Arc<RwLock<WalFileShared>>> {
         let snapshot = authority.snapshot();
         let file = match io.open_file(path, flags, false) {
@@ -5762,12 +5659,8 @@ impl WalFileShared {
             return sqlite3_ondisk::build_shared_wal(&file, io);
         }
         if snapshot.nbackfills != 0 {
-            let Some((db_size_pages, db_header_crc32c)) = read_database_identity_from_storage(
-                io,
-                db_file,
-                io_ctx,
-                snapshot.page_size as usize,
-            )?
+            let Some((db_size_pages, db_header_crc32c)) =
+                read_database_identity_from_storage(io, db_file)?
             else {
                 tracing::debug!(
                     nbackfills = snapshot.nbackfills,
@@ -6041,10 +5934,9 @@ pub mod test {
         io::FileSyncType,
         storage::{
             buffer_pool::BufferPool,
-            database::{
-                DatabaseFile, DatabaseStorage, IOContext, PageCodec, PageCodecId, PageCodecLocation,
-            },
+            database::{DatabaseFile, DatabaseStorage},
             encryption::{CipherMode, EncryptionContext, EncryptionKey},
+            page_transform::{PageCodec, PageCodecContext, PageCodecId},
             pager::{allocate_new_page, PageRef},
             sqlite3_ondisk::{self, PageSize, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE},
             wal::READMARK_NOT_USED,
@@ -6052,7 +5944,7 @@ pub mod test {
         types::IOResult,
         util::IOExt,
         Buffer, CheckpointMode, CheckpointResult, Completion, CompletionError, Connection,
-        Database, File, LimboError, MemoryIO, OpenFlags, PlatformIO, Result, SyncMode,
+        Database, File, IOContext, LimboError, MemoryIO, OpenFlags, PlatformIO, Result, SyncMode,
         WalFileShared, IO,
     };
     use std::num::NonZeroUsize;
@@ -6548,21 +6440,20 @@ pub mod test {
 
         fn encode_page(
             &self,
-            page: &[u8],
+            _context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> Result<()> {
             match self {
                 Self::Xor(mask) => {
-                    for (input, output) in page.iter().zip(output) {
+                    for (input, output) in input.iter().zip(output) {
                         *output = input ^ mask;
                     }
                     Ok(())
                 }
                 Self::ErrorEncode => Err(LimboError::InternalError("codec encode failed".into())),
                 Self::ErrorDecode => {
-                    output.copy_from_slice(page);
+                    output.copy_from_slice(input);
                     Ok(())
                 }
             }
@@ -6570,15 +6461,14 @@ pub mod test {
 
         fn decode_page(
             &self,
-            page: &[u8],
+            context: PageCodecContext,
+            input: &[u8],
             output: &mut [u8],
-            _page_idx: usize,
-            _location: PageCodecLocation,
         ) -> Result<()> {
             match self {
-                Self::Xor(_) => self.encode_page(page, output, _page_idx, _location),
+                Self::Xor(_) => self.encode_page(context, input, output),
                 Self::ErrorEncode => {
-                    output.copy_from_slice(page);
+                    output.copy_from_slice(input);
                     Ok(())
                 }
                 Self::ErrorDecode => Err(LimboError::InternalError("codec decode failed".into())),
@@ -6760,6 +6650,31 @@ pub mod test {
     }
 
     #[test]
+    fn page_codec_raw_wal_read_rejects_wrong_buffer_size() {
+        let page_size = 512;
+        let (_io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::Xor(0xa5)));
+        let page = vec![0; page_size as usize];
+        wal.write_frame_raw(buffer_pool, 1, 44, 0, &page, FileSyncType::Fsync)
+            .unwrap();
+
+        let expected_frame_len = WAL_FRAME_HEADER_SIZE + page_size as usize;
+        for frame_len in [expected_frame_len - 1, expected_frame_len + 1] {
+            let mut frame = vec![0; frame_len];
+            match wal.read_frame_raw(1, &mut frame) {
+                Err(LimboError::InvalidArgument(message)) => assert_eq!(
+                    message,
+                    format!(
+                        "unexpected WAL frame buffer size: got={frame_len}, expected={expected_frame_len}"
+                    )
+                ),
+                Err(error) => panic!("expected invalid argument, got {error:?}"),
+                Ok(_) => panic!("expected frame size {frame_len} to be rejected"),
+            }
+        }
+    }
+
+    #[test]
     fn page_codec_encode_error_does_not_publish_wal_frames() {
         let page_size = 512;
         let (_io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
@@ -6793,6 +6708,26 @@ pub mod test {
         let completion = wal.read_frame_raw(1, &mut frame).unwrap();
         io.wait_for_completion(completion).unwrap();
         assert_eq!(&frame[WAL_FRAME_HEADER_SIZE..], expected.as_slice());
+    }
+
+    #[cfg(feature = "checksum")]
+    #[test]
+    fn checksum_is_applied_to_raw_wal_frames() {
+        let page_size = 4096;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let mut source = (0..page_size).map(|i| i as u8).collect::<Vec<_>>();
+        source[page_size as usize - 8..].fill(0);
+
+        wal.write_frame_raw(buffer_pool.clone(), 1, 44, 0, &source, FileSyncType::Fsync)
+            .unwrap();
+
+        let target = Arc::new(crate::Page::new(44));
+        let completion = wal.read_frame(1, target.clone(), buffer_pool).unwrap();
+        io.wait_for_completion(completion).unwrap();
+        assert_eq!(
+            &target.get_contents().as_ptr()[..page_size as usize - 8],
+            &source[..page_size as usize - 8]
+        );
     }
 
     #[test]
@@ -8015,7 +7950,6 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
-            None,
         )
         .unwrap();
 
@@ -8063,7 +7997,6 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
-            None,
         )
         .unwrap();
         assert!(shared.read().runtime.frame_cache.lock().is_empty());
@@ -8132,7 +8065,6 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
-            None,
         )
         .unwrap();
 
@@ -8221,7 +8153,6 @@ pub mod test {
             crate::OpenFlags::Create,
             &authority,
             &open_test_db_file_for_wal(&io, &wal_path),
-            None,
         )
         .unwrap();
 
@@ -8259,7 +8190,6 @@ pub mod test {
             crate::OpenFlags::Create,
             &authority,
             &open_test_db_file_for_wal(&io, &wal_path),
-            None,
         )
         .unwrap();
         assert!(exclusive
@@ -8292,7 +8222,6 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
-            None,
         )
         .unwrap();
         assert!(!reopened_shared
@@ -8337,7 +8266,6 @@ pub mod test {
             crate::OpenFlags::Create,
             &authority,
             &open_test_db_file_for_wal(&io, &wal_path),
-            None,
         )
         .unwrap();
         assert!(shared
@@ -8399,7 +8327,6 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
-            None,
         )
         .unwrap();
 
@@ -8707,7 +8634,6 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
-            None,
         )
         .unwrap();
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -7,7 +7,6 @@ use crate::{turso_assert, turso_assert_greater_than, turso_debug_assert};
 use branches::mark_unlikely;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::array;
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use strum::EnumString;
@@ -28,7 +27,7 @@ use crate::fast_lock::SpinLock;
 use crate::io::clock::MonotonicInstant;
 use crate::io::CompletionGroup;
 use crate::io::{File, IO};
-use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum};
+use crate::storage::database::{DatabaseStorage, PageCodecLocation, PageTransform};
 #[cfg(host_shared_wal)]
 use crate::storage::shared_wal_coordination::SharedWalCoordinationOpenMode;
 #[cfg(host_shared_wal)]
@@ -37,7 +36,8 @@ use crate::storage::shared_wal_coordination::{
 };
 use crate::storage::sqlite3_ondisk::{
     begin_read_wal_frame, begin_read_wal_frame_raw, finish_read_page, prepare_wal_frame,
-    write_pages_vectored, PageSize, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
+    prepare_wal_frame_header, recompute_wal_frame_checksum, write_pages_vectored, PageSize,
+    WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
 };
 use crate::types::{IOCompletions, IOResult};
 use crate::util::IOExt as _;
@@ -677,11 +677,14 @@ pub trait Wal: Debug + Send + Sync {
         scratch_buf: Option<Arc<Buffer>>,
     ) -> Result<Completion>;
 
-    /// Read a raw frame (header included) from the WAL.
+    /// Read a raw WAL frame with its on-disk header and page body decoded by
+    /// the configured encryption context or external page codec.
     fn read_frame_raw(&self, frame_id: u64, frame: &mut [u8]) -> Result<Completion>;
 
-    /// Write a raw frame (header included) from the WAL.
-    /// Note, that turso-db will use page_no and size_after fields from the header, but will overwrite checksum with proper value
+    /// Write an in-memory page as a WAL frame.
+    ///
+    /// TursoDB uses `page_no` and `size_after` from the supplied header, applies
+    /// any configured page transform to the body, and overwrites the checksum.
     fn write_frame_raw(
         &self,
         buffer_pool: Arc<BufferPool>,
@@ -3530,13 +3533,14 @@ impl Wal for WalFile {
         // important not to hold shared state locks beyond this point to avoid deadlock with
         // completions that re-enter WAL state while a writer is waiting.
         let file = self.coordination.wal_file()?;
+        let io_ctx = self.io_ctx.read();
         begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
             buffer_pool,
             complete,
             page_idx,
-            &self.io_ctx.read(),
+            &io_ctx,
         )
     }
 
@@ -3591,7 +3595,7 @@ impl Wal for WalFile {
         }
 
         let epoch = self.coordination.checkpoint_epoch();
-        let enc_or_csum = self.io_ctx.read().encryption_or_checksum().clone();
+        let page_transform = self.io_ctx.read().page_transform().clone();
         let raw_buf = scratch_buf.unwrap_or_else(|| Arc::new(Buffer::new_temporary(total)));
 
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
@@ -3646,10 +3650,9 @@ impl Wal for WalFile {
                     "read_frames_batch buffer size must match WAL page size",
                     { "buffer_len": body_slice.len(), "page_size": page_size }
                 );
-                body_slice.copy_from_slice(page_body);
-
-                match &enc_or_csum {
-                    EncryptionOrChecksum::Encryption(ctx) => {
+                match &page_transform {
+                    PageTransform::Encryption(ctx) => {
+                        body_slice.copy_from_slice(page_body);
                         match ctx.decrypt_page(body_slice, expected_page_id) {
                             Ok(decrypted) => body_slice.copy_from_slice(&decrypted),
                             Err(e) => {
@@ -3664,7 +3667,28 @@ impl Wal for WalFile {
                             }
                         }
                     }
-                    EncryptionOrChecksum::Checksum(ctx) => {
+                    PageTransform::PageCodec(ctx) => {
+                        match ctx.decode_page(
+                            page_body,
+                            body_slice,
+                            expected_page_id,
+                            PageCodecLocation::Wal,
+                        ) {
+                            Ok(()) => {}
+                            Err(e) => {
+                                mark_unlikely();
+                                tracing::error!(
+                                    "Failed to decode WAL batch frame for page_idx={expected_page_id}: {e}"
+                                );
+                                clear_slots_on_err(&slots);
+                                return Some(CompletionError::PageCodecError {
+                                    page_idx: expected_page_id,
+                                });
+                            }
+                        }
+                    }
+                    PageTransform::Checksum(ctx) => {
+                        body_slice.copy_from_slice(page_body);
                         if let Err(e) = ctx.verify_checksum(body_slice, expected_page_id) {
                             mark_unlikely();
                             tracing::error!(
@@ -3674,7 +3698,7 @@ impl Wal for WalFile {
                             return Some(e);
                         }
                     }
-                    EncryptionOrChecksum::None => {}
+                    PageTransform::None => body_slice.copy_from_slice(page_body),
                 }
             }
 
@@ -3706,6 +3730,13 @@ impl Wal for WalFile {
             let io_ctx = self.io_ctx.read();
             io_ctx.encryption_context().cloned()
         };
+        let page_codec = {
+            let io_ctx = self.io_ctx.read();
+            match io_ctx.page_transform() {
+                PageTransform::PageCodec(ctx) => Some(ctx.clone()),
+                _ => None,
+            }
+        };
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 return None; // IO error already captured in completion
@@ -3721,20 +3752,15 @@ impl Wal for WalFile {
                     actual: bytes_read as usize,
                 });
             }
-            let buf_ptr = buf.as_ptr();
             let frame_ptr = frame_ptr as *mut u8;
             let frame_ref: &mut [u8] =
                 unsafe { std::slice::from_raw_parts_mut(frame_ptr, frame_len) };
 
-            // Copy the just-read WAL frame into the destination buffer
-            unsafe {
-                std::ptr::copy_nonoverlapping(buf_ptr, frame_ptr, frame_len);
-            }
+            frame_ref[..WAL_FRAME_HEADER_SIZE]
+                .copy_from_slice(&buf.as_slice()[..WAL_FRAME_HEADER_SIZE]);
+            let (header, raw_page) = sqlite3_ondisk::parse_wal_frame_header(buf.as_slice());
 
-            // Now parse the header from the freshly-copied data
-            let (header, raw_page) = sqlite3_ondisk::parse_wal_frame_header(frame_ref);
-
-            if let Some(ctx) = encryption_ctx.clone() {
+            if let Some(ctx) = encryption_ctx.as_ref() {
                 match ctx.decrypt_page(raw_page, header.page_number as usize) {
                     Ok(decrypted_data) => {
                         turso_assert!(
@@ -3746,8 +3772,28 @@ impl Wal for WalFile {
                     }
                     Err(_) => {
                         tracing::debug!("Failed to decrypt page data for frame_id={frame_id}");
+                        return Some(CompletionError::DecryptionError {
+                            page_idx: header.page_number as usize,
+                        });
                     }
                 }
+            } else if let Some(ctx) = page_codec.as_ref() {
+                match ctx.decode_page(
+                    raw_page,
+                    &mut frame_ref[WAL_FRAME_HEADER_SIZE..],
+                    header.page_number as usize,
+                    PageCodecLocation::Wal,
+                ) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        tracing::debug!("Failed to decode page data for frame_id={frame_id}: {e}");
+                        return Some(CompletionError::PageCodecError {
+                            page_idx: header.page_number as usize,
+                        });
+                    }
+                }
+            } else {
+                frame_ref[WAL_FRAME_HEADER_SIZE..].copy_from_slice(raw_page);
             }
             None
         });
@@ -3823,13 +3869,14 @@ impl Wal for WalFile {
                 }
             });
             let file = self.coordination.wal_file()?;
+            let io_ctx = self.io_ctx.read();
             let c = begin_read_wal_frame(
                 file.as_ref(),
                 offset + WAL_FRAME_HEADER_SIZE as u64,
                 buffer_pool,
                 complete,
                 page_id as usize,
-                &self.io_ctx.read(),
+                &io_ctx,
             )?;
             self.io.wait_for_completion(c)?;
             return if *conflict.lock() {
@@ -3845,16 +3892,55 @@ impl Wal for WalFile {
         let offset = self.frame_offset(frame_id);
         let header = self.coordination.wal_header();
         let file = self.coordination.wal_file()?;
-        let checksums = *self.last_checksum.read();
-        let (checksums, frame_bytes) = prepare_wal_frame(
-            &self.buffer_pool,
-            &header,
-            checksums,
-            header.page_size,
-            page_id as u32,
-            db_size as u32,
-            page,
-        );
+        let previous_checksums = *self.last_checksum.read();
+        let (checksums, frame_bytes) = match self.io_ctx.read().page_transform() {
+            PageTransform::Encryption(ctx) => {
+                let encrypted_page = ctx.encrypt_page(page, page_id as usize)?;
+                let frame_bytes = prepare_wal_frame_header(
+                    &self.buffer_pool,
+                    &header,
+                    page_id as u32,
+                    db_size as u32,
+                );
+                frame_bytes.as_mut_slice()[WAL_FRAME_HEADER_SIZE..]
+                    .copy_from_slice(&encrypted_page);
+                let checksums = recompute_wal_frame_checksum(
+                    frame_bytes.as_mut_slice(),
+                    &header,
+                    previous_checksums,
+                );
+                (checksums, frame_bytes)
+            }
+            PageTransform::PageCodec(ctx) => {
+                let frame_bytes = prepare_wal_frame_header(
+                    &self.buffer_pool,
+                    &header,
+                    page_id as u32,
+                    db_size as u32,
+                );
+                ctx.encode_page(
+                    page,
+                    &mut frame_bytes.as_mut_slice()[WAL_FRAME_HEADER_SIZE..],
+                    page_id as usize,
+                    PageCodecLocation::Wal,
+                )?;
+                let checksums = recompute_wal_frame_checksum(
+                    frame_bytes.as_mut_slice(),
+                    &header,
+                    previous_checksums,
+                );
+                (checksums, frame_bytes)
+            }
+            PageTransform::Checksum(_) | PageTransform::None => prepare_wal_frame(
+                &self.buffer_pool,
+                &header,
+                previous_checksums,
+                header.page_size,
+                page_id as u32,
+                db_size as u32,
+                page,
+            ),
+        };
         let c = Completion::new_write(|_| {});
         let c = file.pwrite(offset, frame_bytes, c)?;
         self.io.wait_for_completion(c)?;
@@ -4340,24 +4426,11 @@ impl Wal for WalFile {
 
         let mut bufs: Vec<Arc<Buffer>> = Vec::with_capacity(pages.len());
         let mut metadata = Vec::with_capacity(pages.len());
+        let page_transform = self.io_ctx.read().page_transform().clone();
 
         for (idx, page) in pages.iter().enumerate() {
             let page_id = page.get().id;
             let plain = page.get_contents().as_ptr();
-
-            let data: Cow<[u8]> = {
-                let io_ctx = self.io_ctx.read();
-                match io_ctx.encryption_or_checksum() {
-                    EncryptionOrChecksum::Encryption(ctx) => {
-                        Cow::Owned(ctx.encrypt_page(plain, page_id)?)
-                    }
-                    EncryptionOrChecksum::Checksum(ctx) => {
-                        ctx.add_checksum_to_page(plain, page_id)?;
-                        Cow::Borrowed(plain)
-                    }
-                    EncryptionOrChecksum::None => Cow::Borrowed(plain),
-                }
-            };
 
             // if DB size is included for commit frame, it will need to be included only in the last frame of the batch.
             // however it might not be present in this batch so we cannot assert its presence
@@ -4366,15 +4439,61 @@ impl Wal for WalFile {
             } else {
                 0
             };
-            let (checksum, frame_buf) = prepare_wal_frame(
-                &self.buffer_pool,
-                &header,
-                rolling_checksum,
-                header.page_size,
-                page_id as u32,
-                frame_db_size,
-                &data,
-            );
+            let (checksum, frame_buf) = match &page_transform {
+                PageTransform::PageCodec(ctx) => {
+                    let frame_buf = prepare_wal_frame_header(
+                        &self.buffer_pool,
+                        &header,
+                        page_id as u32,
+                        frame_db_size,
+                    );
+                    ctx.encode_page(
+                        plain,
+                        &mut frame_buf.as_mut_slice()[WAL_FRAME_HEADER_SIZE..],
+                        page_id,
+                        PageCodecLocation::Wal,
+                    )?;
+                    let checksum = recompute_wal_frame_checksum(
+                        frame_buf.as_mut_slice(),
+                        &header,
+                        rolling_checksum,
+                    );
+                    (checksum, frame_buf)
+                }
+                PageTransform::Encryption(ctx) => {
+                    let data = ctx.encrypt_page(plain, page_id)?;
+                    prepare_wal_frame(
+                        &self.buffer_pool,
+                        &header,
+                        rolling_checksum,
+                        header.page_size,
+                        page_id as u32,
+                        frame_db_size,
+                        &data,
+                    )
+                }
+                PageTransform::Checksum(ctx) => {
+                    ctx.add_checksum_to_page(plain, page_id)?;
+                    prepare_wal_frame(
+                        &self.buffer_pool,
+                        &header,
+                        rolling_checksum,
+                        header.page_size,
+                        page_id as u32,
+                        frame_db_size,
+                        plain,
+                    )
+                }
+                PageTransform::None => prepare_wal_frame(
+                    &self.buffer_pool,
+                    &header,
+                    rolling_checksum,
+                    header.page_size,
+                    page_id as u32,
+                    frame_db_size,
+                    plain,
+                ),
+            };
             bufs.push(frame_buf);
             metadata.push((page.clone(), next_frame_id, checksum));
             rolling_checksum = checksum;
@@ -4451,6 +4570,7 @@ impl Wal for WalFile {
         let mut iovecs: Vec<Arc<Buffer>> = Vec::with_capacity(pages.len());
         let mut page_frame_and_checksum: Vec<(PageRef, u64, (u32, u32))> =
             Vec::with_capacity(pages.len());
+        let page_transform = self.io_ctx.read().page_transform().clone();
 
         // Rolling checksum input to each frame build
         let mut rolling_checksum: (u32, u32) = *self.last_checksum.read();
@@ -4462,30 +4582,62 @@ impl Wal for WalFile {
             let page_id = page.get().id;
             let plain = page.get_contents().as_ptr();
 
-            let data_to_write: std::borrow::Cow<[u8]> = {
-                let io_ctx = self.io_ctx.read();
-                match &io_ctx.encryption_or_checksum() {
-                    EncryptionOrChecksum::Encryption(ctx) => {
-                        Cow::Owned(ctx.encrypt_page(plain, page_id)?)
-                    }
-                    EncryptionOrChecksum::Checksum(ctx) => {
-                        ctx.add_checksum_to_page(plain, page_id)?;
-                        Cow::Borrowed(plain)
-                    }
-                    EncryptionOrChecksum::None => Cow::Borrowed(plain),
-                }
-            };
-
             let frame_db_size = 0; // this method is not used for the commit path
-            let (new_checksum, frame_bytes) = prepare_wal_frame(
-                &self.buffer_pool,
-                &header,
-                rolling_checksum,
-                shared_page_size,
-                page_id as u32,
-                frame_db_size,
-                &data_to_write,
-            );
+            let (new_checksum, frame_bytes) = match &page_transform {
+                PageTransform::PageCodec(ctx) => {
+                    let frame_bytes = prepare_wal_frame_header(
+                        &self.buffer_pool,
+                        &header,
+                        page_id as u32,
+                        frame_db_size,
+                    );
+                    ctx.encode_page(
+                        plain,
+                        &mut frame_bytes.as_mut_slice()[WAL_FRAME_HEADER_SIZE..],
+                        page_id,
+                        PageCodecLocation::Wal,
+                    )?;
+                    let checksum = recompute_wal_frame_checksum(
+                        frame_bytes.as_mut_slice(),
+                        &header,
+                        rolling_checksum,
+                    );
+                    (checksum, frame_bytes)
+                }
+                PageTransform::Encryption(ctx) => {
+                    let data = ctx.encrypt_page(plain, page_id)?;
+                    prepare_wal_frame(
+                        &self.buffer_pool,
+                        &header,
+                        rolling_checksum,
+                        shared_page_size,
+                        page_id as u32,
+                        frame_db_size,
+                        &data,
+                    )
+                }
+                PageTransform::Checksum(ctx) => {
+                    ctx.add_checksum_to_page(plain, page_id)?;
+                    prepare_wal_frame(
+                        &self.buffer_pool,
+                        &header,
+                        rolling_checksum,
+                        shared_page_size,
+                        page_id as u32,
+                        frame_db_size,
+                        plain,
+                    )
+                }
+                PageTransform::None => prepare_wal_frame(
+                    &self.buffer_pool,
+                    &header,
+                    rolling_checksum,
+                    shared_page_size,
+                    page_id as u32,
+                    frame_db_size,
+                    plain,
+                ),
+            };
             iovecs.push(frame_bytes);
 
             // (page, assigned_frame_id, cumulative_checksum_at_this_frame)
@@ -5253,13 +5405,14 @@ impl WalFile {
         };
         // schedule read of the page payload
         let file = self.coordination.wal_file()?;
+        let io_ctx = self.io_ctx.read();
         let c = begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
             self.buffer_pool.clone(),
             complete,
             page_id,
-            &self.io_ctx.read(),
+            &io_ctx,
         )?;
 
         Ok(InflightRead {
@@ -5382,10 +5535,14 @@ pub(crate) fn database_identity_from_header_bytes(header_bytes: &[u8]) -> Result
 fn read_database_identity_from_storage(
     io: &Arc<dyn IO>,
     db_file: &Arc<dyn DatabaseStorage>,
+    io_ctx: Option<&IOContext>,
+    page_size: usize,
 ) -> Result<Option<(u32, u32)>> {
-    let read_buf = Arc::new(Buffer::new_temporary(PageSize::MIN as usize));
+    let read_buf = Arc::new(Buffer::new_temporary(
+        io_ctx.map_or(PageSize::MIN as usize, |_| page_size),
+    ));
     let bytes_read = Arc::new(AtomicUsize::new(usize::MAX));
-    let c = db_file.read_header(Completion::new_read(read_buf.clone(), {
+    let completion = Completion::new_read(read_buf.clone(), {
         let bytes_read = bytes_read.clone();
         Box::new(move |res| {
             if let Ok((_buf, count)) = res {
@@ -5393,7 +5550,11 @@ fn read_database_identity_from_storage(
             }
             None
         })
-    }))?;
+    });
+    let c = match io_ctx {
+        Some(io_ctx) => db_file.read_page(1, io_ctx, completion)?,
+        None => db_file.read_header(completion)?,
+    };
     io.wait_for_completion(c)?;
     if bytes_read.load(Ordering::Acquire) < DatabaseHeader::SIZE {
         return Ok(None);
@@ -5547,6 +5708,7 @@ impl WalFileShared {
         flags: crate::OpenFlags,
         authority: &Arc<MappedSharedWalCoordination>,
         db_file: &Arc<dyn DatabaseStorage>,
+        io_ctx: Option<&IOContext>,
     ) -> Result<Arc<RwLock<WalFileShared>>> {
         let snapshot = authority.snapshot();
         let file = match io.open_file(path, flags, false) {
@@ -5600,8 +5762,12 @@ impl WalFileShared {
             return sqlite3_ondisk::build_shared_wal(&file, io);
         }
         if snapshot.nbackfills != 0 {
-            let Some((db_size_pages, db_header_crc32c)) =
-                read_database_identity_from_storage(io, db_file)?
+            let Some((db_size_pages, db_header_crc32c)) = read_database_identity_from_storage(
+                io,
+                db_file,
+                io_ctx,
+                snapshot.page_size as usize,
+            )?
             else {
                 tracing::debug!(
                     nbackfills = snapshot.nbackfills,
@@ -5875,15 +6041,19 @@ pub mod test {
         io::FileSyncType,
         storage::{
             buffer_pool::BufferPool,
-            database::{DatabaseFile, DatabaseStorage},
+            database::{
+                DatabaseFile, DatabaseStorage, IOContext, PageCodec, PageCodecId, PageCodecLocation,
+            },
+            encryption::{CipherMode, EncryptionContext, EncryptionKey},
             pager::{allocate_new_page, PageRef},
-            sqlite3_ondisk::{self, PageSize, WAL_HEADER_SIZE},
+            sqlite3_ondisk::{self, PageSize, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE},
             wal::READMARK_NOT_USED,
         },
         types::IOResult,
         util::IOExt,
         Buffer, CheckpointMode, CheckpointResult, Completion, CompletionError, Connection,
-        Database, File, LimboError, MemoryIO, OpenFlags, PlatformIO, SyncMode, WalFileShared, IO,
+        Database, File, LimboError, MemoryIO, OpenFlags, PlatformIO, Result, SyncMode,
+        WalFileShared, IO,
     };
     use std::num::NonZeroUsize;
     #[cfg(unix)]
@@ -6354,6 +6524,83 @@ pub mod test {
         page
     }
 
+    #[derive(Debug)]
+    enum TestPageCodec {
+        Xor(u8),
+        ErrorEncode,
+        ErrorDecode,
+    }
+
+    impl PageCodec for TestPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"wal-test-codec--";
+            id[15] = match self {
+                Self::Xor(mask) => *mask,
+                Self::ErrorEncode => 1,
+                Self::ErrorDecode => 2,
+            };
+            PageCodecId::new(id)
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            0
+        }
+
+        fn encode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            match self {
+                Self::Xor(mask) => {
+                    for (input, output) in page.iter().zip(output) {
+                        *output = input ^ mask;
+                    }
+                    Ok(())
+                }
+                Self::ErrorEncode => Err(LimboError::InternalError("codec encode failed".into())),
+                Self::ErrorDecode => {
+                    output.copy_from_slice(page);
+                    Ok(())
+                }
+            }
+        }
+
+        fn decode_page(
+            &self,
+            page: &[u8],
+            output: &mut [u8],
+            _page_idx: usize,
+            _location: PageCodecLocation,
+        ) -> Result<()> {
+            match self {
+                Self::Xor(_) => self.encode_page(page, output, _page_idx, _location),
+                Self::ErrorEncode => {
+                    output.copy_from_slice(page);
+                    Ok(())
+                }
+                Self::ErrorDecode => Err(LimboError::InternalError("codec decode failed".into())),
+            }
+        }
+    }
+
+    fn set_test_page_codec(wal: &WalFile, codec: Arc<dyn PageCodec>) {
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_page_codec(codec);
+        wal.set_io_context(io_ctx);
+    }
+
+    fn set_test_encryption(wal: &WalFile, page_size: usize) {
+        let key = EncryptionKey::from_hex_string("000102030405060708090a0b0c0d0e0f").unwrap();
+        let mut io_ctx = IOContext::default();
+        io_ctx.set_encryption(
+            EncryptionContext::new(CipherMode::Aes128Gcm, &key, page_size).unwrap(),
+        );
+        wal.set_io_context(io_ctx);
+    }
+
     fn append_test_pages(
         io: &Arc<dyn IO>,
         wal: &WalFile,
@@ -6448,6 +6695,142 @@ pub mod test {
             assert_eq!(page.wal_tag_pair(), ((idx + 1) as u64, 0));
             assert_eq!(page.get_contents().as_ptr(), expected[idx].as_slice());
         }
+    }
+
+    #[test]
+    fn page_codec_round_trips_wal_batch_reads() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::Xor(0xa5)));
+        let source_pages = vec![
+            page_with_pattern(32, 0x10, &buffer_pool),
+            page_with_pattern(33, 0x20, &buffer_pool),
+        ];
+        let expected = append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(32)),
+            Arc::new(crate::Page::new(33)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        for (idx, page) in target_pages.iter().enumerate() {
+            assert_eq!(page.get_contents().as_ptr(), expected[idx].as_slice());
+        }
+    }
+
+    #[test]
+    fn page_codec_round_trips_vectored_wal_spill_frames() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::Xor(0xa5)));
+        let source_page = page_with_pattern(32, 0x10, &buffer_pool);
+        let expected = source_page.get_contents().as_ptr().to_vec();
+
+        let completion = wal
+            .append_frames_vectored(vec![source_page], PageSize::new(page_size).unwrap())
+            .unwrap();
+        io.wait_for_completion(completion).unwrap();
+
+        let target_page = Arc::new(crate::Page::new(32));
+        let completion = wal
+            .read_frames_batch(1, &[target_page.clone()], buffer_pool, None)
+            .unwrap();
+        io.wait_for_completion(completion).unwrap();
+        assert_eq!(target_page.get_contents().as_ptr(), expected.as_slice());
+    }
+
+    #[test]
+    fn page_codec_round_trips_raw_wal_frames() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::Xor(0xa5)));
+        let expected = (0..page_size).map(|i| i as u8).collect::<Vec<_>>();
+
+        wal.write_frame_raw(buffer_pool, 1, 44, 0, &expected, FileSyncType::Fsync)
+            .unwrap();
+
+        let mut frame = vec![0; WAL_FRAME_HEADER_SIZE + page_size as usize];
+        let completion = wal.read_frame_raw(1, &mut frame).unwrap();
+        io.wait_for_completion(completion).unwrap();
+        assert_eq!(&frame[WAL_FRAME_HEADER_SIZE..], expected.as_slice());
+    }
+
+    #[test]
+    fn page_codec_encode_error_does_not_publish_wal_frames() {
+        let page_size = 512;
+        let (_io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::ErrorEncode));
+        let source_page = page_with_pattern(43, 0x43, &buffer_pool);
+
+        assert!(wal
+            .prepare_frames(
+                &[source_page],
+                PageSize::new(page_size).unwrap(),
+                Some(1),
+                None,
+            )
+            .is_err());
+        assert_eq!(wal.get_max_frame(), 0);
+        assert_eq!(wal.find_frame(43, None).unwrap(), None);
+    }
+
+    #[test]
+    fn encryption_round_trips_raw_wal_frames() {
+        let page_size = 4096;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_encryption(&wal, page_size as usize);
+        let mut expected = (0..page_size).map(|i| i as u8).collect::<Vec<_>>();
+        expected[page_size as usize - 64..].fill(0);
+
+        wal.write_frame_raw(buffer_pool, 1, 44, 0, &expected, FileSyncType::Fsync)
+            .unwrap();
+
+        let mut frame = vec![0; WAL_FRAME_HEADER_SIZE + page_size as usize];
+        let completion = wal.read_frame_raw(1, &mut frame).unwrap();
+        io.wait_for_completion(completion).unwrap();
+        assert_eq!(&frame[WAL_FRAME_HEADER_SIZE..], expected.as_slice());
+    }
+
+    #[test]
+    fn page_codec_raw_wal_read_propagates_decode_error() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::ErrorDecode));
+        let source_pages = vec![page_with_pattern(43, 0x43, &buffer_pool)];
+        append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let mut frame = vec![0; WAL_FRAME_HEADER_SIZE + page_size as usize];
+        let c = wal.read_frame_raw(1, &mut frame).unwrap();
+        let err = wait_for_completion_error(&io, c);
+
+        assert!(matches!(
+            err,
+            CompletionError::PageCodecError { page_idx: 43 }
+        ));
+    }
+
+    #[test]
+    fn page_codec_wal_batch_read_reports_codec_error() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::ErrorDecode));
+        let source_pages = vec![page_with_pattern(43, 0x43, &buffer_pool)];
+        append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_page = Arc::new(crate::Page::new(43));
+        let c = wal
+            .read_frames_batch(1, &[target_page], buffer_pool, None)
+            .unwrap();
+        let err = wait_for_completion_error(&io, c);
+
+        assert!(matches!(
+            err,
+            CompletionError::PageCodecError { page_idx: 43 }
+        ));
     }
 
     #[test]
@@ -7632,6 +8015,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 
@@ -7679,6 +8063,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
         assert!(shared.read().runtime.frame_cache.lock().is_empty());
@@ -7747,6 +8132,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 
@@ -7835,6 +8221,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 
@@ -7872,6 +8259,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
         assert!(exclusive
@@ -7904,6 +8292,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
         assert!(!reopened_shared
@@ -7948,6 +8337,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
         assert!(shared
@@ -8009,6 +8399,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 
@@ -8316,6 +8707,7 @@ pub mod test {
             crate::OpenFlags::Create,
             &reopened_authority,
             &open_test_db_file_for_wal(&io, &wal_path),
+            None,
         )
         .unwrap();
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -6613,6 +6613,26 @@ pub mod test {
     }
 
     #[test]
+    fn page_codec_missing_wal_frame_reports_short_read() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        set_test_page_codec(&wal, Arc::new(TestPageCodec::Xor(0xa5)));
+        let target_page = Arc::new(crate::Page::new(43));
+
+        let completion = wal.read_frame(1, target_page, buffer_pool).unwrap();
+        let error = wait_for_completion_error(&io, completion);
+
+        assert!(matches!(
+            error,
+            CompletionError::ShortReadWalFrame {
+                expected: 512,
+                actual: 0,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn page_codec_round_trips_vectored_wal_spill_frames() {
         let page_size = 512;
         let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -16990,7 +16990,9 @@ fn op_journal_mode_inner(
                             .to_string(),
                     ));
                 }
-                if matches!(new_mode, journal_mode::JournalMode::Mvcc) && pager.has_page_codec() {
+                if matches!(new_mode, journal_mode::JournalMode::Mvcc)
+                    && pager.has_external_page_codec()
+                {
                     return Err(LimboError::InvalidArgument(
                         "external page codecs are not supported with MVCC databases".to_string(),
                     ));
@@ -17517,7 +17519,7 @@ fn op_vacuum_into_inner(
                 // Always use PlatformIO for the output file, even if source
                 // is in-memory. This ensures VACUUM INTO writes to disk.
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
-                let page_codec = source_pager.page_codec();
+                let page_codec = source_pager.page_codec_external();
                 let output_db = match &page_codec {
                     Some(codec) => crate::Database::open(
                         io,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -17519,15 +17519,13 @@ fn op_vacuum_into_inner(
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
                 let page_codec = source_pager.page_codec();
                 let output_db = match &page_codec {
-                    Some(codec) => crate::Database::open_file_with_flags_and_page_codec(
+                    Some(codec) => crate::Database::open(
                         io,
                         dest_path,
-                        OpenFlags::Create,
-                        output_opts,
-                        None,
-                        None,
-                        codec.clone(),
-                        source_db.dialect(),
+                        crate::OpenOptions::new(source_db.dialect())
+                            .flags(OpenFlags::Create)
+                            .db_opts(output_opts)
+                            .page_codec(codec.clone()),
                     )?,
                     None => crate::Database::open_file_with_flags(
                         io,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -16990,6 +16990,11 @@ fn op_journal_mode_inner(
                             .to_string(),
                     ));
                 }
+                if matches!(new_mode, journal_mode::JournalMode::Mvcc) && pager.has_page_codec() {
+                    return Err(LimboError::InvalidArgument(
+                        "external page codecs are not supported with MVCC databases".to_string(),
+                    ));
+                }
 
                 state.active_op_state.journal_mode().new_mode = Some(new_mode);
                 state.active_op_state.journal_mode().sub_state = OpJournalModeSubState::Checkpoint;
@@ -17512,15 +17517,31 @@ fn op_vacuum_into_inner(
                 // Always use PlatformIO for the output file, even if source
                 // is in-memory. This ensures VACUUM INTO writes to disk.
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
-                let output_db = crate::Database::open_file_with_flags(
-                    io,
-                    dest_path,
-                    OpenFlags::Create,
-                    output_opts,
-                    None,
-                    source_db.dialect(),
-                )?;
-                let output_conn = output_db.connect()?;
+                let page_codec = source_pager.page_codec();
+                let output_db = match &page_codec {
+                    Some(codec) => crate::Database::open_file_with_flags_and_page_codec(
+                        io,
+                        dest_path,
+                        OpenFlags::Create,
+                        output_opts,
+                        None,
+                        None,
+                        codec.clone(),
+                        source_db.dialect(),
+                    )?,
+                    None => crate::Database::open_file_with_flags(
+                        io,
+                        dest_path,
+                        OpenFlags::Create,
+                        output_opts,
+                        None,
+                        source_db.dialect(),
+                    )?,
+                };
+                let output_conn = match page_codec {
+                    Some(codec) => output_db.connect_with_page_codec(codec)?,
+                    None => output_db.connect()?,
+                };
                 output_conn.reset_page_size(page_size)?;
                 // set reserved_space on output to match source
                 // this is important for databases using encryption or checksums

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1832,6 +1832,7 @@ impl Program {
                                 "Abort also failed during checkpoint error handling: {abort_err}"
                             );
                         }
+                        pager.cleanup_after_checkpoint_failure();
                         return Err(checkpoint_err);
                     }
                     let err = err.into();

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -292,15 +292,31 @@ pub(crate) fn open_vacuum_temp_db(
     let test_path = path.clone();
 
     let (encryption_opts, encryption_key) = vacuum_temp_db_encryption(source_conn)?;
-    let db = Database::open_file_with_flags(
-        source_db.io.clone(),
-        &path,
-        OpenFlags::Create,
-        vacuum_target_opts_from_source(source_db),
-        encryption_opts,
-        source_db.dialect(),
-    )?;
-    let conn = db.connect_with_encryption(encryption_key)?;
+    let page_codec = source_conn.pager.load().page_codec();
+    let db = match &page_codec {
+        Some(codec) => Database::open_file_with_flags_and_page_codec(
+            source_db.io.clone(),
+            &path,
+            OpenFlags::Create,
+            vacuum_target_opts_from_source(source_db),
+            encryption_opts,
+            None,
+            codec.clone(),
+            source_db.dialect(),
+        )?,
+        None => Database::open_file_with_flags(
+            source_db.io.clone(),
+            &path,
+            OpenFlags::Create,
+            vacuum_target_opts_from_source(source_db),
+            encryption_opts,
+            source_db.dialect(),
+        )?,
+    };
+    let conn = match page_codec {
+        Some(codec) => db.connect_with_page_codec(codec)?,
+        None => db.connect_with_encryption(encryption_key)?,
+    };
     conn.reset_page_size(page_size)?;
     conn.set_reserved_bytes(reserved_space)?;
     conn.wal_auto_actions_disable();

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -294,15 +294,14 @@ pub(crate) fn open_vacuum_temp_db(
     let (encryption_opts, encryption_key) = vacuum_temp_db_encryption(source_conn)?;
     let page_codec = source_conn.pager.load().page_codec();
     let db = match &page_codec {
-        Some(codec) => Database::open_file_with_flags_and_page_codec(
+        Some(codec) => Database::open(
             source_db.io.clone(),
             &path,
-            OpenFlags::Create,
-            vacuum_target_opts_from_source(source_db),
-            encryption_opts,
-            None,
-            codec.clone(),
-            source_db.dialect(),
+            crate::OpenOptions::new(source_db.dialect())
+                .flags(OpenFlags::Create)
+                .db_opts(vacuum_target_opts_from_source(source_db))
+                .encryption(encryption_opts)
+                .page_codec(codec.clone()),
         )?,
         None => Database::open_file_with_flags(
             source_db.io.clone(),

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -292,7 +292,7 @@ pub(crate) fn open_vacuum_temp_db(
     let test_path = path.clone();
 
     let (encryption_opts, encryption_key) = vacuum_temp_db_encryption(source_conn)?;
-    let page_codec = source_conn.pager.load().page_codec();
+    let page_codec = source_conn.pager.load().page_codec_external();
     let db = match &page_codec {
         Some(codec) => Database::open(
             source_db.io.clone(),

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -45,6 +45,7 @@ Welcome to Turso database manual!
   - [Full-Text Search](#full-text-search-experimental)
   - [CDC](#cdc-early-preview)
   - [Index Method](#index-method-experimental)
+  - [Page Codecs](#page-codecs-experimental)
   - [Appendix A: Turso Internals](#appendix-a-turso-internals)
     - [Frontend](#frontend)
       - [Parser](#parser)
@@ -1243,6 +1244,52 @@ Each Index Method consists of three traits that work together (for details, see 
 While Index Methods can implement arbitrary logic internally, it's generally recommended to use a B-tree as the underlying storage mechanism. To support this, `tursodb` provides a special `backing_btree` Index Method that other Index Methods can use to create auxiliary tables for storing supporting data.
 
 For more details, see [`toy_vector_sparse_ivf`](../core/index_method/toy_vector_sparse_ivf.rs) implementation.
+
+## Page Codecs (Experimental)
+
+Page codecs lets you transform complete SQLite page images between
+their in-memory and on disk representation. The codec is applied to pages
+stored in both the database file and the WAL. This can be used for formats such
+as application-managed encryption or to support existing SQLite databases encrypted
+with SQLCipher or similar.
+
+The API is experimental. A codec defines a persistent file format, so changing
+its behavior can make existing databases unreadable.
+
+### Codec contract
+
+`PageCodec` implementations must provide:
+
+* `codec_id()`, a stable, non-secret 16-byte identifier for the complete
+  transform configuration. Equivalent codec instances must return the same ID,
+  while configurations that can produce different bytes must return different
+  IDs.
+* `required_reserved_bytes()`, the exact number of bytes the codec owns at the
+  end of every page.
+* `encode_page()` and `decode_page()`, which transform between decoded and
+  persistent page images. The engine supplies separate, equally sized input and
+  output buffers.
+
+`PageCodecContext::page_no` is the one-based SQLite page number.
+`PageCodecContext::location` identifies whether the persistent image is in the
+database file or the WAL. An encoder receives the destination location and a
+decoder receives the source location.
+
+### Page 1 bootstrap
+
+Before page 1 can be decoded, the engine needs its page size and reserved-space
+size. The default `bootstrap_page_info()` reads these from SQLite header bytes
+16–17 and 20. A codec that transforms those bytes must override the method and
+report values that match `required_reserved_bytes()` and the decoded header.
+
+For a complete database and WAL round trip, see
+`page_codec_round_trips_wal_and_checkpointed_database_with_bootstrap_header` in
+[the page codec tests](../core/lib.rs).
+
+External page codecs currently support the in-process WAL, checkpointing,
+`VACUUM`, and `VACUUM INTO`. They do not support MVCC, experimental
+multiprocess WAL, `ATTACH`, or partial sync. Files encoded by a non-identity
+codec are not readable by ordinary SQLite tools without a compatible codec.
 
 ## Appendix A: Turso Internals
 

--- a/sync/engine/src/database_sync_lazy_storage.rs
+++ b/sync/engine/src/database_sync_lazy_storage.rs
@@ -473,8 +473,8 @@ impl<IO: SyncEngineIo> DatabaseStorage for LazyDatabaseStorage<IO> {
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
         assert!(
-            io_ctx.encryption_context().is_none(),
-            "encryption or checksum are not supported with partial sync"
+            !io_ctx.has_codec_transform(),
+            "encryption and external page codecs are not supported with partial sync"
         );
         assert!(page_idx > 0, "page should be positive");
         let r = c.as_read();
@@ -603,8 +603,8 @@ impl<IO: SyncEngineIo> DatabaseStorage for LazyDatabaseStorage<IO> {
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
         assert!(
-            io_ctx.encryption_context().is_none(),
-            "encryption or checksum are not supported with partial sync"
+            !io_ctx.has_codec_transform(),
+            "encryption and external page codecs are not supported with partial sync"
         );
 
         let buffer_size = buffer.len();
@@ -646,8 +646,8 @@ impl<IO: SyncEngineIo> DatabaseStorage for LazyDatabaseStorage<IO> {
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
         assert!(
-            io_ctx.encryption_context().is_none(),
-            "encryption or checksum are not supported with partial sync"
+            !io_ctx.has_codec_transform(),
+            "encryption and external page codecs are not supported with partial sync"
         );
 
         assert!(first_page_idx > 0);


### PR DESCRIPTION
## Description

This patch adds support for Page Codec Interface for transforming complete SQLite pages between their in-memory and on-disk representations. This lets us do some interesting stuffs, like opening SQLCipher databases with Turso. 

This PR also reimplements Turso’s existing page encryption on top of Codec interface.

Most of the work has been "lifted" from @awakecoding's PR: https://github.com/tursodatabase/turso/pull/7600

## Motivation and context

The interface looks like this:

```rust
pub trait PageCodec: Any + Send + Sync {
      fn bootstrap_page_info(
          &self,
          raw_page1_prefix: &[u8],
      ) -> Result<PageCodecHeaderInfo> {
          PageCodecHeaderInfo::from_visible_sqlite_header(raw_page1_prefix)
      }

      fn encode_page(
          &self,
          context: PageCodecContext,
          input: &[u8],
          output: &mut [u8],
      ) -> Result<()>;

      fn decode_page(
          &self,
          context: PageCodecContext,
          input: &[u8],
          output: &mut [u8],
      ) -> Result<()>;
  }
```

The codec receives the SQLite page number and whether the page belongs to the database file or WAL. It is applied consistently during database I/O, WAL operations, recovery, checkpointing, and vacuum.

Built-in encryption now implements PageCodec internally. This allows encryption and external codecs to use the same database and WAL I/O paths.

#### Why

  Page transformations were previously tied to built-in encryption. This interface lets embedders provide other page formats without adding format-specific logic throughout the storage layer.

  Possible uses include:

  - Compatibility with SQLCipher and other SQLite-derived formats
  - Application-managed encryption
  - Custom page authentication or integrity metadata, like different checksum implementation
  - Application-specific fixed-size page encoding

Codecs must preserve the page size. This is not an interface for variable-size compression.

External page codecs cannot currently be used with:

  - MVCC
  - Experimental multiprocess WAL
  - ATTACH
  - Partial sync
  - Built-in encryption at the same time

## Description of AI Usage

For refactoring, tests, and review.