### PR TITLE
core/mvcc: clear pending running CRC when a deferred log write aborts

### DIFF
--- a/core/mvcc/persistent_storage/discard_pending_tests.rs
+++ b/core/mvcc/persistent_storage/discard_pending_tests.rs
@@ -1,0 +1,56 @@
+//! Regression test for issue #7991: `discard_pending_log_write` must clear the
+//! pending running CRC staged by an aborted deferred logical-log write.
+//!
+//! A deferred (two-phase) write stages a pending running CRC via
+//! `log_tx_deferred_offset`. If the commit aborts before the offset advances,
+//! the abort path calls `discard_pending_log_write`, which must discard the
+//! staged CRC so no later success path chains the running CRC from a value
+//! staged for a write that never confirmed.
+
+use std::sync::Arc;
+
+use crate::io::MemoryIO;
+use crate::mvcc::persistent_storage::{DurableStorage, Storage};
+use crate::storage::sqlite3_ondisk::DatabaseHeader;
+use crate::OpenFlags;
+
+#[test]
+fn discard_pending_log_write_clears_staged_pending_crc() {
+    let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+    let file = io
+        .open_file("issue_7991.db-log", OpenFlags::Create, false)
+        .unwrap();
+    let storage = Storage::new(file, io.clone(), None);
+
+    // Stage a deferred write: `Storage::log_tx` routes to
+    // `log_tx_deferred_offset`, which stages the pending running CRC and does
+    // NOT advance the writer offset.
+    let mut tx =
+        crate::mvcc::database::LogRecord::new(1, crate::alloc::DynAllocator::default()).unwrap();
+    storage
+        .serialize_database_header(&mut tx, &DatabaseHeader::default())
+        .unwrap();
+    let (completion, bytes) = storage.log_tx(tx, None).unwrap();
+    io.wait_for_completion(completion).unwrap();
+    assert!(bytes > 0, "deferred write should have framed bytes");
+
+    // Simulate the abort path of the two-phase commit: the commit failed
+    // before the offset advanced, so the staged pending CRC must be discarded.
+    storage.discard_pending_log_write().unwrap();
+
+    // The staged pending running CRC must be gone: the success path must now
+    // refuse to consume it (it panics on the missing pending slot) instead of
+    // silently chaining the running CRC from a write that never confirmed.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {})); // silence the expected panic
+    let advanced = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        storage.advance_logical_log_offset_after_success(bytes)
+    }));
+    std::panic::set_hook(prev_hook);
+
+    assert!(
+        advanced.is_err(),
+        "discard_pending_log_write left the staged pending running CRC in place: \
+         the success path consumed a CRC staged for an aborted deferred write"
+    );
+}

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -947,6 +947,15 @@ impl LogicalLog {
             .expect("advance_offset_after_success called without pending deferred write");
     }
 
+    /// Discard the pending running CRC staged by a deferred write whose
+    /// two-phase commit aborted before the offset advanced.
+    ///
+    /// This must be called on the abort path so no later write chains its
+    /// running CRC from a value staged for a write that never confirmed.
+    pub fn discard_pending_write(&mut self) {
+        self.pending_running_crc = None;
+    }
+
     pub fn sync(&mut self, sync_type: FileSyncType) -> Result<Completion> {
         let completion = Completion::new_sync(move |_| {
             tracing::debug!("logical_log_sync finish");

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -7,6 +7,8 @@ use crate::sync::RwLock;
 use crate::turso_assert;
 use std::fmt::Debug;
 
+#[cfg(test)]
+mod discard_pending_tests;
 pub mod logical_log;
 use crate::mvcc::database::{LogRecord, RowVersion};
 use crate::mvcc::persistent_storage::logical_log::{
@@ -102,9 +104,7 @@ pub trait DurableStorage: Send + Sync + Debug {
         id = "logical_log_pending_crc_cleared_on_abort",
         verify = "full"
     )]
-    fn discard_pending_log_write(&self) -> Result<()> {
-        Ok(())
-    }
+    fn discard_pending_log_write(&self) -> Result<()>;
     fn restore_logical_log_state_after_recovery(&self, offset: u64, running_crc: u32);
 
     /// Set the in-memory log header from a previously-read on-disk header.
@@ -270,6 +270,11 @@ impl DurableStorage for Storage {
     fn advance_logical_log_offset_after_success(&self, bytes: u64) -> Result<()> {
         self.logical_log.write().advance_offset_after_success(bytes);
         self.shadow_offset_advance(bytes);
+        Ok(())
+    }
+
+    fn discard_pending_log_write(&self) -> Result<()> {
+        self.logical_log.write().discard_pending_write();
         Ok(())
     }
 


### PR DESCRIPTION
A deferred (two-phase) logical-log write stages a pending running CRC in
log_tx_deferred_offset and only commits it when the offset advances on
success. On the abort path, cleanup_unfinished_commit calls
discard_pending_log_write, but the trait method had a no-op default body
that Storage never overrode, so the staged pending CRC survived the
abort. A later deferred write could then chain its running CRC from a
value staged for a write that never confirmed, corrupting the log's CRC
chain.

Add LogicalLog::discard_pending_write, which clears pending_running_crc
(mirroring the clears already done by truncate_to_zero and
reset_to_fresh_header), and implement discard_pending_log_write on
Storage to call it. Also remove the no-op default body from the trait so
implementors must handle the abort path explicitly instead of silently
inheriting the broken behavior; all existing implementors already
provide an implementation.

Tests: cargo test -p turso_core --lib mvcc::persistent_storage::discard_pending_tests, plus the full mvcc:: unit test suite

Fixes #7991