### PR TITLE
core/ext: NUL-terminate TextValue storage so sqlite3_value_text returns a valid C string

### DIFF
--- a/bindings/c/tests/compat/mod.rs
+++ b/bindings/c/tests/compat/mod.rs
@@ -3745,4 +3745,71 @@ mod tests {
             assert_eq!(sqlite3_close(db), SQLITE_OK);
         }
     }
+
+    #[test]
+    #[cfg(not(feature = "sqlite3"))]
+    fn test_sqlite3_value_text_nul_terminated() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static NUL_FOUND: AtomicBool = AtomicBool::new(false);
+
+        unsafe extern "C" fn check_nul(
+            _ctx: *mut libc::c_void,
+            _argc: i32,
+            argv: *mut *mut libc::c_void,
+        ) {
+            let val = *argv;
+            let ptr = sqlite3_value_text(val);
+            if ptr.is_null() {
+                return;
+            }
+            let len = sqlite3_value_bytes(val) as usize;
+            // SQLite contract: sqlite3_value_text returns a NUL-terminated string.
+            // The byte at ptr[len] must be '\0'
+            let nul = unsafe { *ptr.add(len) };
+            NUL_FOUND.store(nul == 0, Ordering::SeqCst);
+        }
+
+        unsafe {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("nul_test.db");
+            let path_cstr = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(path_cstr.as_ptr(), &mut db), SQLITE_OK);
+
+            assert_eq!(
+                sqlite3_create_function_v2(
+                    db,
+                    c"check_nul".as_ptr(),
+                    1,
+                    SQLITE_UTF8,
+                    ptr::null_mut(),
+                    Some(check_nul),
+                    None,
+                    None,
+                    None,
+                ),
+                SQLITE_OK
+            );
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT check_nul('hello')".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+
+        assert!(
+            NUL_FOUND.load(Ordering::SeqCst),
+            "sqlite3_value_text must return a NUL-terminated string"
+        );
+    }
 }

--- a/extensions/core/src/types.rs
+++ b/extensions/core/src/types.rs
@@ -194,11 +194,12 @@ impl TextValue {
 
     fn new_boxed(s: String, sub: TextSubtype) -> Box<Self> {
         let len = s.len();
-        let buffer = s.into_boxed_str();
-        let strbox = Box::into_raw(buffer);
+        let mut buf = s.into_bytes();
+        buf.push(0); // NUL-terminate so sqlite3_value_text satisfies the C API contract
+        let text = Box::into_raw(buf.into_boxed_slice()).cast();
         Box::new(Self {
             _type: sub,
-            text: strbox as *const u8,
+            text,
             len: len as u32,
         })
     }
@@ -206,7 +207,9 @@ impl TextValue {
     #[cfg(feature = "core_only")]
     fn free(self) {
         if !self.text.is_null() {
-            let ptr = std::ptr::slice_from_raw_parts_mut(self.text as *mut u8, self.len as usize);
+            // +1 matches new_boxed's NUL byte; len field stays content-only
+            let ptr =
+                std::ptr::slice_from_raw_parts_mut(self.text as *mut u8, self.len as usize + 1);
             let _ = unsafe { Box::from_raw(ptr) };
         }
     }


### PR DESCRIPTION
## Description

`sqlite3_value_text` is supposed to return a NUL-terminated string, but in Turso it handed back a pointer straight from a rust `&str` with no `\0` at the end. so a C extension that runs `strlen` or `CStr::from_ptr` on it reads past the allocation

the fix is in `TextValue::new_boxed`: push a `\0` onto the buffer before storing the pointer so every text value is NUL-terminated. `len` stays content-only so `as_str()` and `sqlite3_value_bytes` dont change. `free()` gets a matching `+1` so the allocation and deallocation lengths still line up

added a compat test that registers a scalar function calls `sqlite3_value_text` inside it and checks the byte at `ptr[len]` is `\0`. it fails before the fix and passes after

## Motivation and context

`from_text` and `from_json` both go thru `new_boxed` so this covers every text value a C caller can reach via `sqlite3_value_text`. `TextValue::new` is left alone because its only used for error messages and never reaches the C API

Closes #7982

## Description of AI Usage

used an agent to scope out the codebase and to help draft this PR description