### PR TITLE
mvcc: mark internal-only commits in the logical log

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -15448,7 +15448,14 @@ fn test_mvcc_portable_changes_emit_header_only_commits() {
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
     let recovery_ops = collect_mvcc_recovery_ops(&db.conn);
 
-    assert!(portable_changes.is_empty());
+    // Header-only commits touch no user object, but a portable-enabled writer
+    // still emits the extension block so readers can tell an empty change set
+    // apart from pre-portable history. The payload therefore carries the frame
+    // cursor and commit timestamp and nothing else.
+    let txns = decode_portable_change_txns(&portable_changes);
+    assert_eq!(txns.len(), 2);
+    assert!(decoded_object_maps(&txns).is_empty());
+    assert!(txns.iter().all(|txn| txn.metadata.is_empty()));
     assert_eq!(
         recovery_ops
             .iter()
@@ -15693,6 +15700,55 @@ fn test_mvcc_portable_changes_do_not_infer_origin_from_application_table() {
     ));
     assert!(txns.iter().all(|txn| !txn.metadata.contains_key("client")));
     assert!(objects.iter().any(|object| object.name == "items"));
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_mark_internal_only_commits_explicitly() {
+    // A push whose user statements match no row commits only the sync
+    // bookkeeping upsert. That transaction has recovery ops but no user-visible
+    // change, and it must still be written as an extension frame: a plain frame
+    // is indistinguishable from pre-portable history, so a sync server planning
+    // a logical pull has to refuse the range, which wedges the database into a
+    // replace-base loop (no fresh replica can bootstrap again).
+    let db = MvccTestDb::new_with_portable_logical_changes();
+    db.conn
+        .execute(
+            "CREATE TABLE turso_sync_last_change_id(client_id TEXT PRIMARY KEY, change_id INTEGER)",
+        )
+        .unwrap();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items VALUES (1, 'alpha')")
+        .unwrap();
+
+    let before = decode_portable_change_txns(&collect_mvcc_portable_change_bytes(&db.conn)).len();
+
+    db.conn.execute("BEGIN").unwrap();
+    db.conn
+        .execute("DELETE FROM items WHERE payload = 'no-such-row'")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO turso_sync_last_change_id VALUES ('client-a', 7)")
+        .unwrap();
+    db.conn.execute("COMMIT").unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let txns = decode_portable_change_txns(&portable_changes);
+
+    assert_eq!(
+        txns.len(),
+        before + 1,
+        "internal-only commit must still emit a portable extension frame"
+    );
+    let internal_only = txns.last().unwrap();
+    assert!(internal_only.objects.is_empty());
+    assert!(!bytes_contain(
+        &portable_changes,
+        b"turso_sync_last_change_id"
+    ));
 }
 
 #[cfg(feature = "conn_raw_api")]

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -685,14 +685,22 @@ impl LogicalLog {
         let payload_size = tx.buf.len() - LOG_RECORD_PREFIX_SIZE;
         let payload_size_u64 = payload_size as u64;
 
+        // Every commit from a portable-enabled writer gets an extension block,
+        // including one whose portable object map is empty. A transaction that
+        // touches only internal objects (`turso_sync_*`, `turso_cdc*`,
+        // `sqlite_*`, indexes) would otherwise be written as a plain frame with
+        // recovery ops, which is byte-identical to pre-portable LML2 history: a
+        // reader planning a logical sync range cannot tell "no user-visible
+        // changes here" from "user data this reader cannot replay", so it must
+        // refuse the range. Emitting the block makes the empty change set
+        // explicit; readers that decode it produce no ops for the frame.
         #[cfg(feature = "conn_raw_api")]
-        let has_portable_changes = tx.portable_changes_required || !tx.portable_changes.is_empty();
-        #[cfg(not(feature = "conn_raw_api"))]
-        let has_portable_changes = false;
-        #[cfg(feature = "conn_raw_api")]
-        let portable_changes_enabled = tx.portable_changes_enabled || has_portable_changes;
+        let portable_changes_enabled = tx.portable_changes_enabled
+            || tx.portable_changes_required
+            || !tx.portable_changes.is_empty();
         #[cfg(not(feature = "conn_raw_api"))]
         let portable_changes_enabled = false;
+        let has_portable_changes = portable_changes_enabled;
 
         // 1. Ensure we have a log header object (created lazily on first write).
         // Non-portable logs remain LML2 so a deployment that does not enable
@@ -7233,13 +7241,19 @@ mod tests {
         let mut reader = StreamingLogicalLogReader::new(file, None);
         reader.read_header(&io).unwrap();
         assert_eq!(reader.header().unwrap().version, LOG_VERSION);
+        // A portable-enabled writer marks an empty change set explicitly: the
+        // frame carries an extension record whose payload has the frame cursor
+        // and commit timestamp but no object map, so readers decode it into no
+        // logical ops instead of having to guess whether a plain frame predates
+        // portable changes.
         let first = io
             .block(|| reader.next_portable_change_frame())
             .unwrap()
             .unwrap();
         assert_eq!(first.commit_ts, 10);
-        assert_eq!(first.extension_record_count, 0);
-        assert!(first.payload.is_empty());
+        assert_eq!(first.extension_record_count, 1);
+        assert!(!first.payload.is_empty());
+        assert_eq!(first.end_offset, reader.last_valid_offset() as u64);
 
         let second = io
             .block(|| reader.next_portable_change_frame())

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -2557,9 +2557,36 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                                         })?;
                                     }
                                 }
-                                (_, PullUpdatesV1Result::Pages { replace_base }, _) => {
+                                (
+                                    advertised_revision,
+                                    PullUpdatesV1Result::Pages { replace_base },
+                                    _,
+                                ) => {
+                                    // A second page snapshot means the remote still cannot serve a
+                                    // direct logical range from this revision: its logical log for
+                                    // that generation has no replayable prefix. Either the
+                                    // generation predates portable logical changes, or its first
+                                    // commits carry only internal recovery ops (`turso_sync_*`
+                                    // bookkeeping from a push whose user statements matched no
+                                    // row) and were written by a remote that predates marking such
+                                    // commits explicitly.
+                                    //
+                                    // Installing this snapshot here is not possible: the WAL
+                                    // sessions for the one we just applied are still open, and the
+                                    // apply path is a single linear pass. Retrying in place would
+                                    // also be pointless - the remote's answer only changes when its
+                                    // log state does. So fail cleanly and let the caller's next
+                                    // pull() re-enter apply from scratch: that retry succeeds once
+                                    // the remote rolls over to a new generation, without recreating
+                                    // the database.
                                     return Err(Error::DatabaseSyncEngineError(format!(
-                                        "replace-base follow-up logical pull unexpectedly returned a page stream: replace_base={replace_base}"
+                                        "remote cannot serve a logical MVCC range for {main_db_path} from revision {revision}: \
+                                         the replace-base follow-up pull returned another page snapshot \
+                                         (replace_base={replace_base}, advertised revision {advertised_revision:?}). \
+                                         The remote's logical log for that generation has no prefix this client can replay. \
+                                         This is safe to retry: pull again after the remote checkpoints to a new generation, \
+                                         or upgrade the remote to a build that marks internal-only commits explicitly.",
+                                        main_db_path = self.main_db_path,
                                     )));
                                 }
                             }


### PR DESCRIPTION
A commit whose recovery ops are all internal — `turso_sync_*` bookkeeping, `turso_cdc*`, `sqlite_*`, index-only or header-only writes: produced an empty portable payload, so `has_portable_changes` was false and the frame was written as a plain `FRAME_MAGIC` frame with no extension block. That frame is byte-identical to pre-portable LML2 history, so a reader planning a logical sync range cannot tell "this commit has no user-visible changes" from "this commit carries user data you cannot replay" and must refuse the range.

A sync push hits this routinely: when its user statements match no remote row (a delete that lost a race, or a conflict-resolved update), the only recovery ops left in the transaction are the `turso_sync_last_change_id` upsert. The server then refused the direct log range for that generation, fell back to a replace-base page snapshot advertising the generation base, and the client's follow-up logical pull re-read the same frame and got another snapshot — so no fresh replica could bootstrap that database again.

Emit the extension block for every commit from a portable-enabled writer, even when the portable object map is empty. The empty change set becomes explicit: readers decode the frame and produce no logical ops, which is what they already did for an empty portable payload. No format-version bump and no new frame flag, so existing readers need no change.

Also make the client's replace-base follow-up failure actionable. It cannot install a second snapshot in place (the WAL sessions for the first are still open, and the apply path is a single linear pass), and retrying in place would not help — the remote's answer only changes when its log state does. So it now names the condition, reports the advertised revision, and says the pull is safe to retry once the remote rolls over to a new generation.