### PR TITLE
core/wal: fsync WAL before checkpoint backfill for crash atomicity

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1466,7 +1466,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         let Some(wal) = &self.pager.wal else {
             panic!("No WAL to checkpoint");
         };
-        match wal.checkpoint(&self.pager, self.mode)? {
+        match wal.checkpoint(&self.pager, self.mode, self.sync_mode)? {
             IOResult::Done(result) => Ok(IOResult::Done(result)),
             IOResult::IO(io) => Ok(IOResult::IO(io)),
         }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -8052,6 +8052,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         CheckpointMode::Truncate {
                             upper_bound_inclusive: None,
                         },
+                        connection.get_sync_mode(),
                     ));
                     if !checkpoint_result.everything_backfilled() {
                         let err = LimboError::Corrupt(

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4620,9 +4620,9 @@ impl Pager {
                 } => {
                     let checkpoint_lock_source = self.checkpoint_state.read().lock_source;
                     let res = return_if_io!(match checkpoint_lock_source {
-                        CheckpointLockSource::Acquire => wal.checkpoint(self, mode),
+                        CheckpointLockSource::Acquire => wal.checkpoint(self, mode, sync_mode),
                         CheckpointLockSource::HeldByCaller => {
-                            wal.vacuum_checkpoint_with_held_lock(self)
+                            wal.vacuum_checkpoint_with_held_lock(self, sync_mode)
                         }
                     });
                     let mut state = self.checkpoint_state.write();

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -43,7 +43,7 @@ use crate::types::{IOCompletions, IOResult};
 use crate::util::IOExt as _;
 use crate::{
     bail_corrupt_error, io_yield_one, Buffer, Completion, CompletionError, IOContext, LimboError,
-    Result,
+    Result, SyncMode,
 };
 
 /// this contains the frame to rollback to and its associated checksum.
@@ -728,8 +728,16 @@ pub trait Wal: Debug + Send + Sync {
     fn finish_append_frames_commit(&self) -> Result<()>;
 
     fn should_checkpoint(&self) -> bool;
-    fn checkpoint(&self, pager: &Pager, mode: CheckpointMode)
-        -> Result<IOResult<CheckpointResult>>;
+    /// Checkpoint the WAL into the database file.
+    /// `sync_mode` controls the WAL durability barrier: unless it is
+    /// [SyncMode::Off], the WAL is fsynced before any frame is backfilled so
+    /// that a crash mid-backfill can always be healed by WAL recovery.
+    fn checkpoint(
+        &self,
+        pager: &Pager,
+        mode: CheckpointMode,
+        sync_mode: SyncMode,
+    ) -> Result<IOResult<CheckpointResult>>;
     fn install_durable_backfill_proof(
         &self,
         max_frame: u64,
@@ -815,8 +823,11 @@ pub trait Wal: Debug + Send + Sync {
     /// method consumes that raw checkpoint-lock ownership: on success the guard
     /// is held by the checkpoint state machine, and on early failure it is
     /// released before returning.
-    fn vacuum_checkpoint_with_held_lock(&self, pager: &Pager)
-        -> Result<IOResult<CheckpointResult>>;
+    fn vacuum_checkpoint_with_held_lock(
+        &self,
+        pager: &Pager,
+        sync_mode: SyncMode,
+    ) -> Result<IOResult<CheckpointResult>>;
 
     /// Release the exclusive VACUUM lock acquired by `begin_vacuum_blocking_tx`.
     /// VACUUM calls this once done, after which new
@@ -2389,6 +2400,12 @@ impl WalCoordination for ShmWalCoordination {
 #[derive(Debug, Clone)]
 pub enum CheckpointState {
     Start,
+    /// Fsync the WAL before backfilling any frame into the database file.
+    /// Under `synchronous=NORMAL` commits do not fsync the WAL, so without
+    /// this durability barrier a crash mid-backfill could persist some
+    /// backfilled DB pages while recovery drops the unsynced WAL tail,
+    /// leaving a torn database that matches no committed prefix.
+    SyncWal,
     Processing,
     /// Determine the checkpoint result: update nBackfills, restart log if needed.
     DetermineResult,
@@ -3859,8 +3876,9 @@ impl Wal for WalFile {
         &self,
         pager: &Pager,
         mode: CheckpointMode,
+        sync_mode: SyncMode,
     ) -> Result<IOResult<CheckpointResult>> {
-        self.checkpoint_inner(pager, mode, CheckpointLockSource::Acquire)
+        self.checkpoint_inner(pager, mode, CheckpointLockSource::Acquire, sync_mode)
             .inspect_err(|e| {
                 tracing::debug!("WAL checkpoint failed: {e}");
                 let _ = self.checkpoint_guard.write().take();
@@ -3871,6 +3889,7 @@ impl Wal for WalFile {
     fn vacuum_checkpoint_with_held_lock(
         &self,
         pager: &Pager,
+        sync_mode: SyncMode,
     ) -> Result<IOResult<CheckpointResult>> {
         self.checkpoint_inner(
             pager,
@@ -3878,6 +3897,7 @@ impl Wal for WalFile {
                 upper_bound_inclusive: None,
             },
             CheckpointLockSource::HeldByCaller,
+            sync_mode,
         )
         .inspect_err(|e| {
             tracing::debug!("WAL checkpoint failed: {e}");
@@ -4703,6 +4723,7 @@ impl WalFile {
         pager: &Pager,
         mode: CheckpointMode,
         lock_source: CheckpointLockSource,
+        sync_mode: SyncMode,
     ) -> Result<IOResult<CheckpointResult>> {
         loop {
             let state = self.ongoing_checkpoint.read().state.clone();
@@ -4777,13 +4798,26 @@ impl WalFile {
                         .iter_latest_frames(oc_min_frame, oc_max_frame);
                     // sort by frame_id for read locality
                     to_checkpoint.sort_unstable_by(|a, b| (a.1, a.0).cmp(&(b.1, b.0)));
+                    // Every frame we are about to backfill must be durable in
+                    // the WAL before it may be copied into the database file:
+                    // commits under synchronous=NORMAL do not fsync the WAL,
+                    // so the checkpoint owes that fsync itself. The barrier is
+                    // issued after the frame range is fixed (under the
+                    // checkpoint locks), so it covers exactly the frames that
+                    // will be backfilled. Skipped only under synchronous=OFF,
+                    // which forgoes crash durability entirely.
+                    let needs_wal_sync = !to_checkpoint.is_empty() && sync_mode != SyncMode::Off;
                     {
                         let mut oc = self.ongoing_checkpoint.write();
                         oc.pages_to_checkpoint = to_checkpoint;
                         oc.current_page = 0;
                         oc.inflight_writes.clear();
                         oc.inflight_reads.clear();
-                        oc.state = CheckpointState::Processing;
+                        oc.state = if needs_wal_sync {
+                            CheckpointState::SyncWal
+                        } else {
+                            CheckpointState::Processing
+                        };
                         oc.time = self.io.current_time_monotonic();
                     }
                     tracing::trace!(
@@ -4791,6 +4825,17 @@ impl WalFile {
                         oc_min_frame,
                         oc_max_frame,
                     );
+                }
+                // Durability barrier: fsync the WAL so every frame selected
+                // for backfill is on stable storage before any of them is
+                // copied into the database file. Without it, a crash during
+                // the backfill could persist some DB pages while recovery
+                // drops the unsynced WAL tail — a torn database that matches
+                // no committed prefix.
+                CheckpointState::SyncWal => {
+                    let c = self.sync(pager.get_sync_type())?;
+                    self.ongoing_checkpoint.write().state = CheckpointState::Processing;
+                    io_yield_one!(c);
                 }
                 // For locality, reading is ordered by frame ID, and writing ordered by page ID.
                 // the more consecutive page ID's that we submit together, the fewer overall
@@ -6124,7 +6169,7 @@ pub mod test {
     ) -> CheckpointResult {
         let wal = pager.wal.as_ref().expect("wal should be present");
         loop {
-            match wal.checkpoint(pager, mode) {
+            match wal.checkpoint(pager, mode, SyncMode::Full) {
                 Ok(IOResult::IO(io)) => io.wait(db.io.as_ref()).unwrap(),
                 Ok(IOResult::Done(result)) => return result,
                 Err(err) => panic!("checkpoint should succeed: {err:?}"),
@@ -9309,7 +9354,7 @@ pub mod test {
         let p = conn1.pager.load();
         let w = p.wal.as_ref().unwrap();
         loop {
-            match w.checkpoint(&p, CheckpointMode::Restart) {
+            match w.checkpoint(&p, CheckpointMode::Restart, SyncMode::Full) {
                 Ok(IOResult::IO(io)) => {
                     io.wait(db.io.as_ref()).unwrap();
                 }
@@ -9337,7 +9382,7 @@ pub mod test {
         let p = conn1.pager.load();
         let w = p.wal.as_ref().unwrap();
         loop {
-            match w.checkpoint(&p, CheckpointMode::Restart) {
+            match w.checkpoint(&p, CheckpointMode::Restart, SyncMode::Full) {
                 Ok(IOResult::IO(io)) => {
                     io.wait(db.io.as_ref()).unwrap();
                 }
@@ -9506,7 +9551,7 @@ pub mod test {
         let result = {
             let pager = conn1.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            wal.checkpoint(&pager, CheckpointMode::Restart)
+            wal.checkpoint(&pager, CheckpointMode::Restart, SyncMode::Full)
         };
 
         assert!(
@@ -9864,7 +9909,7 @@ pub mod test {
         {
             let pager = conn1.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            let result = wal.checkpoint(&pager, CheckpointMode::Restart);
+            let result = wal.checkpoint(&pager, CheckpointMode::Restart, SyncMode::Full);
 
             assert!(
                 matches!(result, Err(LimboError::Busy)),
@@ -9972,7 +10017,7 @@ pub mod test {
             let pager = writer.pager.load();
             let wal = pager.wal.as_ref().unwrap();
             loop {
-                match wal.checkpoint(&pager, CheckpointMode::Full) {
+                match wal.checkpoint(&pager, CheckpointMode::Full, SyncMode::Full) {
                     Ok(IOResult::IO(io)) => {
                         // Drive any pending IO (should quickly become Busy or Done)
                         io.wait(db.io.as_ref()).unwrap();

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2914,8 +2914,10 @@ mod tests {
         );
         assert_eq!(
             after.wal - before.wal,
-            1,
-            "VACUUM INTO finalization must do exactly one WAL fsync after truncation"
+            2,
+            "VACUUM INTO finalization must do one WAL fsync before backfill (the \
+             checkpoint crash-atomicity barrier; finalization forces synchronous=FULL) \
+             and one after truncation"
         );
 
         Ok(())
@@ -3007,7 +3009,7 @@ mod tests {
     }
 
     #[test]
-    fn in_place_vacuum_with_sync_off_syncs_source_db_once_and_wal_once() -> Result<()> {
+    fn in_place_vacuum_with_sync_off_syncs_source_db_once_and_wal_twice() -> Result<()> {
         let io = Arc::new(SyncCountingIo::new("vacuum-source.db"));
         let io_dyn: Arc<dyn IO> = io.clone();
         let db = Database::open_file_with_flags(
@@ -3041,8 +3043,10 @@ mod tests {
         );
         assert_eq!(
             after.wal - before.wal,
-            1,
-            "in-place VACUUM with synchronous=OFF must do exactly one WAL fsync after truncation"
+            2,
+            "in-place VACUUM with synchronous=OFF must do one WAL fsync before backfill \
+             (the checkpoint crash-atomicity barrier; VACUUM forces the checkpoint to \
+             synchronous=FULL) and one after truncation"
         );
 
         Ok(())
@@ -3079,8 +3083,10 @@ mod tests {
         );
         assert_eq!(
             after.wal - before.wal,
-            2,
-            "in-place VACUUM with synchronous=FULL must do one WAL fsync before publish and one after truncation"
+            3,
+            "in-place VACUUM with synchronous=FULL must do one WAL fsync before publish, \
+             one before backfill (the checkpoint crash-atomicity barrier), and one after \
+             truncation"
         );
 
         Ok(())

--- a/tests/integration/checkpoint_crash_atomicity.rs
+++ b/tests/integration/checkpoint_crash_atomicity.rs
@@ -1,0 +1,437 @@
+//! Regression test for issue #7952: checkpoint backfill must be crash-atomic
+//! under `PRAGMA synchronous=NORMAL`.
+//!
+//! Under NORMAL, commits do not fsync the WAL. If a checkpoint then backfills
+//! those committed-but-not-durable frames into the database file without first
+//! forcing the WAL to stable storage, a power loss mid-backfill can persist
+//! *some* of the backfilled DB pages while WAL recovery drops the unsynced
+//! frames — recovering a torn database that matches no committed prefix, and
+//! that `PRAGMA integrity_check` reports as "ok".
+//!
+//! The crash model here is a test-side IO substrate: every write is volatile
+//! until the file it targets is fsynced; at the simulated power-loss point the
+//! durable image plus an arbitrary (here: alternating) subset of the unsynced
+//! DB-file writes survives, and all unsynced WAL writes are lost. This is a
+//! legal power-loss outcome (the kernel may write back dirty DB pages while
+//! the WAL tail never reaches the platter).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use turso_core::{
+    io::FileSyncType, Buffer, Clock, Completion, Database, DatabaseOpts, File, MonotonicInstant,
+    OpenFlags, SqliteDialect, WallClockInstant, IO,
+};
+
+/// A single not-yet-durable file mutation.
+enum UnsyncedOp {
+    Write { pos: usize, data: Vec<u8> },
+    Truncate { len: usize },
+}
+
+impl UnsyncedOp {
+    fn apply(&self, image: &mut Vec<u8>) {
+        match self {
+            UnsyncedOp::Write { pos, data } => {
+                let end = pos + data.len();
+                if image.len() < end {
+                    image.resize(end, 0);
+                }
+                image[*pos..end].copy_from_slice(data);
+            }
+            UnsyncedOp::Truncate { len } => {
+                image.resize(*len, 0);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct FileShadow {
+    /// Bytes guaranteed to be on stable storage (covered by an fsync).
+    durable: Vec<u8>,
+    /// Writes/truncates issued since the last fsync, in submission order.
+    unsynced: Vec<UnsyncedOp>,
+}
+
+impl FileShadow {
+    fn promote_all(&mut self) {
+        for op in self.unsynced.drain(..) {
+            let durable = &mut self.durable;
+            op.apply(durable);
+        }
+    }
+}
+
+/// The captured post-crash disk state.
+struct CrashSnapshot {
+    files: HashMap<String, Vec<u8>>,
+    db_writes_persisted: usize,
+    db_writes_dropped: usize,
+}
+
+struct CrashSimState {
+    files: Mutex<HashMap<String, Arc<Mutex<FileShadow>>>>,
+    /// When set, the next fsync of this file (with pending writes) is the
+    /// simulated power-loss point.
+    armed_db_path: Mutex<Option<String>>,
+    snapshot: Mutex<Option<CrashSnapshot>>,
+}
+
+impl CrashSimState {
+    /// Builds the post-crash disk image: durable bytes everywhere, plus an
+    /// alternating subset of the unsynced writes to the crash-target file
+    /// (torn writeback), and none of the unsynced writes to any other file
+    /// (the WAL tail is lost).
+    fn build_crash_snapshot(&self, db_path: &str) -> CrashSnapshot {
+        let files = self.files.lock().unwrap();
+        let mut images = HashMap::new();
+        let mut persisted = 0usize;
+        let mut dropped = 0usize;
+        for (path, shadow) in files.iter() {
+            let shadow = shadow.lock().unwrap();
+            let mut image = shadow.durable.clone();
+            if path == db_path {
+                let mut write_idx = 0usize;
+                for op in &shadow.unsynced {
+                    if matches!(op, UnsyncedOp::Write { .. }) {
+                        if write_idx % 2 == 0 {
+                            op.apply(&mut image);
+                            persisted += 1;
+                        } else {
+                            dropped += 1;
+                        }
+                        write_idx += 1;
+                    }
+                }
+            }
+            images.insert(path.clone(), image);
+        }
+        CrashSnapshot {
+            files: images,
+            db_writes_persisted: persisted,
+            db_writes_dropped: dropped,
+        }
+    }
+}
+
+struct CrashSimIo {
+    inner: Arc<dyn IO>,
+    state: Arc<CrashSimState>,
+}
+
+impl CrashSimIo {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(turso_core::MemoryIO::new()),
+            state: Arc::new(CrashSimState {
+                files: Mutex::new(HashMap::new()),
+                armed_db_path: Mutex::new(None),
+                snapshot: Mutex::new(None),
+            }),
+        }
+    }
+
+    /// Settle: pretend everything written so far reached stable storage
+    /// (baseline state before the scenario under test).
+    fn mark_all_durable(&self) {
+        for shadow in self.state.files.lock().unwrap().values() {
+            shadow.lock().unwrap().promote_all();
+        }
+    }
+
+    /// Arm the power-loss trigger: the next fsync of `db_path` that has
+    /// pending (unsynced) writes captures the crash snapshot.
+    fn arm_crash_on_db_sync(&self, db_path: &str) {
+        *self.state.armed_db_path.lock().unwrap() = Some(db_path.to_string());
+    }
+
+    fn take_crash_snapshot(&self) -> Option<CrashSnapshot> {
+        self.state.snapshot.lock().unwrap().take()
+    }
+}
+
+impl Clock for CrashSimIo {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        self.inner.current_time_monotonic()
+    }
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        self.inner.current_time_wall_clock()
+    }
+}
+
+impl IO for CrashSimIo {
+    fn open_file(
+        &self,
+        path: &str,
+        flags: OpenFlags,
+        direct: bool,
+    ) -> turso_core::Result<Arc<dyn File>> {
+        let inner = self.inner.open_file(path, flags, direct)?;
+        let shadow = self
+            .state
+            .files
+            .lock()
+            .unwrap()
+            .entry(path.to_string())
+            .or_default()
+            .clone();
+        Ok(Arc::new(CrashSimFile {
+            path: path.to_string(),
+            inner,
+            shadow,
+            state: self.state.clone(),
+        }))
+    }
+
+    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+        self.state.files.lock().unwrap().remove(path);
+        self.inner.remove_file(path)
+    }
+
+    fn step(&self) -> turso_core::Result<()> {
+        self.inner.step()
+    }
+
+    fn cancel(&self, completions: &[Completion]) -> turso_core::Result<()> {
+        self.inner.cancel(completions)
+    }
+
+    fn drain_completions(&self, completions: &[Completion]) -> turso_core::Result<()> {
+        self.inner.drain_completions(completions)
+    }
+
+    fn file_id(&self, path: &str) -> turso_core::Result<turso_core::io::FileId> {
+        self.inner.file_id(path)
+    }
+
+    fn fill_bytes(&self, dest: &mut [u8]) {
+        self.inner.fill_bytes(dest);
+    }
+
+    fn generate_random_number(&self) -> i64 {
+        self.inner.generate_random_number()
+    }
+}
+
+struct CrashSimFile {
+    path: String,
+    inner: Arc<dyn File>,
+    shadow: Arc<Mutex<FileShadow>>,
+    state: Arc<CrashSimState>,
+}
+
+impl File for CrashSimFile {
+    fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
+        self.inner.lock_file(exclusive)
+    }
+
+    fn unlock_file(&self) -> turso_core::Result<()> {
+        self.inner.unlock_file()
+    }
+
+    fn pread(&self, pos: u64, c: Completion) -> turso_core::Result<Completion> {
+        self.inner.pread(pos, c)
+    }
+
+    fn pwrite(
+        &self,
+        pos: u64,
+        buffer: Arc<Buffer>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        self.shadow
+            .lock()
+            .unwrap()
+            .unsynced
+            .push(UnsyncedOp::Write {
+                pos: pos as usize,
+                data: buffer.as_slice().to_vec(),
+            });
+        self.inner.pwrite(pos, buffer, c)
+    }
+
+    fn pwritev(
+        &self,
+        pos: u64,
+        buffers: Vec<Arc<Buffer>>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        {
+            let mut shadow = self.shadow.lock().unwrap();
+            let mut off = pos as usize;
+            for buffer in &buffers {
+                shadow.unsynced.push(UnsyncedOp::Write {
+                    pos: off,
+                    data: buffer.as_slice().to_vec(),
+                });
+                off += buffer.len();
+            }
+        }
+        self.inner.pwritev(pos, buffers, c)
+    }
+
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> turso_core::Result<Completion> {
+        // Simulated power loss: crash while the armed file's fsync is in
+        // flight, i.e. after its writes were submitted but before any of them
+        // were made durable.
+        let crash_here = {
+            let armed = self.state.armed_db_path.lock().unwrap();
+            armed.as_deref() == Some(self.path.as_str())
+                && !self.shadow.lock().unwrap().unsynced.is_empty()
+        };
+        if crash_here {
+            let mut snapshot = self.state.snapshot.lock().unwrap();
+            if snapshot.is_none() {
+                *snapshot = Some(self.state.build_crash_snapshot(&self.path));
+            }
+        }
+        self.shadow.lock().unwrap().promote_all();
+        self.inner.sync(c, sync_type)
+    }
+
+    fn truncate(&self, len: u64, c: Completion) -> turso_core::Result<Completion> {
+        self.shadow
+            .lock()
+            .unwrap()
+            .unsynced
+            .push(UnsyncedOp::Truncate { len: len as usize });
+        self.inner.truncate(len, c)
+    }
+
+    fn size(&self) -> turso_core::Result<u64> {
+        self.inner.size()
+    }
+}
+
+fn query_rows(conn: &Arc<turso_core::Connection>, sql: &str) -> anyhow::Result<Vec<String>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = Vec::new();
+    stmt.run_with_row_callback(|row| {
+        let values: Vec<String> = row.get_values().map(|value| format!("{value}")).collect();
+        rows.push(values.join("|"));
+        Ok(())
+    })?;
+    Ok(rows)
+}
+
+/// Runs the crash scenario under the given `PRAGMA synchronous` mode and
+/// asserts the committed-prefix recovery contract.
+fn run_checkpoint_crash_scenario(sync_pragma: &str) -> anyhow::Result<()> {
+    // Unique per scenario: databases opened on the same path share state
+    // process-wide, so parallel test runs must not collide.
+    let db_path_owned = format!(
+        "checkpoint-crash-atomicity-{}.db",
+        sync_pragma.to_lowercase()
+    );
+    let db_path_sim: &str = &db_path_owned;
+    const N_ROWS: usize = 256;
+    let old = "A".repeat(120);
+    let new = "B".repeat(120);
+
+    let io = Arc::new(CrashSimIo::new());
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        db_path_sim,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )?;
+    let conn = db.connect()?;
+
+    // S0: a multi-page table, fully checkpointed and durable.
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("BEGIN")?;
+    for i in 0..N_ROWS {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{old}')"))?;
+    }
+    conn.execute("COMMIT")?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    io.mark_all_durable();
+
+    // T: a committed transaction touching many pages.
+    conn.execute(format!("PRAGMA synchronous={sync_pragma}"))?;
+    conn.execute(format!("UPDATE t SET v = '{new}'"))?;
+
+    // Checkpoint T's frames into the DB file; power loss strikes while the
+    // backfilled pages are being forced to disk.
+    io.arm_crash_on_db_sync(db_path_sim);
+    conn.execute("PRAGMA wal_checkpoint(PASSIVE)")?;
+
+    let snapshot = io
+        .take_crash_snapshot()
+        .expect("checkpoint never issued the post-backfill DB fsync; crash point not reached");
+    assert!(
+        snapshot.db_writes_persisted >= 1 && snapshot.db_writes_dropped >= 1,
+        "crash model must persist a strict subset of the backfill writes \
+         (persisted={}, dropped={}); grow the workload if the backfill was a single write",
+        snapshot.db_writes_persisted,
+        snapshot.db_writes_dropped,
+    );
+
+    // Materialize the post-crash disk state and recover with a fresh database.
+    let dir = tempfile::TempDir::new()?;
+    let db_path = dir.path().join("recovered.db");
+    let wal_path = dir.path().join("recovered.db-wal");
+    std::fs::write(
+        &db_path,
+        snapshot
+            .files
+            .get(db_path_sim)
+            .expect("db file missing from crash snapshot"),
+    )?;
+    if let Some(wal) = snapshot.files.get(&format!("{db_path_sim}-wal")) {
+        std::fs::write(&wal_path, wal)?;
+    }
+
+    let recovered_db = Database::open_file(
+        Arc::new(turso_core::PlatformIO::new()?),
+        db_path.to_str().unwrap(),
+        Arc::new(SqliteDialect),
+    )?;
+    let recovered = recovered_db.connect()?;
+
+    let integrity = query_rows(&recovered, "PRAGMA integrity_check")?;
+    assert_eq!(
+        integrity,
+        vec!["ok".to_string()],
+        "recovered database failed integrity_check"
+    );
+    let count = query_rows(&recovered, "SELECT COUNT(*) FROM t")?;
+    assert_eq!(
+        count,
+        vec![N_ROWS.to_string()],
+        "row count changed across crash recovery"
+    );
+    let distinct = query_rows(&recovered, "SELECT DISTINCT v FROM t ORDER BY v")?;
+    let labels: Vec<String> = distinct
+        .iter()
+        .map(|v| format!("{}x{}", &v[..1], v.len()))
+        .collect();
+    assert!(
+        distinct == vec![old.clone()] || distinct == vec![new.clone()],
+        "torn recovery: database is neither S0 (all 'A') nor the committed \
+         transaction T (all 'B'); distinct values: {labels:?}",
+    );
+    Ok(())
+}
+
+/// A crash during checkpoint backfill under `synchronous=NORMAL` (the WAL-mode
+/// default durability) must recover to a committed prefix: the database equals
+/// either the pre-transaction state S0 (all rows 'A...') or the committed
+/// transaction T (all rows 'B...'), never a torn mix — and `integrity_check`
+/// must be clean.
+#[test]
+fn checkpoint_backfill_crash_under_synchronous_normal_recovers_committed_prefix(
+) -> anyhow::Result<()> {
+    run_checkpoint_crash_scenario("NORMAL")
+}
+
+/// Control: the same crash point under `synchronous=FULL`, where the
+/// commit-time WAL fsync already made T's frames durable, must heal — this
+/// validates that the crash model itself is not the source of the tear.
+#[test]
+fn checkpoint_backfill_crash_under_synchronous_full_control() -> anyhow::Result<()> {
+    run_checkpoint_crash_scenario("FULL")
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -2,6 +2,7 @@ mod abandoned_create_index;
 mod abandoned_statement_pager;
 mod assert_details;
 mod attach;
+mod checkpoint_crash_atomicity;
 mod common;
 mod conflict_resolution;
 mod custom_types;


### PR DESCRIPTION
Under synchronous=NORMAL commits append WAL frames without fsyncing
them, and the checkpoint backfilled those frames into the database file
without first forcing the WAL to stable storage. A power loss
mid-backfill could then persist a subset of the backfilled DB pages
while the unsynced WAL tail was dropped, so recovery landed on a torn
database that matched no committed prefix and that integrity_check
reported as ok. The recovery contract is a committed prefix: after a
crash during checkpoint the database must equal either the
pre-transaction state or a fully committed transaction.

Add a CheckpointState::SyncWal step to the WAL checkpoint state machine
that fsyncs the WAL after the frame range to backfill is fixed (under
the checkpoint locks, so the barrier covers exactly the frames about to
be copied) and before any frame is written into the database file, the
same barrier SQLite's walCheckpoint issues. With the WAL durable at
backfill time, recovery replays it over any torn pages and heals the
split. The barrier is skipped only when nothing is backfilled or under
synchronous=OFF, which forgoes crash durability entirely; to make that
decision, Wal::checkpoint and vacuum_checkpoint_with_held_lock now take
the effective SyncMode from the caller.

VACUUM forces its checkpoint to synchronous=FULL, so its fsync-count
tests now expect the one additional pre-backfill WAL fsync.

Tests: cargo test -p core_tester --test integration_tests
checkpoint_crash_atomicity, plus turso_core lib tests and the full
integration suite.

Fixes #7952