### PR TITLE
core/vdbe: use Cursor::NullRow variant when NullRow targets unopened slot

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -3271,6 +3271,9 @@ pub enum Cursor {
     Sorter(Box<Sorter>),
     Virtual(VirtualTableCursor),
     MaterializedView(Box<crate::incremental::cursor::MaterializedViewCursor>),
+    /// Permanently-null placeholder installed by `NullRow` on a
+    /// never-opened cursor slot; all reads yield NULL.
+    NullRow,
 }
 
 impl Debug for Cursor {
@@ -3282,6 +3285,7 @@ impl Debug for Cursor {
             Self::Sorter(..) => f.debug_tuple("Sorter").finish(),
             Self::Virtual(..) => f.debug_tuple("Virtual").finish(),
             Self::MaterializedView(..) => f.debug_tuple("MaterializedView").finish(),
+            Self::NullRow => f.debug_tuple("NullRow").finish(),
         }
     }
 }
@@ -3379,6 +3383,8 @@ impl Cursor {
             // column reads untouched: nullRow is the steady state for pseudo
             // cursors there, and OP_Column keeps routing to the register.
             Self::Pseudo(_) => {}
+            // Permanently null; the flag is a no-op.
+            Self::NullRow => {}
             _ => {
                 mark_unlikely();
                 panic!("set_null_flag on unexpected cursor type");

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -718,12 +718,30 @@ pub fn op_null(
 }
 
 pub fn op_null_row(
-    _program: &Program,
+    program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(NullRow { cursor_id }, insn);
+    // NullRow can target a never-opened cursor slot (e.g. a Once-guarded
+    // OpenAutoindex in a loop body that never ran); install a permanently
+    // null placeholder, mirroring SQLite's OP_NullRow.
+    if state.cursors[*cursor_id].is_none() {
+        let (_, cursor_type) = program
+            .cursor_ref
+            .get(*cursor_id)
+            .expect("cursor_id should exist in cursor_ref");
+        turso_assert!(
+            matches!(
+                cursor_type,
+                CursorType::BTreeTable(_) | CursorType::BTreeIndex(_)
+            ),
+            "NullRow on unopened non-btree cursor",
+            { "cursor_id": cursor_id }
+        );
+        state.cursors[*cursor_id] = Some(Cursor::NullRow);
+    }
     state.get_cursor(*cursor_id).set_null_flag(true);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -1875,6 +1893,11 @@ fn op_column_fetch(
             state.registers[dest].set_value(value);
             return Ok(InsnFunctionStepResult::Step);
         }
+        if matches!(cursor, Cursor::NullRow) {
+            tracing::trace!("op_column(null_row placeholder)");
+            state.registers[dest].set_null();
+            return Ok(InsnFunctionStepResult::Step);
+        }
         // Fall back to normal handling
     }
 
@@ -2038,13 +2061,17 @@ pub fn op_column_has_field(
         | CursorType::MaterializedView(_, _) => {
             let cursor_ref =
                 must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "ColumnHasField");
-            let cursor = cursor_ref.as_btree_mut();
-            if cursor.get_null_flag() {
+            if matches!(cursor_ref, Cursor::NullRow) {
                 false
             } else {
-                match return_if_io!(cursor.record()) {
-                    Some(record) => record.column_count() > *column,
-                    None => false,
+                let cursor = cursor_ref.as_btree_mut();
+                if cursor.get_null_flag() {
+                    false
+                } else {
+                    match return_if_io!(cursor.record()) {
+                        Some(record) => record.column_count() > *column,
+                        None => false,
+                    }
                 }
             }
         }
@@ -5191,7 +5218,12 @@ pub fn op_row_id(
             }
             OpRowIdState::GetRowid => {
                 let cursors = &mut state.cursors;
-                if let Some(Cursor::BTree(btree_cursor)) = cursors
+                if let Some(Cursor::NullRow) = cursors
+                    .get_mut(*cursor_id)
+                    .expect("cursor_id should be valid")
+                {
+                    state.registers[*dest].set_null();
+                } else if let Some(Cursor::BTree(btree_cursor)) = cursors
                     .get_mut(*cursor_id)
                     .expect("cursor_id should be valid")
                 {
@@ -5266,6 +5298,7 @@ pub fn op_idx_row_id(
     let rowid = match cursor {
         Cursor::BTree(cursor) => return_if_io!(cursor.rowid()),
         Cursor::IndexMethod(cursor) => return_if_io!(cursor.query_rowid()),
+        Cursor::NullRow => None,
         _ => panic!("unexpected cursor type"),
     };
     match rowid {
@@ -14150,6 +14183,10 @@ pub fn op_open_ephemeral(
             // Fast path: if cursor already has an ephemeral btree, just clear it instead of
             // recreating the entire pager/file/btree. This is important for performance when
             // OpenEphemeral is called repeatedly during statement execution.
+            // A NullRow placeholder is not a real ephemeral btree; drop it.
+            if matches!(state.cursors[cursor_id], Some(Cursor::NullRow)) {
+                state.cursors[cursor_id] = None;
+            }
             if state.cursors[cursor_id].is_some() {
                 *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::ClearExisting;
                 return Ok(InsnFunctionStepResult::Step);

--- a/sqlite/conformance/sqlite-sqltests/join-empty-table-ungrouped-aggregate.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join-empty-table-ungrouped-aggregate.sqltest
@@ -1,0 +1,63 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/5233
+#
+# A JOIN with an ON clause and an ungrouped aggregate panicked when the left
+# table was empty: the autoindex cursor for the join is opened inside the loop
+# body (in a Once block), so when Rewind skips the loop entirely the cursor is
+# never opened, but the post-loop aggregation path still tried to read a
+# non-aggregate column from it via Column, panicking with "cursor id N is
+# None".
+
+setup empty-table {
+    CREATE TABLE t(x);
+}
+
+@setup empty-table
+test left-join-empty-table-ungrouped-aggregate {
+    SELECT b.x, COUNT(*) FROM t a LEFT JOIN t b ON a.x=b.x;
+}
+expect {
+    |0
+}
+
+@setup empty-table
+test inner-join-empty-table-ungrouped-aggregate {
+    SELECT b.x, COUNT(*) FROM t a JOIN t b ON a.x=b.x;
+}
+expect {
+    |0
+}
+
+# RowId (not just Column) must also read NULL from the never-opened cursor.
+@setup empty-table
+test inner-join-empty-table-ungrouped-aggregate-rowid {
+    SELECT a.rowid, b.rowid, COUNT(*) FROM t a JOIN t b ON a.x=b.x;
+}
+expect {
+    ||0
+}
+
+setup populated-table {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1),(2);
+}
+
+# Non-empty table but the WHERE clause filters out every row, so the join
+# body (and the autoindex cursor open) is still skipped.
+@setup populated-table
+test inner-join-filtered-out-ungrouped-aggregate {
+    SELECT b.x, COUNT(*) FROM t a JOIN t b ON a.x=b.x WHERE a.x > 5;
+}
+expect {
+    |0
+}
+
+# Control: with matching rows the non-aggregate column comes from a real row.
+@setup populated-table
+test inner-join-populated-ungrouped-aggregate {
+    SELECT b.x, COUNT(*) FROM t a JOIN t b ON a.x=b.x;
+}
+expect {
+    1|2
+}


### PR DESCRIPTION
A JOIN whose access path uses an automatic (ephemeral) index opens the
index cursor with a Once-guarded OpenAutoindex inside the loop body.
When the outer table is empty, Rewind skips the loop body entirely and
the cursor is never opened, but the ungrouped-aggregation post-loop
path still emits NullRow and Column against that cursor to evaluate
non-aggregate result columns as NULL, panicking with "cursor id N is
None".

Fix this at the VM level, mirroring SQLite's OP_NullRow: when NullRow
targets a btree cursor slot that was never opened, install a
Cursor::NullRow placeholder variant that reads as a permanently null
row, so every subsequent Column/RowId read yields NULL (SQLite
allocates a CURTYPE_PSEUDO cursor backed by
sqlite3BtreeFakeValidCursor() in the same situation). This covers
every current and future NullRow emission site against lazily-opened
cursors instead of patching a single codegen path.

Using an enum variant instead of a fake Box<dyn CursorTrait> keeps the
placeholder out of every code path that matches Cursor::BTree: opcodes
that would move or mutate it fall through to the existing non-btree
panics/errors so misuse fails loudly, cross-cursor scans such as
ClearBtree's pager comparison skip it, and OpenEphemeral/OpenAutoindex
replace it with a real ephemeral btree by matching the variant rather
than downcasting through Any.

Tests: sqlite-sqltests join-empty-table-ungrouped-aggregate passes;
full sqltest conformance, turso_core and core_tester suites pass;
differential checks against sqlite3 for empty/filtered join inputs and
LEFT JOIN null-row paths are identical; issue query also verified
under journal_mode=mvcc.

Fixes #5233