### PR TITLE
core/vdbe: fix round() to break exact ties away from zero

### DIFF
--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -728,6 +728,44 @@ pub fn str_to_f64(input: impl AsRef<str>) -> Option<StrToF64> {
     })
 }
 
+pub fn round_half_away_from_zero_tie(f: f64, precision: usize) -> Option<f64> {
+    use num_traits::Float;
+
+    let (m, k, sign): (u64, i16, i8) = f.integer_decode();
+    let k = k as i32;
+
+    let precision_i32 = precision as i32;
+    let q = -(k + precision_i32);
+
+    const MAX_TIE_PRODUCT_BITS: i32 = 127;
+    if !(1..=MAX_TIE_PRODUCT_BITS).contains(&q) {
+        return None;
+    }
+
+    let precision_u32 = precision as u32;
+    let five_pow = 5u128.pow(precision_u32);
+    let scaled = (m as u128) * five_pow;
+
+    let low_q_bits = scaled & ((1u128 << q) - 1);
+    let is_tie = low_q_bits == (1u128 << (q - 1));
+    if !is_tie {
+        return None;
+    }
+
+    let rounded_int = (scaled >> q) + 1;
+
+    let ten_pow = 10u128.pow(precision_u32);
+    let int_part = rounded_int / ten_pow;
+    let frac_part = rounded_int % ten_pow;
+    let sign_str = if sign.is_negative() { "-" } else { "" };
+    let s = format!("{sign_str}{int_part}.{frac_part:0precision$}");
+
+    let result: f64 = str_to_f64(s)
+        .expect("constructed digit string should always parse")
+        .into();
+    Some(result)
+}
+
 enum FloatParts {
     Special(String),
     Normal {
@@ -897,4 +935,15 @@ fn test_decode_float() {
     assert_eq!(format_float(0.0), "0.0");
     assert_eq!(format_float(4.94e-322), "4.94065645841247e-322");
     assert_eq!(format_float(-20228007.0), "-20228007.0");
+}
+
+#[test]
+fn test_round_half_away_from_zero_tie() {
+    assert_eq!(round_half_away_from_zero_tie(2.25, 1), Some(2.3));
+    assert_eq!(round_half_away_from_zero_tie(0.125, 2), Some(0.13));
+    assert_eq!(round_half_away_from_zero_tie(1.125, 2), Some(1.13));
+    assert_eq!(round_half_away_from_zero_tie(-2.25, 1), Some(-2.3));
+    assert_eq!(round_half_away_from_zero_tie(2.35, 1), None);
+    assert_eq!(round_half_away_from_zero_tie(1.005, 2), None);
+    assert_eq!(round_half_away_from_zero_tie(5e-320, 10), None);
 }

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -851,9 +851,12 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        let f: f64 = crate::numeric::str_to_f64(format!("{f:.precision$}"))
-            .expect("formatted float should always parse successfully")
-            .into();
+        let f: f64 =
+            crate::numeric::round_half_away_from_zero_tie(f, precision).unwrap_or_else(|| {
+                crate::numeric::str_to_f64(format!("{f:.precision$}"))
+                    .expect("formatted float should always parse successfully")
+                    .into()
+            });
 
         Value::from_f64(f)
     }

--- a/sqlite/conformance/sqlite-sqltests/scalar-functions.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/scalar-functions.sqltest
@@ -889,6 +889,9 @@ test round-subnormal-no-panic {
 expect {
     0.0
 }
+expect @js {
+    0
+}
 
 test length-text {
     SELECT length('limbo');

--- a/sqlite/conformance/sqlite-sqltests/scalar-functions.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/scalar-functions.sqltest
@@ -855,6 +855,41 @@ test round-null-precision {
 expect {
 }
 
+test round-exact-tie-away-from-zero {
+    SELECT round(2.25, 1);
+}
+expect {
+    2.3
+}
+
+test round-non-tie-unaffected {
+    SELECT round(2.35, 1);
+}
+expect {
+    2.4
+}
+
+test round-exact-tie-negative {
+    SELECT round(-2.25, 1);
+}
+expect {
+    -2.3
+}
+
+test round-exact-tie-two-decimal {
+    SELECT round(0.125, 2);
+}
+expect {
+    0.13
+}
+
+test round-subnormal-no-panic {
+    SELECT round(5e-320, 10);
+}
+expect {
+    0.0
+}
+
 test length-text {
     SELECT length('limbo');
 }

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -4203,6 +4203,24 @@ mod fuzz_tests {
     }
 
     #[turso_macros::test(mvcc)]
+    pub fn round_ex(db: TempDatabase) {
+        let _ = env_logger::try_init();
+        let limbo_conn = db.connect_limbo();
+        let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+        for query in [
+            "SELECT round(2.25, 1)",
+            "SELECT round(0.125, 2)",
+            "SELECT round(1.125, 2)",
+            "SELECT round(-2.25, 1)",
+            "SELECT round(5e-320, 10)",
+            "SELECT round(1e-300, 30)",
+        ] {
+            helpers::assert_differential(&limbo_conn, &sqlite_conn, query, "");
+        }
+    }
+
+    #[turso_macros::test(mvcc)]
     pub fn math_expression_fuzz_run(db: TempDatabase) {
         let (mut rng, seed) = helpers::init_fuzz_test("math_expression_fuzz_run");
         let g = GrammarGenerator::new();


### PR DESCRIPTION
## Description

round(x, n) used Rust's default float formatting, which breaks an
exact tie (x times 10 to the n lands exactly on .5) with round half to
even. SQLite breaks the same tie away from zero, so the two disagree on
inputs like round(2.25, 1), where sqlite gives 2.3 and turso gives 2.2.

Fixed by detecting the exact tie case directly instead of trusting the
formatted output. Every f64 decomposes exactly as M times 2 to the k,
so scaling by 10 to the n and splitting 10 into 2 times 5 turns the tie
check into plain u128 integer arithmetic with no floating point
rounding involved. Non-tie inputs are unaffected, they still go through
the old format plus str_to_f64 path.

Tests: scalar-functions.sqltest (tie cases including a negative number
and a subnormal), a differential fuzz test against rusqlite, and a unit
test on the new helper directly.

## Motivation and context

round() diverging from sqlite on exact tie inputs affects anything
relying on decimal rounding compatibility with sqlite, like currency
style rounding at a fixed precision.

## Description of AI Usage

Used Claude Code to work through the fix: identifying the tie breaking
mismatch, implementing the M times 2 to the k decomposition, writing
the sqltest, fuzz, and unit tests, and running the verification suite
(cargo test, clippy, the sqltest conformance runner, diff.sh against
real sqlite3, and make test).