### PR TITLE
core/mvcc: publish logical-log truncate state only after durable completion

### DIFF
--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -575,6 +575,59 @@ fn derive_initial_crc(salt: u64) -> u32 {
     crc32c::crc32c(&salt.to_le_bytes())
 }
 
+/// Outcome of a truncate's I/O completion, reported by the completion
+/// callback through a shared atomic (via the `u8` conversions below) and
+/// consumed by [`LogicalLog::settle_pending_truncate`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TruncateIoOutcome {
+    /// Truncate completion has been issued but has not fired yet.
+    InFlight,
+    /// Truncate completion fired successfully: the file change is durable.
+    Succeeded,
+    /// Truncate completion fired with an error: the bytes never became durable.
+    Failed,
+}
+
+impl From<TruncateIoOutcome> for u8 {
+    fn from(outcome: TruncateIoOutcome) -> u8 {
+        match outcome {
+            TruncateIoOutcome::InFlight => 0,
+            TruncateIoOutcome::Succeeded => 1,
+            TruncateIoOutcome::Failed => 2,
+        }
+    }
+}
+
+impl From<u8> for TruncateIoOutcome {
+    fn from(value: u8) -> TruncateIoOutcome {
+        match value {
+            0 => TruncateIoOutcome::InFlight,
+            1 => TruncateIoOutcome::Succeeded,
+            2 => TruncateIoOutcome::Failed,
+            _ => unreachable!("invalid TruncateIoOutcome value: {value}"),
+        }
+    }
+}
+
+/// Post-truncate log state staged by [`LogicalLog::truncate_to_zero`].
+///
+/// The durable-extent offset and running CRC are what recovery trusts as
+/// "data is durable up to here", so they must not advance past a truncate the
+/// I/O layer has not confirmed (#7993). The new state (offset 0, header with a
+/// regenerated salt, CRC reseeded from that salt) is staged here and published
+/// by [`LogicalLog::settle_pending_truncate`] only once the truncate
+/// completion reports success; on failure it is discarded and the durable tail
+/// stays as-is.
+struct PendingTruncate {
+    /// Written by the truncate completion callback; holds a
+    /// [`TruncateIoOutcome`] encoded through its `u8` conversions.
+    outcome: Arc<crate::sync::atomic::AtomicU8>,
+    /// Header carrying the regenerated salt, published on success.
+    header: LogHeader,
+    /// Running CRC reseeded from the new salt, published on success.
+    running_crc: u32,
+}
+
 #[cfg_attr(feature = "aristo-instr", derive(aristo::instrument::Inspect))]
 pub struct LogicalLog {
     pub file: Arc<dyn File>,
@@ -591,6 +644,9 @@ pub struct LogicalLog {
     /// doesn't corrupt the chain.
     #[cfg_attr(feature = "aristo-instr", inspect(name = "pending_running_crc"))]
     pending_running_crc: Option<u32>,
+    /// Post-truncate state waiting for its truncate completion to confirm
+    /// durability. Published (or discarded) by `settle_pending_truncate`.
+    pending_truncate: Option<PendingTruncate>,
     encryption_ctx: Option<EncryptionContext>,
     /// Plaintext bytes per encrypted payload chunk. Production uses the fixed format constant;
     /// tests may override via `new_with_encrypted_payload_chunk_size_for_test`.
@@ -605,6 +661,18 @@ impl LogicalLog {
     /// Both underlying fields are already `pub`; this pairs them under the exact
     /// symbol the routed conformance tests expect.
     pub fn read_logicallog_offset_crc(&self) -> (u64, u32) {
+        // A truncate whose completion has confirmed durability but that has
+        // not been settled through a `&mut self` entry point yet already
+        // describes the durable tail: report the staged post-truncate state.
+        if let Some(pending) = &self.pending_truncate {
+            let outcome: TruncateIoOutcome = pending
+                .outcome
+                .load(crate::sync::atomic::Ordering::SeqCst)
+                .into();
+            if outcome == TruncateIoOutcome::Succeeded {
+                return (0, pending.running_crc);
+            }
+        }
         (self.offset, self.running_crc)
     }
 }
@@ -623,6 +691,7 @@ impl LogicalLog {
             header: None,
             running_crc: 0,
             pending_running_crc: None,
+            pending_truncate: None,
             encryption_ctx,
             encrypted_payload_chunk_size,
             max_appended_commit_ts: 0,
@@ -648,6 +717,7 @@ impl LogicalLog {
     }
 
     pub(crate) fn set_header(&mut self, header: LogHeader) {
+        self.settle_pending_truncate();
         self.running_crc = derive_initial_crc(header.salt);
         self.header = Some(header);
     }
@@ -673,6 +743,7 @@ impl LogicalLog {
         advance_offset_immediately: bool,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {
+        self.settle_pending_truncate();
         let op_count = tx.op_count;
         let commit_ts = tx.tx_timestamp;
         self.max_appended_commit_ts = self.max_appended_commit_ts.max(commit_ts);
@@ -899,6 +970,7 @@ impl LogicalLog {
     }
 
     pub fn upgrade_header_for_log_tx(&mut self, tx: &LogRecord) -> Result<Option<Completion>> {
+        self.settle_pending_truncate();
         #[cfg(feature = "conn_raw_api")]
         let portable_changes_enabled =
             tx.portable_changes_enabled || !tx.portable_changes.is_empty();
@@ -945,6 +1017,7 @@ impl LogicalLog {
 
     #[aristo::intent("the in-memory log offset advances only after the corresponding frame pwrite has completed durably", id = "aristos:logical_log_inmemory_offset_advances_after_durable_write", verify = "full")]
     pub fn advance_offset_after_success(&mut self, bytes: u64) {
+        self.settle_pending_truncate();
         self.offset = self
             .offset
             .checked_add(bytes)
@@ -1013,28 +1086,88 @@ impl LogicalLog {
     }
 
     pub fn update_header(&mut self) -> Result<Completion> {
+        self.settle_pending_truncate();
         let header = self.current_or_new_header()?;
         self.write_header(header)
     }
 
+    /// Publishes or discards the staged post-truncate state depending on
+    /// whether the truncate completion has fired.
+    ///
+    /// The durable-extent offset, running CRC, header, and
+    /// `max_appended_commit_ts` describe the durable tail of the log, so
+    /// every entry point that reads or mutates them must settle first:
+    /// - completion not fired yet: keep the durable tail untouched;
+    /// - completion succeeded: publish offset 0, the new-salt header, and the
+    ///   reseeded running CRC;
+    /// - completion failed: discard the staged state — the on-disk log still
+    ///   holds the old frames, so the durable tail stays where it was.
+    fn settle_pending_truncate(&mut self) {
+        use crate::sync::atomic::Ordering;
+        let Some(pending) = &self.pending_truncate else {
+            return;
+        };
+        match pending.outcome.load(Ordering::SeqCst).into() {
+            TruncateIoOutcome::InFlight => {}
+            TruncateIoOutcome::Succeeded => {
+                let pending = self
+                    .pending_truncate
+                    .take()
+                    .expect("pending truncate checked above");
+                self.header = Some(pending.header);
+                self.running_crc = pending.running_crc;
+                self.pending_running_crc = None;
+                self.offset = 0;
+                self.max_appended_commit_ts = 0;
+            }
+            TruncateIoOutcome::Failed => {
+                self.pending_truncate = None;
+            }
+        }
+    }
+
     #[aristo::intent("the running CRC of the log is reseeded only after the truncate operation has completed durably", id = "aristos:logical_log_truncate_crc_reseed_after_completion", verify = "full")]
     fn truncate_to_zero(&mut self) -> Result<Completion> {
+        use crate::sync::atomic::{AtomicU8, Ordering};
+        self.settle_pending_truncate();
         // Regenerate salt so stale frames (from before truncation) cannot validate
-        // against the new CRC chain.
+        // against the new CRC chain. The new state (offset 0, new-salt header,
+        // reseeded running CRC) is only STAGED here: it is published by
+        // `settle_pending_truncate` once the completion confirms the truncate
+        // is durable. Advancing offset/CRC past an unconfirmed write would let
+        // a later read or recovery trust a position the data never reached
+        // (#7993).
         let mut header = self.current_or_new_header()?;
         header.salt = self.io.generate_random_number() as u64;
-        self.running_crc = derive_initial_crc(header.salt);
-        self.pending_running_crc = None;
-        self.header = Some(header);
+        let running_crc = derive_initial_crc(header.salt);
 
-        let completion = Completion::new_trunc(move |result| {
-            if let Err(err) = result {
-                tracing::error!("logical_log_truncate failed: {}", err);
+        let outcome = Arc::new(AtomicU8::new(TruncateIoOutcome::InFlight.into()));
+        let completion = Completion::new_trunc({
+            let outcome = outcome.clone();
+            move |result| match result {
+                Ok(_) => outcome.store(TruncateIoOutcome::Succeeded.into(), Ordering::SeqCst),
+                Err(err) => {
+                    tracing::error!("logical_log_truncate failed: {}", err);
+                    outcome.store(TruncateIoOutcome::Failed.into(), Ordering::SeqCst);
+                }
             }
         });
-        let c = self.file.truncate(0, completion)?;
-        self.offset = 0;
-        self.max_appended_commit_ts = 0;
+        self.pending_truncate = Some(PendingTruncate {
+            outcome,
+            header,
+            running_crc,
+        });
+        let c = match self.file.truncate(0, completion) {
+            Ok(c) => c,
+            Err(err) => {
+                // The truncate was never issued; nothing to wait for.
+                self.pending_truncate = None;
+                return Err(err);
+            }
+        };
+        // Synchronous I/O layers (e.g. MemoryIO) complete inline: publish now
+        // so callers observing the log right after issuing see settled state.
+        self.settle_pending_truncate();
         Ok(c)
     }
 
@@ -1045,6 +1178,7 @@ impl LogicalLog {
         checkpointed_through_ts: u64,
     ) -> Result<(Completion, super::LogicalLogTruncateOutcome)> {
         use super::LogicalLogTruncateOutcome;
+        self.settle_pending_truncate();
         if self.max_appended_commit_ts > checkpointed_through_ts {
             // Uncheckpointed frames remain — skip truncation.
             let c = Completion::new_trunc(|_| {});
@@ -1063,6 +1197,7 @@ impl LogicalLog {
     /// Either completion order leaves a header-sized file with the fresh header
     /// bytes at offset zero.
     pub fn reset_to_fresh_header(&mut self) -> Result<Completion> {
+        self.settle_pending_truncate();
         // Regenerate salt so stale frames from before the reset cannot validate
         // against this new CRC chain.
         let mut header = self.current_or_new_header()?;

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -10,6 +10,8 @@ use std::fmt::Debug;
 #[cfg(test)]
 mod discard_pending_tests;
 pub mod logical_log;
+#[cfg(test)]
+mod truncate_durability_test;
 use crate::mvcc::database::{LogRecord, RowVersion};
 use crate::mvcc::persistent_storage::logical_log::{
     LogSerializer, LogicalLog, OnSerializationComplete, DEFAULT_LOG_CHECKPOINT_THRESHOLD,
@@ -156,11 +158,6 @@ impl Storage {
     fn shadow_offset_store(&self, value: u64) {
         self.log_offset.store(value, Ordering::Relaxed);
     }
-
-    #[inline(always)]
-    fn shadow_offset_advance(&self, bytes: u64) {
-        self.log_offset.fetch_add(bytes, Ordering::Relaxed);
-    }
 }
 
 impl DurableStorage for Storage {
@@ -270,8 +267,12 @@ impl DurableStorage for Storage {
     }
 
     fn advance_logical_log_offset_after_success(&self, bytes: u64) -> Result<()> {
-        self.logical_log.write().advance_offset_after_success(bytes);
-        self.shadow_offset_advance(bytes);
+        let mut log = self.logical_log.write();
+        log.advance_offset_after_success(bytes);
+        // Store the canonical offset (still under the lock) rather than
+        // fetch_add: a truncate that settled inside the call above may have
+        // reset the base, and a blind add would diverge from LogicalLog::offset.
+        self.shadow_offset_store(log.offset);
         Ok(())
     }
 

--- a/core/mvcc/persistent_storage/truncate_durability_test.rs
+++ b/core/mvcc/persistent_storage/truncate_durability_test.rs
@@ -1,0 +1,162 @@
+//! Regression tests for issue #7993: on the immediate-advance logical-log path
+//! (`LogicalLog::truncate` / `truncate_to_zero`), the durable-extent offset and
+//! the running CRC must not move past the durable tail until the I/O layer has
+//! confirmed the operation. Advancing them right after issuing the request —
+//! before the completion fires, and ignoring failure — lets a later read or
+//! recovery trust a position (offset + CRC chain state) the data never reached.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use crate::io::{FileSyncType, MemoryIO};
+use crate::mvcc::database::tests::generate_simple_string_row;
+use crate::mvcc::database::{LogRecord, MVTableId, PackedTs, RowVersion, TxTimestampOrID, WalPos};
+use crate::sync::Arc;
+use crate::{Buffer, Completion, CompletionError, File, OpenFlags, Result, IO};
+
+use super::logical_log::LogicalLog;
+
+/// File wrapper that forwards all I/O to `inner` but can hold or fail
+/// truncate requests, modeling an unconfirmed or failed durable write.
+struct FaultTruncateFile {
+    inner: Arc<dyn File>,
+    hold_truncate: AtomicBool,
+    fail_truncate: AtomicBool,
+    held: Mutex<Option<(u64, Completion)>>,
+}
+
+impl FaultTruncateFile {
+    fn new(inner: Arc<dyn File>) -> Self {
+        Self {
+            inner,
+            hold_truncate: AtomicBool::new(false),
+            fail_truncate: AtomicBool::new(false),
+            held: Mutex::new(None),
+        }
+    }
+
+    /// Confirm the held truncate: forward it to the inner file so it actually
+    /// becomes durable, then fire the caller's completion.
+    fn release_held_truncate(&self) {
+        let (len, c) = self
+            .held
+            .lock()
+            .unwrap()
+            .take()
+            .expect("no truncate is being held");
+        let inner_c = Completion::new_trunc(|_| {});
+        drop(self.inner.truncate(len, inner_c).unwrap());
+        c.complete(0);
+    }
+}
+
+impl File for FaultTruncateFile {
+    fn lock_file(&self, exclusive: bool) -> Result<()> {
+        self.inner.lock_file(exclusive)
+    }
+    fn unlock_file(&self) -> Result<()> {
+        self.inner.unlock_file()
+    }
+    fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
+        self.inner.pread(pos, c)
+    }
+    fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
+        self.inner.pwrite(pos, buffer, c)
+    }
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> Result<Completion> {
+        self.inner.sync(c, sync_type)
+    }
+    fn size(&self) -> Result<u64> {
+        self.inner.size()
+    }
+    fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+        if self.fail_truncate.load(Ordering::SeqCst) {
+            // Injected failure: the bytes never reach durable storage.
+            c.error(CompletionError::IOError(
+                std::io::ErrorKind::Other,
+                "injected truncate failure (issue #7993)",
+            ));
+            return Ok(c);
+        }
+        if self.hold_truncate.load(Ordering::SeqCst) {
+            // Unconfirmed write: completion is withheld until released.
+            *self.held.lock().unwrap() = Some((len, c.clone()));
+            return Ok(c);
+        }
+        self.inner.truncate(len, c)
+    }
+}
+
+fn row_version(commit_ts: u64) -> RowVersion {
+    let table_id: MVTableId = (-100).into();
+    RowVersion {
+        id: commit_ts,
+        begin: PackedTs::pack(Some(TxTimestampOrID::Timestamp(commit_ts))),
+        end: PackedTs::pack(None),
+        row: generate_simple_string_row(table_id, 1, "issue-7993"),
+        btree_resident: false,
+        materialized_at: WalPos::ORIGIN,
+    }
+}
+
+/// Builds a log with one durably committed frame and returns the log, the IO,
+/// the fault-injection file handle, and the durable tail `(offset, crc)`.
+fn log_with_one_durable_frame(
+    name: &str,
+) -> (LogicalLog, Arc<dyn IO>, Arc<FaultTruncateFile>, (u64, u32)) {
+    let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+    let inner = io.open_file(name, OpenFlags::Create, false).unwrap();
+    let fault = Arc::new(FaultTruncateFile::new(inner));
+    let file: Arc<dyn File> = fault.clone();
+    let mut log = LogicalLog::new(file, io.clone(), None);
+
+    let tx = LogRecord::for_test(10, &[row_version(10)], None);
+    let c = log.log_tx(tx).unwrap();
+    io.wait_for_completion(c).unwrap();
+
+    let durable_tail = (log.offset, log.running_crc);
+    assert!(durable_tail.0 > 0, "expected a non-empty durable log");
+    (log, io, fault, durable_tail)
+}
+
+/// While a truncate is issued but its completion has NOT fired, the offset and
+/// running CRC must still describe the durable tail. Today both are mutated
+/// immediately after (and partly before) issuing the request.
+#[test]
+fn issue_7993_truncate_must_not_move_offset_and_crc_before_completion() {
+    let (mut log, _io, fault, durable_tail) =
+        log_with_one_durable_frame("issue_7993_hold_truncate");
+
+    fault.hold_truncate.store(true, Ordering::SeqCst);
+    let (_c, _outcome) = log.truncate(u64::MAX).unwrap();
+
+    assert_eq!(
+        (log.offset, log.running_crc),
+        durable_tail,
+        "durable-extent offset/running CRC moved past the durable tail before \
+         the truncate completion fired"
+    );
+
+    // Confirm durability so the held completion does not dangle.
+    fault.release_held_truncate();
+}
+
+/// When the truncate FAILS, the offset and running CRC must stay at the
+/// durable tail: the on-disk log still contains the old frames, so publishing
+/// the post-truncate state (offset 0, reseeded CRC) trusts a position the
+/// operation never reached.
+#[test]
+fn issue_7993_failed_truncate_must_not_move_offset_and_crc() {
+    let (mut log, _io, fault, durable_tail) =
+        log_with_one_durable_frame("issue_7993_fail_truncate");
+
+    fault.fail_truncate.store(true, Ordering::SeqCst);
+    let (_c, _outcome) = log.truncate(u64::MAX).unwrap();
+
+    assert_eq!(
+        (log.offset, log.running_crc),
+        durable_tail,
+        "durable-extent offset/running CRC moved past the durable tail even \
+         though the truncate write failed"
+    );
+}


### PR DESCRIPTION
On the immediate-advance truncate path, truncate_to_zero reset the
durable-extent offset, reseeded the running CRC from a fresh salt, and
rotated the header before the file truncate's completion fired — and it
ignored write failures. The offset and running CRC are what a later
read or recovery trusts as "data is durable up to here", so a held or
failed truncate left the in-memory state pointing past the durable
tail.

Stage the post-truncate state in a new PendingTruncate (new-salt
header, reseeded CRC, and an outcome cell written by the truncate
completion) and publish it via settle_pending_truncate only once the
completion confirms success; discard it on failure so the durable tail
stays put. Every LogicalLog entry point that reads or mutates the
durable-tail coordinates settles first, and truncate_to_zero settles
again right after issuing so synchronous I/O layers (MemoryIO) still
expose offset 0 inline, preserving the checkpoint state machine's
fast-path assertion. The aristo harness accessor reports the staged
state once the completion has confirmed, keeping DOI parity with the
reference model.

Storage::advance_logical_log_offset_after_success now stores the
canonical LogicalLog::offset into the shadow atomic under the write
lock instead of fetch_add, since a truncate settling inside the call
can reset the base offset and a blind add would diverge.

Also repairs three CI breakages inherited from the base commit (the
bindings/c statement-introspection merge), which failed this PR's
checks the same way they failed main's:

- core/util: index-method pattern capture rejected any variable that
  carries a name, but the parser now records "?N" as the name of an
  explicit ?N marker, so the FTS patterns using ?1 stopped matching and
  fts_score silently returned 0.0. Treat ? and ?N markers as positional
  and keep rejecting only :x/@x/$x named ones.
- core/statement: build the test blob with crate::alloc::vec! so the
  expanded_sql unit test compiles under --cfg nightly, where Vec is
  allocator-parametric.
- bindings/dotnet: update the missing-parameter test message; an
  anonymous ? has no name now (matching sqlite3_bind_parameter_name),
  so the error reports the position instead.

Tests: cargo test -p turso_core --lib issue_7993; full turso_core lib
suite with --all-features; core_tester index_method suite; nightly cfg
check (RUSTFLAGS="--cfg nightly" cargo +nightly-2025-12-17 check -p
turso_core --all-targets --locked); clippy --workspace --all-features
--all-targets.

Fixes #7993