### PR TITLE
postgres: implement session information functions

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -77,8 +77,12 @@ plus `pg_input_error_info`. Present but always empty: `pg_policy`,
 `pg_get_constraintdef`, `pg_get_indexdef`, `pg_get_userbyid`,
 `pg_*_is_visible`, `pg_encoding_to_char`, `pg_input_is_valid`, `to_char`
 (numeric), `now`/`clock_timestamp`/`transaction_timestamp`/`statement_timestamp`.
-DML against pg_catalog is rejected. `version()`, `pg_typeof`, and
-`current_schema` are not implemented.
+Session information functions: `version()`, `current_database()` /
+`current_catalog`, `current_schema` (call, bare-keyword, and FROM-position
+forms), `pg_backend_pid()`, `quote_ident()`, `quote_literal()`;
+`obj_description()`/`col_description()` always return NULL because COMMENT ON
+is not persisted. DML against pg_catalog is rejected. `pg_typeof` is not
+implemented.
 
 | Feature | Status | Notes |
 |---------|--------|-------|

--- a/postgres/cli/TODO.md
+++ b/postgres/cli/TODO.md
@@ -7,7 +7,7 @@ Sorted by implementation difficulty.
 1. ~~**COMMENT ON**~~ — DONE (accepted as a no-op; comments are not persisted)
 2. **PREPARE / EXECUTE / DEALLOCATE** — wire protocol already handles this; just need the SQL syntax to not error
 3. **GRANT/REVOKE** — parse + ignore (single-user system, just don't error)
-4. **More PG system functions** — register existing Turso functions under PG aliases (e.g. `string_agg` → `group_concat`, `regexp_replace`, etc.)
+4. **More PG system functions** — still missing: `current_setting`, `current_schemas(bool)`, a real `pg_get_expr` (currently a NULL stub), and the regexp functions (`extensions/regexp` is not linked into tursopg); session information functions and the `string_agg` family already resolve
 5. **SET search_path** — intercept in try_prepare_pg, store on connection, use in table resolution
 
 ## Easy (a day or two)

--- a/postgres/cli/tests/tursopg.rs
+++ b/postgres/cli/tests/tursopg.rs
@@ -986,6 +986,9 @@ fn start_tursopg_server() -> (Child, u16) {
 /// Sends startup + simple query and reads responses.
 struct PgTestClient {
     stream: TcpStream,
+    /// Raw startup response bytes, which carry the ParameterStatus messages
+    /// advertising session defaults like server_version.
+    startup_response: Vec<u8>,
 }
 
 impl PgTestClient {
@@ -994,10 +997,18 @@ impl PgTestClient {
         stream
             .set_read_timeout(Some(std::time::Duration::from_secs(5)))
             .unwrap();
-        let mut client = Self { stream };
+        let mut client = Self {
+            stream,
+            startup_response: Vec::new(),
+        };
         client.send_startup();
-        client.read_until_ready();
+        client.startup_response = client.read_until_ready();
         client
+    }
+
+    /// Value of a ParameterStatus ('S') message sent during startup.
+    fn startup_parameter(&self, name: &str) -> Option<String> {
+        extract_parameter_status(&self.startup_response, name)
     }
 
     /// Send StartupMessage (protocol v3.0)
@@ -1072,6 +1083,84 @@ impl PgTestClient {
         let response = self.read_until_ready();
         extract_row_description_oids(&response)
     }
+
+    /// Send query and return the first column of the first DataRow ('D') as text.
+    fn query_single_text(&mut self, sql: &str) -> String {
+        self.send_query(sql);
+        let response = self.read_until_ready();
+        extract_first_data_row_text(&response).expect("query returned no rows")
+    }
+}
+
+/// Walk raw PG wire bytes and return the value of the first ParameterStatus
+/// (`'S'`) message with the given parameter name. Body layout per the PG
+/// protocol docs: cstring name, cstring value.
+fn extract_parameter_status(data: &[u8], name: &str) -> Option<String> {
+    let mut pos = 0;
+    while pos < data.len() {
+        let tag = data[pos];
+        pos += 1;
+        if pos + 4 > data.len() {
+            break;
+        }
+        let len =
+            i32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as usize;
+        pos += 4;
+        let body_end = pos + (len - 4);
+        if body_end > data.len() {
+            break;
+        }
+        if tag == b'S' {
+            let body = &data[pos..body_end];
+            let name_end = body
+                .iter()
+                .position(|&b| b == 0)
+                .expect("ParameterStatus name missing nul terminator");
+            if &body[..name_end] == name.as_bytes() {
+                let value = &body[name_end + 1..];
+                let value_end = value
+                    .iter()
+                    .position(|&b| b == 0)
+                    .expect("ParameterStatus value missing nul terminator");
+                return Some(String::from_utf8(value[..value_end].to_vec()).unwrap());
+            }
+        }
+        pos = body_end;
+    }
+    None
+}
+
+/// Walk raw PG wire bytes, find the first DataRow (`'D'`), and return its
+/// first column as text. Body layout per the PG protocol docs: `int16`
+/// column count, then per column an `int32` value length (-1 for NULL) and
+/// that many bytes.
+fn extract_first_data_row_text(data: &[u8]) -> Option<String> {
+    let mut pos = 0;
+    while pos < data.len() {
+        let tag = data[pos];
+        pos += 1;
+        if pos + 4 > data.len() {
+            break;
+        }
+        let len =
+            i32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as usize;
+        pos += 4;
+        let body_end = pos + (len - 4);
+        if body_end > data.len() {
+            break;
+        }
+        if tag == b'D' {
+            let body = &data[pos..body_end];
+            let value_len = i32::from_be_bytes([body[2], body[3], body[4], body[5]]);
+            if value_len < 0 {
+                return None;
+            }
+            let value = &body[6..6 + value_len as usize];
+            return Some(String::from_utf8(value.to_vec()).unwrap());
+        }
+        pos = body_end;
+    }
+    None
 }
 
 /// Walk raw PG wire bytes, find the first `RowDescription` (`'T'`), and
@@ -1241,6 +1330,36 @@ fn wire_from_position_scalar_reports_text() {
         assert_eq!(
             c.query_column_oids("SELECT * FROM current_schema()"),
             vec![OID_TEXT]
+        );
+    });
+}
+
+/// Leading numeric version of a string like "16.6-pgwire-0.36.3" or "16.6 (...)".
+fn numeric_prefix(s: &str) -> &str {
+    let end = s
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(s.len());
+    &s[..end]
+}
+
+/// The `server_version` startup parameter and version() are from two distinct
+/// sources, and clients see both. Until they share a single source of truth,
+/// this pins their numeric prefixes together so drift is noticed.
+#[test]
+fn wire_server_version_parameter_matches_version_function() {
+    with_pg_client(|c| {
+        let advertised = c
+            .startup_parameter("server_version")
+            .expect("startup must advertise server_version");
+        let version = c.query_single_text("SELECT version()");
+        let reported = version
+            .strip_prefix("PostgreSQL ")
+            .expect("version() must start with 'PostgreSQL '");
+        assert!(!numeric_prefix(&advertised).is_empty(), "{advertised:?}");
+        assert_eq!(
+            numeric_prefix(&advertised),
+            numeric_prefix(reported),
+            "server_version parameter {advertised:?} vs version() {version:?}"
         );
     });
 }

--- a/postgres/cli/tests/tursopg.rs
+++ b/postgres/cli/tests/tursopg.rs
@@ -1233,6 +1233,18 @@ fn wire_integer_literal_reports_int4() {
     });
 }
 
+/// Clients decode values off the OID, so FROM-position scalars must
+/// report their result type rather than bytea.
+#[test]
+fn wire_from_position_scalar_reports_text() {
+    with_pg_client(|c| {
+        assert_eq!(
+            c.query_column_oids("SELECT * FROM current_schema()"),
+            vec![OID_TEXT]
+        );
+    });
+}
+
 /// `SELECT 3.14` reports FLOAT8. PG normally returns NUMERIC for unannotated
 /// numeric literals; FLOAT8 is the tursopg choice because Turso stores
 /// reals as 64-bit floats and the client decodes the wire bytes directly.

--- a/postgres/conformance/pg-sqltests/functions.sqltest
+++ b/postgres/conformance/pg-sqltests/functions.sqltest
@@ -1,0 +1,170 @@
+# Scalar function behavior through the PostgreSQL frontend.
+#
+# Coverage here asserts behavior that real PostgreSQL also exhibits, so the
+# corpus is valid for differential runs against a stock server.
+# Server-specific outputs (version(), current_database(), pg_backend_pid())
+# are covered in postgres/tests/integration instead.
+
+@database :memory:
+
+test quote-ident-plain-lowercase {
+    SELECT quote_ident('abc');
+}
+expect {
+    abc
+}
+
+test quote-ident-underscore-and-digits {
+    SELECT quote_ident('a_1');
+}
+expect {
+    a_1
+}
+
+test quote-ident-mixed-case {
+    SELECT quote_ident('Abc');
+}
+expect {
+    "Abc"
+}
+
+test quote-ident-embedded-space {
+    SELECT quote_ident('a b');
+}
+expect {
+    "a b"
+}
+
+test quote-ident-embedded-quote-doubled {
+    SELECT quote_ident('a"b');
+}
+expect {
+    "a""b"
+}
+
+test quote-ident-reserved-keyword {
+    SELECT quote_ident('select');
+}
+expect {
+    "select"
+}
+
+test quote-ident-unreserved-keyword-unquoted {
+    SELECT quote_ident('commit');
+}
+expect {
+    commit
+}
+
+test quote-ident-col-name-keyword {
+    SELECT quote_ident('between');
+}
+expect {
+    "between"
+}
+
+test quote-ident-type-func-name-keyword {
+    SELECT quote_ident('binary');
+}
+expect {
+    "binary"
+}
+
+test quote-ident-empty-string {
+    SELECT quote_ident('');
+}
+expect {
+    ""
+}
+
+test quote-ident-leading-digit {
+    SELECT quote_ident('1a');
+}
+expect {
+    "1a"
+}
+
+test quote-ident-null-is-null {
+    SELECT quote_ident(NULL);
+}
+expect {
+}
+
+test quote-literal-plain {
+    SELECT quote_literal('abc');
+}
+expect {
+    'abc'
+}
+
+test quote-literal-embedded-quote {
+    SELECT quote_literal('O''Reilly');
+}
+expect {
+    'O''Reilly'
+}
+
+test quote-literal-integer {
+    SELECT quote_literal(42);
+}
+expect {
+    '42'
+}
+
+test quote-literal-null-is-null {
+    SELECT quote_literal(NULL);
+}
+expect {
+}
+
+# The sqltest lexer collapses \\ to \, so the expected E'a\\b' is written
+# with doubled backslashes here.
+test quote-literal-backslash-uses-escape-string {
+    SELECT quote_literal('a\b');
+}
+expect {
+    E'a\\\\b'
+}
+
+test current-schema-default {
+    SELECT current_schema();
+}
+expect {
+    public
+}
+
+test current-schema-bare-keyword {
+    SELECT current_schema;
+}
+expect {
+    public
+}
+
+test current-schema-in-from-position {
+    SELECT * FROM current_schema();
+}
+expect {
+    public
+}
+
+test obj-description-unknown-oid-is-null {
+    SELECT obj_description(0, 'pg_class');
+}
+expect {
+}
+
+test col-description-unknown-oid-is-null {
+    SELECT col_description(0, 1);
+}
+expect {
+}
+
+test version-wrong-arity-errors {
+    SELECT version(1);
+}
+expect error {}
+
+test quote-ident-wrong-arity-errors {
+    SELECT quote_ident();
+}
+expect error {}

--- a/postgres/frontend/catalog.rs
+++ b/postgres/frontend/catalog.rs
@@ -1187,14 +1187,16 @@ impl PgDatabaseTable {
     fn new() -> Self {
         Self
     }
+}
 
-    fn db_name_from_path(path: &str) -> String {
-        std::path::Path::new(path)
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or(path)
-            .to_string()
-    }
+/// Shared by the pg_database virtual table and current_database() so both
+/// report the same database name.
+pub(crate) fn db_name_from_path(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(path)
+        .to_string()
 }
 
 impl InternalVirtualTable for PgDatabaseTable {
@@ -1289,7 +1291,7 @@ impl InternalVirtualTableCursor for PgDatabaseCursor {
         _idx_num: i32,
     ) -> Result<bool, LimboError> {
         self.current_row = 0;
-        let db_name = PgDatabaseTable::db_name_from_path(self.conn.db_file_path());
+        let db_name = db_name_from_path(self.conn.db_file_path());
         self.rows = vec![vec![
             Value::from_i64(16384),           // oid
             Value::build_text(db_name),       // datname

--- a/postgres/frontend/functions.rs
+++ b/postgres/frontend/functions.rs
@@ -17,10 +17,13 @@ pub(crate) fn resolve_scalar(name: &str, arg_count: usize) -> bool {
         | "pg_get_function_result"
         | "pg_get_function_arguments"
         | "pg_get_statisticsobjdef_columns"
-        | "pg_relation_is_publishable" => &[1],
-        "format_type" | "pg_get_constraintdef" | "pg_get_indexdef" => &[1, 2],
+        | "pg_relation_is_publishable"
+        | "quote_ident"
+        | "quote_literal" => &[1],
+        "format_type" | "pg_get_constraintdef" | "pg_get_indexdef" | "obj_description" => &[1, 2],
         "pg_get_expr" => &[2, 3],
-        "to_char" | "pg_input_is_valid" | "booleq" | "boolne" => &[2],
+        "to_char" | "pg_input_is_valid" | "booleq" | "boolne" | "col_description" => &[2],
+        "version" | "current_database" | "current_schema" | "pg_backend_pid" => &[0],
         _ => return false,
     };
     arities.contains(&(arg_count as i64))
@@ -53,12 +56,30 @@ pub(crate) fn exec_scalar(conn: &Connection, name: &str, args: &[Value]) -> Resu
         )),
         "booleq" => Ok(Value::from_i64((args.first() == args.get(1)) as i64)),
         "boolne" => Ok(Value::from_i64((args.first() != args.get(1)) as i64)),
+        "version" => Ok(exec_version()),
+        "current_database" => Ok(Value::build_text(crate::catalog::db_name_from_path(
+            conn.db_file_path(),
+        ))),
+        // pg_catalog presents every user object under the hardcoded "public"
+        // namespace, so that is always the current schema.
+        "current_schema" => Ok(Value::build_text("public")),
+        "pg_backend_pid" => Ok(Value::from_i64(std::process::id() as i64)),
+        "quote_ident" => match args.first() {
+            Some(Value::Null) | None => Ok(Value::Null),
+            _ => Ok(Value::build_text(turso_pg_parser::quote_identifier(
+                &text_arg(0),
+            ))),
+        },
+        "quote_literal" => Ok(exec_quote_literal(args.first().unwrap_or(&Value::Null))),
         // Catalog introspection stubs: accepted for compatibility, no output.
+        // obj_description/col_description are NULL because COMMENT ON is not persisted.
         "pg_get_expr"
         | "pg_get_statisticsobjdef_columns"
         | "pg_relation_is_publishable"
         | "pg_get_function_result"
-        | "pg_get_function_arguments" => Ok(Value::Null),
+        | "pg_get_function_arguments"
+        | "obj_description"
+        | "col_description" => Ok(Value::Null),
         _ => Err(LimboError::ParseError(format!("no such function: {name}"))),
     }
 }
@@ -69,6 +90,40 @@ fn exec_pg_get_user_by_id(_oid: i64) -> Value {
 
 fn exec_pg_is_visible(_oid: i64) -> Value {
     Value::from_i64(1)
+}
+
+/// PostgreSQL version advertised by version(). The major version matches the
+/// server_version startup parameter pgwire's DefaultServerParameterProvider
+/// sends, so the two claims agree.
+const SERVER_VERSION: &str = "16.6";
+
+/// Clients sometimes gate connection setup on this string: knex and TypeORM regex
+/// parse it as `^PostgreSQL ([\d.]+)`, so it must lead with a numeric version.
+fn exec_version() -> Value {
+    Value::build_text(format!(
+        "PostgreSQL {SERVER_VERSION} (Turso v{})",
+        env!("CARGO_PKG_VERSION")
+    ))
+}
+
+/// PostgreSQL's quote_literal(): wrap a value in single quotes for inclusion
+/// in SQL, doubling embedded quotes. Backslashes force the E'' escape-string
+/// form so the result reads back identically regardless of
+/// standard_conforming_strings.
+fn exec_quote_literal(value: &Value) -> Value {
+    if matches!(value, Value::Null) {
+        return Value::Null;
+    }
+    let text = match value {
+        Value::Text(t) => t.as_str().to_string(),
+        other => other.to_string(),
+    };
+    let quoted = if text.contains('\\') {
+        format!("E'{}'", text.replace('\\', "\\\\").replace('\'', "''"))
+    } else {
+        format!("'{}'", text.replace('\'', "''"))
+    };
+    Value::build_text(quoted)
 }
 
 fn exec_pg_encoding_to_char(encoding: i64) -> Value {

--- a/postgres/parser/lib.rs
+++ b/postgres/parser/lib.rs
@@ -46,6 +46,38 @@ pub fn fingerprint(sql: &str) -> Result<String, ParseError> {
         .map_err(|e| ParseError::ParseError(e.to_string()))
 }
 
+/// Quote an identifier following PostgreSQL's server-side quote_identifier()
+/// rules: return it bare only when it is all lower-case ASCII letters,
+/// digits, and underscores, does not start with a digit, and is not a
+/// keyword outside the unreserved category; otherwise wrap it in double
+/// quotes with embedded quotes doubled.
+pub fn quote_identifier(ident: &str) -> String {
+    let safe_chars = !ident.is_empty()
+        && !ident.starts_with(|c: char| c.is_ascii_digit())
+        && ident
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+    if safe_chars && !keyword_requires_quoting(ident) {
+        return ident.to_string();
+    }
+    format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
+/// pg_query's scanner is the same lexer the PostgreSQL server uses, so its
+/// keyword classification matches server-side quote_identifier().
+fn keyword_requires_quoting(ident: &str) -> bool {
+    use pg_query::protobuf::KeywordKind;
+    let scan =
+        pg_query::scan(ident).expect("scanning a bare lower-case ASCII identifier cannot fail");
+    match scan.tokens.as_slice() {
+        [token] => !matches!(
+            token.keyword_kind(),
+            KeywordKind::NoKeyword | KeywordKind::UnreservedKeyword
+        ),
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -1831,6 +1831,59 @@ impl PostgreSQLTranslator {
             .as_ref()
             .map(|a| ast::As::Elided(ast::Name::from_string(a.aliasname.clone())));
 
+        // PostgreSQL exposes scalar functions in FROM position as one-row,
+        // one-column tables (clients issue `SELECT * FROM current_schema()`),
+        // but core's TableCall path resolves only table-valued functions, so
+        // desugar these zero-argument session functions into a subselect.
+        // The TEXT cast keeps the wire column text-typed; a bare subselect
+        // column comes back as bytea.
+        if args.is_empty() && matches!(func_name, "current_schema" | "current_database" | "version")
+        {
+            let column_name = match &alias {
+                Some(ast::As::As(name) | ast::As::Elided(name)) => name.clone(),
+                _ => ast::Name::from_string(func_name),
+            };
+            let call = ast::Expr::FunctionCall {
+                name: ast::Name::from_string(func_name),
+                distinctness: None,
+                args: vec![],
+                order_by: vec![],
+                within_group: vec![],
+                filter_over: ast::FunctionTail {
+                    filter_clause: None,
+                    over_clause: None,
+                },
+            };
+            let cast = ast::Expr::Cast {
+                expr: Box::new(call),
+                type_name: Some(ast::Type {
+                    name: "TEXT".to_string(),
+                    size: None,
+                    array_dimensions: 0,
+                }),
+            };
+            let select = ast::Select {
+                with: None,
+                body: ast::SelectBody {
+                    select: ast::OneSelect::Select {
+                        distinctness: None,
+                        columns: vec![ast::ResultColumn::Expr(
+                            Box::new(cast),
+                            Some(ast::As::Elided(column_name)),
+                        )],
+                        from: None,
+                        where_clause: None,
+                        group_by: None,
+                        window_clause: vec![],
+                    },
+                    compounds: vec![],
+                },
+                order_by: vec![],
+                limit: None,
+            };
+            return Ok(ast::SelectTable::Select(select, alias));
+        }
+
         Ok(ast::SelectTable::TableCall(
             ast::QualifiedName::single(ast::Name::from_string(func_name)),
             args,
@@ -2005,7 +2058,8 @@ impl PostgreSQLTranslator {
                         } else {
                             let expr = self.translate_expr(val)?;
                             let alias: Option<ast::As> = if res_target.name.is_empty() {
-                                None
+                                derived_column_name(val)
+                                    .map(|name| ast::As::Elided(ast::Name::from_string(name)))
                             } else {
                                 Some(ast::As::Elided(ast::Name::from_string(&res_target.name)))
                             };
@@ -2240,9 +2294,30 @@ impl PostgreSQLTranslator {
                         // Return empty string stub for user functions
                         Ok(ast::Expr::Literal(ast::Literal::String("''".into())))
                     }
-                    Ok(SqlValueFunctionOp::SvfopCurrentCatalog) => {
-                        Ok(ast::Expr::Literal(ast::Literal::String("'main'".into())))
-                    }
+                    // The bare keywords route through the frontend scalars so both
+                    // syntaxes share one implementation and agree with pg_catalog.
+                    Ok(SqlValueFunctionOp::SvfopCurrentSchema) => Ok(ast::Expr::FunctionCall {
+                        name: ast::Name::from_string("current_schema"),
+                        distinctness: None,
+                        args: vec![],
+                        order_by: vec![],
+                        within_group: vec![],
+                        filter_over: ast::FunctionTail {
+                            filter_clause: None,
+                            over_clause: None,
+                        },
+                    }),
+                    Ok(SqlValueFunctionOp::SvfopCurrentCatalog) => Ok(ast::Expr::FunctionCall {
+                        name: ast::Name::from_string("current_database"),
+                        distinctness: None,
+                        args: vec![],
+                        order_by: vec![],
+                        within_group: vec![],
+                        filter_over: ast::FunctionTail {
+                            filter_clause: None,
+                            over_clause: None,
+                        },
+                    }),
                     _ => Err(ParseError::ParseError(format!(
                         "Unsupported SqlValueFunction op: {}",
                         svf.op
@@ -3889,6 +3964,43 @@ impl PostgreSQLTranslator {
             not_null,
             constraints,
         })
+    }
+}
+
+/// PostgreSQL derives a name for result columns without an explicit alias
+/// (FigureColname in the server): function calls are named after the function
+/// and SQL value functions after their keyword. Clients read columns by these
+/// names, e.g. knex reads rows[0].version from `select version()`.
+fn derived_column_name(node: &pg_query::protobuf::Node) -> Option<String> {
+    use pg_query::protobuf::node::Node;
+    match &node.node {
+        Some(Node::FuncCall(func_call)) => func_call
+            .funcname
+            .iter()
+            .filter_map(|n| match &n.node {
+                Some(Node::String(s)) => Some(s.sval.clone()),
+                _ => None,
+            })
+            .next_back(),
+        Some(Node::SqlvalueFunction(svf)) => {
+            use pg_query::protobuf::SqlValueFunctionOp as Op;
+            let name = match Op::try_from(svf.op) {
+                Ok(Op::SvfopCurrentDate) => "current_date",
+                Ok(Op::SvfopCurrentTime | Op::SvfopCurrentTimeN) => "current_time",
+                Ok(Op::SvfopCurrentTimestamp | Op::SvfopCurrentTimestampN) => "current_timestamp",
+                Ok(Op::SvfopLocaltime | Op::SvfopLocaltimeN) => "localtime",
+                Ok(Op::SvfopLocaltimestamp | Op::SvfopLocaltimestampN) => "localtimestamp",
+                Ok(Op::SvfopCurrentRole) => "current_role",
+                Ok(Op::SvfopCurrentUser) => "current_user",
+                Ok(Op::SvfopUser) => "user",
+                Ok(Op::SvfopSessionUser) => "session_user",
+                Ok(Op::SvfopCurrentCatalog) => "current_catalog",
+                Ok(Op::SvfopCurrentSchema) => "current_schema",
+                _ => return None,
+            };
+            Some(name.to_string())
+        }
+        _ => None,
     }
 }
 

--- a/postgres/tests/integration/postgres/functions.rs
+++ b/postgres/tests/integration/postgres/functions.rs
@@ -1,0 +1,190 @@
+use crate::common::TempDatabase;
+use turso_core::{Numeric, StepResult, Value};
+use turso_pg::PgConnection;
+
+fn query_text(conn: &PgConnection, sql: &str) -> Vec<String> {
+    let mut rows = conn.query(sql).unwrap().unwrap();
+    let mut result = Vec::new();
+    loop {
+        match rows.step().unwrap() {
+            StepResult::Row => {
+                let row = rows.row().unwrap();
+                match row.get_value(0) {
+                    Value::Text(v) => result.push(v.value.to_string()),
+                    Value::Null => result.push("NULL".to_string()),
+                    other => panic!("expected text, got {other:?}"),
+                }
+            }
+            StepResult::Done => break,
+            _ => {}
+        }
+    }
+    result
+}
+
+fn query_integer(conn: &PgConnection, sql: &str) -> Vec<i64> {
+    let mut rows = conn.query(sql).unwrap().unwrap();
+    let mut result = Vec::new();
+    loop {
+        match rows.step().unwrap() {
+            StepResult::Row => {
+                let row = rows.row().unwrap();
+                match row.get_value(0) {
+                    Value::Numeric(Numeric::Integer(v)) => result.push(*v),
+                    other => panic!("expected integer, got {other:?}"),
+                }
+            }
+            StepResult::Done => break,
+            _ => {}
+        }
+    }
+    result
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pg_version_is_client_parseable(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    for sql in [
+        "SELECT version()",
+        "SELECT pg_catalog.version()",
+        "SELECT * FROM version()",
+    ] {
+        let out = query_text(&conn, sql);
+        assert_eq!(out.len(), 1, "{sql} should return one row");
+        let version = &out[0];
+        // drivers like knex and TypeORM regex-parse this output as /^PostgreSQL ([\d.]+)/,
+        // so the string must lead with "PostgreSQL <numeric version>".
+        let rest = version
+            .strip_prefix("PostgreSQL ")
+            .unwrap_or_else(|| panic!("version() must start with 'PostgreSQL ': {version}"));
+        let number = rest.split(' ').next().unwrap();
+        assert!(
+            !number.is_empty() && number.chars().all(|c| c.is_ascii_digit() || c == '.'),
+            "version() must lead with a numeric version: {version}"
+        );
+    }
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pg_current_database_matches_pg_database(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    let expected = db.path.file_stem().unwrap().to_str().unwrap().to_string();
+    assert_eq!(
+        query_text(&conn, "SELECT current_database()"),
+        [expected.clone()]
+    );
+    assert_eq!(
+        query_text(&conn, "SELECT * FROM current_database()"),
+        [expected.clone()]
+    );
+    // The bare current_catalog keyword is the same function per PG docs.
+    assert_eq!(
+        query_text(&conn, "SELECT current_catalog"),
+        [expected.clone()]
+    );
+    // Must agree with what the pg_database catalog reports as datname.
+    assert_eq!(
+        query_text(&conn, "SELECT datname FROM pg_catalog.pg_database"),
+        [expected]
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pg_current_schema_all_syntactic_forms(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    // Function call, bare SQLValueFunction keyword,
+    // function-in-FROM-position form must all resolve.
+    assert_eq!(query_text(&conn, "SELECT current_schema()"), ["public"]);
+    assert_eq!(query_text(&conn, "SELECT current_schema"), ["public"]);
+    assert_eq!(
+        query_text(&conn, "SELECT * FROM current_schema()"),
+        ["public"]
+    );
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pg_derived_result_column_names(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    // PostgreSQL names unaliased function-call and keyword columns after the
+    // function
+    for (sql, expected) in [
+        ("SELECT version()", "version"),
+        ("SELECT pg_catalog.version()", "version"),
+        ("SELECT current_schema()", "current_schema"),
+        ("SELECT current_schema", "current_schema"),
+        ("SELECT current_catalog", "current_catalog"),
+        ("SELECT current_user", "current_user"),
+        ("SELECT session_user", "session_user"),
+        ("SELECT * FROM current_schema()", "current_schema"),
+        ("SELECT * FROM current_schema() AS cs", "cs"),
+        ("SELECT count(*) FROM pg_catalog.pg_database", "count"),
+        ("SELECT version() AS v", "v"),
+    ] {
+        let stmt = conn.prepare(sql).unwrap();
+        assert_eq!(stmt.get_column_name(0), expected, "{sql}");
+    }
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pg_backend_pid_is_positive_integer(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    let pids = query_integer(&conn, "SELECT pg_backend_pid()");
+    assert_eq!(pids.len(), 1);
+    assert!(pids[0] > 0, "pg_backend_pid() must be a positive pid");
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pg_quote_functions(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    for (input, expected) in [
+        ("SELECT quote_ident('abc')", "abc"),
+        ("SELECT quote_ident('a_1')", "a_1"),
+        ("SELECT quote_ident('Abc')", "\"Abc\""),
+        ("SELECT quote_ident('a b')", "\"a b\""),
+        ("SELECT quote_ident('a\"b')", "\"a\"\"b\""),
+        // Reserved keywords must be quoted, unreserved ones must not.
+        ("SELECT quote_ident('select')", "\"select\""),
+        ("SELECT quote_ident('table')", "\"table\""),
+        ("SELECT quote_ident('commit')", "commit"),
+        ("SELECT quote_ident('')", "\"\""),
+    ] {
+        assert_eq!(query_text(&conn, input), [expected], "{input}");
+    }
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pg_quote_literal(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    for (input, expected) in [
+        ("SELECT quote_literal('abc')", "'abc'"),
+        ("SELECT quote_literal('O''Reilly')", "'O''Reilly'"),
+        ("SELECT quote_literal(42)", "'42'"),
+        ("SELECT quote_literal('a\\b')", "E'a\\\\b'"),
+    ] {
+        assert_eq!(query_text(&conn, input), [expected], "{input}");
+    }
+}
+
+#[turso_macros::test(mvcc)]
+fn test_pg_description_stubs_return_null(db: TempDatabase) {
+    let conn = db.connect_postgres();
+    conn.execute("CREATE TABLE t (id integer PRIMARY KEY)")
+        .unwrap();
+
+    // Comments are not stored, so description lookups report none rather
+    // than erroring.
+    for sql in [
+        "SELECT obj_description(16384, 'pg_class')",
+        "SELECT obj_description(16384)",
+        "SELECT col_description(16384, 1)",
+    ] {
+        assert_eq!(query_text(&conn, sql), ["NULL"], "{sql}");
+    }
+}

--- a/postgres/tests/integration/postgres/mod.rs
+++ b/postgres/tests/integration/postgres/mod.rs
@@ -2,6 +2,7 @@ mod catalog;
 mod copy;
 mod dialect;
 mod domain;
+mod functions;
 mod parse_edge_cases;
 mod sequence;
 mod table;


### PR DESCRIPTION
## Description

Adds version(), current_database(), current_schema(), pg_backend_pid(), quote_ident(), quote_literal(), and NULL stubs for obj_description()/col_description() to the frontend. The bare current_schema and current_catalog keywords translate to the same functions. Zero-argument session functions in FROM position desugar into a one-row subselect (cast to TEXT because bare subselect columns wire as bytea) since core's TableCall path resolves only table-valued functions.

Result columns without an explicit alias are now named after the function or keyword as PostgreSQL derives them (FigureColname). This also fixes `count(*)` reporting as `"count (*)"` instead of `"count"`.

quote_ident classifies keywords with pg_query's scanner, so reserved keywords quote and unreserved ones stay bare. version() reports the same version as the server_version startup parameter pgwire advertises.

Tests: postgres/tests/integration/postgres/functions.rs; pg-sqltests/functions.sqltest validated against stock PostgreSQL 16. Also adds a wire test pinning version() to server_version so reported versions don't drift.

## Motivation and context

Progress on coverage addressing postgres/cli/TODO.md item 4.

## Description of AI Usage

Developed with Claude Code under my direction. I reviewed and take responsibility for the final diff.