### PR TITLE
core: make committed WAL data survive a crash before the first checkpoint

### DIFF
--- a/core/database.rs
+++ b/core/database.rs
@@ -332,12 +332,10 @@ pub enum OpenDbAsyncPhase {
     Done,
 }
 
-/// Sub state machine for [`Database::header_validation`], driven from
-/// [`OpenDbAsyncPhase::ValidatingHeader`]. Keeps WAL recovery on open
-/// non-blocking by yielding through its IO instead of `io.block`.
-/// Non-blocking read of the 512-byte database file header. Used by
-/// [`Database::init_pager`] to recover page size + reserved bytes without
-/// blocking on open.
+/// Sub state machine for [`Database::read_db_header_buf`], the non-blocking
+/// read of the 512-byte database header. Not an open phase: it is driven
+/// from connect-time pager init ([`Database::_init`] via `init_pager`), which
+/// runs outside the open state machine.
 #[derive(Default)]
 pub(crate) enum DbHeaderReadState {
     #[default]
@@ -394,6 +392,11 @@ enum HeaderValidationState {
         pager: Box<Pager>,
         open_mv_store: bool,
         driver: Option<storage::wal::OpenSharedWal>,
+        /// Set once the WAL of an empty database file has been thrown away
+        /// (see the orphan-WAL handling in [`Database::header_validation`]).
+        /// The WAL is reopened after that, and the reopened WAL must come
+        /// back empty, so this can only ever happen once per open.
+        discarded_orphan_wal: bool,
     },
 }
 
@@ -1988,6 +1991,7 @@ impl Database {
                             pager,
                             open_mv_store,
                             driver: None,
+                            discarded_orphan_wal: false,
                         }
                     };
                 }
@@ -2016,16 +2020,18 @@ impl Database {
                         pager,
                         open_mv_store,
                         driver: None,
+                        discarded_orphan_wal: false,
                     };
                 }
                 HeaderValidationState::OpenWal {
                     open_mv_store,
                     driver,
+                    discarded_orphan_wal,
                     ..
                 } => {
                     // Always open shared WAL and set it in the Database and Pager.
                     // MVCC currently requires a WAL open to function.
-                    let shared_wal = {
+                    let mut shared_wal = {
                         #[cfg(not(host_shared_wal))]
                         {
                             if driver.is_none() {
@@ -2070,6 +2076,52 @@ impl Database {
                             }
                         }
                     };
+
+                    // A WAL never belongs to a database file with zero pages:
+                    // `Pager::allocate_page1` fsyncs page 1 to the main file
+                    // before any commit can fsync WAL frames, so no crash of
+                    // ours leaves frames next to an empty database file. When
+                    // that pair shows up anyway, the database file was deleted
+                    // (a common way to reset a database is to remove the `.db`
+                    // and forget the `-wal`) or the image predates the page-1
+                    // fsync. Either way the frames describe a database that no
+                    // longer exists: replaying them would splice a dead
+                    // database's pages into this one as soon as it grows past
+                    // zero pages.
+                    //
+                    // Throw the orphan WAL away and open the database empty,
+                    // which is what SQLite does — `pagerOpenWalIfPresent()`
+                    // deletes a WAL it finds next to a zero-page database —
+                    // and what upstream tests expect.
+                    if shared_wal.read().last_checksum_and_max_frame().1 > 0
+                        && self.db_file.size()? == 0
+                    {
+                        turso_assert!(
+                            !*discarded_orphan_wal,
+                            "orphan WAL reopened with frames after being discarded"
+                        );
+                        *discarded_orphan_wal = true;
+                        tracing::warn!(
+                            "discarding WAL '{}': it holds frames but database file '{}' has no pages, so the WAL does not belong to it",
+                            self.wal_path,
+                            self.path
+                        );
+                        if self.open_flags.contains(OpenFlags::ReadOnly) {
+                            // A read-only open must not delete files, so just
+                            // detach the WAL. This is the same state a
+                            // read-only open reaches when there is no WAL file
+                            // at all.
+                            shared_wal = WalFileShared::new_noop();
+                        } else {
+                            drop(shared_wal);
+                            *driver = None;
+                            self.io.remove_file(&self.wal_path)?;
+                            // Reopen the (now absent) WAL: `open_file` recreates
+                            // it empty and recovery of a WAL shorter than its
+                            // header finishes without any IO.
+                            continue;
+                        }
+                    }
 
                     let open_mv_store = *open_mv_store;
                     let HeaderValidationState::OpenWal { mut pager, .. } = std::mem::take(st)
@@ -2357,8 +2409,6 @@ impl Database {
         self.open_flags.contains(OpenFlags::ReadOnly)
     }
 
-    /// If we do not have a physical WAL file, but we know the database file is initialized on disk,
-    /// we need to read the page_size from the database header.
     /// Non-blocking read of the 512-byte database file header (page 1's
     /// header region). Yields the read completion via the supplied state until
     /// it finishes, then returns the filled buffer.

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1544,7 +1544,14 @@ enum AllocatePageState {
 #[derive(Clone)]
 enum AllocatePage1State {
     Start,
-    Writing { page: PageRef },
+    Writing {
+        page: PageRef,
+    },
+    /// Fsyncing the freshly written page 1 to the main database file, so a
+    /// WAL can never exist next to an empty (0-byte on disk) database file.
+    Syncing {
+        page: PageRef,
+    },
     Done,
 }
 
@@ -5340,25 +5347,54 @@ impl Pager {
             AllocatePage1State::Writing { page } => {
                 turso_assert!(page.is_loaded(), "page should be loaded");
                 tracing::trace!("allocate_page1(Writing done)");
-                let page_key = PageCacheKey::new(page.get().id);
-                let mut cache = self.page_cache.write();
-                cache.insert(page_key, page.clone()).map_err(|e| {
-                    LimboError::InternalError(format!("Failed to insert page 1 into cache: {e:?}"))
-                })?;
-                // After we wrote the header page, we may now set this None, to signify we initialized
-                self.init_page_1.store(None);
-                page.unpin();
-                *self.allocate_page1_state.write() = AllocatePage1State::Done;
-                Ok(IOResult::Done(page))
+                if self.wal.is_some() {
+                    // Fsync page 1 to the main database file before any commit
+                    // can fsync frames into the WAL. This keeps the invariant
+                    // "a WAL exists ⇒ the database file has at least one page"
+                    // that SQLite guarantees (`PRAGMA journal_mode=WAL` on a
+                    // fresh database commits page 1 through a rollback journal
+                    // first). SQLite relies on it: `pagerOpenWalIfPresent()`
+                    // deletes any WAL found next to a zero-page database, so a
+                    // pre-first-checkpoint crash image with a 0-byte main file
+                    // would lose all its committed data if SQLite opened it.
+                    let c = sqlite3_ondisk::begin_sync(
+                        self.db_file.as_ref(),
+                        self.syncing.clone(),
+                        self.get_sync_type(),
+                    )?;
+                    *self.allocate_page1_state.write() = AllocatePage1State::Syncing { page };
+                    io_yield_one!(c);
+                }
+                self.finish_allocate_page1(page)
+            }
+            AllocatePage1State::Syncing { page } => {
+                tracing::trace!("allocate_page1(Syncing done)");
+                self.finish_allocate_page1(page)
             }
             AllocatePage1State::Done => unreachable!("cannot try to allocate page 1 again"),
         }
     }
 
+    /// Final step of [Pager::allocate_page1]: page 1 is written (and, for
+    /// WAL-backed databases, fsync'd) to the main database file; publish it
+    /// in the page cache and mark the database initialized.
+    fn finish_allocate_page1(&self, page: PageRef) -> Result<IOResult<PageRef>> {
+        let page_key = PageCacheKey::new(page.get().id);
+        let mut cache = self.page_cache.write();
+        cache.insert(page_key, page.clone()).map_err(|e| {
+            LimboError::InternalError(format!("Failed to insert page 1 into cache: {e:?}"))
+        })?;
+        // After we wrote the header page, we may now set this None, to signify we initialized
+        self.init_page_1.store(None);
+        page.unpin();
+        *self.allocate_page1_state.write() = AllocatePage1State::Done;
+        Ok(IOResult::Done(page))
+    }
+
     pub fn allocating_page1(&self) -> bool {
         matches!(
             *self.allocate_page1_state.read(),
-            AllocatePage1State::Writing { .. }
+            AllocatePage1State::Writing { .. } | AllocatePage1State::Syncing { .. }
         )
     }
 

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2915,8 +2915,10 @@ mod tests {
 
         let before = io.counts();
         assert_eq!(
-            before.db, 0,
-            "target build with synchronous=OFF must not sync the destination db file before finalization"
+            before.db, 1,
+            "creating the database does exactly one db fsync (page 1 must be durable \
+             before the first WAL commit, even with synchronous=OFF); the target \
+             build must not add more before finalization"
         );
 
         finalize_vacuum_into_output(&VacuumTargetBuildContext::new(conn))?;
@@ -3044,8 +3046,10 @@ mod tests {
 
         let before = io.counts();
         assert_eq!(
-            before.db, 0,
-            "synchronous=OFF writes should not sync the source db file before VACUUM"
+            before.db, 1,
+            "creating the database does exactly one source db fsync (page 1 must be \
+             durable before the first WAL commit, even with synchronous=OFF); \
+             ordinary writes must not add more"
         );
 
         conn.execute("VACUUM")?;

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -268,18 +268,32 @@ fn test_attach_rejects_fresh_read_only_database(_tmp_db: TempDatabase) -> anyhow
     Ok(())
 }
 
+/// A WAL holding frames next to a database file with zero pages does not
+/// belong to it: page 1 reaches the main file before the first WAL commit, so
+/// this pair only shows up when the database file was deleted or truncated
+/// and the `-wal` was left behind. Attaching such a file discards the WAL and
+/// attaches an empty database, the same thing SQLite's
+/// `pagerOpenWalIfPresent()` does when it finds a WAL next to a zero-page
+/// database.
 #[turso_macros::test]
-fn test_attach_rejects_zero_byte_database_with_existing_wal(
+fn test_attach_discards_orphan_wal_of_zero_byte_database(
     _tmp_db: TempDatabase,
 ) -> anyhow::Result<()> {
     let temp_dir = TempDir::new()?;
+    let source_path = temp_dir.path().join("wal_backed_source.db");
     let aux_path = temp_dir.path().join("wal_backed_aux.db");
     let wal_path = aux_path.with_extension("db-wal");
 
-    let sqlite = RusqliteConnection::open(&aux_path)?;
+    // Build the pair with SQLite and copy it aside while the WAL is still hot
+    // (SQLite checkpoints and removes the WAL when the connection closes), so
+    // the files under test have no open handles.
+    let sqlite = RusqliteConnection::open(&source_path)?;
     sqlite.pragma_update(None, "journal_mode", "WAL")?;
     sqlite.execute("CREATE TABLE t(x INTEGER)", ())?;
     sqlite.execute("INSERT INTO t VALUES (1)", ())?;
+    std::fs::copy(&source_path, &aux_path)?;
+    std::fs::copy(source_path.with_extension("db-wal"), &wal_path)?;
+    drop(sqlite);
 
     assert!(std::fs::metadata(&wal_path)?.len() > 0);
     std::fs::OpenOptions::new()
@@ -291,18 +305,21 @@ fn test_attach_rejects_zero_byte_database_with_existing_wal(
     let db = attach_enabled_db(DatabaseOpts::new());
     let conn = db.connect_limbo();
 
-    for attach_sql in [
-        format!("ATTACH '{}' AS aux", aux_path.display()),
-        format!("ATTACH 'file:{}?mode=ro' AS aux", aux_path.display()),
-    ] {
-        let err = conn.execute(attach_sql).unwrap_err().to_string();
-        assert_eq!(
-            err,
-            "Invalid argument supplied: cannot attach database 'aux': main database file is uninitialized but WAL state exists"
-        );
-    }
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    let rows = limbo_exec_rows(&conn, "SELECT count(*) FROM aux.sqlite_schema");
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Integer(0)]],
+        "the orphan WAL must not be replayed into the attached database"
+    );
+    // The orphan frames are gone for good: the WAL file is deleted and
+    // immediately recreated empty by the open that follows the deletion.
+    assert_eq!(
+        std::fs::metadata(&wal_path)?.len(),
+        0,
+        "the orphan frames must be gone so they cannot come back"
+    );
 
-    drop(sqlite);
     Ok(())
 }
 

--- a/tests/integration/checkpoint_crash_atomicity.rs
+++ b/tests/integration/checkpoint_crash_atomicity.rs
@@ -231,11 +231,10 @@ fn full_commit_right_after_truncate_checkpoint_survives_power_loss() -> anyhow::
 /// has raised the WAL dirty flag yet, so before the fix the commit returned
 /// with all of its frames still unsynced.
 ///
-/// This asserts WAL durability only, not crash recovery: the database file
-/// itself is created by writes that are not fsynced before the commit is
-/// acknowledged, and a WAL sitting next to a zero-length database file is
-/// ignored on open (SQLite behaves the same). Closing that bootstrap gap is
-/// separate work; this test pins down the commit fsync.
+/// This asserts WAL durability only; end-to-end crash recovery before the
+/// first checkpoint (page 1 durable in the main file, committed data replayed
+/// from the WAL) is covered by `wal::test_power_loss_before_first_checkpoint`.
+/// This test pins down the commit fsync itself.
 #[test]
 fn first_full_commit_on_fresh_database_fsyncs_the_wal() -> anyhow::Result<()> {
     let db_path_sim = "first-full-commit-on-fresh-database.db";

--- a/tests/integration/wal/mod.rs
+++ b/tests/integration/wal/mod.rs
@@ -1,2 +1,3 @@
+mod test_power_loss_before_first_checkpoint;
 mod test_wal;
 mod test_wal_publish_backfill_race;

--- a/tests/integration/wal/test_power_loss_before_first_checkpoint.rs
+++ b/tests/integration/wal/test_power_loss_before_first_checkpoint.rs
@@ -1,0 +1,248 @@
+//! Regression test for https://github.com/tursodatabase/turso/issues/7995
+//!
+//! With `synchronous=FULL`, every committed transaction is fsync-acknowledged
+//! to the `-wal` file before the commit returns. If the process crashes (power
+//! loss) before the *first* checkpoint, the committed data exists only in the
+//! `-wal`. Recovery must replay that durable `-wal` on reopen — otherwise the
+//! whole first WAL epoch of committed transactions is silently lost.
+//!
+//! The fix keeps the invariant SQLite guarantees: a WAL only ever exists next
+//! to a database file with at least one page, because page 1 is fsync'd to
+//! the main file before the first WAL commit can fsync frames. So the crash
+//! image always has a non-empty main file, and ordinary WAL replay recovers
+//! the committed data. The flip side is that a WAL holding frames next to an
+//! *empty* database file does not belong to it, and is thrown away on open
+//! the way SQLite throws it away.
+//!
+//! The crash model is the shared [`crate::unreliable_io::UnreliableIo`]:
+//! writes only become durable when the file is fsync'd. After the "crash",
+//! only the fsync-acknowledged bytes of each file are materialized on disk,
+//! and the database is reopened with the regular platform IO. All committed
+//! rows must be recovered.
+
+use std::sync::Arc;
+
+use turso_core::{Database, DatabaseOpts, OpenFlags, PlatformIO, SqliteDialect, IO};
+
+use crate::common::limbo_exec_rows;
+use crate::unreliable_io::UnreliableIo;
+
+/// Committed (fsync-acknowledged) transactions must survive power loss even
+/// when the crash happens before the first checkpoint, i.e. while the data
+/// only exists in the `-wal` file.
+#[test]
+fn test_committed_wal_survives_power_loss_before_first_checkpoint() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("crash.db");
+    let db_path_str = db_path.to_str().unwrap().to_string();
+
+    let io = Arc::new(UnreliableIo::new());
+
+    // Phase 1: commit 10 transactions with synchronous=FULL, never checkpoint.
+    {
+        let db = Database::open_file(io.clone(), &db_path_str, Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        limbo_exec_rows(&conn, "PRAGMA synchronous=FULL");
+        limbo_exec_rows(&conn, "CREATE TABLE t(x)");
+        for i in 0..10 {
+            // Autocommit: each INSERT is its own committed transaction whose
+            // WAL frames are fsync'd before the commit returns.
+            limbo_exec_rows(&conn, &format!("INSERT INTO t VALUES ({i})"));
+        }
+        // Crash here: no clean shutdown, no checkpoint. The Database/Connection
+        // are intentionally leaked so no close-time cleanup runs.
+        std::mem::forget(conn);
+        std::mem::forget(db);
+    }
+
+    // Phase 2: materialize only the fsync-acknowledged bytes of every file,
+    // exactly what a power loss would leave on disk.
+    let durable = io.durable_files();
+    let wal_path = format!("{db_path_str}-wal");
+    let durable_wal = durable.get(&wal_path).map(|bytes| bytes.len()).unwrap_or(0);
+    assert!(
+        durable_wal > 0,
+        "synchronous=FULL commits must have fsync'd frames into the -wal"
+    );
+    for (path, bytes) in &durable {
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    // Phase 3: reopen the crashed image with the regular platform IO and
+    // verify that recovery replays the durable WAL.
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, &db_path_str, Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    let rows = limbo_exec_rows(&conn, "SELECT count(*) FROM t");
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Integer(10)]],
+        "all 10 committed (fsync-acknowledged) transactions must be recovered \
+         from the WAL after a crash before the first checkpoint"
+    );
+}
+
+/// SQLite guarantees that a WAL never exists next to an empty main database
+/// file: creating a database in WAL mode commits page 1 to the main file
+/// before any WAL frame. SQLite relies on that invariant —
+/// `pagerOpenWalIfPresent()` deletes a WAL it finds next to a zero-page
+/// database — so if we ever left a pre-first-checkpoint crash image with a
+/// 0-byte main file, stock SQLite would silently destroy all committed data.
+///
+/// Verify that we keep the same invariant: after a power loss before the
+/// first checkpoint, the durable main database file already holds page 1, and
+/// SQLite itself can open the crash image and read every committed row.
+#[test]
+fn test_page1_is_durable_in_main_file_before_first_wal_commit() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("crash.db");
+    let db_path_str = db_path.to_str().unwrap().to_string();
+
+    let io = Arc::new(UnreliableIo::new());
+
+    // Commit transactions with synchronous=FULL, never checkpoint, "crash".
+    {
+        let db = Database::open_file(io.clone(), &db_path_str, Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        limbo_exec_rows(&conn, "PRAGMA synchronous=FULL");
+        limbo_exec_rows(&conn, "CREATE TABLE t(x)");
+        for i in 0..10 {
+            limbo_exec_rows(&conn, &format!("INSERT INTO t VALUES ({i})"));
+        }
+        std::mem::forget(conn);
+        std::mem::forget(db);
+    }
+
+    // Only fsync-acknowledged bytes survive the power loss.
+    let durable = io.durable_files();
+    let durable_db = durable
+        .get(&db_path_str)
+        .map(|bytes| bytes.len())
+        .unwrap_or(0);
+    assert!(
+        durable_db >= 4096,
+        "page 1 must be durable in the main database file before the first \
+         WAL commit (got {durable_db} durable bytes); a WAL next to a 0-byte \
+         database file is a state SQLite deletes the WAL for"
+    );
+    for (path, bytes) in &durable {
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    // Stock SQLite must be able to open the crash image and recover every
+    // committed transaction from the WAL.
+    let sqlite = rusqlite::Connection::open(&db_path).unwrap();
+    let count: i64 = sqlite
+        .query_row("SELECT count(*) FROM t", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        count, 10,
+        "SQLite must recover all committed transactions from the crash image"
+    );
+}
+
+/// A WAL that holds frames next to a database file with zero pages does not
+/// belong to it: page 1 is fsync'd to the main file before the first WAL
+/// commit, so no crash can produce that state. It happens when a user deletes
+/// the database file to reset it but forgets the `-wal`. Replaying such a WAL
+/// would splice a dead database's pages into the new one once it grows past
+/// zero pages, so the WAL is thrown away and the database opens empty —
+/// exactly what SQLite's `pagerOpenWalIfPresent()` does, which the test
+/// checks against stock SQLite on the same pair of files.
+#[test]
+fn test_orphan_wal_of_an_empty_database_is_discarded_like_sqlite() {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join("source.db");
+    let source_path_str = source_path.to_str().unwrap().to_string();
+
+    // Commit data that still sits in the WAL (no checkpoint: leak the
+    // connection so no close-time cleanup runs) and materialize the files.
+    let io = Arc::new(UnreliableIo::new());
+    {
+        let db =
+            Database::open_file(io.clone(), &source_path_str, Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        limbo_exec_rows(&conn, "PRAGMA synchronous=FULL");
+        limbo_exec_rows(&conn, "CREATE TABLE t(x)");
+        limbo_exec_rows(&conn, "INSERT INTO t VALUES (1)");
+        std::mem::forget(conn);
+        std::mem::forget(db);
+    }
+    for (path, bytes) in &io.durable_files() {
+        std::fs::write(path, bytes).unwrap();
+    }
+    let source_wal = std::fs::read(format!("{source_path_str}-wal")).unwrap();
+    assert!(
+        !source_wal.is_empty(),
+        "the committed data must sit in the -wal"
+    );
+
+    // Copy the WAL next to a database file that does not exist, which is what
+    // a user leaves behind by deleting the `.db` to reset the database and
+    // forgetting the `-wal`. Copies keep the leaked handles of the phase above
+    // away from the files under test.
+    let orphan_wal = |name: &str| -> (String, std::path::PathBuf) {
+        let db_path = dir.path().join(format!("{name}.db"));
+        let wal_path = dir.path().join(format!("{name}.db-wal"));
+        std::fs::write(&wal_path, &source_wal).unwrap();
+        (db_path.to_str().unwrap().to_string(), wal_path)
+    };
+
+    // Turso discards the orphan WAL and opens the database empty.
+    let (turso_db_path, turso_wal_path) = orphan_wal("turso_reset");
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, &turso_db_path, Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    let rows = limbo_exec_rows(&conn, "SELECT count(*) FROM sqlite_schema");
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Integer(0)]],
+        "the orphan WAL must not be replayed into the fresh database"
+    );
+    // The orphan frames are gone for good: the WAL file is deleted and
+    // immediately recreated empty by the open that follows the deletion.
+    assert_eq!(
+        std::fs::metadata(&turso_wal_path).unwrap().len(),
+        0,
+        "the orphan frames must be gone so they cannot come back"
+    );
+
+    // A read-only open also refuses to replay the orphan WAL, but writes
+    // nothing: it leaves both files exactly as they are.
+    let (ro_db_path, ro_wal_path) = orphan_wal("turso_reset_readonly");
+    std::fs::write(&ro_db_path, b"").unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file_with_flags(
+        io,
+        &ro_db_path,
+        OpenFlags::ReadOnly,
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    let rows = limbo_exec_rows(&conn, "SELECT count(*) FROM sqlite_schema");
+    assert_eq!(
+        rows,
+        vec![vec![rusqlite::types::Value::Integer(0)]],
+        "a read-only open must not replay the orphan WAL either"
+    );
+    assert_eq!(
+        std::fs::metadata(&ro_wal_path).unwrap().len(),
+        source_wal.len() as u64,
+        "a read-only open must leave the WAL file untouched"
+    );
+
+    // Stock SQLite, given the same files, behaves the same way.
+    let (sqlite_db_path, sqlite_wal_path) = orphan_wal("sqlite_reset");
+    let sqlite = rusqlite::Connection::open(&sqlite_db_path).unwrap();
+    let count: i64 = sqlite
+        .query_row("SELECT count(*) FROM sqlite_schema", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 0, "SQLite also opens the database empty");
+    assert!(
+        !sqlite_wal_path.exists(),
+        "SQLite also deletes the orphan WAL"
+    );
+}


### PR DESCRIPTION
A crash before the first checkpoint used to leave the main database
file empty (0 bytes) while every committed, fsync-acknowledged
transaction — including page 1 itself — lived only in the -wal. On
reopen, Database::new saw the 0-byte file and flagged the database as
brand new (init_page_1), so the pager served the blank in-memory
bootstrap page 1. The whole first WAL epoch was silently lost and
PRAGMA integrity_check reported ok against the blank image.

Fix the write side the way SQLite does: never create that crash state.
SQLite guarantees "a WAL exists ⇒ the database file has at least one
page" (PRAGMA journal_mode=WAL on a fresh database commits page 1
through a rollback journal before WAL mode takes effect), and relies on
it: pagerOpenWalIfPresent() deletes any WAL found next to a zero-page
database. allocate_page1 therefore fsyncs the freshly written page 1 to
the main database file (a new Syncing step in the state machine,
skipped for pagers without a WAL) before any commit can fsync frames
into the WAL. This is a one-time fsync per database creation and runs
even with synchronous=OFF, because the kernel may write back WAL bytes
while dropping the unsynced db-file write, leaving exactly the image
SQLite destroys. After a crash the main file always holds page 1, so
ordinary WAL replay recovers every committed transaction.

The invariant also settles what the leftover state means: a WAL that
holds frames next to a database file with zero pages does not belong to
that database. Either the database file was deleted and the -wal left
behind — deleting the .db to reset a database and forgetting the -wal is
common, and the upstream TCL tests do it — or the WAL is a crash image
from a version that predates the page-1 fsync. Replaying those frames
would splice a dead database's pages into the new one as soon as it grows
past zero pages, so the open throws the orphan WAL away and opens the
database empty, which is what SQLite does. A writable open deletes the
-wal (reopening recreates it empty, and recovery of a WAL shorter than
its header needs no IO); a read-only open only detaches it, so it writes
nothing.

The attach test that asserted rejection of a zero-byte database with an
existing WAL now asserts the SQLite-compatible outcome instead. The
vacuum fsync-counting tests expect the single database-creation fsync.

Tests: cargo test -p core_tester --test integration_tests
test_power_loss_before_first_checkpoint — the recovery test and
test_page1_is_durable_in_main_file_before_first_wal_commit (which also
has stock SQLite open the crash image via rusqlite) fail without the
write-side fsync, and
test_orphan_wal_of_an_empty_database_is_discarded_like_sqlite pins the
discard against stock SQLite on the same pair of files; all three fail
on main. Full core_tester suite, turso_core and turso_sync_engine unit
tests, workspace clippy, the sqltest conformance runner, the upstream
TCL conformance run (per-file result table identical to unpatched main),
and simulator runs across the default, write_heavy, write_heavy_spill
and differential profiles.

Fixes #7995