### PR TITLE
fix: wasm32 unknow unknow compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,6 +20,12 @@ rustflags = [
   "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains",
 ]
 
+# getrandom 0.3 needs this cfg (https://docs.rs/getrandom/latest/getrandom/#webassembly-support)
+[target.wasm32-unknown-unknown]
+rustflags = [
+    '--cfg=getrandom_backend="wasm_js"',
+]
+
 # To be able to run unit tests on Linux, support compilation to 'x86_64-unknown-linux-gnu'.
 # pthread_key_create() destructors and segfault after a DSO unloading https://sourceware.org/bugzilla/show_bug.cgi?id=21031
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,11 +2525,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7330,6 +7332,8 @@ dependencies = [
  "env_logger",
  "fallible-iterator 0.3.0",
  "fastbloom",
+ "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "hex",
  "icu_collator",
  "icu_locale",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -37,7 +37,6 @@ turso_sync_sdk_kit = { workspace = true }
 thiserror = { workspace = true }
 tracing-subscriber.workspace = true
 tracing.workspace = true
-mimalloc = { workspace = true, optional = true }
 
 hyper = { version = "1.8.1", features = ["http1"], optional = true }
 tokio = { workspace = true, features = ["full"], optional = true }
@@ -48,6 +47,9 @@ hyper-util = { version = "0.1.19", features = [
 ], optional = true }
 http-body-util = { version = "0.1.3", optional = true }
 bytes = { version = "1.11.1", optional = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mimalloc = { workspace = true, optional = true }
 
 [[example]]
 name = "sync_example"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -141,6 +141,13 @@ stacker = { version = "0.1", optional = true }
 [target.'cfg(not(any(target_family = "wasm", all(target_os = "windows", target_arch = "aarch64"))))'.dependencies]
 simsimd = "6.5.3"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+# From fastbloom/rand
+getrandom02 = { package = "getrandom", version = "0.2", features = ["js"] }
+# From  aes-gcm
+getrandom03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+uuid = { version = "1.11.0", features = ["js"], optional = true }
+
 [target.'cfg(antithesis)'.dependencies]
 antithesis_sdk = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }

--- a/extensions/core/Cargo.toml
+++ b/extensions/core/Cargo.toml
@@ -17,3 +17,6 @@ turso_macros = { workspace = true }
 
 getrandom = "0.4.2"
 chrono = { workspace = true, default-features = true }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.4.2", features = ["wasm_js"] }

--- a/sdk-kit/Cargo.toml
+++ b/sdk-kit/Cargo.toml
@@ -27,9 +27,13 @@ turso_core = { workspace = true, features = [
 turso_ext = { workspace = true }
 turso_sdk_kit_macros = { workspace = true }
 tracing = { workspace = true }
-tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 parking_lot = { workspace = true, features = ["send_guard"] } # otherwise, TursoDatabase is not Send with an error: `*mut ()` cannot be sent between threads safely
+
+# Rolling file appender: no filesystem to roll onto in a browser, and its symlink path does not
+# compile for wasm.
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tracing-appender = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/sdk-kit/src/capi.rs
+++ b/sdk-kit/src/capi.rs
@@ -354,6 +354,7 @@ pub extern "C" fn turso_connection_enable_load_extension(
     c::turso_status_code_t::TURSO_OK
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[no_mangle]
 #[signature(c)]
 pub extern "C" fn turso_connection_load_extension(

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1057,6 +1057,7 @@ impl TursoConnection {
         self.connection.set_load_extension_enabled(enabled);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     pub fn load_extension(&self, path: &str) -> Result<(), TursoError> {
         turso_core::resolve_ext_path(path)
             .and_then(|path| self.connection.load_extension(path))

--- a/sync/sdk-kit/Cargo.toml
+++ b/sync/sdk-kit/Cargo.toml
@@ -21,10 +21,14 @@ turso_sync_engine = { workspace = true }
 turso_sdk_kit = { workspace = true }
 turso_sdk_kit_macros = { workspace = true }
 tracing = { workspace = true }
-tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 genawaiter = { version = "0.99.1", default-features = false }
 parking_lot = { workspace = true, features = ["arc_lock", "send_guard"] }
+
+# Rolling file appender: no filesystem to roll onto in a browser, and its symlink path does not
+# compile for wasm.
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tracing-appender = { workspace = true }
 
 [build-dependencies]
 bindgen = "0.69.5"


### PR DESCRIPTION
## Description

The goal of this PR is to make `cargo build --target wasm32-unknown-unknown -p turso` work in a minimal state. To achieve this, 5 changes were made:

1. Use the [web-time](https://crates.io/crates/web-time) crate, which re-exports `std::time::Instant` on non-wasm targets and uses `Performance::now` on wasm targets (otherwise you get a panic in wasm).
2. Remove `tracing-appender` on wasm, as the crate's functionality is not supported there. It could probably be replaced with [wasm-tracing](https://crates.io/crates/wasm-tracing) if a replacement is wanted.
3. Fix the `getrandom` compilation errors by following their [guidelines](https://docs.rs/getrandom/latest/getrandom/#webassembly-support).
4. Gate `load_extension` in the SDK-kit crate the same way it is gated in core (`core/ext/dynamic.rs`).
5. Filter out `mimalloc` from the wasm build in the end-user Rust crate, as it is not wasm compatible and the wasm build was already discarding its usage.

## Motivation and context

We want to use the Turso Rust crate in wasm (using Rust natively, as our application is also written in Rust and compiled to wasm).

## Description of AI Usage

- Support with compilation errors for more complex things like mimalloc. I am not too familiar with C bindings and such, but it's pretty straightforward to follow Rust compilation errors.
- Help identifying which libraries use `getrandom` and which versions were used.
- Correcting this PR description because I can't spell for shit 😄

---

Forked-from-PR: #8120
Closes: #8120