### PR TITLE
sync: fix DELETE and upsert replay for tables with composite PK

### DIFF
--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -48,7 +48,7 @@ impl DatabaseReplayGenerator {
         change: &DatabaseTapeRowChange,
     ) -> Result<DatabaseRowMutation> {
         match &change.change {
-            DatabaseTapeRowChangeType::Delete { before } => Ok(DatabaseRowMutation {
+            DatabaseTapeRowChangeType::Delete { before, .. } => Ok(DatabaseRowMutation {
                 change_time: change.change_time,
                 table_name: change.table_name.to_string(),
                 id: change.id,
@@ -133,20 +133,7 @@ impl DatabaseReplayGenerator {
         }
         match change {
             DatabaseChangeType::Delete => {
-                if let Some(pk_column_indices) = info.pk_column_indices.as_ref() {
-                    let mut values = <crate::alloc::Vec<turso_core::Value> as TursoAllocExt>::new();
-                    for pk in pk_column_indices {
-                        let value = if info.rowid_alias_pk_column_index == Some(*pk) {
-                            turso_core::Value::from_i64(id)
-                        } else {
-                            std::mem::replace(&mut record[*pk], turso_core::Value::Null)
-                        };
-                        values.push(value);
-                    }
-                    values
-                } else {
-                    crate::alloc::vec![turso_core::Value::from_i64(id)]
-                }
+                unreachable!("DELETE replay values are built by replay_delete_values")
             }
             DatabaseChangeType::Insert => {
                 if let Some(pk) = info.rowid_alias_pk_column_index {
@@ -203,6 +190,80 @@ impl DatabaseReplayGenerator {
             }
         }
     }
+
+    pub fn replay_delete_values(
+        &self,
+        info: &ReplayInfo,
+        id: i64,
+        mut before: crate::alloc::Vec<turso_core::Value>,
+        key: Option<crate::alloc::Vec<turso_core::Value>>,
+    ) -> Result<crate::alloc::Vec<turso_core::Value>> {
+        if info.is_ddl_replay {
+            return Ok(<crate::alloc::Vec<turso_core::Value> as TursoAllocExt>::new());
+        }
+        if let Some(key) = key {
+            let Some(pk_column_indices) = info.pk_column_indices.as_ref() else {
+                return Err(Error::DatabaseTapeError(format!(
+                    "DELETE primary-key projection cannot be used with a rowid replay query: {}",
+                    info.query
+                )));
+            };
+            if key.len() != pk_column_indices.len() {
+                return Err(Error::DatabaseTapeError(format!(
+                    "DELETE primary-key projection has {} values, expected {}: {}",
+                    key.len(),
+                    pk_column_indices.len(),
+                    info.query
+                )));
+            }
+            return Ok(key);
+        }
+        let Some(pk_column_indices) = info.pk_column_indices.as_ref() else {
+            return Ok(crate::alloc::vec![turso_core::Value::from_i64(id)]);
+        };
+        let mut values = <crate::alloc::Vec<turso_core::Value> as TursoAllocExt>::new();
+        for &pk in pk_column_indices {
+            let value = if info.rowid_alias_pk_column_index == Some(pk) {
+                turso_core::Value::from_i64(id)
+            } else {
+                let Some(value) = before.get_mut(pk) else {
+                    return Err(Error::DatabaseTapeError(format!(
+                        "DELETE before image is missing primary-key column {pk}: {}",
+                        info.query
+                    )));
+                };
+                std::mem::replace(value, turso_core::Value::Null)
+            };
+            values.push(value);
+        }
+        Ok(values)
+    }
+
+    /// Whether a DELETE replay must fall back to the implicit rowid: only when
+    /// the change carries neither a primary-key projection nor a before image.
+    /// In that case the rowid is the row's only identity, so replaying it
+    /// requires rowid preservation — and `delete_query` additionally rejects
+    /// the fallback for tables whose PRIMARY KEY is not the rowid, where a
+    /// rowid-based delete could target the wrong row.
+    pub(crate) fn delete_uses_rowid(
+        &self,
+        before: &[turso_core::Value],
+        key: Option<&[turso_core::Value]>,
+    ) -> Result<bool> {
+        if key.is_some() {
+            return Ok(false);
+        }
+        if !before.is_empty() {
+            return Ok(false);
+        }
+        if self.opts.use_implicit_rowid {
+            return Ok(true);
+        }
+        Err(Error::DatabaseTapeError(
+            "DELETE replay without a row image requires implicit rowid preservation".to_string(),
+        ))
+    }
+
     pub async fn replay_info<Ctx>(
         &self,
         coro: &Coro<Ctx>,
@@ -214,7 +275,7 @@ impl DatabaseReplayGenerator {
         if table_name == SQLITE_SCHEMA_TABLE {
             // sqlite_schema table: type, name, tbl_name, rootpage, sql
             match &change.change {
-                DatabaseTapeRowChangeType::Delete { before } => {
+                DatabaseTapeRowChangeType::Delete { before, .. } => {
                     assert!(before.len() == 5);
                     let Some(turso_core::Value::Text(entity_type)) = before.first() else {
                         panic!(
@@ -284,8 +345,9 @@ impl DatabaseReplayGenerator {
             }
         } else {
             match &change.change {
-                DatabaseTapeRowChangeType::Delete { .. } => {
-                    let delete = self.delete_query(coro, table_name).await?;
+                DatabaseTapeRowChangeType::Delete { before, key } => {
+                    let use_rowid = self.delete_uses_rowid(before, key.as_deref())?;
+                    let delete = self.delete_query(coro, table_name, use_rowid).await?;
                     Ok(delete)
                 }
                 DatabaseTapeRowChangeType::Update { updates, after, .. } => {
@@ -465,6 +527,7 @@ impl DatabaseReplayGenerator {
         &self,
         coro: &Coro<Ctx>,
         table_name: &str,
+        use_rowid: bool,
     ) -> Result<ReplayInfo> {
         let (column_names, pk_column_indices, rowid_alias_pk_column_index) =
             self.table_columns_info(coro, table_name).await?;
@@ -474,7 +537,20 @@ impl DatabaseReplayGenerator {
         }
         let use_implicit_rowid = self.opts.use_implicit_rowid;
         let quoted_table_name = quote_ident(table_name);
-        if pk_column_indices.is_empty() {
+        if use_rowid || pk_column_indices.is_empty() {
+            // A rowid-based delete is exact only when the rowid IS the row's
+            // identity: tables with no PRIMARY KEY, or a rowid-alias INTEGER
+            // PRIMARY KEY. For any other PK the local rowid can diverge from
+            // the remote's, so a delete that arrived without a primary-key
+            // projection (and without a before image) must fail instead of
+            // possibly deleting the wrong row. A current server always encodes
+            // the projection for such tables, so this only rejects logs from
+            // servers predating the portable delete extension.
+            if use_rowid && !pk_column_indices.is_empty() && rowid_alias_pk_column_index.is_none() {
+                return Err(Error::DatabaseTapeError(format!(
+                    "DELETE for table '{table_name}' has no primary-key projection and no before image, but its PRIMARY KEY is not the rowid; refusing rowid-based replay"
+                )));
+            }
             let query = format!("DELETE FROM {quoted_table_name} WHERE rowid = ?");
             tracing::trace!("delete_query: table_name={table_name}, query={query}, use_implicit_rowid={use_implicit_rowid}");
             return Ok(ReplayInfo {
@@ -622,7 +698,7 @@ impl DatabaseReplayGenerator {
         let mut table_info_stmt = self.conn.prepare(format!(
             "SELECT cid, name, type, pk FROM pragma_table_info({table_name_literal})"
         ))?;
-        let mut pk_column_indices = Vec::with_capacity(1);
+        let mut pk_columns = Vec::with_capacity(1);
         let mut column_names = Vec::new();
         let mut column_types = Vec::new();
         while let Some(column) = run_stmt_once(coro, &mut table_info_stmt).await? {
@@ -649,12 +725,32 @@ impl DatabaseReplayGenerator {
                     "unexpected column type for pragma_table_info query".to_string(),
                 ));
             };
-            if *pk == 1 {
-                pk_column_indices.push(*column_id as usize);
+            let column_id = usize::try_from(*column_id).map_err(|_| {
+                Error::DatabaseTapeError(format!(
+                    "negative column index returned for table '{table_name}'"
+                ))
+            })?;
+            if column_id != column_names.len() {
+                return Err(Error::DatabaseTapeError(format!(
+                    "non-contiguous column index {column_id} returned for table '{table_name}'"
+                )));
+            }
+            if *pk > 0 {
+                let pk_ordinal = usize::try_from(*pk).map_err(|_| {
+                    Error::DatabaseTapeError(format!(
+                        "invalid primary key ordinal returned for table '{table_name}'"
+                    ))
+                })?;
+                pk_columns.push((pk_ordinal, column_id));
             }
             column_names.push(name.as_str().to_string());
             column_types.push(column_type.as_str().to_string());
         }
+        pk_columns.sort_unstable_by_key(|(ordinal, _)| *ordinal);
+        let pk_column_indices = pk_columns
+            .into_iter()
+            .map(|(_, column_id)| column_id)
+            .collect::<Vec<_>>();
         let rowid_alias_pk_column_index = if pk_column_indices.len() == 1 {
             let pk = pk_column_indices[0];
             column_types

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -72,6 +72,7 @@ const MVCC_OP_UPDATE_HEADER: u8 = 4;
 const MVCC_OP_FLAG_PORTABLE_EXTENSION: u8 = 1 << 1;
 const MVCC_SQLITE_SCHEMA_TABLE_ID: i64 = -1;
 const MVCC_DELETE_EXT_IDENTITY_RECORD_FIELD: u64 = 1;
+const MVCC_DELETE_EXT_PK_RECORD_FIELD: u64 = 2;
 const PORTABLE_TXN_META_CLIENT_KEY: &str = "client";
 const SQLITE_INTERNAL_PREFIX: &str = "sqlite_";
 const SQLITE_SCHEMA_TABLE: &str = "sqlite_schema";
@@ -209,6 +210,11 @@ fn logical_op_to_tape_operations(
                     change_time: commit_ts,
                     change: DatabaseTapeRowChangeType::Delete {
                         before: turso_core::alloc::vec![],
+                        key: if op.record.is_empty() {
+                            None
+                        } else {
+                            Some(parse_bin_record(&op.record)?)
+                        },
                     },
                     table_name: op.table_name,
                     id: op.rowid,
@@ -328,7 +334,7 @@ fn sqlite_schema_change_name(change: &DatabaseTapeRowChange) -> Result<Option<St
         return Ok(None);
     }
     let values = match &change.change {
-        DatabaseTapeRowChangeType::Delete { before } => before,
+        DatabaseTapeRowChangeType::Delete { before, .. } => before,
         DatabaseTapeRowChangeType::Insert { after } => after,
         DatabaseTapeRowChangeType::Update { after, .. } => after,
     };
@@ -1067,37 +1073,35 @@ fn skip_mvcc_proto_field(buf: &[u8], cursor: &mut usize, wire_type: u64) -> Resu
     Ok(())
 }
 
-fn decode_mvcc_delete_identity_record(extension: &[u8]) -> Result<Vec<u8>> {
+fn decode_mvcc_delete_record(extension: &[u8], record_field: u64) -> Result<Vec<u8>> {
     let mut cursor = 0usize;
-    let mut identity_record = Vec::new();
+    let mut record = Vec::new();
     while cursor < extension.len() {
         let key = read_mvcc_proto_varint(extension, &mut cursor)?;
         let field = key >> 3;
         let wire_type = key & 7;
-        if field == MVCC_DELETE_EXT_IDENTITY_RECORD_FIELD && wire_type == 2 {
+        if field == record_field && wire_type == 2 {
             let len =
                 usize::try_from(read_mvcc_proto_varint(extension, &mut cursor)?).map_err(|_| {
                     Error::DatabaseSyncEngineError(
-                        "MVCC delete identity record length overflows usize".to_string(),
+                        "MVCC delete record length overflows usize".to_string(),
                     )
                 })?;
             let end = cursor.checked_add(len).ok_or_else(|| {
-                Error::DatabaseSyncEngineError(
-                    "MVCC delete identity record length overflow".to_string(),
-                )
+                Error::DatabaseSyncEngineError("MVCC delete record length overflow".to_string())
             })?;
             if end > extension.len() {
                 return Err(Error::DatabaseSyncEngineError(
-                    "truncated MVCC delete identity record".to_string(),
+                    "truncated MVCC delete record".to_string(),
                 ));
             }
-            identity_record = extension[cursor..end].to_vec();
+            record = extension[cursor..end].to_vec();
             cursor = end;
         } else {
             skip_mvcc_proto_field(extension, &mut cursor, wire_type)?;
         }
     }
-    Ok(identity_record)
+    Ok(record)
 }
 
 fn portable_string(strings: &[String], idx: u64, context: &str) -> Result<String> {
@@ -1372,7 +1376,10 @@ fn decode_recovery_ops_to_logical_txn(
                 let mut payload_cursor = 0usize;
                 let rowid = read_mvcc_sqlite_varint(payload, &mut payload_cursor)? as i64;
                 if table_id == MVCC_SQLITE_SCHEMA_TABLE_ID {
-                    let identity_record = decode_mvcc_delete_identity_record(portable_extension)?;
+                    let identity_record = decode_mvcc_delete_record(
+                        portable_extension,
+                        MVCC_DELETE_EXT_IDENTITY_RECORD_FIELD,
+                    )?;
                     if identity_record.is_empty() {
                         return Err(Error::DatabaseSyncEngineError(
                             "MVCC sqlite_schema delete is missing portable identity record"
@@ -1382,11 +1389,15 @@ fn decode_recovery_ops_to_logical_txn(
                     schema_deltas.entry(rowid).or_default().old =
                         Some(decode_schema_row(&identity_record)?);
                 } else if let Some(table_name) = object_names.get(&table_id) {
+                    let primary_key_record = decode_mvcc_delete_record(
+                        portable_extension,
+                        MVCC_DELETE_EXT_PK_RECORD_FIELD,
+                    )?;
                     row_ops.push(LogicalOp {
                         op_type: LogicalOpType::DeleteRow as i32,
                         table_name: table_name.clone(),
                         rowid,
-                        record: Bytes::new(),
+                        record: Bytes::from(primary_key_record),
                         sql: String::new(),
                         user_version: None,
                         application_id: None,
@@ -3025,14 +3036,13 @@ async fn send_push_batch<IO: SyncEngineIo, Ctx>(
                     }
                 }
                 match &change.change {
-                    DatabaseTapeRowChangeType::Delete { before } => {
-                        let values = generator.replay_values(
+                    DatabaseTapeRowChangeType::Delete { before, key } => {
+                        let values = generator.replay_delete_values(
                             &replay_info,
-                            replay_info.change_type,
                             change.id,
                             before.clone(),
-                            None,
-                        );
+                            key.clone(),
+                        )?;
                         sql_over_http_requests
                             .push(step(replay_info.query.clone(), convert_to_args(values)))
                     }
@@ -4322,6 +4332,32 @@ mod tests {
         recovery_payload.extend_from_slice(&payload);
     }
 
+    fn append_test_table_delete(
+        recovery_payload: &mut Vec<u8>,
+        table_id: i64,
+        rowid: i64,
+        primary_key_record: &[u8],
+    ) {
+        let mut payload = Vec::new();
+        write_test_varint(rowid as u64, &mut payload);
+
+        let mut extension = Vec::new();
+        write_test_varint(
+            (super::MVCC_DELETE_EXT_PK_RECORD_FIELD << 3) | 2,
+            &mut extension,
+        );
+        write_test_varint(primary_key_record.len() as u64, &mut extension);
+        extension.extend_from_slice(primary_key_record);
+
+        recovery_payload.push(super::MVCC_OP_DELETE_TABLE);
+        recovery_payload.push(super::MVCC_OP_FLAG_PORTABLE_EXTENSION);
+        recovery_payload.extend_from_slice(&(table_id as i32).to_le_bytes());
+        write_test_varint(payload.len() as u64, recovery_payload);
+        recovery_payload.extend_from_slice(&payload);
+        write_test_varint(extension.len() as u64, recovery_payload);
+        recovery_payload.extend_from_slice(&extension);
+    }
+
     fn raw_mvcc_log_frame_from_payloads(
         commit_ts: u64,
         portable_payload: &[u8],
@@ -4441,6 +4477,7 @@ mod tests {
             turso_core::Value::from_i64(1),
             turso_core::Value::build_text("one"),
         ]);
+        let primary_key_record = record(&[turso_core::Value::from_i64(1)]);
         let portable_txn = super::PortableLogicalTxn {
             end_offset: 104,
             commit_ts: 77,
@@ -4467,12 +4504,13 @@ mod tests {
             &schema_record,
         );
         append_test_table_upsert(&mut recovery_payload, table_id, 1, &row_record);
+        append_test_table_delete(&mut recovery_payload, table_id, 1, &primary_key_record);
 
         let salt = 0x0123_4567_89ab_cdefu64;
         let log_header = raw_mvcc_log_header(salt);
         let initial_crc = crc32c::crc32c(&salt.to_le_bytes());
         let (frame, _) =
-            raw_mvcc_log_frame_with_crc(77, &portable_payload, &recovery_payload, 2, initial_crc);
+            raw_mvcc_log_frame_with_crc(77, &portable_payload, &recovery_payload, 3, initial_crc);
         let end_offset = (log_header.len() + frame.len()) as u64;
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
@@ -4502,7 +4540,7 @@ mod tests {
         assert_eq!(txns[0].end_offset, 104);
         assert_eq!(txns[0].commit_ts, 77);
         assert_eq!(txns[0].origin_client_id, "client-a");
-        assert_eq!(txns[0].ops.len(), 2);
+        assert_eq!(txns[0].ops.len(), 3);
         assert_eq!(txns[0].ops[0].op_type, LogicalOpType::Schema as i32);
         assert_eq!(txns[0].ops[0].schema_name, "t");
         assert_eq!(txns[0].ops[0].stable_table_id, 0);
@@ -4510,6 +4548,10 @@ mod tests {
         assert_eq!(txns[0].ops[1].table_name, "t");
         assert_eq!(txns[0].ops[1].rowid, 1);
         assert_eq!(txns[0].ops[1].record, row_record);
+        assert_eq!(txns[0].ops[2].op_type, LogicalOpType::DeleteRow as i32);
+        assert_eq!(txns[0].ops[2].table_name, "t");
+        assert_eq!(txns[0].ops[2].rowid, 1);
+        assert_eq!(txns[0].ops[2].record, primary_key_record);
     }
 
     #[test]
@@ -5287,11 +5329,24 @@ mod tests {
                     schema_name: String::new(),
                     stable_table_id: 9,
                 },
+                LogicalOp {
+                    op_type: LogicalOpType::DeleteRow as i32,
+                    table_name: String::new(),
+                    rowid: 99,
+                    record: record(&[turso_core::Value::from_i64(1)]),
+                    sql: String::new(),
+                    user_version: None,
+                    application_id: None,
+                    schema_action: None,
+                    schema_kind: None,
+                    schema_name: String::new(),
+                    stable_table_id: 9,
+                },
             ],
         };
 
         let operations = logical_txn_to_tape_operations(&txn).unwrap();
-        assert_eq!(operations.len(), 2);
+        assert_eq!(operations.len(), 3);
         assert!(matches!(
             &operations[0],
             DatabaseTapeOperation::SchemaReplay(DatabaseSchemaReplay::Create { sql })
@@ -5305,6 +5360,20 @@ mod tests {
                 assert!(matches!(
                     change.change,
                     DatabaseTapeRowChangeType::Insert { .. }
+                ));
+            }
+            other => panic!("expected row change, got {other:?}"),
+        }
+        match &operations[2] {
+            DatabaseTapeOperation::RowChange(change) => {
+                assert_eq!(change.table_name, "items");
+                assert_eq!(change.id, 99);
+                assert!(matches!(
+                    &change.change,
+                    DatabaseTapeRowChangeType::Delete {
+                        before,
+                        key: Some(key)
+                    } if before.is_empty() && *key == vec![turso_core::Value::from_i64(1)]
                 ));
             }
             other => panic!("expected row change, got {other:?}"),

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -582,7 +582,7 @@ pub(crate) struct CachedStmt {
 
 pub struct DatabaseReplaySession {
     pub(crate) conn: Arc<turso_core::Connection>,
-    pub(crate) cached_delete_stmt: HashMap<String, CachedStmt>,
+    pub(crate) cached_delete_stmt: HashMap<(String, bool), CachedStmt>,
     pub(crate) cached_insert_stmt: HashMap<(String, usize), CachedStmt>,
     pub(crate) cached_update_stmt: HashMap<(String, Vec<bool>), CachedStmt>,
     pub(crate) in_txn: bool,
@@ -702,21 +702,26 @@ impl DatabaseReplaySession {
                     }
                 } else {
                     match change.change {
-                        DatabaseTapeRowChangeType::Delete { before } => {
-                            let key = self.populate_delete_stmt(coro, table).await?;
+                        DatabaseTapeRowChangeType::Delete {
+                            before,
+                            key: primary_key,
+                        } => {
+                            let use_rowid = self
+                                .generator
+                                .delete_uses_rowid(&before, primary_key.as_deref())?;
+                            let cache_key =
+                                self.populate_delete_stmt(coro, table, use_rowid).await?;
                             tracing::trace!(
-                                "ready to use prepared delete statement for replay: key={}",
-                                key
+                                "ready to use prepared delete statement for replay: key={cache_key:?}"
                             );
-                            let cached = self.cached_delete_stmt.get_mut(key).unwrap();
+                            let cached = self.cached_delete_stmt.get_mut(&cache_key).unwrap();
                             cached.stmt.reset()?;
-                            let values = self.generator.replay_values(
+                            let values = self.generator.replay_delete_values(
                                 &cached.info,
-                                change_type,
                                 change.id,
                                 before,
-                                None,
-                            );
+                                primary_key,
+                            )?;
                             replay_stmt(coro, &mut cached.stmt, values).await?;
                         }
                         DatabaseTapeRowChangeType::Insert { after } => {
@@ -771,20 +776,20 @@ impl DatabaseReplaySession {
                             after,
                             updates: None,
                         } => {
-                            let key = self.populate_delete_stmt(coro, table).await?;
+                            let use_rowid = self.generator.delete_uses_rowid(&before, None)?;
+                            let key = self.populate_delete_stmt(coro, table, use_rowid).await?;
                             tracing::trace!(
                                 "ready to use prepared delete statement for replay of update: key={:?}",
                                 key
                             );
-                            let cached = self.cached_delete_stmt.get_mut(key).unwrap();
+                            let cached = self.cached_delete_stmt.get_mut(&key).unwrap();
                             cached.stmt.reset()?;
-                            let values = self.generator.replay_values(
+                            let values = self.generator.replay_delete_values(
                                 &cached.info,
-                                DatabaseChangeType::Delete,
                                 change.id,
                                 before,
                                 None,
-                            );
+                            )?;
                             replay_stmt(coro, &mut cached.stmt, values).await?;
 
                             let key = self.populate_insert_stmt(coro, table, after.len()).await?;
@@ -809,20 +814,22 @@ impl DatabaseReplaySession {
         }
         Ok(())
     }
-    async fn populate_delete_stmt<'a, Ctx>(
+    async fn populate_delete_stmt<Ctx>(
         &mut self,
         coro: &Coro<Ctx>,
-        table: &'a str,
-    ) -> Result<&'a str> {
-        if self.cached_delete_stmt.contains_key(table) {
-            return Ok(table);
+        table: &str,
+        use_rowid: bool,
+    ) -> Result<(String, bool)> {
+        let key = (table.to_string(), use_rowid);
+        if self.cached_delete_stmt.contains_key(&key) {
+            return Ok(key);
         }
         tracing::trace!("prepare delete statement for replay: table={}", table);
-        let info = self.generator.delete_query(coro, table).await?;
+        let info = self.generator.delete_query(coro, table, use_rowid).await?;
         let stmt = self.conn.prepare(&info.query)?;
         self.cached_delete_stmt
-            .insert(table.to_string(), CachedStmt { stmt, info });
-        Ok(table)
+            .insert(key.clone(), CachedStmt { stmt, info });
+        Ok(key)
     }
     async fn populate_insert_stmt<Ctx>(
         &mut self,
@@ -1173,6 +1180,250 @@ mod tests {
                 ],
             ]
         );
+    }
+
+    #[test]
+    pub fn test_database_tape_replay_composite_primary_key() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db =
+            turso_core::Database::open_file(io.clone(), db_path, Arc::new(SqliteDialect)).unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE z(x TEXT, y TEXT, payload TEXT, PRIMARY KEY(y, x))")
+                    .unwrap();
+                conn.execute("INSERT INTO z VALUES ('1', '2', 'old'), ('4', '2', 'untouched')")
+                    .unwrap();
+
+                let opts = DatabaseReplaySessionOpts {
+                    use_implicit_rowid: false,
+                };
+                let mut session = db.start_replay_session(&coro, opts).await.unwrap();
+                session
+                    .replay(
+                        &coro,
+                        DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                            change_id: 1,
+                            change_time: 1,
+                            table_name: "z".to_string(),
+                            id: 1,
+                            change: DatabaseTapeRowChangeType::Insert {
+                                after: crate::alloc::vec![
+                                    turso_core::Value::build_text("1"),
+                                    turso_core::Value::build_text("2"),
+                                    turso_core::Value::build_text("inserted"),
+                                ],
+                            },
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                session
+                    .replay(
+                        &coro,
+                        DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                            change_id: 2,
+                            change_time: 2,
+                            table_name: "z".to_string(),
+                            id: 1,
+                            change: DatabaseTapeRowChangeType::Update {
+                                before: crate::alloc::vec![
+                                    turso_core::Value::build_text("1"),
+                                    turso_core::Value::build_text("2"),
+                                    turso_core::Value::build_text("inserted"),
+                                ],
+                                after: crate::alloc::vec![
+                                    turso_core::Value::build_text("1"),
+                                    turso_core::Value::build_text("2"),
+                                    turso_core::Value::build_text("updated"),
+                                ],
+                                updates: Some(crate::alloc::vec![
+                                    turso_core::Value::from_i64(0),
+                                    turso_core::Value::from_i64(0),
+                                    turso_core::Value::from_i64(1),
+                                    turso_core::Value::Null,
+                                    turso_core::Value::Null,
+                                    turso_core::Value::build_text("updated"),
+                                ]),
+                            },
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                session
+                    .replay(
+                        &coro,
+                        DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                            change_id: 3,
+                            change_time: 3,
+                            table_name: "z".to_string(),
+                            id: 1,
+                            change: DatabaseTapeRowChangeType::Delete {
+                                before: crate::alloc::vec![
+                                    turso_core::Value::build_text("1"),
+                                    turso_core::Value::build_text("2"),
+                                    turso_core::Value::build_text("updated"),
+                                ],
+                                key: None,
+                            },
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                session
+                    .replay(&coro, DatabaseTapeOperation::Commit)
+                    .await
+                    .unwrap();
+
+                let mut stmt = conn
+                    .prepare("SELECT x, y, payload FROM z ORDER BY x")
+                    .unwrap();
+                let mut rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                rows
+            }
+        });
+        let rows = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+        assert_eq!(
+            rows,
+            vec![vec![
+                turso_core::Value::build_text("4"),
+                turso_core::Value::build_text("2"),
+                turso_core::Value::build_text("untouched"),
+            ]]
+        );
+    }
+
+    #[test]
+    pub fn test_database_tape_replay_delete_key_rules() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db =
+            turso_core::Database::open_file(io.clone(), db_path, Arc::new(SqliteDialect)).unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE q(x TEXT PRIMARY KEY, y TEXT UNIQUE, z TEXT UNIQUE)")
+                    .unwrap();
+                conn.execute(
+                    "INSERT INTO q(rowid, x, y, z) VALUES
+                        (7, '1', '2', '3'),
+                        (8, '4', '5', '6')",
+                )
+                .unwrap();
+                conn.execute("CREATE TABLE nopk(a TEXT, b TEXT)").unwrap();
+                conn.execute("INSERT INTO nopk(rowid, a, b) VALUES (3, 'r3', 'v3')")
+                    .unwrap();
+
+                let opts = DatabaseReplaySessionOpts {
+                    use_implicit_rowid: true,
+                };
+                let mut session = db.start_replay_session(&coro, opts).await.unwrap();
+                session
+                    .replay(
+                        &coro,
+                        DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                            change_id: 1,
+                            change_time: 1,
+                            table_name: "q".to_string(),
+                            // The remote rowid can differ after an earlier PK upsert.
+                            // The portable primary-key projection must win.
+                            id: 99,
+                            change: DatabaseTapeRowChangeType::Delete {
+                                before: crate::alloc::vec![],
+                                key: Some(crate::alloc::vec![turso_core::Value::build_text("1")]),
+                            },
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                // A delete without projection or before image on a table whose
+                // PRIMARY KEY is not the rowid must be refused: the local
+                // rowid may not match the remote's, so a rowid-based delete
+                // could remove the wrong row.
+                let refused = session
+                    .replay(
+                        &coro,
+                        DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                            change_id: 2,
+                            change_time: 2,
+                            table_name: "q".to_string(),
+                            id: 8,
+                            change: DatabaseTapeRowChangeType::Delete {
+                                before: crate::alloc::vec![],
+                                key: None,
+                            },
+                        }),
+                    )
+                    .await;
+                let err = format!("{:?}", refused.expect_err("rowid fallback must be refused"));
+                assert!(
+                    err.contains("refusing rowid-based replay"),
+                    "unexpected error for refused rowid fallback: {err}"
+                );
+                // Tables with no PRIMARY KEY have the rowid as their only
+                // identity: the fallback is exact and stays allowed.
+                session
+                    .replay(
+                        &coro,
+                        DatabaseTapeOperation::RowChange(DatabaseTapeRowChange {
+                            change_id: 3,
+                            change_time: 3,
+                            table_name: "nopk".to_string(),
+                            id: 3,
+                            change: DatabaseTapeRowChangeType::Delete {
+                                before: crate::alloc::vec![],
+                                key: None,
+                            },
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                session
+                    .replay(&coro, DatabaseTapeOperation::Commit)
+                    .await
+                    .unwrap();
+
+                let mut stmt = conn.prepare("SELECT x FROM q ORDER BY x").unwrap();
+                let mut q_rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    q_rows.push(row.get_values().cloned().collect::<Vec<_>>());
+                }
+                let mut stmt = conn.prepare("SELECT a FROM nopk").unwrap();
+                let nopk_empty = run_stmt_once(&coro, &mut stmt).await.unwrap().is_none();
+                (q_rows, nopk_empty)
+            }
+        });
+        let (q_rows, nopk_empty) = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+        // The key-based delete removed x='1'; the refused rowid delete left
+        // x='4' in place; the no-PK rowid delete emptied nopk.
+        assert_eq!(q_rows, vec![vec![turso_core::Value::build_text("4")]]);
+        assert!(nopk_empty);
     }
 
     #[test]

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -328,6 +328,7 @@ impl DatabaseChange {
                         "cdc_mode must be set to either 'full' or 'before'".to_string(),
                     )
                 })?)?,
+                key: None,
             },
             DatabaseChangeType::Update => DatabaseTapeRowChangeType::Update {
                 before: parse_bin_record(self.before.ok_or_else(|| {
@@ -390,6 +391,7 @@ impl DatabaseChange {
                         "cdc_mode must be set to either 'full' or 'after'".to_string(),
                     )
                 })?)?,
+                key: None,
             },
             DatabaseChangeType::Commit => {
                 return Err(Error::DatabaseTapeError(
@@ -541,6 +543,9 @@ pub enum DatabaseRowTransformResult {
 pub enum DatabaseTapeRowChangeType {
     Delete {
         before: crate::alloc::Vec<turso_core::Value>,
+        /// Primary-key values in declared key order when the source only
+        /// provides a delete key rather than a complete before image.
+        key: Option<crate::alloc::Vec<turso_core::Value>>,
     },
     Update {
         before: crate::alloc::Vec<turso_core::Value>,
@@ -614,9 +619,10 @@ pub struct DatabaseTapeRowChange {
 impl std::fmt::Debug for DatabaseTapeRowChangeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Delete { before } => f
+            Self::Delete { before, key } => f
                 .debug_struct("Delete")
                 .field("before.len()", &before.len())
+                .field("key.len()", &key.as_ref().map(|key| key.len()))
                 .finish(),
             Self::Update {
                 before,


### PR DESCRIPTION
Fixes two bugs that break `pull()` on databases using composite or non-rowid primary keys.

## Bug 1: composite primary keys break upsert replay

```sql
CREATE TABLE z (x, y, z, PRIMARY KEY (x, y));
INSERT INTO z VALUES ('1', '2', '3');
-- client pull() fails:
-- Parse error: ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint
```

`pragma_table_info` reports `pk` as the column's **1-based position within the primary key**, but the replay generator treated it as a boolean flag (`pk == 1`). For a composite key only the first column was collected, so the generated upsert was `ON CONFLICT(x)` instead of `ON CONFLICT(x, y)`.

The generator now collects every column with `pk > 0` and sorts by the ordinal, so PK columns come out in declared key order: matching both the generated `ON CONFLICT`/`WHERE` clauses and the order the server encodes primary-key values on the wire. Column ids returned by the pragma are also validated (non-negative, contiguous) instead of being cast blindly.

## Bug 2: replaying a DELETE panics

```sql
CREATE TABLE q (x TEXT PRIMARY KEY, y UNIQUE, z UNIQUE);
INSERT INTO q VALUES ('1', '2', '3');
DELETE FROM q;
-- client pull() panics:
-- index out of bounds: the len is 0 but the index is 0
```

MVCC portable deletes carry no before image. The server already encodes the row's primary-key values in the delete op's portable extension, but the client discarded that record and then tried to build the delete arguments by indexing into the (empty) before image: an out-of-bounds panic.

The client now decodes the primary-key record from the delete extension and threads it through as `DatabaseTapeRowChangeType::Delete { key }`. Replay uses the key directly when present (it takes precedence over the local rowid, which can diverge from the remote's), falls back to the before image, and only uses the implicit rowid when the change carries no row identity at all. Every failure mode is a descriptive error now — no panics. Servers that don't send the projection keep working via the rowid fallback.

## Related hardening

- Prepared delete statements are cached per `(table, use_rowid)` instead of per table, since the query shape now varies per change.
- Both replay paths (tape and SQL-over-HTTP) report the same clear error when a delete has no row image and implicit rowids are disabled, instead of one of them silently deleting by an unpreserved rowid.
- The old delete branch of `replay_values` is unreachable and now says so explicitly; all deletes go through the new `replay_delete_values`.