### PR TITLE
testing/differential: make differential fuzzer reliable enough to run in CI, and run it in CI

### DIFF
--- a/.claude/skills/differential-fuzzer/SKILL.md
+++ b/.claude/skills/differential-fuzzer/SKILL.md
@@ -81,33 +81,48 @@ All output goes to `simulator-output/` directory:
 
 Always follow these steps
 
-1. **Find the seed** in the error output:
+1. **Find the seed and profile** in the error output:
    ```
-   INFO: Starting differential_fuzzer with config: SimConfig { seed: 12345, ... }
+   INFO: Starting differential_fuzzer with config: SimConfig { seed: 12345, ..., weight_profile: Writes }
    ```
 
-2. **Re-run with that seed**:
+2. **Re-run with that seed and profile** (a seed only replays under the same profile):
    ```bash
-   cargo run --bin differential_fuzzer -- --seed 12345 --verbose --keep-files
+   cargo run --bin differential_fuzzer -- --seed 12345 --profile writes --verbose --keep-files
    ```
 
-3. **Check output files**:
-   - `simulator-output/test.sql` - Find the failing statement (look for `-- FAILED:`)
-   - `simulator-output/schema.json` - Check table structure at failure time
+3. **Read the minimized reproduction first.** On an oracle failure the fuzzer
+   writes these files to `simulator-output/`:
+   - `minimized.sql` - a shrunken state script plus the shrunken failing
+     statement, produced automatically. Start here.
+   - `turso-state.sql` / `sqlite-state.sql` - each engine's full state as a
+     replayable script, when you need more than the minimized version kept.
+   - `test.sql` - every executed statement (the failing one is marked
+     `-- FAILED:`). The minimizer falls back to replaying this history when
+     the failure depends on how the state was built, not just its contents.
+   - `schema.json` - table structure at failure time.
 
-4. **Create a minimal reproducer**
-   - Create reproducer in `.sqltest` or in `.rs` always load [Debugging skill for reference](../debugging/)
-
-5. **Compare behavior manually**:
-   If needed try to compare the behaviour and produce a report in the end.
-   Always write to a tmp file first with Edit tool to test the sql and then pass it to the binaries.
+4. **Probe the reproduction with `differential_probe`.** It runs a
+   statement-per-line script on Turso and SQLite side by side, prints both
+   outcomes for every statement, marks divergences, and compares the final
+   table contents. Exit code 1 means something diverged.
    ```bash
-   # Run failing SQL against SQLite
-   sqlite3 :memory: < simulator-output/test.sql
-
-   # Run against tursodb CLI
-   tursodb :memory: < simulator-output/test.sql
+   cargo run -q -p differential-fuzzer --bin differential_probe -- \
+       simulator-output/minimized.sql
    ```
+   Use it instead of piping SQL into the two shells: the tursodb shell cannot
+   `ATTACH ':memory:' AS aux`, so fuzzer reproductions with an `aux` schema
+   only run correctly through the probe. Reading from stdin also works:
+   `echo "SELECT ~X'96';" | cargo run -q -p differential-fuzzer --bin differential_probe`.
+
+5. **Bisect by editing the script.** Copy `minimized.sql`, simplify one thing
+   at a time (replace an expression with a constant, drop a column, drop a
+   state line), and re-run the probe after each edit. The divergence marker
+   tells you immediately whether the edit kept the bug. This loop usually
+   ends at a one-line kernel you can hand to `EXPLAIN` on both engines.
+
+6. **Create a regression test** in `.sqltest` (preferred) or `.rs` from the
+   kernel. Always load the [Debugging skill for reference](../debugging/).
 
 ## Understanding Failures
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -363,6 +363,11 @@ jobs:
   #           }
   #         }
 
+  # Pull requests run a fixed set of seeds so the fuzzer is deterministic: the
+  # same PR always generates the same SQL, a green run stays green, and a
+  # failure blocks the merge and reproduces exactly. New random seeds run only
+  # on pushes to main (differential-fuzzer-random below), where a failure is a
+  # signal to investigate rather than a gate on an unrelated change.
   differential-fuzzer:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
@@ -370,8 +375,7 @@ jobs:
       fail-fast: false
       matrix:
         # Each profile weights top-level statements differently so CI covers
-        # several statement mixes instead of one distribution. A failure
-        # reproduces with `--seed <seed> --profile <profile>`.
+        # several statement mixes instead of one distribution.
         profile: [balanced, ddl, triggers, writes]
     steps:
       - uses: actions/checkout@v4
@@ -382,9 +386,43 @@ jobs:
         with:
           prefix-key: "v1-rust"
           cache-on-failure: true
-      - name: Run differential_fuzzer
+      - name: Run differential_fuzzer on a fixed set of seeds
         run: |
-          cargo run -p differential-fuzzer --bin differential_fuzzer -- --profile ${{ matrix.profile }} -n 1000 loop 10
+          # Reproduce a failure locally with:
+          #   cargo run -p differential-fuzzer --bin differential_fuzzer -- \
+          #     --seed <seed> --profile ${{ matrix.profile }} -n 1000
+          for seed in 1 2 3 4 5 6; do
+            cargo run -p differential-fuzzer --bin differential_fuzzer -- \
+              --seed "$seed" --profile ${{ matrix.profile }} -n 1000
+          done
+
+  # Random seeds keep discovering new divergences. Run them only on pushes to
+  # main, so a newly generated failing statement flags a real bug to look at
+  # without blocking an unrelated pull request.
+  differential-fuzzer-random:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [balanced, ddl, triggers, writes]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup mold linker
+        uses: "./.github/shared/setup-mold"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust"
+          cache-on-failure: true
+      - name: Run differential_fuzzer with random seeds
+        run: |
+          # A failure prints its seed and profile; reproduce with
+          #   cargo run -p differential-fuzzer --bin differential_fuzzer -- \
+          #     --seed <seed> --profile ${{ matrix.profile }} -n 1000
+          cargo run -p differential-fuzzer --bin differential_fuzzer -- \
+            --profile ${{ matrix.profile }} -n 1000 loop 10
 
   test-limbo:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -366,6 +366,13 @@ jobs:
   differential-fuzzer:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each profile weights top-level statements differently so CI covers
+        # several statement mixes instead of one distribution. A failure
+        # reproduces with `--seed <seed> --profile <profile>`.
+        profile: [balanced, ddl, triggers, writes]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -377,7 +384,7 @@ jobs:
           cache-on-failure: true
       - name: Run differential_fuzzer
         run: |
-          cargo run -p differential-fuzzer --bin differential_fuzzer -- -n 1000 loop 10
+          cargo run -p differential-fuzzer --bin differential_fuzzer -- --profile ${{ matrix.profile }} -n 1000 loop 10
 
   test-limbo:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -363,22 +363,21 @@ jobs:
   #           }
   #         }
 
-  # TODO: for now leave this commented out, as it always fails
-  # differential-fuzzer:
-  #   runs-on: blacksmith-4vcpu-ubuntu-2404
-  #   timeout-minutes: 30
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - name: Setup mold linker
-  #       uses: rui314/setup-mold@v1
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         prefix-key: "v1-rust"
-  #         cache-on-failure: true
-  #     - name: Run differential_fuzzer
-  #       run: |
-  #         cargo run -p differential-fuzzer -- -n 1000 loop 10
+  differential-fuzzer:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup mold linker
+        uses: "./.github/shared/setup-mold"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust"
+          cache-on-failure: true
+      - name: Run differential_fuzzer
+        run: |
+          cargo run -p differential-fuzzer --bin differential_fuzzer -- -n 1000 loop 10
 
   test-limbo:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -76,6 +76,25 @@ ongoing work to pass the full SQLite TCL test suite.
 * 🚧 SQLite query language [[status](#sqlite-query-language)] is partially supported
 * 🚧 SQLite C API [[status](#sqlite-c-api)] is partially supported
 
+### Limitations
+
+**Text values must be valid UTF-8.** SQLite text is a plain byte string: it
+never validates encoding, so a text value can hold any bytes. Turso represents
+text as a Rust string, which must be valid UTF-8. When a conversion produces
+text from bytes that are not valid UTF-8, Turso substitutes the U+FFFD
+replacement character where SQLite keeps the original bytes:
+
+```sql
+SELECT HEX(CAST(X'96' AS TEXT));
+-- SQLite: 96
+-- Turso:  EFBFBD
+```
+
+This affects every operation that turns a blob into text: `CAST`, string
+functions such as `UPPER` and `REPLACE`, and concatenation with `||`. Reading
+an existing database that already contains invalid UTF-8 in a text column is
+affected the same way. Storing and reading blobs is not affected; bytes only
+change when they are converted to text.
 
 ## SQLite query language
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "turso_core",
+ "turso_parser",
 ]
 
 [[package]]

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1301,6 +1301,26 @@ impl Schema {
         self.triggers.remove(&table_name);
     }
 
+    pub fn set_trigger_target_database_id(
+        &mut self,
+        trigger_name: &str,
+        target_database_id: usize,
+    ) -> Result<()> {
+        let trigger_name = normalize_ident(trigger_name);
+        let trigger = self
+            .triggers
+            .values_mut()
+            .flatten()
+            .find(|trigger| normalize_ident(&trigger.name) == trigger_name)
+            .ok_or_else(|| {
+                crate::LimboError::InternalError(format!(
+                    "new trigger {trigger_name} was not loaded into the schema"
+                ))
+            })?;
+        Arc::make_mut(trigger).target_database_id = Some(target_database_id);
+        Ok(())
+    }
+
     /// Like [`remove_triggers_for_table`] but only removes triggers whose
     /// `target_database_id` matches `target_db` (or is `None`, meaning
     /// "targets the parent schema's table of this name", which also

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7369,6 +7369,10 @@ impl CursorTrait for BTreeCursor {
         loop {
             match self.seek_to_last_state {
                 SeekToLastState::Start => {
+                    // A write through another cursor may save this cursor's old
+                    // position. We need the current largest rowid, not that old
+                    // position. Otherwise rowid() restores the old position.
+                    self.clear_saved_seek();
                     let has_record = return_if_io!(self.move_to_rightmost());
                     self.invalidate_record();
                     self.set_has_record(has_record);

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -18,8 +18,12 @@ use super::{
         resolve_expr, translate_condition_expr, translate_expr, translate_expr_no_constant_opt,
         ConditionMetadata, NoConstantOptReason,
     },
-    plan::{Aggregate, Distinctness, SelectPlan, TableReferences},
+    plan::{
+        Aggregate, Distinctness, NonFromClauseSubquery, SelectPlan, SubqueryEvalPhase,
+        TableReferences,
+    },
     result_row::emit_select_result,
+    subquery::emit_non_from_clause_subqueries_for_phase,
 };
 
 /// Emits the bytecode for processing an aggregate without a GROUP BY clause.
@@ -29,6 +33,7 @@ pub fn emit_ungrouped_aggregation<'a>(
     program: &mut ProgramBuilder,
     t_ctx: &mut TranslateCtx<'a>,
     plan: &'a SelectPlan,
+    output_subqueries: &mut [NonFromClauseSubquery],
 ) -> Result<()> {
     let agg_start_reg = t_ctx.reg_agg_start.unwrap();
 
@@ -51,6 +56,20 @@ pub fn emit_ungrouped_aggregation<'a>(
         );
     }
     t_ctx.resolver.enable_expr_to_reg_cache();
+
+    // Subqueries that read an aggregate this query computes need the
+    // aggregate's finalized register, so they must be emitted now — after
+    // AggFinal and the cache population above, and before the result row that
+    // reads them.
+    emit_non_from_clause_subqueries_for_phase(
+        program,
+        &t_ctx.resolver,
+        output_subqueries,
+        &plan.join_order,
+        Some(&plan.table_references),
+        SubqueryEvalPhase::UngroupedAggregateOutput,
+        |_| true,
+    )?;
 
     // Allocate a label for the end (used by both HAVING and OFFSET to skip row emission)
     let end_label = program.allocate_label();

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -4048,6 +4048,7 @@ fn validate_trigger_columns_after_drop(
             ast::TriggerCmd::Update {
                 tbl_name,
                 sets,
+                from,
                 where_clause,
                 ..
             } => {
@@ -4061,15 +4062,41 @@ fn validate_trigger_columns_after_drop(
                     altered_database_id,
                     None,
                 );
-                // Check expressions in SET values and WHERE — these can reference
-                // the command target table and the trigger's owning table via NEW/OLD.
-                // Bare references to the trigger table are still invalid here.
+                let mut visible_columns = cmd_table_cols.clone().unwrap_or_default();
+                if let Some(from_clause) = from {
+                    if let Some(bad) = validate_from_clause_column_refs_after_drop(
+                        from_clause,
+                        &visible_columns,
+                        &owning_table_columns,
+                        allow_bare_owning_columns,
+                        altered_table_norm,
+                        post_drop_table,
+                        resolver,
+                        trigger_database_id,
+                        altered_database_id,
+                    )? {
+                        return Ok(Some(bad));
+                    }
+                    visible_columns = merge_column_lists(
+                        &visible_columns,
+                        &collect_from_clause_visible_columns(
+                            from_clause,
+                            altered_table_norm,
+                            post_drop_table,
+                            resolver,
+                            trigger_database_id,
+                            altered_database_id,
+                        ),
+                    );
+                }
+                // Check expressions in SET values and WHERE. They can use the
+                // table being updated, tables named by FROM, and NEW/OLD.
                 // Note: SET target column names are NOT checked here — SQLite defers
                 // that validation to trigger execution time.
                 for set in sets {
                     if let Some(bad) = validate_expr_column_refs_after_drop(
                         &set.expr,
-                        cmd_table_cols.as_deref().unwrap_or(&[]),
+                        &visible_columns,
                         &owning_table_columns,
                         allow_bare_owning_columns,
                         altered_table_norm,
@@ -4084,7 +4111,7 @@ fn validate_trigger_columns_after_drop(
                 if let Some(ref where_expr) = where_clause {
                     if let Some(bad) = validate_expr_column_refs_after_drop(
                         where_expr,
-                        cmd_table_cols.as_deref().unwrap_or(&[]),
+                        &visible_columns,
                         &owning_table_columns,
                         allow_bare_owning_columns,
                         altered_table_norm,
@@ -5479,20 +5506,71 @@ fn collect_select_table_visible_columns(
     altered_database_id: usize,
 ) -> Vec<String> {
     match select_table {
-        ast::SelectTable::Table(qualified_name, _, _)
-        | ast::SelectTable::TableCall(qualified_name, _, _) => get_table_columns(
-            &normalize_ident(qualified_name.name.as_str()),
-            altered_table_norm,
-            post_drop_table,
-            resolver,
-            trigger_database_id,
-            altered_database_id,
-            qualified_name.db_name.as_ref().map(|name| name.as_str()),
-        )
-        .unwrap_or_default(),
+        ast::SelectTable::Table(qualified_name, alias, _) => {
+            collect_qualified_table_visible_columns(
+                qualified_name,
+                alias.as_ref(),
+                altered_table_norm,
+                post_drop_table,
+                resolver,
+                trigger_database_id,
+                altered_database_id,
+            )
+        }
+        ast::SelectTable::TableCall(qualified_name, _, alias) => {
+            collect_qualified_table_visible_columns(
+                qualified_name,
+                alias.as_ref(),
+                altered_table_norm,
+                post_drop_table,
+                resolver,
+                trigger_database_id,
+                altered_database_id,
+            )
+        }
         ast::SelectTable::Select(select, _) => collect_select_output_columns(select),
         ast::SelectTable::Sub(from_clause, _) => collect_from_clause_output_columns(from_clause),
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_qualified_table_visible_columns(
+    qualified_name: &ast::QualifiedName,
+    alias: Option<&ast::As>,
+    altered_table_norm: &str,
+    post_drop_table: &BTreeTable,
+    resolver: &Resolver,
+    trigger_database_id: usize,
+    altered_database_id: usize,
+) -> Vec<String> {
+    let columns = get_table_columns(
+        &normalize_ident(qualified_name.name.as_str()),
+        altered_table_norm,
+        post_drop_table,
+        resolver,
+        trigger_database_id,
+        altered_database_id,
+        qualified_name.db_name.as_ref().map(|name| name.as_str()),
+    )
+    .unwrap_or_default();
+    let qualifier = alias.map_or_else(
+        || normalize_ident(qualified_name.name.as_str()),
+        |alias| normalize_ident(alias.name().as_str()),
+    );
+    let mut visible = columns.clone();
+    visible.extend(columns.iter().map(|column| format!("{qualifier}.{column}")));
+    if alias.is_none() {
+        if let Some(db_name) = &qualified_name.db_name {
+            let database = normalize_ident(db_name.as_str());
+            let table = normalize_ident(qualified_name.name.as_str());
+            visible.extend(
+                columns
+                    .iter()
+                    .map(|column| format!("{database}.{table}.{column}")),
+            );
+        }
+    }
+    visible
 }
 
 fn collect_select_output_columns(select: &ast::Select) -> Vec<String> {
@@ -5554,6 +5632,17 @@ fn check_column_ref_valid(
                     }
                 }
             } else {
+                let qualified_col = format!("{ns_norm}.{col_norm}");
+                if valid_columns.contains(&qualified_col) {
+                    return None;
+                }
+                let qualifier_prefix = format!("{ns_norm}.");
+                if valid_columns
+                    .iter()
+                    .any(|valid| valid.starts_with(&qualifier_prefix))
+                {
+                    return Some(format!("{ns}.{col}"));
+                }
                 // table.col — validate against that table's columns
                 let table_cols = get_table_columns(
                     &ns_norm,
@@ -5572,8 +5661,22 @@ fn check_column_ref_valid(
             }
         }
         ast::Expr::DoublyQualified(db_name, table_name, col) => {
+            let database_norm = normalize_ident(db_name.as_str());
+            let table_norm = normalize_ident(table_name.as_str());
+            let col_norm = normalize_ident(col.as_str());
+            let qualifier_prefix = format!("{database_norm}.{table_norm}.");
+            let qualified_col = format!("{qualifier_prefix}{col_norm}");
+            if valid_columns.contains(&qualified_col) {
+                return None;
+            }
+            if valid_columns
+                .iter()
+                .any(|valid| valid.starts_with(&qualifier_prefix))
+            {
+                return Some(format!("{db_name}.{table_name}.{col}"));
+            }
             let table_cols = get_table_columns(
-                &normalize_ident(table_name.as_str()),
+                &table_norm,
                 altered_table_norm,
                 post_drop_table,
                 resolver,
@@ -5581,7 +5684,6 @@ fn check_column_ref_valid(
                 altered_database_id,
                 Some(db_name.as_str()),
             );
-            let col_norm = normalize_ident(col.as_str());
             if let Some(cols) = table_cols {
                 if !cols.contains(&col_norm) {
                     return Some(format!("{db_name}.{table_name}.{col}"));

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1550,7 +1550,7 @@ pub fn translate_alter_table(
             let new_name = new_name.as_str();
             let normalized_old_name = normalize_ident(table_name);
             let normalized_new_name = normalize_ident(new_name);
-            let mut temp_triggers_to_rewrite: Vec<(String, String)> = Vec::new();
+            let mut temp_triggers_to_rewrite: Vec<(String, String, bool)> = Vec::new();
 
             if resolver.with_schema(database_id, |s| {
                 s.get_table(new_name).is_some()
@@ -1578,6 +1578,14 @@ pub fn translate_alter_table(
                     )));
                 }
                 if trigger_entry.database_id == crate::TEMP_DB_ID {
+                    let temp_trigger_targets_renamed_table =
+                        normalize_ident(&trigger_entry.trigger.table_name) == normalized_old_name
+                            && match trigger_entry.trigger.target_database_id {
+                                Some(target_db) => target_db == database_id,
+                                None => resolver.with_schema(crate::TEMP_DB_ID, |schema| {
+                                    schema.get_table(&normalized_old_name).is_none()
+                                }),
+                            };
                     // Pass the renamed database's NAME so the rewrite
                     // only touches triggers whose `tbl_name.db_name`
                     // actually points at the db we are renaming in
@@ -1594,8 +1602,11 @@ pub fn translate_alter_table(
                         &renamed_db_name,
                     )?;
                     if new_sql != trigger_entry.trigger.sql {
-                        temp_triggers_to_rewrite
-                            .push((trigger_entry.trigger.name.clone(), new_sql));
+                        temp_triggers_to_rewrite.push((
+                            trigger_entry.trigger.name.clone(),
+                            new_sql,
+                            temp_trigger_targets_renamed_table,
+                        ));
                     }
                 }
             }
@@ -1712,14 +1723,20 @@ pub fn translate_alter_table(
                 );
             }
 
-            for (trigger_name, new_sql) in temp_triggers_to_rewrite {
+            for (trigger_name, new_sql, renames_target) in temp_triggers_to_rewrite {
                 let escaped_sql = escape_sql_string_literal(&new_sql);
                 let escaped_trigger_name = escape_sql_string_literal(&trigger_name);
                 let qualified_schema_table = schema_table_name_for_db(resolver, crate::TEMP_DB_ID);
+                let tbl_name_update = if renames_target {
+                    let escaped_new_name = escape_sql_string_literal(new_name);
+                    format!(", tbl_name = '{escaped_new_name}'")
+                } else {
+                    String::new()
+                };
                 let update_stmt = format!(
                     r#"
                         UPDATE {qualified_schema_table}
-                        SET sql = '{escaped_sql}'
+                        SET sql = '{escaped_sql}'{tbl_name_update}
                         WHERE name = '{escaped_trigger_name}' COLLATE NOCASE AND type = 'trigger'
                     "#,
                 );

--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -225,6 +225,7 @@ pub fn translate_analyze(
         program.emit_insn(Insn::ParseSchema {
             db: database_id,
             where_clause: Some(parse_schema_where_clause),
+            trigger_target_database_id: None,
         });
 
         // Bump schema cookie so subsequent statements reparse schema.

--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -948,21 +948,17 @@ fn emit_delete_insns_when_triggers_present(
                 .map(|i| columns_start_reg + i)
                 .chain(std::iter::once(rowid_reg))
                 .collect::<Vec<_>>();
-            // If the program has a trigger_conflict_override, propagate it to the trigger context.
-            let trigger_ctx = if let Some(override_conflict) = program.trigger_conflict_override {
-                TriggerContext::new_with_override_conflict(
-                    btree_table,
-                    None, // No NEW for DELETE
-                    Some(old_registers),
-                    override_conflict,
-                )
-            } else {
-                TriggerContext::new(
-                    btree_table,
-                    None, // No NEW for DELETE
-                    Some(old_registers),
-                )
-            };
+            // A DELETE always fires its triggers with the default conflict
+            // resolution, never the enclosing statement's OR clause: SQLite
+            // codes row-delete triggers with OE_Default (delete.c). So a plain
+            // INSERT inside such a trigger aborts on a constraint violation
+            // even when an outer UPDATE/INSERT OR REPLACE is what ultimately
+            // fired this DELETE.
+            let trigger_ctx = TriggerContext::new(
+                btree_table,
+                None, // No NEW for DELETE
+                Some(old_registers),
+            );
 
             for trigger in relevant_triggers {
                 fire_trigger(
@@ -1019,22 +1015,14 @@ fn emit_delete_insns_when_triggers_present(
                 .map(|i| columns_start_reg + i)
                 .chain(std::iter::once(rowid_reg))
                 .collect::<Vec<_>>();
-            // If the program has a trigger_conflict_override, propagate it to the trigger context.
-            let trigger_ctx_after =
-                if let Some(override_conflict) = program.trigger_conflict_override {
-                    TriggerContext::new_with_override_conflict(
-                        btree_table,
-                        None, // No NEW for DELETE
-                        Some(old_registers),
-                        override_conflict,
-                    )
-                } else {
-                    TriggerContext::new(
-                        btree_table,
-                        None, // No NEW for DELETE
-                        Some(old_registers),
-                    )
-                };
+            // A DELETE always fires its triggers with the default conflict
+            // resolution, never the enclosing statement's OR clause (see the
+            // BEFORE-trigger case above and SQLite's delete.c).
+            let trigger_ctx_after = TriggerContext::new(
+                btree_table,
+                None, // No NEW for DELETE
+                Some(old_registers),
+            );
 
             for trigger in relevant_triggers {
                 fire_trigger(

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -29,7 +29,7 @@ use crate::schema::{
     EXPR_INDEX_SENTINEL,
 };
 use crate::translate::fkeys::FkActionCompileStack;
-use crate::translate::plan::ColumnMask;
+use crate::translate::plan::{Aggregate, ColumnMask};
 use crate::vdbe::{
     affinity::Affinity,
     builder::{CursorType, DmlColumnContext, ProgramBuilder, SelfTableContext},
@@ -164,6 +164,16 @@ pub struct Resolver<'a> {
     /// Context and metadata for resolving Expr::Column values that use
     /// [TableInternalId::SELF_TABLE] as a placeholder.
     self_table_scope: RefCell<Option<SelfTableScope>>,
+    /// One list per enclosing query, mirroring SQLite's NameContext chain
+    /// (resolve.c `resolveExprStep`). An aggregate whose argument columns
+    /// belong to an enclosing query is computed by that query, not by the
+    /// subquery it is written in. When a subquery resolves such an aggregate it
+    /// adds it to the enclosing query's list here (the last entry) instead of
+    /// keeping it, so the outer query never has to reach in and take it out
+    /// later. Each query adds an empty list before planning its subqueries and
+    /// removes it — folding the collected aggregates into its own aggregate
+    /// list — afterwards.
+    enclosing_query_aggregates: RefCell<Vec<Vec<Aggregate>>>,
     pub enable_custom_types: bool,
     /// Controls whether unresolved double-quoted identifiers fall back to string
     /// literals (SQLite's DQS misfeature) in DML statements.
@@ -302,6 +312,7 @@ impl<'a> Resolver<'a> {
             register_collations: HashMap::default(),
             subquery_affinities: RefCell::new(HashMap::default()),
             self_table_scope: RefCell::new(None),
+            enclosing_query_aggregates: RefCell::new(Vec::new()),
             enable_custom_types,
             dqs_dml,
             dialect,
@@ -334,6 +345,7 @@ impl<'a> Resolver<'a> {
             register_collations: HashMap::default(),
             subquery_affinities: RefCell::new(self.subquery_affinities.borrow().clone()),
             self_table_scope: RefCell::new(self.self_table_scope.borrow().clone()),
+            enclosing_query_aggregates: RefCell::new(Vec::new()),
             enable_custom_types: self.enable_custom_types,
             dqs_dml: self.dqs_dml,
             dialect: self.dialect.clone(),
@@ -358,6 +370,7 @@ impl<'a> Resolver<'a> {
             register_collations: self.register_collations.clone(),
             subquery_affinities: RefCell::new(self.subquery_affinities.borrow().clone()),
             self_table_scope: RefCell::new(self.self_table_scope.borrow().clone()),
+            enclosing_query_aggregates: RefCell::new(Vec::new()),
             enable_custom_types: self.enable_custom_types,
             dqs_dml: self.dqs_dml,
             dialect: self.dialect.clone(),
@@ -498,6 +511,37 @@ impl<'a> Resolver<'a> {
 
     pub(crate) fn enable_expr_to_reg_cache(&mut self) {
         self.expr_to_reg_cache_enabled = true;
+    }
+
+    /// Start collecting aggregates that this query's subqueries find to belong
+    /// to this query, before planning those subqueries.
+    /// [`Self::take_aggregates_from_subqueries`] retrieves them afterwards.
+    pub(crate) fn begin_collecting_aggregates_from_subqueries(&self) {
+        self.enclosing_query_aggregates
+            .borrow_mut()
+            .push(Vec::new());
+    }
+
+    /// Stop collecting and return the aggregates this query's subqueries moved
+    /// up to it.
+    pub(crate) fn take_aggregates_from_subqueries(&self) -> Vec<Aggregate> {
+        self.enclosing_query_aggregates
+            .borrow_mut()
+            .pop()
+            .unwrap_or_default()
+    }
+
+    /// Move an aggregate up to the innermost enclosing query that is
+    /// collecting. Returns false when there is none — the aggregate then stays
+    /// with the query that resolved it.
+    pub(crate) fn move_aggregate_to_enclosing_query(&self, agg: Aggregate) -> bool {
+        match self.enclosing_query_aggregates.borrow_mut().last_mut() {
+            Some(collected) => {
+                collected.push(agg);
+                true
+            }
+            None => false,
+        }
     }
 
     pub fn cache_expr_reg(

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -283,7 +283,7 @@ pub fn emit_query<'a>(
         group_by_emit_row_phase(program, t_ctx, plan, &mut grouped_output_subqueries)?;
     } else if !plan.aggregates.is_empty() {
         // Handle aggregation without GROUP BY (or HAVING without GROUP BY)
-        emit_ungrouped_aggregation(program, t_ctx, plan)?;
+        emit_ungrouped_aggregation(program, t_ctx, plan, &mut grouped_output_subqueries)?;
     } else if plan.window.is_some() {
         emit_window_flush(program, t_ctx, plan)?;
     }

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -569,13 +569,16 @@ fn emit_notnull_constraint_check(
                     NoConstantOptReason::RegisterReuse,
                 )?;
                 program.preassign_label_to_next_insn(continue_label);
-            } else {
-                program.emit_insn(Insn::HaltIfNull {
-                    target_reg,
-                    err_code: SQLITE_CONSTRAINT_NOTNULL,
-                    description: description(),
-                });
             }
+            // The value must still satisfy NOT NULL, whether it is the original
+            // (non-null) value or the substituted default: a column may declare
+            // DEFAULT (NULL), so substituting the default does not resolve the
+            // violation and SQLite aborts.
+            program.emit_insn(Insn::HaltIfNull {
+                target_reg,
+                err_code: SQLITE_CONSTRAINT_NOTNULL,
+                description: description(),
+            });
         }
         _ => {
             program.emit_insn(Insn::HaltIfNull {

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1262,6 +1262,26 @@ fn emit_update_insns<'a>(
     };
     let skip_set_clauses = false;
 
+    // A BEFORE UPDATE trigger can change the row before constraint checks run,
+    // so NOT NULL checks on SET-clause columns are deferred until after those
+    // triggers fire (see emit_deferred_notnull_checks below). AFTER triggers
+    // run once the row is already written and do not affect this ordering, so
+    // they must not defer the checks. Skipping the inline check for any update
+    // trigger, but only re-emitting it when a BEFORE trigger exists, would drop
+    // the NOT NULL check entirely for a table that has only AFTER triggers.
+    let relevant_before_update_triggers = match target_table.table.btree() {
+        Some(btree_table) => get_triggers_including_temp(
+            &t_ctx.resolver,
+            update_database_id,
+            TriggerEvent::Update,
+            TriggerTime::Before,
+            Some(updated_column_indices.clone()),
+            &btree_table,
+        ),
+        None => Vec::new(),
+    };
+    let has_before_triggers = !relevant_before_update_triggers.is_empty();
+
     emit_update_column_values(
         program,
         table_references,
@@ -1270,7 +1290,7 @@ fn emit_update_insns<'a>(
         t_ctx,
         skip_set_clauses,
         skip_row_label,
-        has_any_update_triggers,
+        has_before_triggers,
     )?;
 
     // For non-STRICT tables, apply column affinity to the NEW values early.
@@ -1298,18 +1318,9 @@ fn emit_update_insns<'a>(
     }
 
     // Fire BEFORE UPDATE triggers and preserve old_registers for AFTER triggers
-    let mut has_before_triggers = false;
     let mut has_after_triggers = false;
     let preserved_old_registers: Option<Vec<usize>> =
         if let Some(btree_table) = target_table.table.btree() {
-            let relevant_before_update_triggers = get_triggers_including_temp(
-                &t_ctx.resolver,
-                update_database_id,
-                TriggerEvent::Update,
-                TriggerTime::Before,
-                Some(updated_column_indices.clone()),
-                &btree_table,
-            );
             has_after_triggers = has_triggers_including_temp(
                 &t_ctx.resolver,
                 update_database_id,
@@ -1323,7 +1334,6 @@ fn emit_update_insns<'a>(
                     s.any_resolved_fks_referencing(table_name)
                 });
 
-            has_before_triggers = !relevant_before_update_triggers.is_empty();
             let needs_old_registers = has_before_triggers || has_after_triggers || has_fk_cascade;
 
             // Only read OLD row values when triggers or FK cascades need them

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2406,87 +2406,11 @@ fn emit_update_insns<'a>(
                 )?;
             }
 
-            // Fire AFTER UPDATE triggers
-            if let Some(btree_table) = target_table.table.btree() {
-                let relevant_triggers = get_triggers_including_temp(
-                    &t_ctx.resolver,
-                    update_database_id,
-                    TriggerEvent::Update,
-                    TriggerTime::After,
-                    Some(updated_column_indices.clone()),
-                    &btree_table,
-                );
-                if !relevant_triggers.is_empty() {
-                    let columns = target_table.table.columns();
-
-                    // Compute VIRTUAL columns for NEW values
-                    //TODO only emit required virtual columns
-                    let bt = target_table.table.btree().ok_or_else(|| {
-                        crate::LimboError::InternalError(
-                            "UPDATE on virtual table has no btree".into(),
-                        )
-                    })?;
-                    let new_ctx = DmlColumnContext::layout(columns, start, beg, layout.clone());
-                    compute_virtual_columns(
-                        program,
-                        &btree_table.columns_topo_sort()?,
-                        &new_ctx,
-                        &t_ctx.resolver,
-                        &bt,
-                    )?;
-
-                    // Compute VIRTUAL columns for OLD values if we have preserved OLD registers
-                    if let Some(ref old_regs) = preserved_old_registers {
-                        let pairs = columns.iter().zip(old_regs.iter().copied());
-                        //TODO only emit required virtual columns
-                        let old_ctx = DmlColumnContext::from_column_reg_mapping(pairs);
-                        compute_virtual_columns(
-                            program,
-                            &btree_table.columns_topo_sort()?,
-                            &old_ctx,
-                            &t_ctx.resolver,
-                            &bt,
-                        )?;
-                    }
-
-                    // Build raw NEW registers. Values are encoded at this point;
-                    // fire_trigger will decode them via decode_trigger_registers.
-                    let new_registers_after: Vec<usize> = (0..col_len)
-                        .map(|i| layout.to_register(start, i))
-                        .chain(std::iter::once(effective_rowid_reg))
-                        .collect();
-
-                    // Use preserved OLD registers from BEFORE trigger
-                    let old_registers_after = preserved_old_registers;
-
-                    // Propagate conflict resolution to AFTER trigger context (same logic as BEFORE)
-                    let trigger_ctx_after = update_trigger_context(
-                        program,
-                        &btree_table,
-                        Some(new_registers_after),
-                        old_registers_after,
-                        or_conflict,
-                        TriggerTime::After,
-                    );
-
-                    // RAISE(IGNORE) in an AFTER trigger should only abort the trigger body,
-                    // not skip post-row work (RETURNING, CDC).
-                    let after_trigger_done = program.allocate_label();
-                    for trigger in relevant_triggers {
-                        fire_trigger(
-                            program,
-                            &mut t_ctx.resolver,
-                            trigger,
-                            &trigger_ctx_after,
-                            connection,
-                            update_database_id,
-                            after_trigger_done,
-                        )?;
-                    }
-                    program.preassign_label_to_next_insn(after_trigger_done);
-                }
-            }
-
+            // RETURNING and CDC must capture the row as written by this UPDATE,
+            // before any AFTER trigger runs. SQLite fires its RETURNING pseudo-
+            // trigger ahead of user AFTER triggers, so an AFTER trigger that
+            // rewrites or deletes the row does not change what RETURNING reports.
+            // The AFTER trigger is therefore fired at the end of this block.
             let has_post_write_returning_subqueries = non_from_clause_subqueries
                 .iter()
                 .any(|s| !s.has_been_evaluated() && s.is_post_write_returning());
@@ -2614,6 +2538,90 @@ fn emit_update_insns<'a>(
                         cdc_updates_record,
                         table_name,
                     )?;
+                }
+            }
+
+            // Fire AFTER UPDATE triggers last, after RETURNING and CDC have
+            // captured the row this UPDATE wrote. An AFTER trigger that rewrites
+            // or deletes the row then cannot change what RETURNING reports,
+            // matching SQLite.
+            if let Some(btree_table) = target_table.table.btree() {
+                let relevant_triggers = get_triggers_including_temp(
+                    &t_ctx.resolver,
+                    update_database_id,
+                    TriggerEvent::Update,
+                    TriggerTime::After,
+                    Some(updated_column_indices.clone()),
+                    &btree_table,
+                );
+                if !relevant_triggers.is_empty() {
+                    let columns = target_table.table.columns();
+
+                    // Compute VIRTUAL columns for NEW values
+                    //TODO only emit required virtual columns
+                    let bt = target_table.table.btree().ok_or_else(|| {
+                        crate::LimboError::InternalError(
+                            "UPDATE on virtual table has no btree".into(),
+                        )
+                    })?;
+                    let new_ctx = DmlColumnContext::layout(columns, start, beg, layout.clone());
+                    compute_virtual_columns(
+                        program,
+                        &btree_table.columns_topo_sort()?,
+                        &new_ctx,
+                        &t_ctx.resolver,
+                        &bt,
+                    )?;
+
+                    // Compute VIRTUAL columns for OLD values if we have preserved OLD registers
+                    if let Some(ref old_regs) = preserved_old_registers {
+                        let pairs = columns.iter().zip(old_regs.iter().copied());
+                        //TODO only emit required virtual columns
+                        let old_ctx = DmlColumnContext::from_column_reg_mapping(pairs);
+                        compute_virtual_columns(
+                            program,
+                            &btree_table.columns_topo_sort()?,
+                            &old_ctx,
+                            &t_ctx.resolver,
+                            &bt,
+                        )?;
+                    }
+
+                    // Build raw NEW registers. Values are encoded at this point;
+                    // fire_trigger will decode them via decode_trigger_registers.
+                    let new_registers_after: Vec<usize> = (0..col_len)
+                        .map(|i| layout.to_register(start, i))
+                        .chain(std::iter::once(effective_rowid_reg))
+                        .collect();
+
+                    // Use preserved OLD registers from BEFORE trigger
+                    let old_registers_after = preserved_old_registers;
+
+                    // Propagate conflict resolution to AFTER trigger context (same logic as BEFORE)
+                    let trigger_ctx_after = update_trigger_context(
+                        program,
+                        &btree_table,
+                        Some(new_registers_after),
+                        old_registers_after,
+                        or_conflict,
+                        TriggerTime::After,
+                    );
+
+                    // RAISE(IGNORE) in an AFTER trigger should only abort the trigger body,
+                    // not skip post-row work (RETURNING, CDC).
+                    let after_trigger_done = program.allocate_label();
+                    for trigger in relevant_triggers {
+                        fire_trigger(
+                            program,
+                            &mut t_ctx.resolver,
+                            trigger,
+                            &trigger_ctx_after,
+                            connection,
+                            update_database_id,
+                            after_trigger_done,
+                        )?;
+                    }
+                    program.preassign_label_to_next_insn(after_trigger_done);
                 }
             }
         }

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -294,6 +294,7 @@ pub fn translate_create_index(
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
         where_clause: Some(parse_schema_where_clause),
+        trigger_target_database_id: None,
     });
     // Close the final sqlite_schema cursor
     program.emit_insn(Insn::Close {

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -13,6 +13,7 @@ use crate::{
             break_predicate_at_and_boundaries, rewrite_between_exprs, table_mask_from_expr,
             TableMask, ROWID_STRS,
         },
+        Resolver,
     },
     util::exprs_are_equivalent,
     vdbe::affinity::Affinity,
@@ -125,6 +126,7 @@ impl Constraint {
         &self,
         where_clause: &[WhereTerm],
         referenced_tables: Option<&TableReferences>,
+        resolver: Option<&Resolver>,
     ) -> (ast::Operator, ast::Expr, Affinity) {
         // For multi-index branches, use the pre-computed constraining expression
         if let Some(constraining) = &self.constraining_expr {
@@ -138,7 +140,11 @@ impl Constraint {
         };
         let mut affinity = Affinity::Blob;
         if op.as_ast_operator().is_some_and(|op| op.is_comparison()) {
-            affinity = comparison_affinity(lhs, rhs, referenced_tables, None);
+            // The resolver matters here: a scalar subquery's affinity is only
+            // known through it. Without it, `text_col < (SELECT int_col ...)`
+            // would take the TEXT side's affinity and the seek would compare
+            // the integer as text.
+            affinity = comparison_affinity(lhs, rhs, referenced_tables, resolver);
         }
 
         if side == BinaryExprSide::Lhs {
@@ -1084,22 +1090,28 @@ impl RangeConstraintRef {
         constraints: &[Constraint],
         where_clause: &[WhereTerm],
         referenced_tables: Option<&TableReferences>,
+        resolver: Option<&Resolver>,
     ) -> SeekRangeConstraint {
         if let Some(ref eq) = self.eq {
             return SeekRangeConstraint::new_eq(
                 self.sort_order,
                 self.nulls_order,
-                constraints[eq.constraint_pos]
-                    .get_constraining_expr(where_clause, referenced_tables),
+                constraints[eq.constraint_pos].get_constraining_expr(
+                    where_clause,
+                    referenced_tables,
+                    resolver,
+                ),
             );
         }
         SeekRangeConstraint::new_range(
             self.sort_order,
             self.nulls_order,
-            self.lower_bound
-                .map(|x| constraints[x].get_constraining_expr(where_clause, referenced_tables)),
-            self.upper_bound
-                .map(|x| constraints[x].get_constraining_expr(where_clause, referenced_tables)),
+            self.lower_bound.map(|x| {
+                constraints[x].get_constraining_expr(where_clause, referenced_tables, resolver)
+            }),
+            self.upper_bound.map(|x| {
+                constraints[x].get_constraining_expr(where_clause, referenced_tables, resolver)
+            }),
         )
     }
 }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -2993,18 +2993,21 @@ impl Optimizable for ast::Expr {
             Expr::Binary(_, ast::Operator::Modulus | ast::Operator::Divide, _) => false, // 1 % 0, 1 / 0
             Expr::Binary(expr, _, expr1) => expr.is_nonnull(tables) && expr1.is_nonnull(tables),
             Expr::Case {
-                base,
                 when_then_pairs,
                 else_expr,
                 ..
             } => {
-                base.as_ref().is_none_or(|base| base.is_nonnull(tables))
-                    && when_then_pairs
-                        .iter()
-                        .all(|(_, then)| then.is_nonnull(tables))
+                // With no ELSE, the CASE yields NULL when no WHEN matches.
+                // Otherwise its result is one of the THEN values or the ELSE
+                // value, so it is non-null only when all of those are. The base
+                // is only compared in the WHEN tests and never becomes the
+                // result, so its nullability does not matter.
+                when_then_pairs
+                    .iter()
+                    .all(|(_, then)| then.is_nonnull(tables))
                     && else_expr
                         .as_ref()
-                        .is_none_or(|else_expr| else_expr.is_nonnull(tables))
+                        .is_some_and(|else_expr| else_expr.is_nonnull(tables))
             }
             Expr::Cast { expr, .. } => expr.is_nonnull(tables),
             Expr::Collate(expr, _) => expr.is_nonnull(tables),

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -801,6 +801,7 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
     let best_join_order = optimize_table_access(
         schema,
         resolver.dialect.as_ref(),
+        resolver,
         &mut plan.result_columns,
         &mut plan.table_references,
         &available_indexes,
@@ -881,6 +882,7 @@ fn optimize_delete_plan(plan: &mut DeletePlan, resolver: &Resolver) -> Result<()
     let _ = optimize_table_access(
         schema,
         resolver.dialect.as_ref(),
+        resolver,
         &mut plan.result_columns,
         &mut plan.table_references,
         &available_indexes,
@@ -943,6 +945,7 @@ fn optimize_update_plan(
     let optimize_result = optimize_table_access(
         schema,
         resolver.dialect.as_ref(),
+        resolver,
         &mut [],
         &mut target_tables,
         &available_indexes,
@@ -1871,6 +1874,7 @@ fn enforce_indexed_by_hints(
 fn optimize_table_access(
     schema: &Schema,
     dialect: &dyn crate::dialect::Dialect,
+    resolver: &Resolver,
     result_columns: &mut [ResultSetColumn],
     table_references: &mut TableReferences,
     available_indexes: &AvailableIndexes,
@@ -2399,6 +2403,7 @@ fn optimize_table_access(
                                 *iter_dir,
                                 where_clause,
                                 Some(table_references),
+                                Some(resolver),
                             )?,
                         });
                 } else {
@@ -2432,6 +2437,7 @@ fn optimize_table_access(
                                     *iter_dir,
                                     where_clause,
                                     Some(table_references),
+                                    Some(resolver),
                                 )?,
                             });
                         continue;
@@ -2447,7 +2453,11 @@ fn optimize_table_access(
                             Operation::Search(Search::RowidEq {
                                 cmp_expr: constraints_per_table[table_idx].constraints
                                     [eq.constraint_pos]
-                                    .get_constraining_expr(where_clause, Some(table_references))
+                                    .get_constraining_expr(
+                                        where_clause,
+                                        Some(table_references),
+                                        Some(resolver),
+                                    )
                                     .1,
                             })
                         } else {
@@ -2459,6 +2469,7 @@ fn optimize_table_access(
                                     *iter_dir,
                                     where_clause,
                                     Some(table_references),
+                                    Some(resolver),
                                 )?,
                             })
                         };
@@ -2515,6 +2526,7 @@ fn optimize_table_access(
                     *iter_dir,
                     where_clause,
                     Some(table_references),
+                    Some(resolver),
                 )?;
 
                 table_references.joined_tables_mut()[table_idx].op =
@@ -2593,6 +2605,7 @@ fn optimize_table_access(
                                 IterationDirection::Forwards, // Multi-index always scans forward
                                 where_clause,
                                 Some(table_references),
+                                Some(resolver),
                             )?,
                         },
                         MultiIndexBranchAccessParams::InSeek { source } => {
@@ -2773,7 +2786,7 @@ fn build_vtab_scan_op(
         if usage.omit {
             where_clause[constraint.where_clause_pos.0].consumed = true;
         }
-        let (_, expr, _) = constraint.get_constraining_expr(where_clause, referenced_tables);
+        let (_, expr, _) = constraint.get_constraining_expr(where_clause, referenced_tables, None);
         constraints[zero_based_argv_index] = Some(expr);
         arg_count += 1;
     }
@@ -3327,6 +3340,7 @@ pub fn build_seek_def_from_constraints(
     iter_dir: IterationDirection,
     where_clause: &[WhereTerm],
     referenced_tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
 ) -> Result<SeekDef> {
     if constraint_refs.is_empty() {
         // Zero-prefix seeks are used for extremum scans over an already ordered
@@ -3354,7 +3368,9 @@ pub fn build_seek_def_from_constraints(
     // Extract the key values and operators
     let key = constraint_refs
         .iter()
-        .map(|cref| cref.as_seek_range_constraint(constraints, where_clause, referenced_tables))
+        .map(|cref| {
+            cref.as_seek_range_constraint(constraints, where_clause, referenced_tables, resolver)
+        })
         .collect();
 
     let seek_def = build_seek_def(iter_dir, key)?;

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -184,8 +184,11 @@ fn get_table_local_constraints_for_branch(
         {
             continue;
         }
-        constraint.constraining_expr =
-            Some(constraint.get_constraining_expr(&synthetic_where_terms, Some(table_references)));
+        constraint.constraining_expr = Some(constraint.get_constraining_expr(
+            &synthetic_where_terms,
+            Some(table_references),
+            None,
+        ));
     }
     Ok((synthetic_where_terms, table_constraints))
 }

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1451,6 +1451,7 @@ pub fn translate_create_table(
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
         where_clause: Some(parse_schema_where_clause),
+        trigger_target_database_id: None,
     });
 
     // For CTAS, emit bytecode to populate the new table from the SELECT
@@ -1770,6 +1771,7 @@ pub fn translate_create_virtual_table(
     program.emit_insn(Insn::ParseSchema {
         db: sqlite_schema_cursor_id,
         where_clause: Some(parse_schema_where_clause),
+        trigger_target_database_id: None,
     });
 
     Ok(())
@@ -2564,6 +2566,7 @@ fn persist_type_definition(
             where_clause: Some(format!(
                 "tbl_name = '{TURSO_TYPES_TABLE_NAME}' AND type != 'trigger'"
             )),
+            trigger_target_database_id: None,
         });
     }
 

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -694,6 +694,18 @@ fn prepare_one_select_plan(
 
             plan.aggregates = aggregate_expressions;
 
+            // An aggregate whose argument columns belong to the enclosing query
+            // is computed by that query, not by this subquery (SQLite binds an
+            // aggregate to the nearest query that supplies a referenced column).
+            // Move those up so this subquery never computes them; the enclosing
+            // query collects them once its subqueries are planned. When there is
+            // no enclosing query the move fails and the aggregate stays here.
+            let tables = &plan.table_references;
+            plan.aggregates.retain(|agg| {
+                !(aggregate_belongs_to_enclosing_query(agg, tables)
+                    && resolver.move_aggregate_to_enclosing_query(agg.clone()))
+            });
+
             // HAVING without GROUP BY requires aggregates in the SELECT
             if let Some(ref group_by) = plan.group_by {
                 if group_by.exprs.is_empty()
@@ -826,7 +838,14 @@ fn prepare_one_select_plan(
                 plan_windows(program, &mut plan, resolver, connection, &mut windows)?;
             }
 
+            // Collect aggregates that this query's subqueries find to belong to
+            // this query. Collection starts before the subqueries are planned
+            // and ends after; the collected aggregates become this query's,
+            // making it an aggregate query.
+            resolver.begin_collecting_aggregates_from_subqueries();
             plan_subqueries_from_select_plan(program, &mut plan, resolver, connection)?;
+            let aggregates_from_subqueries = resolver.take_aggregates_from_subqueries();
+            plan.aggregates.extend(aggregates_from_subqueries);
 
             {
                 trace_stack!("validate_plan");
@@ -1786,6 +1805,41 @@ pub fn emit_simple_count(
         t_ctx.limit_ctx,
     )?;
     Ok(true)
+}
+
+/// True when this aggregate belongs to the immediate enclosing query rather
+/// than the subquery it is written in: every argument column is a reference to
+/// the enclosing query (scope depth 0), and none is this query's own column.
+/// SQLite binds an aggregate to the nearest query that supplies a referenced
+/// column; an argument column referencing a further ancestor (scope depth > 0)
+/// is not handled here, so the aggregate stays with this query.
+fn aggregate_belongs_to_enclosing_query(
+    agg: &super::plan::Aggregate,
+    tables: &TableReferences,
+) -> bool {
+    let mut belongs = false;
+    let mut disqualified = false;
+    for arg in agg.args.iter().chain(agg.filter_expr.iter()) {
+        let _ = walk_expr(arg, &mut |e: &ast::Expr| -> Result<WalkControl> {
+            if let ast::Expr::Column { table, .. } | ast::Expr::RowId { table, .. } = e {
+                if tables
+                    .joined_tables()
+                    .iter()
+                    .any(|t| t.internal_id == *table)
+                {
+                    disqualified = true;
+                } else if let Some(outer) = tables.find_outer_query_ref_by_internal_id(*table) {
+                    if outer.scope_depth == 0 {
+                        belongs = true;
+                    } else {
+                        disqualified = true;
+                    }
+                }
+            }
+            Ok(WalkControl::Continue)
+        });
+    }
+    belongs && !disqualified
 }
 
 fn process_having_clause(

--- a/core/translate/sequence.rs
+++ b/core/translate/sequence.rs
@@ -153,6 +153,7 @@ pub fn emit_sequence_backing_table(
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
         where_clause: Some(format!("name = '{escaped}'")),
+        trigger_target_database_id: None,
     });
 
     Ok(())

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -2151,7 +2151,21 @@ fn assign_select_subquery_eval_phases(plan: &mut SelectPlan) {
         }
     }
 
+    let mut outer_aggregate_subquery_ids: Vec<ast::TableInternalId> = Vec::new();
     for subquery in plan.non_from_clause_subqueries.iter_mut() {
+        // A subquery that reads an aggregate the outer query computes must run
+        // in the outer query's aggregate-output phase, after that aggregate has
+        // been finalized into a register; run earlier, the aggregate expression
+        // inside the subquery has no register to read.
+        if subquery_reads_outer_aggregate(subquery) {
+            subquery.eval_phase = if has_grouped_output {
+                SubqueryEvalPhase::GroupedOutput
+            } else {
+                SubqueryEvalPhase::UngroupedAggregateOutput
+            };
+            outer_aggregate_subquery_ids.push(subquery.internal_id);
+            continue;
+        }
         subquery.eval_phase = match subquery.origin {
             SubqueryOrigin::SelectHaving | SubqueryOrigin::SelectOrderBy
                 if has_grouped_output
@@ -2162,4 +2176,77 @@ fn assign_select_subquery_eval_phases(plan: &mut SelectPlan) {
             _ => subquery.origin.phase_floor(),
         };
     }
+
+    // A result column that reads one of these subqueries depends on an
+    // aggregate computed in the output phase, so it must be evaluated there
+    // rather than once per input row — the same treatment SQLite gives any
+    // result-column expression that references an aggregate result (select.c
+    // evaluates those after the aggregation loop, in the output step). Mark it
+    // so the emitter defers it, instead of taking an arbitrary row's NULL
+    // during the scan.
+    for rc in plan.result_columns.iter_mut() {
+        if !rc.contains_aggregates && expr_reads_subquery(&rc.expr, &outer_aggregate_subquery_ids) {
+            rc.contains_aggregates = true;
+        }
+    }
+}
+
+/// True when `expr` reads one of the given subqueries.
+fn expr_reads_subquery(expr: &ast::Expr, subquery_ids: &[ast::TableInternalId]) -> bool {
+    let mut found = false;
+    let _ = walk_expr(expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
+        if let ast::Expr::SubqueryResult { subquery_id, .. } = e {
+            if subquery_ids.contains(subquery_id) {
+                found = true;
+                return Ok(WalkControl::SkipChildren);
+            }
+        }
+        Ok(WalkControl::Continue)
+    });
+    found
+}
+
+/// True when a result column of the subquery contains an aggregate whose value
+/// the outer query computes: a plain aggregate call that is not one of the
+/// subquery's own aggregates, because its argument referenced an outer column
+/// and it was moved to the outer query during resolution. The subquery reads
+/// that aggregate back from the register the outer query finalizes it into.
+///
+/// Window functions (an aggregate name with an `OVER` clause) are computed by
+/// the subquery itself, not the outer query, so they are not counted here even
+/// though they also do not appear in `aggregates`.
+fn subquery_reads_outer_aggregate(subquery: &NonFromClauseSubquery) -> bool {
+    let SubqueryState::Unevaluated { plan: Some(plan) } = &subquery.state else {
+        return false;
+    };
+    let Plan::Select(select) = plan.as_ref() else {
+        return false;
+    };
+    let mut found = false;
+    for rc in &select.result_columns {
+        let _ = walk_expr(&rc.expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
+            if let ast::Expr::FunctionCall {
+                name,
+                args,
+                filter_over,
+                ..
+            } = e
+            {
+                let is_plain_aggregate = filter_over.over_clause.is_none()
+                    && matches!(
+                        crate::function::Func::resolve_function(name.as_str(), args.len()),
+                        Ok(Some(crate::function::Func::Agg(_)))
+                    );
+                if is_plain_aggregate && !select.aggregates.iter().any(|a| a.original_expr == *e) {
+                    found = true;
+                    return Ok(WalkControl::SkipChildren);
+                }
+            }
+            Ok(WalkControl::Continue)
+        });
+        if found {
+            break;
+        }
+    }
+    found
 }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -726,6 +726,17 @@ fn get_subquery_parser<'a>(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
+                // EXISTS only checks whether a row comes out, so ORDER BY and
+                // DISTINCT cannot change the result and SQLite drops them
+                // (select.c, "dropping superfluous ORDER BY"). Dropping them
+                // here — after the plan is prepared, so name errors in the
+                // ORDER BY still surface — also means their expressions are
+                // never evaluated: an ORDER BY term that would error at
+                // runtime (e.g. an integer overflow) must not fail the query.
+                // LIMIT and OFFSET stay: with DISTINCT gone they count plain
+                // rows, which matches SQLite.
+                plan.order_by.clear();
+                plan.distinctness = crate::translate::plan::Distinctness::NonDistinct;
                 optimize_select_plan(&mut plan, resolver)?;
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -215,6 +215,8 @@ pub fn translate_create_trigger(
         where_clause: Some(format!(
             "name = '{escaped_trigger_name}' AND type = 'trigger'"
         )),
+        trigger_target_database_id: (temporary && tbl_name.db_name.is_none())
+            .then_some(target_table_database_id),
     });
 
     Ok(())

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -822,7 +822,19 @@ pub fn get_triggers_including_temp(
                 })
                 .collect()
         });
-        triggers.extend(temp_triggers);
+        // TEMP triggers fire before the table's own triggers, and among
+        // themselves in creation order. SQLite builds its trigger list by
+        // walking the temp schema's trigger hash — which iterates newest
+        // first — and prepending each hit onto the table's own list
+        // (sqlite3TriggerList in trigger.c), so the temp group nets out
+        // oldest-first at the front. Mirror that exactly: push each temp
+        // trigger onto the front in the same newest-first walk. The order is
+        // observable whenever one trigger's changes feed another.
+        let mut list: std::collections::VecDeque<Arc<Trigger>> = triggers.into();
+        for trigger in temp_triggers {
+            list.push_front(trigger);
+        }
+        triggers = list.into();
     }
     triggers
 }

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -894,6 +894,19 @@ pub fn fire_trigger(
     let saved_register_collations = std::mem::take(&mut resolver.register_collations);
     populate_trigger_register_affinities(resolver, ctx);
     let result = (|| -> Result<()> {
+        // A trigger body is inlined and re-executed once per affected row. Any
+        // run-once block inside it (an uncorrelated subquery, a hash or
+        // ephemeral-index build) is guarded by Insn::Once, whose "already ran"
+        // state otherwise persists across firings and would reuse a value
+        // cached during an earlier firing. Clear that state at the start of
+        // each firing so every firing re-evaluates from the current table
+        // state, the same fresh start SQLite gets from a per-invocation trigger
+        // sub-program.
+        let firing_end = program.allocate_label();
+        program.emit_insn(Insn::ResetOnce {
+            region_end: firing_end,
+        });
+
         // Evaluate WHEN clause if present
         if let Some(mut when_expr) = trigger.when_clause.clone() {
             crate::stack::trace_stack!("when_clause");
@@ -960,6 +973,8 @@ pub fn fire_trigger(
             )?;
         }
 
+        // Marks the end of this firing's instruction range for ResetOnce above.
+        program.preassign_label_to_next_insn(firing_end);
         Ok(())
     })();
     resolver.register_affinities = saved_register_affinities;

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -255,6 +255,7 @@ pub fn translate_create_materialized_view(
         where_clause: Some(format!(
             "name = '{escaped_view_name}' OR name = '{escaped_dbsp_table_name}' OR name = '{escaped_dbsp_index_name}'"
         )),
+        trigger_target_database_id: None,
     });
 
     let schema_version = resolver.with_schema(database_id, |s| s.schema_version);
@@ -386,6 +387,7 @@ pub fn translate_create_view(
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
         where_clause: Some(format!("name = '{escaped_view_name}'")),
+        trigger_target_database_id: None,
     });
 
     let schema_version = resolver.with_schema(database_id, |s| s.schema_version);

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1525,6 +1525,9 @@ impl ProgramBuilder {
                 } => {
                     resolve(target_pc_when_reentered, "Once")?;
                 }
+                Insn::ResetOnce { region_end, .. } => {
+                    resolve(region_end, "ResetOnce")?;
+                }
                 Insn::Prev { pc_if_prev, .. } => {
                     resolve(pc_if_prev, "Prev")?;
                 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3478,6 +3478,19 @@ pub fn halt(
             }
         }
 
+        // A FAIL resolution that cannot commit here because an outer statement
+        // is still running (this is a trigger subprogram fired mid-statement)
+        // must still tell the enclosing statement to keep the changes made
+        // before the error. Re-tag the constraint as a FAIL raise so the outer
+        // program's abort() preserves and commits them instead of rolling the
+        // statement back. FK errors do not respect ON CONFLICT, so leave them
+        // as-is.
+        if program.resolve_type == ResolveType::Fail {
+            if let LimboError::Constraint(msg) = error {
+                return Err(LimboError::Raise(ResolveType::Fail, msg));
+            }
+        }
+
         // For non-FAIL modes (or non-autocommit), just return the error.
         // abort() will handle rollback based on resolve_type.
         return Err(error);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -15324,6 +15324,26 @@ pub fn op_once(
     Ok(InsnFunctionStepResult::Step)
 }
 
+/// Execute the [Insn::ResetOnce] instruction.
+///
+/// Forgets that any [Insn::Once] between this instruction and `region_end` has
+/// run, so a re-executed inlined trigger body re-evaluates its run-once blocks
+/// instead of reusing a value cached during an earlier firing.
+pub fn op_reset_once(
+    _program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(ResetOnce { region_end }, insn);
+    assert!(region_end.is_offset());
+    let start = state.pc;
+    let end = region_end.as_offset_int();
+    state.once.retain(|pc| *pc <= start || *pc >= end);
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
 pub fn op_found(
     program: &Program,
     state: &mut ProgramState,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6116,9 +6116,15 @@ pub fn seek_internal(
                         IOResult::Done(()) => {}
                         IOResult::IO(io) => return Ok(SeekInternalResult::IO(io)),
                     }
-                    // the MoveLast variant is only used for SeekOp::LT and SeekOp::LE when the seek condition is always true,
-                    // so we have always found what we were looking for.
-                    return Ok(SeekInternalResult::Found);
+                    // The MoveLast variant is only used for SeekOp::LT and SeekOp::LE when
+                    // the seek condition is true for every row, so the last row satisfies
+                    // it — but an empty table has no row to sit on, and reporting Found
+                    // there would make the scan loop emit one garbage row.
+                    return Ok(if cursor.is_empty() {
+                        SeekInternalResult::NotFound
+                    } else {
+                        SeekInternalResult::Found
+                    });
                 }
             }
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14043,6 +14043,7 @@ pub struct OpParseSchemaInner {
     dbsp_state_roots: crate::HashMap<String, i64>,
     dbsp_state_index_roots: crate::HashMap<String, i64>,
     materialized_view_info: crate::HashMap<String, (String, i64)>,
+    trigger_target_database_id: Option<usize>,
     db: usize,
     previous_auto_commit: bool,
 }
@@ -14063,7 +14064,14 @@ pub fn op_parse_schema(
     insn: &Insn,
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(ParseSchema { db, where_clause }, insn);
+    load_insn!(
+        ParseSchema {
+            db,
+            where_clause,
+            trigger_target_database_id
+        },
+        insn
+    );
 
     let conn = program.connection.clone();
 
@@ -14147,6 +14155,7 @@ pub fn op_parse_schema(
         dbsp_state_roots: Default::default(),
         dbsp_state_index_roots: Default::default(),
         materialized_view_info: Default::default(),
+        trigger_target_database_id: *trigger_target_database_id,
         db: *db,
         previous_auto_commit,
     }));
@@ -14207,6 +14216,11 @@ fn op_parse_schema_step(
                     &attached_resolver,
                     conn.dialect().as_ref(),
                 )?;
+                if ty == "trigger" {
+                    if let Some(target_database_id) = inner.trigger_target_database_id {
+                        schema.set_trigger_target_database_id(name, target_database_id)?;
+                    }
+                }
                 continue;
             }
             StepResult::Done => {
@@ -14219,6 +14233,7 @@ fn op_parse_schema_step(
                     dbsp_state_roots,
                     dbsp_state_index_roots,
                     materialized_view_info,
+                    trigger_target_database_id: _,
                     db,
                     previous_auto_commit,
                 } = *state

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -15909,6 +15909,41 @@ pub fn op_rename_table(
 
     if *db != crate::TEMP_DB_ID && conn.temp.database.read().is_some() {
         conn.with_database_schema_mut(crate::TEMP_DB_ID, |schema| -> crate::Result<()> {
+            // A TEMP trigger may run on a table in another database. Triggers
+            // are found by the name of that table. When the table is renamed,
+            // move its TEMP triggers to the new name. Changing only the stored
+            // SQL would leave them under the old name, so they would no longer
+            // run.
+            let temp_shadows_old_name = schema.tables.contains_key(&normalized_from);
+            if let Some(triggers) = schema.triggers.remove(&normalized_from) {
+                let mut triggers_to_keep = std::collections::VecDeque::new();
+                let mut triggers_to_rename = std::collections::VecDeque::new();
+                for mut trigger_arc in triggers {
+                    let targets_renamed_database = match trigger_arc.target_database_id {
+                        Some(target_db) => target_db == *db,
+                        None => !temp_shadows_old_name,
+                    };
+                    if targets_renamed_database {
+                        let trigger = Arc::make_mut(&mut trigger_arc);
+                        normalized_to.clone_into(&mut trigger.table_name);
+                        rewrite_trigger_for_table_rename(trigger, &normalized_from, &normalized_to);
+                        triggers_to_rename.push_back(trigger_arc);
+                    } else {
+                        triggers_to_keep.push_back(trigger_arc);
+                    }
+                }
+                if !triggers_to_keep.is_empty() {
+                    schema
+                        .triggers
+                        .insert(normalized_from.to_owned(), triggers_to_keep);
+                }
+                schema
+                    .triggers
+                    .entry(normalized_to.to_owned())
+                    .or_default()
+                    .extend(triggers_to_rename);
+            }
+
             for triggers in schema.triggers.values_mut() {
                 for trigger_arc in triggers.iter_mut() {
                     if !sql_might_reference_identifier(&trigger_arc.sql, &normalized_from) {

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1992,7 +1992,9 @@ pub fn insn_to_row(
                 0,
                 format!("if (r[{}]==NULL) goto {}", reg, target_pc.as_debug_int()),
             ),
-            Insn::ParseSchema { db, where_clause } => (
+            Insn::ParseSchema {
+                db, where_clause, ..
+            } => (
                 "ParseSchema",
                 *db as i64,
                 0,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -2233,6 +2233,15 @@ pub fn insn_to_row(
                 0,
                 format!("goto {}", target_pc_when_reentered.as_debug_int()),
             ),
+            Insn::ResetOnce { region_end } => (
+                "ResetOnce",
+                region_end.as_debug_int() as i64,
+                0,
+                0,
+                Value::build_text(""),
+                0,
+                format!("clear once flags before {}", region_end.as_debug_int()),
+            ),
             Insn::BeginSubrtn { dest, dest_end } => (
                 "BeginSubrtn",
                 *dest as i64,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1716,6 +1716,16 @@ pub enum Insn {
     Once {
         target_pc_when_reentered: BranchOffset,
     },
+    /// Forget that any [Insn::Once] between this instruction and `region_end`
+    /// has already run. Trigger bodies are inlined and re-executed once per
+    /// affected row, so their run-once blocks (uncorrelated subqueries,
+    /// hash/ephemeral builds) must re-run each firing instead of reusing a
+    /// value cached during an earlier firing. Emitted at the start of each
+    /// trigger firing, this restores the fresh once-state that SQLite gets from
+    /// a per-invocation trigger sub-program.
+    ResetOnce {
+        region_end: BranchOffset,
+    },
     /// Search for a record in the index cursor.
     /// If any entry for which the key is a prefix exists, jump to target_pc.
     /// Otherwise, continue to the next instruction.
@@ -2217,6 +2227,7 @@ impl InsnVariants {
             InsnVariants::SetCookie => execute::op_set_cookie,
             InsnVariants::OpenEphemeral | InsnVariants::OpenAutoindex => execute::op_open_ephemeral,
             InsnVariants::Once => execute::op_once,
+            InsnVariants::ResetOnce => execute::op_reset_once,
             InsnVariants::Found | InsnVariants::NotFound => execute::op_found,
             InsnVariants::Affinity => execute::op_affinity,
             InsnVariants::IdxDelete => execute::op_idx_delete,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1577,6 +1577,16 @@ pub enum Insn {
     ParseSchema {
         db: usize,
         where_clause: Option<String>,
+        /// The database containing the table used by an unqualified TEMP trigger.
+        ///
+        /// SQLite can look through every attached database while rebuilding a
+        /// trigger. Turso's schema reader handles one schema at a time, so it
+        /// cannot repeat the lookup already done by CREATE TRIGGER. The SQL in
+        /// temp.sqlite_schema only says `ON table`, not which database supplied
+        /// `table`. CREATE TRIGGER passes the answer here so ParseSchema can keep
+        /// it on the in-memory trigger. Every other ParseSchema use leaves this
+        /// as `None`.
+        trigger_target_database_id: Option<usize>,
     },
 
     /// Populate all materialized views after schema parsing

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1443,20 +1443,28 @@ impl Value {
 
     pub fn exec_char<'a, T: Iterator<Item = &'a Self>>(values: T) -> Self {
         let result: String = values
-            .filter_map(|x| match x {
-                Value::Numeric(Numeric::Integer(i)) => {
-                    // Convert integer to Unicode codepoint.
-                    // For invalid codepoints (negative, surrogates, or > U+10FFFF),
-                    // output U+FFFD (replacement character) to match SQLite behavior.
-                    if *i >= 0 {
-                        Some(char::from_u32(*i as u32).unwrap_or('\u{FFFD}'))
-                    } else {
-                        Some('\u{FFFD}')
+            .map(|x| {
+                // char() coerces every argument to an integer codepoint, the
+                // same way sqlite3_value_int64 / CAST(... AS INTEGER) does:
+                // text and blobs by their numeric prefix (0 if none), floats by
+                // truncation, NULL as 0. Turso previously accepted only integer
+                // arguments and dropped the rest.
+                let codepoint = match x {
+                    Value::Numeric(Numeric::Integer(i)) => *i,
+                    Value::Numeric(Numeric::Float(f)) => real_to_i64(f64::from(*f)),
+                    Value::Text(t) => crate::numeric::str_to_i64(t.as_str()).unwrap_or(0),
+                    Value::Blob(b) => {
+                        crate::numeric::str_to_i64(String::from_utf8_lossy(b).as_ref()).unwrap_or(0)
                     }
+                    Value::Null => 0,
+                };
+                // Invalid codepoints (negative, surrogates, or > U+10FFFF)
+                // become U+FFFD, matching SQLite.
+                if codepoint >= 0 {
+                    char::from_u32(codepoint as u32).unwrap_or('\u{FFFD}')
+                } else {
+                    '\u{FFFD}'
                 }
-                // NULL arguments produce NUL characters to match SQLite behavior.
-                Value::Null => Some('\0'),
-                _ => None,
             })
             .collect();
         Value::build_text(result)
@@ -2761,13 +2769,15 @@ mod tests {
             ),
             Value::build_text("\0")
         );
+        // Non-numeric text coerces to integer 0, so char('a') is a NUL byte,
+        // the same as SQLite (it feeds every argument through integer coercion).
         assert_eq!(
             Value::exec_char(
                 [Register::Value(Value::build_text("a"))]
                     .iter()
                     .map(|reg| reg.get_value())
             ),
-            Value::build_text("")
+            Value::build_text("\0")
         );
     }
 

--- a/sqlite/conformance/sqlite-sqltests/aggregate-of-outer-column.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/aggregate-of-outer-column.sqltest
@@ -1,0 +1,94 @@
+@database :memory:
+
+# An aggregate function binds to the nearest enclosing query whose FROM clause
+# supplies a column its argument references, not to the subquery it is written
+# in. That enclosing query becomes an aggregate query and collapses to one row
+# per group. This mirrors SQLite name resolution (resolve.c resolveExprStep
+# walks outward to the context that owns a referenced column and marks it
+# NC_HasAgg). Turso used to bind the aggregate to the subquery, counting only
+# the single correlated row.
+#
+# The tests select only the aggregate itself or GROUP BY columns: a bare
+# non-grouped column alongside an aggregate over an outer column takes its
+# value from an arbitrary row in both engines, which is not a stable
+# comparison.
+
+# count(t.a) references the outer table t, so it is an aggregate of the outer
+# query: one row, count of all three.
+@cross-check-integrity
+test count-of-outer-column-is-an-aggregate-of-the-outer-query {
+    CREATE TABLE t(a);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT (SELECT count(t.a)) FROM t;
+}
+expect {
+    3
+}
+
+# count(u.b) references the subquery's own table u, so it stays a subquery
+# aggregate and runs once per outer row.
+@cross-check-integrity
+test count-of-local-column-stays-in-the-subquery {
+    CREATE TABLE t(a);
+    INSERT INTO t VALUES (1), (2), (3);
+    CREATE TABLE u(b);
+    INSERT INTO u VALUES (10), (20);
+    SELECT a, (SELECT count(u.b) FROM u) FROM t;
+}
+expect {
+    1|2
+    2|2
+    3|2
+}
+
+# The subquery has its own FROM (u), but the aggregate's argument references
+# the outer t, so it is still an aggregate of the outer query. The subquery's
+# own FROM just multiplies rows, and the scalar subquery takes the first.
+@cross-check-integrity
+test count-of-outer-column-wins-over-the-subquerys-own-from {
+    CREATE TABLE t(a);
+    INSERT INTO t VALUES (1), (2), (3);
+    CREATE TABLE u(b);
+    INSERT INTO u VALUES (10), (20);
+    SELECT (SELECT count(t.a) FROM u) FROM t;
+}
+expect {
+    3
+}
+
+# The outer WHERE is applied before the outer aggregate, so count() sees only
+# the two surviving rows.
+@cross-check-integrity
+test outer-where-filters-before-the-outer-aggregate {
+    CREATE TABLE t(a);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT (SELECT count(t.a)) FROM t WHERE a > 1;
+}
+expect {
+    2
+}
+
+# No outer column reference, so the aggregate stays in the subquery: count(*)
+# over t inside a subquery with no outer query in scope.
+@cross-check-integrity
+test aggregate-without-an-outer-column-stays-in-the-subquery {
+    CREATE TABLE t(a);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT (SELECT count(*) FROM t);
+}
+expect {
+    3
+}
+
+# The outer query already has a GROUP BY: the outer aggregate is computed per
+# group. Group a<=1 sums to 1, group a>1 sums to 5.
+@cross-check-integrity
+test outer-aggregate-is-computed-per-group {
+    CREATE TABLE t(a);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT (a > 1) AS g, (SELECT sum(t.a)) FROM t GROUP BY a > 1;
+}
+expect {
+    0|1
+    1|5
+}

--- a/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
@@ -2602,6 +2602,40 @@ expect error {
     error in trigger trg after drop column: no such column: m
 }
 
+# DROP COLUMN must understand table aliases when it checks triggers. The
+# reference to target_alias.dropped_col below must make the DROP fail.
+@cross-check-integrity
+test fail-drop-column-trigger-select-table-alias {
+    CREATE TABLE alias_drop_target (keep_col, dropped_col);
+    CREATE TRIGGER alias_drop_trigger AFTER UPDATE ON alias_drop_target BEGIN
+        SELECT keep_col
+        FROM alias_drop_target AS target_alias
+        ORDER BY target_alias.dropped_col;
+    END;
+    ALTER TABLE alias_drop_target DROP COLUMN dropped_col;
+}
+expect error {
+    error in trigger alias_drop_trigger after drop column: no such column: target_alias.dropped_col
+}
+
+# The same check must include aliases introduced by UPDATE FROM.
+@cross-check-integrity
+test fail-drop-column-trigger-update-from-alias {
+    CREATE TABLE update_from_drop_target (keep_col, dropped_col);
+    CREATE TABLE update_from_trigger_owner (value);
+    CREATE TRIGGER update_from_alias_trigger
+    AFTER INSERT ON update_from_trigger_owner BEGIN
+        UPDATE update_from_trigger_owner
+        SET value = source.keep_col
+        FROM update_from_drop_target AS source
+        WHERE source.dropped_col;
+    END;
+    ALTER TABLE update_from_drop_target DROP COLUMN dropped_col;
+}
+expect error {
+    error in trigger update_from_alias_trigger after drop column: no such column: source.dropped_col
+}
+
 # Cross-table trigger: UPDATE SET value expr references dropped column → fail
 @cross-check-integrity
 test fail-drop-column-cross-table-trigger-set-value-expr {

--- a/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
@@ -1269,6 +1269,26 @@ expect {
     1|2
 }
 
+# A TEMP trigger on a main table is stored in temp.sqlite_schema. Renaming the
+# table must update both the stored table name and the name used to find the
+# trigger in memory. Otherwise the trigger no longer runs.
+@cross-check-integrity
+test alter-table-rename-temp-trigger-target-fires-after-rename {
+    CREATE TABLE temp_trigger_target (a, b);
+    CREATE TABLE temp_trigger_log (x, y);
+    CREATE TEMP TRIGGER temp_trig AFTER INSERT ON temp_trigger_target BEGIN
+        INSERT INTO temp_trigger_log VALUES (new.a, new.b);
+    END;
+    ALTER TABLE temp_trigger_target RENAME TO temp_trigger_target_renamed;
+    INSERT INTO temp_trigger_target_renamed VALUES (3, 4);
+    SELECT * FROM temp_trigger_log;
+    SELECT tbl_name FROM temp.sqlite_schema WHERE name = 'temp_trig';
+}
+expect {
+    3|4
+    temp_trigger_target_renamed
+}
+
 # Verify trigger body UPDATE command targets renamed table
 @cross-check-integrity
 test alter-table-rename-trigger-body-update {

--- a/sqlite/conformance/sqlite-sqltests/char-coerces-arguments-to-integers.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/char-coerces-arguments-to-integers.sqltest
@@ -1,0 +1,56 @@
+@database :memory:
+
+# char() coerces every argument to an integer codepoint, the same way
+# sqlite3_value_int64 / CAST(... AS INTEGER) does: text and blobs by their
+# numeric prefix (0 when there is none), floats by truncation, and NULL as 0.
+# Turso previously accepted only integer arguments and dropped text, float, and
+# blob ones, so char('65') was empty instead of 'A' and char(65,'',66) dropped
+# the middle NUL.
+
+@cross-check-integrity
+test char-of-text-numeric-prefix {
+    SELECT hex(char('65'));
+}
+expect {
+    41
+}
+
+@cross-check-integrity
+test char-of-empty-text-is-nul {
+    SELECT hex(char(''));
+}
+expect {
+    00
+}
+
+@cross-check-integrity
+test char-of-non-numeric-text-is-nul {
+    SELECT hex(char('abc'));
+}
+expect {
+    00
+}
+
+@cross-check-integrity
+test char-truncates-a-float {
+    SELECT hex(char(65.9));
+}
+expect {
+    41
+}
+
+@cross-check-integrity
+test char-keeps-every-argument {
+    SELECT hex(char(65, '', 66));
+}
+expect {
+    410042
+}
+
+@cross-check-integrity
+test char-of-negative-is-replacement-char {
+    SELECT hex(char(-1));
+}
+expect {
+    EFBFBD
+}

--- a/sqlite/conformance/sqlite-sqltests/char.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/char.sqltest
@@ -27,10 +27,13 @@ expect {
     00
 }
 
+# A non-numeric text argument coerces to integer 0, so char('a') is a NUL byte
+# (SQLite coerces every argument to an integer, it does not drop non-integers).
 test char-non-integer {
-    select char('a')
+    select hex(char('a'))
 }
 expect {
+    00
 }
 
 # char() with unicode codepoints >= 256

--- a/sqlite/conformance/sqlite-sqltests/delete-trigger-resets-conflict-policy.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/delete-trigger-resets-conflict-policy.sqltest
@@ -1,0 +1,46 @@
+@database :memory:
+
+# A statement's OR REPLACE conflict policy propagates into the triggers it
+# fires, but a DELETE always fires its triggers with the default (ABORT)
+# policy — SQLite codes row-delete triggers with OE_Default (delete.c). So a
+# plain INSERT inside a DELETE trigger still aborts on a UNIQUE violation even
+# when the DELETE was ultimately fired by an outer UPDATE OR REPLACE. Turso
+# used to propagate the outer REPLACE through the DELETE, silently swallowing
+# the violation.
+
+test delete-trigger-does-not-inherit-outer-or-replace {
+    CREATE TABLE t (pk INTEGER PRIMARY KEY, x INTEGER);
+    INSERT INTO t VALUES (1, 0);
+    CREATE TABLE t2 (pk INTEGER PRIMARY KEY, y INTEGER);
+    INSERT INTO t2 VALUES (1, 0);
+    CREATE TRIGGER t2_bd BEFORE DELETE ON t2 FOR EACH ROW BEGIN
+        INSERT INTO t2(pk, y) VALUES (1, 1), (1, 2);
+    END;
+    CREATE TRIGGER t_au AFTER UPDATE ON t FOR EACH ROW BEGIN
+        DELETE FROM t2 WHERE pk = 1;
+    END;
+    UPDATE OR REPLACE t SET x = 9;
+}
+expect error {
+}
+
+# An explicit OR clause on the trigger's own statement still wins, so the same
+# INSERT written with OR REPLACE resolves the conflict instead of aborting.
+# The DELETE that fired the trigger then removes the row, leaving t2 empty.
+@cross-check-integrity
+test delete-trigger-statement-keeps-its-own-or-clause {
+    CREATE TABLE t (pk INTEGER PRIMARY KEY, x INTEGER);
+    INSERT INTO t VALUES (1, 0);
+    CREATE TABLE t2 (pk INTEGER PRIMARY KEY, y INTEGER);
+    INSERT INTO t2 VALUES (1, 0);
+    CREATE TRIGGER t2_bd BEFORE DELETE ON t2 FOR EACH ROW BEGIN
+        INSERT OR REPLACE INTO t2(pk, y) VALUES (1, 1), (1, 2);
+    END;
+    CREATE TRIGGER t_au AFTER UPDATE ON t FOR EACH ROW BEGIN
+        DELETE FROM t2 WHERE pk = 1;
+    END;
+    UPDATE OR REPLACE t SET x = 9;
+    SELECT pk, y FROM t2 ORDER BY pk;
+}
+expect {
+}

--- a/sqlite/conformance/sqlite-sqltests/exists-drops-order-by-distinct.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/exists-drops-order-by-distinct.sqltest
@@ -1,0 +1,62 @@
+@database :memory:
+
+# EXISTS only checks whether a row comes out, so SQLite drops ORDER BY and
+# DISTINCT from the subquery (select.c, "dropping superfluous ORDER BY").
+# Dropped ORDER BY terms are still name-resolved but never evaluated, so a
+# term that would fail at runtime must not fail the query. Turso previously
+# kept both: an overflowing ORDER BY term errored the whole statement, and
+# DISTINCT+OFFSET counted distinct rows where SQLite counts plain rows.
+
+@cross-check-integrity
+test exists-order-by-term-is-not-evaluated {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), (1), (2);
+    SELECT EXISTS (SELECT x FROM t ORDER BY ABS(-9223372036854775807 - 1));
+}
+expect {
+    1
+}
+
+@cross-check-integrity
+test exists-order-by-term-not-evaluated-with-limit {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), (1), (2);
+    SELECT EXISTS (SELECT x FROM t ORDER BY ABS(-9223372036854775807 - 1) LIMIT 2);
+}
+expect {
+    1
+}
+
+# Name resolution still runs on the dropped ORDER BY.
+@cross-check-integrity
+test exists-order-by-still-resolves-names {
+    CREATE TABLE t(x);
+    SELECT EXISTS (SELECT x FROM t ORDER BY nosuchcol);
+}
+expect error {
+    no such column: nosuchcol
+}
+
+# With DISTINCT dropped, OFFSET counts plain rows: 3 rows, OFFSET 2 leaves one.
+# Counting the 2 distinct values instead would leave none.
+@cross-check-integrity
+test exists-distinct-offset-counts-plain-rows {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), (1), (2);
+    SELECT EXISTS (SELECT DISTINCT x FROM t ORDER BY x LIMIT 5 OFFSET 2);
+}
+expect {
+    1
+}
+
+# IN subqueries are not EXISTS: their ORDER BY is still evaluated, so the
+# overflowing term fails the statement in both engines.
+@cross-check-integrity
+test in-subquery-order-by-is-still-evaluated {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1);
+    SELECT 1 IN (SELECT x FROM t ORDER BY ABS(-9223372036854775807 - 1));
+}
+expect error {
+    integer overflow
+}

--- a/sqlite/conformance/sqlite-sqltests/in-parenthesized-subquery.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/in-parenthesized-subquery.sqltest
@@ -1,0 +1,56 @@
+@database :memory:
+
+# A single parenthesized subquery on the right of IN is subquery membership,
+# the same as `x IN (SELECT ...)`: an empty subquery yields 0 (or 1 for NOT
+# IN), never NULL. Turso previously parsed `IN ((SELECT ...))` as a value list
+# holding one scalar subquery, so an empty subquery made it return NULL.
+
+@cross-check-integrity
+test in-parenthesized-empty-subquery-is-false {
+    SELECT 5 IN ((SELECT 1 WHERE 0));
+}
+expect {
+    0
+}
+
+@cross-check-integrity
+test in-parenthesized-subquery-no-match {
+    SELECT 5 IN ((SELECT 1 WHERE 1));
+}
+expect {
+    0
+}
+
+@cross-check-integrity
+test in-parenthesized-subquery-match {
+    SELECT 5 IN ((SELECT 5));
+}
+expect {
+    1
+}
+
+@cross-check-integrity
+test not-in-parenthesized-empty-subquery-is-true {
+    SELECT 5 NOT IN ((SELECT 1 WHERE 0));
+}
+expect {
+    1
+}
+
+@cross-check-integrity
+test in-doubly-parenthesized-empty-subquery-is-false {
+    SELECT 5 IN (((SELECT 1 WHERE 0)));
+}
+expect {
+    0
+}
+
+# Two or more elements stay a value list: an empty scalar subquery is NULL, so
+# the whole IN is NULL.
+@cross-check-integrity
+test in-two-element-list-with-empty-subquery-is-null {
+    SELECT 5 IN ((SELECT 1 WHERE 0), (SELECT 2 WHERE 0));
+}
+expect {
+
+}

--- a/sqlite/conformance/sqlite-sqltests/index-seek-null-computed-bound.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/index-seek-null-computed-bound.sqltest
@@ -1,0 +1,54 @@
+@database :memory:
+
+# An index range seek uses a bound expression as its seek key. When that
+# expression evaluates to NULL, no row satisfies the comparison (NULL
+# comparisons are never true), so SQLite guards the seek with an IsNull jump.
+# Turso decided whether to emit that guard with is_nonnull(), which wrongly
+# treated a CASE with no ELSE as never-NULL — but such a CASE yields NULL when
+# no WHEN matches. The seek then ran on a NULL key and returned rows.
+
+@cross-check-integrity
+test case-without-else-bound-is-null-le {
+    CREATE TABLE t(k INTEGER PRIMARY KEY, c REAL);
+    INSERT INTO t VALUES (1, -47175.8);
+    CREATE INDEX i ON t(c);
+    SELECT 1 FROM t WHERE CASE WHEN '' THEN 1 END <= c;
+}
+expect {
+}
+
+@cross-check-integrity
+test case-without-else-bound-is-null-lt {
+    CREATE TABLE t(k INTEGER PRIMARY KEY, c REAL);
+    INSERT INTO t VALUES (1, -47175.8);
+    CREATE INDEX i ON t(c);
+    SELECT 1 FROM t WHERE CASE WHEN '' THEN 1 END < c;
+}
+expect {
+}
+
+# A matching WHEN gives a real bound, so the seek runs normally and returns
+# only the row above it. Select the integer primary key rather than the REAL
+# column, whose "50.0" prints as "50" through some bindings.
+@cross-check-integrity
+test case-with-matching-when-bounds-normally {
+    CREATE TABLE t(k INTEGER PRIMARY KEY, c REAL);
+    INSERT INTO t VALUES (1, 5.0), (2, 50.0);
+    CREATE INDEX i ON t(c);
+    SELECT k FROM t WHERE CASE WHEN 1 THEN 10 END <= c ORDER BY k;
+}
+expect {
+    2
+}
+
+# An ELSE makes the CASE non-null, so it is a valid bound.
+@cross-check-integrity
+test case-with-else-bounds-normally {
+    CREATE TABLE t(k INTEGER PRIMARY KEY, c REAL);
+    INSERT INTO t VALUES (1, 5.0), (2, 50.0);
+    CREATE INDEX i ON t(c);
+    SELECT k FROM t WHERE CASE WHEN '' THEN 1 ELSE 10 END <= c ORDER BY k;
+}
+expect {
+    2
+}

--- a/sqlite/conformance/sqlite-sqltests/index-seek-subquery-affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/index-seek-subquery-affinity.sqltest
@@ -1,0 +1,44 @@
+@database :memory:
+
+# Comparing a TEXT column against a scalar subquery over an INTEGER column
+# uses numeric comparison affinity, so the integer keeps its type and sorts
+# before every text value (SQLite's sqlite3CompareAffinity). When the TEXT
+# column had a UNIQUE index, Turso's index seek ignored the subquery's column
+# affinity, fell back to the TEXT side's affinity, converted the integer to
+# text, and compared '4x' < '602393' as strings — returning rows SQLite does
+# not.
+
+@cross-check-integrity
+test text-index-less-than-integer-subquery-matches-nothing {
+    CREATE TABLE a(t TEXT UNIQUE);
+    INSERT INTO a VALUES ('4x');
+    CREATE TABLE b(i INTEGER);
+    INSERT INTO b VALUES (602393);
+    SELECT 1 FROM a WHERE t < (SELECT i FROM b);
+}
+expect {
+}
+
+@cross-check-integrity
+test text-index-greater-than-integer-subquery-matches-all {
+    CREATE TABLE a(t TEXT UNIQUE);
+    INSERT INTO a VALUES ('4x');
+    CREATE TABLE b(i INTEGER);
+    INSERT INTO b VALUES (602393);
+    SELECT 1 FROM a WHERE t > (SELECT i FROM b);
+}
+expect {
+    1
+}
+
+# A bare integer literal has no affinity of its own, so the TEXT side wins and
+# the comparison happens as text: '4x' < '602393'. This must keep working.
+@cross-check-integrity
+test text-index-less-than-integer-literal-compares-as-text {
+    CREATE TABLE a(t TEXT UNIQUE);
+    INSERT INTO a VALUES ('4x');
+    SELECT 1 FROM a WHERE t < 602393;
+}
+expect {
+    1
+}

--- a/sqlite/conformance/sqlite-sqltests/insert.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/insert.sqltest
@@ -2221,3 +2221,26 @@ test insert-two-partial-unique-indexes-expr-key-no-hang {
 expect {
     1|B|
 }
+
+# A BEFORE trigger updates this table while a multi-row INSERT is choosing an
+# automatic rowid. The new rowid must be one greater than the largest rowid in
+# the table, not based on a cursor position saved before the trigger ran.
+@cross-check-integrity
+test insert-auto-rowid-after-before-trigger-updates-same-table {
+    CREATE TABLE rowid_trigger_target (id INTEGER PRIMARY KEY, value TEXT);
+    INSERT INTO rowid_trigger_target VALUES (591505, 'prior');
+    CREATE TRIGGER rowid_trigger BEFORE INSERT ON rowid_trigger_target BEGIN
+        UPDATE rowid_trigger_target SET value = 'updated';
+    END;
+    INSERT INTO rowid_trigger_target VALUES
+        (-915518, 'first'),
+        (-513681, 'second'),
+        (NULL, 'generated');
+    SELECT id, value FROM rowid_trigger_target ORDER BY id;
+}
+expect {
+    -915518|updated
+    -513681|updated
+    591505|updated
+    591506|generated
+}

--- a/sqlite/conformance/sqlite-sqltests/or-replace-not-null-default-null.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/or-replace-not-null-default-null.sqltest
@@ -1,0 +1,39 @@
+@database :memory:
+
+# OR REPLACE resolves a NOT NULL violation by substituting the column default,
+# but the substituted value must still satisfy NOT NULL. A column can declare
+# DEFAULT (NULL), so the substitution can leave the value NULL — SQLite then
+# aborts. Turso's UPDATE path substituted the default without re-checking, so
+# it stored NULL instead of failing.
+
+@cross-check-integrity
+test update-or-replace-not-null-default-null-aborts {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, c BLOB NOT NULL DEFAULT (NULL));
+    INSERT INTO t VALUES(1, X'AA');
+    UPDATE OR REPLACE t SET c = NULL;
+}
+expect error {
+    NOT NULL constraint failed: t\.c
+}
+
+# A non-null default is substituted normally and the UPDATE succeeds.
+@cross-check-integrity
+test update-or-replace-not-null-default-value-substitutes {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, c INTEGER NOT NULL DEFAULT 7);
+    INSERT INTO t VALUES(1, 100);
+    UPDATE OR REPLACE t SET c = NULL;
+    SELECT c FROM t;
+}
+expect {
+    7
+}
+
+# INSERT OR REPLACE behaves the same way.
+@cross-check-integrity
+test insert-or-replace-not-null-default-null-aborts {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, c BLOB NOT NULL DEFAULT (NULL));
+    INSERT OR REPLACE INTO t VALUES(1, NULL);
+}
+expect error {
+    NOT NULL constraint failed: t\.c
+}

--- a/sqlite/conformance/sqlite-sqltests/returning.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/returning.sqltest
@@ -890,7 +890,10 @@ expect {
     2|11|2
 }
 
-@skip-if sqlite "Turso intentionally exposes same-row AFTER UPDATE trigger writes through UPDATE RETURNING"
+# UPDATE RETURNING reports the row as written by the UPDATE, before the
+# AFTER trigger runs — matching SQLite and Turso's own INSERT RETURNING. The
+# trigger's later +100 shows up in the final SELECT, not in RETURNING.
+@cross-check-integrity
 test update-returning-after-trigger-same-row-direct {
     CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER);
     INSERT INTO t VALUES (1, 10);
@@ -902,11 +905,13 @@ test update-returning-after-trigger-same-row-direct {
     SELECT val FROM t;
 }
 expect {
-    120
+    20
     120
 }
 
-@skip-if sqlite "Turso intentionally exposes same-row AFTER UPDATE trigger writes through UPDATE RETURNING"
+# The RETURNING subquery reads the target table after the write but before the
+# AFTER trigger, so it also sees the UPDATE's new value (20), not the trigger's.
+@cross-check-integrity
 test update-returning-after-trigger-same-row-subquery {
     CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER);
     INSERT INTO t VALUES (1, 10);
@@ -919,7 +924,7 @@ test update-returning-after-trigger-same-row-subquery {
     SELECT val FROM t;
 }
 expect {
-    120|120
+    20|20
     120
 }
 

--- a/sqlite/conformance/sqlite-sqltests/rowid-text-bound-empty-table.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/rowid-text-bound-empty-table.sqltest
@@ -1,0 +1,34 @@
+@database :memory:
+
+# Every integer sorts before every text value, so `rowid <= <text>` is true
+# for all rows and the seek turns into "jump to the last row". On an empty
+# table there is no last row, but Turso reported the seek as found anyway and
+# the scan emitted one garbage row.
+
+@cross-check-integrity
+test rowid-le-text-on-empty-table-returns-nothing {
+    CREATE TABLE b(id INTEGER PRIMARY KEY);
+    SELECT 1 FROM b WHERE id <= '' ORDER BY id DESC;
+}
+expect {
+}
+
+@cross-check-integrity
+test rowid-lt-text-on-empty-table-returns-nothing {
+    CREATE TABLE b(id INTEGER PRIMARY KEY);
+    SELECT 1 FROM b WHERE id < 'x' ORDER BY id DESC;
+}
+expect {
+}
+
+# With a row present, the rewritten seek must still find it.
+@cross-check-integrity
+test rowid-le-text-still-scans-existing-rows {
+    CREATE TABLE b(id INTEGER PRIMARY KEY);
+    INSERT INTO b VALUES (7), (9);
+    SELECT id FROM b WHERE id <= '' ORDER BY id DESC;
+}
+expect {
+    9
+    7
+}

--- a/sqlite/conformance/sqlite-sqltests/temp-trigger-fires-before-main.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/temp-trigger-fires-before-main.sqltest
@@ -1,0 +1,48 @@
+@database :memory:
+
+# TEMP triggers fire before the table's own triggers, and among themselves in
+# creation order; the table's own triggers fire newest-first. SQLite builds
+# its trigger list by walking the temp schema's trigger hash (newest first)
+# and prepending each hit onto the table's own list, which is itself built by
+# prepending at CREATE TRIGGER time. Turso appended temp triggers after the
+# main ones, so when one trigger's changes feed another the final table
+# differed.
+
+@cross-check-integrity
+test temp-triggers-fire-first-in-creation-order {
+    CREATE TABLE t(x);
+    CREATE TABLE log(seq INTEGER PRIMARY KEY AUTOINCREMENT, who TEXT);
+    CREATE TRIGGER main1 BEFORE INSERT ON t BEGIN INSERT INTO log(who) VALUES ('main1'); END;
+    CREATE TRIGGER main2 BEFORE INSERT ON t BEGIN INSERT INTO log(who) VALUES ('main2'); END;
+    CREATE TEMP TRIGGER temp1 BEFORE INSERT ON t BEGIN INSERT INTO log(who) VALUES ('temp1'); END;
+    CREATE TEMP TRIGGER temp2 BEFORE INSERT ON t BEGIN INSERT INTO log(who) VALUES ('temp2'); END;
+    INSERT INTO t VALUES (1);
+    SELECT seq, who FROM log ORDER BY seq;
+}
+expect {
+    1|temp1
+    2|temp2
+    3|main2
+    4|main1
+}
+
+# The order is observable through data: the temp trigger empties the table
+# before the main trigger refills it, so the main trigger's rows survive.
+# In the other order the temp trigger would delete them.
+@cross-check-integrity
+test temp-delete-all-runs-before-main-insert {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+    INSERT INTO t VALUES (1, 'old');
+    CREATE TRIGGER main_tr BEFORE INSERT ON t
+        WHEN NEW.v = 'outer'
+        BEGIN INSERT INTO t(id, v) VALUES (100, 'from-main'); END;
+    CREATE TEMP TRIGGER temp_tr BEFORE INSERT ON t
+        WHEN NEW.v = 'outer'
+        BEGIN DELETE FROM t WHERE v = 'old' OR v = 'from-main'; END;
+    INSERT INTO t VALUES (2, 'outer');
+    SELECT id, v FROM t ORDER BY id;
+}
+expect {
+    2|outer
+    100|from-main
+}

--- a/sqlite/conformance/sqlite-sqltests/temp_trigger.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/temp_trigger.sqltest
@@ -156,6 +156,31 @@ expect {
     big value: 15
 }
 
+# An unqualified TEMP trigger stays with the table found when it is
+# created. A same-named table created later must not take it over.
+test unqualified-temp-trigger-stays-with-attached-table {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.attached_target (x INTEGER);
+    CREATE TEMP TRIGGER attached_trigger AFTER INSERT ON attached_target BEGIN
+        SELECT raise(FAIL, 'wrong table');
+    END;
+
+    CREATE TABLE main.attached_target (x INTEGER);
+    INSERT INTO main.attached_target VALUES (1);
+
+    DROP TABLE main.attached_target;
+    SELECT count(*) FROM temp.sqlite_schema
+        WHERE type = 'trigger' AND name = 'attached_trigger';
+
+    DROP TABLE aux.attached_target;
+    SELECT count(*) FROM temp.sqlite_schema
+        WHERE type = 'trigger' AND name = 'attached_trigger';
+}
+expect {
+    1
+    0
+}
+
 #  regression: DROP TABLE main.t must not wipe temp triggers
 # that target temp.t. `remove_triggers_for_table` used to key only on
 # the table name, so a temp trigger trying to follow `temp.t` was

--- a/sqlite/conformance/sqlite-sqltests/trigger-reevaluates-once-subquery-each-firing.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/trigger-reevaluates-once-subquery-each-firing.sqltest
@@ -1,0 +1,56 @@
+@database :memory:
+
+# A trigger body is inlined and re-executed once per affected row. An
+# uncorrelated subquery inside a trigger WHEN is guarded by a run-once flag so
+# it is evaluated once and its result reused. That flag used to persist across
+# firings, so the WHEN kept reusing the value computed at the first firing
+# instead of re-evaluating against the table as later rows were inserted.
+#
+# Here the inner EXISTS is false at the first firing (no d=1 row yet) and must
+# become true once row (2,1) is inserted. SQLite fires the trigger for rows 2
+# and 3; Turso used to fire for none because it cached the first firing's false.
+
+@cross-check-integrity
+test trigger-when-reevaluates-nested-exists-each-firing {
+    CREATE TABLE tt (pk INTEGER PRIMARY KEY, d INTEGER);
+    CREATE TABLE log (n INTEGER);
+    CREATE TRIGGER trg AFTER INSERT ON tt FOR EACH ROW
+      WHEN EXISTS (SELECT 1 FROM tt WHERE EXISTS (SELECT 1 FROM tt WHERE d) IN (1))
+      BEGIN INSERT INTO log VALUES (NEW.pk); END;
+    INSERT INTO tt (pk, d) VALUES (1, 0), (2, 1), (3, 1);
+    SELECT n FROM log ORDER BY n;
+}
+expect {
+    2
+    3
+}
+
+# Same staleness for a nested uncorrelated IN (SELECT ...), whose ephemeral
+# index is also built under the run-once flag.
+@cross-check-integrity
+test trigger-when-reevaluates-nested-in-subquery-each-firing {
+    CREATE TABLE tt (pk INTEGER PRIMARY KEY, d INTEGER);
+    CREATE TABLE log (n INTEGER);
+    CREATE TRIGGER trg AFTER INSERT ON tt FOR EACH ROW
+      WHEN EXISTS (SELECT 1 FROM tt WHERE pk IN (SELECT pk FROM tt WHERE d))
+      BEGIN INSERT INTO log VALUES (NEW.pk); END;
+    INSERT INTO tt (pk, d) VALUES (1, 0), (2, 1), (3, 1);
+    SELECT n FROM log ORDER BY n;
+}
+expect {
+    2
+    3
+}
+
+# The trigger's body re-inserts a fixed key, so once the WHEN turns true the
+# second firing's INSERT collides with the existing row and aborts — matching
+# SQLite, which used to differ because Turso's WHEN never turned true.
+test trigger-when-turning-true-aborts-on-conflict {
+    CREATE TABLE tt (pk INTEGER PRIMARY KEY, d INTEGER);
+    CREATE TRIGGER trg AFTER INSERT ON tt FOR EACH ROW
+      WHEN EXISTS (SELECT 1 FROM tt WHERE EXISTS (SELECT 1 FROM tt WHERE d) IN (1))
+      BEGIN INSERT INTO tt (pk, d) VALUES (1, 0); END;
+    INSERT INTO tt (pk, d) VALUES (1, 0), (2, 1), (3, 1);
+}
+expect error {
+}

--- a/sqlite/conformance/sqlite-sqltests/update-after-trigger-not-null.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/update-after-trigger-not-null.sqltest
@@ -1,0 +1,32 @@
+@database :memory:
+
+# Regression: an UPDATE on a table with an AFTER UPDATE trigger must still
+# enforce NOT NULL constraints. The NOT NULL check was skipped whenever the
+# table had any update trigger, but it was only re-emitted when a BEFORE
+# trigger existed. A table with only an AFTER trigger therefore dropped the
+# check entirely and stored NULL into a NOT NULL column.
+
+@cross-check-integrity
+test after-update-trigger-still-enforces-not-null {
+    CREATE TABLE t(k INTEGER PRIMARY KEY, n TEXT NOT NULL);
+    INSERT INTO t VALUES(1, 'keep');
+    CREATE TRIGGER tr AFTER UPDATE ON t BEGIN SELECT 1; END;
+    UPDATE t SET n = NULL;
+}
+expect error {
+    NOT NULL constraint failed: t\.n
+}
+
+# OR REPLACE substitutes the column default for a NULL, so this UPDATE
+# succeeds even with an AFTER trigger present.
+@cross-check-integrity
+test after-update-trigger-or-replace-uses-default {
+    CREATE TABLE t(k INTEGER PRIMARY KEY, n TEXT NOT NULL DEFAULT 'def');
+    INSERT INTO t VALUES(1, 'x');
+    CREATE TRIGGER tr AFTER UPDATE ON t BEGIN SELECT 1; END;
+    UPDATE OR REPLACE t SET n = NULL;
+    SELECT n FROM t;
+}
+expect {
+    def
+}

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -466,7 +466,7 @@ set test_files {
   rowhash              fail
   rowid                skip {hangs at rowid-13.1}
   rowvalue             fail
-  rowvalue2            fail
+  rowvalue2            pass
   rowvalue3            fail
   rowvalue4            fail
   rowvalue5            fail
@@ -474,7 +474,7 @@ set test_files {
   rowvalue7            pass
   rowvalue8            fail
   rowvalue9          skip {aborts the harness on an engine panic at core/vdbe/builder.rs:1580}
-  rowvalueA            fail
+  rowvalueA            pass
   rowvaluevtab         fail
   savepoint            fail
   savepoint2           fail
@@ -612,9 +612,9 @@ set test_files {
   tkt-bd484a090c       fail
   tkt-bdc6bbbb38       fail
   tkt-c48d99d690       pass
-  tkt-c694113d5        fail
+  tkt-c694113d5        pass
   tkt-cbd054fa6b       fail
-  tkt-d11f09d36e       fail
+  tkt-d11f09d36e       pass
   tkt-d635236375       pass
   tkt-d82e3f3721       fail
   tkt-f3e5abed55       fail
@@ -685,7 +685,7 @@ set test_files {
   tkt35xx              fail
   tkt3630              pass
   tkt3718              skip {hangs at tkt3718-1.2}
-  tkt3731              fail
+  tkt3731              pass
   tkt3757              fail
   tkt3761              fail
   tkt3762              fail
@@ -704,7 +704,7 @@ set test_files {
   tkt3922              fail
   tkt3929              pass
   tkt3935              fail
-  tkt3992              fail
+  tkt3992              pass
   tkt3997              fail
   tkt4018              fail
   tokenize             fail
@@ -782,7 +782,7 @@ set test_files {
   wal8                 pass
   wal9                 fail
   walbak               fail
-  walbig               fail
+  walbig               pass
   walblock             fail
   walcksum             fail
   walhook              fail

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -897,20 +897,45 @@ while {$__runner_i < [llength $test_files]} {
     continue
   }
 
-  set __runner_errors0 $TC(errors)
-  set __runner_count0 $TC(count)
   set testprefix ""
 
-  # Contain TCL-level crashes (e.g. a missing harness command) so one bad
-  # file cannot abort the whole run.
+  # Run each test file in its own tclsh process. A file that hard-crashes the
+  # engine - a segfault, an abort, a stack overflow, or the OOM killer - takes
+  # down only its own process, so the run keeps going and the report names the
+  # file that died and the signal that killed it, instead of the whole suite
+  # aborting silently with no summary. A plain Tcl error in the file surfaces
+  # the same way, as a non-zero exit.
+  #
+  # Each file is self-contained (it sources tester.tcl and calls finish_test),
+  # so running it standalone prints its own "All N tests passed!" or "N errors
+  # out of M tests" line, which we parse below for this file's counts.
   set __runner_crashed 0
-  if {[catch {source $testdir/$__runner_name.test} __runner_err]} {
+  set __runner_out ""
+  set __runner_rc [catch {
+    exec [info nameofexecutable] $testdir/$__runner_name.test 2>@1
+  } __runner_out __runner_opts]
+  puts $__runner_out
+  if {$__runner_rc
+      && [lindex [dict get $__runner_opts -errorcode] 0] eq "CHILDKILLED"} {
     set __runner_crashed 1
-    puts "CRASH in $__runner_name.test: $__runner_err"
+    set __runner_signal [lindex [dict get $__runner_opts -errorcode] 2]
+    puts "CRASH in $__runner_name.test: killed by signal $__runner_signal"
   }
 
-  set __runner_nerr [expr {$TC(errors) - $__runner_errors0}]
-  set __runner_ntest [expr {$TC(count) - $__runner_count0}]
+  # Derive this file's counts from the summary line its finish_test printed. A
+  # file that crashed before finishing leaves both at 0, and the crash flag
+  # above still marks it.
+  set __runner_ntest 0
+  set __runner_nerr 0
+  if {[regexp {All (\d+) tests passed!} $__runner_out -> __runner_m]} {
+    set __runner_ntest $__runner_m
+  } elseif {[regexp {(\d+) errors out of (\d+) tests} \
+                 $__runner_out -> __runner_e __runner_t]} {
+    set __runner_nerr $__runner_e
+    set __runner_ntest $__runner_t
+  }
+  incr TC(count) $__runner_ntest
+  incr TC(errors) $__runner_nerr
 
   if {$__runner_status eq "pass"} {
     if {$__runner_crashed || $__runner_nerr > 0} {

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -143,6 +143,25 @@ fn new_join_type(n0: &[u8], n1: Option<&[u8]>, n2: Option<&[u8]>) -> Result<Join
     Ok(jt)
 }
 
+/// True if `e` is a bare subquery, possibly wrapped in one or more layers of
+/// single-element parentheses (e.g. `(SELECT ...)`, `((SELECT ...))`).
+fn is_bare_subquery(e: &Expr) -> bool {
+    match e {
+        Expr::Subquery(_) => true,
+        Expr::Parenthesized(inner) => inner.len() == 1 && is_bare_subquery(&inner[0]),
+        _ => false,
+    }
+}
+
+/// Unwrap a bare subquery previously confirmed by [`is_bare_subquery`].
+fn into_bare_subquery(e: Box<Expr>) -> Select {
+    match *e {
+        Expr::Subquery(select) => select,
+        Expr::Parenthesized(mut inner) => into_bare_subquery(inner.pop().expect("single element")),
+        _ => unreachable!("into_bare_subquery called on a non-subquery expression"),
+    }
+}
+
 pub struct Parser<'a> {
     lexer: Lexer<'a>,
 
@@ -2202,6 +2221,21 @@ impl<'a> Parser<'a> {
                                         // Simplified to a constant leaf.
                                         leaf = true;
                                         Box::new(Expr::Literal(Literal::Numeric(name.into())))
+                                    } else if exprs.len() == 1 && is_bare_subquery(&exprs[0]) {
+                                        // `x IN ((SELECT ...))` is subquery membership,
+                                        // the same as `x IN (SELECT ...)`: an empty
+                                        // subquery yields 0/1, not NULL. This matches
+                                        // SQLite. A list of two or more values, or a
+                                        // subquery embedded in a larger expression, stays
+                                        // a value list.
+                                        self.last_expr_height = 1;
+                                        Box::new(Expr::InSelect {
+                                            lhs: result,
+                                            not,
+                                            rhs: into_bare_subquery(
+                                                exprs.into_iter().next().expect("one element"),
+                                            ),
+                                        })
                                     } else {
                                         Box::new(Expr::InList {
                                             lhs: result,

--- a/testing/differential-oracle/fuzzer/Cargo.toml
+++ b/testing/differential-oracle/fuzzer/Cargo.toml
@@ -23,6 +23,7 @@ path = "lib.rs"
 
 [dependencies]
 turso_core = { workspace = true, features = ["simulator"] }
+turso_parser = { workspace = true }
 sql_gen_prop = { path = "../sql_gen_prop" }
 sql_gen = { path = "../sql_gen", features = ["serde"] }
 rusqlite.workspace = true

--- a/testing/differential-oracle/fuzzer/Cargo.toml
+++ b/testing/differential-oracle/fuzzer/Cargo.toml
@@ -18,6 +18,10 @@ path = "printf_fuzzer.rs"
 name = "custom_types_fuzzer"
 path = "custom_types_fuzzer.rs"
 
+[[bin]]
+name = "differential_probe"
+path = "probe.rs"
+
 [lib]
 path = "lib.rs"
 

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -51,6 +51,31 @@ pub struct SqlGenBackend {
     policy: Policy,
 }
 
+fn disable_alter_actions_that_revalidate_schema(policy: &mut Policy) {
+    policy.alter_table_config.action_weights.rename_table = 0;
+    policy.alter_table_config.action_weights.drop_column = 0;
+    policy.alter_table_config.action_weights.rename_column = 0;
+}
+
+fn disable_prop_alter_actions_that_revalidate_schema(profile: &mut sql_gen_prop::StatementProfile) {
+    profile.alter_table.extra.rename_to = 0;
+    profile.alter_table.extra.drop_column = 0;
+    profile.alter_table.extra.rename_column = 0;
+}
+
+/// True when two tables share a name in different database scopes, e.g. a TEMP
+/// table shadowing a permanent table of the same name. SQLite resolves the
+/// shared name to the temp table, so re-validating an index or trigger that
+/// belongs to the permanent table can fail against the temp table's columns.
+fn schema_has_a_shadowed_table_name(schema: &sql_gen::Schema) -> bool {
+    schema.tables.iter().any(|table| {
+        schema
+            .tables
+            .iter()
+            .any(|other| other.name == table.name && other.database != table.database)
+    })
+}
+
 impl SqlGenBackend {
     pub fn new(seed: u64) -> Self {
         Self::new_with_window_weight(seed, 0.0)
@@ -103,7 +128,23 @@ impl SqlGenBackend {
 
 impl SqlGenerator for SqlGenBackend {
     fn generate(&mut self, schema: &sql_gen::Schema) -> Result<GeneratedStatement> {
-        let generator: SqlGen<Full> = SqlGen::new(schema.clone(), self.policy.clone());
+        let mut policy = self.policy.clone();
+        if !schema.triggers.is_empty() || schema_has_a_shadowed_table_name(schema) {
+            // SQLite re-resolves every stored index and trigger during a table
+            // rename, column rename, or column drop. Turso does not, so it may
+            // accept an ALTER that SQLite rejects. Two situations hit this:
+            //   - A trigger body refers to a table that was dropped earlier.
+            //     The fuzzer records the table a trigger belongs to, but not
+            //     every table and column its body uses, so it cannot tell
+            //     whether a DROP left a trigger broken.
+            //   - A TEMP table shadows a permanent table of the same name.
+            //     SQLite re-resolves an index or trigger on the permanent table
+            //     against the temp table, which lacks the column.
+            // Do not generate these ALTER actions in either case. Separate
+            // tests still cover them with schemas that are known to be valid.
+            disable_alter_actions_that_revalidate_schema(&mut policy);
+        }
+        let generator: SqlGen<Full> = SqlGen::new(schema.clone(), policy);
         let stmt = generator
             .statement(&mut self.ctx)
             .map_err(|e| anyhow::anyhow!("Failed to generate statement: {e}"))?;
@@ -178,14 +219,15 @@ impl PropTestBackend {
 impl SqlGenerator for PropTestBackend {
     fn generate(&mut self, schema: &sql_gen::Schema) -> Result<GeneratedStatement> {
         let prop_schema = to_prop_schema(schema);
-        let bootstrap_profile;
-        let profile = if self.recursive_cte_focus && prop_schema.tables.is_empty() {
-            bootstrap_profile = sql_gen_prop::StatementProfile::default();
-            &bootstrap_profile
+        let mut profile = if self.recursive_cte_focus && prop_schema.tables.is_empty() {
+            sql_gen_prop::StatementProfile::default()
         } else {
-            &self.profile
+            self.profile.clone()
         };
-        let strategy = sql_gen_prop::strategies::statement_for_schema(&prop_schema, profile);
+        if !schema.triggers.is_empty() || schema_has_a_shadowed_table_name(schema) {
+            disable_prop_alter_actions_that_revalidate_schema(&mut profile);
+        }
+        let strategy = sql_gen_prop::strategies::statement_for_schema(&prop_schema, &profile);
         let value_tree = strategy
             .new_tree(&mut self.test_runner)
             .map_err(|e| anyhow::anyhow!("Failed to generate statement: {e}"))?;
@@ -286,6 +328,14 @@ fn to_prop_schema(schema: &sql_gen::Schema) -> sql_gen_prop::Schema {
         }
         builder = builder.add_index(idx);
     }
+    for trigger in &schema.triggers {
+        let mut prop_trigger =
+            sql_gen_prop::Trigger::new(trigger.name.clone(), trigger.table_name.clone());
+        if let Some(db) = &trigger.database {
+            prop_trigger = prop_trigger.in_database(db.clone());
+        }
+        builder = builder.add_trigger(prop_trigger);
+    }
     builder.build()
 }
 
@@ -298,5 +348,47 @@ mod tests {
         let sql_gen = SqlGenBackend::new(1);
         assert_eq!(sql_gen.policy.update_config.or_ignore_probability, 0.0);
         assert_eq!(sql_gen.policy.update_config.self_join_probability, 0.0);
+    }
+
+    #[test]
+    fn disabling_alter_actions_leaves_add_column_enabled() {
+        let mut policy = Policy::default();
+        disable_alter_actions_that_revalidate_schema(&mut policy);
+        assert_eq!(policy.alter_table_config.action_weights.rename_table, 0);
+        assert_eq!(policy.alter_table_config.action_weights.drop_column, 0);
+        assert_eq!(policy.alter_table_config.action_weights.rename_column, 0);
+        assert_ne!(policy.alter_table_config.action_weights.add_column, 0);
+
+        let mut profile = sql_gen_prop::StatementProfile::default();
+        disable_prop_alter_actions_that_revalidate_schema(&mut profile);
+        assert_eq!(profile.alter_table.extra.rename_to, 0);
+        assert_eq!(profile.alter_table.extra.drop_column, 0);
+        assert_eq!(profile.alter_table.extra.rename_column, 0);
+        assert_ne!(profile.alter_table.extra.add_column, 0);
+    }
+
+    #[test]
+    fn a_temp_table_shadowing_a_permanent_one_counts_as_shadowed() {
+        use sql_gen::{ColumnDef, DataType, Table};
+        let make = |name: &str, database: Option<&str>| Table {
+            name: name.to_string(),
+            columns: vec![ColumnDef::new("x", DataType::Integer)],
+            database: database.map(str::to_string),
+            strict: false,
+        };
+
+        // Same name in main and temp scopes: shadowed.
+        let schema = sql_gen::Schema {
+            tables: vec![make("t", None), make("t", Some("temp"))],
+            ..Default::default()
+        };
+        assert!(schema_has_a_shadowed_table_name(&schema));
+
+        // Distinct names, and the same name in one scope only: not shadowed.
+        let schema = sql_gen::Schema {
+            tables: vec![make("t", None), make("u", Some("temp"))],
+            ..Default::default()
+        };
+        assert!(!schema_has_a_shadowed_table_name(&schema));
     }
 }

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -175,13 +175,17 @@ impl SqlGenBackend {
         // Boost UPDATE FROM coverage
         policy.update_config.from_probability = 0.4;
         policy.update_config.returning_probability = 0.2;
-        // An UPDATE FROM self-join can find several source rows for one row
-        // being updated. SQLite allows any one of them to supply the new
-        // values, so Turso may make a different but equally valid choice.
-        // UPDATE FROM with two different tables remains enabled.
+        // An UPDATE ... FROM whose source matches a target row several times
+        // uses one of them, chosen by scan order. For a single source table the
+        // generator forces NOT INDEXED so both engines do a rowid-order table
+        // scan and agree. That does not extend to joins: Turso builds an
+        // ephemeral index to evaluate a JOIN while SQLite scans, so the match
+        // order still differs and NOT INDEXED (which only pins base-table
+        // access) cannot align them. Keep UPDATE FROM to a single real table:
+        // no joins, no self-joins, and no subquery sources.
         policy.update_config.self_join_probability = 0.0;
-        policy.update_config.join_in_from_probability = 0.3;
-        policy.update_config.subquery_from_probability = 0.15;
+        policy.update_config.join_in_from_probability = 0.0;
+        policy.update_config.subquery_from_probability = 0.0;
         policy.update_config.target_alias_probability = 0.2;
         policy.update_config.from_set_reference_probability = 0.5;
         Self { ctx, policy }

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -34,6 +34,65 @@ pub enum GeneratorKind {
     SqlGenProp,
 }
 
+/// A named mix of top-level statement weights. Each profile stresses a
+/// different part of the engine so CI can cover several statement mixes
+/// instead of the single default distribution. Profiles are static, so a
+/// failing run reproduces from its seed once the same profile is selected.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum WeightProfile {
+    /// The general-purpose mix: mostly reads and writes, a little DDL.
+    #[default]
+    Balanced,
+    /// Heavy schema churn: create/drop/alter tables and indexes.
+    Ddl,
+    /// Heavy trigger creation plus writes, so triggers fire often.
+    Triggers,
+    /// Heavy insert/update/delete to stress constraint and conflict paths.
+    Writes,
+}
+
+impl WeightProfile {
+    /// The top-level statement weights for this profile. Transaction and
+    /// not-yet-implemented statements stay at 0, matching the fuzzer's scope.
+    fn stmt_weights(self) -> sql_gen::StmtWeights {
+        let base = |select,
+                    insert,
+                    update,
+                    delete,
+                    create_table,
+                    drop_table,
+                    alter_table,
+                    create_index,
+                    drop_index,
+                    pragma_foreign_key_list,
+                    create_trigger,
+                    drop_trigger| {
+            sql_gen::StmtWeights {
+                select,
+                insert,
+                update,
+                delete,
+                create_table,
+                drop_table,
+                alter_table,
+                create_index,
+                drop_index,
+                pragma_foreign_key_list,
+                create_trigger,
+                drop_trigger,
+                ..sql_gen::StmtWeights::default()
+            }
+        };
+        match self {
+            //                sel ins upd del  ct dt at  ci di pfk cg dg
+            WeightProfile::Balanced => base(40, 20, 30, 10, 2, 1, 1, 2, 1, 1, 1, 1),
+            WeightProfile::Ddl => base(15, 20, 10, 10, 20, 12, 20, 15, 10, 5, 5, 3),
+            WeightProfile::Triggers => base(10, 25, 25, 20, 8, 3, 3, 5, 2, 2, 30, 10),
+            WeightProfile::Writes => base(10, 35, 30, 20, 5, 2, 3, 5, 2, 1, 5, 3),
+        }
+    }
+}
+
 /// Trait abstracting SQL generation backends.
 pub trait SqlGenerator {
     /// Generate the next SQL statement given the current schema.
@@ -78,19 +137,22 @@ fn schema_has_a_shadowed_table_name(schema: &sql_gen::Schema) -> bool {
 
 impl SqlGenBackend {
     pub fn new(seed: u64) -> Self {
-        Self::new_with_window_weight(seed, 0.0)
+        Self::new_with_window_weight(seed, 0.0, WeightProfile::default())
     }
 
     /// Construct with a non-zero probability that each expression-list
-    /// result column is a window function. Used by the window-function-
-    /// focused fuzzing path.
-    pub fn new_with_window_weight(seed: u64, window_function_probability: f64) -> Self {
+    /// result column is a window function (used by the window-function-
+    /// focused fuzzing path) and a chosen statement-weight profile.
+    pub fn new_with_window_weight(
+        seed: u64,
+        window_function_probability: f64,
+        profile: WeightProfile,
+    ) -> Self {
         let ctx = sql_gen::Context::new_with_seed(seed);
+        let stmt_weights = profile.stmt_weights();
+        tracing::info!("Statement weight profile {profile:?}: {stmt_weights:?}");
         let mut policy = Policy::default()
-            .with_stmt_weights(sql_gen::StmtWeights {
-                update: 30,
-                ..sql_gen::StmtWeights::default()
-            })
+            .with_stmt_weights(stmt_weights)
             .with_function_config(
                 sql_gen::FunctionConfig::deterministic().disable(&["LIKELY", "UNLIKELY"]),
             );
@@ -390,5 +452,37 @@ mod tests {
             ..Default::default()
         };
         assert!(!schema_has_a_shadowed_table_name(&schema));
+    }
+
+    #[test]
+    fn every_profile_can_read_and_write() {
+        // A profile that never selects, inserts, updates, or deletes would
+        // generate an empty or read-only workload and quietly cover nothing.
+        for profile in [
+            WeightProfile::Balanced,
+            WeightProfile::Ddl,
+            WeightProfile::Triggers,
+            WeightProfile::Writes,
+        ] {
+            let w = profile.stmt_weights();
+            assert!(w.select > 0, "{profile:?} never selects");
+            assert!(w.insert > 0, "{profile:?} never inserts");
+            assert!(w.update > 0, "{profile:?} never updates");
+            assert!(w.delete > 0, "{profile:?} never deletes");
+        }
+    }
+
+    #[test]
+    fn profiles_emphasize_their_theme() {
+        let ddl = WeightProfile::Ddl.stmt_weights();
+        assert!(
+            ddl.create_table > WeightProfile::Balanced.stmt_weights().create_table,
+            "ddl profile should create tables more often than balanced"
+        );
+        let triggers = WeightProfile::Triggers.stmt_weights();
+        assert!(
+            triggers.create_trigger > WeightProfile::Balanced.stmt_weights().create_trigger,
+            "triggers profile should create triggers more often than balanced"
+        );
     }
 }

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -80,11 +80,19 @@ impl SqlGenBackend {
         policy.insert_config.or_ignore_probability = 0.0;
         policy.update_config.expression_value_probability = 0.0;
         policy.update_config.or_replace_probability = 0.1;
-        policy.update_config.or_ignore_probability = 0.1;
+        // If several rows try to set the same UNIQUE value, OR IGNORE keeps
+        // whichever row is visited first. SQLite and Turso may visit the rows
+        // in a different order. Both results are allowed, but the final tables
+        // do not match.
+        policy.update_config.or_ignore_probability = 0.0;
         // Boost UPDATE FROM coverage
         policy.update_config.from_probability = 0.4;
         policy.update_config.returning_probability = 0.2;
-        policy.update_config.self_join_probability = 0.3;
+        // An UPDATE FROM self-join can find several source rows for one row
+        // being updated. SQLite allows any one of them to supply the new
+        // values, so Turso may make a different but equally valid choice.
+        // UPDATE FROM with two different tables remains enabled.
+        policy.update_config.self_join_probability = 0.0;
         policy.update_config.join_in_from_probability = 0.3;
         policy.update_config.subquery_from_probability = 0.15;
         policy.update_config.target_alias_probability = 0.2;
@@ -279,4 +287,16 @@ fn to_prop_schema(schema: &sql_gen::Schema) -> sql_gen_prop::Schema {
         builder = builder.add_index(idx);
     }
     builder.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn updates_that_can_choose_different_rows_are_disabled() {
+        let sql_gen = SqlGenBackend::new(1);
+        assert_eq!(sql_gen.policy.update_config.or_ignore_probability, 0.0);
+        assert_eq!(sql_gen.policy.update_config.self_join_probability, 0.0);
+    }
 }

--- a/testing/differential-oracle/fuzzer/lib.rs
+++ b/testing/differential-oracle/fuzzer/lib.rs
@@ -9,7 +9,7 @@ pub mod printf_gen;
 pub mod runner;
 pub mod schema;
 
-pub use generate::{GeneratedStatement, GeneratorKind, SqlGenerator};
+pub use generate::{GeneratedStatement, GeneratorKind, SqlGenerator, WeightProfile};
 pub use memory::{MemorySimFile, MemorySimIO, SimIO};
 pub use oracle::{DifferentialOracle, Oracle, OracleResult, check_differential};
 pub use runner::{Fuzzer, SimConfig, SimStats, TreeMode};

--- a/testing/differential-oracle/fuzzer/lib.rs
+++ b/testing/differential-oracle/fuzzer/lib.rs
@@ -8,6 +8,7 @@ pub mod oracle;
 pub mod printf_gen;
 pub mod runner;
 pub mod schema;
+pub mod shrink;
 
 pub use generate::{GeneratedStatement, GeneratorKind, SqlGenerator, WeightProfile};
 pub use memory::{MemorySimFile, MemorySimIO, SimIO};

--- a/testing/differential-oracle/fuzzer/main.rs
+++ b/testing/differential-oracle/fuzzer/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use differential_fuzzer::{Fuzzer, GeneratorKind, SimConfig, TreeMode};
+use differential_fuzzer::{Fuzzer, GeneratorKind, SimConfig, TreeMode, WeightProfile};
 use rand::RngCore;
 use serde::Serialize;
 
@@ -68,6 +68,12 @@ struct Args {
     /// Focus sql-gen-prop on bounded recursive CTE SELECT workloads.
     #[arg(long, requires = "generator")]
     recursive_cte_focus: bool,
+
+    /// Named statement-weight mix to generate with. Each profile stresses a
+    /// different part of the engine. A failing seed reproduces under the same
+    /// profile.
+    #[arg(long, default_value = "balanced", value_enum)]
+    profile: WeightProfile,
 }
 
 #[derive(Subcommand, Debug)]
@@ -105,6 +111,7 @@ struct ConfigRecord {
     generator: String,
     mvcc: bool,
     recursive_cte_focus: bool,
+    profile: String,
 }
 
 /// Summary written to the JSON report file.
@@ -124,6 +131,7 @@ impl ConfigRecord {
             generator: format!("{:?}", args.generator),
             mvcc: args.mvcc,
             recursive_cte_focus: args.recursive_cte_focus,
+            profile: format!("{:?}", args.profile),
         }
     }
 }
@@ -257,6 +265,7 @@ fn run_single_inner(args: &Args) -> Result<differential_fuzzer::SimStats> {
         mvcc: args.mvcc,
         window_function_probability: args.window_function_probability.clamp(0.0, 1.0),
         recursive_cte_focus: args.recursive_cte_focus,
+        weight_profile: args.profile,
     };
 
     tracing::info!("Starting differential_fuzzer with config: {:?}", config);

--- a/testing/differential-oracle/fuzzer/main.rs
+++ b/testing/differential-oracle/fuzzer/main.rs
@@ -137,6 +137,21 @@ impl ConfigRecord {
 }
 
 fn main() -> Result<()> {
+    // Preparing a deeply nested expression recurses once per nesting level,
+    // and debug-build parser frames are large enough that a statement within
+    // Turso's expression depth limit can still blow the default 8 MiB stack.
+    // Run everything on a thread with plenty of stack; statements over the
+    // depth limit still get the parser's clean "expression tree is too large"
+    // error and are skipped. The memory is only committed as it is used.
+    std::thread::Builder::new()
+        .name("fuzzer".to_string())
+        .stack_size(256 * 1024 * 1024)
+        .spawn(fuzzer_main)?
+        .join()
+        .expect("fuzzer thread panicked")
+}
+
+fn fuzzer_main() -> Result<()> {
     // Initialize tracing
     let mut subscriber = tracing_subscriber::fmt().with_env_filter(
         tracing_subscriber::EnvFilter::from_default_env()

--- a/testing/differential-oracle/fuzzer/oracle.rs
+++ b/testing/differential-oracle/fuzzer/oracle.rs
@@ -23,6 +23,8 @@ use crate::generate::GeneratedStatement;
 pub enum OracleResult {
     /// The oracle check passed.
     Pass,
+    /// EXPLAIN failed in at least one engine, so neither engine ran the statement.
+    Skipped(String),
     /// The oracle check passed but with a warning (e.g., LIMIT without ORDER BY).
     Warning(String),
     /// The oracle check failed with a reason.
@@ -32,6 +34,10 @@ pub enum OracleResult {
 impl OracleResult {
     pub fn is_pass(&self) -> bool {
         matches!(self, OracleResult::Pass)
+    }
+
+    pub fn is_skipped(&self) -> bool {
+        matches!(self, OracleResult::Skipped(_))
     }
 
     pub fn is_warning(&self) -> bool {
@@ -188,6 +194,27 @@ fn short_sql(sql: &str, max_chars: usize) -> String {
         out.push(ch);
     }
     out
+}
+
+fn format_skipped_statement(
+    stmt: &GeneratedStatement,
+    turso_error: Option<&str>,
+    sqlite_error: Option<&str>,
+) -> String {
+    let error_prefix = |error: &str| {
+        let error = error
+            .find(&stmt.sql)
+            .map(|sql_start| error[..sql_start].trim_end_matches(" in ").trim())
+            .unwrap_or(error);
+        short_sql(error, 240)
+    };
+    let turso_error = turso_error.map(error_prefix);
+    let sqlite_error = sqlite_error.map(error_prefix);
+    format!(
+        "Statement skipped because EXPLAIN failed: sql_hash={:016x} Turso error={turso_error:?} SQLite error={sqlite_error:?}\n  SQL: {}",
+        sql_hash(&stmt.sql),
+        short_sql(&stmt.sql, 240),
+    )
 }
 
 fn format_nondet_limit_warning(
@@ -378,6 +405,32 @@ pub fn check_differential(
     schema: &Schema,
     stmt: &GeneratedStatement,
 ) -> OracleResult {
+    // Generated SQL can contain an error in a branch that never runs. SQLite
+    // may remove that branch before checking it, while Turso may reject it.
+    // If the accepted statement writes data, running it in only one database
+    // would spoil every comparison that follows. EXPLAIN asks each engine to
+    // prepare the statement without changing data. Run it only if both agree
+    // that it can run.
+    let explain_sql = format!("EXPLAIN {}", stmt.sql);
+    let turso_explain = DifferentialOracle::execute_turso(turso_conn, &explain_sql);
+    let sqlite_explain = DifferentialOracle::execute_sqlite(sqlite_conn, &explain_sql);
+    match (&turso_explain, &sqlite_explain) {
+        (QueryResult::Error(turso_error), QueryResult::Error(sqlite_error)) => {
+            return OracleResult::Skipped(format_skipped_statement(
+                stmt,
+                Some(turso_error),
+                Some(sqlite_error),
+            ));
+        }
+        (QueryResult::Error(turso_error), _) => {
+            return OracleResult::Skipped(format_skipped_statement(stmt, Some(turso_error), None));
+        }
+        (_, QueryResult::Error(sqlite_error)) => {
+            return OracleResult::Skipped(format_skipped_statement(stmt, None, Some(sqlite_error)));
+        }
+        _ => {}
+    }
+
     let turso_result = DifferentialOracle::execute_turso(turso_conn, &stmt.sql);
     let sqlite_result = DifferentialOracle::execute_sqlite(sqlite_conn, &stmt.sql);
 
@@ -421,7 +474,13 @@ mod tests {
     fn test_oracle_result() {
         assert!(OracleResult::Pass.is_pass());
         assert!(!OracleResult::Pass.is_fail());
+        assert!(!OracleResult::Pass.is_skipped());
         assert!(!OracleResult::Pass.is_warning());
+
+        assert!(OracleResult::Skipped("test".into()).is_skipped());
+        assert!(!OracleResult::Skipped("test".into()).is_pass());
+        assert!(!OracleResult::Skipped("test".into()).is_fail());
+        assert!(!OracleResult::Skipped("test".into()).is_warning());
 
         assert!(OracleResult::Warning("test".into()).is_warning());
         assert!(!OracleResult::Warning("test".into()).is_pass());
@@ -515,5 +574,58 @@ mod tests {
             result.is_fail(),
             "post-DML state verification should catch hidden row mismatches"
         );
+    }
+
+    #[test]
+    fn statement_rejected_by_one_engine_is_skipped() {
+        let io = Arc::new(MemorySimIO::new(456));
+        let turso_db = Database::open_file_with_flags(
+            io,
+            "oracle-validation-skip.db",
+            turso_core::OpenFlags::default(),
+            turso_core::DatabaseOpts::new(),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let turso_conn = turso_db.connect().unwrap();
+        let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+        let schema = SchemaBuilder::new()
+            .table(Table::new(
+                "t",
+                vec![ColumnDef::new("a", DataType::Integer)],
+            ))
+            .build();
+
+        for sql in ["CREATE TABLE t(a)", "INSERT INTO t VALUES (1)"] {
+            assert!(matches!(
+                DifferentialOracle::execute_turso(&turso_conn, sql),
+                QueryResult::Ok
+            ));
+            assert!(matches!(
+                DifferentialOracle::execute_sqlite(&sqlite_conn, sql),
+                QueryResult::Ok
+            ));
+        }
+
+        let stmt = GeneratedStatement {
+            sql: "WITH cte(x) AS (SELECT 1, 2) \
+                  UPDATE t SET a = 2 WHERE 0 AND EXISTS (SELECT * FROM cte)"
+                .to_string(),
+            is_ddl: false,
+            mutates_data: true,
+            has_unordered_limit: false,
+            unordered_limit_reason: None,
+        };
+
+        let result = check_differential(&turso_conn, &sqlite_conn, &schema, &stmt);
+        match result {
+            OracleResult::Skipped(reason) => {
+                assert!(reason.contains("Statement skipped because EXPLAIN failed"));
+                assert!(reason.contains("Turso error=Some"));
+                assert!(reason.contains("SQLite error=None"));
+            }
+            other => panic!("expected skipped statement, got {other:?}"),
+        }
     }
 }

--- a/testing/differential-oracle/fuzzer/probe.rs
+++ b/testing/differential-oracle/fuzzer/probe.rs
@@ -1,0 +1,101 @@
+//! Run a SQL script on Turso and SQLite side by side and show where they
+//! disagree.
+//!
+//! This is the follow-up tool to a fuzzer failure: `minimized.sql` (or any
+//! statement-per-line script) goes in, and every statement's outcome on both
+//! engines comes out, with divergences marked. Unlike the tursodb shell, the
+//! Turso connection here has ATTACH enabled and an `aux` in-memory database
+//! attached when the script asks for one, so fuzzer reproductions run
+//! unmodified.
+//!
+//! Usage:
+//!
+//!     cargo run -q -p differential-fuzzer --bin differential_probe -- \
+//!         simulator-output/minimized.sql
+//!
+//! With no argument the script is read from stdin. Statements are one per
+//! line; lines starting with `--` are skipped. The exit code is 1 when any
+//! statement diverged or the final table contents differ, 0 otherwise.
+
+use std::io::Read;
+
+use anyhow::Result;
+use differential_fuzzer::oracle::QueryResult;
+use differential_fuzzer::shrink::{EnginePair, query_results_differ};
+
+fn brief(result: &QueryResult) -> String {
+    match result {
+        QueryResult::Ok => "ok (no rows)".to_string(),
+        QueryResult::Error(e) => format!("error: {}", e.lines().next().unwrap_or("")),
+        QueryResult::Rows(rows) => {
+            let mut out = format!("{} row(s): ", rows.len());
+            for (i, row) in rows.iter().take(4).enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push_str(&format!("{:?}", row.0));
+            }
+            if rows.len() > 4 {
+                out.push_str(", ...");
+            }
+            if out.len() > 300 {
+                out.truncate(300);
+                out.push_str("...");
+            }
+            out
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let script = match std::env::args().nth(1) {
+        Some(path) => std::fs::read_to_string(&path)?,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin().read_to_string(&mut buf)?;
+            buf
+        }
+    };
+
+    // An empty state: the script itself builds everything.
+    let pair = EnginePair::build("")?;
+    let mut divergences = 0usize;
+
+    for (lineno, line) in script.lines().enumerate() {
+        let stmt = line.trim();
+        if stmt.is_empty() || stmt.starts_with("--") {
+            continue;
+        }
+        let (turso, sqlite) = pair.run_both(stmt);
+        let statement_diverges = match (&turso, &sqlite) {
+            (QueryResult::Error(_), QueryResult::Error(_)) => false,
+            (QueryResult::Error(_), _) | (_, QueryResult::Error(_)) => true,
+            _ => query_results_differ(&turso, &sqlite),
+        };
+        let show = if stmt.len() > 160 {
+            format!("{}...", &stmt[..160])
+        } else {
+            stmt.to_string()
+        };
+        println!("line {:>3}: {show}", lineno + 1);
+        println!("  turso : {}", brief(&turso));
+        println!("  sqlite: {}", brief(&sqlite));
+        if statement_diverges {
+            divergences += 1;
+            println!("  ^^^ DIVERGES");
+        }
+    }
+
+    if pair.states_differ() {
+        divergences += 1;
+        println!("final table contents DIVERGE between the engines");
+    } else {
+        println!("final table contents match");
+    }
+
+    if divergences > 0 {
+        println!("{divergences} divergence(s)");
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -480,8 +480,9 @@ impl Fuzzer {
     /// On an oracle failure, dump each engine's full state as reconstructable
     /// SQL (turso-state.sql, sqlite-state.sql). This captures main, temp, and
     /// aux tables with all rows, so a divergence that depends on accumulated
-    /// state can be replayed as a small self-contained script.
-    fn dump_failure_state(&self, schema: &sql_gen::Schema, failing_sql: &str) {
+    /// state can be replayed as a small self-contained script. Returns the
+    /// SQLite-side dump, which the shrinker uses as its replay baseline.
+    fn dump_failure_state(&self, schema: &sql_gen::Schema, failing_sql: &str) -> String {
         let turso_conn = self.turso_conn.clone();
         let turso_query = move |sql: &str, ncols: usize| turso_text_rows(&turso_conn, sql, ncols);
         let turso_dump = build_state_dump(schema, failing_sql, &turso_query);
@@ -489,8 +490,8 @@ impl Fuzzer {
             |sql: &str, ncols: usize| sqlite_text_rows(&self.sqlite_conn, sql, ncols);
         let sqlite_dump = build_state_dump(schema, failing_sql, &sqlite_query);
         for (name, body) in [
-            ("turso-state.sql", turso_dump),
-            ("sqlite-state.sql", sqlite_dump),
+            ("turso-state.sql", turso_dump.as_str()),
+            ("sqlite-state.sql", sqlite_dump.as_str()),
         ] {
             let path = self.out_dir.join(name);
             if let Err(e) = std::fs::write(&path, body) {
@@ -498,6 +499,33 @@ impl Fuzzer {
             } else {
                 tracing::info!("Wrote state dump to {}", path.display());
             }
+        }
+        sqlite_dump
+    }
+
+    /// Minimize the failing statement against the dumped state and write the
+    /// result (state script + minimized statement) to minimized.sql.
+    fn shrink_and_write(&self, state_dump: &str, failing_sql: &str) {
+        match crate::shrink::shrink_statement(state_dump, failing_sql) {
+            Ok(Some(minimized)) => {
+                let path = self.out_dir.join("minimized.sql");
+                let body = format!(
+                    "{}\n-- MINIMIZED STATEMENT:\n{};\n",
+                    minimized.state_sql, minimized.statement
+                );
+                if let Err(e) = std::fs::write(&path, body) {
+                    tracing::warn!("Failed to write {}: {e}", path.display());
+                } else {
+                    tracing::info!(
+                        "Wrote minimized reproduction ({} state lines, {} byte statement) to {}",
+                        minimized.state_sql.lines().count(),
+                        minimized.statement.len(),
+                        path.display()
+                    );
+                }
+            }
+            Ok(None) => {}
+            Err(e) => tracing::warn!("Shrinking failed: {e}"),
         }
     }
 
@@ -627,7 +655,8 @@ impl Fuzzer {
                     if !self.config.verbose {
                         tracing::error!("Failing SQL: {}", stmt.sql);
                     }
-                    self.dump_failure_state(&schema, &stmt.sql);
+                    let state_dump = self.dump_failure_state(&schema, &stmt.sql);
+                    self.shrink_and_write(&state_dump, &stmt.sql);
                     return Err(anyhow::anyhow!("Oracle failure: {reason}"));
                 }
             }

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -85,6 +85,8 @@ impl Default for SimConfig {
 pub struct SimStats {
     /// Number of statements executed.
     pub statements_executed: usize,
+    /// Number of statements skipped because EXPLAIN failed in at least one engine.
+    pub statements_skipped: usize,
     /// Number of oracle warnings (e.g., LIMIT without ORDER BY mismatches).
     pub warnings: usize,
     /// Number of oracle failures.
@@ -134,6 +136,10 @@ impl SimStats {
         table.add_row(vec![
             Cell::new("Statements Executed").fg(Color::Blue),
             Cell::new(self.statements_executed).fg(Color::Blue),
+        ]);
+        table.add_row(vec![
+            Cell::new("Statements Skipped").fg(Color::Yellow),
+            Cell::new(self.statements_skipped).fg(Color::Yellow),
         ]);
 
         // Warnings - yellow if any
@@ -413,6 +419,13 @@ impl Fuzzer {
                 OracleResult::Pass => {
                     stats.statements_executed += 1;
                     executed_sql.push(stmt.sql.clone());
+                }
+                OracleResult::Skipped(reason) => {
+                    stats.statements_skipped += 1;
+                    push_warning_comments(executed_sql, i, &reason);
+                    executed_sql.push(format!("-- SKIPPED: {}", stmt.sql));
+                    tracing::debug!("Skipped generated statement {i}: {reason}");
+                    continue;
                 }
                 OracleResult::Warning(reason) => {
                     stats.statements_executed += 1;

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -35,6 +35,141 @@ fn generated_sql_is_too_large(sql: &str) -> bool {
     sql.len() > MAX_GENERATED_SQL_BYTES
 }
 
+/// Run `sql` on Turso and return each row as a vector of `ncols` text columns.
+/// Used by the failure-state dumper, whose queries only ever select text.
+fn turso_text_rows(
+    conn: &Arc<turso_core::Connection>,
+    sql: &str,
+    ncols: usize,
+) -> Vec<Vec<String>> {
+    let mut out = Vec::new();
+    let Ok(mut stmt) = conn.prepare(sql) else {
+        return out;
+    };
+    let _ = stmt.run_with_row_callback(|row| {
+        let mut cols = Vec::with_capacity(ncols);
+        for c in 0..ncols {
+            cols.push(match row.get_value(c).clone() {
+                turso_core::Value::Text(s) => s.as_str().to_string(),
+                turso_core::Value::Null => String::new(),
+                other => format!("{other:?}"),
+            });
+        }
+        out.push(cols);
+        Ok(())
+    });
+    out
+}
+
+/// Same as [`turso_text_rows`] but for the SQLite reference connection.
+fn sqlite_text_rows(conn: &rusqlite::Connection, sql: &str, ncols: usize) -> Vec<Vec<String>> {
+    let mut out = Vec::new();
+    let Ok(mut stmt) = conn.prepare(sql) else {
+        return out;
+    };
+    let Ok(mut rows) = stmt.query([]) else {
+        return out;
+    };
+    while let Ok(Some(r)) = rows.next() {
+        let mut cols = Vec::with_capacity(ncols);
+        for c in 0..ncols {
+            cols.push(
+                r.get::<_, Option<String>>(c)
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default(),
+            );
+        }
+        out.push(cols);
+    }
+    out
+}
+
+/// The sqlite_master query for one object kind in one database.
+fn state_ddl_query(db: &str, kind: &str) -> String {
+    let master = if db == "main" {
+        "sqlite_master".to_string()
+    } else {
+        format!("{db}.sqlite_master")
+    };
+    format!("SELECT name, sql FROM {master} WHERE type='{kind}' AND sql IS NOT NULL")
+}
+
+/// Rewrite a stored CREATE statement so it recreates the object in the same
+/// database it came from: temp objects get the TEMP keyword, aux objects get
+/// an `aux.` prefix on the object name. Generated names are simple unquoted
+/// identifiers, so a single textual replacement is enough.
+fn rewrite_state_ddl(db: &str, name: &str, sql: &str, keyword: &str) -> String {
+    match db {
+        "temp" => sql.replacen("CREATE ", "CREATE TEMP ", 1),
+        "aux" => sql.replacen(
+            &format!("{keyword} {name}"),
+            &format!("{keyword} aux.{name}"),
+            1,
+        ),
+        _ => sql.to_string(),
+    }
+}
+
+/// Build a self-contained SQL script that reconstructs one engine's full state
+/// (main, temp, and aux tables with all rows), followed by the failing
+/// statement as a comment. `query` runs a text-only query against that engine.
+fn build_state_dump(
+    schema: &sql_gen::Schema,
+    failing_sql: &str,
+    query: &dyn Fn(&str, usize) -> Vec<Vec<String>>,
+) -> String {
+    let mut out = String::new();
+    out.push_str("-- Reconstructed engine state captured at an oracle failure.\n");
+    out.push_str("ATTACH ':memory:' AS aux;\n\n-- tables\n");
+
+    // Tables first, so the data inserts below have somewhere to go.
+    for db in ["main", "temp", "aux"] {
+        for row in query(&state_ddl_query(db, "table"), 2) {
+            out.push_str(&rewrite_state_ddl(db, &row[0], &row[1], "TABLE"));
+            out.push_str(";\n");
+        }
+    }
+
+    // Data. qualified_name() already carries the temp./aux. prefix.
+    out.push_str("\n-- data\n");
+    for table in &schema.tables {
+        if table.columns.is_empty() {
+            continue;
+        }
+        let quoted: Vec<String> = table
+            .columns
+            .iter()
+            .map(|c| format!("quote(\"{}\")", c.name))
+            .collect();
+        let qname = table.qualified_name();
+        let insert_query = format!(
+            "SELECT 'INSERT INTO {qname} VALUES(' || {} || ');' FROM {qname}",
+            quoted.join(" || ',' || ")
+        );
+        for row in query(&insert_query, 1) {
+            out.push_str(&row[0]);
+            out.push('\n');
+        }
+    }
+
+    // Indexes and triggers last, so inserting the data above did not fire them.
+    out.push_str("\n-- indexes and triggers\n");
+    for db in ["main", "temp", "aux"] {
+        for (kind, keyword) in [("index", "INDEX"), ("trigger", "TRIGGER")] {
+            for row in query(&state_ddl_query(db, kind), 2) {
+                out.push_str(&rewrite_state_ddl(db, &row[0], &row[1], keyword));
+                out.push_str(";\n");
+            }
+        }
+    }
+
+    out.push_str("\n-- FAILING STATEMENT:\n-- ");
+    out.push_str(failing_sql);
+    out.push('\n');
+    out
+}
+
 /// Configuration for the simulator.
 #[derive(Debug, Clone)]
 pub struct SimConfig {
@@ -342,6 +477,30 @@ impl Fuzzer {
         Ok(())
     }
 
+    /// On an oracle failure, dump each engine's full state as reconstructable
+    /// SQL (turso-state.sql, sqlite-state.sql). This captures main, temp, and
+    /// aux tables with all rows, so a divergence that depends on accumulated
+    /// state can be replayed as a small self-contained script.
+    fn dump_failure_state(&self, schema: &sql_gen::Schema, failing_sql: &str) {
+        let turso_conn = self.turso_conn.clone();
+        let turso_query = move |sql: &str, ncols: usize| turso_text_rows(&turso_conn, sql, ncols);
+        let turso_dump = build_state_dump(schema, failing_sql, &turso_query);
+        let sqlite_query =
+            |sql: &str, ncols: usize| sqlite_text_rows(&self.sqlite_conn, sql, ncols);
+        let sqlite_dump = build_state_dump(schema, failing_sql, &sqlite_query);
+        for (name, body) in [
+            ("turso-state.sql", turso_dump),
+            ("sqlite-state.sql", sqlite_dump),
+        ] {
+            let path = self.out_dir.join(name);
+            if let Err(e) = std::fs::write(&path, body) {
+                tracing::warn!("Failed to write {}: {e}", path.display());
+            } else {
+                tracing::info!("Wrote state dump to {}", path.display());
+            }
+        }
+    }
+
     fn run_inner(
         &self,
         stats: &mut SimStats,
@@ -468,6 +627,7 @@ impl Fuzzer {
                     if !self.config.verbose {
                         tracing::error!("Failing SQL: {}", stmt.sql);
                     }
+                    self.dump_failure_state(&schema, &stmt.sql);
                     return Err(anyhow::anyhow!("Oracle failure: {reason}"));
                 }
             }

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -503,10 +503,19 @@ impl Fuzzer {
         sqlite_dump
     }
 
-    /// Minimize the failing statement against the dumped state and write the
-    /// result (state script + minimized statement) to minimized.sql.
-    fn shrink_and_write(&self, state_dump: &str, failing_sql: &str) {
-        match crate::shrink::shrink_statement(state_dump, failing_sql) {
+    /// Minimize the failing statement against the dumped state — or against
+    /// the run's executed statements when the divergence needs the history —
+    /// and write the result (state script + minimized statement) to
+    /// minimized.sql.
+    fn shrink_and_write(&self, state_dump: &str, executed_sql: &[String], failing_sql: &str) {
+        // The executed statements double as a replay script. Skip comment
+        // lines (skipped/warning markers) the runner interleaves.
+        let history: String = executed_sql
+            .iter()
+            .filter(|s| !s.trim_start().starts_with("--"))
+            .map(|s| format!("{s};\n"))
+            .collect();
+        match crate::shrink::shrink_statement(state_dump, &history, failing_sql) {
             Ok(Some(minimized)) => {
                 let path = self.out_dir.join("minimized.sql");
                 let body = format!(
@@ -656,7 +665,7 @@ impl Fuzzer {
                         tracing::error!("Failing SQL: {}", stmt.sql);
                     }
                     let state_dump = self.dump_failure_state(&schema, &stmt.sql);
-                    self.shrink_and_write(&state_dump, &stmt.sql);
+                    self.shrink_and_write(&state_dump, executed_sql, &stmt.sql);
                     return Err(anyhow::anyhow!("Oracle failure: {reason}"));
                 }
             }

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -22,7 +22,7 @@ use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use turso_core::Database;
 
-use crate::generate::{GeneratorKind, PropTestBackend, SqlGenBackend, SqlGenerator};
+use crate::generate::{GeneratorKind, PropTestBackend, SqlGenBackend, SqlGenerator, WeightProfile};
 use crate::memory::{MemorySimIO, SimIO};
 use crate::oracle::{DifferentialOracle, OracleResult, QueryResult, check_differential};
 use crate::schema::SchemaIntrospector;
@@ -65,6 +65,8 @@ pub struct SimConfig {
     pub window_function_probability: f64,
     /// Generate SELECT-only workloads whose CTE definitions are all recursive.
     pub recursive_cte_focus: bool,
+    /// Named statement-weight mix to generate with.
+    pub weight_profile: WeightProfile,
 }
 
 impl Default for SimConfig {
@@ -82,6 +84,7 @@ impl Default for SimConfig {
             mvcc: false,
             window_function_probability: 0.0,
             recursive_cte_focus: false,
+            weight_profile: WeightProfile::default(),
         }
     }
 }
@@ -359,6 +362,7 @@ impl Fuzzer {
                 Box::new(SqlGenBackend::new_with_window_weight(
                     seed,
                     self.config.window_function_probability,
+                    self.config.weight_profile,
                 ))
             }
             GeneratorKind::SqlGenProp => {
@@ -730,6 +734,7 @@ mod tests {
             mvcc: false,
             window_function_probability: 0.0,
             recursive_cte_focus: false,
+            weight_profile: WeightProfile::default(),
         };
         let sim = Fuzzer::new(config);
         assert!(sim.is_ok());

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -574,6 +574,35 @@ impl Fuzzer {
             );
         }
 
+        let turso_triggers: std::collections::HashSet<_> = turso_schema
+            .triggers
+            .iter()
+            .map(|trigger| {
+                (
+                    trigger.qualified_name(),
+                    trigger.table_name.as_str().to_string(),
+                )
+            })
+            .collect();
+        let sqlite_triggers: std::collections::HashSet<_> = sqlite_schema
+            .triggers
+            .iter()
+            .map(|trigger| {
+                (
+                    trigger.qualified_name(),
+                    trigger.table_name.as_str().to_string(),
+                )
+            })
+            .collect();
+
+        if turso_triggers != sqlite_triggers {
+            bail!(
+                "Trigger mismatch: Turso has {:?}, SQLite has {:?}",
+                turso_triggers,
+                sqlite_triggers
+            );
+        }
+
         // Verify each table's columns and strict flags match
         for turso_table in turso_schema.tables.iter() {
             let sqlite_table = sqlite_schema

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -29,6 +29,12 @@ use crate::schema::SchemaIntrospector;
 pub use sql_gen::TreeMode;
 use sql_gen_prop::SqlValue;
 
+const MAX_GENERATED_SQL_BYTES: usize = 64 * 1024;
+
+fn generated_sql_is_too_large(sql: &str) -> bool {
+    sql.len() > MAX_GENERATED_SQL_BYTES
+}
+
 /// Configuration for the simulator.
 #[derive(Debug, Clone)]
 pub struct SimConfig {
@@ -372,6 +378,23 @@ impl Fuzzer {
 
         for i in 0..self.config.num_statements {
             let stmt = generator.generate(&schema)?;
+
+            // A generated expression can branch into several subqueries at
+            // each level. This occasionally produces hundreds of kilobytes of
+            // SQL. Preparing such a statement uses enough recursive calls to
+            // exhaust the process stack before either engine can return an
+            // error. These statements add little useful coverage, so skip
+            // them before passing them to either engine.
+            if generated_sql_is_too_large(&stmt.sql) {
+                stats.statements_skipped += 1;
+                let reason = format!(
+                    "Statement skipped because it is {} bytes; the limit is {MAX_GENERATED_SQL_BYTES} bytes",
+                    stmt.sql.len()
+                );
+                push_warning_comments(executed_sql, i, &reason);
+                tracing::debug!("Skipped generated statement {i}: {reason}");
+                continue;
+            }
 
             if self.config.verbose {
                 let stmt_type = if stmt.is_ddl { "DDL" } else { "DML" };
@@ -718,5 +741,15 @@ mod tests {
         push_warning_comments(&mut out, 465, "first\nsecond");
         assert_eq!(out[0], "-- WARNING stmt=465 line=0: first");
         assert_eq!(out[1], "-- WARNING stmt=465 line=1: second");
+    }
+
+    #[test]
+    fn statements_over_64_kib_are_too_large() {
+        assert!(!generated_sql_is_too_large(
+            &"x".repeat(MAX_GENERATED_SQL_BYTES)
+        ));
+        assert!(generated_sql_is_too_large(
+            &"x".repeat(MAX_GENERATED_SQL_BYTES + 1)
+        ));
     }
 }

--- a/testing/differential-oracle/fuzzer/schema.rs
+++ b/testing/differential-oracle/fuzzer/schema.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use sql_gen::schema::Trigger;
 use sql_gen::{ColumnDef, DataType, Index, Schema, SchemaBuilder, Table};
 
 /// Introspects schema from a database connection.
@@ -85,6 +86,62 @@ impl SchemaIntrospector {
             .context("Failed to collect table info")?;
 
         Ok(tables)
+    }
+
+    fn get_triggers_turso(
+        conn: &Arc<turso_core::Connection>,
+        db_name: Option<&str>,
+    ) -> Result<Vec<Trigger>> {
+        let prefix = db_name.map_or_else(String::new, |db| format!("{db}."));
+        let query = format!(
+            "SELECT name, tbl_name FROM {prefix}sqlite_master WHERE type='trigger' ORDER BY name"
+        );
+        let mut triggers = Vec::new();
+        let mut rows = conn
+            .query(&query)
+            .context("Failed to query trigger info")?
+            .context("Expected rows from trigger query")?;
+
+        rows.run_with_row_callback(|row| {
+            let (turso_core::Value::Text(name), turso_core::Value::Text(table_name)) =
+                (row.get_value(0), row.get_value(1))
+            else {
+                return Ok(());
+            };
+            let trigger = Trigger::new(name.as_str(), table_name.as_str());
+            triggers.push(match db_name {
+                Some(db_name) => trigger.in_database(db_name),
+                None => trigger,
+            });
+            Ok(())
+        })
+        .context("Failed to iterate trigger info")?;
+
+        Ok(triggers)
+    }
+
+    fn get_triggers_sqlite(
+        conn: &rusqlite::Connection,
+        db_name: Option<&str>,
+    ) -> Result<Vec<Trigger>> {
+        let prefix = db_name.map_or_else(String::new, |db| format!("{db}."));
+        let query = format!(
+            "SELECT name, tbl_name FROM {prefix}sqlite_master WHERE type='trigger' ORDER BY name"
+        );
+        let mut stmt = conn
+            .prepare(&query)
+            .context("Failed to prepare trigger query")?;
+
+        stmt.query_map([], |row| {
+            let trigger = Trigger::new(row.get::<_, String>(0)?, row.get::<_, String>(1)?);
+            Ok(match db_name {
+                Some(db_name) => trigger.in_database(db_name),
+                None => trigger,
+            })
+        })
+        .context("Failed to query triggers")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("Failed to collect trigger info")
     }
 
     /// Determine if a CREATE TABLE SQL statement declares a STRICT table.
@@ -254,6 +311,10 @@ impl SchemaIntrospector {
             }
         }
 
+        for trigger in Self::get_triggers_turso(conn, db_name)? {
+            builder = builder.trigger(trigger);
+        }
+
         Ok(builder)
     }
 
@@ -284,6 +345,10 @@ impl SchemaIntrospector {
             for index in Self::get_indexes_sqlite(conn, db_name, &table_name)? {
                 builder = builder.index(index);
             }
+        }
+
+        for trigger in Self::get_triggers_sqlite(conn, db_name)? {
+            builder = builder.trigger(trigger);
         }
 
         Ok(builder)
@@ -583,5 +648,38 @@ mod tests {
         let temp_tables = schema.table_names_in_database(Some("temp"));
 
         assert_eq!(temp_tables, HashSet::from([String::from("t")]));
+    }
+
+    #[test]
+    fn test_sqlite_with_attached_discovers_triggers() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE main_table(x INTEGER);
+            CREATE TRIGGER main_trigger AFTER INSERT ON main_table BEGIN SELECT 1; END;
+            CREATE TEMP TRIGGER temp_trigger AFTER INSERT ON main_table BEGIN SELECT 1; END;
+            ",
+        )
+        .unwrap();
+
+        let schema = SchemaIntrospector::from_sqlite_with_attached(&conn).unwrap();
+        let triggers: HashSet<_> = schema
+            .triggers
+            .iter()
+            .map(|trigger| {
+                (
+                    trigger.qualified_name(),
+                    trigger.table_name.as_str().to_string(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            triggers,
+            HashSet::from([
+                ("main_trigger".to_string(), "main_table".to_string()),
+                ("temp.temp_trigger".to_string(), "main_table".to_string()),
+            ])
+        );
     }
 }

--- a/testing/differential-oracle/fuzzer/shrink.rs
+++ b/testing/differential-oracle/fuzzer/shrink.rs
@@ -35,7 +35,7 @@ const MAX_CANDIDATES: usize = 800;
 /// edit if the candidate reproduces the same class (and, for errors, the same
 /// error prefix), so the reduction cannot drift onto a different bug.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum Divergence {
+pub enum Divergence {
     /// Turso returned an error, SQLite did not. Holds an error prefix.
     TursoErr(String),
     /// SQLite returned an error, Turso did not. Holds an error prefix.
@@ -54,7 +54,7 @@ fn error_prefix(msg: &str) -> String {
 }
 
 /// A fresh pair of engines with the failure state loaded.
-struct EnginePair {
+pub struct EnginePair {
     turso: Arc<turso_core::Connection>,
     sqlite: rusqlite::Connection,
     /// Keeps the database (and its in-memory IO) alive for `turso`.
@@ -67,7 +67,7 @@ impl EnginePair {
     /// from a live database, so failures here would only come from replay
     /// artifacts, and the baseline check below decides whether the replayed
     /// state is good enough to shrink against.
-    fn build(state_sql: &str) -> Result<Self> {
+    pub fn build(state_sql: &str) -> Result<Self> {
         let io = Arc::new(MemorySimIO::new(0));
         let opts = turso_core::DatabaseOpts::new().with_attach(true);
         let turso_db = Database::open_file_with_flags(
@@ -95,9 +95,17 @@ impl EnginePair {
         })
     }
 
+    /// Run `sql` on both engines and return both raw results (turso, sqlite).
+    pub fn run_both(&self, sql: &str) -> (QueryResult, QueryResult) {
+        (
+            DifferentialOracle::execute_turso(&self.turso, sql),
+            DifferentialOracle::execute_sqlite(&self.sqlite, sql),
+        )
+    }
+
     /// Run `sql` on both engines and classify the outcome. `None` means the
     /// engines agreed (no divergence).
-    fn classify(&self, sql: &str) -> Option<Divergence> {
+    pub fn classify(&self, sql: &str) -> Option<Divergence> {
         let t = DifferentialOracle::execute_turso(&self.turso, sql);
         let s = DifferentialOracle::execute_sqlite(&self.sqlite, sql);
         match (&t, &s) {
@@ -116,7 +124,7 @@ impl EnginePair {
     }
 
     /// Compare the full contents of every table on both engines.
-    fn states_differ(&self) -> bool {
+    pub fn states_differ(&self) -> bool {
         for db in ["main", "temp", "aux"] {
             let master = if db == "main" {
                 "sqlite_master".to_string()
@@ -148,7 +156,7 @@ impl EnginePair {
     }
 }
 
-fn query_results_differ(a: &QueryResult, b: &QueryResult) -> bool {
+pub fn query_results_differ(a: &QueryResult, b: &QueryResult) -> bool {
     match (a, b) {
         (QueryResult::Rows(ra), QueryResult::Rows(rb)) => {
             !sql_gen_prop::result::diff_results(ra, rb).is_empty()

--- a/testing/differential-oracle/fuzzer/shrink.rs
+++ b/testing/differential-oracle/fuzzer/shrink.rs
@@ -1012,15 +1012,39 @@ pub struct Minimized {
 }
 
 /// Minimize `failing_sql` — and then the state script it needs — against the
-/// state in `state_sql`. Returns None when the divergence does not reproduce
-/// on the rebuilt state (nothing trustworthy to shrink against).
-pub fn shrink_statement(state_sql: &str, failing_sql: &str) -> Result<Option<Minimized>> {
-    let baseline = {
+/// state in `state_sql`, falling back to `history_sql` (the run's executed
+/// statements) when the divergence needs the statement history rather than
+/// just the final data. Returns None when neither replay reproduces it.
+///
+/// The fallback matters for history-dependent bugs: a wrong trigger firing
+/// order, for example, leaves a table whose *contents* replay cleanly from a
+/// dump, so the dump-based baseline shows no divergence — but replaying the
+/// statements that built the table hits the divergence again. The ddmin pass
+/// then deletes every history line the divergence does not need.
+pub fn shrink_statement(
+    state_sql: &str,
+    history_sql: &str,
+    failing_sql: &str,
+) -> Result<Option<Minimized>> {
+    let mut state_sql = state_sql;
+    let mut baseline = {
         let pair = EnginePair::build(state_sql)?;
         pair.classify(failing_sql)
     };
+    if baseline.is_none() {
+        let pair = EnginePair::build(history_sql)?;
+        baseline = pair.classify(failing_sql);
+        if baseline.is_some() {
+            tracing::info!(
+                "Divergence needs the statement history; shrinking against it instead of the state dump"
+            );
+            state_sql = history_sql;
+        }
+    }
     let Some(original) = baseline else {
-        tracing::info!("Shrink skipped: divergence does not reproduce on rebuilt state");
+        tracing::info!(
+            "Shrink skipped: divergence reproduces on neither the rebuilt state nor the statement history"
+        );
         return Ok(None);
     };
     tracing::info!(
@@ -1168,7 +1192,7 @@ mod tests {
         // Same statement behaves identically on both engines, so there is
         // nothing to shrink against.
         let state = "CREATE TABLE t(x);\nINSERT INTO t VALUES (1);\n";
-        let out = shrink_statement(state, "SELECT x + 1 FROM t").unwrap();
+        let out = shrink_statement(state, state, "SELECT x + 1 FROM t").unwrap();
         assert!(out.is_none());
     }
 

--- a/testing/differential-oracle/fuzzer/shrink.rs
+++ b/testing/differential-oracle/fuzzer/shrink.rs
@@ -1,0 +1,1191 @@
+//! Statement minimization for oracle failures.
+//!
+//! A failing statement from the generator is often thousands of bytes of
+//! nested expressions, most of which have nothing to do with the divergence.
+//! This module rebuilds both engines from the failure-state dump, confirms the
+//! divergence still reproduces there, and then repeatedly simplifies the
+//! statement, keeping each edit only if the same kind of divergence still
+//! occurs. The result is written next to the other run artifacts as
+//! `minimized.sql`.
+//!
+//! Candidates come from the SQL parser, not from text manipulation: the
+//! statement is parsed, one AST node is simplified — a clause dropped, an
+//! expression replaced by `1` or `''` or one of its own children — and the
+//! tree is printed back to SQL. Every candidate is therefore syntactically
+//! valid, and edits cannot be confused by quotes or keywords inside literals.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::Result;
+use turso_core::{Database, SqliteDialect};
+use turso_parser::ast::{
+    Cmd, Expr, InsertBody, Literal, OneSelect, ResultColumn, Select, SelectTable, Stmt,
+};
+use turso_parser::parser::Parser;
+
+use crate::memory::MemorySimIO;
+use crate::oracle::{DifferentialOracle, QueryResult};
+
+/// Upper bound on candidate executions per shrink, so a pathological
+/// statement cannot stall a fuzzing loop.
+const MAX_CANDIDATES: usize = 800;
+
+/// How the two engines diverged on a statement. Shrinking only accepts an
+/// edit if the candidate reproduces the same class (and, for errors, the same
+/// error prefix), so the reduction cannot drift onto a different bug.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Divergence {
+    /// Turso returned an error, SQLite did not. Holds an error prefix.
+    TursoErr(String),
+    /// SQLite returned an error, Turso did not. Holds an error prefix.
+    SqliteErr(String),
+    /// Both succeeded but returned different rows, or left the databases in
+    /// different states.
+    ResultMismatch,
+}
+
+/// Take a stable prefix of an error message for matching candidates against
+/// the original failure. Long enough to pin the error kind ("integer
+/// overflow", "UNIQUE constraint failed: ..."), short enough to tolerate
+/// differing identifiers further into the message.
+fn error_prefix(msg: &str) -> String {
+    msg.chars().take(40).collect()
+}
+
+/// A fresh pair of engines with the failure state loaded.
+struct EnginePair {
+    turso: Arc<turso_core::Connection>,
+    sqlite: rusqlite::Connection,
+    /// Keeps the database (and its in-memory IO) alive for `turso`.
+    _turso_db: Arc<Database>,
+}
+
+impl EnginePair {
+    /// Build both engines and replay the state script into each. Individual
+    /// statement errors during replay are ignored: the script was produced
+    /// from a live database, so failures here would only come from replay
+    /// artifacts, and the baseline check below decides whether the replayed
+    /// state is good enough to shrink against.
+    fn build(state_sql: &str) -> Result<Self> {
+        let io = Arc::new(MemorySimIO::new(0));
+        let opts = turso_core::DatabaseOpts::new().with_attach(true);
+        let turso_db = Database::open_file_with_flags(
+            io,
+            "shrink.db",
+            turso_core::OpenFlags::default(),
+            opts,
+            None,
+            Arc::new(SqliteDialect),
+        )?;
+        let turso = turso_db.connect()?;
+        let sqlite = rusqlite::Connection::open_in_memory()?;
+        for stmt in state_sql.lines() {
+            let stmt = stmt.trim();
+            if stmt.is_empty() || stmt.starts_with("--") {
+                continue;
+            }
+            let _ = DifferentialOracle::execute_turso(&turso, stmt);
+            let _ = DifferentialOracle::execute_sqlite(&sqlite, stmt);
+        }
+        Ok(Self {
+            turso,
+            sqlite,
+            _turso_db: turso_db,
+        })
+    }
+
+    /// Run `sql` on both engines and classify the outcome. `None` means the
+    /// engines agreed (no divergence).
+    fn classify(&self, sql: &str) -> Option<Divergence> {
+        let t = DifferentialOracle::execute_turso(&self.turso, sql);
+        let s = DifferentialOracle::execute_sqlite(&self.sqlite, sql);
+        match (&t, &s) {
+            // Both rejected the candidate; not a divergence.
+            (QueryResult::Error(_), QueryResult::Error(_)) => None,
+            (QueryResult::Error(te), _) => Some(Divergence::TursoErr(error_prefix(te))),
+            (_, QueryResult::Error(se)) => Some(Divergence::SqliteErr(error_prefix(se))),
+            _ => {
+                if query_results_differ(&t, &s) || self.states_differ() {
+                    Some(Divergence::ResultMismatch)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// Compare the full contents of every table on both engines.
+    fn states_differ(&self) -> bool {
+        for db in ["main", "temp", "aux"] {
+            let master = if db == "main" {
+                "sqlite_master".to_string()
+            } else {
+                format!("{db}.sqlite_master")
+            };
+            let names_sql = format!("SELECT name FROM {master} WHERE type='table' ORDER BY name");
+            let turso_names = DifferentialOracle::execute_turso(&self.turso, &names_sql);
+            let sqlite_names = DifferentialOracle::execute_sqlite(&self.sqlite, &names_sql);
+            if query_results_differ(&turso_names, &sqlite_names) {
+                return true;
+            }
+            let QueryResult::Rows(names) = sqlite_names else {
+                continue;
+            };
+            for row in &names {
+                let Some(sql_gen_prop::SqlValue::Text(name)) = row.0.first() else {
+                    continue;
+                };
+                let table_sql = format!("SELECT * FROM {db}.{name} ORDER BY rowid");
+                let t = DifferentialOracle::execute_turso(&self.turso, &table_sql);
+                let s = DifferentialOracle::execute_sqlite(&self.sqlite, &table_sql);
+                if query_results_differ(&t, &s) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+fn query_results_differ(a: &QueryResult, b: &QueryResult) -> bool {
+    match (a, b) {
+        (QueryResult::Rows(ra), QueryResult::Rows(rb)) => {
+            !sql_gen_prop::result::diff_results(ra, rb).is_empty()
+        }
+        (QueryResult::Ok, QueryResult::Ok) => false,
+        (QueryResult::Error(_), QueryResult::Error(_)) => false,
+        // Ok vs empty Rows means the same thing here: no differing rows.
+        (QueryResult::Ok, QueryResult::Rows(r)) | (QueryResult::Rows(r), QueryResult::Ok) => {
+            !r.is_empty()
+        }
+        _ => true,
+    }
+}
+
+/// `true` if `candidate` reproduces the same kind of divergence as `original`.
+fn matches_divergence(original: &Divergence, candidate: Option<Divergence>) -> bool {
+    match (original, candidate) {
+        (Divergence::TursoErr(p), Some(Divergence::TursoErr(q))) => p == &q,
+        (Divergence::SqliteErr(p), Some(Divergence::SqliteErr(q))) => p == &q,
+        (Divergence::ResultMismatch, Some(Divergence::ResultMismatch)) => true,
+        _ => false,
+    }
+}
+
+// --- candidate generation ------------------------------------------------
+
+fn parse_one(sql: &str) -> Option<Stmt> {
+    let mut parser = Parser::new(sql.as_bytes());
+    match parser.next()?.ok()? {
+        Cmd::Stmt(stmt) => Some(stmt),
+        _ => None,
+    }
+}
+
+/// Ways to simplify one expression node.
+#[derive(Clone, Copy)]
+enum ExprAction {
+    /// Replace the node with the literal 1.
+    One,
+    /// Replace the node with the literal ''.
+    EmptyText,
+    /// Replace the node with its n-th expression child (`x AND y` -> `x`,
+    /// `RTRIM(a)` -> `a`).
+    Child(usize),
+    /// Remove the n-th element of the node's own list (a function argument or
+    /// an IN-list value), keeping the node itself.
+    DropListItem(usize),
+}
+
+/// Direct expression children that can stand in for the whole node.
+fn expr_children(e: &mut Expr) -> Vec<&mut Expr> {
+    match e {
+        Expr::Between {
+            lhs, start, end, ..
+        } => vec![lhs, start, end],
+        Expr::Binary(l, _, r) => vec![l, r],
+        Expr::Case {
+            base,
+            when_then_pairs,
+            else_expr,
+        } => {
+            let mut v: Vec<&mut Expr> = Vec::new();
+            if let Some(b) = base {
+                v.push(b);
+            }
+            for (w, t) in when_then_pairs {
+                v.push(w);
+                v.push(t);
+            }
+            if let Some(x) = else_expr {
+                v.push(x);
+            }
+            v
+        }
+        Expr::Cast { expr, .. }
+        | Expr::Collate(expr, _)
+        | Expr::IsNull(expr)
+        | Expr::NotNull(expr)
+        | Expr::Unary(_, expr)
+        | Expr::FieldAccess { base: expr, .. } => vec![expr],
+        Expr::FunctionCall { args, .. } => args.iter_mut().map(|a| &mut **a).collect(),
+        Expr::InList { lhs, rhs, .. } => {
+            let mut v: Vec<&mut Expr> = vec![lhs];
+            v.extend(rhs.iter_mut().map(|a| &mut **a));
+            v
+        }
+        Expr::InSelect { lhs, .. } => vec![lhs],
+        Expr::InTable { lhs, args, .. } => {
+            let mut v: Vec<&mut Expr> = vec![lhs];
+            v.extend(args.iter_mut().map(|a| &mut **a));
+            v
+        }
+        Expr::Like {
+            lhs, rhs, escape, ..
+        } => {
+            let mut v: Vec<&mut Expr> = vec![lhs, rhs];
+            if let Some(esc) = escape {
+                v.push(esc);
+            }
+            v
+        }
+        Expr::Parenthesized(exprs) => exprs.iter_mut().map(|a| &mut **a).collect(),
+        Expr::Raise(_, Some(expr)) => vec![expr],
+        Expr::Subscript { base, index } => vec![base, index],
+        Expr::Array { elements } => elements.iter_mut().map(|a| &mut **a).collect(),
+        _ => vec![],
+    }
+}
+
+/// Actions worth trying on this node, cheapest-to-verify structural wins
+/// first. Skips no-ops like replacing `1` with `1`.
+fn expr_actions(e: &Expr) -> Vec<ExprAction> {
+    let mut actions = Vec::new();
+    let child_count = match e {
+        Expr::Between { .. } => 3,
+        Expr::Binary(..) | Expr::Subscript { .. } => 2,
+        Expr::Case { .. } => 0, // covered by One; branches vary in count
+        Expr::Cast { .. }
+        | Expr::Collate(..)
+        | Expr::IsNull(..)
+        | Expr::NotNull(..)
+        | Expr::Unary(..)
+        | Expr::FieldAccess { .. } => 1,
+        Expr::FunctionCall { args, .. } => args.len().min(1),
+        Expr::InList { .. } | Expr::InSelect { .. } | Expr::InTable { .. } => 1,
+        Expr::Like { .. } => 2,
+        Expr::Parenthesized(exprs) => exprs.len().min(1),
+        _ => 0,
+    };
+    for i in 0..child_count {
+        actions.push(ExprAction::Child(i));
+    }
+    match e {
+        Expr::FunctionCall { args, .. } if args.len() > 1 => {
+            for i in 0..args.len() {
+                actions.push(ExprAction::DropListItem(i));
+            }
+        }
+        Expr::InList { rhs, .. } if rhs.len() > 1 => {
+            for i in 0..rhs.len() {
+                actions.push(ExprAction::DropListItem(i));
+            }
+        }
+        _ => {}
+    }
+    if !matches!(e, Expr::Literal(Literal::Numeric(n)) if n == "1") {
+        actions.push(ExprAction::One);
+    }
+    if !matches!(e, Expr::Literal(Literal::String(s)) if s == "''") {
+        actions.push(ExprAction::EmptyText);
+    }
+    actions
+}
+
+fn apply_expr_action(e: &mut Expr, action: ExprAction) {
+    match action {
+        ExprAction::One => *e = Expr::Literal(Literal::Numeric("1".to_string())),
+        ExprAction::EmptyText => *e = Expr::Literal(Literal::String("''".to_string())),
+        ExprAction::Child(i) => {
+            let mut children = expr_children(e);
+            if i < children.len() {
+                let child = std::mem::take(children[i]);
+                *e = child;
+            }
+        }
+        ExprAction::DropListItem(i) => match e {
+            Expr::FunctionCall { args, .. } if i < args.len() && args.len() > 1 => {
+                args.remove(i);
+            }
+            Expr::InList { rhs, .. } if i < rhs.len() && rhs.len() > 1 => {
+                rhs.remove(i);
+            }
+            _ => {}
+        },
+    }
+}
+
+/// Clauses that can be dropped from one SELECT/UPDATE/DELETE site.
+#[derive(Clone, Copy)]
+enum ClauseDrop {
+    Where,
+    GroupBy,
+    Having,
+    Distinct,
+    SelectColumn(usize),
+    OrderByItem(usize),
+    Limit,
+    Compound(usize),
+    Cte(usize),
+    Join(usize),
+    SetItem(usize),
+    ReturningItem(usize),
+}
+
+/// A place where clause-level edits apply.
+enum Site<'a> {
+    Core(&'a mut OneSelect),
+    Outer(&'a mut Select),
+    Update(&'a mut turso_parser::ast::Update),
+    Delete {
+        where_clause: &'a mut Option<Box<Expr>>,
+        returning: &'a mut Vec<ResultColumn>,
+    },
+    InsertReturning(&'a mut Vec<ResultColumn>),
+}
+
+fn site_actions(site: &Site<'_>) -> Vec<ClauseDrop> {
+    let mut actions = Vec::new();
+    match site {
+        Site::Core(OneSelect::Select {
+            distinctness,
+            columns,
+            where_clause,
+            group_by,
+            ..
+        }) => {
+            if where_clause.is_some() {
+                actions.push(ClauseDrop::Where);
+            }
+            if let Some(gb) = group_by {
+                actions.push(ClauseDrop::GroupBy);
+                if gb.having.is_some() {
+                    actions.push(ClauseDrop::Having);
+                }
+            }
+            if distinctness.is_some() {
+                actions.push(ClauseDrop::Distinct);
+            }
+            if columns.len() > 1 {
+                for i in 0..columns.len() {
+                    actions.push(ClauseDrop::SelectColumn(i));
+                }
+            }
+        }
+        Site::Core(OneSelect::Values(..)) => {}
+        Site::Outer(select) => {
+            for i in 0..select.order_by.len() {
+                actions.push(ClauseDrop::OrderByItem(i));
+            }
+            if select.limit.is_some() {
+                actions.push(ClauseDrop::Limit);
+            }
+            for i in 0..select.body.compounds.len() {
+                actions.push(ClauseDrop::Compound(i));
+            }
+            if let Some(with) = &select.with {
+                for i in 0..with.ctes.len() {
+                    actions.push(ClauseDrop::Cte(i));
+                }
+            }
+            if let OneSelect::Select {
+                from: Some(from), ..
+            } = &select.body.select
+            {
+                for i in 0..from.joins.len() {
+                    actions.push(ClauseDrop::Join(i));
+                }
+            }
+        }
+        Site::Update(update) => {
+            if update.where_clause.is_some() {
+                actions.push(ClauseDrop::Where);
+            }
+            if update.sets.len() > 1 {
+                for i in 0..update.sets.len() {
+                    actions.push(ClauseDrop::SetItem(i));
+                }
+            }
+            for i in 0..update.returning.len() {
+                actions.push(ClauseDrop::ReturningItem(i));
+            }
+        }
+        Site::Delete {
+            where_clause,
+            returning,
+        } => {
+            if where_clause.is_some() {
+                actions.push(ClauseDrop::Where);
+            }
+            for i in 0..returning.len() {
+                actions.push(ClauseDrop::ReturningItem(i));
+            }
+        }
+        Site::InsertReturning(returning) => {
+            for i in 0..returning.len() {
+                actions.push(ClauseDrop::ReturningItem(i));
+            }
+        }
+    }
+    actions
+}
+
+fn apply_clause_action(site: &mut Site<'_>, action: ClauseDrop) {
+    match (site, action) {
+        (Site::Core(OneSelect::Select { where_clause, .. }), ClauseDrop::Where) => {
+            *where_clause = None
+        }
+        (Site::Core(OneSelect::Select { group_by, .. }), ClauseDrop::GroupBy) => *group_by = None,
+        (
+            Site::Core(OneSelect::Select {
+                group_by: Some(gb), ..
+            }),
+            ClauseDrop::Having,
+        ) => gb.having = None,
+        (Site::Core(OneSelect::Select { distinctness, .. }), ClauseDrop::Distinct) => {
+            *distinctness = None
+        }
+        (Site::Core(OneSelect::Select { columns, .. }), ClauseDrop::SelectColumn(i)) => {
+            if i < columns.len() && columns.len() > 1 {
+                columns.remove(i);
+            }
+        }
+        (Site::Outer(select), ClauseDrop::OrderByItem(i)) => {
+            if i < select.order_by.len() {
+                select.order_by.remove(i);
+            }
+        }
+        (Site::Outer(select), ClauseDrop::Limit) => select.limit = None,
+        (Site::Outer(select), ClauseDrop::Compound(i)) => {
+            if i < select.body.compounds.len() {
+                select.body.compounds.remove(i);
+            }
+        }
+        (Site::Outer(select), ClauseDrop::Cte(i)) => {
+            if let Some(with) = &mut select.with {
+                if i < with.ctes.len() {
+                    with.ctes.remove(i);
+                    if with.ctes.is_empty() {
+                        select.with = None;
+                    }
+                }
+            }
+        }
+        (Site::Outer(select), ClauseDrop::Join(i)) => {
+            if let OneSelect::Select {
+                from: Some(from), ..
+            } = &mut select.body.select
+            {
+                if i < from.joins.len() {
+                    from.joins.remove(i);
+                }
+            }
+        }
+        (Site::Update(update), ClauseDrop::Where) => update.where_clause = None,
+        (Site::Update(update), ClauseDrop::SetItem(i)) => {
+            if i < update.sets.len() && update.sets.len() > 1 {
+                update.sets.remove(i);
+            }
+        }
+        (Site::Update(update), ClauseDrop::ReturningItem(i)) => {
+            if i < update.returning.len() {
+                update.returning.remove(i);
+            }
+        }
+        (Site::Delete { where_clause, .. }, ClauseDrop::Where) => **where_clause = None,
+        (Site::Delete { returning, .. }, ClauseDrop::ReturningItem(i))
+        | (Site::InsertReturning(returning), ClauseDrop::ReturningItem(i)) => {
+            if i < returning.len() {
+                returning.remove(i);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Pre-order walk over every expression in the statement, including inside
+/// subqueries and CTE bodies. `f` returning `true` stops the walk (used to
+/// apply an edit at one position).
+fn walk_exprs(stmt: &mut Stmt, f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
+    match stmt {
+        Stmt::Select(select) => walk_select(select, f),
+        Stmt::Insert {
+            body, returning, ..
+        } => {
+            if let InsertBody::Select(select, _) = body {
+                if walk_select(select, f) {
+                    return true;
+                }
+            }
+            walk_result_columns(returning, f)
+        }
+        Stmt::Update(update) => {
+            if let Some(with) = &mut update.with {
+                for cte in &mut with.ctes {
+                    if walk_select(&mut cte.select, f) {
+                        return true;
+                    }
+                }
+            }
+            for set in &mut update.sets {
+                if walk_expr(&mut set.expr, f) {
+                    return true;
+                }
+            }
+            if let Some(from) = &mut update.from {
+                if walk_from(from, f) {
+                    return true;
+                }
+            }
+            if let Some(w) = &mut update.where_clause {
+                if walk_expr(w, f) {
+                    return true;
+                }
+            }
+            if walk_result_columns(&mut update.returning, f) {
+                return true;
+            }
+            for sc in &mut update.order_by {
+                if walk_expr(&mut sc.expr, f) {
+                    return true;
+                }
+            }
+            walk_limit(&mut update.limit, f)
+        }
+        Stmt::Delete {
+            with,
+            where_clause,
+            returning,
+            order_by,
+            limit,
+            ..
+        } => {
+            if let Some(with) = with {
+                for cte in &mut with.ctes {
+                    if walk_select(&mut cte.select, f) {
+                        return true;
+                    }
+                }
+            }
+            if let Some(w) = where_clause {
+                if walk_expr(w, f) {
+                    return true;
+                }
+            }
+            if walk_result_columns(returning, f) {
+                return true;
+            }
+            for sc in order_by {
+                if walk_expr(&mut sc.expr, f) {
+                    return true;
+                }
+            }
+            walk_limit(limit, f)
+        }
+        _ => false,
+    }
+}
+
+fn walk_limit(
+    limit: &mut Option<turso_parser::ast::Limit>,
+    f: &mut dyn FnMut(&mut Expr) -> bool,
+) -> bool {
+    if let Some(limit) = limit {
+        if walk_expr(&mut limit.expr, f) {
+            return true;
+        }
+        if let Some(offset) = &mut limit.offset {
+            if walk_expr(offset, f) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn walk_result_columns(columns: &mut [ResultColumn], f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
+    for rc in columns {
+        if let ResultColumn::Expr(expr, _) = rc {
+            if walk_expr(expr, f) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn walk_select(select: &mut Select, f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
+    if let Some(with) = &mut select.with {
+        for cte in &mut with.ctes {
+            if walk_select(&mut cte.select, f) {
+                return true;
+            }
+        }
+    }
+    if walk_one_select(&mut select.body.select, f) {
+        return true;
+    }
+    for compound in &mut select.body.compounds {
+        if walk_one_select(&mut compound.select, f) {
+            return true;
+        }
+    }
+    for sc in &mut select.order_by {
+        if walk_expr(&mut sc.expr, f) {
+            return true;
+        }
+    }
+    walk_limit(&mut select.limit, f)
+}
+
+fn walk_one_select(one: &mut OneSelect, f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
+    match one {
+        OneSelect::Select {
+            columns,
+            from,
+            where_clause,
+            group_by,
+            ..
+        } => {
+            if walk_result_columns(columns, f) {
+                return true;
+            }
+            if let Some(from) = from {
+                if walk_from(from, f) {
+                    return true;
+                }
+            }
+            if let Some(w) = where_clause {
+                if walk_expr(w, f) {
+                    return true;
+                }
+            }
+            if let Some(gb) = group_by {
+                for e in &mut gb.exprs {
+                    if walk_expr(e, f) {
+                        return true;
+                    }
+                }
+                if let Some(h) = &mut gb.having {
+                    if walk_expr(h, f) {
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+        OneSelect::Values(rows) => {
+            for row in rows {
+                for e in row {
+                    if walk_expr(e, f) {
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+    }
+}
+
+fn walk_from(
+    from: &mut turso_parser::ast::FromClause,
+    f: &mut dyn FnMut(&mut Expr) -> bool,
+) -> bool {
+    if walk_select_table(&mut from.select, f) {
+        return true;
+    }
+    for join in &mut from.joins {
+        if walk_select_table(&mut join.table, f) {
+            return true;
+        }
+        if let Some(turso_parser::ast::JoinConstraint::On(e)) = &mut join.constraint {
+            if walk_expr(e, f) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn walk_select_table(table: &mut SelectTable, f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
+    match table {
+        SelectTable::Table(..) => false,
+        SelectTable::TableCall(_, args, _) => {
+            for a in args {
+                if walk_expr(a, f) {
+                    return true;
+                }
+            }
+            false
+        }
+        SelectTable::Select(select, _) => walk_select(select, f),
+        SelectTable::Sub(from, _) => walk_from(from, f),
+    }
+}
+
+fn walk_expr(e: &mut Expr, f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
+    if f(e) {
+        return true;
+    }
+    // Subquery-carrying variants recurse through the select walker; everything
+    // else recurses through its expression children.
+    match e {
+        Expr::Exists(select) | Expr::Subquery(select) => return walk_select(select, f),
+        Expr::InSelect { lhs, rhs, .. } => {
+            if walk_expr(lhs, f) {
+                return true;
+            }
+            return walk_select(rhs, f);
+        }
+        _ => {}
+    }
+    for child in expr_children(e) {
+        if walk_expr(child, f) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Walk every clause site. `f` returning `true` stops the walk.
+fn walk_sites(stmt: &mut Stmt, f: &mut dyn FnMut(&mut Site<'_>) -> bool) -> bool {
+    match stmt {
+        Stmt::Select(select) => walk_select_sites(select, f),
+        Stmt::Insert {
+            body, returning, ..
+        } => {
+            if let InsertBody::Select(select, _) = body {
+                if walk_select_sites(select, f) {
+                    return true;
+                }
+            }
+            f(&mut Site::InsertReturning(returning))
+        }
+        Stmt::Update(update) => {
+            if let Some(with) = &mut update.with {
+                for cte in &mut with.ctes {
+                    if walk_select_sites(&mut cte.select, f) {
+                        return true;
+                    }
+                }
+            }
+            if let Some(from) = &mut update.from {
+                if walk_from_sites(from, f) {
+                    return true;
+                }
+            }
+            f(&mut Site::Update(update))
+        }
+        Stmt::Delete {
+            with,
+            where_clause,
+            returning,
+            ..
+        } => {
+            if let Some(with) = with {
+                for cte in &mut with.ctes {
+                    if walk_select_sites(&mut cte.select, f) {
+                        return true;
+                    }
+                }
+            }
+            f(&mut Site::Delete {
+                where_clause,
+                returning,
+            })
+        }
+        _ => false,
+    }
+}
+
+fn walk_select_sites(select: &mut Select, f: &mut dyn FnMut(&mut Site<'_>) -> bool) -> bool {
+    if let Some(with) = &mut select.with {
+        for cte in &mut with.ctes {
+            if walk_select_sites(&mut cte.select, f) {
+                return true;
+            }
+        }
+    }
+    if f(&mut Site::Outer(select)) {
+        return true;
+    }
+    if f(&mut Site::Core(&mut select.body.select)) {
+        return true;
+    }
+    for compound in &mut select.body.compounds {
+        if f(&mut Site::Core(&mut compound.select)) {
+            return true;
+        }
+    }
+    // Subquery sites inside FROM.
+    if let OneSelect::Select {
+        from: Some(from), ..
+    } = &mut select.body.select
+    {
+        if walk_from_sites(from, f) {
+            return true;
+        }
+    }
+    false
+}
+
+fn walk_from_sites(
+    from: &mut turso_parser::ast::FromClause,
+    f: &mut dyn FnMut(&mut Site<'_>) -> bool,
+) -> bool {
+    if let SelectTable::Select(select, _) = &mut *from.select {
+        if walk_select_sites(select, f) {
+            return true;
+        }
+    }
+    for join in &mut from.joins {
+        if let SelectTable::Select(select, _) = &mut *join.table {
+            if walk_select_sites(select, f) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// All simplified renderings of `sql`, structural (clause) edits first, then
+/// expression edits in pre-order so outer nodes are tried before inner ones.
+fn candidates(sql: &str) -> Vec<String> {
+    let Some(stmt) = parse_one(sql) else {
+        return vec![];
+    };
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+
+    // Clause edits.
+    let mut site_action_counts = Vec::new();
+    {
+        let mut probe = stmt.clone();
+        walk_sites(&mut probe, &mut |site| {
+            site_action_counts.push(site_actions(site).len());
+            false
+        });
+    }
+    for (site_idx, &count) in site_action_counts.iter().enumerate() {
+        for action_idx in 0..count {
+            let mut cand = stmt.clone();
+            let mut pos = 0usize;
+            walk_sites(&mut cand, &mut |site| {
+                if pos == site_idx {
+                    let actions = site_actions(site);
+                    if let Some(&action) = actions.get(action_idx) {
+                        apply_clause_action(site, action);
+                    }
+                    return true;
+                }
+                pos += 1;
+                false
+            });
+            push_candidate(&cand, sql, &mut seen, &mut out);
+        }
+    }
+
+    // Expression edits.
+    let mut expr_action_counts = Vec::new();
+    {
+        let mut probe = stmt.clone();
+        walk_exprs(&mut probe, &mut |e| {
+            expr_action_counts.push(expr_actions(e).len());
+            false
+        });
+    }
+    for (expr_idx, &count) in expr_action_counts.iter().enumerate() {
+        for action_idx in 0..count {
+            let mut cand = stmt.clone();
+            let mut pos = 0usize;
+            walk_exprs(&mut cand, &mut |e| {
+                if pos == expr_idx {
+                    let actions = expr_actions(e);
+                    if let Some(&action) = actions.get(action_idx) {
+                        apply_expr_action(e, action);
+                    }
+                    return true;
+                }
+                pos += 1;
+                false
+            });
+            push_candidate(&cand, sql, &mut seen, &mut out);
+        }
+    }
+    out
+}
+
+/// Render a candidate and keep it when it is new and strictly shorter, which
+/// also guarantees the shrink loop terminates.
+fn push_candidate(cand: &Stmt, original: &str, seen: &mut HashSet<String>, out: &mut Vec<String>) {
+    let rendered = cand.to_string();
+    if rendered.len() < original.len() && seen.insert(rendered.clone()) {
+        out.push(rendered);
+    }
+}
+
+// --- driver -------------------------------------------------------------
+
+/// Repeatedly apply the first candidate edit that `judge` accepts, until no
+/// edit is accepted or the attempt budget runs out.
+fn shrink_with(initial: &str, mut judge: impl FnMut(&str) -> Result<bool>) -> Result<String> {
+    let mut current = initial.to_string();
+    let mut attempts = 0usize;
+    let mut progress = true;
+    while progress && attempts < MAX_CANDIDATES {
+        progress = false;
+        for candidate in candidates(&current) {
+            attempts += 1;
+            if attempts >= MAX_CANDIDATES {
+                break;
+            }
+            if judge(&candidate)? {
+                current = candidate;
+                progress = true;
+                break;
+            }
+        }
+    }
+    tracing::info!(
+        "Shrink finished: {} -> {} bytes in {attempts} attempts",
+        initial.len(),
+        current.len()
+    );
+    Ok(current)
+}
+
+/// Classic ddmin-style list reduction: repeatedly try dropping chunks of
+/// lines from the state script, keeping a deletion when `judge` still accepts
+/// the remaining script. Halves the chunk size down to single lines.
+fn reduce_state_lines(
+    state_sql: &str,
+    mut judge: impl FnMut(&str) -> Result<bool>,
+) -> Result<String> {
+    let mut lines: Vec<&str> = state_sql
+        .lines()
+        .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with("--"))
+        .collect();
+    let mut chunk = lines.len().div_ceil(2).max(1);
+    let mut attempts = 0usize;
+    loop {
+        let mut i = 0;
+        let mut deleted_any = false;
+        while i < lines.len() && attempts < MAX_CANDIDATES {
+            let end = (i + chunk).min(lines.len());
+            let mut candidate: Vec<&str> = Vec::with_capacity(lines.len());
+            candidate.extend_from_slice(&lines[..i]);
+            candidate.extend_from_slice(&lines[end..]);
+            attempts += 1;
+            if judge(&candidate.join("\n"))? {
+                lines = candidate;
+                deleted_any = true;
+                // Do not advance: the next chunk slid into position i.
+            } else {
+                i = end;
+            }
+        }
+        if attempts >= MAX_CANDIDATES || (chunk == 1 && !deleted_any) {
+            break;
+        }
+        chunk = (chunk / 2).max(1);
+    }
+    Ok(lines.join("\n"))
+}
+
+/// The minimized reproduction for an oracle failure.
+pub struct Minimized {
+    /// The reduced state script the divergence needs.
+    pub state_sql: String,
+    /// The reduced failing statement.
+    pub statement: String,
+}
+
+/// Minimize `failing_sql` — and then the state script it needs — against the
+/// state in `state_sql`. Returns None when the divergence does not reproduce
+/// on the rebuilt state (nothing trustworthy to shrink against).
+pub fn shrink_statement(state_sql: &str, failing_sql: &str) -> Result<Option<Minimized>> {
+    let baseline = {
+        let pair = EnginePair::build(state_sql)?;
+        pair.classify(failing_sql)
+    };
+    let Some(original) = baseline else {
+        tracing::info!("Shrink skipped: divergence does not reproduce on rebuilt state");
+        return Ok(None);
+    };
+    tracing::info!(
+        "Shrinking {} byte statement ({original:?})",
+        failing_sql.len()
+    );
+
+    let statement = shrink_with(failing_sql, |candidate| {
+        // Fresh engines per attempt: a DML candidate that ran on both engines
+        // would otherwise contaminate the next attempt's state.
+        let pair = EnginePair::build(state_sql)?;
+        Ok(matches_divergence(&original, pair.classify(candidate)))
+    })?;
+
+    // With the statement fixed, drop every state line it does not need.
+    let state_sql = reduce_state_lines(state_sql, |candidate_state| {
+        let pair = EnginePair::build(candidate_state)?;
+        Ok(matches_divergence(&original, pair.classify(&statement)))
+    })?;
+    tracing::info!(
+        "State script reduced to {} lines",
+        state_sql.lines().count()
+    );
+    Ok(Some(Minimized {
+        state_sql,
+        statement,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Normalize SQL through the parser so tests compare renderings, not
+    /// hand-written spacing.
+    fn norm(sql: &str) -> String {
+        parse_one(sql).expect("test SQL must parse").to_string()
+    }
+
+    #[test]
+    fn function_calls_shrink_to_one_and_their_argument() {
+        let results = candidates("SELECT ABS(x + 1) FROM t");
+        assert!(results.contains(&norm("SELECT 1 FROM t")), "{results:?}");
+        assert!(
+            results.contains(&norm("SELECT x + 1 FROM t")),
+            "{results:?}"
+        );
+    }
+
+    #[test]
+    fn nested_case_shrinks_as_a_unit() {
+        let sql = "SELECT CASE WHEN CASE WHEN a THEN b END THEN c END FROM t";
+        let results = candidates(sql);
+        assert!(results.contains(&norm("SELECT 1 FROM t")), "{results:?}");
+        assert!(
+            results.contains(&norm("SELECT CASE WHEN 1 THEN c END FROM t")),
+            "{results:?}"
+        );
+    }
+
+    #[test]
+    fn literals_inside_strings_do_not_confuse_edits() {
+        // The string contains parens and would break a text-based scanner.
+        let results = candidates("SELECT f('((', x) FROM t");
+        assert!(results.contains(&norm("SELECT 1 FROM t")), "{results:?}");
+        assert!(
+            results.contains(&norm("SELECT f('', x) FROM t")),
+            "{results:?}"
+        );
+    }
+
+    #[test]
+    fn and_operands_can_replace_the_conjunction() {
+        let results = candidates("SELECT a FROM t WHERE x AND f(y) ORDER BY z");
+        assert!(
+            results.contains(&norm("SELECT a FROM t WHERE x ORDER BY z")),
+            "{results:?}"
+        );
+        let results = candidates("SELECT a FROM t WHERE x OR y OR z");
+        assert!(
+            results.contains(&norm("SELECT a FROM t WHERE x OR z")),
+            "{results:?}"
+        );
+    }
+
+    #[test]
+    fn clauses_and_list_items_can_be_dropped() {
+        let results = candidates("SELECT a FROM t WHERE x ORDER BY a DESC, b ASC LIMIT 3");
+        assert!(
+            results.contains(&norm("SELECT a FROM t WHERE x ORDER BY a DESC LIMIT 3")),
+            "{results:?}"
+        );
+        assert!(
+            results.contains(&norm("SELECT a FROM t ORDER BY a DESC, b ASC LIMIT 3")),
+            "{results:?}"
+        );
+        assert!(
+            results.contains(&norm("SELECT a FROM t WHERE x ORDER BY a DESC, b ASC")),
+            "{results:?}"
+        );
+        let results = candidates("SELECT MAX(a, b) FROM t");
+        assert!(
+            results.contains(&norm("SELECT MAX(a) FROM t")),
+            "{results:?}"
+        );
+    }
+
+    #[test]
+    fn function_calls_also_shrink_to_empty_string() {
+        let results = candidates("SELECT c <= RTRIM('ab') FROM t");
+        assert!(
+            results.contains(&norm("SELECT c <= '' FROM t")),
+            "{results:?}"
+        );
+        assert!(
+            results.contains(&norm("SELECT c <= 'ab' FROM t")),
+            "{results:?}"
+        );
+    }
+
+    #[test]
+    fn shrink_loop_keeps_only_the_load_bearing_kernel() {
+        // Synthetic judge: the "divergence" needs ABS( to survive. Everything
+        // else — the CASE block, the other function call, the literals — must
+        // be simplified away.
+        let sql = "SELECT ABS(CASE WHEN LENGTH('hello world') THEN 123456 \
+                   ELSE UPPER('junk') END), COALESCE(999999, X'DEADBEEF') FROM t";
+        let out = shrink_with(sql, |cand| Ok(cand.contains("ABS"))).unwrap();
+        assert!(out.contains("ABS"), "{out}");
+        assert!(!out.contains("CASE"), "{out}");
+        assert!(!out.contains("hello world"), "{out}");
+        assert!(!out.contains("123456"), "{out}");
+        assert!(!out.contains("999999"), "{out}");
+    }
+
+    #[test]
+    fn shrink_loop_terminates_when_everything_is_accepted() {
+        let sql = "SELECT MAX(1, MIN(2, 3)), 'literal', X'AB' FROM t";
+        let out = shrink_with(sql, |_| Ok(true)).unwrap();
+        assert!(out.len() < sql.len(), "{out}");
+    }
+
+    #[test]
+    fn shrink_statement_returns_none_without_divergence() {
+        // Same statement behaves identically on both engines, so there is
+        // nothing to shrink against.
+        let state = "CREATE TABLE t(x);\nINSERT INTO t VALUES (1);\n";
+        let out = shrink_statement(state, "SELECT x + 1 FROM t").unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn state_reduction_keeps_only_needed_lines() {
+        // Synthetic judge: the reproduction needs the CREATE and one INSERT;
+        // every other line must be deleted.
+        let state = "CREATE TABLE t(x);\nINSERT INTO t VALUES (1);\n\
+                     CREATE TABLE junk(y);\nINSERT INTO junk VALUES (2);\n\
+                     CREATE INDEX i ON junk(y);";
+        let out = reduce_state_lines(state, |cand| {
+            Ok(cand.contains("CREATE TABLE t(x);") && cand.contains("INSERT INTO t VALUES (1);"))
+        })
+        .unwrap();
+        assert_eq!(
+            out, "CREATE TABLE t(x);\nINSERT INTO t VALUES (1);",
+            "{out}"
+        );
+    }
+}

--- a/testing/differential-oracle/sql_gen/src/ast.rs
+++ b/testing/differential-oracle/sql_gen/src/ast.rs
@@ -1003,6 +1003,13 @@ pub struct UpdateStmt {
     pub where_clause: Option<Expr>,
     pub conflict: Option<ConflictClause>,
     pub returning: Option<Vec<Expr>>,
+    /// Emit `NOT INDEXED` on the target and every FROM/JOIN table, forcing a
+    /// rowid-order table scan. An `UPDATE ... FROM` where a target row matches
+    /// several source rows uses one of them, and which one depends on the scan
+    /// order the planner picks — Turso favors a covering index, SQLite a table
+    /// scan, so the results differ. Pinning both engines to a table scan makes
+    /// the choice deterministic.
+    pub not_indexed: bool,
 }
 
 impl fmt::Display for UpdateStmt {
@@ -1014,10 +1021,23 @@ impl fmt::Display for UpdateStmt {
         if let Some(conflict) = &self.conflict {
             write!(f, "{conflict}")?;
         }
+        // `NOT INDEXED` follows the (optional) alias on the target and on every
+        // FROM/JOIN table, per the qualified-table-name grammar. It only
+        // applies to real tables: a subquery source (`(SELECT ...)`) cannot
+        // take it, so skip those.
+        let not_indexed = |table: &str| -> &'static str {
+            if self.not_indexed && !table.trim_start().starts_with('(') {
+                " NOT INDEXED"
+            } else {
+                ""
+            }
+        };
+
         write!(f, " {}", self.table)?;
         if let Some(alias) = &self.alias {
             write!(f, " AS {alias}")?;
         }
+        write!(f, "{}", not_indexed(&self.table))?;
         write!(f, " SET ")?;
 
         for (i, (col, val)) in self.sets.iter().enumerate() {
@@ -1032,6 +1052,7 @@ impl fmt::Display for UpdateStmt {
             if let Some(alias) = &from.alias {
                 write!(f, " AS {alias}")?;
             }
+            write!(f, "{}", not_indexed(&from.table))?;
         }
 
         for join in &self.joins {
@@ -1044,6 +1065,7 @@ impl fmt::Display for UpdateStmt {
             if let Some(alias) = &join.alias {
                 write!(f, " AS {alias}")?;
             }
+            write!(f, "{}", not_indexed(&join.table))?;
             if let Some(JoinConstraint::On(expr)) = &join.constraint {
                 write!(f, " ON {expr}")?;
             }
@@ -2391,6 +2413,67 @@ mod tests {
         assert_eq!(
             insert.to_string(),
             "INSERT INTO users (name, age) VALUES ('Alice', 30)"
+        );
+    }
+
+    #[test]
+    fn update_from_not_indexed_display() {
+        let mut ctx = Context::new_with_seed(42);
+        let stmt = UpdateStmt {
+            with_clause: None,
+            table: "t".to_string(),
+            alias: None,
+            sets: vec![(
+                "v".to_string(),
+                Expr::literal(&mut ctx, Literal::Integer(1)),
+            )],
+            from: Some(FromClause {
+                table: "s".to_string(),
+                alias: None,
+            }),
+            joins: vec![JoinClause {
+                join_type: JoinType::Inner,
+                table: "j".to_string(),
+                alias: None,
+                constraint: None,
+            }],
+            where_clause: None,
+            conflict: None,
+            returning: None,
+            not_indexed: true,
+        };
+        assert_eq!(
+            stmt.to_string(),
+            "UPDATE t NOT INDEXED SET v = 1 FROM s NOT INDEXED JOIN j NOT INDEXED"
+        );
+    }
+
+    #[test]
+    fn update_from_not_indexed_skips_subquery_source() {
+        let mut ctx = Context::new_with_seed(42);
+        // NOT INDEXED is not valid on a subquery source, so it must be omitted
+        // there while still applying to the real target table.
+        let stmt = UpdateStmt {
+            with_clause: None,
+            table: "t".to_string(),
+            alias: None,
+            sets: vec![(
+                "v".to_string(),
+                Expr::literal(&mut ctx, Literal::Integer(1)),
+            )],
+            from: Some(FromClause {
+                table: "(SELECT k FROM s)".to_string(),
+                alias: Some("x".to_string()),
+            }),
+            joins: vec![],
+            where_clause: None,
+            conflict: None,
+            returning: None,
+            not_indexed: true,
+        };
+        assert_eq!(
+            stmt.to_string(),
+            "UPDATE t NOT INDEXED SET v = 1 FROM (SELECT k FROM s) AS x"
         );
     }
 

--- a/testing/differential-oracle/sql_gen/src/ast.rs
+++ b/testing/differential-oracle/sql_gen/src/ast.rs
@@ -1903,7 +1903,9 @@ pub struct UnaryOpExpr {
 impl fmt::Display for UnaryOpExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.op {
-            UnaryOp::Neg => write!(f, "-{}", self.operand),
+            // Without the space, two nested minus operators become `--`,
+            // which starts a SQL comment and hides the rest of the statement.
+            UnaryOp::Neg => write!(f, "- {}", self.operand),
             UnaryOp::Not => write!(f, "NOT {}", self.operand),
             UnaryOp::BitNot => write!(f, "~{}", self.operand),
         }
@@ -2268,6 +2270,19 @@ mod tests {
         assert_eq!(Literal::Text("hello".to_string()).to_string(), "'hello'");
         assert_eq!(Literal::Text("it's".to_string()).to_string(), "'it''s'");
         assert_eq!(Literal::Blob(vec![0xDE, 0xAD]).to_string(), "X'DEAD'");
+    }
+
+    #[test]
+    fn nested_minus_does_not_start_a_comment() {
+        let expr = Expr::UnaryOp(Box::new(UnaryOpExpr {
+            op: UnaryOp::Neg,
+            operand: Expr::UnaryOp(Box::new(UnaryOpExpr {
+                op: UnaryOp::Neg,
+                operand: Expr::Literal(Literal::Integer(1)),
+            })),
+        }));
+
+        assert_eq!(expr.to_string(), "- - 1");
     }
 
     #[test]

--- a/testing/differential-oracle/sql_gen/src/generate/literal.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/literal.rs
@@ -79,9 +79,19 @@ fn generate_string_with_charset(ctx: &mut Context, len: usize, charset: StringCh
 }
 
 /// Generate a blob literal.
+///
+/// Blob bytes are printable ASCII, so every blob is valid UTF-8. SQLite text
+/// is a plain byte string, but Turso's text type is a Rust string and cannot
+/// hold invalid UTF-8: casting a blob with a byte like 0x96 to TEXT keeps the
+/// byte in SQLite and becomes U+FFFD in Turso. This is a documented Turso
+/// limitation (see "Limitations" in COMPAT.md), and it reaches TEXT through
+/// many doors — CAST, UPPER, TRIM, REPLACE, || — so keeping generated blobs
+/// valid UTF-8 is the one place to make both engines see the same characters.
 pub fn generate_blob(ctx: &mut Context, config: &LiteralConfig) -> Literal {
     let len = ctx.gen_range_inclusive(config.blob_min_size, config.blob_max_size);
-    let bytes = ctx.gen_bytes(len);
+    let bytes = (0..len)
+        .map(|_| ctx.gen_range_inclusive(0x20, 0x7E) as u8)
+        .collect();
     Literal::Blob(bytes)
 }
 
@@ -247,6 +257,23 @@ mod tests {
             assert!(!b.is_empty());
         } else {
             panic!("Expected Blob literal");
+        }
+    }
+
+    #[test]
+    fn blobs_are_valid_utf8() {
+        // Casting a blob with invalid UTF-8 to TEXT keeps the bytes in SQLite
+        // but becomes replacement characters in Turso, so generated blobs must
+        // stay valid UTF-8 for the two engines to agree.
+        let mut ctx = Context::new_with_seed(7);
+        let config = default_config();
+        for _ in 0..200 {
+            if let Literal::Blob(b) = generate_blob(&mut ctx, &config) {
+                assert!(
+                    std::str::from_utf8(&b).is_ok(),
+                    "generated blob is not valid UTF-8: {b:x?}"
+                );
+            }
         }
     }
 

--- a/testing/differential-oracle/sql_gen/src/generate/select.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/select.rs
@@ -257,11 +257,12 @@ fn generate_select_impl_inner<C: Capabilities>(
     // --- DISTINCT ---
     let distinct = match mode {
         SelectMode::Full => ctx.gen_bool_with_prob(select_config.distinct_probability),
-        // Scalar: only when not grouped
-        SelectMode::Scalar => {
-            group_by.is_none()
-                && ctx.gen_bool_with_prob(select_config.subquery_distinct_probability)
-        }
+        // Scalar subqueries carry LIMIT 1, and DISTINCT makes that pick
+        // undecidable: when duplicates collapse, which duplicate's ORDER BY
+        // key survives is the engine's choice, so SQLite and Turso can return
+        // different rows and both are allowed. No tiebreaker can help because
+        // a unique column cannot be added through the deduplication.
+        SelectMode::Scalar => false,
     };
 
     let from = {
@@ -363,6 +364,47 @@ fn generate_select_impl_inner<C: Capabilities>(
             } else {
                 generate_order_by(generator, ctx)?
             };
+        }
+
+        // A scalar subquery's LIMIT 1 must pick the same row in both engines,
+        // and an ORDER BY key with duplicate values leaves the pick to scan
+        // order. Grouped: order by every GROUP BY expression — groups are
+        // distinct combinations of them, so that is a total order. Ungrouped:
+        // append the table's primary key as a final tiebreaker.
+        if mode == SelectMode::Scalar {
+            if let Some(gb) = &group_by {
+                let covered: Vec<String> = order_by.iter().map(|i| i.expr.to_string()).collect();
+                for expr in &gb.exprs {
+                    if !covered.contains(&expr.to_string()) {
+                        let direction =
+                            select_order_direction(ctx, &select_config.order_direction_weights);
+                        order_by.push(OrderByItem {
+                            expr: expr.clone(),
+                            direction,
+                            nulls: None,
+                        });
+                    }
+                }
+            } else {
+                let scoped = &ctx.tables_in_scope()[0];
+                let qualifier = scoped.qualifier.clone();
+                let pk = scoped
+                    .table
+                    .columns
+                    .iter()
+                    .find(|c| c.primary_key)
+                    .map(|c| c.name.clone())
+                    .unwrap_or_else(|| "rowid".to_string());
+                let direction = select_order_direction(ctx, &select_config.order_direction_weights);
+                order_by.push(OrderByItem {
+                    expr: Expr::ColumnRef(crate::ast::ColumnRef {
+                        table: Some(qualifier),
+                        column: pk,
+                    }),
+                    direction,
+                    nulls: None,
+                });
+            }
         }
 
         Ok(SelectStmt {
@@ -2059,6 +2101,45 @@ mod tests {
              offset_range={saw_offset_range}, \
              unexcluded_removable_prefix={saw_unexcluded_removable_prefix}"
         );
+    }
+
+    #[test]
+    fn scalar_subqueries_pick_a_deterministic_row() {
+        // LIMIT 1 must select the same row in both engines, so a scalar
+        // subquery may not use DISTINCT, and its ORDER BY must fully decide
+        // the winner: the primary key as a tiebreaker, or (when grouped)
+        // every GROUP BY expression.
+        let generator = test_generator();
+        for seed in 0..300 {
+            let mut ctx = Context::new_with_seed(seed);
+            ctx.with_table_scope(
+                [(generator.schema().tables[0].clone(), None)],
+                |ctx| -> Result<(), GenError> {
+                    let stmt = generate_simple_select(&generator, ctx)?;
+                    assert!(!stmt.distinct, "seed {seed}: scalar subquery uses DISTINCT");
+                    if let Some(gb) = &stmt.group_by {
+                        let ordered: Vec<String> =
+                            stmt.order_by.iter().map(|i| i.expr.to_string()).collect();
+                        for e in &gb.exprs {
+                            assert!(
+                                ordered.contains(&e.to_string()),
+                                "seed {seed}: GROUP BY expr {e} missing from ORDER BY"
+                            );
+                        }
+                    } else {
+                        let last = stmt.order_by.last().expect("scalar must have ORDER BY");
+                        assert!(
+                            matches!(&last.expr, Expr::ColumnRef(c) if c.column == "id"
+                                || c.column == "rowid"),
+                            "seed {seed}: last ORDER BY term is not the tiebreaker: {}",
+                            last.expr
+                        );
+                    }
+                    Ok(())
+                },
+            )
+            .unwrap();
+        }
     }
 
     #[test]

--- a/testing/differential-oracle/sql_gen/src/generate/select.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/select.rs
@@ -288,20 +288,24 @@ fn generate_select_impl_inner<C: Capabilities>(
     // --- Compound SELECT decision ---
     // Only at top level (not inside subqueries) since Turso doesn't support
     // compound SELECTs in subquery positions yet.
+    let compound_column_types = compound_column_types(&columns, ctx);
     let is_compound = mode == SelectMode::Full
         && ctx.subquery_depth() == 0
         && joins.is_empty()
         && group_by.is_none()
+        && compound_column_types.as_ref().is_some_and(|column_types| {
+            generator.schema().tables.iter().any(|table| {
+                column_types
+                    .iter()
+                    .all(|data_type| table.columns_of_type(*data_type).next().is_some())
+            })
+        })
         && ctx.gen_bool_with_prob(select_config.compound_probability);
 
     if is_compound {
-        let num_result_cols = if columns.is_empty() {
-            // SELECT * — count columns from primary table
-            ctx.tables_in_scope()[0].table.columns.len()
-        } else {
-            columns.len()
-        };
-        let compounds = generate_compound_arms(generator, ctx, num_result_cols)?;
+        let column_types = compound_column_types.as_ref().unwrap();
+        let num_result_cols = column_types.len();
+        let compounds = generate_compound_arms(generator, ctx, column_types)?;
 
         // ORDER BY for compounds uses positional indices (1..N)
         let mut order_by = if ctx.gen_bool_with_prob(select_config.compound_order_by_probability) {
@@ -1276,14 +1280,57 @@ pub(crate) fn generate_join_on_condition<C: Capabilities>(
     Ok(Expr::binary_op(ctx, col_expr, op, lit_expr))
 }
 
+/// Return the declared type of each result column when every result is a table
+/// column. Expressions have no dependable declared type for compound queries.
+fn compound_column_types(columns: &[SelectColumn], ctx: &Context) -> Option<Vec<DataType>> {
+    if columns.is_empty() {
+        return Some(
+            ctx.tables_in_scope()[0]
+                .table
+                .columns
+                .iter()
+                .map(|column| column.data_type)
+                .collect(),
+        );
+    }
+
+    columns
+        .iter()
+        .map(|column| {
+            let Expr::ColumnRef(column_ref) = &column.expr else {
+                return None;
+            };
+            ctx.tables_in_scope()
+                .iter()
+                .filter(|table| {
+                    column_ref.table.as_ref().is_none_or(|qualifier| {
+                        qualifier == &table.qualifier || qualifier == &table.table.name
+                    })
+                })
+                .find_map(|table| {
+                    table
+                        .table
+                        .columns
+                        .iter()
+                        .find(|column| column.name == column_ref.column)
+                        .map(|column| column.data_type)
+                })
+        })
+        .collect()
+}
+
 /// Generate compound arms for a compound SELECT.
 ///
-/// Each arm picks a table, generates columns matching `num_cols`, and optionally
-/// generates a WHERE clause. The compound operator is chosen by weighted random.
+/// Each arm picks a table, generates columns matching `column_types`, and
+/// optionally generates a WHERE clause. SQLite is free to choose the declared
+/// type of a compound result column from any SELECT arm. If the arms use
+/// different types, SQLite may turn an integer into a real while Turso leaves it
+/// unchanged, and both results are allowed. Using the same type in every arm
+/// gives the fuzzer one result to compare.
 fn generate_compound_arms<C: Capabilities>(
     generator: &SqlGen<C>,
     ctx: &mut Context,
-    num_cols: usize,
+    column_types: &[DataType],
 ) -> Result<Vec<CompoundSelectArm>, GenError> {
     let select_config = &generator.policy().select_config;
     let weights = &select_config.compound_operator_weights;
@@ -1317,18 +1364,43 @@ fn generate_compound_arms<C: Capabilities>(
 
         let arm = ctx.scope(origin, |ctx| {
             // Pick a table for this arm
+            let tables: Vec<_> = generator
+                .schema()
+                .tables
+                .iter()
+                .filter(|table| {
+                    column_types
+                        .iter()
+                        .all(|data_type| table.columns_of_type(*data_type).next().is_some())
+                })
+                .cloned()
+                .collect();
             let table = ctx
-                .choose(&generator.schema().tables)
-                .ok_or_else(|| GenError::schema_empty("tables"))?;
-            let table = table.clone();
+                .choose(&tables)
+                .ok_or_else(|| {
+                    GenError::exhausted("compound_select", "no table has matching columns")
+                })?
+                .clone();
             let table_name = table.qualified_name();
 
             // Generate columns in a temporary table scope for this arm's table
             let (columns, where_clause) = ctx.with_table_scope(vec![(table, None)], |ctx| {
-                // Generate columns matching the required count
-                let mut cols = Vec::with_capacity(num_cols);
-                for _ in 0..num_cols {
-                    let expr = pick_scoped_column_ref(ctx)?;
+                let matching_columns: Vec<Vec<String>> = {
+                    let table = &ctx.tables_in_scope()[0].table;
+                    column_types
+                        .iter()
+                        .map(|data_type| {
+                            table
+                                .columns_of_type(*data_type)
+                                .map(|column| column.name.clone())
+                                .collect()
+                        })
+                        .collect()
+                };
+                let mut cols = Vec::with_capacity(column_types.len());
+                for column_names in matching_columns {
+                    let column_name = ctx.choose(&column_names).unwrap().clone();
+                    let expr = Expr::column_ref(ctx, None, column_name);
                     cols.push(SelectColumn { expr, alias: None });
                 }
 
@@ -1981,6 +2053,35 @@ mod tests {
              offset_range={saw_offset_range}, \
              unexcluded_removable_prefix={saw_unexcluded_removable_prefix}"
         );
+    }
+
+    #[test]
+    fn test_compound_arms_use_matching_column_types() {
+        let schema = SchemaBuilder::new()
+            .table(Table::new(
+                "mixed",
+                vec![
+                    ColumnDef::new("integer_value", DataType::Integer),
+                    ColumnDef::new("real_value", DataType::Real),
+                ],
+            ))
+            .table(Table::new(
+                "integers",
+                vec![ColumnDef::new("integer_value", DataType::Integer)],
+            ))
+            .build();
+        let generator: SqlGen<Full> = SqlGen::new(schema, Policy::default());
+        let mut ctx = Context::new_with_seed(42);
+
+        let arms =
+            generate_compound_arms(&generator, &mut ctx, &[DataType::Integer, DataType::Real])
+                .unwrap();
+
+        for arm in arms {
+            assert_eq!(arm.from.unwrap().table, "mixed");
+            assert_eq!(arm.columns[0].expr.to_string(), "integer_value");
+            assert_eq!(arm.columns[1].expr.to_string(), "real_value");
+        }
     }
 
     #[test]

--- a/testing/differential-oracle/sql_gen/src/generate/select.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/select.rs
@@ -1010,7 +1010,13 @@ fn generate_order_by<C: Capabilities>(
                 // Avoid bare literals — SQLite interprets integer literals in
                 // ORDER BY as column-ordinal positions (e.g. ORDER BY 2).
                 // Also catch unary wrappers like -478008 or +3.
-                if looks_like_literal(&e) {
+                //
+                // Also avoid any term without a column reference: it computes
+                // the same value for every row, so all keys tie and the order
+                // is whatever scan order the engine used. With a LIMIT that
+                // makes the surviving rows engine-specific, and both answers
+                // are allowed.
+                if looks_like_literal(&e) || !e.contains_column_ref() {
                     pick_scoped_column_ref(ctx)?
                 } else {
                     e
@@ -2053,6 +2059,32 @@ mod tests {
              offset_range={saw_offset_range}, \
              unexcluded_removable_prefix={saw_unexcluded_removable_prefix}"
         );
+    }
+
+    #[test]
+    fn order_by_terms_always_reference_a_column() {
+        // A term that computes the same value for every row (e.g.
+        // REPLACE('a','b','c')) makes every key tie, so with a LIMIT the
+        // surviving rows depend on engine scan order.
+        let generator = test_generator();
+        for seed in 0..300 {
+            let mut ctx = Context::new_with_seed(seed);
+            ctx.with_table_scope(
+                [(generator.schema().tables[0].clone(), None)],
+                |ctx| -> Result<(), GenError> {
+                    let items = generate_order_by(&generator, ctx)?;
+                    for item in items {
+                        assert!(
+                            item.expr.contains_column_ref(),
+                            "seed {seed} produced constant ORDER BY term: {}",
+                            item.expr
+                        );
+                    }
+                    Ok(())
+                },
+            )
+            .unwrap();
+        }
     }
 
     #[test]

--- a/testing/differential-oracle/sql_gen/src/generate/stmt.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/stmt.rs
@@ -1809,7 +1809,10 @@ mod tests {
         assert!(stmt.is_ok());
 
         let sql = stmt.unwrap().to_string();
-        assert!(sql.starts_with("CREATE TRIGGER"));
+        assert!(
+            sql.starts_with("CREATE TRIGGER") || sql.starts_with("CREATE TEMP TRIGGER"),
+            "{sql}"
+        );
         assert!(sql.contains("ON users"));
         assert!(sql.contains("BEGIN"));
         assert!(sql.contains("END"));

--- a/testing/differential-oracle/sql_gen/src/generate/stmt.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/stmt.rs
@@ -173,7 +173,9 @@ fn is_stmt_valid_for_schema(
         // SELECT is always valid (SELECT 1, SELECT ABS(-5), etc.)
         StmtKind::Select => true,
         // INSERT/DELETE/UPDATE require tables
-        StmtKind::Insert | StmtKind::Delete | StmtKind::Update => has_tables,
+        StmtKind::Insert | StmtKind::Delete | StmtKind::Update | StmtKind::PragmaForeignKeyList => {
+            has_tables
+        }
         // DDL that operates on existing tables
         StmtKind::DropTable
         | StmtKind::AlterTable
@@ -184,11 +186,7 @@ fn is_stmt_valid_for_schema(
         // DROP TRIGGER requires triggers to exist
         StmtKind::DropTrigger => has_triggers,
         // These are always valid
-        StmtKind::CreateTable
-        | StmtKind::Begin
-        | StmtKind::Commit
-        | StmtKind::Rollback
-        | StmtKind::PragmaForeignKeyList => true,
+        StmtKind::CreateTable | StmtKind::Begin | StmtKind::Commit | StmtKind::Rollback => true,
         // Stubs — always valid (would require tables for views but weight is 0 anyway)
         StmtKind::CreateView => has_tables,
         StmtKind::DropView => true,
@@ -1709,6 +1707,17 @@ mod tests {
 
         let stmt = generate_statement(&generator, &mut ctx);
         assert!(stmt.is_ok());
+    }
+
+    #[test]
+    fn empty_schema_never_chooses_a_statement_that_needs_a_table() {
+        let generator: SqlGen<Full> = SqlGen::new(SchemaBuilder::new().build(), Policy::default());
+
+        for seed in 0..1000 {
+            let mut ctx = Context::new_with_seed(seed);
+            let stmt = generate_statement(&generator, &mut ctx);
+            assert!(stmt.is_ok(), "generation failed for seed {seed}: {stmt:?}");
+        }
     }
 
     #[test]

--- a/testing/differential-oracle/sql_gen/src/generate/stmt.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/stmt.rs
@@ -269,11 +269,13 @@ pub fn generate_insert<C: Capabilities>(
         return Err(GenError::exhausted("insert", "no columns to insert"));
     }
 
-    // Generate conflict clause
+    // Generate conflict clause. INSERT applies rows in VALUES order, so OR
+    // FAIL's partial result is deterministic and safe to generate.
     let conflict = generate_conflict_clause(
         ctx,
         insert_config.or_replace_probability,
         insert_config.or_ignore_probability,
+        true,
     );
 
     // Generate values (push table into scope for expression generation)
@@ -425,11 +427,14 @@ pub fn generate_update<C: Capabilities>(
     };
 
     ctx.with_table_scope(scope_tables, |ctx| {
-        // Generate conflict clause
+        // Generate conflict clause. OR FAIL is excluded: a multi-row UPDATE
+        // that hits it keeps whichever rows were visited first, and that order
+        // is not guaranteed to match between engines.
         let conflict = generate_conflict_clause(
             ctx,
             update_config.or_replace_probability,
             update_config.or_ignore_probability,
+            false,
         );
 
         // Generate SET clause
@@ -469,6 +474,11 @@ pub fn generate_update<C: Capabilities>(
             where_clause,
             conflict,
             returning,
+            // An UPDATE ... FROM whose join matches a target row against several
+            // source rows uses one of them, chosen by scan order. Force a table
+            // scan on the target and sources so SQLite and Turso pick the same
+            // one. Plain UPDATEs are order-independent and keep their coverage.
+            not_indexed: from_clause.is_some(),
         }))
     })
 }
@@ -649,10 +659,16 @@ fn generate_from_column_ref(
 /// Uses the existing `or_replace_probability` and `or_ignore_probability` from the config,
 /// plus equal weights for Abort, Fail, and Rollback. If neither or_replace nor or_ignore
 /// has any probability, no conflict clause is generated.
+///
+/// `allow_fail` gates OR FAIL. OR FAIL keeps the rows updated before the
+/// conflicting one, so for a multi-row UPDATE the surviving rows depend on the
+/// order rows are visited — which SQLite and Turso need not share. Callers
+/// whose result would then be order-dependent pass `false`.
 fn generate_conflict_clause(
     ctx: &mut Context,
     or_replace_prob: f64,
     or_ignore_prob: f64,
+    allow_fail: bool,
 ) -> Option<ConflictClause> {
     // Total probability of getting any conflict clause
     let total_prob = or_replace_prob + or_ignore_prob;
@@ -670,12 +686,13 @@ fn generate_conflict_clause(
     let replace_w = (or_replace_prob * 100.0) as u32;
     let ignore_w = (or_ignore_prob * 100.0) as u32;
     let other_w = ((replace_w + ignore_w) / 3).max(1);
+    let fail_w = if allow_fail { other_w } else { 0 };
 
     let items = [
         (ConflictClause::Replace, replace_w),
         (ConflictClause::Ignore, ignore_w),
         (ConflictClause::Abort, other_w),
-        (ConflictClause::Fail, other_w),
+        (ConflictClause::Fail, fail_w),
         (ConflictClause::Rollback, other_w),
     ];
 

--- a/testing/differential-oracle/sql_gen/src/schema.rs
+++ b/testing/differential-oracle/sql_gen/src/schema.rs
@@ -249,6 +249,7 @@ impl Index {
 pub struct Trigger {
     pub name: String,
     pub table_name: String,
+    pub database: Option<String>,
 }
 
 impl Trigger {
@@ -256,6 +257,19 @@ impl Trigger {
         Self {
             name: name.into(),
             table_name: table_name.into(),
+            database: None,
+        }
+    }
+
+    pub fn in_database(mut self, db: impl Into<String>) -> Self {
+        self.database = Some(db.into());
+        self
+    }
+
+    pub fn qualified_name(&self) -> String {
+        match &self.database {
+            Some(db) => format!("{}.{}", db, self.name),
+            None => self.name.clone(),
         }
     }
 }

--- a/testing/differential-oracle/sql_gen_prop/schema.rs
+++ b/testing/differential-oracle/sql_gen_prop/schema.rs
@@ -241,6 +241,7 @@ impl View {
 pub struct Trigger {
     pub name: String,
     pub table_name: String,
+    pub database: Option<String>,
 }
 
 impl Trigger {
@@ -248,6 +249,19 @@ impl Trigger {
         Self {
             name: name.into(),
             table_name: table_name.into(),
+            database: None,
+        }
+    }
+
+    pub fn in_database(mut self, db: impl Into<String>) -> Self {
+        self.database = Some(db.into());
+        self
+    }
+
+    pub fn qualified_name(&self) -> String {
+        match &self.database {
+            Some(db) => format!("{}.{}", db, self.name),
+            None => self.name.clone(),
         }
     }
 }

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -2116,6 +2116,55 @@ fn test_update_or_fail_partial_success_in_txn(tmp_db: TempDatabase) -> anyhow::R
     Ok(())
 }
 
+/// A BEFORE INSERT trigger runs an `UPDATE OR FAIL` that conflicts. The FAIL
+/// belongs to the trigger's UPDATE, not to the outer INSERT, so it must govern
+/// how much is rolled back: SQLite keeps the changes made before the conflict
+/// (the trigger's earlier updates and the already-inserted row) rather than
+/// undoing the whole INSERT. Turso used the outer INSERT's ABORT resolution and
+/// rolled everything back.
+#[turso_macros::test]
+fn test_trigger_or_fail_preserves_prior_changes(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let limbo_db = tmp_db.connect_limbo();
+    let sqlite_db = rusqlite::Connection::open_in_memory()?;
+
+    let setup = [
+        "CREATE TABLE t(id INTEGER PRIMARY KEY)",
+        "INSERT INTO t VALUES(-1)",
+        "CREATE TRIGGER tr BEFORE INSERT ON t BEGIN \
+           UPDATE OR FAIL t SET id = 807742 WHERE (SELECT id FROM t LIMIT 1); \
+         END",
+    ];
+    for sql in &setup {
+        limbo_db.execute(sql)?;
+        sqlite_db.execute(sql, params![])?;
+    }
+
+    // Inserting the first row fires the trigger, which renames -1 to 807742,
+    // then the row is inserted. The second row fires the trigger again, whose
+    // UPDATE now conflicts with the existing 807742 and fails.
+    let insert = "INSERT INTO t VALUES(1), (2)";
+    let limbo_res = limbo_db.execute(insert);
+    let sqlite_res = sqlite_db.execute(insert, params![]);
+    assert!(limbo_res.is_err(), "limbo should return UNIQUE error");
+    assert!(sqlite_res.is_err(), "sqlite should return UNIQUE error");
+
+    let verify = "SELECT id FROM t ORDER BY id";
+    let limbo_rows = limbo_exec_rows(&limbo_db, verify);
+    let sqlite_rows = sqlite_exec_rows(&sqlite_db, verify);
+    assert_eq!(
+        limbo_rows, sqlite_rows,
+        "data mismatch after trigger UPDATE OR FAIL: limbo={limbo_rows:?} sqlite={sqlite_rows:?}"
+    );
+    use rusqlite::types::Value::Integer;
+    assert_eq!(
+        sqlite_rows,
+        vec![vec![Integer(1)], vec![Integer(807742)]],
+        "expected the first row's insert and rename to persist"
+    );
+
+    Ok(())
+}
+
 /// Test DDL-level REPLACE on two unique indexes where INSERT conflicts with
 /// two DIFFERENT existing rows. Both conflicting rows should be deleted.
 #[turso_macros::test]


### PR DESCRIPTION
# Make the differential fuzzer reliable enough to run in CI, and run it in CI

## What's the differential fuzzer bro

It runs generated SQL against Turso and SQLite, then compares the results and database state and expects them to match.

## The Problem ™️ 

 We haven't been running the fuzzer in CI because it always fails somewhere.

## The Solution ©️ 

This PR fixes that in two ways:

- **Fix Turso bugs.** Some differences are real Turso bugs. They are fixed here, each with a test.
- **Make the fuzzer avoid SQL with more than one allowed answer.** Some SQL is allowed to give different results in different engines. Comparing those results tells us nothing, so the fuzzer stops generating them.

## Bonus features

It also adds tooling:

- Statement weight profiles, so CI covers several statement mixes instead of one.
- Automatic minimization of failures: every failure now comes with a small reproduction script.
- The SQLite TCL conformance runner now runs every test file in its own process, so one crashing file can't kill the whole run — and seven previously known-bad files now fully pass and are pinned green.

---

## Turso bugs fixed

**A TEMP trigger stopped running after its table was renamed.**

```sql
CREATE TABLE t(x);
CREATE TEMP TRIGGER tr AFTER INSERT ON t BEGIN INSERT INTO log VALUES (1); END;
ALTER TABLE t RENAME TO t2;
INSERT INTO t2 VALUES (1);
-- SQLite: trigger fires. Turso: trigger never fired again.
```

Turso updated the stored SQL but kept the trigger under the old table name in memory. The rename now updates both.

**`DROP COLUMN` missed trigger references written as `alias.column`.**

```sql
CREATE TABLE t(a, b);
CREATE TRIGGER tr BEFORE UPDATE ON t WHEN t.b > 0 BEGIN SELECT 1; END;
ALTER TABLE t DROP COLUMN b;
-- SQLite: error "no such column: t.b". Turso: allowed the drop.
```

References spelled `t.b` or `main.t.b` were not checked. Such drops are now rejected.

**A `BEFORE INSERT` trigger could make the outer insert pick a wrong automatic rowid.**

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, v);
CREATE TRIGGER tr BEFORE INSERT ON t BEGIN INSERT INTO t VALUES (100, 'x'); END;
INSERT INTO t(v) VALUES ('a'), ('b');
```

The outer insert chose its automatic rowid from a stale cursor position, as if the trigger's row didn't exist. Rowid lookup now seeks to the actual largest rowid first.

**An unqualified TEMP trigger could forget which database its table came from.**

```sql
CREATE TABLE t(x);                 -- in main
CREATE TEMP TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
CREATE TABLE aux.t(x);             -- same name in aux
DROP TABLE main.t;
INSERT INTO aux.t VALUES (1);
-- Turso: the temp trigger could fire on aux.t, or survive the drop of main.t.
```

Turso now remembers the correct database.

**`UPDATE` skipped `NOT NULL` checks when the table's only trigger was `AFTER UPDATE`.**

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, n TEXT NOT NULL);
INSERT INTO t VALUES (1, 'keep');
CREATE TRIGGER tr AFTER UPDATE ON t BEGIN SELECT 1; END;
UPDATE t SET n = NULL;
-- SQLite: error "NOT NULL constraint failed". Turso: stored NULL.
```

The check is deferred so `BEFORE` triggers can run first. But it was skipped for *any* trigger and only re-added when a `BEFORE` trigger existed, so a table with only an `AFTER` trigger lost the check entirely.

**`UPDATE OR FAIL` inside a trigger rolled back too much.**

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY);
INSERT INTO t VALUES (-1);
CREATE TRIGGER tr BEFORE INSERT ON t BEGIN
  UPDATE OR FAIL t SET id = 807742 WHERE (SELECT id FROM t LIMIT 1);
END;
INSERT INTO t VALUES (1), (2);
-- Both engines report a UNIQUE error.
-- SQLite table afterwards: {1, 807742}. Turso: {-1} — everything rolled back.
```

`OR FAIL` means: keep the rows already changed. That worked in a plain statement, but when the conflict happened inside a trigger, Turso applied the outer statement's rollback instead. SQLite keeps the earlier changes; now Turso does too.

**`UPDATE ... RETURNING` showed values written by the `AFTER` trigger.**

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
INSERT INTO t VALUES (1, 10);
CREATE TRIGGER tr AFTER UPDATE ON t BEGIN
  UPDATE t SET val = val + 100 WHERE id = NEW.id;
END;
UPDATE t SET val = 20 WHERE id = 1 RETURNING val;
-- SQLite returns 20 (what the UPDATE wrote). Turso returned 120.
-- The final table holds 120 in both engines.
```

Turso now fires `AFTER` triggers after RETURNING has captured the row. Two existing tests pinned the old behavior as intentional; they now expect SQLite's behavior.

**`x IN ((SELECT ...))` returned NULL for an empty subquery.**

```sql
SELECT 5 IN ((SELECT 1 WHERE 0));
-- SQLite: 0. Turso: NULL.
```

Turso parsed the double parentheses as a value list containing one scalar subquery, and an empty scalar subquery is NULL. SQLite reads it the same as `x IN (SELECT ...)`: an empty subquery means "not in", never NULL.

**`OR REPLACE` stored a NULL default into a `NOT NULL` column.**

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, c BLOB NOT NULL DEFAULT (NULL));
INSERT INTO t VALUES (1, X'AA');
UPDATE OR REPLACE t SET c = NULL;
-- SQLite: error "NOT NULL constraint failed". Turso: stored NULL.
```

`OR REPLACE` fixes a `NOT NULL` violation by swapping in the column default — but the default can itself be NULL. Turso never re-checked the swapped-in value. Now it does.

**`EXISTS` kept `ORDER BY` and `DISTINCT` that SQLite throws away.**

`EXISTS` only asks whether a row comes back, so SQLite deletes `ORDER BY` and `DISTINCT` inside it. Turso kept them, which showed up in two ways:

```sql
-- 1. An ORDER BY term that fails at runtime:
SELECT EXISTS (SELECT x FROM t ORDER BY ABS(-9223372036854775807 - 1));
-- SQLite: 1 (the term is never evaluated). Turso: error "integer overflow".

-- 2. DISTINCT changing what OFFSET counts (t has rows 1, 1, 2):
SELECT EXISTS (SELECT DISTINCT x FROM t ORDER BY x LIMIT 5 OFFSET 2);
-- SQLite: 1 (OFFSET skips 2 of 3 plain rows). Turso: 0 (OFFSET skipped both distinct rows).
```

Turso now drops both clauses in `EXISTS`. Name errors in the dropped clauses still surface, matching SQLite.

**A backward scan with a text bound returned a phantom row from an empty table.**

```sql
CREATE TABLE b(id INTEGER PRIMARY KEY);
SELECT 1 FROM b WHERE id <= '' ORDER BY id DESC;
-- SQLite: no rows. Turso: one row. The table is empty.
```

Every integer sorts before every text value, so `id <= ''` is true for all rows and the seek turns into "jump to the last row". On an empty table there is no last row, but Turso reported the seek as successful anyway, and the scan emitted one garbage row. Found by this PR's own CI setup: the `ddl` profile hit it, and the minimizer cut the failure down to a two-line reproduction on its own.

**An index seek ignored a subquery's column type and compared an integer as text.**

```sql
CREATE TABLE a(t TEXT UNIQUE);
INSERT INTO a VALUES ('4x');
SELECT 1 FROM a WHERE t < (SELECT 602393 AS i);
-- SQLite: no rows (the integer sorts before all text).
-- Turso: one row ('4x' < '602393' compared as strings).
```

When both sides of a comparison have a type, and one is numeric, the comparison is numeric — so the integer keeps its type and sorts before the text. Turso's optimizer couldn't see the subquery's INTEGER type when building the index seek key, treated it as typeless, and let the TEXT column win: the seek converted the integer to text and string-compared. Only the index seek was wrong; a full table scan compared correctly. Also found by this PR's own CI setup: the `writes` profile hit it as a DELETE that removed a row SQLite kept, and the minimizer reduced it to five lines.

**An aggregate over an outer column ran against the wrong table.**

```sql
CREATE TABLE t(a); INSERT INTO t VALUES (1), (2), (3);
SELECT (SELECT count(t.a)) FROM t;
-- SQLite: one row, 3. Turso: three rows, 1 1 1.
```

An aggregate whose argument references a column from an outer query belongs to that outer query, not the subquery it is written in — the outer query becomes an aggregate query and collapses to one row. Turso bound every aggregate to the innermost query it was written in, so `count(t.a)` counted the subquery's own rows (a single correlated row) instead of the outer query's. The fix mirrors SQLite name resolution: when a subquery resolves an aggregate whose columns belong to the enclosing query, it moves the aggregate up to that query during resolution. Found by the `balanced` and `writes` profiles.

**A CASE with no ELSE was treated as never producing NULL.**

```sql
CREATE TABLE t(k INTEGER PRIMARY KEY, c REAL);
INSERT INTO t VALUES (1, -47175.8);
CREATE INDEX i ON t(c);
SELECT 1 FROM t WHERE CASE WHEN '' THEN 1 END <= c;
-- SQLite: no rows. Turso: one row.
```

An index range seek guards its seek key with an "is it NULL?" jump, because a NULL comparison is never true. Turso decided whether to emit that guard with a helper that wrongly reported a CASE with no ELSE as never-NULL — but such a CASE yields NULL when no WHEN matches. The seek then ran on a NULL key and returned rows. A CASE is non-null only when it has an ELSE and every branch is non-null. Found by the `balanced` profile.

**A DELETE trigger inherited an outer `OR REPLACE` it should not have.**

```sql
CREATE TABLE t(pk INTEGER PRIMARY KEY, x);
CREATE TABLE t2(pk INTEGER PRIMARY KEY, y);
INSERT INTO t VALUES(1,0); INSERT INTO t2 VALUES(1,0);
CREATE TRIGGER t2_bd BEFORE DELETE ON t2 FOR EACH ROW BEGIN
  INSERT INTO t2(pk,y) VALUES(1,1),(1,2); END;
CREATE TRIGGER t_au AFTER UPDATE ON t FOR EACH ROW BEGIN
  DELETE FROM t2 WHERE pk=1; END;
UPDATE OR REPLACE t SET x=9;
-- SQLite: UNIQUE constraint failed: t2.pk. Turso: silently succeeded.
```

A statement's `OR REPLACE` policy propagates into the triggers it fires, but a DELETE is an exception: it always fires its triggers with the default (ABORT) policy. Turso propagated the outer REPLACE through a delete-fired trigger, so a plain INSERT that duplicated a key was quietly resolved instead of raising the error SQLite raises. Found by the `triggers` profile; reduced from a three-trigger cascade to the two-trigger case above.

**A trigger's `WHEN` reused a stale subquery result on every firing after the first.**

```sql
CREATE TABLE tt (pk INTEGER PRIMARY KEY, d INTEGER);
CREATE TRIGGER trg AFTER INSERT ON tt FOR EACH ROW
  WHEN EXISTS (SELECT 1 FROM tt WHERE EXISTS (SELECT 1 FROM tt WHERE d) IN (1))
  BEGIN INSERT INTO tt (pk, d) VALUES (1, 0); END;
INSERT INTO tt (pk, d) VALUES (1, 0), (2, 1), (3, 1);
-- SQLite: UNIQUE constraint failed (the WHEN turns true at row 2, the body re-inserts pk=1).
-- Turso: silently succeeded (the WHEN stayed false for every row).
```

A trigger body is inlined and re-run once per inserted row. An uncorrelated subquery is normally evaluated once and its result cached — but the cache is only valid within one run of the query. Turso kept the cache across trigger firings, so the inner `EXISTS` — false at the first firing, when no `d = 1` row exists yet — was reused as false forever, even after later rows made it true. The fix clears that "already evaluated" state at the start of each firing, so each firing re-evaluates against the current table. This matches SQLite, which gives every trigger firing a fresh start. It was not limited to `EXISTS`: a nested `IN (SELECT …)`, whose lookup table is also built once, went stale the same way. Found by the `triggers` profile; reduced from a large nested subquery to the five lines above.

## Harness fix 1: only run statements both engines can prepare, using EXPLAIN

The flow is:

1. Generate a statement.
2. Run `EXPLAIN` in both engines.
3. If either engine rejects it, run it in neither.
4. Otherwise, run it in both and compare the results.
5. After writes, compare the database contents and schema, including triggers.

Without this check, a statement accepted by only one engine could change only one database and spoil every later comparison. `EXPLAIN` checks acceptance without changing either database.

- Skipped statements are reported separately from failures.
- We may miss some real accept/reject bugs this way. That's a fair tradeoff: those can be tested elsewhere, while this fuzzer is most useful for comparing execution after both engines accept the same statement.

## Harness fix 2: avoid updates where row order decides the result

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, value INTEGER UNIQUE);
INSERT INTO t VALUES (1, 10), (2, 20);
UPDATE OR IGNORE t SET value = 30;
-- Whichever row is visited first gets 30. Both answers are allowed.
```

`UPDATE OR FAIL` has the same problem: it keeps the rows changed before the conflict, so the survivors depend on visit order.

`UPDATE ... FROM` has a related one:

```sql
UPDATE t SET v = s.val FROM s WHERE s.k = t.id;
-- If several s rows match one t row, either engine may pick any of them.
-- Turso often scans s through an index while SQLite scans the table,
-- so they pick different rows.
```

What the generator does now:

- `UPDATE OR IGNORE` and `UPDATE OR FAIL` are not generated. `UPDATE OR REPLACE`, `OR ABORT`, and `OR ROLLBACK` still are — their results don't depend on visit order.
- `UPDATE ... FROM` is limited to one source table, and the generator writes `NOT INDEXED` on the target and the source. That forces a plain table scan in both engines, so they visit rows in the same order and pick the same matching row.
- Joins and self-joins in `UPDATE ... FROM` are not generated. `NOT INDEXED` only controls how a table is scanned; Turso may still build a temporary index to run a join, and then the match order differs again.
- Subquery sources are not generated either, because `NOT INDEXED` cannot be written on a subquery.

This loses some random coverage. It is the price of a fuzzer that only flags real differences. These forms can still be covered by focused tests where the expected result is known.

## Harness fix 2b: make scalar subqueries pick a deterministic row

A scalar subquery carries `LIMIT 1`, and both engines must pick the same row for the comparison to mean anything. Two generated shapes left the pick to engine scan order:

```sql
-- Sort key can tie: rows with equal k are ordered by scan order.
(SELECT v FROM t ORDER BY k DESC LIMIT 1)

-- DISTINCT collapse: which duplicate's ORDER BY key survives is the
-- engine's choice.
(SELECT DISTINCT v FROM t ORDER BY k LIMIT 1)

-- A constant ORDER BY term ties everything.
(SELECT v FROM t ORDER BY REPLACE('a', 'b', 'c') LIMIT 1)
```

What the generator does now:

- ORDER BY terms must reference a column; constant terms are replaced with a column reference.
- Scalar subqueries get the table's primary key appended as a final ORDER BY tiebreaker. Grouped ones order by every GROUP BY expression instead — groups are distinct combinations of those, so that is already a total order.
- Scalar subqueries no longer use DISTINCT; no tiebreaker can be added through the deduplication.

## Harness fix 2c: generate blob literals as valid UTF-8

```sql
SELECT HEX(CAST(X'96' AS TEXT));
-- SQLite: 96 (text is a plain byte string; the byte passes through).
-- Turso:  EFBFBD (text is a Rust string; the invalid byte becomes U+FFFD).
```

This is a real, documented Turso limitation (see the new Limitations section in COMPAT.md), not fuzzer noise: Turso's text type must be valid UTF-8, and blobs reach text through many doors — `CAST`, `UPPER`, `TRIM`, `REPLACE`, `||`. The fuzzer hit it as an UPDATE whose WHERE was `HEX(CAST(<blob> AS TEXT))`: the hex string starts with a digit in SQLite (truthy) and with 'E' in Turso (falsy), so one engine updated every row and the other none.

The generator now produces blob bytes from printable ASCII, so every blob is valid UTF-8 and both engines see the same characters. Deciding whether Turso should store text as raw bytes like SQLite is a separate design question.

## Harness fix 3: use matching column types in compound queries

```sql
WITH values_cte(x) AS (
  SELECT real_column FROM real_table
  UNION ALL
  SELECT integer_column FROM integer_table
)
SELECT x, typeof(x) FROM values_cte;
-- SQLite may take the type from either arm: 7.0 as REAL or 7 as INTEGER.
```

The generator now uses matching declared types in every arm. This keeps `UNION`, `UNION ALL`, `INTERSECT`, and `EXCEPT` coverage while giving the fuzzer one answer to compare.

## Harness fix 4: don't rename tables or columns when SQLite would re-check the schema

SQLite re-resolves *every* stored index and trigger during a table rename, column rename, or column drop. Turso does not, so it can accept a rename that SQLite rejects. Two schemas trigger this.

**A trigger that uses a table that was dropped earlier.** SQLite allows dropping a table a trigger still uses:

```sql
CREATE TRIGGER source_trigger AFTER INSERT ON source BEGIN
  INSERT INTO log VALUES (new.x);
END;
DROP TABLE log;   -- fine in both engines; the trigger errors when it next runs
```

A later rename then fails in SQLite (it re-checks the now-broken trigger) but can succeed in Turso.

- The fuzzer knows which table owns a trigger, but not every table used inside its body.
- So it cannot tell whether an earlier drop broke a remaining trigger.

**A TEMP table shadowing a permanent table of the same name.** SQLite resolves the shared name to the temp table, so re-checking an index on the permanent table fails against the temp table, which lacks the column:

```sql
CREATE TABLE a(id INTEGER PRIMARY KEY, c INTEGER);
CREATE UNIQUE INDEX ia ON a(c);
CREATE TEMP TABLE a(x INTEGER PRIMARY KEY);   -- shadows main.a, no column c
CREATE TABLE b(z);
ALTER TABLE b RENAME TO b2;   -- unrelated rename
-- SQLite: error "error in index ia after rename: no such column: c". Turso: succeeds.
```

What the generator does now:

- It avoids table/column renames and column drops whenever any trigger exists, or any table name is shadowed across database scopes. `ADD COLUMN` stays enabled.
- Focused tests still cover renames with valid schemas.

## Harness fix 5: don't generate `PRAGMA foreign_key_list('some_table')` before a table exists

The fuzzer run would abort during SQL generation because there were no tables to choose from.

## Harness fix 6: skip statements over 64 KiB

```text
Statement skipped because it is 367502 bytes; the limit is 65536 bytes
```

A generated expression can branch into several subqueries at each level, and occasionally the result is hundreds of kilobytes of SQL. Preparing that recurses deep enough to blow the process stack before either engine can return an error. Statements over 64 KiB are now skipped and counted separately. They add almost no coverage.

The fuzzer also runs on a thread with a 256 MiB stack: debug-build parser frames are large enough that even a statement inside Turso's expression depth limit could overflow the default 8 MiB stack. Statements over the depth limit still get the parser's clean "expression tree is too large" error and are skipped. (The engine itself still can't prepare near-limit expressions on a default thread in debug builds; that needs its own parser fix.)

## Harness fix 7: print nested negation with a space

```sql
SELECT --5;    -- "--" starts a comment; the rest of the line is gone
SELECT - -5;   -- what the generator now prints
```

The SQL printer wrote nested minus as `--value`, silently turning the rest of the statement into a comment.

## New: statement weight profiles

The fuzzer used one fixed mix of statement types, so every run stressed the same things. A new `--profile` flag picks a named mix:

- `balanced` — the old default: mostly reads and writes, a little DDL
- `ddl` — heavy table, index, and alter churn
- `triggers` — heavy trigger creation, so triggers fire often
- `writes` — heavy insert/update/delete, for constraint and conflict paths

The profiles are fixed weight tables, not random, so a failing run reproduces with the same `--seed` and `--profile`. Most of the bugs above were found by the heavier mixes; the old default mix never hit them.

## New: failures come with a small reproduction

When a comparison fails, the fuzzer now:

1. Writes `turso-state.sql` and `sqlite-state.sql` — scripts that recreate each engine's full state (all tables and rows, including temp and attached) plus the failing statement.
2. Shrinks the failing statement using the SQL parser: parse it, simplify one AST node — drop a clause (WHERE, LIMIT, an ORDER BY term, a select column, a CTE, a join), or replace an expression with `1`, `''`, or one of its own children — and print the tree back to SQL. Every candidate is valid SQL, so no time is wasted on candidates that don't parse.
3. Deletes every state line the shrunken statement doesn't need.
4. Writes the result to `minimized.sql`.

A change is kept only if the same failure still happens — the same engine failing with the same error, or the same kind of result difference. That stops the shrinking from wandering onto a different bug.

In practice this turns a 10 KB statement on top of 200 setup statements into a repro of a few lines. For example, the `EXISTS` bug above was found as a 10,610-byte subquery; shrinking it exposed the one load-bearing expression:

```sql
-- before: 10,610 bytes of nested CASE/EXISTS/aggregate expressions
-- after:
SELECT EXISTS (SELECT x FROM t ORDER BY ABS(-9223372036854775807 - 1));
```

## Enable the differential fuzzer in CI

The fuzzer runs as a matrix over the four profiles, but a random seed on every run would make it non-deterministic: a pull request could go red because of a newly generated statement unrelated to its change, and a green run wouldn't promise the next one passes. So CI runs it two ways:

- **Pull requests** run a fixed set of seeds per profile. The generated SQL is identical every time, so a green run stays green and any failure blocks the merge and reproduces exactly:
  ```bash
  cargo run -p differential-fuzzer --bin differential_fuzzer -- \
    --seed <seed> --profile <profile> -n 1000
  ```
- **Pushes to main** additionally run random seeds, so new SQL keeps turning up divergences without gating unrelated pull requests:
  ```bash
  cargo run -p differential-fuzzer --bin differential_fuzzer -- \
    --profile <profile> -n 1000 loop 10
  ```

A failure prints its seed and profile, which reproduce it locally. The fixed seed set is a green baseline on this branch; it widens as more divergences are fixed.

## TCL conformance: crash-proof runner, seven files blessed

The engine fixes above made previously-failing upstream SQLite tests pass, which surfaced two things in the TCL conformance suite.

**Each test file now runs in its own process.** Before, `all.test` sourced every file into one tclsh process. A file that hard-crashed the engine — a segfault, a stack overflow, the OOM killer — took the whole run down with it: no summary, no hint of which file died or why. Now every file runs as a separate tclsh process, so:

- A crash is contained to its own file. The runner reports `CRASH in <file>.test: killed by signal SIGSEGV` (the signal tells apart a stack overflow, a panic, and an OOM kill), keeps going, and still prints the full summary.
- Test files can no longer leak state into each other, so each file's result reflects that file alone.

**Seven known-bad files now fully pass and are blessed.** The suite marks each file `pass` (must stay green) or `fail` (known-bad, failures tolerated) — and it fails the run if a known-bad file goes fully green, so the known-bad list only ever shrinks. This branch tripped exactly that check:

- `tkt3731` passes because of the engine fixes in this PR.
- `rowvalue2`, `rowvalueA`, `tkt-c694113d5`, `tkt-d11f09d36e`, `tkt3992`, and `walbig` pass once files stop leaking state into each other.

All seven are now marked `pass`, so any future failure in them fails CI.

