### PR TITLE
perf: core/storage: specialize record payload extraction

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7,7 +7,7 @@ use tracing::{instrument, Level};
 
 use super::{
     pager::PageRef,
-    sqlite3_ondisk::{IndexInteriorCell, IndexLeafCell, OverflowCell, MINIMUM_CELL_SIZE},
+    sqlite3_ondisk::{IndexInteriorCell, OverflowCell, MINIMUM_CELL_SIZE},
 };
 use crate::alloc::{TursoFromIterator, TursoSliceExt, TursoVecExt};
 #[cfg(any(test, injected_yields))]
@@ -21,7 +21,7 @@ use crate::{
         pager::{BtreePageAllocMode, Pager},
         sqlite3_ondisk::{
             payload_overflows, read_u32, read_varint, write_varint, BTreeCell, DatabaseHeader,
-            PageContent, PageSize, PageType, TableInteriorCell, TableLeafCell, CELL_PTR_SIZE_BYTES,
+            PageContent, PageSize, PageType, TableInteriorCell, CELL_PTR_SIZE_BYTES,
             FREELIST_LEAF_PTR_SIZE, FREELIST_TRUNK_HEADER_SIZE,
             FREELIST_TRUNK_OFFSET_FIRST_LEAF_PTR, FREELIST_TRUNK_OFFSET_LEAF_COUNT,
             FREELIST_TRUNK_OFFSET_NEXT_TRUNK_PTR, INTERIOR_PAGE_HEADER_SIZE_BYTES,
@@ -2223,7 +2223,7 @@ impl BTreeCursor {
             .stack
             .get_page_contents_at_level(old_top_idx)
             .unwrap()
-            .cell_index_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
+            .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
 
         if let Some(next_page) = first_overflow_page {
             let res = self.process_overflow_read(payload, next_page, payload_size)?;
@@ -2662,7 +2662,7 @@ impl BTreeCursor {
             .stack
             .get_page_contents_at_level(old_top_idx)
             .unwrap()
-            .cell_index_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
+            .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
 
         if let Some(next_page) = first_overflow_page {
             let res = self.process_overflow_read(payload, next_page, payload_size)?;
@@ -6485,27 +6485,8 @@ impl CursorTrait for BTreeCursor {
         let page = self.stack.top_ref();
         let contents = page.get_contents();
         let cell_idx = self.stack.current_cell_index();
-        let cell = contents.cell_get(cell_idx as usize, self.usable_space())?;
-        let (payload, payload_size, first_overflow_page) = match cell {
-            BTreeCell::TableLeafCell(TableLeafCell {
-                payload,
-                payload_size,
-                first_overflow_page,
-                ..
-            }) => (payload, payload_size, first_overflow_page),
-            BTreeCell::IndexInteriorCell(IndexInteriorCell {
-                payload,
-                payload_size,
-                first_overflow_page,
-                ..
-            }) => (payload, payload_size, first_overflow_page),
-            BTreeCell::IndexLeafCell(IndexLeafCell {
-                payload,
-                first_overflow_page,
-                payload_size,
-            }) => (payload, payload_size, first_overflow_page),
-            _ => unreachable!("unexpected page_type"),
-        };
+        let (payload, payload_size, first_overflow_page) =
+            contents.cell_read_payload_ptr(cell_idx as usize, self.usable_space())?;
         if let Some(next_page) = first_overflow_page {
             return_if_io!(self.process_overflow_read(payload, next_page, payload_size))
         } else {
@@ -9997,7 +9978,7 @@ mod tests {
     use crate::{
         storage::{
             btree::{compute_free_space, fill_cell_payload, payload_overflow_threshold_max},
-            sqlite3_ondisk::{BTreeCell, PageContent, PageType},
+            sqlite3_ondisk::{BTreeCell, PageContent, PageType, TableLeafCell},
         },
         types::Value,
         Database, Page, Pager, PlatformIO,

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -443,14 +443,16 @@ impl PageInner {
         Ok(rowid as i64)
     }
 
-    /// Fast path for index cells: returns payload slice and overflow info without constructing BTreeCell.
+    /// Returns a cell's record payload and overflow info without constructing
+    /// a `BTreeCell`.
     ///
-    /// This bypasses the full `cell_get()` to `read_btree_cell()` path for binary search hot loops.
+    /// This bypasses the full `cell_get()` to `read_btree_cell()` path for
+    /// record reads and index binary-search hot loops.
     /// The returned slice is valid as long as the page is alive.
     ///
     /// Returns: (payload_slice, payload_size, first_overflow_page)
     #[inline(always)]
-    pub fn cell_index_read_payload_ptr(
+    pub fn cell_read_payload_ptr(
         &self,
         idx: usize,
         usable_size: usize,
@@ -461,21 +463,29 @@ impl PageInner {
         let cell_offset = self.read_u16(cell_pointer) as usize;
 
         let page_type = self.page_type()?;
-        let (payload_size, varint_len, header_skip) = match page_type {
+        let (payload_size, payload_start) = match page_type {
             PageType::IndexInterior => {
                 let (size, len) =
                     read_varint(crate::slice_in_bounds_or_corrupt!(buf, cell_offset + 4..))?;
-                (size, len, 4usize)
+                (size, cell_offset + 4 + len)
             }
             PageType::IndexLeaf => {
                 let (size, len) =
                     read_varint(crate::slice_in_bounds_or_corrupt!(buf, cell_offset..))?;
-                (size, len, 0usize)
+                (size, cell_offset + len)
             }
-            _ => unreachable!("cell_index_read_payload_ptr called on non-index page"),
+            PageType::TableLeaf => {
+                let (size, payload_size_len) =
+                    read_varint(crate::slice_in_bounds_or_corrupt!(buf, cell_offset..))?;
+                let rowid_start = cell_offset + payload_size_len;
+                let (_, rowid_len) =
+                    read_varint(crate::slice_in_bounds_or_corrupt!(buf, rowid_start..))?;
+                (size, rowid_start + rowid_len)
+            }
+            PageType::TableInterior => {
+                unreachable!("table interior cells do not contain record payloads")
+            }
         };
-
-        let payload_start = cell_offset + header_skip + varint_len;
 
         let max_local = payload_overflow_threshold_max(page_type, usable_size);
         let min_local = payload_overflow_threshold_min(page_type, usable_size);


### PR DESCRIPTION
Record reads only need the serialized payload and overflow metadata, but the generic cell path constructs and then immediately destructures a BTreeCell. Extend the existing index payload fast path to table leaves and use it from BTreeCursor::record().