### PR TITLE
github: strip debug info from Linux JS native libraries

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -163,6 +163,17 @@ jobs:
         run: ${{ matrix.settings.build }}
         if: ${{ !matrix.settings.docker }}
         shell: bash
+      # The release profile keeps debug info, which on Linux is embedded in the
+      # .node file itself (~80% of its size). macOS and Windows keep debug info
+      # in separate files, so only Linux needs stripping.
+      - name: Strip debug info
+        if: ${{ contains(matrix.settings.target, 'unknown-linux-gnu') }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(packages/native/turso.*.node sync/packages/native/sync.*.node)
+          strip "${files[@]}"
+          ls -la "${files[@]}"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -172,6 +172,9 @@ jobs:
         run: |
           shopt -s nullglob
           files=(packages/native/turso.*.node sync/packages/native/sync.*.node)
+          # Docker builds run as root, leaving the outputs unwritable for the
+          # runner user, and strip rewrites the file in place.
+          sudo chown "$(id -u):$(id -g)" "${files[@]}"
           strip "${files[@]}"
           ls -la "${files[@]}"
       - name: Upload artifact


### PR DESCRIPTION
The release profile keeps line-table debug info, which macOS and Windows place in separate files but Linux embeds in the .node binary itself. The published Linux packages are 97 MB, of which 79% is DWARF sections, so a per-platform install is far larger than better-sqlite3's 27 MB all-platforms bundle. Stripping after the build cuts the binary to 18 MB and the compressed npm download from ~24 MB to ~7 MB.

Stripping happens as a separate workflow step rather than via napi's --strip flag because that flag sets RUSTFLAGS, which would override the workspace .cargo/config.toml rustflags (tokio_unstable and the Linux linker workarounds) instead of merging with them.

Tests: the strip step runs before artifact upload, so the existing Linux binding test jobs run against the stripped libraries.