### PR TITLE
core/incremental: keep DbspStateCursors alive across ProcessingInputs re-polls

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2933,6 +2933,9 @@ impl Connection {
 
     #[cfg(any(test, injected_yields))]
     pub fn set_yield_injector(&self, injector: Option<Arc<dyn YieldInjector>>) {
+        // Mirror onto the pager: cursors built outside the VDBE (IVM/DBSP)
+        // have no `Connection` in scope and take their injector from there.
+        self.pager.load().set_yield_injector(injector.clone());
         let mut slot = self.yield_injector.write();
         match injector {
             Some(injector) => {

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3038,6 +3038,9 @@ impl Connection {
 
     #[cfg(any(test, injected_yields))]
     pub fn set_yield_injector(&self, injector: Option<Arc<dyn YieldInjector>>) {
+        // Mirror onto the pager: cursors built outside the VDBE (IVM/DBSP)
+        // have no `Connection` in scope and take their injector from there.
+        self.pager.load().set_yield_injector(injector.clone());
         let mut slot = self.yield_injector.write();
         match injector {
             Some(injector) => {

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -9,8 +9,9 @@ use crate::incremental::aggregate_operator::AggregateOperator;
 use crate::incremental::dbsp::{Delta, DeltaPair};
 use crate::incremental::expr_compiler::CompiledExpression;
 use crate::incremental::operator::{
-    create_dbsp_state_index, DbspStateCursors, EvalState, FilterOperator, FilterPredicate,
-    IncrementalOperator, InputOperator, JoinOperator, JoinType, ProjectOperator,
+    create_dbsp_state_index, install_dbsp_yield_context, DbspStateCursors, EvalState,
+    FilterOperator, FilterPredicate, IncrementalOperator, InputOperator, JoinOperator, JoinType,
+    ProjectOperator,
 };
 use crate::schema::Type;
 use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
@@ -506,15 +507,17 @@ impl DbspCircuit {
     ) -> Result<IOResult<Delta>> {
         if let Some(root_id) = self.root {
             // Create temporary cursors for execute (non-commit) operations
-            let table_cursor =
+            let mut table_cursor =
                 BTreeCursor::new_table(pager.clone(), self.internal_state_root, OPERATOR_COLUMNS);
+            install_dbsp_yield_context(&mut table_cursor, &pager);
             let index_def = create_dbsp_state_index(self.internal_state_index_root);
-            let index_cursor = BTreeCursor::new_index(
+            let mut index_cursor = BTreeCursor::new_index(
                 pager.clone(),
                 self.internal_state_index_root,
                 &index_def,
                 3,
             )?;
+            install_dbsp_yield_context(&mut index_cursor, &pager);
             let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
             self.execute_node(root_id, pager, execute_state, false, &mut cursors)
         } else {
@@ -557,18 +560,20 @@ impl DbspCircuit {
             match &mut state {
                 CommitState::Init => {
                     // Create state cursors when entering CommitOperators state
-                    let state_table_cursor = BTreeCursor::new_table(
+                    let mut state_table_cursor = BTreeCursor::new_table(
                         pager.clone(),
                         self.internal_state_root,
                         OPERATOR_COLUMNS,
                     );
+                    install_dbsp_yield_context(&mut state_table_cursor, &pager);
                     let index_def = create_dbsp_state_index(self.internal_state_index_root);
-                    let state_index_cursor = BTreeCursor::new_index(
+                    let mut state_index_cursor = BTreeCursor::new_index(
                         pager.clone(),
                         self.internal_state_index_root,
                         &index_def,
                         3, // Index on first 3 columns
                     )?;
+                    install_dbsp_yield_context(&mut state_index_cursor, &pager);
 
                     let state_cursors = Box::new(DbspStateCursors::new(
                         state_table_cursor,
@@ -593,11 +598,12 @@ impl DbspCircuit {
                     );
 
                     // Create view cursor when entering UpdateView state
-                    let view_cursor = Box::new(BTreeCursor::new_table(
-                        pager.clone(),
-                        main_data_root,
-                        num_columns,
-                    ));
+                    let view_cursor = {
+                        let mut cursor =
+                            BTreeCursor::new_table(pager.clone(), main_data_root, num_columns);
+                        install_dbsp_yield_context(&mut cursor, &pager);
+                        Box::new(cursor)
+                    };
 
                     self.commit_state = CommitState::UpdateView {
                         delta,
@@ -622,11 +628,10 @@ impl DbspCircuit {
                         // If we're starting a new row (GetRecord state), we need a fresh cursor
                         // due to btree cursor state machine limitations
                         if matches!(write_row_state, WriteRowView::GetRecord) {
-                            *view_cursor = Box::new(BTreeCursor::new_table(
-                                pager.clone(),
-                                main_data_root,
-                                num_columns,
-                            ));
+                            let mut cursor =
+                                BTreeCursor::new_table(pager.clone(), main_data_root, num_columns);
+                            install_dbsp_yield_context(&mut cursor, &pager);
+                            *view_cursor = Box::new(cursor);
                         }
 
                         // Build the view row format: row values + weight
@@ -647,14 +652,12 @@ impl DbspCircuit {
                         // Move to next row
                         let delta = std::mem::take(delta);
                         // Take ownership of view_cursor - we'll create a new one for next row if needed
-                        let view_cursor = std::mem::replace(
-                            view_cursor,
-                            Box::new(BTreeCursor::new_table(
-                                pager.clone(),
-                                main_data_root,
-                                num_columns,
-                            )),
-                        );
+                        let view_cursor = std::mem::replace(view_cursor, {
+                            let mut cursor =
+                                BTreeCursor::new_table(pager.clone(), main_data_root, num_columns);
+                            install_dbsp_yield_context(&mut cursor, &pager);
+                            Box::new(cursor)
+                        });
 
                         self.commit_state = CommitState::UpdateView {
                             delta,
@@ -744,18 +747,20 @@ impl DbspCircuit {
                         let (input_node_id, input_state) = &mut input_states[*current_index];
 
                         // Create temporary cursors for the recursive call
-                        let temp_table_cursor = BTreeCursor::new_table(
+                        let mut temp_table_cursor = BTreeCursor::new_table(
                             pager.clone(),
                             self.internal_state_root,
                             OPERATOR_COLUMNS,
                         );
+                        install_dbsp_yield_context(&mut temp_table_cursor, &pager);
                         let index_def = create_dbsp_state_index(self.internal_state_index_root);
-                        let temp_index_cursor = BTreeCursor::new_index(
+                        let mut temp_index_cursor = BTreeCursor::new_index(
                             pager.clone(),
                             self.internal_state_index_root,
                             &index_def,
                             3,
                         )?;
+                        install_dbsp_yield_context(&mut temp_index_cursor, &pager);
                         let mut temp_cursors =
                             DbspStateCursors::new(temp_table_cursor, temp_index_cursor);
 

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -6159,4 +6159,89 @@ mod tests {
         assert_eq!(actual_right.name, "right_id");
         assert_eq!(right_idx, 0);
     }
+
+    mod write_row_view_repoll {
+        use super::super::WriteRowView;
+        use crate::incremental::yield_test_support::OneShotYieldInjector;
+        use crate::mvcc::yield_hooks::YieldPointMarker;
+        use crate::storage::btree::{
+            BTreeCursor, BTreeWriteYieldPoint, CursorTrait, BTREE_WRITE_YIELD_FAMILY,
+        };
+        use crate::storage::pager::CreateBTreeFlags;
+        use crate::sync::Arc;
+        use crate::types::{SeekKey, SeekOp, SeekResult};
+        use crate::util::IOExt;
+        use crate::{Connection, Database, MemoryIO, SqliteDialect, Value, IO};
+
+        fn setup() -> (Arc<Connection>, Arc<crate::Pager>, i64) {
+            let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+            let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+            let conn = db.connect().unwrap();
+            let pager = conn.pager.load().clone();
+            let _ = pager.io.block(|| pager.allocate_page1());
+            let root = pager
+                .io
+                .block(|| pager.btree_create(&CreateBTreeFlags::new_table()))
+                .unwrap() as i64;
+            (conn, pager, root)
+        }
+
+        /// Same re-poll contract as `persistence::WriteRow`, for the per-row view cursor:
+        /// a mid-balance yield must not lose the matview row.
+        #[test]
+        fn write_row_view_completes_yielded_overflowing_insert() {
+            let (conn, pager, root) = setup();
+
+            let injector = OneShotYieldInjector::new(
+                BTreeWriteYieldPoint::AfterInsertOverflowCellBeforeBalance.point(),
+                BTREE_WRITE_YIELD_FAMILY ^ root as u64,
+            );
+            conn.set_yield_injector(Some(injector.clone()));
+
+            // ~1200-byte on-page cells fill leaves; the insert that overflows a page
+            // triggers the mid-balance yield. Fresh per-row cursor, as in UpdateView.
+            let mut victim_rowid = None;
+            for rowid in 1i64..=200 {
+                let mut cursor = BTreeCursor::new_table(pager.clone(), root, 2);
+                cursor.install_yield_context(&conn);
+
+                let key = SeekKey::TableRowId(rowid);
+                let build = move |final_weight: isize| -> Vec<Value> {
+                    vec![
+                        Value::from_slice(&[0xcd_u8; 1200]).unwrap(),
+                        Value::from_i64(final_weight as i64),
+                    ]
+                };
+
+                let mut wr = WriteRowView::new();
+                pager
+                    .io
+                    .block(|| wr.write_row(&mut cursor, key.clone(), build, 1))
+                    .unwrap();
+
+                if injector.fired() {
+                    victim_rowid = Some(rowid);
+                    break;
+                }
+            }
+            let victim_rowid = victim_rowid
+                .expect("no insert ever overflowed a page; test does not exercise the bug");
+            conn.set_yield_injector(None);
+
+            let mut verify = BTreeCursor::new_table(pager.clone(), root, 2);
+            let found = pager
+                .io
+                .block(|| {
+                    verify.seek(
+                        SeekKey::TableRowId(victim_rowid),
+                        SeekOp::GE { eq_only: true },
+                    )
+                })
+                .unwrap();
+            assert!(
+                matches!(found, SeekResult::Found),
+                "matview row {victim_rowid} lost: WriteRowView advanced to Done past a yielded insert"
+            );
+        }
+    }
 }

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -207,7 +207,6 @@ impl std::fmt::Debug for CommitState {
 
 /// State machine for circuit execution across I/O operations
 /// Similar to EvalState but for tracking execution state through the circuit
-#[derive(Debug)]
 pub enum ExecuteState {
     /// Empty state so we can allocate the space without executing
     Uninitialized,
@@ -226,6 +225,11 @@ pub enum ExecuteState {
         current_index: usize,
         /// Collected deltas from processed inputs
         input_deltas: Vec<Delta>,
+        /// Cursors for the child nodes' operator state, owned by this state
+        /// rather than built per poll: a btree write's balance state lives in
+        /// the cursor, so a child resuming a yielded write must resume on the
+        /// *same* cursor (as `CommitState::CommitOperators::state_cursors`).
+        state_cursors: Box<DbspStateCursors>,
     },
 
     /// Processing a specific node in the circuit
@@ -233,6 +237,33 @@ pub enum ExecuteState {
         /// Node's evaluation state (includes the delta in its Init state)
         eval_state: Box<EvalState>,
     },
+}
+
+impl std::fmt::Debug for ExecuteState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Uninitialized => write!(f, "Uninitialized"),
+            Self::Init { input_data } => f
+                .debug_struct("Init")
+                .field("input_data", input_data)
+                .finish(),
+            Self::ProcessingInputs {
+                input_states,
+                current_index,
+                input_deltas,
+                ..
+            } => f
+                .debug_struct("ProcessingInputs")
+                .field("input_states", input_states)
+                .field("current_index", current_index)
+                .field("input_deltas", input_deltas)
+                .finish_non_exhaustive(),
+            Self::ProcessingNode { eval_state } => f
+                .debug_struct("ProcessingNode")
+                .field("eval_state", eval_state)
+                .finish(),
+        }
+    }
 }
 
 /// A set of deltas for multiple tables/operators
@@ -472,6 +503,33 @@ impl DbspCircuit {
         id
     }
 
+    /// Build a cursor pair over the circuit's internal DBSP state btrees.
+    ///
+    /// Every caller must keep the returned pair alive for as long as the state
+    /// machine that drives it: a yielded btree write can only be re-driven on
+    /// the cursor that started it.
+    fn new_dbsp_state_cursors(&self, pager: &Arc<Pager>) -> Result<DbspStateCursors> {
+        let mut table_cursor =
+            BTreeCursor::new_table(pager.clone(), self.internal_state_root, OPERATOR_COLUMNS);
+        install_dbsp_yield_context(&mut table_cursor, pager);
+        let index_def = create_dbsp_state_index(self.internal_state_index_root);
+        let mut index_cursor = BTreeCursor::new_index(
+            pager.clone(),
+            self.internal_state_index_root,
+            &index_def,
+            3, // Index on first 3 columns
+        )?;
+        install_dbsp_yield_context(&mut index_cursor, pager);
+        Ok(DbspStateCursors::new(table_cursor, index_cursor))
+    }
+
+    /// Cursor over the materialized view's own data btree.
+    fn new_view_cursor(&self, pager: &Arc<Pager>, num_columns: usize) -> BTreeCursor {
+        let mut cursor = BTreeCursor::new_table(pager.clone(), self.main_data_root, num_columns);
+        install_dbsp_yield_context(&mut cursor, pager);
+        cursor
+    }
+
     pub fn run_circuit(
         &mut self,
         execute_state: &mut ExecuteState,
@@ -506,19 +564,11 @@ impl DbspCircuit {
         execute_state: &mut ExecuteState,
     ) -> Result<IOResult<Delta>> {
         if let Some(root_id) = self.root {
-            // Create temporary cursors for execute (non-commit) operations
-            let mut table_cursor =
-                BTreeCursor::new_table(pager.clone(), self.internal_state_root, OPERATOR_COLUMNS);
-            install_dbsp_yield_context(&mut table_cursor, &pager);
-            let index_def = create_dbsp_state_index(self.internal_state_index_root);
-            let mut index_cursor = BTreeCursor::new_index(
-                pager.clone(),
-                self.internal_state_index_root,
-                &index_def,
-                3,
-            )?;
-            install_dbsp_yield_context(&mut index_cursor, &pager);
-            let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
+            // Read-only path: no operator writes state here, so this pair may be
+            // rebuilt per poll. It is only sound because every read in the eval
+            // path re-derives its position from a key on each re-entry — see the
+            // contract note on `IncrementalOperator::eval`.
+            let mut cursors = self.new_dbsp_state_cursors(&pager)?;
             self.execute_node(root_id, pager, execute_state, false, &mut cursors)
         } else {
             Err(LimboError::ParseError(
@@ -543,9 +593,6 @@ impl DbspCircuit {
             return Ok(IOResult::Done(Delta::new()));
         }
 
-        // Get btree root pages
-        let main_data_root = self.main_data_root;
-
         // Add 1 for the weight column that we store in the btree
         let num_columns = self.output_schema.columns.len() + 1;
 
@@ -560,25 +607,7 @@ impl DbspCircuit {
             match &mut state {
                 CommitState::Init => {
                     // Create state cursors when entering CommitOperators state
-                    let mut state_table_cursor = BTreeCursor::new_table(
-                        pager.clone(),
-                        self.internal_state_root,
-                        OPERATOR_COLUMNS,
-                    );
-                    install_dbsp_yield_context(&mut state_table_cursor, &pager);
-                    let index_def = create_dbsp_state_index(self.internal_state_index_root);
-                    let mut state_index_cursor = BTreeCursor::new_index(
-                        pager.clone(),
-                        self.internal_state_index_root,
-                        &index_def,
-                        3, // Index on first 3 columns
-                    )?;
-                    install_dbsp_yield_context(&mut state_index_cursor, &pager);
-
-                    let state_cursors = Box::new(DbspStateCursors::new(
-                        state_table_cursor,
-                        state_index_cursor,
-                    ));
+                    let state_cursors = Box::new(self.new_dbsp_state_cursors(&pager)?);
 
                     self.commit_state = CommitState::CommitOperators {
                         execute_state: Box::new(ExecuteState::Init {
@@ -598,12 +627,7 @@ impl DbspCircuit {
                     );
 
                     // Create view cursor when entering UpdateView state
-                    let view_cursor = {
-                        let mut cursor =
-                            BTreeCursor::new_table(pager.clone(), main_data_root, num_columns);
-                        install_dbsp_yield_context(&mut cursor, &pager);
-                        Box::new(cursor)
-                    };
+                    let view_cursor = Box::new(self.new_view_cursor(&pager, num_columns));
 
                     self.commit_state = CommitState::UpdateView {
                         delta,
@@ -628,10 +652,7 @@ impl DbspCircuit {
                         // If we're starting a new row (GetRecord state), we need a fresh cursor
                         // due to btree cursor state machine limitations
                         if matches!(write_row_state, WriteRowView::GetRecord) {
-                            let mut cursor =
-                                BTreeCursor::new_table(pager.clone(), main_data_root, num_columns);
-                            install_dbsp_yield_context(&mut cursor, &pager);
-                            *view_cursor = Box::new(cursor);
+                            *view_cursor = Box::new(self.new_view_cursor(&pager, num_columns));
                         }
 
                         // Build the view row format: row values + weight
@@ -652,12 +673,10 @@ impl DbspCircuit {
                         // Move to next row
                         let delta = std::mem::take(delta);
                         // Take ownership of view_cursor - we'll create a new one for next row if needed
-                        let view_cursor = std::mem::replace(view_cursor, {
-                            let mut cursor =
-                                BTreeCursor::new_table(pager.clone(), main_data_root, num_columns);
-                            install_dbsp_yield_context(&mut cursor, &pager);
-                            Box::new(cursor)
-                        });
+                        let view_cursor = std::mem::replace(
+                            view_cursor,
+                            Box::new(self.new_view_cursor(&pager, num_columns)),
+                        );
 
                         self.commit_state = CommitState::UpdateView {
                             delta,
@@ -719,10 +738,13 @@ impl DbspCircuit {
                                 })
                                 .collect();
 
+                            let state_cursors = Box::new(self.new_dbsp_state_cursors(&pager)?);
+
                             *execute_state = ExecuteState::ProcessingInputs {
                                 input_states,
                                 current_index: 0,
                                 input_deltas: Vec::new(),
+                                state_cursors,
                             };
                         }
                     }
@@ -731,6 +753,7 @@ impl DbspCircuit {
                     input_states,
                     current_index,
                     input_deltas,
+                    state_cursors,
                 } => {
                     if *current_index >= input_states.len() {
                         // All inputs processed
@@ -746,30 +769,14 @@ impl DbspCircuit {
                         // Get the (node_id, state) pair for the current index
                         let (input_node_id, input_state) = &mut input_states[*current_index];
 
-                        // Create temporary cursors for the recursive call
-                        let mut temp_table_cursor = BTreeCursor::new_table(
-                            pager.clone(),
-                            self.internal_state_root,
-                            OPERATOR_COLUMNS,
-                        );
-                        install_dbsp_yield_context(&mut temp_table_cursor, &pager);
-                        let index_def = create_dbsp_state_index(self.internal_state_index_root);
-                        let mut temp_index_cursor = BTreeCursor::new_index(
-                            pager.clone(),
-                            self.internal_state_index_root,
-                            &index_def,
-                            3,
-                        )?;
-                        install_dbsp_yield_context(&mut temp_index_cursor, &pager);
-                        let mut temp_cursors =
-                            DbspStateCursors::new(temp_table_cursor, temp_index_cursor);
-
+                        // Must be the state-owned pair: a yielded child write
+                        // resumes on the cursor that started it.
                         let delta = return_if_io!(self.execute_node(
                             *input_node_id,
                             pager.clone(),
                             input_state,
                             commit_operators,
-                            &mut temp_cursors
+                            state_cursors
                         ));
                         input_deltas.push(delta);
                         *current_index += 1;

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -32,12 +32,19 @@ use std::fmt::{self, Display, Formatter};
 const OPERATOR_COLUMNS: usize = 5;
 
 /// State machine for writing rows to simple materialized views (table-only, no index)
+///
+/// Each arm issues exactly one cursor op and advances only after it returns `Done`:
+/// `IOResult::IO` means "call me again", so advancing first abandons an in-flight
+/// balance. The seek therefore gets its own arm.
 #[derive(Debug, Default)]
 pub enum WriteRowView {
     #[default]
     GetRecord,
     Delete,
     Insert {
+        final_weight: isize,
+    },
+    InsertRow {
         final_weight: isize,
     },
     Done,
@@ -106,13 +113,16 @@ impl WriteRowView {
                     }
                 }
                 WriteRowView::Delete => {
-                    // Mark as Done before delete to avoid retry on I/O
-                    *self = WriteRowView::Done;
                     return_if_io!(cursor.delete());
+                    *self = WriteRowView::Done;
                 }
                 WriteRowView::Insert { final_weight } => {
                     return_if_io!(cursor.seek(key.clone(), SeekOp::GE { eq_only: true }));
-
+                    *self = WriteRowView::InsertRow {
+                        final_weight: *final_weight,
+                    };
+                }
+                WriteRowView::InsertRow { final_weight } => {
                     // Extract the row ID from the key
                     let key_i64 = match key {
                         SeekKey::TableRowId(id) => id,
@@ -131,9 +141,8 @@ impl WriteRowView {
                         ImmutableRecord::from_values(&record_values, record_values.len())?;
                     let btree_key = BTreeKey::new_table_rowid(key_i64, Some(&immutable_record));
 
-                    // Mark as Done before insert to avoid retry on I/O
-                    *self = WriteRowView::Done;
                     return_if_io!(cursor.insert(&btree_key));
+                    *self = WriteRowView::Done;
                 }
                 WriteRowView::Done => {
                     return Ok(IOResult::Done(()));

--- a/core/incremental/mod.rs
+++ b/core/incremental/mod.rs
@@ -11,3 +11,41 @@ pub mod operator;
 pub mod persistence;
 pub mod project_operator;
 pub mod view;
+
+#[cfg(test)]
+pub(crate) mod yield_test_support {
+    use crate::mvcc::yield_points::{YieldInjector, YieldPoint};
+    use crate::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Fires the requested yield point exactly once, for the btree whose write
+    /// selection key matches.
+    #[derive(Debug)]
+    pub(crate) struct OneShotYieldInjector {
+        point: YieldPoint,
+        selection_key: u64,
+        fired: AtomicBool,
+    }
+
+    impl OneShotYieldInjector {
+        pub(crate) fn new(point: YieldPoint, selection_key: u64) -> Arc<Self> {
+            Arc::new(Self {
+                point,
+                selection_key,
+                fired: AtomicBool::new(false),
+            })
+        }
+
+        pub(crate) fn fired(&self) -> bool {
+            self.fired.load(Ordering::Acquire)
+        }
+    }
+
+    impl YieldInjector for OneShotYieldInjector {
+        fn should_yield(&self, _instance_id: u64, selection_key: u64, point: YieldPoint) -> bool {
+            point == self.point
+                && selection_key == self.selection_key
+                && !self.fired.swap(true, Ordering::AcqRel)
+        }
+    }
+}

--- a/core/incremental/mod.rs
+++ b/core/incremental/mod.rs
@@ -10,6 +10,8 @@ pub mod merge_operator;
 pub mod operator;
 pub mod persistence;
 pub mod project_operator;
+#[cfg(test)]
+mod temp_cursor_lifetime;
 pub mod view;
 
 #[cfg(test)]

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -39,6 +39,19 @@ impl DbspStateCursors {
     }
 }
 
+/// Give a circuit-owned cursor the same deterministic-yield context a VDBE
+/// cursor gets. Without this the DBSP state and view btrees are invisible to
+/// yield injection, so no simulator seed can schedule a yield inside an IVM
+/// write.
+#[inline]
+pub fn install_dbsp_yield_context(
+    _cursor: &mut BTreeCursor,
+    _pager: &crate::storage::pager::Pager,
+) {
+    #[cfg(any(test, injected_yields))]
+    _cursor.install_yield_context_from_pager(_pager);
+}
+
 /// Create an index definition for the DBSP state table
 /// This defines the primary key index on (operator_id, zset_id, element_id)
 pub fn create_dbsp_state_index(root_page: i64) -> Index {
@@ -211,6 +224,19 @@ pub trait IncrementalOperator: Debug + Send {
     /// # Arguments
     /// * `state` - The evaluation state (may be in progress from a previous I/O operation)
     /// * `cursors` - Cursors for reading operator state from storage (table and optional index)
+    ///
+    /// # Cursor contract
+    /// `cursors` is only guaranteed to live as long as one poll:
+    /// `DbspCircuit::execute` rebuilds it on every `IOResult::IO`. So `state`
+    /// must never encode "continue from wherever the cursor is now" — every
+    /// re-entry must re-derive its position from a key it stores itself
+    /// (`SeekKey`, a group key, `last_element_hash`, ...). A bare
+    /// `rewind()`/`next()` scan whose progress lives in `state` would silently
+    /// restart or drop rows, with no assertion to catch it. Writes have no
+    /// such freedom at all — a yielded btree write can only be re-driven on the
+    /// cursor that started it, which is why `commit` runs against a pair owned
+    /// by the caller's state (`CommitState::CommitOperators`,
+    /// `ExecuteState::ProcessingInputs`).
     ///
     /// # Returns
     /// The output delta from the evaluation

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -63,6 +63,9 @@ impl ReadRecord {
     }
 }
 
+/// Each arm issues exactly one cursor op and advances only after it returns `Done`:
+/// `IOResult::IO` means "call me again", so advancing first abandons an in-flight
+/// balance. Seeks therefore get their own arm.
 #[derive(Debug, Default)]
 pub enum WriteRow {
     #[default]

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -63,6 +63,9 @@ impl ReadRecord {
     }
 }
 
+/// Each arm issues exactly one cursor op and advances only after it returns `Done`:
+/// `IOResult::IO` means "call me again", so advancing first abandons an in-flight
+/// balance. Seeks therefore get their own arm.
 #[derive(Debug, Default)]
 pub enum WriteRow {
     #[default]
@@ -70,11 +73,16 @@ pub enum WriteRow {
     Delete {
         rowid: i64,
     },
+    DeleteTable,
     DeleteIndex,
     ComputeNewRowId {
         final_weight: isize,
     },
     InsertNew {
+        rowid: i64,
+        final_weight: isize,
+    },
+    InsertNewRow {
         rowid: i64,
         final_weight: isize,
     },
@@ -184,19 +192,18 @@ impl WriteRow {
                     }
                 }
                 WriteRow::Delete { rowid } => {
-                    // Seek to the row and delete it
                     return_if_io!(cursors
                         .table_cursor
                         .seek(SeekKey::TableRowId(*rowid), SeekOp::GE { eq_only: true }));
-
-                    // Transition to DeleteIndex to also delete the index entry
-                    *self = WriteRow::DeleteIndex;
+                    *self = WriteRow::DeleteTable;
+                }
+                WriteRow::DeleteTable => {
                     return_if_io!(cursors.table_cursor.delete());
+                    *self = WriteRow::DeleteIndex;
                 }
                 WriteRow::DeleteIndex => {
-                    // Mark as Done before delete to avoid retry on I/O
-                    *self = WriteRow::Done;
                     return_if_io!(cursors.index_cursor.delete());
+                    *self = WriteRow::Done;
                 }
                 WriteRow::ComputeNewRowId { final_weight } => {
                     // Find the last rowid to compute the next one
@@ -224,15 +231,20 @@ impl WriteRow {
                     rowid,
                     final_weight,
                 } => {
+                    return_if_io!(cursors
+                        .table_cursor
+                        .seek(SeekKey::TableRowId(*rowid), SeekOp::GE { eq_only: false }));
+                    *self = WriteRow::InsertNewRow {
+                        rowid: *rowid,
+                        final_weight: *final_weight,
+                    };
+                }
+                WriteRow::InsertNewRow {
+                    rowid,
+                    final_weight,
+                } => {
                     let rowid_val = *rowid;
                     let final_weight_val = *final_weight;
-
-                    // Seek to where we want to insert
-                    // The insert will position the cursor correctly
-                    return_if_io!(cursors.table_cursor.seek(
-                        SeekKey::TableRowId(rowid_val),
-                        SeekOp::GE { eq_only: false }
-                    ));
 
                     // Build the complete record with weight
                     // Use the function parameter record_values directly
@@ -244,9 +256,8 @@ impl WriteRow {
                         ImmutableRecord::from_values(&complete_record, complete_record.len())?;
                     let btree_key = BTreeKey::new_table_rowid(rowid_val, Some(&immutable_record));
 
-                    // Transition to InsertIndex state after table insertion
-                    *self = WriteRow::InsertIndex { rowid: rowid_val };
                     return_if_io!(cursors.table_cursor.insert(&btree_key));
+                    *self = WriteRow::InsertIndex { rowid: rowid_val };
                 }
                 WriteRow::InsertIndex { rowid } => {
                     // For has_rowid indexes, we need to append the rowid to the index key
@@ -259,9 +270,8 @@ impl WriteRow {
                         ImmutableRecord::from_values(&index_values, index_values.len())?;
                     let index_btree_key = BTreeKey::new_index_key(index_record.as_record_ref());
 
-                    // Mark as Done before index insert to avoid retry on I/O
-                    *self = WriteRow::Done;
                     return_if_io!(cursors.index_cursor.insert(&index_btree_key));
+                    *self = WriteRow::Done;
                 }
                 WriteRow::UpdateExisting {
                     rowid,
@@ -276,10 +286,9 @@ impl WriteRow {
                         ImmutableRecord::from_values(&complete_record, complete_record.len())?;
                     let btree_key = BTreeKey::new_table_rowid(*rowid, Some(&immutable_record));
 
-                    // Mark as Done before insert to avoid retry on I/O
-                    *self = WriteRow::Done;
                     // BTree insert with existing key will replace the old value
                     return_if_io!(cursors.table_cursor.insert(&btree_key));
+                    *self = WriteRow::Done;
                 }
                 WriteRow::Done => {
                     return Ok(IOResult::Done(()));

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -288,3 +288,109 @@ impl WriteRow {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::incremental::operator::{create_dbsp_state_index, DbspStateCursors};
+    use crate::incremental::yield_test_support::OneShotYieldInjector;
+    use crate::mvcc::yield_hooks::YieldPointMarker;
+    use crate::storage::btree::{
+        BTreeCursor, BTreeWriteYieldPoint, CursorTrait, BTREE_WRITE_YIELD_FAMILY,
+    };
+    use crate::storage::pager::CreateBTreeFlags;
+    use crate::sync::Arc;
+    use crate::util::IOExt;
+    use crate::{Connection, Database, MemoryIO, SqliteDialect, IO};
+
+    fn setup() -> (Arc<Connection>, Arc<crate::Pager>, i64, i64) {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        let pager = conn.pager.load().clone();
+        let _ = pager.io.block(|| pager.allocate_page1());
+        let table_root = pager
+            .io
+            .block(|| pager.btree_create(&CreateBTreeFlags::new_table()))
+            .unwrap() as i64;
+        let index_root = pager
+            .io
+            .block(|| pager.btree_create(&CreateBTreeFlags::new_index()))
+            .unwrap() as i64;
+        (conn, pager, table_root, index_root)
+    }
+
+    // ~1200-byte cells stay on the leaf, so enough of them overflow the page and trip
+    // AfterInsertOverflowCellBeforeBalance.
+    fn page_filling_record(op_id: i64, zset_id: i64, elem_id: i64) -> Vec<Value> {
+        vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(elem_id),
+            Value::from_slice(&[0xcd_u8; 1200]).unwrap(),
+        ]
+    }
+
+    /// If the table insert yields mid-balance, `WriteRow` must re-drive it before
+    /// advancing; advancing first strands the overflow cell and the row vanishes.
+    #[test]
+    fn write_row_completes_yielded_overflowing_table_insert() {
+        let (conn, pager, table_root, index_root) = setup();
+
+        let injector = OneShotYieldInjector::new(
+            BTreeWriteYieldPoint::AfterInsertOverflowCellBeforeBalance.point(),
+            BTREE_WRITE_YIELD_FAMILY ^ table_root as u64,
+        );
+        conn.set_yield_injector(Some(injector.clone()));
+
+        let mut table_cursor = BTreeCursor::new_table(pager.clone(), table_root, 5);
+        table_cursor.install_yield_context(&conn);
+        let index_def = create_dbsp_state_index(index_root);
+        let mut index_cursor =
+            BTreeCursor::new_index(pager.clone(), index_root, &index_def, 4).unwrap();
+        index_cursor.install_yield_context(&conn);
+        let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
+
+        let (op_id, zset_id) = (1i64, 1i64);
+        // rowid == elem_id here: ComputeNewRowId assigns last+1.
+        let mut victim_rowid = None;
+        for elem_id in 1i64..=200 {
+            let index_key = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(elem_id),
+            ];
+            let record_values = page_filling_record(op_id, zset_id, elem_id);
+
+            let mut wr = WriteRow::new();
+            pager
+                .io
+                .block(|| wr.write_row(&mut cursors, index_key.clone(), record_values.clone(), 1))
+                .unwrap();
+
+            if injector.fired() {
+                victim_rowid = Some(elem_id);
+                break;
+            }
+        }
+        let victim_rowid =
+            victim_rowid.expect("no insert ever overflowed a page; test does not exercise the bug");
+        conn.set_yield_injector(None);
+
+        // Fresh cursor: the working one may be parked mid-balance.
+        let mut verify_cursor = BTreeCursor::new_table(pager.clone(), table_root, 5);
+        let found = pager
+            .io
+            .block(|| {
+                verify_cursor.seek(
+                    SeekKey::TableRowId(victim_rowid),
+                    SeekOp::GE { eq_only: true },
+                )
+            })
+            .unwrap();
+        assert!(
+            matches!(found, SeekResult::Found),
+            "table row {victim_rowid} lost: WriteRow advanced past a yielded (mid-balance) insert"
+        );
+    }
+}

--- a/core/incremental/temp_cursor_lifetime.rs
+++ b/core/incremental/temp_cursor_lifetime.rs
@@ -1,0 +1,176 @@
+//! Regression coverage for the DBSP circuit's cursor *lifetime*: a non-root
+//! operator's state write must survive re-poll after a mid-balance yield (see
+//! the `ProcessingInputs` cursor-ownership note in compiler.rs). Root nodes
+//! are covered separately by `CommitState::CommitOperators`.
+
+use crate::incremental::compiler::{DbspCircuit, DbspCompiler};
+use crate::incremental::dbsp::Delta;
+use crate::mvcc::yield_hooks::YieldPointMarker;
+use crate::mvcc::yield_points::{YieldInjector, YieldPoint};
+use crate::storage::btree::{
+    BTreeCursor, BTreeWriteYieldPoint, CursorTrait, BTREE_WRITE_YIELD_FAMILY,
+};
+use crate::storage::pager::CreateBTreeFlags;
+use crate::sync::Arc;
+use crate::translate::logical::LogicalPlanBuilder;
+use crate::util::IOExt;
+use crate::{Connection, Database, MemoryIO, Pager, SqliteDialect, Value, IO};
+use rustc_hash::FxHashMap as HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use turso_parser::ast;
+use turso_parser::parser::Parser;
+
+/// Fires the requested yield point exactly once, for the btree whose write
+/// selection key matches.
+#[derive(Debug)]
+struct OneShotYieldInjector {
+    point: YieldPoint,
+    selection_key: u64,
+    fired: AtomicBool,
+}
+
+impl OneShotYieldInjector {
+    fn new(point: YieldPoint, selection_key: u64) -> Arc<Self> {
+        Arc::new(Self {
+            point,
+            selection_key,
+            fired: AtomicBool::new(false),
+        })
+    }
+
+    fn fired(&self) -> bool {
+        self.fired.load(Ordering::Acquire)
+    }
+}
+
+impl YieldInjector for OneShotYieldInjector {
+    fn should_yield(&self, _instance_id: u64, selection_key: u64, point: YieldPoint) -> bool {
+        point == self.point
+            && selection_key == self.selection_key
+            && !self.fired.swap(true, Ordering::AcqRel)
+    }
+}
+
+struct Fixture {
+    conn: Arc<Connection>,
+    pager: Arc<Pager>,
+    circuit: DbspCircuit,
+    main_data_root: i64,
+    state_root: i64,
+}
+
+/// Compiles a circuit whose state-persisting operator (the aggregate) is a
+/// *non-root* node, so it gets its cursor pair from `ExecuteState::ProcessingInputs`.
+fn fixture() -> Fixture {
+    let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER, v INTEGER)")
+        .unwrap();
+    let pager = conn.pager.load().clone();
+
+    let main_data_root = pager
+        .io
+        .block(|| pager.btree_create(&CreateBTreeFlags::new_table()))
+        .unwrap() as i64;
+    let state_root = pager
+        .io
+        .block(|| pager.btree_create(&CreateBTreeFlags::new_table()))
+        .unwrap() as i64;
+    let state_index_root = pager
+        .io
+        .block(|| pager.btree_create(&CreateBTreeFlags::new_index()))
+        .unwrap() as i64;
+
+    let schema = conn.schema.read().clone();
+    // `count(*) + 0` forces a Projection above the aggregate (a bare `count(*)`
+    // would be elided, leaving the aggregate at the root).
+    let mut parser = Parser::new(b"SELECT k, count(*) + 0 AS c FROM t GROUP BY k");
+    let cmd = parser.next().unwrap().unwrap();
+    let ast::Cmd::Stmt(stmt) = cmd else {
+        panic!("expected a statement");
+    };
+    let logical_plan = LogicalPlanBuilder::new(&schema)
+        .build_statement(&stmt)
+        .unwrap();
+    let circuit = DbspCompiler::new(main_data_root, state_root, state_index_root)
+        .compile(&logical_plan)
+        .unwrap();
+
+    Fixture {
+        conn,
+        pager,
+        circuit,
+        main_data_root,
+        state_root,
+    }
+}
+
+fn count_btree_rows(pager: &Arc<Pager>, root: i64, num_columns: usize) -> usize {
+    let mut cursor = BTreeCursor::new_table(pager.clone(), root, num_columns);
+    pager.io.block(|| cursor.rewind()).unwrap();
+    let mut n = 0;
+    while pager.io.block(|| cursor.rowid()).unwrap().is_some() {
+        n += 1;
+        pager.io.block(|| cursor.next()).unwrap();
+    }
+    n
+}
+
+/// Enough distinct groups that persisting the aggregate's state fills a leaf of
+/// the DBSP state btree and the next insert balances it.
+const GROUPS: i64 = 400;
+
+#[test]
+fn non_root_operator_survives_mid_balance_yield_in_state_write() {
+    let Fixture {
+        conn,
+        pager,
+        mut circuit,
+        main_data_root,
+        state_root,
+    } = fixture();
+
+    let injector = OneShotYieldInjector::new(
+        BTreeWriteYieldPoint::AfterInsertOverflowCellBeforeBalance.point(),
+        BTREE_WRITE_YIELD_FAMILY ^ state_root as u64,
+    );
+    // IVM-owned cursors must carry a yield context (`install_dbsp_yield_context`)
+    // or they are invisible to injection and no fuzzer seed can reach this write.
+    conn.set_yield_injector(Some(injector.clone()));
+
+    let mut delta = Delta::new();
+    for k in 0..GROUPS {
+        delta.insert(
+            k + 1,
+            vec![
+                Value::from_i64(k + 1),
+                Value::from_i64(k),
+                Value::from_i64(k * 2),
+            ],
+        );
+    }
+    let mut input = HashMap::default();
+    input.insert("t".to_string(), delta);
+
+    pager
+        .io
+        .block(|| circuit.commit(input.clone(), pager.clone()))
+        .unwrap();
+
+    conn.set_yield_injector(None);
+    assert!(
+        injector.fired(),
+        "no mid-balance yield was injected into the DBSP state btree; the test \
+         does not exercise the bug (are IVM cursors missing their yield context?)"
+    );
+
+    // One materialized row per group. A child node that resumed its yielded
+    // state write on a rebuilt cursor either faults or drops the row.
+    assert_eq!(
+        count_btree_rows(&pager, main_data_root, 3),
+        GROUPS as usize,
+        "materialized rows lost: a non-root node's state write did not survive a \
+         mid-balance yield (compiler.rs ProcessingInputs cursor lifetime)"
+    );
+}

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -9936,6 +9936,17 @@ fn drop_cell(page: &mut PageContent, cell_idx: usize, usable_space: usize) -> Re
         page.write_fragmented_bytes_count(0);
     }
     page.write_cell_count(page.cell_count() as u16 - 1);
+
+    // Only balance_non_root drops cells from a page with pending overflow cells, and
+    // it always consumes the divider at or before cell_idx.
+    for overflow_cell in page.overflow_cells.iter() {
+        turso_assert!(
+            overflow_cell.index <= cell_idx,
+            "drop_cell: pending overflow cell positioned after dropped cell",
+            { "overflow_index": overflow_cell.index, "cell_idx": cell_idx }
+        );
+    }
+
     debug_validate_cells!(page, usable_space);
     Ok(())
 }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10607,6 +10607,52 @@ mod tests {
         }
     }
 
+    /// No sanctioned path reaches drop_cell with an overflow cell after cell_idx, so build it by hand.
+    #[test]
+    #[should_panic(expected = "pending overflow cell positioned after dropped cell")]
+    fn test_drop_cell_rejects_overflow_cell_after_dropped_cell() {
+        let (pager, _, _, _) = empty_btree();
+        let usable_space = pager.usable_space();
+
+        let page = run_until_done(|| pager.allocate_page(), &pager).unwrap();
+        btree_init_page(&page, PageType::TableLeaf, 0, usable_space);
+        let page_contents = page.get_contents();
+
+        // Populate the leaf with a handful of regular cells.
+        for i in 0..10 {
+            let regs = &[Register::Value(Value::from_i64(i))];
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
+            let mut payload = crate::alloc::vec![];
+            let mut fill_state = FillCellPayloadState::Start;
+            run_until_done(
+                || {
+                    fill_cell_payload(
+                        &PinGuard::new(page.clone()),
+                        Some(i),
+                        &mut payload,
+                        i as usize,
+                        &record,
+                        usable_space,
+                        pager.clone(),
+                        &mut fill_state,
+                    )
+                },
+                &pager,
+            )
+            .unwrap();
+            insert_into_cell(page_contents, &payload, i as usize, usable_space).unwrap();
+        }
+        assert_eq!(page_contents.cell_count(), 10);
+
+        // Illegal state: pending overflow at index 8, dropping index 5.
+        page_contents.overflow_cells.push(OverflowCell {
+            index: 8,
+            payload: std::pin::Pin::new(crate::alloc::vec![1, 2, 3, 4]),
+        });
+
+        let _ = drop_cell(page_contents, 5, usable_space);
+    }
+
     fn validate_btree(pager: Arc<Pager>, page_idx: i64) -> (usize, bool) {
         let num_columns = 5;
         let cursor = BTreeCursor::new_table(pager.clone(), page_idx, num_columns);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10611,6 +10611,52 @@ mod tests {
         }
     }
 
+    /// No sanctioned path reaches drop_cell with an overflow cell after cell_idx, so build it by hand.
+    #[test]
+    #[should_panic(expected = "pending overflow cell positioned after dropped cell")]
+    fn test_drop_cell_rejects_overflow_cell_after_dropped_cell() {
+        let (pager, _, _, _) = empty_btree();
+        let usable_space = pager.usable_space();
+
+        let page = run_until_done(|| pager.allocate_page(), &pager).unwrap();
+        btree_init_page(&page, PageType::TableLeaf, 0, usable_space);
+        let page_contents = page.get_contents();
+
+        // Populate the leaf with a handful of regular cells.
+        for i in 0..10 {
+            let regs = &[Register::Value(Value::from_i64(i))];
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
+            let mut payload = crate::alloc::vec![];
+            let mut fill_state = FillCellPayloadState::Start;
+            run_until_done(
+                || {
+                    fill_cell_payload(
+                        &PinGuard::new(page.clone()),
+                        Some(i),
+                        &mut payload,
+                        i as usize,
+                        &record,
+                        usable_space,
+                        pager.clone(),
+                        &mut fill_state,
+                    )
+                },
+                &pager,
+            )
+            .unwrap();
+            insert_into_cell(page_contents, &payload, i as usize, usable_space).unwrap();
+        }
+        assert_eq!(page_contents.cell_count(), 10);
+
+        // Illegal state: pending overflow at index 8, dropping index 5.
+        page_contents.overflow_cells.push(OverflowCell {
+            index: 8,
+            payload: std::pin::Pin::new(crate::alloc::vec![1, 2, 3, 4]),
+        });
+
+        let _ = drop_cell(page_contents, 5, usable_space);
+    }
+
     fn validate_btree(pager: Arc<Pager>, page_idx: i64) -> (usize, bool) {
         let num_columns = 5;
         let cursor = BTreeCursor::new_table(pager.clone(), page_idx, num_columns);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -376,7 +376,7 @@ pub(crate) enum BTreeWriteYieldPoint {
 }
 
 #[cfg(any(test, injected_yields))]
-const BTREE_WRITE_YIELD_FAMILY: u64 = 0x4254_5245_5752_4954;
+pub(crate) const BTREE_WRITE_YIELD_FAMILY: u64 = 0x4254_5245_5752_4954;
 
 #[cfg(any(test, injected_yields))]
 impl YieldPointMarker for BTreeWriteYieldPoint {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1137,6 +1137,15 @@ impl BTreeCursor {
         self.yield_instance_id = connection.next_yield_instance_id();
     }
 
+    /// Same as `install_yield_context`, for cursors created where no
+    /// `Connection` is in scope (the IVM/DBSP circuit's own state and view
+    /// cursors). The pager mirrors its connection's injector.
+    #[cfg(any(test, injected_yields))]
+    pub(crate) fn install_yield_context_from_pager(&mut self, pager: &Pager) {
+        self.yield_injector = pager.yield_injector();
+        self.yield_instance_id = pager.next_yield_instance_id();
+    }
+
     pub fn new_table(pager: Arc<Pager>, root_page: i64, num_columns: usize) -> Self {
         Self::new(pager, root_page, num_columns)
     }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1350,6 +1350,12 @@ pub struct Pager {
     /// `read_page_nonblock(idx)` reuses the stored `(page, disk_read)` pair
     /// instead of issuing a duplicate disk read.
     pending_reads: RwLock<HashMap<i64, PendingRead>>,
+    /// Yield injector mirrored from the owning connection; see
+    /// [`Pager::set_yield_injector`].
+    #[cfg(any(test, injected_yields))]
+    yield_injector: RwLock<Option<Arc<dyn crate::mvcc::yield_points::YieldInjector>>>,
+    #[cfg(any(test, injected_yields))]
+    yield_instance_id_counter: AtomicU64,
     #[cfg(test)]
     spill_yield: SpillYieldHook,
     /// Dirty pages as a bitmap, naturally sorted by page number.
@@ -1618,6 +1624,31 @@ pub struct CollectingState {
 }
 
 impl Pager {
+    /// Mirror the owning connection's yield injector onto this pager so that
+    /// cursors created without a `Connection` in scope (IVM/DBSP state and view
+    /// cursors) participate in deterministic yield injection.
+    #[cfg(any(test, injected_yields))]
+    pub(crate) fn set_yield_injector(
+        &self,
+        injector: Option<Arc<dyn crate::mvcc::yield_points::YieldInjector>>,
+    ) {
+        *self.yield_injector.write() = injector;
+    }
+
+    #[cfg(any(test, injected_yields))]
+    pub(crate) fn yield_injector(
+        &self,
+    ) -> Option<Arc<dyn crate::mvcc::yield_points::YieldInjector>> {
+        self.yield_injector.read().clone()
+    }
+
+    #[cfg(any(test, injected_yields))]
+    #[inline(always)]
+    pub(crate) fn next_yield_instance_id(&self) -> u64 {
+        self.yield_instance_id_counter
+            .fetch_add(1, Ordering::Relaxed)
+    }
+
     pub fn new(
         db_file: Arc<dyn DatabaseStorage>,
         wal: Option<Arc<dyn Wal>>,
@@ -1638,6 +1669,10 @@ impl Pager {
             page_cache: Arc::new(RwLock::new(page_cache)),
             io,
             pending_reads: RwLock::new(HashMap::new()),
+            #[cfg(any(test, injected_yields))]
+            yield_injector: RwLock::new(None),
+            #[cfg(any(test, injected_yields))]
+            yield_instance_id_counter: AtomicU64::new(0),
             #[cfg(test)]
             spill_yield: SpillYieldHook::new(),
             dirty_pages: Arc::new(RwLock::new(RoaringBitmap::new())),

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1361,6 +1361,12 @@ pub struct Pager {
     /// `read_page_nonblock(idx)` reuses the stored `(page, disk_read)` pair
     /// instead of issuing a duplicate disk read.
     pending_reads: RwLock<HashMap<i64, PendingRead>>,
+    /// Yield injector mirrored from the owning connection; see
+    /// [`Pager::set_yield_injector`].
+    #[cfg(any(test, injected_yields))]
+    yield_injector: RwLock<Option<Arc<dyn crate::mvcc::yield_points::YieldInjector>>>,
+    #[cfg(any(test, injected_yields))]
+    yield_instance_id_counter: AtomicU64,
     #[cfg(test)]
     spill_yield: SpillYieldHook,
     /// Dirty pages as a bitmap, naturally sorted by page number.
@@ -1636,6 +1642,31 @@ pub struct CollectingState {
 }
 
 impl Pager {
+    /// Mirror the owning connection's yield injector onto this pager so that
+    /// cursors created without a `Connection` in scope (IVM/DBSP state and view
+    /// cursors) participate in deterministic yield injection.
+    #[cfg(any(test, injected_yields))]
+    pub(crate) fn set_yield_injector(
+        &self,
+        injector: Option<Arc<dyn crate::mvcc::yield_points::YieldInjector>>,
+    ) {
+        *self.yield_injector.write() = injector;
+    }
+
+    #[cfg(any(test, injected_yields))]
+    pub(crate) fn yield_injector(
+        &self,
+    ) -> Option<Arc<dyn crate::mvcc::yield_points::YieldInjector>> {
+        self.yield_injector.read().clone()
+    }
+
+    #[cfg(any(test, injected_yields))]
+    #[inline(always)]
+    pub(crate) fn next_yield_instance_id(&self) -> u64 {
+        self.yield_instance_id_counter
+            .fetch_add(1, Ordering::Relaxed)
+    }
+
     pub fn new(
         db_file: Arc<dyn DatabaseStorage>,
         wal: Option<Arc<dyn Wal>>,
@@ -1656,6 +1687,10 @@ impl Pager {
             page_cache: Arc::new(RwLock::new(page_cache)),
             io,
             pending_reads: RwLock::new(HashMap::new()),
+            #[cfg(any(test, injected_yields))]
+            yield_injector: RwLock::new(None),
+            #[cfg(any(test, injected_yields))]
+            yield_instance_id_counter: AtomicU64::new(0),
             #[cfg(test)]
             spill_yield: SpillYieldHook::new(),
             dirty_pages: Arc::new(RwLock::new(RoaringBitmap::new())),


### PR DESCRIPTION
> **Stacks on #8027.** The first four commits here are #8027 (`f8e76955`…`028be150`); please review the last two. #8027 makes this bug *visible* (panic instead of silent row loss), this PR fixes it — details below.

`DbspCircuit::execute` built the `DbspStateCursors` pair for non-root circuit nodes *inside* the poll and `return_if_io!`'d through it:

```rust
ExecuteState::ProcessingInputs { input_states, current_index, input_deltas } => {
    ...
    // Create temporary cursors for the recursive call
    let temp_table_cursor = BTreeCursor::new_table(...);
    let temp_index_cursor = BTreeCursor::new_index(...)?;
    let mut temp_cursors = DbspStateCursors::new(temp_table_cursor, temp_index_cursor);

    let delta = return_if_io!(self.execute_node(..., input_state, ..., &mut temp_cursors));
```

`IOResult::IO` means "re-poll the same call", and a b-tree write's balance state lives inside the cursor. On every yield the pair was dropped (`Drop` → `clear_transient_overflow_cells` discards the staged balance) and rebuilt unpositioned, while the child's `WriteRow` state survived in `input_state` — so the state machine resumed mid-write against a cursor that knew nothing about its in-flight b-tree work. Root nodes were never affected: `CommitState::CommitOperators` already owns its `state_cursors`. But a matview `SELECT` puts a `Projection` at the root, so the operators that persist state (aggregates, joins) are non-root in practice.

Without #8027, this defect is a **silent `row N lost`**; with #8027, a fresh cursor is *unpositioned* rather than *mispositioned*, so every position-dependent `WriteRow` state asserts and the symptom becomes a panic (`self.current_page >= 0`). The two changes belong together, and #8027 alone is not a regression.

## The fix

Tolerating a rebuilt cursor is not possible — a yielded write can only be re-driven on the cursor that started it. So extend the lifetime instead: `ExecuteState::ProcessingInputs` gains an owned `Box<DbspStateCursors>`, exactly the shape `CommitState::CommitOperators` already uses. The ad-hoc cursor constructions are funneled through two helpers (`new_dbsp_state_cursors`, `new_view_cursor`) so one place builds them and one place states the rule. The read-only `execute()` path keeps per-poll cursors deliberately — every read re-derives its position from a key on re-entry — and that contract is now documented on `IncrementalOperator::eval`.

## Why no fuzzer ever caught this

IVM-created cursors carried no yield injector, so no simulator seed could schedule a yield inside a DBSP state-btree write: the entire `BTREE_WRITE_YIELD` surface was unreachable for IVM. The test commit threads the connection's injector through the pager onto circuit-owned cursors, behind `cfg(any(test, injected_yields))`. It is deliberately *not* installed in `BTreeCursor::new`, which would enrol every cursor in the process and silently change the meaning of existing simulator seeds.

Note on test shape: `SELECT k, count(*) FROM t GROUP BY k` elides the projection and leaves the aggregate at the root, where the bug is unreachable — the reproducer uses `count(*) + 0` to force `Projection → Aggregate → Input`. For the same reason the reproducer is circuit-level (it drives the real `DbspCircuit::commit` path) rather than SQL-level.

## Commits

Red then green, verifiable by checkout:

- `c275b516` threads yield injection into IVM-owned cursors and adds the reproducer. Red: `incremental::temp_cursor_lifetime::non_root_operator_survives_mid_balance_yield_in_state_write` panics with `self.current_page >= 0` at `core/storage/btree.rs:8343`; the rest of `incremental::` stays green (172 passed, 1 failed).
- `09005ba3` the lifetime fix. The reproducer and the full suites go green.

## Verification

- `cargo test -p turso_core --lib incremental::` 173 passed, 0 failed; `storage::` 384 passed, 0 failed (at the fix commit).
- `cargo fmt --check` clean at both commits.
- `cargo clippy -p turso_core --all-targets -- -D warnings` introduces no new lints: the identical (toolchain-version-dependent) pre-existing findings fire at the base commit `028be150` and at this head.
- Whopper concurrent-simulator, debug, seeds 1–60, `--mode fast --reopen-probability 0.001` — 0 failures, run at the fix commit.

## Relation to #7879

#8027 closed #7879's state-advancement half. #7879's *other* concern — a cursor left stale across a yielded index insert — pointed at a real window, but its `needs_seek` re-seek could not have closed it: on the re-poll path the whole pair, table cursor included, was dropped and rebuilt, and the failure occurs in the table insert before `InsertIndex` is ever reached. This PR closes that window at its source: the cursors now live exactly as long as the state machines that drive them.

Fix drafted with Claude Code and adversarially reviewed by a separate model; reviewed by me at the level I can judge.
